### PR TITLE
Fix memory leaks

### DIFF
--- a/meos/examples/ais_expand.c
+++ b/meos/examples/ais_expand.c
@@ -170,6 +170,7 @@ int main(void)
     char *t_out = pg_timestamp_out(rec.T);
     sprintf(inst_buffer, "SRID=4326;Point(%lf %lf)@%s", rec.Longitude,
       rec.Latitude, t_out);
+    free(t_out);
     // TInstant *inst1 = (TInstant *) tgeogpoint_in(inst_buffer);
     // if (! trips[ship].trip)
       // trips[ship].trip = (Temporal *) tsequence_make_exp(

--- a/meos/examples/ais_generalize.c
+++ b/meos/examples/ais_generalize.c
@@ -180,6 +180,7 @@ int main(void)
     temp = temporal_simplify_dp(trips[i].trip, 10, true);
     dp_sed_10 += temporal_mem_size(temp);
     no_dp_sed_10 += temporal_num_instants(temp);
+    free(temp);
 
     /* Douglas-Peucker maximum distance simplification */
     temp = temporal_simplify_max_dist(trips[i].trip, 1, false);
@@ -197,6 +198,7 @@ int main(void)
     temp = temporal_simplify_max_dist(trips[i].trip, 10, true);
     max_dist_sed_10 += temporal_mem_size(temp);
     no_max_dist_sed_10 += temporal_num_instants(temp);
+    free(temp);
 
     /* Minimum distance simplification */
     temp = temporal_simplify_min_dist(trips[i].trip, 1);
@@ -230,6 +232,8 @@ int main(void)
     tprec_10s += temporal_mem_size(temp);
     no_tprec_10s += temporal_num_instants(temp);
     free(temp);
+    free(secs1);
+    free(secs10);
   }
 
   printf("\n---------------------------------------------------------------------------------\n");

--- a/meos/examples/ais_transform.c
+++ b/meos/examples/ais_transform.c
@@ -84,6 +84,9 @@ int main(void)
   printf("--------------------------------\n%s\n", str_out);
   free(str_out);
 
+  free(trip);
+  free(trip_out);
+
   /* Clean up */
   meos_finalize();
   return 0;

--- a/meos/examples/floatspanset_agg.c
+++ b/meos/examples/floatspanset_agg.c
@@ -111,7 +111,11 @@ int main(void)
     /* Transform the string representing the span set into a span set value */
     rec.ss = floatspanset_in(spanset_buffer);
 
-    state[rec.k%NUMBER_GROUPS] = spanset_union_transfn(state[rec.k%NUMBER_GROUPS], rec.ss);
+    SpanSet *ss = state[rec.k%NUMBER_GROUPS];
+    state[rec.k%NUMBER_GROUPS] = spanset_union_transfn(ss, rec.ss);
+    /* Free previous state if we allocated a new one */
+    if (ss && state[rec.k%NUMBER_GROUPS] != ss)
+      free(ss);
 
     /* Output the float spanset value read */
     char *spanset_out = floatspanset_out(rec.ss, 3);

--- a/meos/examples/intspan_agg.c
+++ b/meos/examples/intspan_agg.c
@@ -109,7 +109,10 @@ int main(void)
     /* Transform the string representing the span into a span value */
     rec.span = intspan_in(span_buffer);
 
-    state = span_union_transfn(state, rec.span);
+    SpanSet *ss = state;
+    state = span_union_transfn(ss, rec.span);
+    if (ss && state != ss)
+      free(ss);
 
     /* Output the input span */
     char *span_out = intspan_out(rec.span);

--- a/meos/examples/set_agg.c
+++ b/meos/examples/set_agg.c
@@ -62,7 +62,8 @@ int main()
   printf("Result of the set union aggregation: %s\n", result_out);
 
   /* Clean up allocated objects */
-  free(agg); free(result); free(result_out);
+  free(agg); free(result);
+  free(agg_out); free(result_out);
 
   /* Finalize MEOS */
   meos_finalize();

--- a/meos/examples/spanset_conv.c
+++ b/meos/examples/spanset_conv.c
@@ -68,6 +68,8 @@ int main()
   printf("Float span set converted to integer span: %s\n", fss_conv_out);
 
   /* Clean up allocated objects */
+  free(iss); free(fss);
+  free(iss_conv); free(fss_conv);
   free(iss_out); free(fss_out);
   free(iss_conv_out); free(fss_conv_out);
 

--- a/meos/examples/stbox_tile.c
+++ b/meos/examples/stbox_tile.c
@@ -74,7 +74,7 @@ int main(void)
   int count;
   if (spacesplit)
     boxes = stbox_tile_list(box, 5.0, 5.0, 5.0, timesplit ? interv : NULL,
-      sorigin, torigin, &count);
+      sorigin, torigin, true, &count);
   else
     spans = tstzspan_bucket_list(&box->period, interv, torigin, &count);
 
@@ -101,6 +101,14 @@ int main(void)
 
   /* Print information about the result */
   printf("\nNumber of tiles: %d\n", count);
+
+  /* Clean up allocated objects */
+  free(box); free(interv);
+  free(sorigin);
+  if (spacesplit)
+    free(boxes);
+  else
+    free(spans);
 
   /* Finalize MEOS */
   meos_finalize();

--- a/meos/examples/tbox_tile.c
+++ b/meos/examples/tbox_tile.c
@@ -106,6 +106,13 @@ int main(void)
   /* Print information about the result */
   printf("\nNumber of tiles: %d\n", count);
 
+  /* Clean up allocated objects */
+  free(box); free(interv);
+  if (valuesplit)
+    free(boxes);
+  else
+    free(spans);
+
   /* Finalize MEOS */
   meos_finalize();
 

