### PR TITLE
Add back intervalstyle and datestyle setters and getters to meos.h

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -348,6 +348,11 @@ extern void meos_initialize_timezone(const char *name);
 extern void meos_initialize_error_handler(error_handler_fn err_handler);
 extern void meos_finalize_timezone(void);
 
+extern bool meos_set_datestyle(char *newval, void *extra);
+extern bool meos_set_intervalstyle(char *newval, int extra);
+extern char *meos_get_datestyle(void);
+extern char *meos_get_intervalstyle(void);
+
 extern void meos_initialize(const char *tz_str, error_handler_fn err_handler);
 extern void meos_finalize(void);
 


### PR DESCRIPTION
Add back setters and getters of intervalstyle and datestyle in meos.h that were lost in #411, the implementations were recovered in #412.