### PR TITLE
Swap 'diff' arguments for intuitive test reporting

### DIFF
--- a/mobilitydb/test/scripts/test.cmake
+++ b/mobilitydb/test/scripts/test.cmake
@@ -204,7 +204,7 @@ elseif(TEST_OPER MATCHES "run_compare")
       )
   else()
     execute_process(
-      COMMAND diff -urdN ${TEST_DIR_OUT}/${TEST_NAME}.out ${TEST_FILE_DIR}/expected/${TEST_FILE_NAME}.test.out
+      COMMAND diff -urdN ${TEST_FILE_DIR}/expected/${TEST_FILE_NAME}.test.out ${TEST_DIR_OUT}/${TEST_NAME}.out
       OUTPUT_FILE ${TEST_DIR_OUT}/${TEST_NAME}.diff
       RESULT_VARIABLE TEST_RESULT
       )


### PR DESCRIPTION
Reverses the order of 'output' and 'expected' files in the diff command to ensure that:
- '+' indicates an unexpected line added to the output.
- '-' indicates a line missing from the output.