### PR TITLE
Create docker image for PG 17

### DIFF
--- a/.github/workflows/docker-image.yaml
+++ b/.github/workflows/docker-image.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [13,14,15,16]
+          psql: [13,14,15,16,17]
           postgis: [3.4]
           os: [ubuntu-latest]
 


### PR DESCRIPTION
I am still keeping Postgis version at 3.4, because postgis is only building docker images with 3.5 for PG 16 and 17. We can update this later in case they produce images with 3.5 for PG 15 and below.