### PR TITLE
Fix seg2d_intersection

### DIFF
--- a/meos/src/point/tpoint_spatialfuncs.c
+++ b/meos/src/point/tpoint_spatialfuncs.c
@@ -875,21 +875,21 @@ bool tgeogpoint_always_eq(const Temporal *temp, GSERIALIZED *gs)
  * static
  */
 static bool
-lw_seg_interact(const POINT2D p1, const POINT2D p2, const POINT2D q1,
-  const POINT2D q2)
+lw_seg_interact(const POINT2D *p1, const POINT2D *p2, const POINT2D *q1,
+  const POINT2D *q2)
 {
-  double minq = FP_MIN(q1.x, q2.x);
-  double maxq = FP_MAX(q1.x, q2.x);
-  double minp = FP_MIN(p1.x, p2.x);
-  double maxp = FP_MAX(p1.x, p2.x);
+  double minq = FP_MIN(q1->x, q2->x);
+  double maxq = FP_MAX(q1->x, q2->x);
+  double minp = FP_MIN(p1->x, p2->x);
+  double maxp = FP_MAX(p1->x, p2->x);
 
   if (FP_GT(minp, maxq) || FP_LT(maxp, minq))
     return false;
 
-  minq = FP_MIN(q1.y, q2.y);
-  maxq = FP_MAX(q1.y, q2.y);
-  minp = FP_MIN(p1.y, p2.y);
-  maxp = FP_MAX(p1.y, p2.y);
+  minq = FP_MIN(q1->y, q2->y);
+  maxq = FP_MAX(q1->y, q2->y);
+  minp = FP_MIN(p1->y, p2->y);
+  maxp = FP_MAX(p1->y, p2->y);
 
   if (FP_GT(minp,maxq) || FP_LT(maxp,minq))
     return false;
@@ -3125,8 +3125,7 @@ bearing_tpoint_tpoint(const Temporal *temp1, const Temporal *temp2)
 }
 
 /*****************************************************************************
- * Functions computing the intersection of two segments derived from
- * http://www.science.smith.edu/~jorourke/books/ftp.html
+ * Functions computing the intersection of two segments derived from PostGIS
  *****************************************************************************/
 
 /*
@@ -3138,7 +3137,8 @@ enum
   MEOS_SEG_NO_INTERSECTION,  /* Segments do not intersect */
   MEOS_SEG_OVERLAP,          /* Segments overlap */
   MEOS_SEG_CROSS,            /* Segments cross */
-  MEOS_SEG_TOUCH,            /* Segments touch in a vertex */
+  MEOS_SEG_TOUCH_END,        /* Segments touch in two equal enpoints */
+  MEOS_SEG_TOUCH,            /* Segments touch without equal enpoints */
 } MEOS_SEG_INTER_TYPE;
 
 /**
@@ -3150,31 +3150,31 @@ enum
  * collinear and that their bounding boxes intersect.
  */
 static int
