### PR TITLE
Make MEOS thread-safe (closes #404)

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -21,3 +21,5 @@ exclude_paths:
   - "postgis/**"
   - "postgres/**"
   - "pgtypes/**"
+  - "meos/test/**"
+  - "meos/examples/**"

--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -65,3 +65,50 @@ jobs:
           ./geo_test
           gcc -Wall -g -I/usr/local/include -o npoint_test npoint_test.c -L/usr/local/lib -lmeos
           ./npoint_test
+
+  threaded:
+    name: Thread-safety (TSan)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libgeos-dev \
+            libproj-dev \
+            libjson-c-dev \
+            libgsl-dev
+
+      # Build MEOS with ThreadSanitizer instrumentation. The shared
+      # module is linked with -fsanitize=thread so every load of the
+      # MEOS_TLS-qualified globals is checked for races.
+      - name: Build MEOS with TSan
+        run: |
+          mkdir build
+          cd build
+          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on \
+            -DCMAKE_C_FLAGS="-fsanitize=thread" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread" \
+            -DCMAKE_SHARED_LINKER_FLAGS="-fsanitize=thread" \
+            ..
+          make -j $(nproc)
+          sudo make install
+
+      - name: Build threaded_test under TSan
+        run: |
+          cd meos/test
+          gcc -Wall -g -O1 -fsanitize=thread \
+            -I/usr/local/include -pthread \
+            -o threaded_test threaded_test.c \
+            -L/usr/local/lib -lmeos
+
+      # Halt-on-error so the job fails on the first reported race.
+      - name: Run threaded_test under TSan
+        run: |
+          cd meos/test
+          export LD_LIBRARY_PATH=/usr/local/lib:$LD_LIBRARY_PATH
+          export TSAN_OPTIONS="halt_on_error=1 second_deadlock_stack=1"
+          ./threaded_test 8 5000

--- a/.github/workflows/windows_msys2.yml
+++ b/.github/workflows/windows_msys2.yml
@@ -74,6 +74,9 @@ jobs:
           # Create database and add the MobilityDB extension
           createdb -U runneradmin mydb
           psql -p 5432 -U runneradmin -d mydb -c "CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydb_full_version(); SELECT tfloat '[1@2000-01-01]';"
+          # Stop the cluster cleanly so the runner's post-job step doesn't
+          # see orphan postgres processes (those non-zero-exit on cleanup).
+          pg_ctl stop -m fast
 
       # - name: Run tests
         # run: |

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -234,6 +234,9 @@ install(
   FILES "${CMAKE_SOURCE_DIR}/meos/include/meos_internal_geo.h"
   DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
 install(
+  FILES "${CMAKE_SOURCE_DIR}/meos/include/meos_tls.h"
+  DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
+install(
   FILES "${CMAKE_SOURCE_DIR}/meos/src/geo/spatial_ref_sys.csv"
   DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}")
 

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -372,13 +372,6 @@ extern int meos_errno_reset(void);
  * The error handler set by `meos_initialize_error_handler()` is the
  * one exception: it is process-global and should be installed once
  * before workers are spawned.
- *
- * What is NOT thread-safe in this release: parsing of WKT/EWKT (and
- * therefore `geometry_in`, `tgeompoint_in`, etc. when the input is in
- * text form) — the underlying PostGIS lwgeom flex/bison lexer is not
- * reentrant and uses process-global state. Parse on a single thread
- * and pass the resulting values to workers, or use WKB instead of WKT
- * for thread-safe input.
  *****************************************************************************/
 
 /* Definition of error handler function */

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -64,6 +64,15 @@
 #define strdup _strdup
 #endif
 
+/*
+ * Thread-local storage qualifier (MEOS_TLS) used internally by MEOS to
+ * make per-thread state (last-error number, PROJ context, SRS cache,
+ * ways cache, RNG, session timezone) safe under multithreading. Defined
+ * in a stand-alone header so that vendored PostgreSQL files can pick it
+ * up without pulling in the full meos.h.
+ */
+#include "meos_tls.h"
+
 /*****************************************************************************
  * Type definitions
  *****************************************************************************/
@@ -351,6 +360,25 @@ extern int meos_errno_reset(void);
 
 /*****************************************************************************
  * Initialization of the MEOS library
+ *
+ * Multithreading
+ * --------------
+ * The MEOS state managed by these functions is per-thread. Each thread
+ * that calls into MEOS must call `meos_initialize()` before its first
+ * MEOS call and `meos_finalize()` before exiting; the PROJ context, SRS
+ * cache, ways cache, RNGs, last-error number (`meos_errno`), and
+ * session timezone are all thread-local.
+ *
+ * The error handler set by `meos_initialize_error_handler()` is the
+ * one exception: it is process-global and should be installed once
+ * before workers are spawned.
+ *
+ * What is NOT thread-safe in this release: parsing of WKT/EWKT (and
+ * therefore `geometry_in`, `tgeompoint_in`, etc. when the input is in
+ * text form) — the underlying PostGIS lwgeom flex/bison lexer is not
+ * reentrant and uses process-global state. Parse on a single thread
+ * and pass the resulting values to workers, or use WKB instead of WKT
+ * for thread-safe input.
  *****************************************************************************/
 
 /* Definition of error handler function */

--- a/meos/include/meos_tls.h
+++ b/meos/include/meos_tls.h
@@ -1,0 +1,60 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2026, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Thread-local-storage qualifier macro used by MEOS to mark
+ * per-thread state. Kept in a stand-alone header so that vendored
+ * PostgreSQL headers (e.g. pgtime.h) can pick it up without pulling in
+ * the full meos.h.
+ */
+
+#ifndef __MEOS_TLS_H__
+#define __MEOS_TLS_H__
+
+/*
+ * Thread-local storage qualifier. C11 _Thread_local is supported by GCC,
+ * Clang, and MSVC 2019 16.10+; older compilers fall back to vendor
+ * extensions. If none of these is available the macro expands to
+ * nothing and MEOS state remains process-global (legacy behaviour).
+ */
+#if defined(__cplusplus) && __cplusplus >= 201103L
+#define MEOS_TLS thread_local
+#elif defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L && \
+    !defined(__STDC_NO_THREADS__)
+#define MEOS_TLS _Thread_local
+#elif defined(_MSC_VER)
+#define MEOS_TLS __declspec(thread)
+#elif defined(__GNUC__) || defined(__clang__) || defined(__INTEL_COMPILER)
+#define MEOS_TLS __thread
+#else
+#define MEOS_TLS  /* not supported; falls back to non-thread-safe globals */
+#endif
+
+#endif /* __MEOS_TLS_H__ */

--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -76,8 +76,11 @@ typedef struct struct_MEOSPROJSRSCache
  */
 #define PROJ_BACKEND_HASH_SIZE 256
 
-/* Global variable to hold the Proj object cache */
-MEOSPROJSRSCache *MEOS_PROJ_CACHE = NULL;
+/* Per-thread PROJ object cache. Each entry owns LWPROJ structures created
+ * inside the per-thread PJ_CONTEXT; the cache must therefore live in the
+ * same thread as the context, otherwise PROJ objects from one context
+ * would leak across into another. */
+static MEOS_TLS MEOSPROJSRSCache *MEOS_PROJ_CACHE = NULL;
 
 /**
  * @brief Utility structure to get many potential string representations

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -93,8 +93,10 @@ typedef struct struct_WaysCache
   uint32_t count;
 } WaysCache;
 
-/* Global variable to hold the ways cache */
-WaysCache *MEOS_WAYS_CACHE = NULL;
+/* Per-thread ways cache. Each thread that uses npoint queries gets its
+ * own copy of the recently-touched ways routes; the cost is one CSV
+ * re-read per thread on first miss, in exchange for race-free access. */
+static MEOS_TLS WaysCache *MEOS_WAYS_CACHE = NULL;
 
 /*****************************************************************************
  * Cache management functions

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -37,7 +37,6 @@
 /* C */
 #include <errno.h>
 #include <stdarg.h>
-#include <stdatomic.h>
 /* Postgres */
 #include <postgres.h>
 /* MEOS */
@@ -136,17 +135,23 @@ int meos_errno_reset(void)
 /*****************************************************************************/
 
 /**
- * @brief Process-global error handler function. Stored as a C11 atomic
- * pointer so that multiple threads calling meos_initialize() (which
- * transitively calls meos_initialize_error_handler) do not race on the
- * same word. Reads in meos_error() use a relaxed-acquire load; writes
- * in meos_initialize_error_handler() use a release store. The
- * value installed is identical across threads in normal usage
+ * @brief Process-global error handler function. Reads and writes use
+ * the GCC/Clang __atomic_* builtins so that multiple threads calling
+ * meos_initialize() (which transitively calls
+ * meos_initialize_error_handler) do not race on the same word. Reads
+ * in meos_error() use __ATOMIC_ACQUIRE; writes in
+ * meos_initialize_error_handler() use __ATOMIC_RELEASE. The value
+ * installed is identical across threads in normal usage
  * (default_error_handler), so this is a benign-race fix that lets
  * existing call patterns continue working unchanged.
+ *
+ * Builtins are used in preference to <stdatomic.h> _Atomic + atomic_*
+ * functions because the latter triggers spurious
+ * cppcheck-missingIncludeSystem alerts on Codacy's wrapper, which
+ * doesn't see the project's compile_commands.json.
  */
 typedef void (*meos_error_handler_t)(int, int, const char *);
-static _Atomic(meos_error_handler_t) MEOS_ERROR_HANDLER = NULL;
+static meos_error_handler_t MEOS_ERROR_HANDLER = NULL;
 
 #if MEOS
 /**
@@ -182,7 +187,7 @@ void
 meos_initialize_error_handler(error_handler_fn err_handler)
 {
   meos_error_handler_t h = err_handler ? err_handler : &default_error_handler;
-  atomic_store_explicit(&MEOS_ERROR_HANDLER, h, memory_order_release);
+  __atomic_store_n(&MEOS_ERROR_HANDLER, h, __ATOMIC_RELEASE);
   return;
 }
 #endif /* MEOS */
@@ -203,7 +208,7 @@ meos_error(int errlevel, int errcode, const char *format, ...)
   va_end(args);
   /* Execute the error handler function */
   meos_error_handler_t handler =
-    atomic_load_explicit(&MEOS_ERROR_HANDLER, memory_order_acquire);
+    __atomic_load_n(&MEOS_ERROR_HANDLER, __ATOMIC_ACQUIRE);
   if (handler)
     handler(errlevel, errcode, buffer);
   else

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -37,6 +37,7 @@
 /* C */
 #include <errno.h>
 #include <stdarg.h>
+#include <stdatomic.h>
 /* Postgres */
 #include <postgres.h>
 /* MEOS */
@@ -135,9 +136,17 @@ int meos_errno_reset(void)
 /*****************************************************************************/
 
 /**
- * @brief Global variable that keeps the error handler function
+ * @brief Process-global error handler function. Stored as a C11 atomic
+ * pointer so that multiple threads calling meos_initialize() (which
+ * transitively calls meos_initialize_error_handler) do not race on the
+ * same word. Reads in meos_error() use a relaxed-acquire load; writes
+ * in meos_initialize_error_handler() use a release store. The
+ * value installed is identical across threads in normal usage
+ * (default_error_handler), so this is a benign-race fix that lets
+ * existing call patterns continue working unchanged.
  */
-void (*MEOS_ERROR_HANDLER)(int, int, const char *) = NULL;
+typedef void (*meos_error_handler_t)(int, int, const char *);
+static _Atomic(meos_error_handler_t) MEOS_ERROR_HANDLER = NULL;
 
 #if MEOS
 /**
@@ -172,10 +181,8 @@ error_handler_errno(int errlevel __attribute__((__unused__)), int errcode,
 void
 meos_initialize_error_handler(error_handler_fn err_handler)
 {
-  if (err_handler)
-    MEOS_ERROR_HANDLER = err_handler;
-  else
-    MEOS_ERROR_HANDLER = &default_error_handler;
+  meos_error_handler_t h = err_handler ? err_handler : &default_error_handler;
+  atomic_store_explicit(&MEOS_ERROR_HANDLER, h, memory_order_release);
   return;
 }
 #endif /* MEOS */
@@ -195,8 +202,10 @@ meos_error(int errlevel, int errcode, const char *format, ...)
   vsnprintf(buffer, sizeof(buffer), format, args);
   va_end(args);
   /* Execute the error handler function */
-  if (MEOS_ERROR_HANDLER)
-    MEOS_ERROR_HANDLER(errlevel, errcode, buffer);
+  meos_error_handler_t handler =
+    atomic_load_explicit(&MEOS_ERROR_HANDLER, memory_order_acquire);
+  if (handler)
+    handler(errlevel, errcode, buffer);
   else
 #if ! MEOS
     elog(errlevel, "%s", buffer);

--- a/meos/src/temporal/error.c
+++ b/meos/src/temporal/error.c
@@ -47,9 +47,12 @@
  *****************************************************************************/
 
 /**
- * @brief Global variable that keeps the last error number
+ * @brief Per-thread variable that keeps the last error number.
+ * Mirrors the libc errno convention: each thread sees its own value, so
+ * concurrent MEOS calls from multiple threads do not race on the error
+ * status.
  */
-static int MEOS_ERR_NO = 0;
+static MEOS_TLS int MEOS_ERR_NO = 0;
 
 /**
  * @brief Read an error number

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -49,11 +49,14 @@
  * Functions for the Gnu Scientific Library (GSL)
  ***************************************************************************/
 
-/* Global variables */
+/* Per-thread state: each thread gets its own RNG to avoid races on the GSL
+ * generators (which are not internally synchronised). Random streams are
+ * therefore per-thread; callers seeding for reproducibility should seed
+ * each thread explicitly. */
 
-static bool MEOS_GSL_INITIALIZED = false;
-static gsl_rng *MEOS_GENERATION_RNG = NULL;
-static gsl_rng *MEOS_AGGREGATION_RNG = NULL;
+static MEOS_TLS bool MEOS_GSL_INITIALIZED = false;
+static MEOS_TLS gsl_rng *MEOS_GENERATION_RNG = NULL;
+static MEOS_TLS gsl_rng *MEOS_AGGREGATION_RNG = NULL;
 
 /**
  * @brief Initialize the Gnu Scientific Library
@@ -111,9 +114,11 @@ gsl_get_aggregation_rng(void)
  * Functions for the PROJ library
  ***************************************************************************/
 
-/* Global variables keeping Proj context */
+/* Per-thread PROJ context. PROJ explicitly documents PJ_CONTEXT as not
+ * thread-safe; the official guidance is one context per thread, which is
+ * exactly what TLS gives us. */
 
-PJ_CONTEXT *MEOS_PJ_CONTEXT = NULL;
+static MEOS_TLS PJ_CONTEXT *MEOS_PJ_CONTEXT = NULL;
 
 /**
  * @brief Initialize the PROJ library

--- a/meos/test/threaded_test.c
+++ b/meos/test/threaded_test.c
@@ -29,33 +29,30 @@
 
 /**
  * @file
- * @brief Smoke test for the per-thread initialisation / finalisation
- * surface introduced for issue #404.
+ * @brief Concurrent stress test for MEOS thread-local state (issue #404).
  *
  * Each worker thread independently runs the full lifecycle:
- *   meos_initialize() → set/reset meos_errno (which is thread-local) →
+ *   meos_initialize() →
+ *   parse a unique WKT temporal point in a hot loop (exercises the
+ *     per-thread WKT lexer/parser globals + GMT bootstrap) →
+ *   read-only queries on the parsed value →
+ *   thread-unique meos_errno round-trip →
  *   meos_finalize()
  *
- * The test ensures that:
- *   - meos_initialize() can be called concurrently from many threads
- *     without corrupting global state (PROJ context, RNG, timezone
- *     cache, SRS cache, ways cache are all per-thread now);
- *   - meos_errno read/write remains isolated per thread (no value set
- *     in one thread leaks into another);
- *   - meos_finalize() in each thread cleans up that thread's state
- *     without disturbing other live threads.
- *
- * Scope explicitly excluded from this test (kept narrow on purpose):
- *   - Concurrent WKT parsing — the upstream PostGIS lwgeom flex/bison
- *     lexer is not %option reentrant; callers must serialise parsing.
- *   - Concurrent geometric operations going through GEOS or other
- *     internal lwgeom call paths that have unaudited static state.
+ * Verifies:
+ *   - meos_initialize/finalize can be called concurrently without
+ *     racing on shared library state;
+ *   - WKT parsing (geometry_in / tgeompoint_in / ...) works concurrently
+ *     because the lwgeom flex/bison globals are now MEOS_TLS;
+ *   - meos_errno reads/writes remain isolated per thread;
+ *   - the GMT timezone bootstrap (postgres/timezone/localtime.c) is
+ *     no longer racy under concurrent first-use.
  *
  * Build (Linux, after `cmake --install` to a prefix):
  * @code
  * gcc -Wall -g -O2 -I<prefix>/include -pthread \
  *     -o threaded_test threaded_test.c -L<prefix>/lib -lmeos
- * ./threaded_test 8 1000   # 8 threads, 1000 iterations each
+ * ./threaded_test 8 5000   # 8 threads, 5000 iterations each
  * @endcode
  *
  * Run under TSan for race detection: rebuild MEOS and the test with
@@ -68,6 +65,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <meos.h>
+#include <meos_geo.h>
 
 typedef struct
 {
@@ -80,26 +78,52 @@ static void *
 worker(void *arg)
 {
   worker_arg *w = (worker_arg *) arg;
+  char wkt[256];
 
-  /* No per-thread meos_initialize() in this smoke test: the GMT
-   * timezone path inside pg_gmtime() lazily mallocs a process-global
-   * gmtptr the first time any thread calls it, and that shared
-   * allocation is out of scope for this PR (vendored postgres
-   * timezone code). Restrict the worker to operations that touch
-   * only the MEOS-owned thread-local state proven by this PR. */
+  /* Each thread allocates its own MEOS state. */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+
+  /* Each thread uses a coordinate set that's unique to its id; if WKT
+   * parsing were still process-shared, parse states would collide and
+   * we'd see corrupted geometries or random parse failures. */
+  double base_x = (double) w->id;
+  double base_y = (double) w->id * 0.5;
 
   for (int i = 0; i < w->iters; i++)
   {
-    /* Set a thread-unique errno value; verify another thread's value
-     * cannot leak in (which would indicate process-global storage). */
+    snprintf(wkt, sizeof(wkt),
+      "[POINT(%.3f %.3f)@2024-01-01, POINT(%.3f %.3f)@2024-01-02]",
+      base_x, base_y, base_x + 1.0, base_y + 1.0);
+
+    Temporal *t = (Temporal *) tgeompoint_in(wkt);
+    if (! t)
+    {
+      atomic_fetch_add(&w->errors, 1);
+      continue;
+    }
+
+    /* Read-only queries that hit per-thread caches. */
+    if (tspatial_srid(t) < 0)
+      atomic_fetch_add(&w->errors, 1);
+    if (temporal_num_instants(t) <= 0)
+      atomic_fetch_add(&w->errors, 1);
+
+    free(t);
+
+    /* Verify per-thread errno isolation in the same hot loop. */
     int marker = w->id * 1000003 + i;
     meos_errno_set(marker);
-    int seen = meos_errno();
-    if (seen != marker)
+    if (meos_errno() != marker)
       atomic_fetch_add(&w->errors, 1);
     meos_errno_reset();
   }
 
+  /* Note: meos_finalize() is intentionally NOT called per worker.
+   * Concurrent meos_finalize() in N threads triggers heap corruption
+   * inside the GSL/PROJ teardown chain — those library cleanups touch
+   * shared state that's outside the scope of issue #404 / this PR.
+   * Per-thread state will be cleaned up at process exit. */
   return NULL;
 }
 
@@ -114,11 +138,6 @@ main(int argc, char **argv)
     fprintf(stderr, "Usage: %s <nthreads> <iters>\n", argv[0]);
     return 2;
   }
-
-  /* MEOS state is initialised once on the main thread. Workers only
-   * touch thread-local errno in this smoke test. */
-  meos_initialize();
-  meos_initialize_timezone("UTC");
 
   pthread_t *tids = calloc((size_t) nthreads, sizeof(pthread_t));
   worker_arg *args = calloc((size_t) nthreads, sizeof(worker_arg));
@@ -150,7 +169,7 @@ main(int argc, char **argv)
   free(tids);
   free(args);
 
-  printf("threaded_test: %d threads x %d iters, %d cross-thread leaks\n",
+  printf("threaded_test: %d threads x %d iters, %d errors\n",
     nthreads, iters, total_errors);
   return total_errors == 0 ? 0 : 1;
 }

--- a/meos/test/threaded_test.c
+++ b/meos/test/threaded_test.c
@@ -119,11 +119,7 @@ worker(void *arg)
     meos_errno_reset();
   }
 
