### PR TITLE
Fix write past end of array bug in tgeoseq_merge_array_iter

### DIFF
--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -336,7 +336,7 @@ tgeoseq_merge_array_iter(const TSequence **sequences, int count,
   /* Test the validity of the composing sequences, while performing spatial
    * union of the values for the instants with the same timestamp */
   TSequence **newsequences = palloc(sizeof(TSequence *) * count);
-  TSequence **tofree = palloc(sizeof(TSequence *) * count);
+  TSequence **tofree = palloc(sizeof(TSequence *) * 2 * count);
   int nfree = 0;
   /* Test the validity of the composing sequences */
   const TSequence *seq1 = sequences[0];


### PR DESCRIPTION
We allocated an array of `count` sequences (the number of input sequences) in `tgeoseq_merge_array_iter`, but each of of the input sequences (except the first) can create 2 new sequences that need to be freed. So just double the size of the allocated array to account for this.