### PR TITLE
Improve external function names to align with PG naming

### DIFF
--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -139,7 +139,7 @@ Cbuffer_send(PG_FUNCTION_ARGS)
  * @sqlfn asText()
  */
 static Datum
-Cbuffer_as_text_ext(FunctionCallInfo fcinfo, bool extended)
+Cbuffer_as_text_common(FunctionCallInfo fcinfo, bool extended)
 {
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
   int dbl_dig_for_wkt = OUT_DEFAULT_DECIMAL_DIGITS;
@@ -163,7 +163,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_as_text);
 Datum
 Cbuffer_as_text(PG_FUNCTION_ARGS)
 {
-  return Cbuffer_as_text_ext(fcinfo, false);
+  return Cbuffer_as_text_common(fcinfo, false);
 }
 
 PGDLLEXPORT Datum Cbuffer_as_ewkt(PG_FUNCTION_ARGS);
@@ -178,7 +178,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_as_ewkt);
 Datum
 Cbuffer_as_ewkt(PG_FUNCTION_ARGS)
 {
-  return Cbuffer_as_text_ext(fcinfo, true);
+  return Cbuffer_as_text_common(fcinfo, true);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/src/geo/spatialset.c
+++ b/mobilitydb/src/geo/spatialset.c
@@ -141,7 +141,7 @@ Spatialset_as_ewkt(PG_FUNCTION_ARGS)
  * an array of spatial values (external function)
  */
 Datum
-Spatialarr_as_text_ext(FunctionCallInfo fcinfo, bool extended)
+Spatialarr_as_text_common(FunctionCallInfo fcinfo, bool extended)
 {
   ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
   /* Return NULL on empty array */
@@ -177,7 +177,7 @@ PG_FUNCTION_INFO_V1(Spatialarr_as_text);
 Datum
 Spatialarr_as_text(PG_FUNCTION_ARGS)
 {
-  return Spatialarr_as_text_ext(fcinfo, false);
+  return Spatialarr_as_text_common(fcinfo, false);
 }
 
 PGDLLEXPORT Datum Spatialarr_as_ewkt(PG_FUNCTION_ARGS);
@@ -192,7 +192,7 @@ PG_FUNCTION_INFO_V1(Spatialarr_as_ewkt);
 Datum
 Spatialarr_as_ewkt(PG_FUNCTION_ARGS)
 {
-  return Spatialarr_as_text_ext(fcinfo, true);
+  return Spatialarr_as_text_common(fcinfo, true);
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/geo/tgeo_tile.c
+++ b/mobilitydb/src/geo/tgeo_tile.c
@@ -61,7 +61,7 @@
  * spatiotemporal box (external function)
  */
 static Datum
-Stbox_space_time_tiles_ext(FunctionCallInfo fcinfo, bool spacetiles,
+Stbox_space_time_tiles_common(FunctionCallInfo fcinfo, bool spacetiles,
   bool timetiles)
 {
   assert(spacetiles || timetiles);
@@ -197,7 +197,7 @@ PG_FUNCTION_INFO_V1(Stbox_space_tiles);
 inline Datum
 Stbox_space_tiles(PG_FUNCTION_ARGS)
 {
-  return Stbox_space_time_tiles_ext(fcinfo, true, false);
+  return Stbox_space_time_tiles_common(fcinfo, true, false);
 }
 
 PGDLLEXPORT Datum Stbox_time_tiles(PG_FUNCTION_ARGS);
@@ -210,7 +210,7 @@ PG_FUNCTION_INFO_V1(Stbox_time_tiles);
 inline Datum
 Stbox_time_tiles(PG_FUNCTION_ARGS)
 {
-  return Stbox_space_time_tiles_ext(fcinfo, false, true);
+  return Stbox_space_time_tiles_common(fcinfo, false, true);
 }
 
 PGDLLEXPORT Datum Stbox_space_time_tiles(PG_FUNCTION_ARGS);
@@ -223,7 +223,7 @@ PG_FUNCTION_INFO_V1(Stbox_space_time_tiles);
 inline Datum
 Stbox_space_time_tiles(PG_FUNCTION_ARGS)
 {
-  return Stbox_space_time_tiles_ext(fcinfo, true, true);
+  return Stbox_space_time_tiles_common(fcinfo, true, true);
 }
 
 /*****************************************************************************/
@@ -233,7 +233,7 @@ Stbox_space_time_tiles(PG_FUNCTION_ARGS)
  * (external function)
  */
 static Datum
-Stbox_get_space_time_tile_ext(FunctionCallInfo fcinfo, bool spacetile,
+Stbox_get_space_time_tile_common(FunctionCallInfo fcinfo, bool spacetile,
   bool timetile)
 {
   assert(spacetile || timetile);
@@ -289,7 +289,7 @@ PG_FUNCTION_INFO_V1(Stbox_get_space_tile);
 inline Datum
 Stbox_get_space_tile(PG_FUNCTION_ARGS)
 {
-  return Stbox_get_space_time_tile_ext(fcinfo, true, false);
+  return Stbox_get_space_time_tile_common(fcinfo, true, false);
 }
 
 PGDLLEXPORT Datum Stbox_get_time_tile(PG_FUNCTION_ARGS);
@@ -302,7 +302,7 @@ PG_FUNCTION_INFO_V1(Stbox_get_time_tile);
 inline Datum
 Stbox_get_time_tile(PG_FUNCTION_ARGS)
 {
-  return Stbox_get_space_time_tile_ext(fcinfo, false, true);
+  return Stbox_get_space_time_tile_common(fcinfo, false, true);
 }
 
 PGDLLEXPORT Datum Stbox_get_space_time_tile(PG_FUNCTION_ARGS);
@@ -315,7 +315,7 @@ PG_FUNCTION_INFO_V1(Stbox_get_space_time_tile);
 inline Datum
 Stbox_get_space_time_tile(PG_FUNCTION_ARGS)
 {
-  return Stbox_get_space_time_tile_ext(fcinfo, true, true);
+  return Stbox_get_space_time_tile_common(fcinfo, true, true);
 }
 
 /*****************************************************************************
@@ -327,7 +327,7 @@ Stbox_get_space_time_tile(PG_FUNCTION_ARGS)
  * respect to a spatial or spatiotemporal grid
  */
 static Datum
-Tgeo_space_time_boxes_ext(FunctionCallInfo fcinfo, bool spacetiles,
+Tgeo_space_time_boxes_common(FunctionCallInfo fcinfo, bool spacetiles,
   bool timetiles)
 {
   /* Get input parameters */
@@ -369,7 +369,7 @@ PG_FUNCTION_INFO_V1(Tgeo_space_boxes);
 inline Datum
 Tgeo_space_boxes(PG_FUNCTION_ARGS)
 {
-  return Tgeo_space_time_boxes_ext(fcinfo, true, false);
+  return Tgeo_space_time_boxes_common(fcinfo, true, false);
 }
 
 PGDLLEXPORT Datum Tgeo_time_boxes(PG_FUNCTION_ARGS);
@@ -383,7 +383,7 @@ PG_FUNCTION_INFO_V1(Tgeo_time_boxes);
 inline Datum
 Tgeo_time_boxes(PG_FUNCTION_ARGS)
 {
-  return Tgeo_space_time_boxes_ext(fcinfo, false, true);
+  return Tgeo_space_time_boxes_common(fcinfo, false, true);
 }
 
 PGDLLEXPORT Datum Tgeo_space_time_boxes(PG_FUNCTION_ARGS);
@@ -397,7 +397,7 @@ PG_FUNCTION_INFO_V1(Tgeo_space_time_boxes);
 inline Datum
 Tgeo_space_time_boxes(PG_FUNCTION_ARGS)
 {
-  return Tgeo_space_time_boxes_ext(fcinfo, true, true);
+  return Tgeo_space_time_boxes_common(fcinfo, true, true);
 }
 
 /*****************************************************************************
@@ -409,7 +409,7 @@ Tgeo_space_time_boxes(PG_FUNCTION_ARGS)
  * spatiotemporal grid
  */
 static Datum
-Tgeo_space_time_split_ext(FunctionCallInfo fcinfo, bool timesplit)
+Tgeo_space_time_split_common(FunctionCallInfo fcinfo, bool timesplit)
 {
   FuncCallContext *funcctx;
 
@@ -519,7 +519,7 @@ PG_FUNCTION_INFO_V1(Tgeo_space_split);
 inline Datum
 Tgeo_space_split(PG_FUNCTION_ARGS)
 {
-  return Tgeo_space_time_split_ext(fcinfo, false);
+  return Tgeo_space_time_split_common(fcinfo, false);
 }
 
 PGDLLEXPORT Datum Tgeo_space_time_split(PG_FUNCTION_ARGS);
@@ -532,7 +532,7 @@ PG_FUNCTION_INFO_V1(Tgeo_space_time_split);
 inline Datum
 Tgeo_space_time_split(PG_FUNCTION_ARGS)
 {
-  return Tgeo_space_time_split_ext(fcinfo, true);
+  return Tgeo_space_time_split_common(fcinfo, true);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/src/geo/tspatial.c
+++ b/mobilitydb/src/geo/tspatial.c
@@ -122,7 +122,7 @@ Tspatial_from_ewkt(PG_FUNCTION_ARGS)
  * @sqlfn asText()
  */
 static Datum
-Tspatial_as_text_ext(FunctionCallInfo fcinfo, bool extended)
+Tspatial_as_text_common(FunctionCallInfo fcinfo, bool extended)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   int dbl_dig_for_wkt = OUT_DEFAULT_DECIMAL_DIGITS;
@@ -147,7 +147,7 @@ PG_FUNCTION_INFO_V1(Tspatial_as_text);
 Datum
 Tspatial_as_text(PG_FUNCTION_ARGS)
 {
-  return Tspatial_as_text_ext(fcinfo, false);
+  return Tspatial_as_text_common(fcinfo, false);
 }
 
 PGDLLEXPORT Datum Tspatial_as_ewkt(PG_FUNCTION_ARGS);
@@ -162,7 +162,7 @@ PG_FUNCTION_INFO_V1(Tspatial_as_ewkt);
 Datum
 Tspatial_as_ewkt(PG_FUNCTION_ARGS)
 {
-  return Tspatial_as_text_ext(fcinfo, true);
+  return Tspatial_as_text_common(fcinfo, true);
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/npoint/npoint.c
+++ b/mobilitydb/src/npoint/npoint.c
@@ -256,7 +256,7 @@ Npoint_from_hexwkb(PG_FUNCTION_ARGS)
  * @sqlfn asText()
  */
 static Datum
-Npoint_as_text_ext(FunctionCallInfo fcinfo, bool extended)
+Npoint_as_text_common(FunctionCallInfo fcinfo, bool extended)
 {
   Npoint *np = PG_GETARG_NPOINT_P(0);
   int dbl_dig_for_wkt = OUT_DEFAULT_DECIMAL_DIGITS;
@@ -279,7 +279,7 @@ PG_FUNCTION_INFO_V1(Npoint_as_text);
 Datum
 Npoint_as_text(PG_FUNCTION_ARGS)
 {
-  return Npoint_as_text_ext(fcinfo, false);
+  return Npoint_as_text_common(fcinfo, false);
 }
 
 PGDLLEXPORT Datum Npoint_as_ewkt(PG_FUNCTION_ARGS);
@@ -294,7 +294,7 @@ PG_FUNCTION_INFO_V1(Npoint_as_ewkt);
 Datum
 Npoint_as_ewkt(PG_FUNCTION_ARGS)
 {
-  return Npoint_as_text_ext(fcinfo, true);
+  return Npoint_as_text_common(fcinfo, true);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -200,7 +200,7 @@ Pose_from_hexwkb(PG_FUNCTION_ARGS)
  * @sqlfn asText(), asEWKT()
  */
 static Datum
-Pose_as_text_ext(FunctionCallInfo fcinfo, bool extended)
+Pose_as_text_common(FunctionCallInfo fcinfo, bool extended)
 {
   Pose *pose = PG_GETARG_POSE_P(0);
   int dbl_dig_for_wkt = OUT_DEFAULT_DECIMAL_DIGITS;
@@ -224,7 +224,7 @@ PG_FUNCTION_INFO_V1(Pose_as_text);
 Datum
 Pose_as_text(PG_FUNCTION_ARGS)
 {
-  return Pose_as_text_ext(fcinfo, false);
+  return Pose_as_text_common(fcinfo, false);
 }
 
 PGDLLEXPORT Datum Pose_as_ewkt(PG_FUNCTION_ARGS);
@@ -238,7 +238,7 @@ PG_FUNCTION_INFO_V1(Pose_as_ewkt);
 Datum
 Pose_as_ewkt(PG_FUNCTION_ARGS)
 {
-  return Pose_as_text_ext(fcinfo, true);
+  return Pose_as_text_common(fcinfo, true);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -203,7 +203,7 @@ Trgeometry_from_ewkt(PG_FUNCTION_ARGS)
  * a temporal rigid geometry
  */
 static Datum
-Trgeometry_as_text_ext(FunctionCallInfo fcinfo, bool extended)
+Trgeometry_as_text_common(FunctionCallInfo fcinfo, bool extended)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   int dbl_dig_for_wkt = OUT_DEFAULT_DECIMAL_DIGITS;
@@ -227,7 +227,7 @@ PG_FUNCTION_INFO_V1(Trgeometry_as_text);
 Datum
 Trgeometry_as_text(PG_FUNCTION_ARGS)
 {
-  return Trgeometry_as_text_ext(fcinfo, false);
+  return Trgeometry_as_text_common(fcinfo, false);
 }
 
 PGDLLEXPORT Datum Trgeometry_as_ewkt(PG_FUNCTION_ARGS);
@@ -242,7 +242,7 @@ PG_FUNCTION_INFO_V1(Trgeometry_as_ewkt);
 Datum
 Trgeometry_as_ewkt(PG_FUNCTION_ARGS)
 {
-  return Trgeometry_as_text_ext(fcinfo, true);
+  return Trgeometry_as_text_common(fcinfo, true);
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/temporal/temporal_tile.c
+++ b/mobilitydb/src/temporal/temporal_tile.c
@@ -229,7 +229,7 @@ Tnumber_value_bins(PG_FUNCTION_ARGS)
  * @brief Return the tiles of a temporal box
  */
 Datum
-Tbox_value_time_tiles_ext(FunctionCallInfo fcinfo, bool valuetiles,
+Tbox_value_time_tiles_common(FunctionCallInfo fcinfo, bool valuetiles,
   bool timetiles)
 {
   assert(valuetiles || timetiles);
@@ -318,7 +318,7 @@ PG_FUNCTION_INFO_V1(Tbox_value_tiles);
 inline Datum
 Tbox_value_tiles(PG_FUNCTION_ARGS)
 {
-  return Tbox_value_time_tiles_ext(fcinfo, true, false);
+  return Tbox_value_time_tiles_common(fcinfo, true, false);
 }
 
 PGDLLEXPORT Datum Tbox_time_tiles(PG_FUNCTION_ARGS);
@@ -331,7 +331,7 @@ PG_FUNCTION_INFO_V1(Tbox_time_tiles);
 inline Datum
 Tbox_time_tiles(PG_FUNCTION_ARGS)
 {
-  return Tbox_value_time_tiles_ext(fcinfo, false, true);
+  return Tbox_value_time_tiles_common(fcinfo, false, true);
 }
 
 PGDLLEXPORT Datum Tbox_value_time_tiles(PG_FUNCTION_ARGS);
@@ -344,7 +344,7 @@ PG_FUNCTION_INFO_V1(Tbox_value_time_tiles);
 inline Datum
 Tbox_value_time_tiles(PG_FUNCTION_ARGS)
 {
-  return Tbox_value_time_tiles_ext(fcinfo, true, true);
+  return Tbox_value_time_tiles_common(fcinfo, true, true);
 }
 
 /*****************************************************************************/
@@ -354,7 +354,7 @@ Tbox_value_time_tiles(PG_FUNCTION_ARGS)
  * (external function)
  */
 Datum
-Tbox_get_value_time_tile_ext(FunctionCallInfo fcinfo, bool valuetile,
+Tbox_get_value_time_tile_common(FunctionCallInfo fcinfo, bool valuetile,
   bool timetile)
 {
   assert(valuetile || timetile);
@@ -393,7 +393,7 @@ PG_FUNCTION_INFO_V1(Tbox_get_value_tile);
 inline Datum
 Tbox_get_value_tile(PG_FUNCTION_ARGS)
 {
-  return Tbox_get_value_time_tile_ext(fcinfo, true, false);
+  return Tbox_get_value_time_tile_common(fcinfo, true, false);
 }
 
 PGDLLEXPORT Datum Tbox_get_time_tile(PG_FUNCTION_ARGS);
@@ -406,7 +406,7 @@ PG_FUNCTION_INFO_V1(Tbox_get_time_tile);
 inline Datum
 Tbox_get_time_tile(PG_FUNCTION_ARGS)
 {
-  return Tbox_get_value_time_tile_ext(fcinfo, false, true);
+  return Tbox_get_value_time_tile_common(fcinfo, false, true);
 }
 
 PGDLLEXPORT Datum Tbox_get_value_time_tile(PG_FUNCTION_ARGS);
@@ -419,7 +419,7 @@ PG_FUNCTION_INFO_V1(Tbox_get_value_time_tile);
 inline Datum
 Tbox_get_value_time_tile(PG_FUNCTION_ARGS)
 {
-  return Tbox_get_value_time_tile_ext(fcinfo, true, true);
+  return Tbox_get_value_time_tile_common(fcinfo, true, true);
 }
 
 /*****************************************************************************
@@ -431,7 +431,7 @@ Tbox_get_value_time_tile(PG_FUNCTION_ARGS)
  * a value and/or time grid (external function)
  */
 Datum
-Tnumber_value_time_boxes_ext(FunctionCallInfo fcinfo, bool valueboxes,
+Tnumber_value_time_boxes_common(FunctionCallInfo fcinfo, bool valueboxes,
   bool timeboxes)
 {
   assert(valueboxes || timeboxes);
@@ -473,7 +473,7 @@ PG_FUNCTION_INFO_V1(Tnumber_value_boxes);
 inline Datum
 Tnumber_value_boxes(PG_FUNCTION_ARGS)
 {
-  return Tnumber_value_time_boxes_ext(fcinfo, true, false);
+  return Tnumber_value_time_boxes_common(fcinfo, true, false);
 }
 
 PGDLLEXPORT Datum Tnumber_time_boxes(PG_FUNCTION_ARGS);
@@ -487,7 +487,7 @@ PG_FUNCTION_INFO_V1(Tnumber_time_boxes);
 inline Datum
 Tnumber_time_boxes(PG_FUNCTION_ARGS)
 {
-  return Tnumber_value_time_boxes_ext(fcinfo, false, true);
+  return Tnumber_value_time_boxes_common(fcinfo, false, true);
 }
 
 PGDLLEXPORT Datum Tnumber_value_time_boxes(PG_FUNCTION_ARGS);
@@ -501,7 +501,7 @@ PG_FUNCTION_INFO_V1(Tnumber_value_time_boxes);
 inline Datum
 Tnumber_value_time_boxes(PG_FUNCTION_ARGS)
 {
-  return Tnumber_value_time_boxes_ext(fcinfo, true, true);
+  return Tnumber_value_time_boxes_common(fcinfo, true, true);
 }
 
 /*****************************************************************************
@@ -726,7 +726,7 @@ Temporal_time_split(PG_FUNCTION_ARGS)
  * and time bins
  */
 Datum
-Tnumber_value_time_split_ext(FunctionCallInfo fcinfo, bool valuesplit,
+Tnumber_value_time_split_common(FunctionCallInfo fcinfo, bool valuesplit,
   bool timesplit)
 {
   FuncCallContext *funcctx;
@@ -834,7 +834,7 @@ PG_FUNCTION_INFO_V1(Tnumber_value_split);
 inline Datum
 Tnumber_value_split(PG_FUNCTION_ARGS)
 {
-  return Tnumber_value_time_split_ext(fcinfo, true, false);
+  return Tnumber_value_time_split_common(fcinfo, true, false);
 }
 
 PGDLLEXPORT Datum Tnumber_value_time_split(PG_FUNCTION_ARGS);
@@ -848,7 +848,7 @@ PG_FUNCTION_INFO_V1(Tnumber_value_time_split);
 inline Datum
 Tnumber_value_time_split(PG_FUNCTION_ARGS)
 {
-  return Tnumber_value_time_split_ext(fcinfo, true, true);
+  return Tnumber_value_time_split_common(fcinfo, true, true);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
Change the suffix of shared external SQL functions from '_ext' to '_common' to match PostgreSQL function names having the same behavior