### PR TITLE
Updated meos.h to include extern keyword

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -2051,10 +2051,10 @@ extern SkipList *ttext_tmin_transfn(SkipList *state, const Temporal *temp);
 
 /* Simplification functions for temporal types */
 
-Temporal *temporal_simplify_dp(const Temporal *temp, double eps_dist, bool synchronized);
-Temporal *temporal_simplify_max_dist(const Temporal *temp, double eps_dist, bool synchronized);
-Temporal *temporal_simplify_min_dist(const Temporal *temp, double dist);
-Temporal *temporal_simplify_min_tdelta(const Temporal *temp, const Interval *mint);
+extern Temporal *temporal_simplify_dp(const Temporal *temp, double eps_dist, bool synchronized);
+extern Temporal *temporal_simplify_max_dist(const Temporal *temp, double eps_dist, bool synchronized);
+extern Temporal *temporal_simplify_min_dist(const Temporal *temp, double dist);
+extern Temporal *temporal_simplify_min_tdelta(const Temporal *temp, const Interval *mint);
 
 /*****************************************************************************/
 


### PR DESCRIPTION
JMEOS and other FFI that use regex pattern matching for extracting functions from the meos header file require an extern keyword in the function signature.  Therefore, adding an extern keyword to all the temporal functions that do not have that results in uniform function extraction across FFIs.