### PR TITLE
Fix: correct PG port configuration in pgversion.yml

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -35,25 +35,30 @@ jobs:
         matrix:
           psql: [13,14,15,16,17]
           postgis: [3]
-          os: [ubuntu-latest]
+          os: ["ubuntu-24.04"]
           coverage: [0]
           include:
             - psql: 17
               postgis: 3
-              os: ubuntu-latest
+              os: "ubuntu-24.04"
               coverage: 1
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: get postgres version
+      - name: Remove existing PostgreSQL installations [prefer apt.postgresql.org ]
         run: |
-          sudo service postgresql start
-          pgver=$(psql --version | grep -Po '(?<=psql \(PostgreSQL\) )[^;]+(?=\.\d+ \()')
-          echo "PGVER=${pgver}" >> $GITHUB_ENV
-          PGP=5433
-          if [ "${{ matrix.psql }}" == "${pgver}" ]; then PGP=5432; fi
-          echo "PGPORT=${PGP}" >> $GITHUB_ENV
+          sudo service postgresql stop || true
+          sudo apt-get --purge remove postgresql* -y || true
+          sudo rm -rf /var/lib/postgresql/ || true
+          sudo rm -rf /etc/postgresql/ || true
+          sudo rm -rf /var/log/postgresql/ || true
+          echo "Removed existing PostgreSQL installation"
+
+      - name: Set postgresql port as a default
+        run: |
+          PGP=5432
+          echo "PGPORT=${PGP}" >> $GITHUB_ENV        
 
       - name: Add PostgreSQL APT repository
         run: |
@@ -118,6 +123,3 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           path-to-lcov: "./build/lcov.info"
-
-
-


### PR DESCRIPTION
- Removes any existing PostgreSQL installations
- Sets a consistent port (PGPORT=5432)
- Installs PostgreSQL from the official repository
- Uses the standard port for all PostgreSQL operations

--------

Problem: 
* the PostgreSQL service was started before configuring its port. Once started, changing the PGPORT environment variable doesn't affect which port the server listens on.

My proposal:
- Removing existing PostgreSQL installations:   So no conflicts between Ubuntu's default PostgreSQL and the version from PostgreSQL's official repository.
- Simplifying port configuration:   Set a fixed port (PGPORT=5432) which is PostgreSQL's default port, eliminating the conditional logic that was causing issues.
 
Additional Notes:

**This update specifically addresses the port configuration issue and does not resolve all existing problems.**
Expected workflow outcomes:
- PG 16 and 17: Expected to work correctly.
- PG 13, 14, and 15:   `070_tpoint_spatialrels_tbl (Failed)`
- PG 17 (coverage=1): May show the error: `geninfo: ERROR: 'include' pattern '*/MobilityDB/meos/src/*' is unused.`
