### PR TITLE
Fix developer documentation generation

### DIFF
--- a/.github/workflows/generate_dev_docs.yml
+++ b/.github/workflows/generate_dev_docs.yml
@@ -1,15 +1,15 @@
 # Automatic generation of developer documentation will be copied
 # and checked into the gh-pages branch.
-name: Generate MEOS documentation with Doxygen
+name: Generate MEOS dev documentation
 
 on:
   workflow_dispatch:
   push:
     paths:
       - '.github/workflows/generate_dev_docs.yml'
-      - './meos/**'
-      - './mobilitydb/**'
-      - './doxygen/**'
+      - 'meos/**'
+      - 'mobilitydb/**'
+      - 'doxygen/**'
     branches:
       - 'master'
       - 'stable-[0-9]+.[0-9]+'

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -1,6 +1,6 @@
 # Automatic generation of documentation will be copied and checked into the
 # gh-pages branch.
-name: Documentation generation CI
+name: Generate MobilityDB documentation
 
 on:
   workflow_dispatch:

--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = MobilityDB
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.1
+PROJECT_NUMBER         = 1.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/doxygen/Doxyfile_gha
+++ b/doxygen/Doxyfile_gha
@@ -50,7 +50,7 @@ PROJECT_NAME           = MobilityDB
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 1.1
+PROJECT_NUMBER         = 1.3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a


### PR DESCRIPTION
The github action for the develop documentation wasn't being run, probably due to the syntax used for the paths.
I removed the leading `./` before the path specifications, let's see if this fixed things.
Also, it seems that the version number is hard-coded in the doxygen file instead of being configured from the `mobdb_version.txt` file. I just updated the version to 1.3 for now, but this should be fixed in a future PR.