### PR TITLE
Update python references in readme to point to PyMEOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,7 @@ Benefits
 
 *   Adopted by the [Open Source Geospatial Foundation](https://www.osgeo.org/) (OSGeo) as a [community project](https://www.osgeo.org/projects/mobilitydb/)
 
-*   Database adapters to access MobilityDB from Python are also available
-
-    *   [MobilityDB-python](https://github.com/MobilityDB/MobilityDB-python) supports both the [psycopg2](https://www.psycopg.org/) and the [asyncpg](https://github.com/MagicStack/asyncpg) adapters for PostgreSQL and uses the [postgis](https://github.com/tilery/python-postgis) adapter for PostGIS. This package is developed by the MobilityDB Team.
-    *   [MobilityDB SQLAlchemy](https://github.com/adonmo/mobilitydb-sqlalchemy) is another independent package that provides extensions to [SQLAlchemy](https://www.sqlalchemy.org/) for interacting with MobilityDB
+*   Database adapters to access MobilityDB from Python are provided by the [PyMEOS](https://github.com/MobilityDB/PyMEOS) package, supporting [psycopg2](https://www.psycopg.org/docs/), [psycopg](https://www.psycopg.org/psycopg3/docs/) and [asyncpg](https://magicstack.github.io/asyncpg/current/) libraries.
 
 *   Data generator and benchmark tool based on the [BerlinMOD](https://secondo-database.github.io/BerlinMOD/BerlinMOD.html) benchmark. The data generator takes input data from [Open Street Map](https://www.openstreetmap.org/) and uses [pgRouting](https://pgrouting.org/) to generate routes between pairs of source and target locations.
 


### PR DESCRIPTION
I only mention the database adapters since MEOS is not mentioned anywhere else in the Readme, so it would be weird to do so here.
The SQLAlchemy extension is no longer supported, and it's addition to PyMEOS will not be soon