### PR TITLE
Run workflows only when required

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -1,8 +1,19 @@
 name: Check code
 
 on:
-  push:
+  workflow_dispatch:
   pull_request:
+    paths:
+      - '.github/workflows/check-code.yml'
+      - 'datagen/**'
+      - 'doc/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'LICENSE.txt'
+    branch:
+      - master
+      - develop
 
 jobs:
   license_check:

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -1,24 +1,23 @@
 name: Build for Ubuntu with clang
 
-# This action runs:
-# - When this file changes
-# - When changes on code (src, include)
-# - When changes on data or testing scripts (tools/testers)
-# - When the way the build changes (CMakeLists.txt)
-#
-# Test is done on:
-# - the preinstalled postgres version
-# - postgis 3
-
 on:
+  workflow_dispatch:
   push:
-    branches-ignore:
-      - 'gh-pages'
-    tags: []
-
+    paths:
+      - 'cmake/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
   pull_request:
-    branches-ignore:
-      - 'gh-pages'
+    paths:
+      - 'cmake/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
 
 jobs:
   Test_clang:

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -3,6 +3,7 @@
 name: Documentation generation CI
 
 on:
+  workflow_dispatch:
   push:
     paths:
       - '.github/workflows/generate_docs.yml'

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -11,7 +11,7 @@ on:
     branches:
       - master
       - develop
-  pull-request:
+  pull_request:
     paths:
       - '.github/workflows/generate_docs.yml'
       - 'doc/**'

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -10,6 +10,13 @@ on:
     branches:
       - master
       - develop
+  pull-request:
+    paths:
+      - '.github/workflows/generate_docs.yml'
+      - 'doc/**'
+    branches:
+      - master
+      - develop
 
 jobs:
   build:
@@ -84,17 +91,31 @@ jobs:
 
       # Rename the directory to master
       - name: Rename the directory to master
-        if: ${{ github.ref == 'refs/heads/master' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
         run: |
           rm -rf master
           mv docs-temp master
 
       # Rename the directory to master
       - name: Rename the directory to develop
-        if: ${{ github.ref == 'refs/heads/develop' }}
+        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/develop' }}
         run: |
           rm -rf develop
           mv docs-temp develop
+
+      # Rename the directory to master
+      - name: Rename the directory to master
+        if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/master' }}
+        run: |
+          rm -rf master-pr
+          mv docs-temp master-pr
+
+      # Rename the directory to master
+      - name: Rename the directory to develop
+        if: ${{ github.event_name == 'pull_request' && github.ref == 'refs/heads/develop' }}
+        run: |
+          rm -rf develop-pr
+          mv docs-temp develop-pr
 
       # add, commit and push to gh-pages
       - name: Commit changes

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,13 +1,22 @@
 name: Build for macOS
 
-# manually triggered workflow
-# - macOS test takes too much time
-
 on:
   workflow_dispatch:
   push:
+    paths:
+      - 'cmake/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
     branch_ignore: gh-pages
   pull_request:
+    paths:
+      - 'cmake/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
     branch_ignore: gh-pages
 
 jobs:

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -7,8 +7,20 @@ name: Main Build
 on:
   workflow_dispatch:
   push:
+    paths:
+      - 'cmake/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
     branch_ignore: gh-pages
   pull_request:
+    paths:
+      - 'cmake/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
     branch_ignore: gh-pages
 
 jobs:

--- a/.github/workflows/windows_msys2.yml
+++ b/.github/workflows/windows_msys2.yml
@@ -1,11 +1,23 @@
 name: Build for Windows
 
 on:
-  push:
-    # branches: [ main ]
-  pull_request:
-    # branches: [ main ]
   workflow_dispatch:
+  push:
+    paths:
+      - 'cmake/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
+  pull_request:
+    paths:
+      - 'cmake/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'postgis/**'
+      - 'CMakeLists.txt'
+    branch_ignore: gh-pages
 
 jobs:
   build:


### PR DESCRIPTION
Run workflows in the following conditions:

- Run build and test workflows when source files or build file (CMakeLists.txt) change. Run for all branches on pushes and PR.
- Run licensecheck workflow only when PR to develop or master
- Run doc generation on PR and pushes to master and develop. During PR, generate docs in master-pr or develop-pr folders to avoid overriding the existing documenation.