### PR TITLE
Change timezone from PST8PDT to America/Los_Angeles

### DIFF
--- a/mobilitydb/test/scripts/test.cmake
+++ b/mobilitydb/test/scripts/test.cmake
@@ -96,7 +96,7 @@ if(TEST_OPER MATCHES "test_setup")
 
   set(mobilitydb.config "shared_preload_libraries = '${POSTGIS_LIBRARY}'\n")
   string(APPEND mobilitydb.config "max_locks_per_transaction = 128\n")
-  string(APPEND mobilitydb.config "timezone = 'PST8PDT'\n")
+  string(APPEND mobilitydb.config "timezone = 'America/Los_Angeles'\n")
   string(APPEND mobilitydb.config "datestyle = 'Postgres, MDY'\n")
   string(APPEND mobilitydb.config "log_error_verbosity = 'TERSE'\n")
   string(APPEND mobilitydb.config "parallel_tuple_cost = 100\n")


### PR DESCRIPTION
Apply the same change as PostgreSQL in commit [b8ea0f675f35c3f0c2c](https://github.com/postgres/postgres/commit/b8ea0f675f35c3f0c2cf62175517ba0dacad4abd) to fix issue with change in tzdata in release 2024b. This doesn't seem to affect our expected test output, but I couldn't test it on 2024b. Hopefully this is enough.