### PR TITLE
Update code for PG18

### DIFF
--- a/mobilitydb/src/general/span_analyze.c
+++ b/mobilitydb/src/general/span_analyze.c
@@ -305,7 +305,11 @@ span_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
     non_null_cnt++;
 
     /* Give backend a chance of interrupting us */
+#if POSTGRESQL_VERSION_NUMBER >= 180000
+    vacuum_delay_point(true);
+#else
     vacuum_delay_point();
+#endif
   }
 
   /* We can only compute real stats if we found some non-null values. */

--- a/mobilitydb/src/general/temporal_analyze.c
+++ b/mobilitydb/src/general/temporal_analyze.c
@@ -140,7 +140,11 @@ temporal_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
   for (int i = 0; i < samplerows; i++)
   {
     /* Give backend a chance of interrupting us */
+#if POSTGRESQL_VERSION_NUMBER >= 180000
+    vacuum_delay_point(true);
+#else
     vacuum_delay_point();
+#endif
 
     bool isnull;
     Datum value = fetchfunc(stats, i, &isnull);

--- a/mobilitydb/src/point/tpoint_analyze.c
+++ b/mobilitydb/src/point/tpoint_analyze.c
@@ -664,7 +664,11 @@ gserialized_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
     notnull_cnt++;
 
     /* Give backend a chance of interrupting us */
+#if POSTGRESQL_VERSION_NUMBER >= 180000
+    vacuum_delay_point(true);
+#else
     vacuum_delay_point();
+#endif
   }
 
   /*
@@ -868,7 +872,11 @@ gserialized_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
     if (! nd_box) continue; /* Skip Null'ed out hard deviants */
 
     /* Give backend a chance of interrupting us */
+#if POSTGRESQL_VERSION_NUMBER >= 180000
+    vacuum_delay_point(true);
+#else
     vacuum_delay_point();
+#endif
 
     /* Find the cells that overlap with this box and put them into the ND_IBOX */
     nd_box_overlap(nd_stats, nd_box, &nd_ibox);
@@ -1002,7 +1010,11 @@ spatialset_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
       pfree(set);
 
     /* Give backend a chance of interrupting us */
+#if POSTGRESQL_VERSION_NUMBER >= 180000
+    vacuum_delay_point(true);
+#else
     vacuum_delay_point();
+#endif
   }
 
   /* We can only compute real stats if we found some non-null values. */
@@ -1096,7 +1108,11 @@ tpoint_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
       pfree(temp);
 
     /* Give backend a chance of interrupting us */
+#if POSTGRESQL_VERSION_NUMBER >= 180000
+    vacuum_delay_point(true);
+#else
     vacuum_delay_point();
+#endif
   }
 
   /* We can only compute real stats if we found some non-null values. */


### PR DESCRIPTION
Update the calls to `vacuum_delay_point`, which took an additional parameter in PG 18.
Couldn't cherry pick these changes from master as they were part of a larger commit.