-parseg2d_intersection(const POINT2D a, const POINT2D b, const POINT2D c,
-  const POINT2D d, POINT2D *p)
+parseg2d_intersection(const POINT2D *a, const POINT2D *b, const POINT2D *c,
+  const POINT2D *d, POINT2D *p)
 {
   /* Compute the intersection of the bounding boxes */
-  double xmin = Max(Min(a.x, b.x), Min(c.x, d.x));
-  double xmax = Min(Max(a.x, b.x), Max(c.x, d.x));
-  double ymin = Max(Min(a.y, b.y), Min(c.y, d.y));
-  double ymax = Min(Max(a.y, b.y), Max(c.y, d.y));
+  double xmin = Max(Min(a->x, b->x), Min(c->x, d->x));
+  double xmax = Min(Max(a->x, b->x), Max(c->x, d->x));
+  double ymin = Max(Min(a->y, b->y), Min(c->y, d->y));
+  double ymax = Min(Max(a->y, b->y), Max(c->y, d->y));
   /* If the intersection of the bounding boxes is not a point */
   if (xmin < xmax || ymin < ymax )
     return MEOS_SEG_OVERLAP;
   /* We are sure that the segments touch each other */
-  if ((b.x == c.x && b.y == c.y) ||
-      (b.x == d.x && b.y == d.y))
+  if ((b->x == c->x && b->y == c->y) ||
+      (b->x == d->x && b->y == d->y))
   {
-    p->x = b.x;
-    p->y = b.y;
-    return MEOS_SEG_TOUCH;
+    p->x = b->x;
+    p->y = b->y;
+    return MEOS_SEG_TOUCH_END;
   }
-  if ((a.x == c.x && a.y == c.y) ||
-      (a.x == d.x && a.y == d.y))
+  if ((a->x == c->x && a->y == c->y) ||
+      (a->x == d->x && a->y == d->y))
   {
-    p->x = a.x;
-    p->y = a.y;
-    return MEOS_SEG_TOUCH;
+    p->x = a->x;
+    p->y = a->y;
+    return MEOS_SEG_TOUCH_END;
   }
   /* We should never arrive here since this function is called after verifying
    * that the bounding boxes of the segments intersect */
@@ -3184,41 +3184,65 @@ parseg2d_intersection(const POINT2D a, const POINT2D b, const POINT2D c,
 /**
  * @brief Find the UNIQUE point of intersection p between two closed segments
  * ab and cd. Return p and a MEOS_SEG_INTER_TYPE value.
+ * @note Currently, the function only computes p if the result value is
+ * MEOS_SEG_TOUCH_END, since the return value is never used in other cases.
  * @note If the segments overlap no point is returned since they can be an
- * infinite number of them
+ * infinite number of them.
  */
 static int
-seg2d_intersection(const POINT2D a, const POINT2D b, const POINT2D c,
-  const POINT2D d, POINT2D *p)
+seg2d_intersection(const POINT2D *a, const POINT2D *b, const POINT2D *c,
+  const POINT2D *d, POINT2D *p)
 {
-  double s, t;        /* The two parameters of the parametric equations */
-  double num, denom;  /* Numerator and denominator of equations */
-  int result;         /* Return value characterizing the intersection */
+  /* assume the following names: p = Segment(a, b), q = Segment(c, d) */
+  int pq1, pq2, qp1, qp2;
 
-  denom = a.x * (d.y - c.y) + b.x * (c.y - d.y) +
-          d.x * (b.y - a.y) + c.x * (a.y - b.y);
+  /* No envelope interaction => we are done. */
+  if (!lw_seg_interact(a, b, c, d))
+    return MEOS_SEG_NO_INTERSECTION;
 
-  /* If denom is zero, then segments are parallel: handle separately */
-  if (fabs(denom) < MEOS_EPSILON)
+  /* Are the start and end points of q on the same side of p? */
+  pq1 = lw_segment_side(a,b,c);
+  pq2 = lw_segment_side(a,b,d);
+  if ((pq1 > 0 && pq2 > 0) || (pq1 < 0 && pq2 < 0))
+    return MEOS_SEG_NO_INTERSECTION;
+
+  /* Are the start and end points of p on the same side of q? */
+  qp1 = lw_segment_side(c,d,a);
+  qp2 = lw_segment_side(c,d,b);
+  if ((qp1 > 0 && qp2 > 0) || (qp1 < 0 && qp2 < 0))
+    return MEOS_SEG_NO_INTERSECTION;
+
+  /* Nobody is on one side or another? Must be colinear. */
+  if (pq1 == 0 && pq2 == 0 && qp1 == 0 && qp2 == 0)
     return parseg2d_intersection(a, b, c, d, p);
 
-  num = a.x * (d.y - c.y) + c.x * (a.y - d.y) + d.x * (c.y - a.y);
-  s = num / denom;
+  /* Check if the intersection is an endpoint */
+  if (pq1 == 0 || pq2 == 0 || qp1 == 0 || qp2 == 0)
+  {
+    /* Check for two equal endpoints */
+    if ((b->x == c->x && b->y == c->y) ||
+        (b->x == d->x && b->y == d->y))
+    {
+      p->x = b->x;
+      p->y = b->y;
+      return MEOS_SEG_TOUCH_END;
+    }
+    if ((a->x == c->x && a->y == c->y) ||
+        (a->x == d->x && a->y == d->y))
+    {
+      p->x = a->x;
+      p->y = a->y;
+      return MEOS_SEG_TOUCH_END;
+    }
 
-  num = -(a.x * (c.y - b.y) + b.x * (a.y - c.y) + c.x * (b.y - a.y));
-  t = num / denom;
+    /* The intersection is inside one of the segments
+     * note: p is not compute for this type of intersection */
+    return MEOS_SEG_TOUCH;
+  }
 
-  if ((0.0 == s || s == 1.0) && (0.0 == t || t == 1.0))
-   result = MEOS_SEG_TOUCH;
-  else if (0.0 <= s && s <= 1.0 && 0.0 <= t && t <= 1.0)
-   result = MEOS_SEG_CROSS;
-  else
-   result = MEOS_SEG_NO_INTERSECTION;
-
-  p->x = a.x + s * (b.x - a.x);
-  p->y = a.y + s * (b.y - a.y);
-
-  return result;
+  /* Crossing
+   * note: p is not compute for this type of intersection */
+  return MEOS_SEG_CROSS;
 }
 
 /*****************************************************************************
@@ -3340,17 +3364,17 @@ tpointseq_linear_find_splits(const TSequence *seq, int *count)
     while (j < end)
     {
       /* If the bounding boxes of the segments intersect */
-      if (lw_seg_interact(points[i], points[i + 1],
-          points[j], points[j + 1]))
+      if (lw_seg_interact(&points[i], &points[i + 1],
+          &points[j], &points[j + 1]))
       {
         /* Candidate for intersection */
         POINT2D p = { 0 }; /* make compiler quiet */
-        int intertype = seg2d_intersection(points[i], points[i + 1],
-          points[j], points[j + 1], &p);
+        int intertype = seg2d_intersection(&points[i], &points[i + 1],
+          &points[j], &points[j + 1], &p);
         if (intertype > 0 &&
           /* Exclude the case when two consecutive segments that
            * necessarily touch each other in their common point */
-          (intertype != MEOS_SEG_TOUCH || j != i + 1 ||
+          (intertype != MEOS_SEG_TOUCH_END || j != i + 1 ||
            p.x != points[j].x || p.y != points[j].y))
         {
           /* Set the new end */

--- a/meos/src/point/tpoint_spatialfuncs.c
+++ b/meos/src/point/tpoint_spatialfuncs.c
@@ -3126,6 +3126,11 @@ bearing_tpoint_tpoint(const Temporal *temp1, const Temporal *temp2)
 
 /*****************************************************************************
  * Functions computing the intersection of two segments derived from PostGIS
+ * The seg2d_intersection function is a modified version of the PostGIS
+ * lw_segment_intersects function and also returns the intersection point
+ * in case the two segments intersect at equal endpoints.
+ * The intersection point is required in tpointseq_linear_find_splits
+ * only for this intersection type (MEOS_SEG_TOUCH_END).
  *****************************************************************************/
 
 /*

--- a/mobilitydb/test/npoint/expected/087_tnpoint_spatialfuncs_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/087_tnpoint_spatialfuncs_tbl.test.out
@@ -13,7 +13,7 @@ SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_geometry t2 WHERE atGeometry(t1.temp, S
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_geometry t2 WHERE minusGeometry(t1.temp, ST_SetSRID(t2.g, 5676)) IS NOT NULL;
  count 
 -------
-  9705
+  9716
 (1 row)
 
 SELECT round(MAX(length(temp))::numeric, 6) FROM tbl_tnpoint;

--- a/mobilitydb/test/point/expected/056_tpoint_spatialfuncs_tbl.test.out
+++ b/mobilitydb/test/point/expected/056_tpoint_spatialfuncs_tbl.test.out
@@ -555,25 +555,25 @@ WHERE bearing(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeompoint WHERE isSimple(temp);
  count 
 -------
-    57
+    67
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D WHERE isSimple(temp);
  count 
 -------
-    61
+    65
 (1 row)
 
 SELECT SUM(numInstants(t)) FROM tbl_tgeompoint, unnest(makeSimple(temp)) t;
  sum  
 ------
- 1134
+ 1034
 (1 row)
 
 SELECT SUM(numInstants(t)) FROM tbl_tgeompoint3D, unnest(makeSimple(temp)) t;
  sum  
 ------
- 1120
+ 1028
 (1 row)
 
 SELECT DISTINCT merge(makeSimple(temp)) = temp from tbl_tgeompoint;


### PR DESCRIPTION
This PR modfies the seg2d_intersection function to avoid the errors caused by floating point precision errors in the old function. The new function is a modified version of the PostGIS function `lw_segment_intersects` and also returns the intersection point in case the two segments intersect at equal endpoints. The intersection point is required in `tpointseq_linear_find_splits` only for this intersection type.