### PR TITLE
Macos action

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,45 @@
+name: Build for macOS
+
+# manually triggered workflow
+# - macOS test takes too much time
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: install deps
+        run: |
+          brew install postgresql postgis proj liblwgeom
+          # installed with postgis just making it splicit:
+          brew install json-c
+
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+
+      - name: Build
+        run: |
+          cd build
+          make -j
+          sudo make install
+
+      - name: test install
+        run: |
+          pg_ctl -D /usr/local/var/postgres start
+          sudo -u postgres createdb  ___mob___test___
+          sudo -u postgres psql   -d ___mob___test___ -c "CREATE EXTENSION mobilitydb CASCADE; SELECT mobilitydb_version()"
+
+      - name: Test
+        run: |
+          cd build
+          make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,9 +88,6 @@ endif ()
 set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")
 
 
-if (APPLE)
-	SET_TARGET_PROPERTIES(${CMAKE_PROJECT_NAME} PROPERTIES LINK_FLAGS "-Wl,-undefined,dynamic_lookup -bundle_loader /usr/local/bin/postgres")
-endif ()
 
 #--------------------------------
 # Belongs to MobilityDB
@@ -102,6 +99,15 @@ set(PROJECT_OBJECTS "$<TARGET_OBJECTS:general>")
 set(PROJECT_OBJECTS ${PROJECT_OBJECTS} "$<TARGET_OBJECTS:point>")
 set(PROJECT_OBJECTS ${PROJECT_OBJECTS} "$<TARGET_OBJECTS:npoint>")
 add_library(${MOBILITYDB_LIB_NAME} MODULE ${PROJECT_OBJECTS})
+
+if(APPLE)
+  set_target_properties(${MOBILITYDB_LIB_NAME}
+    PROPERTIES
+    LINK_FLAGS "-Wl ,-undefined,dynamic_lookup -bundle_loader ${POSTGRESQL_EXECUTABLE} -bundle")
+endif()
+if(WIN32 AND MSVC)
+  set_target_properties(${PROJECT_LIB_NAME} PROPERTIES PREFIX "lib")
+endif()
 
 #--------------------------------
 # other requirements

--- a/cmake/FindPROJ.cmake
+++ b/cmake/FindPROJ.cmake
@@ -1,29 +1,84 @@
-# - Find proj
-# Find the PostgreSQL includes and client library
-# This module defines
-#  PROJ_INCLUDE_DIR
-#  PROJ_LIBRARIES
+# Find Proj
+# ~~~~~~~~~
+# Copyright (c) 2021, Vicky Vergara <vicky at georepublic dot de>
+# Adjustments for MobilityDB
+# Copyright (c) 2007, Martin Dobias <wonder.sk at gmail.com>
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
-# TODO lots of refinement to be able to work on windows & mac at least
-# Copyright (c) 2021, Vicky Vergara <vicky@georepublic.org>
+# CMake module to search for Proj library
+#
+# If it's found it sets PROJ_FOUND to TRUE
+# and following variables are set:
+#    PROJ_INCLUDE_DIRS
+#    PROJ_LIBRARIES
 
-find_library(PROJ_LIBRARIES
-  NAMES proj
-  PATHS
-     /lib /lib64 /usr/lib /usr/lib64
+# FIND_PATH and FIND_LIBRARY normally search standard locations
+# before the specified paths. To search non-standard paths first,
+# FIND_* is invoked first with specified paths and NO_DEFAULT_PATH
+# and then again with no specified paths to search the default
+# locations. When an earlier FIND_* succeeds, subsequent FIND_*s
+# searching for the same item do nothing.
+
+# try to use framework on mac
+# want clean framework path, not unix compatibility path
+if(APPLE)
+  if(CMAKE_FIND_FRAMEWORK MATCHES "FIRST"
+      OR CMAKE_FRAMEWORK_PATH MATCHES "ONLY"
+      OR NOT CMAKE_FIND_FRAMEWORK)
+    SET (CMAKE_FIND_FRAMEWORK_save ${CMAKE_FIND_FRAMEWORK} CACHE STRING "" FORCE)
+    SET (CMAKE_FIND_FRAMEWORK "ONLY" CACHE STRING "" FORCE)
+    #FIND_PATH(PROJ_INCLUDE_DIRS PROJ/proj_api.h)
+    FIND_LIBRARY(PROJ_LIBRARIES PROJ)
+    if(PROJ_LIBRARIES)
+      # FIND_PATH doesn't add "Headers" for a framework
+      SET (PROJ_INCLUDE_DIRS ${PROJ_LIBRARIES}/Headers CACHE PATH "Path to a file.")
+    endif()
+    SET (CMAKE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK_save} CACHE STRING "" FORCE)
+  endif()
+endif()
+
+FIND_PATH(PROJ_INCLUDE_DIRS proj_api.h
+  "$ENV{INCLUDE}"
+  "$ENV{LIB_DIR}/include"
   )
 
