### PR TITLE
Adding actions to check licenses and shell script

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,0 +1,28 @@
+name: Check code
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  license_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Requirements
+        run: |
+          sudo apt install -y licensecheck
+      - name: Run License Check
+        run: ./tools/scripts/test_license.sh
+
+  shell_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install Requirements
+        run: |
+          sudo apt install -y shellcheck
+      - name: Run Shell Check
+        run: ./tools/scripts/test_shell.sh

--- a/tools/scripts/test_license.sh
+++ b/tools/scripts/test_license.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# This test checks that all source files correctly have license headers
+
+EXCLUDE_LIST="png|jpeg|control|pdf"
+
+mylicensecheck() {
+    licensecheck -r --copyright -l 30 --tail 0 -i "$EXCLUDE_LIST" "$1"
+}
+
+DIR=$(git rev-parse --show-toplevel)
+
+pushd "${DIR}" > /dev/null || exit
+missing=$(! { mylicensecheck src & mylicensecheck  point &  mylicensecheck include;}  | grep "No copyright\|UNKNOWN")
+missing1=$(mylicensecheck doc  | grep "No copyright")
+missing2=$(grep --files-without-match 'Creative Commons' doc/*/*.rst)
+popd > /dev/null || exit
+
+#mylicensecheck doc
+error=0
+if [[ $missing ]]; then
+  echo " ****************************************************"
+  echo " *** Found source files without valid license headers"
+  echo " ****************************************************"
+  echo "$missing"
+  error=1
+fi
+
+if [[ $missing1 ]]; then
+  echo " ****************************************************"
+  echo " *** Found documentation files without copyright"
+  echo " ****************************************************"
+  echo "$missing1"
+  error=1
+fi
+
+if [[ $missing2 ]]; then
+  echo " ****************************************************"
+  echo " *** Found documentation files without valid license headers"
+  echo " ****************************************************"
+  echo "$missing2"
+  error=1
+fi
+exit $error
+

--- a/tools/scripts/test_license.sh
+++ b/tools/scripts/test_license.sh
@@ -2,21 +2,21 @@
 
 # This test checks that all source files correctly have license headers
 
-EXCLUDE_LIST="png|jpeg|control|pdf"
+EXCLUDE_LIST="control.in|\.out|\.xz|\.cmake|\.md|\.txt"
+DOC_EXCLUDE_LIST="\.png|\.svg|\.po|\.pot|\.pdf|\.sh|\.sty|\.vsdx|\.tx|po/es"
 
 mylicensecheck() {
-    licensecheck -r --copyright -l 30 --tail 0 -i "$EXCLUDE_LIST" "$1"
+    licensecheck -r --copyright -l 30 --tail 0 -i "$1" "$2"
 }
 
 DIR=$(git rev-parse --show-toplevel)
 
 pushd "${DIR}" > /dev/null || exit
-missing=$(! { mylicensecheck src & mylicensecheck  point &  mylicensecheck include;}  | grep "No copyright\|UNKNOWN")
-missing1=$(mylicensecheck doc  | grep "No copyright")
-missing2=$(grep --files-without-match 'Creative Commons' doc/*/*.rst)
+missing=$(! { mylicensecheck ${EXCLUDE_LIST} src & mylicensecheck ${EXCLUDE_LIST}  point & mylicensecheck ${EXCLUDE_LIST} npoint & mylicensecheck ${EXCLUDE_LIST} include;}  | grep "No copyright\|UNKNOWN")
+missing1=$(mylicensecheck ${DOC_EXCLUDE_LIST} doc  | grep "No copyright")
+#missing2=$(grep --files-without-match 'Creative Commons' doc/*.xml)
 popd > /dev/null || exit
 
-#mylicensecheck doc
 error=0
 if [[ $missing ]]; then
   echo " ****************************************************"

--- a/tools/scripts/test_shell.sh
+++ b/tools/scripts/test_shell.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# This runs shellcheck on all sh files
+
+
+DIR=$(git rev-parse --show-toplevel)
+
+pushd "${DIR}" > /dev/null || exit
+read -ra files < <(git ls-files | grep '\.sh')
+
+result=$(shellcheck "${files[@]}")
+if [[ $result ]]; then
+  echo "$result"
+  echo " *** shellcheck found script errors"
+  exit 1
+fi


### PR DESCRIPTION
This adds action checks on:
* licenses
* shell code
Following the same work done on pgRouting in the last week

As you can see here:
https://github.com/cvvergara/MobilityDB/runs/1370853374?check_suite_focus=true
Many files lack license
and from here:
https://github.com/cvvergara/MobilityDB/runs/1370853365?check_suite_focus=true
There are not so many shell warnings

After merging change `tools/scripts/test_license.sh` needs to be updated to the licenses needs.
For example right now it tests for license in `src, `include and `points` directories
And for the documentation what is there is what I use for pgRouting (I find .rst which you don't use), because `licensecheck` does not find Creative Commons, I just find it, and using `licensecheck` to find the copyright

