### PR TITLE
Use self-defined `hash_bytes_uint32` function when using pg12

### DIFF
--- a/meos/src/general/tsequence.c
+++ b/meos/src/general/tsequence.c
@@ -44,7 +44,7 @@
 #if POSTGRESQL_VERSION_NUMBER >= 130000
   #include <common/hashfn.h>
 #else
-  #include <access/hash.h>
+  #include "general/pg_types.h"
 #endif
 #if POSTGRESQL_VERSION_NUMBER >= 160000
   #include "varatt.h"

--- a/mobilitydb/src/general/meos_catalog.c
+++ b/mobilitydb/src/general/meos_catalog.c
@@ -68,7 +68,7 @@
 #if POSTGRESQL_VERSION_NUMBER >= 130000
   #include <common/hashfn.h>
 #else
-  #include <access/hash.h>
+  #include "general/pg_types.h"
 #endif
 #include <utils/fmgroids.h>
 #include <utils/syscache.h>


### PR DESCRIPTION
This should fix the issue detected by Bradford Boyle