### PR TITLE
Add arm to macOS workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -29,6 +29,11 @@ jobs:
       fail-fast: false
       matrix:
         os: [ macos-13, macos-14 ]
+        include:
+          - os: macos-13
+            pg_path: "/usr/local/var/postgres"
+          - os: macos-14
+            pg_path: "/opt/homebrew/var/postgres"
 
     steps:
       - name: Checkout repository
@@ -52,9 +57,9 @@ jobs:
 
       - name: test install
         run: |
-          mkdir /usr/local/var/postgres
-          initdb -D /usr/local/var/postgres
-          pg_ctl -D /usr/local/var/postgres start
+          mkdir ${{ matrix.pg_path }}
+          initdb -D ${{ matrix.pg_path }}
+          pg_ctl -D ${{ matrix.pg_path }} start
           createdb ___mobdb___test___
           psql -d ___mobdb___test___ -c "CREATE EXTENSION mobilitydb CASCADE;  SELECT postgis_full_version(); SELECT mobilitydb_full_version();"
 

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -24,7 +24,11 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: macos-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ macos-13, macos-14 ]
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Run the MobilityDB tests on both intel- and arm-based macOS.
Explicitely  specify macos versions (`macos-13` and `macos-14`) instead of `macos-latest` (which now, or at least soon, is the same as `macos-14`, see [GitHub docs](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories))