### PR TITLE
Follow unary_union parameter in tpointseqset_linear_trajectory

### DIFF
--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -953,8 +953,11 @@ tpointseqset_linear_trajectory(const TSequenceSet *ss, bool unary_union)
     coll = geopointarr_make_trajectory(points, npoints, STEP);
   else
     coll = geopointlinearr_make_trajectory(points, npoints, lines, nlines);
+  pfree(points); pfree_array((void **) lines, nlines);
+  if (! unary_union)
+    return coll;
   GSERIALIZED *result = geom_unary_union(coll, -1);
-  pfree(points); pfree_array((void **) lines, nlines); pfree(coll);
+  pfree(coll);
   return result;
 }
 

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
@@ -1331,7 +1331,7 @@ SELECT ST_AsText(trajectory(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-
 SELECT ST_AsText(trajectory(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}'));
                      st_astext                      
 ----------------------------------------------------
- GEOMETRYCOLLECTION(POINT(3 3),LINESTRING(1 1,2 2))
+ GEOMETRYCOLLECTION(POINT(3 3),LINESTRING(1 1,2 2,1 1))
 (1 row)
 
 SELECT ST_AsText(trajectory(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}'));
@@ -1373,7 +1373,7 @@ SELECT ST_AsText(trajectory(tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.
 SELECT ST_AsText(trajectory(tgeogpoint '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}'));
                            st_astext                            
 ----------------------------------------------------------------
- GEOMETRYCOLLECTION(POINT(3.5 3.5),LINESTRING(1.5 1.5,2.5 2.5))
+ GEOMETRYCOLLECTION(POINT(3.5 3.5),LINESTRING(1.5 1.5,2.5 2.5,1.5 1.5))
 (1 row)
 
 SELECT array_agg(ST_AsText((dp).geom)) FROM (SELECT ST_DumpPoints(trajectory(tgeogpoint 'Interp=Step;[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]')::geometry)) AS t(dp);
@@ -1409,7 +1409,7 @@ SELECT ST_AsText(trajectory(tgeompoint '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2
 SELECT ST_AsText(trajectory(tgeompoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02, Point(1 1 1)@2000-01-03],[Point(3 3 3)@2000-01-04, Point(3 3 3)@2000-01-05]}'));
                              st_astext                             
 -------------------------------------------------------------------
- GEOMETRYCOLLECTION Z (POINT Z (3 3 3),LINESTRING Z (1 1 1,2 2 2))
+ GEOMETRYCOLLECTION Z (POINT Z (3 3 3),LINESTRING Z (1 1 1,2 2 2,1 1 1))
 (1 row)
 
 SELECT ST_AsText(trajectory(tgeogpoint 'Point(1.5 1.5 1.5)@2000-01-01'));
@@ -1433,19 +1433,19 @@ SELECT ST_AsText(trajectory(tgeogpoint '[Point(1.5 1.5 1.5)@2000-01-01, Point(2.
 SELECT ST_AsText(trajectory(tgeogpoint '{[Point(1.5 1.5 1.5)@2000-01-01, Point(2.5 2.5 2.5)@2000-01-02, Point(1.5 1.5 1.5)@2000-01-03],[Point(3.5 3.5 3.5)@2000-01-04, Point(3.5 3.5 3.5)@2000-01-05]}'));
                                       st_astext                                      
 -------------------------------------------------------------------------------------
- GEOMETRYCOLLECTION Z (POINT Z (3.5 3.5 3.5),LINESTRING Z (1.5 1.5 1.5,2.5 2.5 2.5))
+ GEOMETRYCOLLECTION Z (POINT Z (3.5 3.5 3.5),LINESTRING Z (1.5 1.5 1.5,2.5 2.5 2.5,1.5 1.5 1.5))
 (1 row)
 
 SELECT array_agg(ST_AsText((dp).geom)) FROM (SELECT ST_DumpPoints(trajectory(tgeompoint '{[Point(1 1)@2001-01-01], [Point(1 1)@2001-02-01], [Point(1 1)@2001-03-01]}'))) AS t(dp);
    array_agg    
 ----------------
- {"POINT(1 1)"}
+ {"POINT(1 1)","POINT(1 1)","POINT(1 1)"}
 (1 row)
 
 SELECT array_agg(ST_AsText((dp).geom)) FROM (SELECT ST_DumpPoints(trajectory(tgeogpoint '{[Point(1 1)@2001-01-01], [Point(1 1)@2001-02-01], [Point(1 1)@2001-03-01]}')::geometry)) AS t(dp);
    array_agg    
 ----------------
- {"POINT(1 1)"}
+ {"POINT(1 1),"POINT(1 1)","POINT(1 1)""}
 (1 row)
 
 SELECT array_agg(ST_AsText((dp).geom)) FROM (SELECT ST_DumpPoints(trajectory(tgeompoint 'Interp=Step;{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02],[Point(1 1)@2000-01-03, Point(2 2)@2000-01-04]}'))) AS t(dp);


### PR DESCRIPTION
Related to #692.
Apply final `geom_unary_union` in `tpointseqset_linear_trajectory` according to `unary_union` parameter.