### PR TITLE
Various minor fixes

### DIFF
--- a/meos/src/geo/tgeo_meos.c
+++ b/meos/src/geo/tgeo_meos.c
@@ -661,7 +661,7 @@ tgeo_from_base_temp_int(const GSERIALIZED *gs, const Temporal *temp,
   bool ispoint)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TGEO(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
+  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(gs, NULL);
   if (! ensure_not_empty(gs))
     return NULL;
   meosType tgeotype;

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1061,7 +1061,7 @@ tgeom_tgeog(const Temporal *temp, bool oper)
 Temporal *
 tgeometry_to_tgeography(const Temporal *temp)
 {
-  VALIDATE_TGEOMETRY(temp, NULL);
+  VALIDATE_TGEOM(temp, NULL);
   return tgeom_tgeog(temp, TGEOM_TO_TGEOG);
 }
 
@@ -1075,7 +1075,7 @@ Temporal *
 tgeography_to_tgeometry(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TGEOGRAPHY(temp, NULL);
+  VALIDATE_TGEOG(temp, NULL);
   return tgeom_tgeog(temp, TGEOG_TO_TGEOM);
 }
 #endif /* MEOS */

--- a/meos/src/temporal/set_meos.c
+++ b/meos/src/temporal/set_meos.c
@@ -486,7 +486,6 @@ floatset_start_value(const Set *s)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_FLOATSET(s, DBL_MAX);
-    return DBL_MAX;
   return DatumGetFloat8(SET_VAL_N(s, 0));
 }
 

--- a/meos/src/temporal/set_meos.c
+++ b/meos/src/temporal/set_meos.c
@@ -682,7 +682,7 @@ bool
 floatset_value_n(const Set *s, int n, double *result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSET(s, false); VALIDATE_NOT_NULL(result, false);
+  VALIDATE_FLOATSET(s, false); VALIDATE_NOT_NULL(result, false);
   if (n < 1 || n > s->count)
     return false;
   *result = DatumGetFloat8(SET_VAL_N(s, n - 1));

--- a/meos/src/temporal/temporal_meos.c
+++ b/meos/src/temporal/temporal_meos.c
@@ -475,7 +475,7 @@ text *
 ttext_start_value(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TFLOAT(temp, NULL);
+  VALIDATE_TTEXT(temp, NULL);
   return DatumGetTextP(temporal_start_value(temp));
 }
 

--- a/meos/src/temporal/tnumber_distance_meos.c
+++ b/meos/src/temporal/tnumber_distance_meos.c
@@ -102,7 +102,7 @@ nad_tint_int(const Temporal *temp, int i)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TINT(temp, -1.0);
-  return DatumGetInt32(nad_tnumber_number(temp, Int32GetDatum(i)));
+  return (int) nad_tnumber_number(temp, Int32GetDatum(i));
 }
 
 /**
@@ -119,7 +119,7 @@ nad_tfloat_float(const Temporal *temp, double d)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TFLOAT(temp, -1.0);
-  return DatumGetFloat8(nad_tnumber_number(temp, Float8GetDatum(d)));
+  return nad_tnumber_number(temp, Float8GetDatum(d));
 }
 
 /**
@@ -137,7 +137,7 @@ nad_tint_tbox(const Temporal *temp, const TBox *box)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tnumber_numspan(temp, &box->span))
     return -1;
-  return DatumGetInt32(nad_tnumber_tbox(temp, box));
+  return (int) nad_tnumber_tbox(temp, box);
 }
 
 /**
@@ -155,7 +155,7 @@ nad_tfloat_tbox(const Temporal *temp, const TBox *box)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tnumber_numspan(temp, &box->span))
     return -1;
-  return DatumGetFloat8(nad_tnumber_tbox(temp, box));
+  return nad_tnumber_tbox(temp, box);
 }
 
 /**
@@ -172,7 +172,7 @@ nad_tboxint_tboxint(const TBox *box1, const TBox *box2)
       ! ensure_span_isof_type(&box2->span, T_INTSPAN))
     return -1;
 
-  return DatumGetInt32(nad_tbox_tbox(box1, box2));
+  return (int) nad_tbox_tbox(box1, box2);
 }
 
 /**
@@ -189,7 +189,7 @@ nad_tboxfloat_tboxfloat(const TBox *box1, const TBox *box2)
       ! ensure_span_isof_type(&box2->span, T_FLOATSPAN))
     return -1;
 
-  return DatumGetFloat8(nad_tbox_tbox(box1, box2));
+  return nad_tbox_tbox(box1, box2);
 }
 
 /**
@@ -204,8 +204,7 @@ nad_tint_tint(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TINT(temp1, -1); VALIDATE_TINT(temp2, -1);
-  Datum result = nad_tnumber_tnumber(temp1, temp2);
-  return Int32GetDatum(result);
+    return (int) nad_tnumber_tnumber(temp1, temp2);
 }
 
 /**
@@ -220,8 +219,7 @@ nad_tfloat_tfloat(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TFLOAT(temp1, -1.0); VALIDATE_TFLOAT(temp2, -1.0);
-  Datum result = nad_tnumber_tnumber(temp1, temp2);
-  return Float8GetDatum(result);
+    return nad_tnumber_tnumber(temp1, temp2);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Fixes some issues in a few functions (one fix per commit), namely:

- Use proper type assertion in `ttext_start_value` and `floatset_value_n`
- Remove random return in `floatset_start_value`
- Remove casts from Datum to to proper return values in nad functions (`nad_tnumber_number` returns double directly)
- Allow the conversion of TPoints in tgeometry-tgeography conversion functions
- Allow the use of any temporal value as a base temporal framework for `t[geo|point]_from_base`