### PR TITLE
Truncate error message if longer than 1024 characters

### DIFF
--- a/meos/src/general/error.c
+++ b/meos/src/general/error.c
@@ -188,7 +188,8 @@ meos_error(int errlevel, int errcode, char *format, ...)
   char buffer[1024];
   va_list args;
   va_start(args, format);
-  vsprintf(buffer, format, args);
+  /* TODO: maybe check if the error message was truncated */
+  vsnprintf(buffer, 1024, format, args);
   va_end(args);
   /* Execute the error handler function */
   if (_ERROR_HANDLER)


### PR DESCRIPTION
Use `vsnprintf` instead of `vsprintf`, to make sure we don't write more than the size of our buffer.
Currently just truncate the error message in case it overflows, but I left a `TODO` in case we want to change that later.