### PR TITLE
Fix the commutators of the ttext temporal compops (#722)

### DIFF
--- a/mobilitydb/sql/general/030_temporal_compops.in.sql
+++ b/mobilitydb/sql/general/030_temporal_compops.in.sql
@@ -1804,17 +1804,17 @@ CREATE FUNCTION temporal_tgt(ttext, ttext)
 CREATE OPERATOR #> (
   PROCEDURE = temporal_tgt,
   LEFTARG = text, RIGHTARG = ttext,
-  COMMUTATOR = #<=
+  COMMUTATOR = #<
 );
 CREATE OPERATOR #> (
   PROCEDURE = temporal_tgt,
   LEFTARG = ttext, RIGHTARG = text,
-  COMMUTATOR = #<=
+  COMMUTATOR = #<
 );
 CREATE OPERATOR #> (
   PROCEDURE = temporal_tgt,
   LEFTARG = ttext, RIGHTARG = ttext,
-  COMMUTATOR = #<=
+  COMMUTATOR = #<
 );
 
 /*****************************************************************************


### PR DESCRIPTION
Fixes the issue mentioned by #680.

The commutators of the temporal compops for the `ttext` were wrong. Previously this didn't raise an error, but starting with PG 17, postgres raises an error when two operators have the same commutator. Strangely, this error was only raised when running `pg_upgrade` to go from PG 16 to PG 17, and does not get raised when running `CREATE INSTALL`.

Cherry-pick of c2c5608f4