### PR TITLE
Fix pointer conversion errors reported by CLang 15/16

### DIFF
--- a/meos/postgres/utils/datetime.c
+++ b/meos/postgres/utils/datetime.c
@@ -4400,7 +4400,7 @@ FetchDynamicTimeZone(TimeZoneAbbrevTable *tbl, const datetkn *tp)
      */
     if (dtza->tz == NULL)
     {
-      meos_error(ERROR, "time zone \"%s\" not recognized", dtza->zone);
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "time zone \"%s\" not recognized", dtza->zone);
       return NULL;
     }
   }

--- a/meos/postgres/utils/formatting.c
+++ b/meos/postgres/utils/formatting.c
@@ -3288,6 +3288,7 @@ pg_interval_to_char(Interval *it, text *fmt)
  */
 /**
  * @brief Input a timestamp from date text.
+ * @return On error return @p DT_NOEND
  */
 TimestampTz
 pg_to_timestamp(text *date_txt, text *fmt)
@@ -3310,7 +3311,7 @@ pg_to_timestamp(text *date_txt, text *fmt)
     if (dterr)
     {
       DateTimeParseError(dterr, text2cstring(date_txt), "timestamptz");
-      return NULL;
+      return DT_NOEND;
     }
   }
   else
@@ -3319,7 +3320,7 @@ pg_to_timestamp(text *date_txt, text *fmt)
   if (tm2timestamp(&tm, fsec, &tz, &result) != 0)
   {
     meos_error(ERROR, MEOS_ERR_VALUE_OUT_OF_RANGE, "timestamp out of range");
-    return NULL;
+    return DT_NOEND;
   }
 
   /* Use the specified fractional precision, if any. */


### PR DESCRIPTION
Remake of #459
This PR fixes three pointer conversion errors that were reported during compilation of the MEOS library in the macOS env of the conda PR, which uses CLang 16.
They were not being reported because these int-conversion errors were only "upgraded" to default errors in CLang 15 ([see release notes](https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html#improvements-to-clang-s-diagnostics), third to last bullet point)