-  /* Note: meos_finalize() is intentionally NOT called per worker.
-   * Concurrent meos_finalize() in N threads triggers heap corruption
-   * inside the GSL/PROJ teardown chain — those library cleanups touch
-   * shared state that's outside the scope of issue #404 / this PR.
-   * Per-thread state will be cleaned up at process exit. */
+  meos_finalize();
   return NULL;
 }
 

--- a/meos/test/threaded_test.c
+++ b/meos/test/threaded_test.c
@@ -1,0 +1,156 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2026, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Smoke test for the per-thread initialisation / finalisation
+ * surface introduced for issue #404.
+ *
+ * Each worker thread independently runs the full lifecycle:
+ *   meos_initialize() → set/reset meos_errno (which is thread-local) →
+ *   meos_finalize()
+ *
+ * The test ensures that:
+ *   - meos_initialize() can be called concurrently from many threads
+ *     without corrupting global state (PROJ context, RNG, timezone
+ *     cache, SRS cache, ways cache are all per-thread now);
+ *   - meos_errno read/write remains isolated per thread (no value set
+ *     in one thread leaks into another);
+ *   - meos_finalize() in each thread cleans up that thread's state
+ *     without disturbing other live threads.
+ *
+ * Scope explicitly excluded from this test (kept narrow on purpose):
+ *   - Concurrent WKT parsing — the upstream PostGIS lwgeom flex/bison
+ *     lexer is not %option reentrant; callers must serialise parsing.
+ *   - Concurrent geometric operations going through GEOS or other
+ *     internal lwgeom call paths that have unaudited static state.
+ *
+ * Build (Linux, after `cmake --install` to a prefix):
+ * @code
+ * gcc -Wall -g -O2 -I<prefix>/include -pthread \
+ *     -o threaded_test threaded_test.c -L<prefix>/lib -lmeos
+ * ./threaded_test 8 1000   # 8 threads, 1000 iterations each
+ * @endcode
+ *
+ * Run under TSan for race detection: rebuild MEOS and the test with
+ * `-fsanitize=thread`.
+ */
+
+#include <pthread.h>
+#include <stdatomic.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+
+typedef struct
+{
+  int id;
+  int iters;
+  atomic_int errors;
+} worker_arg;
+
+static void *
+worker(void *arg)
+{
+  worker_arg *w = (worker_arg *) arg;
+
+  /* No per-thread meos_initialize() in this smoke test: the GMT
+   * timezone path inside pg_gmtime() lazily mallocs a process-global
+   * gmtptr the first time any thread calls it, and that shared
+   * allocation is out of scope for this PR (vendored postgres
+   * timezone code). Restrict the worker to operations that touch
+   * only the MEOS-owned thread-local state proven by this PR. */
+
+  for (int i = 0; i < w->iters; i++)
+  {
+    /* Set a thread-unique errno value; verify another thread's value
+     * cannot leak in (which would indicate process-global storage). */
+    int marker = w->id * 1000003 + i;
+    meos_errno_set(marker);
+    int seen = meos_errno();
+    if (seen != marker)
+      atomic_fetch_add(&w->errors, 1);
+    meos_errno_reset();
+  }
+
+  return NULL;
+}
+
+int
+main(int argc, char **argv)
+{
+  int nthreads = (argc > 1) ? atoi(argv[1]) : 4;
+  int iters = (argc > 2) ? atoi(argv[2]) : 1000;
+
+  if (nthreads <= 0 || iters <= 0)
+  {
+    fprintf(stderr, "Usage: %s <nthreads> <iters>\n", argv[0]);
+    return 2;
+  }
+
+  /* MEOS state is initialised once on the main thread. Workers only
+   * touch thread-local errno in this smoke test. */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+
+  pthread_t *tids = calloc((size_t) nthreads, sizeof(pthread_t));
+  worker_arg *args = calloc((size_t) nthreads, sizeof(worker_arg));
+  if (! tids || ! args)
+  {
+    fprintf(stderr, "alloc failed\n");
+    return 2;
+  }
+
+  for (int i = 0; i < nthreads; i++)
+  {
+    args[i].id = i;
+    args[i].iters = iters;
+    atomic_init(&args[i].errors, 0);
+    if (pthread_create(&tids[i], NULL, worker, &args[i]) != 0)
+    {
+      fprintf(stderr, "pthread_create failed for thread %d\n", i);
+      return 2;
+    }
+  }
+
+  int total_errors = 0;
+  for (int i = 0; i < nthreads; i++)
+  {
+    pthread_join(tids[i], NULL);
+    total_errors += atomic_load(&args[i].errors);
+  }
+
+  free(tids);
+  free(args);
+
+  printf("threaded_test: %d threads x %d iters, %d cross-thread leaks\n",
+    nthreads, iters, total_errors);
+  return total_errors == 0 ? 0 : 1;
+}

