### PR TITLE
Add libgsl and libgeos dependencies to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Requirements
 
 For example, you can build the following command to install all MobilityDB build dependencies for Debian-based systems using PostgreSQL 15 and PostGIS 3:
 ```bash
-apt install build-essential cmake postgresql-server-dev-15 libproj-dev libjson-c-dev
+apt install build-essential cmake postgresql-server-dev-15 libproj-dev libjson-c-dev libgsl-dev libgeos-dev
 ```
 
 Building & Installation


### PR DESCRIPTION
Using the docker image for [postgis](https://registry.hub.docker.com/r/postgis/postgis/) I wasn't able to compile MobilityDB following the instructions on the README.md file.

By installing two extra packages (namely `libgsl-dev` and `libgeos-dev`) the problems were solved and the instructions work perfectly.

This PR adds those two packages to the README.md instruction.

(Technically speaking, `git` is also required to following the instructions as is. But since it is possible manually download the repository from the web, I think that `git` shouldn't be considered a dependency.)


For the record, these are the errors encountered before installing the two packages:

```
Could NOT find GSL (missing: GSL_INCLUDE_DIR GSL_LIBRARY GSL_CBLAS_LIBRARY)
```

and

```
FindGEOS.cmake: geos-config not found. Please set it manually. GEOS_CONFIG=GEOS_CONFIG-NOTFOUND
```
