### PR TITLE
Edit geo_as_ewkb to return standard type instead of bytea

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -398,7 +398,7 @@ extern DateADT timestamptz_to_date(TimestampTz t);
  * Functions for PostGIS types
  *===========================================================================*/
 
-extern bytea *geo_as_ewkb(const GSERIALIZED *gs, const char *endian);
+extern uint8_t *geo_as_ewkb(const GSERIALIZED *gs, const char *endian, size_t *size);
 extern char *geo_as_ewkt(const GSERIALIZED *gs, int precision);
 extern char *geo_as_geojson(const GSERIALIZED *gs, int option, int precision, const char *srs);
 extern char *geo_as_hexewkb(const GSERIALIZED *gs, const char *endian);

--- a/meos/src/point/pgis_types.c
+++ b/meos/src/point/pgis_types.c
@@ -1963,10 +1963,11 @@ geo_from_ewkb(const uint8_t *wkb, size_t wkb_size, int32 srid)
  * geometry/geography
  * @param[in] gs Geometry/geography
  * @param[in] endian Endianness
+ * @param[in] size Size of result
  * @note PostGIS function: @p WKBFromLWGEOM(PG_FUNCTION_ARGS)
  */
-bytea *
-geo_as_ewkb(const GSERIALIZED *gs, const char *endian)
+uint8_t *
+geo_as_ewkb(const GSERIALIZED *gs, const char *endian, size_t *size)
 {
   /* Ensure validity of the arguments */
   if (! ensure_not_null((void *) gs))
@@ -1986,9 +1987,12 @@ geo_as_ewkb(const GSERIALIZED *gs, const char *endian)
   /* Create WKB hex string */
   LWGEOM *geom = lwgeom_from_gserialized(gs);
   lwvarlena_t *wkb = lwgeom_to_wkb_varlena(geom, variant | WKB_EXTENDED);
-  bytea *result = palloc(wkb->size - LWVARHDRSZ);
-  memcpy(result, wkb->data, wkb->size - LWVARHDRSZ);
+
+  size_t data_size = wkb->size - LWVARHDRSZ;
+  uint8_t *result = palloc(data_size);
+  memcpy(result, wkb->data, data_size);
   pfree(geom); pfree(wkb);
+  *size = data_size;
   return result;
 }
 


### PR DESCRIPTION
Use directly the bytes (u8) instead of varlena type in geo_as_ewkb.

## Rationale
In the Rust wrapper, I need a fast way to create a `Geos` geometry from a a `GSERIALIZED`, and since getting and parsing the `WKT` is very slow, I want to use `WKB` instead. Unfortunately, currently the function to create a `GSERIALIZED` from a WKB returns a `bytea` (`varlena`), and the function to create the bytes from `bytea` is private. I therefore think that it makes more sense from the user point of view to have the bytes directly returned.


## Note
This function is not used in this repository or in any of the wrappers