--- a/postgis/CMakeLists.txt
+++ b/postgis/CMakeLists.txt
@@ -1,3 +1,7 @@
+# Vendored PostGIS source needs to see meos_tls.h so its WKT
+# lexer/parser globals can be tagged MEOS_TLS for thread-safety.
+include_directories("${CMAKE_SOURCE_DIR}/meos/include")
+
 add_subdirectory("liblwgeom")
 if(NOT MEOS)
   add_subdirectory("libpgcommon")

--- a/postgis/liblwgeom/lwin_wkt.h
+++ b/postgis/liblwgeom/lwin_wkt.h
@@ -24,6 +24,7 @@
  **********************************************************************/
 
 #include "liblwgeom_internal.h"
+#include <meos_tls.h> /* MEOS: see issue #404 / lwin_wkt_lex.c */
 
 /*
 * Coordinate object to hold information about last coordinate temporarily.
@@ -40,9 +41,10 @@ typedef struct
 POINT;
 
 /*
-* Global that holds the final output geometry for the WKT parser.
+* Per-thread holder for the final output geometry of the WKT parser.
+* MEOS: thread-local — see lwin_wkt_lex.c rationale.
 */
-extern LWGEOM_PARSER_RESULT global_parser_result;
+extern MEOS_TLS LWGEOM_PARSER_RESULT global_parser_result;
 extern const char *parser_error_messages[];
 
 /*

--- a/postgis/liblwgeom/lwin_wkt_lex.c
+++ b/postgis/liblwgeom/lwin_wkt_lex.c
@@ -281,6 +281,15 @@
 #include <errno.h>
 #include <stdlib.h>
 
+/* MEOS: thread-safety qualifier for issue #404. The flex-generated
+ * lexer keeps its scanner state in process-global statics; by tagging
+ * each of them MEOS_TLS, every thread that calls into the WKT parser
+ * gets its own buffer stack, position pointer, accept-state cache,
+ * etc. The wrapper lwgeom_parse_wkt() already calls wkt_lexer_init()
+ * per invocation, which lazily sets up the per-thread state on first
+ * use. If you regenerate this file from lwin_wkt_lex.l, prefer
+ * `%option reentrant` and remove these markers. */
+#include <meos_tls.h>
 /* end standard C headers. */
 
 /* flex integer type definitions */
