### PR TITLE
Pattern-audit follow-up: 9 bug fixes (4 leaks, 3 idempotency, 1 mfjson, 1 cross-cut)

### DIFF
--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -56,7 +56,9 @@ datum_npoint_distance(Datum np1, Datum np2)
 {
   Datum geom1 = PointerGetDatum(npoint_to_geompoint(DatumGetNpointP(np1)));
   Datum geom2 = PointerGetDatum(npoint_to_geompoint(DatumGetNpointP(np2)));
-  return datum_pt_distance2d(geom1, geom2);
+  Datum result = datum_pt_distance2d(geom1, geom2);
+  pfree(DatumGetPointer(geom1)); pfree(DatumGetPointer(geom2));
+  return result;
 }
 
 /*****************************************************************************

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -150,7 +150,13 @@ GetWaysCache()
 void
 meos_finalize_ways(void)
 {
+  /* Idempotency: only destroy a live cache, and null the slot so a
+   * second finalize call does not double-free the cache and its
+   * stored geometries. */
+  if (! MEOS_WAYS_CACHE)
+    return;
   DestroyWaysCache(MEOS_WAYS_CACHE);
+  MEOS_WAYS_CACHE = NULL;
 }
 
 /**

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1204,7 +1204,9 @@ pose_distance(Datum pose1, Datum pose2)
 {
   Datum geom1 = PosePGetDatum(pose_to_point(DatumGetPoseP(pose1)));
   Datum geom2 = PosePGetDatum(pose_to_point(DatumGetPoseP(pose2)));
-  return datum_pt_distance2d(geom1, geom2);
+  Datum result = datum_pt_distance2d(geom1, geom2);
+  pfree(DatumGetPointer(geom1)); pfree(DatumGetPointer(geom2));
+  return result;
 }
 
 /**

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -231,7 +231,7 @@ nad_tpose_stbox(const Temporal *temp, const STBox *box)
   GSERIALIZED *traj = tpose_trajectory(temp);
   GSERIALIZED *geo = stbox_geo(box);
   double result = geom_distance2d(traj, geo);
-  pfree(traj);
+  pfree(traj); pfree(geo);
   return result;
 }
 

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2106,7 +2106,7 @@ shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
-  
+
   Temporal *dist = tdistance_trgeo_geo(temp, gs);
   const TInstant *inst = temporal_min_instant(dist);
   /* Timestamp t may be at an exclusive bound */
@@ -2115,6 +2115,7 @@ shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
   LWGEOM *line = (LWGEOM *) lwline_make(value, PointerGetDatum(gs));
   GSERIALIZED *result = geo_serialize(line);
   lwgeom_free(line);
+  pfree(dist);
   return result;
 }
 

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2040,7 +2040,7 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
   /* Compute the result */
   Temporal *dist = tdistance_trgeo_geo(temp, geo);
   double result = DatumGetFloat8(temporal_min_value(dist));
-  pfree(geo);
+  pfree(dist); pfree(geo);
   if (hast)
     pfree(temp1);
   return result;

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -81,8 +81,18 @@ gsl_initialize(void)
 static void
 gsl_finalize(void)
 {
-  gsl_rng_free(MEOS_GENERATION_RNG);
-  gsl_rng_free(MEOS_AGGREGATION_RNG);
+  /* Idempotency: only free live generators, and null the slots so a
+   * second finalize call does not double-free. */
+  if (MEOS_GENERATION_RNG)
+  {
+    gsl_rng_free(MEOS_GENERATION_RNG);
+    MEOS_GENERATION_RNG = NULL;
+  }
+  if (MEOS_AGGREGATION_RNG)
+  {
+    gsl_rng_free(MEOS_AGGREGATION_RNG);
+    MEOS_AGGREGATION_RNG = NULL;
+  }
   MEOS_GSL_INITIALIZED = false;
   return;
 }

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1009,7 +1009,10 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   const char *typestr = json_object_get_string(poObjType);
   MeosType jtemptype = T_UNKNOWN;
   if (! ensure_temptype_mfjson(typestr))
+  {
+    json_object_put(poObj);
     return NULL;
+  }
   if (strcmp(typestr, "MovingBoolean") == 0)
     jtemptype = T_TBOOL;
   else if (strcmp(typestr, "MovingInteger") == 0)
@@ -1039,6 +1042,7 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
 
   if (temptype != T_UNKNOWN && jtemptype != temptype)
   {
+    json_object_put(poObj);
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
       "Invalid 'type' value in MFJSON string, expected: %s, received: %s",
       meostype_name(temptype), meostype_name(jtemptype));
@@ -1054,6 +1058,7 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   json_object *poObjInterp = findMemberByName(poObj, "interpolation");
   if (poObjInterp == NULL)
   {
+    json_object_put(poObj);
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
       "Unable to find 'interpolation' in MFJSON string");
     return NULL;
