### PR TITLE
Add PJ definition in postgis_ext_defs.in.h

### DIFF
--- a/meos/include/postgis_ext_defs.in.h
+++ b/meos/include/postgis_ext_defs.in.h
@@ -408,7 +408,10 @@ extern double lwpoint_get_m(const LWPOINT *point);
 extern int lwgeom_has_z(const LWGEOM *geom);
 extern int lwgeom_has_m(const LWGEOM *geom);
 
-#include "proj.h"
+/* PROJ */
+
+struct PJconsts;
+typedef struct PJconsts PJ;
 
 typedef struct LWPROJ
 {


### PR DESCRIPTION
The previous PR (#441) was not completely ready, as it was missing some pieces to make it usable in PyMEOS.
I've added the definition of `PJ` (copied from the [proj.h header](https://github.com/OSGeo/PROJ/blob/deb1a5720fdfcd50d53c93ffb4011cacb36f2c89/src/proj.h#L221)).
I've checked all versions from 6.1 (the minimum required by MobilityDB) until the last (9.3) and it is defined like this, so I think we're safe.
I've also removed the `#include "proj.h"` since I don't think it's necessary here (although please check :).