### PR TITLE
Fix macos 13 workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,10 +47,9 @@ jobs:
           brew reinstall python@3.12 || brew link --overwrite python@3.12
           brew update
 
-      - name: Get dependencies from homebrew (cache)
-        uses: tecolicom/actions-use-homebrew-tools@v1
-        with:
-          tools: brew install postgresql postgis proj gsl
+      - name: install deps
+        run: |
+          brew install postgresql postgis proj gsl
 
       - name: Configure
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -39,9 +39,18 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
-      - name: install deps
+      - name: update brew
+        if: matrix.os == 'macos-13'
+        # Necessary to avoid issue with macOS runners. See
+        # https://github.com/actions/runner-images/issues/4020
         run: |
-          brew install postgresql postgis proj gsl
+          brew reinstall python@3.12 || brew link --overwrite python@3.12
+          brew update
+
+      - name: Get dependencies from homebrew (cache)
+        uses: tecolicom/actions-use-homebrew-tools@v1
+        with:
+          tools: brew install postgresql postgis proj gsl
 
       - name: Configure
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -47,9 +47,10 @@ jobs:
           brew reinstall python@3.12 || brew link --overwrite python@3.12
           brew update
 
-      - name: install deps
-        run: |
-          brew install postgresql postgis proj gsl
+      - name: Get dependencies from homebrew (cache)
+        uses: tecolicom/actions-use-homebrew-tools@v1
+        with:
+          tools: postgresql postgis proj gsl
 
       - name: Configure
         run: |


### PR DESCRIPTION
* Fix macos-13 workflow by reinstalling python 3.12
* Use [tecolicom/actions-use-homebrew-tools](https://github.com/marketplace/actions/install-and-cache-homebrew-tools) to cache homebrew packages and speed up macos workflows