### PR TITLE
added path for source compilation of PostgreSQL

### DIFF
--- a/cmake/FindPOSTGRESQL.cmake
+++ b/cmake/FindPOSTGRESQL.cmake
@@ -24,10 +24,20 @@ if(NOT "${POSTGRESQL_BIN}" STREQUAL "")
     )
 else()
   # Checking POSTGRESQL_PG_CONFIG
+  # First we search for installation via source compilation
+  # If not found, we search for normal installation (via package repositories)
   find_program(POSTGRESQL_PG_CONFIG NAMES pg_config
     PATHS
-    /usr/lib/postgresql/*/bin/
+    /usr/local/pgsql/bin/
+    NO_DEFAULT_PATH
     )
+  if(NOT POSTGRESQL_PG_CONFIG)
+    unset(POSTGRESQL_PG_CONFIG CACHE)
+    find_program(POSTGRESQL_PG_CONFIG NAMES pg_config
+      PATHS
+      /usr/lib/postgresql/*/bin/
+      )
+  endif()
 endif()
 
 if(POSTGRESQL_PG_CONFIG)


### PR DESCRIPTION
This PR addresses the addition of path of PostgreSQL installation by compiling and installing from source. 
When compiled and installed from source, PostgreSQL puts all header files and binaries in `/usr/local/pgsql` directory. This was not take into consideration in CMake files. In this new version of CMake we first see `/usr/local/pgsql` directory for PostgreSQL installation and if we found one, we use it and if not we do what we did before (look in `/usr/lib/postgresql/*/bin/` directory).