### PR TITLE
Update pgversion.yml to start testing PG18

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -33,7 +33,7 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [13,14,15,16,17]
+          psql: [13,14,15,16,17,18]
           postgis: [3]
           os: ["ubuntu-24.04"]
           coverage: [0]


### PR DESCRIPTION
Now that PG18 is released, should start testing PG 18.