### PR TITLE
Towards fixing Issue #152

### DIFF
--- a/tools/scripts/test_license.sh
+++ b/tools/scripts/test_license.sh
@@ -22,7 +22,7 @@ done < <(! { mylicensecheck "${SRC_EXCLUDE_LIST}" include ; mylicensecheck "${SR
   mylicensecheck "${SRC_EXCLUDE_LIST}" sql ; mylicensecheck "${SRC_EXCLUDE_LIST}" test ; } )
 
 missing_doc1=""
-while IFS= read -a ROW; do
+while IFS= read -r ROW; do
   if [[ "$ROW" == *"No copyright"* ]]; then
     missing_doc1+="$ROW"$'\n'
   fi


### PR DESCRIPTION
Already removing the need two uses of grep, still needs to find a solution for the last grep.

Example of output in which I modified momentarily the files for testing purposes
```
esteban@DESKTOP-9FBND60:~/src/PR/MobilityDB$ tools/scripts/test_license.sh
 ****************************************************
 *** Found source files without valid license headers
 ****************************************************
include/general/doublen.h: UNKNOWN
include/general/lifting.h: *No copyright* PostgreSQL License
src/general/doublen.c: UNKNOWN
src/general/geo_constructors.c: *No copyright* PostgreSQL License
sql/general/00_catalog.in.sql: *No copyright* PostgreSQL License
sql/general/01_period.in.sql: UNKNOWN
test/general/queries/03_timestampset.test.sql: *No copyright* PostgreSQL License

 ****************************************************
 *** Found documentation files without copyright
 ****************************************************
doc/data_generator.xml: *No copyright* UNKNOWN
doc/es/reference.xml: *No copyright* UNKNOWN

esteban@DESKTOP-9FBND60:~/src/PR/MobilityDB$
```