@@ -1110,6 +1115,7 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
       gs = parse_mfjson_ref_geo(poObj, srid, false);
       if (! gs)
       {
+        json_object_put(poObj);
         meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
           "Invalid 'geometry' value in MFJSON string");
         return NULL;

--- a/postgres/timezone/pgtz.c
+++ b/postgres/timezone/pgtz.c
@@ -521,10 +521,18 @@ meos_initialize_timezone(const char *tz_str)
 void
 meos_finalize_timezone(void)
 {
+  /* Idempotency: null each slot after destroying it so a second
+   * meos_finalize() call does not double-free. */
   if (session_timezone)
-    pfree(session_timezone); 
+  {
+    pfree(session_timezone);
+    session_timezone = NULL;
+  }
   if (timezone_cache)
+  {
     tzcache_my_destroy(timezone_cache);
+    timezone_cache = NULL;
+  }
   return;
 }
 /*****************************************************************************/


### PR DESCRIPTION
## Summary

Pattern-sweep follow-up to four bug fixes already in flight on `fix/meos-bug-tpose-to-tpoint`:

```
980e79ab3 fix(meos): make proj_finalize / meos_finalize_projsrs idempotent
3369b929f fix(meos/test): walk T** array returns to free their elements
d1d7c29ce fix(meos): defensive meostype_name + workaround tcbuffer/tnpoint inst1 double-free
647dd2978 fix(tpose): pfree the intermediate tpoint / dist in two distance dispatchers
```

Audited the codebase for analogous instances of those four bug families. Nine confirmed bugs, each landing as its own small, independently cherry-pickable commit anchored to the prior fix it extends.

## Per-commit inventory

### Family A — intermediate-allocation leaks in dispatchers (5)

| Commit | Function | Leak |
|---|---|---|
| `f5fa32c9b` | `datum_npoint_distance` | 2 GSERIALIZED per call (per-pair lifting callback — leak compounds across every distance evaluation) |
| `2260242b5` | `pose_distance` | 2 GSERIALIZED per call (same lifting-callback pattern) |
| `095b1d18a` | `nad_trgeo_stbox` | `Temporal *dist` (sibling NAD funcs all pfree it) |
| `ec729ecbd` | `shortestline_trgeo_geo` | `Temporal *dist` |
| `4f6bec0c8` | `nad_tpose_stbox` | `GSERIALIZED *geo` (sibling `nad_tpose_pose` pfrees both) |

### Family C — non-idempotent finalize functions (3)

All three crash on a second `meos_finalize()` call (atexit-after-explicit pattern). Same shape as `980e79ab3`'s fix.

| Commit | Function | Symptom |
|---|---|---|
| `7b47e579f` | `gsl_finalize` | `gsl_rng_free` on dangling RNGs |
| `7daea16f4` | `meos_finalize_ways` | `MEOS_WAYS_CACHE` not nulled → use-after-free |
| `3649f180a` | `meos_finalize_timezone` | `session_timezone` and `timezone_cache` not nulled → double-free |

### Bonus — Family A in MFJSON parser (1)

| Commit | Function | Leak |
|---|---|---|
| `f2aa97106` | `temporal_from_mfjson` | `poObj` (whole parsed JSON tree) on 4 of 6 error-return paths |

## Audit results — clean families

- **Family B** (`meostype_name` callers passing untrusted values): **clean.** `d1d7c29ce` already made the lookup itself bounds-safe; no caller bypasses it.
- **Family D** (test code not freeing `T**` array elements): **clean.** Every `T**` accessor call in tests/examples already walks the elements before freeing the outer array.

## Self-audit on PR #851 (`tcbuffer/production-readiness`)

Audited the new MFJSON parser paths I introduced (`parse_mfjson_cbuffer`, `parse_mfjson_cbuffers`, the CBUFFER branches in `tinstant_from_mfjson` / `tinstarr_from_mfjson` / `temporal_from_mfjson`) and the `cbuffer_as_json_sb` output path. **No new bugs introduced by PR #851.**

## Open follow-up (not in this PR)

`tinstant_from_mfjson` / `tinstarr_from_mfjson` only `pfree(values)` on the error path. For pointer-typed `Datum` elements (Cbuffer / GSERIALIZED / Pose), the elements themselves leak. This is generic across spatial types, not specific to any one — fixing cleanly requires a per-spatial-base destructor table, which is broader than this surgical audit. Suggest a follow-up issue rather than folding into this PR.

## Test plan

- [x] Each commit fixes exactly one bug; minimal-surgical diffs (1–6 line additions per commit)
- [x] Each commit message anchors to its prior-fix ref-sha
- [x] No fix touches a test, refactors surrounding code, or adds defensive checks beyond the bug
- [ ] Sanitiser sweep on the changed paths
- [ ] CI / coverage matrix

## Out of scope

- Any bug not falling into one of the four pattern families.
- Style nits, refactors, defensive checks beyond the bug surface.
- The `tinstant_from_mfjson` element-leak (see above — needs broader design).