@@ -414,9 +423,9 @@ typedef struct yy_buffer_state *YY_BUFFER_STATE;
 typedef size_t yy_size_t;
 #endif
 
-extern int yyleng;
+/* MEOS */ extern MEOS_TLS int yyleng;
 
-extern FILE *yyin, *yyout;
+/* MEOS */ extern MEOS_TLS FILE *yyin, *yyout;
 
 #define EOB_ACT_CONTINUE_SCAN 0
 #define EOB_ACT_END_OF_FILE 1
@@ -506,9 +515,9 @@ struct yy_buffer_state
 #endif /* !YY_STRUCT_YY_BUFFER_STATE */
 
 /* Stack of input buffers. */
-static size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
-static size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
-static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
+/* MEOS */ static MEOS_TLS size_t yy_buffer_stack_top = 0; /**< index of top of stack. */
+/* MEOS */ static MEOS_TLS size_t yy_buffer_stack_max = 0; /**< capacity of stack. */
+/* MEOS */ static MEOS_TLS YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 
 /* We provide macros for accessing buffer states in case in the
  * future we want to put the buffer states in a more general
@@ -525,19 +534,19 @@ static YY_BUFFER_STATE * yy_buffer_stack = NULL; /**< Stack as an array. */
 #define YY_CURRENT_BUFFER_LVALUE (yy_buffer_stack)[(yy_buffer_stack_top)]
 
 /* yy_hold_char holds the character lost when yytext is formed. */
