### PR TITLE
Use CMAKE_INSTALL_PREFIX in CMakeLists

### DIFF
--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -180,38 +180,20 @@ target_link_libraries(${MEOS_LIB_NAME} ${GSL_CBLAS_LIBRARY})
 # Belongs to MEOS
 #--------------------------------
 
-if(APPLE AND ${CMAKE_SYSTEM_PROCESSOR} MATCHES "arm")
-  install(FILES "${CMAKE_BINARY_DIR}/meos_export.h"
-    DESTINATION "/opt/homebrew/include"
-    RENAME "meos.h")
-  install(
-    FILES "${CMAKE_BINARY_DIR}/meos_internal_export.h"
-    DESTINATION "/opt/homebrew/include"
-    RENAME "meos_internal.h")
-  install(
-    FILES "${CMAKE_SOURCE_DIR}/meos/include/general/meos_catalog.h"
-    DESTINATION "/opt/homebrew/include")
-  install(TARGETS ${MEOS_LIB_NAME} DESTINATION "/opt/homebrew/lib")
-  message(STATUS "Building MEOS:")
-  message(STATUS "  Library file: '/opt/homebrew/lib'")
-  message(STATUS "  Include file: '/opt/homebrew/include'")
-else()
-  install(
-    FILES "${CMAKE_BINARY_DIR}/meos_export.h"
-    DESTINATION "/usr/local/include"
-    RENAME "meos.h")
-  install(
-    FILES "${CMAKE_BINARY_DIR}/meos_internal_export.h"
-    DESTINATION "/usr/local/include"
-    RENAME "meos_internal.h")
-  install(
-    FILES "${CMAKE_SOURCE_DIR}/meos/include/general/meos_catalog.h"
-    DESTINATION "/usr/local/include")
-  install(TARGETS ${MEOS_LIB_NAME} DESTINATION "/usr/local/lib")
-  message(STATUS "Building MEOS:")
-  message(STATUS "  Library file: '/usr/local/lib'")
-  message(STATUS "  Include file: '/usr/local/include'")
-endif()
+install(FILES "${CMAKE_BINARY_DIR}/meos_export.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  RENAME "meos.h")
+install(
+  FILES "${CMAKE_BINARY_DIR}/meos_internal_export.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}"
+  RENAME "meos_internal.h")
+install(
+  FILES "${CMAKE_SOURCE_DIR}/meos/include/general/meos_catalog.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(TARGETS ${MEOS_LIB_NAME} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
+message(STATUS "Building MEOS:")
+message(STATUS "  Library file: '${CMAKE_INSTALL_LIBDIR}'")
+message(STATUS "  Include file: '${CMAKE_INSTALL_INCLUDEDIR}'")
 
 #-----------------------------------------------------------------------------
 # Configure pkg-config file meos.pc

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -192,6 +192,7 @@ install(
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(TARGETS ${MEOS_LIB_NAME} DESTINATION "${CMAKE_INSTALL_LIBDIR}")
 message(STATUS "Building MEOS:")
+message(STATUS "  Install prefix: '${CMAKE_INSTALL_PREFIX}'")
 message(STATUS "  Library file: '${CMAKE_INSTALL_LIBDIR}'")
 message(STATUS "  Include file: '${CMAKE_INSTALL_INCLUDEDIR}'")
 


### PR DESCRIPTION
Use CMAKE_INSTALL_PREFIX instead of hard-coded paths such as `/usr/lib` or `/opt/homebrew`