### PR TITLE
Hide Postgis and and Postgres functions in MEOS library

### DIFF
--- a/meos/include/postgis_ext_defs.in.h
+++ b/meos/include/postgis_ext_defs.in.h
@@ -393,20 +393,9 @@ typedef struct
 }
 LWTIN;
 
-extern LWPOINT *lwpoint_make(int32_t srid, int hasz, int hasm, const POINT4D *p);
+/* Functions */
 
-extern LWGEOM *lwgeom_from_gserialized(const GSERIALIZED *g);
-extern GSERIALIZED *geo_from_lwgeom(LWGEOM *geom, size_t *size);
-
-extern int32_t lwgeom_get_srid(const LWGEOM *geom);
-
-extern double lwpoint_get_x(const LWPOINT *point);
-extern double lwpoint_get_y(const LWPOINT *point);
-extern double lwpoint_get_z(const LWPOINT *point);
-extern double lwpoint_get_m(const LWPOINT *point);
-
-extern int lwgeom_has_z(const LWGEOM *geom);
-extern int lwgeom_has_m(const LWGEOM *geom);
+extern int32 geo_get_srid(const GSERIALIZED *g);
 
 /* PROJ */
 

--- a/meos/postgres/common/CMakeLists.txt
+++ b/meos/postgres/common/CMakeLists.txt
@@ -2,3 +2,6 @@ add_library(common OBJECT
   hashfn.c
   pgfnames.c
   )
+
+set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/meos/postgres/port/CMakeLists.txt
+++ b/meos/postgres/port/CMakeLists.txt
@@ -5,3 +5,6 @@ add_library(port OBJECT
   qsort_arg.c
   snprintf.c
   )
+
+set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/meos/postgres/timezone/CMakeLists.txt
+++ b/meos/postgres/timezone/CMakeLists.txt
@@ -3,3 +3,6 @@ add_library(timezone OBJECT
   localtime.c
   pgtz.c
   )
+
+set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/meos/postgres/utils/CMakeLists.txt
+++ b/meos/postgres/utils/CMakeLists.txt
@@ -6,3 +6,6 @@ add_library(utils OBJECT
   numutils.c
   timestamp.c
   )
+
+set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/meos/src/point/pgis_types.c
+++ b/meos/src/point/pgis_types.c
@@ -74,6 +74,19 @@ void srid_check_latlong(int32_t srid);
 GSERIALIZED *
 geography_from_lwgeom(LWGEOM *geom, int32 geog_typmod);
 
+/*****************************************************************************/
+
+/**
+ * @brief Return the srid of a geometry
+ * @note PostGIS function: @p gserialized_get_srid(const GSERIALIZED *g).
+ */
+int32
+geo_get_srid(const GSERIALIZED *g)
+{
+  return gserialized_get_srid(g);
+}
+
+
 /*****************************************************************************
  * Functions adapted from lwgeom_box.c
  *****************************************************************************/

--- a/postgis/liblwgeom/CMakeLists.txt
+++ b/postgis/liblwgeom/CMakeLists.txt
@@ -77,3 +77,6 @@ add_library(liblwgeom OBJECT
   stringbuffer.c
   varint.c
   )
+
+set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/postgis/libpgcommon/CMakeLists.txt
+++ b/postgis/libpgcommon/CMakeLists.txt
@@ -5,3 +5,6 @@ add_library(libpgcommon OBJECT
   lwgeom_transform.c
   shared_gserialized.c
   )
+
+set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/postgis/ryu/CMakeLists.txt
+++ b/postgis/ryu/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_library(ryu OBJECT
   d2s.c
   )
+
+set_property(TARGET liblwgeom PROPERTY C_VISIBILITY_PRESET hidden)
+set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
* This PR adds CMake parameters to hide the Postgis and Postgres functions used by the MEOS library.
* The only exported Postgis function is `geo_get_srid`, which is a MEOS function wrapping the Postgis `gserialized_get_srid` function.