-find_path(PROJ_INCLUDE_DIRS
-  NAMES proj_api.h
-  PATHS
-    /usr/include
+if(NOT PROJ_INCLUDE_DIRS)
+  FIND_PATH(PROJ_INCLUDE_DIRS proj.h
+    "$ENV{INCLUDE}"
+    "$ENV{LIB_DIR}/include"
+    )
+endif()
+
+FIND_LIBRARY(PROJ_LIBRARIES NAMES proj_i proj PATHS
+  "$ENV{LIB}"
+  "$ENV{LIB_DIR}/lib"
   )
 
+if(PROJ_INCLUDE_DIRS)
+   if(EXISTS ${PROJ_INCLUDE_DIRS}/proj.h AND EXISTS ${PROJ_INCLUDE_DIRS}/proj_experimental.h)
+     file(READ ${PROJ_INCLUDE_DIRS}/proj.h proj_version)
+     string(REGEX REPLACE "^.*PROJ_VERSION_MAJOR +([0-9]+).*$" "\\1" PROJ_VERSION_MAJOR "${proj_version}")
+     string(REGEX REPLACE "^.*PROJ_VERSION_MINOR +([0-9]+).*$" "\\1" PROJ_VERSION_MINOR "${proj_version}")
+     string(REGEX REPLACE "^.*PROJ_VERSION_PATCH +([0-9]+).*$" "\\1" PROJ_VERSION_PATCH "${proj_version}")
+     string(CONCAT PROJ_VERSION_STR "(" ${PROJ_VERSION_MAJOR} "." ${PROJ_VERSION_MINOR} "." ${PROJ_VERSION_PATCH} ")")
+   else()
+     file(READ ${PROJ_INCLUDE_DIRS}/proj_api.h proj_version)
+     string(REGEX REPLACE "^.*PJ_VERSION ([0-9]+).*$" "\\1" PJ_VERSION "${proj_version}")
+
+     # This will break if 4.10.0 ever will be released (highly unlikely)
+     string(REGEX REPLACE "([0-9])([0-9])([0-9])" "\\1" PROJ_VERSION_MAJOR "${PJ_VERSION}")
+     string(REGEX REPLACE "([0-9])([0-9])([0-9])" "\\2" PROJ_VERSION_MINOR "${PJ_VERSION}")
+     string(REGEX REPLACE "([0-9])([0-9])([0-9])" "\\3" PROJ_VERSION_PATCH "${PJ_VERSION}")
+     string(CONCAT PROJ_VERSION_STR "(" ${PROJ_VERSION_MAJOR} "." ${PROJ_VERSION_MINOR} "." ${PROJ_VERSION_PATCH} ")")
+   endif()
+ endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(PROJ
   FOUND_VAR PROJ_FOUND
   REQUIRED_VARS PROJ_INCLUDE_DIRS PROJ_LIBRARIES
+  VERSION_VAR PROJ_VERSION_STR
   FAIL_MESSAGE "Could NOT find proj")
 
 if (PROJ_FOUND)


### PR DESCRIPTION
Creating a macos action that will be manually triggered
Because currently only postgis 2.5 is required and macos installs postgis 3
The idea of having this action is to have it ready for when postgis 3 is used.

Do not merge, as this PR currently has many commits that will be squashed to only one commit that solves this issue when it is ready to be merged. Which will be announced on a comment and it will be ready for review.
