### PR TITLE
Use directly the bytes instead of varlena type in geo_from_ewkb

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -403,7 +403,7 @@ extern char *geo_as_ewkt(const GSERIALIZED *gs, int precision);
 extern char *geo_as_geojson(const GSERIALIZED *gs, int option, int precision, const char *srs);
 extern char *geo_as_hexewkb(const GSERIALIZED *gs, const char *endian);
 extern char *geo_as_text(const GSERIALIZED *gs, int precision);
-extern GSERIALIZED *geo_from_ewkb(const bytea *bytea_wkb, int32 srid);
+extern GSERIALIZED *geo_from_ewkb(const uint8_t *wkb, size_t wkb_size, int32 srid);
 extern GSERIALIZED *geo_from_geojson(const char *geojson);
 extern char *geo_out(const GSERIALIZED *gs);
 extern bool geo_same(const GSERIALIZED *gs1, const GSERIALIZED *gs2);

--- a/meos/src/point/pgis_types.c
+++ b/meos/src/point/pgis_types.c
@@ -1931,14 +1931,13 @@ geo_as_hexewkb(const GSERIALIZED *gs, const char *endian)
  * @note wkb is in *binary* not hex form
  */
 GSERIALIZED *
-geo_from_ewkb(const bytea *bytea_wkb, int32 srid)
+geo_from_ewkb(const uint8_t *wkb, size_t wkb_size, int32 srid)
 {
   /* Ensure validity of the arguments */
-  if (! ensure_not_null((void *) bytea_wkb))
+  if (! ensure_not_null((void *) wkb))
     return NULL;
 
-  uint8_t *wkb = (uint8_t *) VARDATA(bytea_wkb);
-  LWGEOM *geom = lwgeom_from_wkb(wkb, VARSIZE_ANY_EXHDR(bytea_wkb),
+  LWGEOM *geom = lwgeom_from_wkb(wkb, wkb_size,
     LW_PARSER_CHECK_ALL);
   if (!geom)
   {

--- a/meos/src/point/pgis_types.c
+++ b/meos/src/point/pgis_types.c
@@ -1925,7 +1925,8 @@ geo_as_hexewkb(const GSERIALIZED *gs, const char *endian)
  * @brief Return a geometry/geography from its EWKB representation
  * @details This function parses EWKB (extended form) which also contains SRID
  * info.
- * @param[in] bytea_wkb WKB string
+ * @param[in] wkb WKB bytes
+ * @param[in] wkb_size Number of WKB bytes
  * @param[in] srid SRID
  * @note PostGIS function: @p LWGEOMFromEWKB(wkb, [SRID])
  * @note wkb is in *binary* not hex form


### PR DESCRIPTION
Use directly the bytes instead of varlena type in geo_from_ewkb.

## Rationale
In the Rust wrapper, I need a fast way to create a `GSERIALIZED` from a `Geos` geometry, and since getting and parsing the `WKT` is very slow, I want to use `WKB` instead. Unfortunately, currently the function to create a `GSERIALIZED` from a WKB requires a `bytea` (`varlena`) parameter, and the function to create the `bytea` from bytes is private. I therefore think that it makes more sense from the user point of view to have to pass the bytes directly since either way in the function the `bytea` is parsed to `bytes`.


## Note
This function is not used in this repository or in any of the wrappers