### PR TITLE
Allow reusing LWPROJ

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1438,6 +1438,8 @@ extern Temporal *tint_shift_value(const Temporal *temp, int shift);
 extern Temporal *tpoint_round(const Temporal *temp, int maxdd);
 extern Temporal *tpoint_transform(const Temporal *temp, int32 srid);
 extern Temporal *tpoint_transform_pipeline(const Temporal *temp, char *pipelinestr, int32 srid, bool is_forward);
+extern Temporal *tpoint_transform_pj(const Temporal *temp, int32 srid, const LWPROJ*);
+extern LWPROJ *lwproj_transform(int32 srid_from, int32 srid_to);
 extern Temporal **tpointarr_round(const Temporal **temp, int count, int maxdd);
 
 /*****************************************************************************

--- a/meos/include/point/tpoint_spatialfuncs.h
+++ b/meos/include/point/tpoint_spatialfuncs.h
@@ -182,6 +182,8 @@ extern TSequence *tpointdiscseq_transform(const TSequence *is, int srid);
 extern TSequence *tpointcontseq_transform(const TSequence *seq, int srid);
 extern TSequenceSet *tpointseqset_transform(const TSequenceSet *ss, int srid);
 extern Temporal *tpoint_transform(const Temporal *temp, int srid);
+extern Temporal *tpoint_transform_pj(const Temporal *temp, int32 srid, const LWPROJ*);
+extern LWPROJ *lwproj_transform(int32 srid_from, int32 srid_to);
 
 /* Stop function */
 

--- a/meos/include/postgis_ext_defs.in.h
+++ b/meos/include/postgis_ext_defs.in.h
@@ -408,4 +408,21 @@ extern double lwpoint_get_m(const LWPOINT *point);
 extern int lwgeom_has_z(const LWGEOM *geom);
 extern int lwgeom_has_m(const LWGEOM *geom);
 
+#include "proj.h"
+
+typedef struct LWPROJ
+{
+    PJ* pj;
+
+    /* for pipeline transforms, whether to do a forward or inverse */
+    bool pipeline_is_forward;
+
+    /* Source crs is geographic: Used in geography calls (source srid == dst srid) */
+    uint8_t source_is_latlong;
+    /* Source ellipsoid parameters */
+    double source_semi_major_metre;
+    double source_semi_minor_metre;
+} LWPROJ;
+
+
 #endif              /* _LIBLWGEOM_H */

--- a/meos/src/point/type_srid.c
+++ b/meos/src/point/type_srid.c
@@ -391,7 +391,7 @@ to_dec(POINT4D *pt)
  * @brief Return a structure with the information to perform a transformation
  * @param[in] srid_from,srid_to SRIDs
  */
