### PR TITLE
Add tfloat_max_value

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1293,6 +1293,7 @@ extern bool temporal_upper_inc(const Temporal *temp);
 extern double tfloat_avg_value(const Temporal *temp);
 extern double tfloat_end_value(const Temporal *temp);
 extern double tfloat_min_value(const Temporal *temp);
+extern double tfloat_max_value(const Temporal *temp);
 extern double tfloat_start_value(const Temporal *temp);
 extern bool tfloat_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict, double *value);
 extern bool tfloat_value_n(const Temporal *temp, int n, double *result);


### PR DESCRIPTION
I believe `tfloat_max_value` was missing from meos.h, the function is defined in https://github.com/MobilityDB/MobilityDB/blob/2abab6bd74ab362e3684b480ae7ab2735bd28e81/meos/src/temporal/temporal_meos.c#L615C8-L615C8