### PR TITLE
Fix for mingw64 PG16

### DIFF
--- a/mobilitydb/src/npoint/tnpoint_posops.c
+++ b/mobilitydb/src/npoint/tnpoint_posops.c
@@ -43,10 +43,10 @@
  * arguments is a stbox.
  */
 
-/* MEOS */
-#include <meos.h>
 /* MobilityDB */
 #include "pg_npoint/tnpoint_boxops.h"
+/* MEOS */
+#include <meos.h>
 
 /*****************************************************************************/
 /* stbox op Temporal */


### PR DESCRIPTION
Closes #366
Move meos.h include after tnpoint_boxops.h
otherwise some functions don't get exported under mingw64 pg16.

Not sure why it's only an issue with pg16 and not lower PGs, might be because they reshuffled includes too in PG16