--- a/meos/examples/tfloat_assemble.c
+++ b/meos/examples/tfloat_assemble.c
@@ -92,6 +92,7 @@ int main(void)
     temporal_num_instants(seq), tnumber_twavg(seq));
 
   /* Free memory */
+  free(oneday);
   free(seq);
 
   /* Finalize MEOS */

--- a/meos/examples/tpoint_assemble.c
+++ b/meos/examples/tpoint_assemble.c
@@ -114,7 +114,7 @@ int main(void)
     temporal_num_instants(seq), tpoint_length(seq));
 
   /* Free memory */
-  free(seq);
+  free(seq); free(oneday);
   for (i = 0; i < MAX_INSTANTS; i++)
     free(instants[i]);
 

--- a/meos/examples/ttext_expand.c
+++ b/meos/examples/ttext_expand.c
@@ -199,7 +199,9 @@ int main(void)
     seq->count, str);
 
   /* Free memory */
-  free(ss1); free(onehour); free(txt); free(str);
+  free(ss1); free(onehour);
+  free(txt); free(str);
+  free(seq);
 
   /* Calculate the elapsed time */
   tm = clock() - tm;

--- a/meos/src/general/set.c
+++ b/meos/src/general/set.c
@@ -808,7 +808,6 @@ set_make_exp(const Datum *values, int count, int maxcount, meosType basetype,
   return result;
 }
 
-#if MEOS
 /**
  * @ingroup meos_internal_setspan_constructor
  * @brief Return a set from an array of values
@@ -826,6 +825,7 @@ set_make(const Datum *values, int count, meosType basetype, bool order)
   return set_make_exp(values, count, count, basetype, order);
 }
 
+#if MEOS
 /**
  * @ingroup meos_setspan_constructor
  * @brief Return an integer set from an array of values

--- a/meos/src/general/temporal_analytics.c
+++ b/meos/src/general/temporal_analytics.c
@@ -254,7 +254,7 @@ tsequence_tprecision(const TSequence *seq, const Interval *duration,
           timestamptz_cmp_internal(ininsts[k - 1]->t, upper) < 0)
       {
         tsequence_value_at_timestamptz(seq, upper, false, &value);
-        ininsts[k++] = end = tinstant_make(value, seq->temptype, upper);
+        ininsts[k++] = end = tinstant_make_free(value, seq->temptype, upper);
       }
       seq1 = tsequence_make((const TInstant **) ininsts, k, true, true, interp,
         NORMALIZE);
@@ -298,6 +298,7 @@ tsequence_tprecision(const TSequence *seq, const Interval *duration,
     value = twavg ? Float8GetDatum(tnumberseq_twavg(seq1)) :
       PointerGetDatum(tpointseq_twcentroid(seq1));
     outinsts[l++] = tinstant_make(value, temptype_out, lower);
+    pfree(seq1);
     if (! twavg)
       pfree(DatumGetPointer(value));
   }

--- a/meos/src/general/temporal_tile.c
+++ b/meos/src/general/temporal_tile.c
@@ -424,6 +424,7 @@ span_bucket_list(const Span *s, Datum size, Datum origin, int count)
     span_bucket_set(state->value, state->size, state->basetype, &buckets[i]);
     span_bucket_state_next(state);
   }
+  free(state);
   return buckets;
 }
 
@@ -1761,8 +1762,12 @@ tnumber_value_time_split(Temporal *temp, Datum size, Interval *duration,
   *count = nfrags;
   if (value_buckets)
     *value_buckets = v_buckets;
+  else
+    pfree(v_buckets);
   if (time_buckets)
     *time_buckets = t_buckets;
+  else
+    pfree(t_buckets);
   return fragments;
 }
 
@@ -1869,6 +1874,8 @@ tint_value_time_split(Temporal *temp, int size, Interval *duration,
     values[i] = DatumGetInt32(datum_buckets[i]);
   if (value_buckets)
     *value_buckets = values;
+  else
+    pfree(values);
   pfree(datum_buckets);
   return result;
 }
@@ -1910,6 +1917,8 @@ tfloat_value_time_split(Temporal *temp, double size, Interval *duration,
     values[i] = DatumGetFloat8(datum_buckets[i]);
   if (value_buckets)
     *value_buckets = values;
+  else
+    pfree(values);
   pfree(datum_buckets);
   return result;
 }

--- a/meos/src/point/pgis_types.c
+++ b/meos/src/point/pgis_types.c
@@ -1915,9 +1915,8 @@ geo_as_hexewkb(const GSERIALIZED *gs, const char *endian)
   }
   /* Create WKB hex string */
   LWGEOM *geom = lwgeom_from_gserialized(gs);
-  lwvarlena_t *hexwkb = lwgeom_to_hexwkb_varlena(geom, variant | WKB_EXTENDED);
-  char *result = strdup(VARDATA(hexwkb));
-  pfree(hexwkb);
+  char *result = lwgeom_to_hexwkb_buffer(geom, variant | WKB_EXTENDED);
+  lwgeom_free(geom);
   return result;
 }
 
@@ -2105,7 +2104,7 @@ geo_same(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
   char result = lwgeom_same(geom1, geom2);
-  pfree(geom1); pfree(geom2);
+  lwgeom_free(geom1); lwgeom_free(geom2);
   return (result == LW_TRUE);
 }
 


### PR DESCRIPTION
While fixing memory leaks in the examples, I realised that the aggregation functions had to be used like this:

```C
SpanSet *ss = state;
state = span_union_transfn(ss, rec.span);
if (ss && state != ss)
    free(ss);
```

This does not seem very user-friendly.
Perhaps we should free the input state inside `span_union_transfn` if needed.
This would allow to write simply:

```C
state = span_union_transfn(state, rec.span);
```

Of course we need to explicitly mention it if we free the input state to avoid user errors.