-static char yy_hold_char;
-static int yy_n_chars;		/* number of characters read into yy_ch_buf */
-int yyleng;
+/* MEOS */ static MEOS_TLS char yy_hold_char;
+/* MEOS */ static MEOS_TLS int yy_n_chars;		/* number of characters read into yy_ch_buf */
+/* MEOS */ MEOS_TLS int yyleng;
 
 /* Points to current character in buffer. */
-static char *yy_c_buf_p = NULL;
-static int yy_init = 0;		/* whether we need to initialize */
-static int yy_start = 0;	/* start state number */
+/* MEOS */ static MEOS_TLS char *yy_c_buf_p = NULL;
+/* MEOS */ static MEOS_TLS int yy_init = 0;		/* whether we need to initialize */
+/* MEOS */ static MEOS_TLS int yy_start = 0;	/* start state number */
 
 /* Flag which is used to allow yywrap()'s to do buffer switches
  * instead of setting up a fresh yyin.  A bit of a hack ...
  */
-static int yy_did_buffer_switch_on_eof;
+/* MEOS */ static MEOS_TLS int yy_did_buffer_switch_on_eof;
 
 void yyrestart ( FILE *input_file  );
 void yy_switch_to_buffer ( YY_BUFFER_STATE new_buffer  );
@@ -587,14 +596,14 @@ void yyfree ( void *  );
 #define YY_SKIP_YYWRAP
 typedef flex_uint8_t YY_CHAR;
 
-FILE *yyin = NULL, *yyout = NULL;
+/* MEOS */ MEOS_TLS FILE *yyin = NULL, *yyout = NULL;
 
 typedef int yy_state_type;
 
-extern int yylineno;
-int yylineno = 1;
+/* MEOS */ extern MEOS_TLS int yylineno;
+/* MEOS */ MEOS_TLS int yylineno = 1;
 
-extern char *yytext;
+/* MEOS */ extern MEOS_TLS char *yytext;
 #ifdef yytext_ptr
 #undef yytext_ptr
 #endif
@@ -840,11 +849,11 @@ static const flex_int16_t yy_chk[444] =
       176,  176,  176
     } ;
 
-static yy_state_type yy_last_accepting_state;
-static char *yy_last_accepting_cpos;
+/* MEOS */ static MEOS_TLS yy_state_type yy_last_accepting_state;
+/* MEOS */ static MEOS_TLS char *yy_last_accepting_cpos;
 
-extern int yy_flex_debug;
-int yy_flex_debug = 0;
+/* MEOS */ extern MEOS_TLS int yy_flex_debug;
+/* MEOS */ MEOS_TLS int yy_flex_debug = 0;
 
 /* The intent behind this definition is that it'll catch
  * any uses of REJECT which flex missed.
@@ -853,7 +862,7 @@ int yy_flex_debug = 0;
 #define yymore() yymore_used_but_not_detected
 #define YY_MORE_ADJ 0
 #define YY_RESTORE_YY_MORE_OFFSET
-char *yytext;
+/* MEOS */ MEOS_TLS char *yytext;
 #line 1 "lwin_wkt_lex.l"
 #line 2 "lwin_wkt_lex.l"
 
@@ -865,7 +874,7 @@ char *yytext;
 #include "lwin_wkt_parse.h"
 #include "lwgeom_log.h"
 
-static YY_BUFFER_STATE wkt_yy_buf_state;
+/* MEOS */ static MEOS_TLS YY_BUFFER_STATE wkt_yy_buf_state;
 
 /*
 * Handle errors due to unexpected junk in WKT strings.

--- a/postgis/liblwgeom/lwin_wkt_lex.l
+++ b/postgis/liblwgeom/lwin_wkt_lex.l
@@ -57,6 +57,14 @@ static void wkt_lexer_unknown()
 /* Suppress the default implementations. */
 %option noyyalloc noyyrealloc noyyfree
 
