### PR TITLE
Bring back the timezone pg functions to MEOS to fix meos_initialize_timezone in stable-1.2

### DIFF
--- a/meos/postgres/timezone/CMakeLists.txt
+++ b/meos/postgres/timezone/CMakeLists.txt
@@ -4,5 +4,5 @@ add_library(timezone OBJECT
   pgtz.c
   )
 
-set_property(TARGET timezone PROPERTY C_VISIBILITY_PRESET hidden)
+# set_property(TARGET timezone PROPERTY C_VISIBILITY_PRESET hidden)
 set_property(TARGET timezone PROPERTY POSITION_INDEPENDENT_CODE ON)


### PR DESCRIPTION
Right now `meos_initialize_timezone` does not work in the branch `stable-1.2`. The reason is that the timezone library is not accessible since #447, this make meos throw the following error when trying to use `meos_initialize_timezone`:
```
undefined reference to `meos_initialize_timezone'
```

This is already changed in master since https://github.com/MobilityDB/MobilityDB/pull/634, but it's not fixed. This PR is against stable1.2, so I'm not sure about the consequences of the versioning.

## Unknowns
Maybe I should comment line 8?