### PR TITLE
Fix bug in atstbox function

### DIFF
--- a/meos/src/point/tpoint_restrict.c
+++ b/meos/src/point/tpoint_restrict.c
@@ -1448,9 +1448,9 @@ tpointseq_linear_at_stbox_xyz(const TSequence *seq, const STBox *box,
         &p3_inc, &p4_inc);
       if (found)
       {
-        /* If p2 != p4, we exit the box,
+        /* If p2 != p4 or p4_inc is false, we exit the box,
          * so end the previous sequence and start a new one */
-        if (! geopoint_eq(p2, p4))
+        if (! geopoint_eq(p2, p4) || ! p4_inc)
           makeseq = true;
         /* To reduce roundoff errors, (1) find the timestamps at which the
          * segment take the points returned by the clipping function and
@@ -1550,14 +1550,11 @@ tpointseq_linear_at_stbox_xyz(const TSequence *seq, const STBox *box,
       else
         makeseq = true;
     }
-    if (makeseq)
+    if (makeseq && ninsts > 0)
     {
-      if (ninsts > 0)
-      {
-        sequences[nseqs++] = tsequence_make((const TInstant **) instants, ninsts,
-          lower_inc, upper_inc, LINEAR, NORMALIZE_NO);
-        ninsts = 0;
-      }
+      sequences[nseqs++] = tsequence_make((const TInstant **) instants, ninsts,
+        lower_inc, upper_inc, LINEAR, NORMALIZE_NO);
+      ninsts = 0;
       lower_inc = true;
     }
     inst1 = inst2;

--- a/mobilitydb/test/point/expected/056_tpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/point/expected/056_tpoint_spatialfuncs.test.out
@@ -3535,6 +3535,42 @@ SELECT asText(atStbox(tgeompoint '[Point(1 3 2)@2000-01-01, Point(3 1 2)@2000-01
  {[POINT Z (2 2 2)@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
+select astext(atStbox(tgeompoint '[Point(1 1)@2000-01-01, Point(1 3)@2000-01-02, Point(1 1)@2000-01-03]', stbox 'STBOX X((0,0),(2 2))'));
+                                                                                  astext                                                                                  
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(1 2)@Sat Jan 01 12:00:00 2000 PST], [POINT(1 2)@Sun Jan 02 12:00:00 2000 PST, POINT(1 1)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+select astext(atStbox(tgeompoint '[Point(1 1)@2000-01-01, Point(1 2)@2000-01-02, Point(1 1)@2000-01-03]', stbox 'STBOX X((0,0),(2 2))'));
+                                                            astext                                                             
+-------------------------------------------------------------------------------------------------------------------------------
+ {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(1 2)@Sun Jan 02 00:00:00 2000 PST, POINT(1 1)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+select astext(atStbox(tgeompoint '[Point(1 2)@2000-01-01, Point(1 1)@2000-01-02, Point(2 1)@2000-01-03]', stbox 'STBOX X((0,0),(1 1))'));
+                   astext                    
+---------------------------------------------
+ {[POINT(1 1)@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+select astext(atStbox(tgeompoint '[Point(0 2)@2000-01-01, Point(2 0)@2000-01-02]', stbox 'STBOX X((0,0),(1 1))'));
+                   astext                    
+---------------------------------------------
+ {[POINT(1 1)@Sat Jan 01 12:00:00 2000 PST]}
+(1 row)
+
+select astext(atStbox(tgeompoint '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-02]', stbox 'STBOX X((0,0),(1 1))'));
+                                        astext                                        
+--------------------------------------------------------------------------------------
+ {[POINT(0 0)@Sat Jan 01 00:00:00 2000 PST, POINT(1 1)@Sat Jan 01 12:00:00 2000 PST]}
+(1 row)
+
+select astext(atStbox(tgeompoint '[Point(-2 1)@2000-01-01, Point(2 1)@2000-01-02]', stbox 'STBOX X((0,0),(1 1))'));
+                                        astext                                        
+--------------------------------------------------------------------------------------
+ {[POINT(0 1)@Sat Jan 01 12:00:00 2000 PST, POINT(1 1)@Sat Jan 01 18:00:00 2000 PST]}
+(1 row)
+
 /* Errors */
 SELECT asText(atStbox(tgeompoint 'SRID=4326;Point(1 1)@2000-01-01', 'GEODSTBOX ZT(((1,1,1),(2,2,2)),[2000-01-01,2000-01-02])'));
 ERROR:  Operation on mixed planar and geodetic coordinates

--- a/mobilitydb/test/point/expected/076_tpoint_analytics_tbl.test.out
+++ b/mobilitydb/test/point/expected/076_tpoint_analytics_tbl.test.out
@@ -243,6 +243,6 @@ FROM (SELECT asMVTGeom(temp, stbox 'STBOX X((0,0),(50,50))') AS mvt
   FROM tbl_tgeompoint ) AS t;
     round     | max 
 --------------+-----
- 67571.620989 |  43
+ 67717.649686 |  45
 (1 row)
 

--- a/mobilitydb/test/point/queries/056_tpoint_spatialfuncs.test.sql
+++ b/mobilitydb/test/point/queries/056_tpoint_spatialfuncs.test.sql
@@ -954,6 +954,14 @@ SELECT asText(atStbox(tgeompoint 'Point(1 1)@2000-01-01', 'STBOX ZT(((1,1,1),(2,
 SELECT asText(atStbox(tgeompoint '[Point(1 3 2)@2000-01-01, Point(3 1 2)@2000-01-03]', stbox 'STBOX X((0 0),(2 2)
 )'));
 
+-- Edge cases
+select astext(atStbox(tgeompoint '[Point(1 1)@2000-01-01, Point(1 3)@2000-01-02, Point(1 1)@2000-01-03]', stbox 'STBOX X((0,0),(2 2))'));
+select astext(atStbox(tgeompoint '[Point(1 1)@2000-01-01, Point(1 2)@2000-01-02, Point(1 1)@2000-01-03]', stbox 'STBOX X((0,0),(2 2))'));
+select astext(atStbox(tgeompoint '[Point(1 2)@2000-01-01, Point(1 1)@2000-01-02, Point(2 1)@2000-01-03]', stbox 'STBOX X((0,0),(1 1))'));
+select astext(atStbox(tgeompoint '[Point(0 2)@2000-01-01, Point(2 0)@2000-01-02]', stbox 'STBOX X((0,0),(1 1))'));
+select astext(atStbox(tgeompoint '[Point(0 0)@2000-01-01, Point(2 2)@2000-01-02]', stbox 'STBOX X((0,0),(1 1))'));
+select astext(atStbox(tgeompoint '[Point(-2 1)@2000-01-01, Point(2 1)@2000-01-02]', stbox 'STBOX X((0,0),(1 1))'));
+
 /* Errors */
 SELECT asText(atStbox(tgeompoint 'SRID=4326;Point(1 1)@2000-01-01', 'GEODSTBOX ZT(((1,1,1),(2,2,2)),[2000-01-01,2000-01-02])'));
 SELECT asText(atStbox(tgeompoint 'SRID=5676;Point(1 1)@2000-01-01', 'STBOX XT(((1,1),(2,2)),[2000-01-01,2000-01-02])'));


### PR DESCRIPTION
This PR fixes a bug in atstbox that happened when a tpoint exited and entered the box in two contiguous segments.
For example:
```sql
select astext(atStbox(
    tgeompoint '[Point(1 1)@2000-01-01, Point(1 3)@2000-01-02, Point(1 1)@2000-01-03]', 
    stbox 'STBOX X((0,0),(2 2))'));
```
Before:
```
                                                   astext                                                    
-------------------------------------------------------------------------------------------------------------
 {[POINT(1 1)@2000-01-01 00:00:00+01, POINT(1 2)@2000-01-01 12:00:00+01, POINT(1 1)@2000-01-03 00:00:00+01]}
(1 row)
```
After:
```
                                                                      astext                                                                      
--------------------------------------------------------------------------------------------------------------------------------------------------
 {[POINT(1 1)@2000-01-01 00:00:00+01, POINT(1 2)@2000-01-01 12:00:00+01], [POINT(1 2)@2000-01-02 12:00:00+01, POINT(1 1)@2000-01-03 00:00:00+01]}
(1 row)

```

Also added a few more edge cases in the tests.