### PR TITLE
Action to compile with clang

### DIFF
--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,0 +1,86 @@
+name: Build for Ubuntu with clang
+
+# This action runs:
+# - When this file changes
+# - When changes on code (src, include)
+# - When changes on data or testing scripts (tools/testers)
+# - When the way the build changes (CMakeLists.txt)
+#
+# Test is done on:
+# - the preinstalled postgres version
+# - postgis 3
+
+on:
+  push:
+    branches-ignore:
+      - 'gh-pages'
+    tags: []
+
+  pull_request:
+    branches-ignore:
+      - 'gh-pages'
+
+jobs:
+  Test_clang:
+    name: Build
+    runs-on: ubuntu-latest
+
+    strategy:
+        fail-fast: false
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Get postgres version
+        run: |
+          sudo service postgresql start
+          pgver=$(psql --version | grep -Po '(?<=psql \(PostgreSQL\) )[^;]+(?=\.\d \()')
+          echo "PGVER=${pgver}" >> $GITHUB_ENV
+          echo "PGIS=2.5" >> $GITHUB_ENV
+          echo "PGPORT=5432" >> $GITHUB_ENV
+
+      - name: Add PostgreSQL APT repository
+        run: |
+          sudo apt-get install curl ca-certificates gnupg
+          curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | sudo apt-key add -
+          sudo sh -c 'echo "deb http://apt.postgresql.org/pub/repos/apt/ \
+            $(lsb_release -cs)-pgdg main" > /etc/apt/sources.list.d/pgdg.list'
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            clang \
+            liblwgeom-dev \
+            libproj-dev \
+            libjson-c-dev \
+            libgsl-dev \
+            postgresql-${PGVER} \
+            postgresql-${PGVER}-postgis-${PGIS} \
+            postgresql-server-dev-${PGVER}
+          xzcat --version
+
+      - name: Configure
+        run: |
+          export PATH=/usr/lib/postgresql/${PGVER}/bin:$PATH
+          mkdir build
+          cd build
+          CC=clang cmake -DCMAKE_BUILD_TYPE=Debug ..
+
+      - name: Build
+        run: |
+          cd build
+          make -j 4
+          sudo make install
+
+      - name: test install
+        run: |
+          sudo service postgresql start
+          sudo -u postgres createdb -p ${PGPORT}  ___pgr___test___
+          sudo -u postgres psql -p ${PGPORT}  -d ___pgr___test___ -c "CREATE EXTENSION mobilitydb CASCADE; SELECT mobilitydb_version()"
+
+
+      - name: Test
+        run: |
+          cd build
+          make test

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,10 @@ add_definitions(-DPOSTGIS_VERSION_NUMBER=${POSTGIS_VERSION_NUMBER})
 
 #--------------------------------
 
+if(CMAKE_CXX_COMPILER_ID STREQUAL "Clang" AND CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(-Werror)
+endif()
+
 
 add_definitions(-Wall -Wextra -std=gnu1x -Wno-unused-parameter)
 if (CMAKE_COMPILER_IS_GNUCC)

--- a/src/point/tpoint_in.c
+++ b/src/point/tpoint_in.c
@@ -364,7 +364,7 @@ tpoint_from_mfjson_internal(FunctionCallInfo fcinfo, text *mfjson_input,
   char *mfjson = text2cstring(mfjson_input);
   char *srs = NULL;
   int srid = 0;
-  Temporal *result;
+  Temporal *result = NULL;
 
   json_tokener *jstok = NULL;
   json_object *poObj = NULL;


### PR DESCRIPTION
Adding an action to compile with clang
- warnings are treated as errors `-DWerror` when Clang is used and its compiled with -DCMAKE_BUILD_TYPE=Debug
- when -DCMAKE_BUILD_TYPE is not Debug warnings will be warnings.