-static LWPROJ *
+LWPROJ *
 lwproj_transform(int32 srid_from, int32 srid_to)
 {
   char srid_from_str[MAX_EPSG_STR];
@@ -667,7 +667,7 @@ geoset_transform_pipeline(const Set *s, char *pipeline, int32 srid_to,
  * @param[in] pj Information about the transformation
  */
 static bool
-stbox_transf_pj(STBox *box, int32 srid_to, LWPROJ *pj)
+stbox_transf_pj(STBox *box, int32 srid_to, const LWPROJ *pj)
 {
   assert(box); assert(pj);
   /* Create the points corresponding to the bounds */
@@ -800,7 +800,7 @@ stbox_transform_pipeline(const STBox *box, char *pipeline,
  * @param[in] pj Information about the transformation
  */
 static bool
-tpointinst_transf_pj(TInstant *inst, int32 srid_to, LWPROJ *pj)
+tpointinst_transf_pj(TInstant *inst, int32 srid_to, const LWPROJ *pj)
 {
   assert(inst); assert(pj); assert(tgeo_type(inst->temptype));
   GSERIALIZED *gs = DatumGetGserializedP(tinstant_val(inst));
@@ -817,7 +817,7 @@ tpointinst_transf_pj(TInstant *inst, int32 srid_to, LWPROJ *pj)
  * @param[in] pj Information about the transformation
  */
 static bool
-tpointseq_transf_pj(TSequence *seq, int32 srid_to, LWPROJ *pj)
+tpointseq_transf_pj(TSequence *seq, int32 srid_to, const LWPROJ *pj)
 {
   assert(seq); assert(pj); assert(tgeo_type(seq->temptype));
   for (int i = 0; i < seq->count; i++)
@@ -841,7 +841,7 @@ tpointseq_transf_pj(TSequence *seq, int32 srid_to, LWPROJ *pj)
  * @param[in] pj Information about the transformation
  */
 static bool
-tpointseqset_transf_pj(TSequenceSet *ss, int32 srid_to, LWPROJ *pj)
+tpointseqset_transf_pj(TSequenceSet *ss, int32 srid_to, const LWPROJ *pj)
 {
   assert(ss); assert(pj); assert(tgeo_type(ss->temptype));
   for (int i = 0; i < ss->count; i++)
@@ -867,8 +867,8 @@ tpointseqset_transf_pj(TSequenceSet *ss, int32 srid_to, LWPROJ *pj)
  * transformation
  * @param[in] pj Information about the transformation
  */
-static Temporal *
-tpoint_transform_pj(const Temporal *temp, int32 srid_to, LWPROJ *pj)
+Temporal *
+tpoint_transform_pj(const Temporal *temp, int32 srid_to, const LWPROJ *pj)
 {
   assert(temp); assert(pj);
   /* Copy the temporal point to transform its composing points in place */
@@ -892,7 +892,6 @@ tpoint_transform_pj(const Temporal *temp, int32 srid_to, LWPROJ *pj)
     result = NULL;
   }
   /* Clean up and return */
-  proj_destroy(pj->pj); pfree(pj);
   return result;
 }
 
@@ -922,7 +921,11 @@ tpoint_transform(const Temporal *temp, int32 srid_to)
     return NULL;
 
   /* Transform the temporal point */
-  return tpoint_transform_pj(temp, srid_to, pj);
+  Temporal * result = tpoint_transform_pj(temp, srid_to, pj);
+
+  proj_destroy(pj->pj); pfree(pj);
+
+  return result;
 }
 
 /**
@@ -952,7 +955,11 @@ tpoint_transform_pipeline(const Temporal *temp, char *pipeline,
     return NULL;
 
   /* Transform the temporal point */
-  return tpoint_transform_pj(temp, srid_to, pj);
+  Temporal * result = tpoint_transform_pj(temp, srid_to, pj);
+
+  proj_destroy(pj->pj); pfree(pj);
+
+  return result;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
To allow reusing `LWPROJ`objects across calls, I've made the following changes (by file):
- `type_srid.c`:
  - Move destruction of `LWPROJ`object from `tpoint_transform_pj` to `tpoint_transform` and `tpoint_transform_pipeline` .
  - Make `LWPROJ` parameter `const` in `tpoint_transform_pj` and `tpoint*_transf_pj` functions.
  - Make `tpoint_transform_pj` and `lwproj_transform` non-static.
- `tpoint_spatialfuncs.h`: Add declarations of `tpoint_transform_pj` and `lwproj_transform`.
- `meos.h`: Add declarations of `tpoint_transform_pj` and `lwproj_transform`.
- `postgis_ext_defs.in.h`: Add `proj.h` import and definition of `LWPROJ` struct. This is copied from `liblwgeom.h`.

Currently there is no check in `tpoint_transform_pj` to ensure that the projection source `srid` match the temporal passed, since I haven't seen how to retrieve it. The declaration of `LWPROJ` in `liblwgeom.h.in` has the source and target `srid`s, but they are not present in the declaration in `liblwgeom.h`, which is the one used.