### PR TITLE
Fixed build for systems without ffsl()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,7 @@
 cmake_minimum_required(VERSION 3.1) 
 project(MobilityDB VERSION 1.0)
 set(MOBILITYDB_VERSION 1.0)
+include(CheckSymbolExists)
 
 set(SRCS
 src/doublen.c
@@ -155,6 +156,11 @@ if (HAS_GSL AND HAS_GSLCBLAS)
 else()
     message(FATAL_ERROR "Could not find gsl or gslcblas; ")
 endif ()
+
+check_symbol_exists(ffsl "string.h" HAS_FFSL)
+if(NOT HAS_FFSL)
+       add_definitions(-D NO_FFSL)
+endif()
 
 add_custom_command(
 	OUTPUT ${SQLPP}

--- a/include/temporal_aggfuncs.h
+++ b/include/temporal_aggfuncs.h
@@ -21,7 +21,7 @@
 
 /* SkipList - Internal type for computing aggregates */
 
-#define SKIPLIST_MAXLEVEL 32
+#define SKIPLIST_MAXLEVEL 32   // maximum possible is 47 with current RNG
 #define SKIPLIST_INITIAL_CAPACITY 1024
 #define SKIPLIST_GROW 2
 #define SKIPLIST_INITIAL_FREELIST 32


### PR DESCRIPTION
Using an internal (naïve) implementation of ffsl() for systems without it.

Also, the random()s for aggregation skiplists were too short, so using numbers from GSL instead.