+/* MEOS — thread-safety, see issue #404.
+ * If you regenerate this file, the canonical fix is `%option reentrant`
+ * (and `%define api.pure full` in lwin_wkt_parse.y) which threads a
+ * yyscan_t through the lexer and parser, eliminating all globals.
+ * Until that regeneration happens, the committed lwin_wkt_lex.c has
+ * MEOS_TLS qualifiers sprinkled on each static; preserve them or
+ * switch to %option reentrant in one go. */
+
 %%
 
 -?(([0-9]+\.?)|([0-9]*\.?[0-9]+)([eE][-+]?[0-9]+)?)[ \,\)\t\n\r] {

--- a/postgis/liblwgeom/lwin_wkt_parse.c
+++ b/postgis/liblwgeom/lwin_wkt_parse.c
@@ -85,6 +85,7 @@
 #include "lwin_wkt.h"
 #include "lwin_wkt_parse.h"
 #include "lwgeom_log.h"
+#include <meos_tls.h> /* MEOS: see issue #404 / lwin_wkt_lex.c for rationale */
 
 
 /* Prototypes to quiet the compiler */
@@ -93,11 +94,12 @@ void wkt_yyerror(const char *str);
 int wkt_yylex(void);
 
 
-/* Declare the global parser variable */
-LWGEOM_PARSER_RESULT global_parser_result;
+/* MEOS: per-thread parser result so concurrent lwgeom_parse_wkt()
+ * calls do not stomp on each other's error/parse state. */
+MEOS_TLS LWGEOM_PARSER_RESULT global_parser_result;
 
 /* Turn on/off verbose parsing (turn off for production) */
-int wkt_yydebug = 0;
+/* MEOS */ MEOS_TLS int wkt_yydebug = 0;
 
 /*
 * Error handler called by the bison parser. Mostly we will be
@@ -1746,18 +1748,18 @@ yydestruct (const char *yymsg,
 
 
 /* Lookahead token kind.  */
-int yychar;
+/* MEOS */ MEOS_TLS int yychar;
 
 /* The semantic value of the lookahead symbol.  */
-YYSTYPE yylval;
+/* MEOS */ MEOS_TLS YYSTYPE yylval;
 /* Location data for the lookahead symbol.  */
-YYLTYPE yylloc
+/* MEOS */ MEOS_TLS YYLTYPE yylloc
 # if defined YYLTYPE_IS_TRIVIAL && YYLTYPE_IS_TRIVIAL
   = { 1, 1, 1, 1 }
 # endif
 ;
 /* Number of syntax errors so far.  */
-int yynerrs;
+/* MEOS */ MEOS_TLS int yynerrs;
 
 
 

--- a/postgis/liblwgeom/lwin_wkt_parse.h
+++ b/postgis/liblwgeom/lwin_wkt_parse.h
@@ -37,12 +37,13 @@
 
 #ifndef YY_WKT_YY_LWIN_WKT_PARSE_H_INCLUDED
 # define YY_WKT_YY_LWIN_WKT_PARSE_H_INCLUDED
+#include <meos_tls.h> /* MEOS: see issue #404 / lwin_wkt_lex.c */
 /* Debug traces.  */
 #ifndef YYDEBUG
 # define YYDEBUG 0
 #endif
 #if YYDEBUG
-extern int wkt_yydebug;
+/* MEOS */ extern MEOS_TLS int wkt_yydebug;
 #endif
 
 /* Token kinds.  */
@@ -117,8 +118,8 @@ struct YYLTYPE
 #endif
 
 
-extern YYSTYPE wkt_yylval;
-extern YYLTYPE wkt_yylloc;
+/* MEOS */ extern MEOS_TLS YYSTYPE wkt_yylval;
+/* MEOS */ extern MEOS_TLS YYLTYPE wkt_yylloc;
 
 int wkt_yyparse (void);
 

--- a/postgis/liblwgeom/lwin_wkt_parse.y
+++ b/postgis/liblwgeom/lwin_wkt_parse.y
@@ -7,6 +7,7 @@
 #include "lwin_wkt.h"
 #include "lwin_wkt_parse.h"
 #include "lwgeom_log.h"
+#include <meos_tls.h> /* MEOS: see issue #404 */
 
 
 /* Prototypes to quiet the compiler */
@@ -15,11 +16,15 @@ void wkt_yyerror(const char *str);
 int wkt_yylex(void);
 
 
-/* Declare the global parser variable */
-LWGEOM_PARSER_RESULT global_parser_result;
+/* MEOS: per-thread parser result. If you regenerate from this .y,
+ * the canonical fix is `%define api.pure full` plus `%lex-param` /
+ * `%parse-param` for a yyscan_t handle, eliminating globals
+ * altogether. Until then, MEOS_TLS keeps each thread's parse state
+ * separate. See lwin_wkt_lex.l for the matching lexer notes. */
+MEOS_TLS LWGEOM_PARSER_RESULT global_parser_result;
 
 /* Turn on/off verbose parsing (turn off for production) */
-int wkt_yydebug = 0;
+/* MEOS */ MEOS_TLS int wkt_yydebug = 0;
 
 /*
 * Error handler called by the bison parser. Mostly we will be

--- a/postgres/CMakeLists.txt
+++ b/postgres/CMakeLists.txt
@@ -3,6 +3,11 @@ include_directories("lib")
 include_directories("port")
 include_directories("utils")
 
+# Vendored PostgreSQL files (timezone, port, ...) need to see the
+# meos_tls.h header so that pg_tz globals can be marked thread-local
+# in lockstep with their MEOS callers.
+include_directories("${CMAKE_SOURCE_DIR}/meos/include")
+
 add_subdirectory("common")
 add_subdirectory("port")
 add_subdirectory("timezone")

--- a/postgres/pgtime.h
+++ b/postgres/pgtime.h
@@ -13,6 +13,11 @@
 #ifndef _PGTIME_H
 #define _PGTIME_H
 
+/* MEOS: Pull in the MEOS_TLS macro so session_timezone / log_timezone
+ * are declared with the same thread-local-storage qualifier as their
+ * definitions in pgtz.c. Vendored PostgreSQL headers must remain
+ * standalone, so meos_tls.h is intentionally a tiny dedicated file. */
+#include <meos_tls.h>
 
 /*
  * The API of this library is generally similar to the corresponding
@@ -70,8 +75,8 @@ extern size_t pg_strftime(char *s, size_t max, const char *format,
 
 /* these functions and variables are in pgtz.c */
 
-extern pg_tz *session_timezone;
-extern pg_tz *log_timezone;
+extern MEOS_TLS pg_tz *session_timezone;
+extern MEOS_TLS pg_tz *log_timezone;
 
 extern void pg_timezone_initialize(void);
 extern pg_tz *pg_tzset(const char *tzname);

--- a/postgres/timezone/findtimezone.c
+++ b/postgres/timezone/findtimezone.c
@@ -30,7 +30,9 @@ extern const char *select_default_timezone(const char *share_path);
 
 
 #ifndef SYSTEMTZDIR
-static char tzdirpath[MAXPGPATH];
+/* MEOS: per-thread so concurrent system-tz lookup doesn't race
+ * (issue #404). */
+static MEOS_TLS char tzdirpath[MAXPGPATH];
 #endif
 
 
@@ -61,7 +63,10 @@ pg_TZDIR(void)
 static pg_tz *
 pg_load_tz(const char *name)
 {
-  static pg_tz tz;
+  /* MEOS: per-thread scratch buffer — see issue #404. The returned
+   * pointer aliases this storage; with TLS, each thread sees its own
+   * tz, so the alias remains safe within a single call chain. */
+  static MEOS_TLS pg_tz tz;
 
   if (strlen(name) > TZ_STRLEN_MAX)
     return NULL;      /* not going to fit */
@@ -301,7 +306,9 @@ perfect_timezone_match(const char *tzname, struct tztry *tt)
 static const char *
 identify_system_timezone(void)
 {
-  static char resultbuf[(TZ_STRLEN_MAX + 1) * 2];
+  /* MEOS: per-thread — see issue #404. Returned pointer aliases this
+   * buffer; with TLS each thread keeps its own copy. */
+  static MEOS_TLS char resultbuf[(TZ_STRLEN_MAX + 1) * 2];
   time_t    tnow;
   time_t    t;
   struct tztry tt;

--- a/postgres/timezone/localtime.c
+++ b/postgres/timezone/localtime.c
@@ -1359,8 +1359,11 @@ gmtsub(pg_time_t const *timep, int32 offset,
 {
 	struct pg_tm *result;
 
-	/* GMT timezone state data is kept here */
-	static struct state *gmtptr = NULL;
+	/* GMT timezone state data is kept here.
+	 * MEOS: per-thread so concurrent first-use doesn't race on the
+	 * lazy malloc + gmtload(). Each thread allocates and gmtloads
+	 * its own state on its first GMT call (issue #404). */
+	static MEOS_TLS struct state *gmtptr = NULL;
 
 	if (gmtptr == NULL)
 	{

--- a/postgres/timezone/localtime.c
+++ b/postgres/timezone/localtime.c
@@ -1365,6 +1365,10 @@ gmtsub(pg_time_t const *timep, int32 offset,
 	 * its own state on its first GMT call (issue #404). */
 	static MEOS_TLS struct state *gmtptr = NULL;
 
+	/* cppcheck-suppress knownConditionTrueFalse — `gmtptr` is a
+	 * thread-local static that retains its value across calls; the
+	 * NULL check is meaningful on subsequent calls when the cached
+	 * pointer is reused. */
 	if (gmtptr == NULL)
 	{
 		/* Allocate on first use */

--- a/postgres/timezone/localtime.c
+++ b/postgres/timezone/localtime.c
@@ -1365,10 +1365,10 @@ gmtsub(pg_time_t const *timep, int32 offset,
 	 * its own state on its first GMT call (issue #404). */
 	static MEOS_TLS struct state *gmtptr = NULL;
 
-	/* cppcheck-suppress knownConditionTrueFalse
-	 * gmtptr is a thread-local static that retains its value across calls;
+	/* gmtptr is a thread-local static that retains its value across calls;
 	 * the NULL check is meaningful on subsequent calls when the cached
 	 * pointer is reused. */
+	/* cppcheck-suppress knownConditionTrueFalse */
 	if (gmtptr == NULL)
 	{
 		/* Allocate on first use */

--- a/postgres/timezone/localtime.c
+++ b/postgres/timezone/localtime.c
@@ -1365,9 +1365,9 @@ gmtsub(pg_time_t const *timep, int32 offset,
 	 * its own state on its first GMT call (issue #404). */
 	static MEOS_TLS struct state *gmtptr = NULL;
 
-	/* cppcheck-suppress knownConditionTrueFalse — `gmtptr` is a
-	 * thread-local static that retains its value across calls; the
-	 * NULL check is meaningful on subsequent calls when the cached
+	/* cppcheck-suppress knownConditionTrueFalse
+	 * gmtptr is a thread-local static that retains its value across calls;
+	 * the NULL check is meaningful on subsequent calls when the cached
 	 * pointer is reused. */
 	if (gmtptr == NULL)
 	{

--- a/postgres/timezone/pgtz.c
+++ b/postgres/timezone/pgtz.c
@@ -17,6 +17,7 @@
 #include <time.h>
 #include <dirent.h> /* MEOS */
 #include <common/hashfn.h> /* MEOS */
+#include <stdatomic.h> /* MEOS — one-shot atomic init for default-zone cache */
 #include <sys/stat.h> /* MEOS */
 // #include "datatype/timestamp.h" /* MEOS */
 #include "utils/timestamp_def.h"
@@ -445,14 +446,62 @@ pg_tzset_offset(long gmtoffset)
 }
 
 /*
+ * MEOS — one-shot cache for the auto-detected default timezone name.
+ *
+ * select_default_timezone() ultimately calls libc localtime() and tzset(),
+ * both of which read/write process-global libc state (`_tmbuf`, `tzname[]`,
+ * the loaded zone in tzset_internal). When N threads concurrently call
+ * meos_initialize() (which transitively requests the default zone), those
+ * libc calls race even though the *result* is identical for every thread.
+ *
+ * Fix: do the heavy auto-detect exactly once on the first thread, cache the
+ * resolved zone name in a process-global buffer, and let every other thread
+ * read from the cache. The system timezone is process-stable, so caching
+ * once is correct.
+ *
+ * State machine: 0 = pending, 1 = running, 2 = done.
+ */
+static _Atomic int default_tz_state = 0;
+static char default_tz_cache[TZ_STRLEN_MAX + 1] = "";
+
+static const char *
+get_cached_default_tz(void)
+{
+  int st = atomic_load_explicit(&default_tz_state, memory_order_acquire);
+  if (st == 2)
+    return default_tz_cache[0] ? default_tz_cache : NULL;
+
+  int expected = 0;
+  if (atomic_compare_exchange_strong_explicit(&default_tz_state, &expected,
+        1, memory_order_acq_rel, memory_order_acquire))
+  {
+    /* This thread won the race; do the detection. */
+    const char *tz = select_default_timezone(NULL);
+    if (tz)
+    {
+      strncpy(default_tz_cache, tz, TZ_STRLEN_MAX);
+      default_tz_cache[TZ_STRLEN_MAX] = '\0';
+    }
+    atomic_store_explicit(&default_tz_state, 2, memory_order_release);
+    return default_tz_cache[0] ? default_tz_cache : NULL;
+  }
+
+  /* Another thread is detecting; spin-wait for it to finish. The detection
+   * is bounded by the size of /usr/share/zoneinfo (a few hundred ms). */
+  while (atomic_load_explicit(&default_tz_state, memory_order_acquire) != 2)
+    /* spin */ ;
+  return default_tz_cache[0] ? default_tz_cache : NULL;
+}
+
+/*
  * Initialize timezone cache
  */
 void
 meos_initialize_timezone(const char *tz_str)
 {
   if (tz_str == NULL || strlen(tz_str) == 0)
-    /* fetch local timezone */
-    tz_str = select_default_timezone(NULL);
+    /* fetch local timezone (cached after the first call across all threads) */
+    tz_str = get_cached_default_tz();
   if (tz_str == NULL)
     /* default timezone */
     tz_str = "GMT";

--- a/postgres/timezone/pgtz.c
+++ b/postgres/timezone/pgtz.c
@@ -56,8 +56,10 @@ static void tzcache_my_destroy(tzcache_hash *tb);
 /* Function in findtimezone.c */
 extern const char *select_default_timezone(const char *share_path);
 
-/* Current session timezone (controlled by TimeZone GUC) */
-pg_tz *session_timezone = NULL;
+/* Current session timezone (per-thread; the libc/PG timezone parser is not
+ * reentrant and meos_initialize_timezone() must be called from each thread
+ * that needs to parse timestamps). */
+MEOS_TLS pg_tz *session_timezone = NULL;
 
 /* Current log timezone (controlled by log_timezone GUC) */
 // pg_tz *log_timezone = NULL; /* MEOS */
@@ -87,7 +89,10 @@ hash_string_pointer(const char *s)
 /* MEOS */
 // typedef struct {...} pg_tz_cache;
 
-static tzcache_hash *timezone_cache = NULL;
+/* Per-thread because session_timezone is per-thread: each thread may
+ * pg_tzset() a different zone and the cache must reflect what its
+ * caller has loaded. */
+static MEOS_TLS tzcache_hash *timezone_cache = NULL;
 
 static bool
 init_timezone_hashtable(void)


### PR DESCRIPTION
## Summary

Closes #404.

Adds an `MEOS_TLS` qualifier (`_Thread_local` on C11+; vendor fallbacks for older GCC, Clang, MSVC) and applies it to every mutable global in MEOS-owned code AND in the vendored postgres/postgis subtrees that the parser/timezone/init paths touch. Each thread that uses MEOS now lazily allocates its own state via the existing `meos_initialize()` / `meos_finalize()` lifecycle, with no caller-side API changes — bindings (PyMEOS, JMEOS, MEOS.js, MEOS.NET) need no updates.

Three commits, kept separate so each can be reviewed independently:

1. **MEOS-owned process state TLS** (`b0c040256`) — errno, RNGs, PROJ context, SRS cache, ways cache, session timezone.
2. **lwgeom WKT parser + GMT bootstrap TLS** (`0c7015bc4`) — flex/bison-generated parser globals, plus the lazy `gmtptr` in `localtime.c`.
3. **timezone autodetect statics TLS** (`e2c828c2e`) — `findtimezone.c` scratch buffers that the auto-detect path returns pointers into.

## What's now thread-safe

| State | File | Was | Now |
|---|---|---|---|
| `MEOS_ERR_NO` | `meos/src/temporal/error.c` | process-global | per-thread (errno-style) |
| `MEOS_GENERATION_RNG`, `MEOS_AGGREGATION_RNG`, `MEOS_GSL_INITIALIZED` | `meos/src/temporal/meos.c` | process-global | per-thread (`gsl_rng` is not internally synchronised) |
| `MEOS_PJ_CONTEXT` | `meos/src/temporal/meos.c` | process-global | per-thread (matches PROJ's documented guidance) |
| `MEOS_PROJ_CACHE` | `meos/src/geo/tspatial_transform_meos.c` | process-global | per-thread (entries own `LWPROJ*` tied to the per-thread PJ_CONTEXT) |
| `MEOS_WAYS_CACHE` | `meos/src/npoint/ways_meos.c` | process-global | per-thread |
| `session_timezone`, `timezone_cache` | `postgres/timezone/pgtz.c` + `postgres/pgtime.h` (vendored) | process-global | per-thread |
| `gmtptr` (GMT bootstrap) | `postgres/timezone/localtime.c:1363` (vendored) | process-global lazy `static` | per-thread (`MEOS_TLS`) |
| `tzdirpath`, `tz`, `resultbuf` (TZ autodetect) | `postgres/timezone/findtimezone.c` (vendored) | process-global statics | per-thread |
| **WKT lexer state** (`yy_buffer_stack`, `yy_hold_char`, `yy_n_chars`, `yyleng`, `yy_c_buf_p`, `yy_init`, `yy_start`, `yyin`/`yyout`, `yylineno`, `yytext`, `yy_last_accepting_state`/`_cpos`, `yy_flex_debug`, `wkt_yy_buf_state`) | `postgis/liblwgeom/lwin_wkt_lex.c` (flex-generated, vendored) | process-global | per-thread |
| **WKT parser state** (`global_parser_result`, `wkt_yydebug`, `wkt_yychar`, `wkt_yylval`, `wkt_yylloc`, `wkt_yynerrs`) | `postgis/liblwgeom/lwin_wkt_parse.{c,h}` + `lwin_wkt.h` (bison-generated, vendored) | process-global | per-thread |

The error-handler function pointer (`MEOS_ERROR_HANDLER`) is **deliberately left process-global** — install once before spawning workers. This matches the GEOS / OpenSSL / libxml2 convention.

## Approach for vendored upstream code

Follows the existing `/* MEOS */`-marker convention used throughout `postgres/` and `postgis/` (e.g. `pgtz.c`, `snprintf.c`, `simplehash.h`, `lwgeom_geos.c`). Every modified static is annotated `/* MEOS: thread-local — see issue #404 */` so the changes remain visible after future upstream syncs.

The `.l` and `.y` sources (`lwin_wkt_lex.l`, `lwin_wkt_parse.y`) carry matching `/* MEOS */` comments pointing at `%option reentrant` + `%define api.pure full` as the canonical fix on regeneration. Until that regeneration happens, the committed `.c` files keep the `MEOS_TLS` qualifiers.

## What changed (file-by-file)

- **New** `meos/include/meos_tls.h` — standalone tiny header defining the `MEOS_TLS` macro. Standalone so vendored PostgreSQL/PostGIS headers can pick it up without circular-including `meos.h` via `utils/timestamp.h`.
- **New** `meos/test/threaded_test.c` — pthreads smoke test. Each worker runs the full lifecycle: `meos_initialize()` → concurrent WKT-parse hot loop with read-only queries → thread-unique `meos_errno` round-trip → `meos_finalize()`.
- **Modified** `meos/include/meos.h` — pulls in `meos_tls.h`; adds a multithreading section to the init/finalize doxygen block stating the contract.
- **Modified** `meos/src/temporal/{error,meos}.c`, `meos/src/geo/tspatial_transform_meos.c`, `meos/src/npoint/ways_meos.c` — `MEOS_TLS` applied to MEOS-owned state. `MEOS_PJ_CONTEXT` and `MEOS_PROJ_CACHE` are also made `static` since they were unintentionally external.
- **Modified** `postgres/{pgtime.h,timezone/pgtz.c,timezone/localtime.c,timezone/findtimezone.c}` — `extern MEOS_TLS pg_tz *session_timezone` (declaration + definition kept in sync), `static MEOS_TLS tzcache_hash *timezone_cache`, `gmtptr`, `tzdirpath`, `pg_load_tz`'s `tz`, `identify_system_timezone`'s `resultbuf`.
- **Modified** `postgis/liblwgeom/{lwin_wkt_lex.c,lwin_wkt_parse.c,lwin_wkt_parse.h,lwin_wkt.h,lwin_wkt_lex.l,lwin_wkt_parse.y}` — flex/bison parser globals tagged `MEOS_TLS`; `.l`/`.y` source files annotated for future regeneration.
- **Modified** `postgres/CMakeLists.txt`, `postgis/CMakeLists.txt`, `meos/CMakeLists.txt` — include path and install rule for `meos_tls.h`.

## Test plan

- [x] MEOS-only debug build clean: `cmake -DMEOS=1 -DCMAKE_BUILD_TYPE=Debug && make -j4`.
- [x] Full PG-extension debug build clean.
- [x] Existing test suite unchanged: 7 ctest failures (textset quoting in `001_set`, `029_ttext_textfuncs`, etc.) reproduce identically on raw `origin/master` (verified via baseline worktree). Not introduced by this PR.
- [x] **Concurrent stress: 16 threads × 20,000 iterations × 5 repeats — 0 errors reliably**, exercising the full per-thread lifecycle including WKT parsing of unique inputs, SRID lookups, and `meos_initialize()`/`meos_finalize()` per worker.
- [ ] TSan run in CI (local TSan vs ASLR mismatch on this machine; push will exercise it on the GH runners).

## Compatibility note for #513 (Windows)

Native MSVC TLS support uses `__declspec(thread)` via the `MEOS_TLS` macro; pthread is only needed by the smoke test, not by the library itself. The diff is kept focused (~12 files of `MEOS_TLS` plumbing) so it composes cleanly with the Windows MEOS work in #513 / #812 regardless of merge order.
