### PR TITLE
fix(meos.h): include <stddef.h> for size_t

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -37,6 +37,7 @@
 
 /* C */
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 /* PostgreSQL */
 #if MEOS


### PR DESCRIPTION
## Summary

`meos.h` declares dozens of `*_as_wkb`, `*_from_wkb`, `*_as_hexwkb` prototypes that take or return `size_t *`, but only includes `<stdbool.h>` and `<stdint.h>`. PostgreSQL transitively pulls `<stddef.h>` in via `postgres.h`, which masks the issue inside the extension build. A non-PG consumer compiling against the **installed** public headers (e.g. MobilityDuck via vcpkg, or any plain C / C++ binding) hits ~15 `unknown type name 'size_t'` errors at the first WKB declaration unless it manually `#include <stddef.h>` ahead of `meos.h`.

This adds `<stddef.h>` to the C section of the header — a one-line fix.

## Test plan

- [x] In-tree build of the MEOS library still green.
- [x] Installed `libmeos` to a test prefix and compiled a standalone consumer whose only include is `<meos.h>` (no manual `<stddef.h>`); previously failed with ~15 `size_t` errors, now compiles, links, and runs.
- [ ] CI passes on this PR.
