### PR TITLE
Fixed MEOS build

### DIFF
--- a/meos/include/general/type_round.h
+++ b/meos/include/general/type_round.h
@@ -50,12 +50,13 @@ extern Datum datum_round_float(Datum value, Datum size);
 extern Datum datum_round_geo(Datum value, Datum size);
 
 
-extern Datum datum_npoint_round(Datum npoint, Datum size);
-extern Npoint *npoint_round(const Npoint *np, int maxdd);
-extern Nsegment *nsegment_round(const Nsegment *ns, int maxdd);
-extern Set *npointset_round(const Set *s, int maxdd);
-extern Temporal *tnpoint_round(const Temporal *temp, Datum size);
-
+#if NPOINT
+  extern Datum datum_npoint_round(Datum npoint, Datum size);
+  extern Npoint *npoint_round(const Npoint *np, int maxdd);
+  extern Nsegment *nsegment_round(const Nsegment *ns, int maxdd);
+  extern Set *npointset_round(const Set *s, int maxdd);
+  extern Temporal *tnpoint_round(const Temporal *temp, Datum size);
+#endif /* NPOINT */
 
 /*****************************************************************************/
 


### PR DESCRIPTION
When trying to build MEOS using the following command:
`rm -rf build && mkdir build && cd build && cmake .. -DMEOS=1 && sudo make && sudo make install`, I get the following error:
```c
In file included from /home/dgm/MobilityDB/meos/src/general/type_round.c:35:
/home/dgm/MobilityDB/meos/include/general/type_round.h:54:8: error: unknown type name ‘Npoint’
   54 | extern Npoint *npoint_round(const Npoint *np, int maxdd);
      |        ^~~~~~
/home/dgm/MobilityDB/meos/include/general/type_round.h:54:35: error: unknown type name ‘Npoint’
   54 | extern Npoint *npoint_round(const Npoint *np, int maxdd);
      |                                   ^~~~~~
/home/dgm/MobilityDB/meos/include/general/type_round.h:55:8: error: unknown type name ‘Nsegment’
   55 | extern Nsegment *nsegment_round(const Nsegment *ns, int maxdd);
      |        ^~~~~~~~
/home/dgm/MobilityDB/meos/include/general/type_round.h:55:39: error: unknown type name ‘Nsegment’
   55 | extern Nsegment *nsegment_round(const Nsegment *ns, int maxdd);
      |                                       ^~~~~~~~
make[2]: *** [meos/src/general/CMakeFiles/general.dir/build.make:580: meos/src/general/CMakeFiles/general.dir/type_round.c.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1270: meos/src/general/CMakeFiles/general.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
```

Probably due to this change: https://github.com/MobilityDB/MobilityDB/pull/621/files#diff-2f09bd544c745dfb34d9084252b21187965a42aabe51f75956b63148c131367dL41.

So I've added a guard to have that piece of code only defined when NPOINT is true.