### PR TITLE
Replace macro defining SPATIAL_REF_SYS_CSV with a global variable

### DIFF
--- a/meos/examples/read_spatial_ref_sys.c
+++ b/meos/examples/read_spatial_ref_sys.c
@@ -55,7 +55,7 @@
 /* Maximum length in characters of a header record in the input CSV file */
 #define MAX_LENGTH_HEADER 1024
 /* Location of the spatial_ref_sys.csv file */
-#define SPATIAL_REF_SYS "/usr/local/lib/spatial_ref_sys.csv"
+#define SPATIAL_REF_SYS "/usr/local/share/spatial_ref_sys.csv"
 
 /**
  * @brief Utility structure to get many potential string representations

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -349,6 +349,8 @@ extern bool meos_set_intervalstyle(const char *newval, int extra);
 extern char *meos_get_datestyle(void);
 extern char *meos_get_intervalstyle(void);
 
+extern void meos_set_spatial_ref_sys_csv(const char* path);
+
 extern void meos_initialize(void);
 extern void meos_finalize(void);
 

--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -101,7 +101,13 @@ typedef struct
 /* Maximum length in characters of a geometry in the input data */
 #define MAX_LENGTH_SRS_RECORD 5120
 /* Location of the spatial_ref_sys.csv file */
-#define SPATIAL_REF_SYS_CSV "/usr/local/lib/spatial_ref_sys.csv"
+
+char* SPATIAL_REF_SYS_CSV = "/usr/local/share/spatial_ref_sys.csv";
+
+void meos_set_spatial_ref_sys_csv(const char* path) {
+    SPATIAL_REF_SYS_CSV = malloc(strlen(path) + 1);
+    strcpy(SPATIAL_REF_SYS_CSV, path);
+}
 
 typedef struct
 {
@@ -240,7 +246,7 @@ GetProjStringsSPI(int32_t srid)
 
   if (! file)
   {
-    printf("Cannot open the spatial_ref_sys.csv file");
+    printf("Cannot open the spatial_ref_sys.csv file (reading from %s)\n", SPATIAL_REF_SYS_CSV);
     return strs;
   }
 


### PR DESCRIPTION
Fixes #683.

Convert `SPATIAL_REF_SYS_CSV` from a macro to a global variable, as the ones used for the date order and style, and adds a function to modify it (`meos_set_spatial_ref_sys_csv`).
Also changes the default value of the macros to the proper path in `/usr/local/share` (and not `/usr/local/lib`).
Improves log on load error.