### PR TITLE
Do not compile pg_bitutils.c (#610)

### DIFF
--- a/meos/postgres/port/CMakeLists.txt
+++ b/meos/postgres/port/CMakeLists.txt
@@ -1,5 +1,4 @@
 add_library(port OBJECT
-  pg_bitutils.c
   pgstrcasecmp.c
   qsort.c
   qsort_arg.c


### PR DESCRIPTION
Related to #609 