### PR TITLE
Fix tsequenceset_make_gaps for non-exit error handling

### DIFF
--- a/meos/src/general/tsequenceset.c
+++ b/meos/src/general/tsequenceset.c
@@ -542,6 +542,8 @@ tsequenceset_make_gaps(const TInstant **instants, int count, interpType interp,
   {
     seq = tsequence_make_exp((const TInstant **) instants, count, count, true,
       true, interp, NORMALIZE);
+    if (! seq)
+      return NULL;
     result = tsequenceset_make_exp((const TSequence **) &seq, 1, 1,
       NORMALIZE_NO);
     pfree(seq);


### PR DESCRIPTION
Checks the result of `tsequence_make_exp` before moving on.
It was crashing on PyMEOS when, for example, trying to create a `TBoolSeqSet` from gaps with Linear interpolation.
That error was never happening on MEOS because the default error handler just exits the problem (which is not the case in the PyMEOS error handler)