### PR TITLE
Fix spgist indices

### DIFF
--- a/mobilitydb/src/general/tnumber_spgist.c
+++ b/mobilitydb/src/general/tnumber_spgist.c
@@ -921,6 +921,7 @@ tbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
   /* Allocate enough memory for nodes */
   out->nNodes = 0;
   out->nodeNumbers = palloc(sizeof(int) * in->nNodes);
+  out->levelAdds = palloc(sizeof(int) * in->nNodes);
   out->traversalValues = palloc(sizeof(void *) * in->nNodes);
   if (in->norderbys > 0)
     out->distances = palloc(sizeof(double *) * in->nNodes);
@@ -939,7 +940,7 @@ tbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
     if (idxtype == SPGIST_QUADTREE)
       tboxnode_quadtree_next(nodebox, centroid, node, &next_nodebox);
     else
-      tboxnode_kdtree_next(nodebox, centroid, node, (in->level) + 1,
+      tboxnode_kdtree_next(nodebox, centroid, node, in->level,
         &next_nodebox);
     bool flag = true;
     for (i = 0; i < in->nkeys; i++)
@@ -993,6 +994,8 @@ tbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
       /* Pass traversalValue and node */
       out->traversalValues[out->nNodes] = tboxnode_copy(&next_nodebox);
       out->nodeNumbers[out->nNodes] = node;
+      /* Increase level */
+      out->levelAdds[out->nNodes] = 1;
       /* Pass distances */
       if (in->norderbys > 0)
       {

--- a/mobilitydb/src/point/tpoint_spgist.c
+++ b/mobilitydb/src/point/tpoint_spgist.c
@@ -1217,6 +1217,7 @@ stbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
   /* Allocate enough memory for nodes */
   out->nNodes = 0;
   out->nodeNumbers = palloc(sizeof(int) * in->nNodes);
+  out->levelAdds = palloc(sizeof(int) * in->nNodes);
   out->traversalValues = palloc(sizeof(void *) * in->nNodes);
   if (in->norderbys > 0)
     out->distances = palloc(sizeof(double *) * in->nNodes);
@@ -1235,7 +1236,7 @@ stbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
     if (idxtype == SPGIST_QUADTREE)
       stboxnode_quadtree_next(nodebox, centroid, (uint8) node, &next_nodebox);
     else
-      stboxnode_kdtree_next(nodebox, centroid, (uint8) node, (in->level) + 1,
+      stboxnode_kdtree_next(nodebox, centroid, (uint8) node, in->level,
         &next_nodebox);
     bool flag = true;
     for (i = 0; i < in->nkeys; i++)
@@ -1317,6 +1318,8 @@ stbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
       /* Pass traversalValue and node */
       out->traversalValues[out->nNodes] = stboxnode_copy(&next_nodebox);
       out->nodeNumbers[out->nNodes] = node;
+      /* Increase level */
+      out->levelAdds[out->nNodes] = 1;
       /* Pass distances */
       if (in->norderbys > 0)
       {

--- a/mobilitydb/test/general/expected/011_span_indexes_tbl.test.out
+++ b/mobilitydb/test/general/expected/011_span_indexes_tbl.test.out
@@ -603,10 +603,9 @@ SELECT * FROM test_idxops
 WHERE no_idx <> rtree_idx OR no_idx <> quadtree_idx OR no_idx <> kdtree_idx OR
   no_idx IS NULL OR rtree_idx IS NULL OR quadtree_idx IS NULL OR kdtree_idx IS NULL
 ORDER BY op, leftarg, rightarg;
- op  | leftarg | rightarg | no_idx | rtree_idx | quadtree_idx | kdtree_idx 
------+---------+----------+--------+-----------+--------------+------------
- -|- | intspan | intspan  |    214 |       214 |          174 |        214
-(1 row)
+ op | leftarg | rightarg | no_idx | rtree_idx | quadtree_idx | kdtree_idx 
+----+---------+----------+--------+-----------+--------------+------------
+(0 rows)
 
 DROP TABLE test_idxops;
 DROP TABLE

--- a/mobilitydb/test/general/expected/044_temporal_indexes_tbl.test.out
+++ b/mobilitydb/test/general/expected/044_temporal_indexes_tbl.test.out
@@ -2089,12 +2089,9 @@ SELECT * FROM test_idxops
 WHERE no_idx <> rtree_idx OR no_idx <> quadtree_idx OR no_idx <> kdtree_idx OR
   no_idx IS NULL OR rtree_idx IS NULL OR quadtree_idx IS NULL OR kdtree_idx IS NULL
 ORDER BY op, leftarg, rightarg;
- op  | leftarg | rightarg  | no_idx | rtree_idx | quadtree_idx | kdtree_idx 
------+---------+-----------+--------+-----------+--------------+------------
- &>  | tfloat  | floatspan |    110 |       110 |          110 |         29
- &>  | tint    | intspan   |     94 |        94 |           94 |         30
- >>  | tfloat  | floatspan |      2 |         2 |            2 |          0
-(3 rows)
+ op | leftarg | rightarg | no_idx | rtree_idx | quadtree_idx | kdtree_idx 
+----+---------+----------+--------+-----------+--------------+------------
+(0 rows)
 
 DROP TABLE test_idxops;
 DROP TABLE


### PR DESCRIPTION
Changes:
- Add levels correctly when traversing a kdtree
- Always assume inclusive bounds of the span quadtree nodes. Not as optimal as handling the bounds correctly, but this would sometimes cause empty spans to be created, so this was the simplest fix.
- Use the same code for spam overlaps and contains in both quadtree and kdtree. I believe the code for kdtree was trying to only test one dimension at a time, but it was wrong, so I just used the same code as quadtree. This is similar to what spgist does for tbox and stbox.