### PR TITLE
added path for PostgreSQL installation from source

### DIFF
--- a/cmake/FindPOSTGRESQL.cmake
+++ b/cmake/FindPOSTGRESQL.cmake
@@ -24,10 +24,20 @@ if(NOT "${POSTGRESQL_BIN}" STREQUAL "")
     )
 else()
   # Checking POSTGRESQL_PG_CONFIG
+  # First we search for installation via source compilation
+  # If not found, we search for normal installation (via package repositories)
   find_program(POSTGRESQL_PG_CONFIG NAMES pg_config
     PATHS
-    /usr/lib/postgresql/*/bin/
+    /usr/local/pgsql/bin/
+    NO_DEFAULT_PATH
     )
+  if(NOT POSTGRESQL_PG_CONFIG)
+    unset(POSTGRESQL_PG_CONFIG CACHE)
+    find_program(POSTGRESQL_PG_CONFIG NAMES pg_config
+      PATHS
+      /usr/lib/postgresql/*/bin/
+      )
+  endif()
 endif()
 
 if(POSTGRESQL_PG_CONFIG)


### PR DESCRIPTION
In CMake files and particularly in the file that searches for PostgreSQL installation (`FindPOSTGRESQL.cmake`), the path of  PostgreSQL installation from source is forgotten. This could cause problems for users who have headers installed from OS package repository but binaries installed by compiling from source. 

This issus is fixed in this PR by considering first the path of PostgreSQL installation from source (`/usr/local/pgsql/`) and than the path from OS packages (`/usr/lib/postgresql/*/`) if there was not any installation from source.