### PR TITLE
fix(meos): idempotent finalize functions and pfree intermediate results in distance paths

### DIFF
--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -174,15 +174,18 @@ void
 meos_finalize_projsrs(void)
 {
   MEOSPROJSRSCache *cache = MEOS_PROJ_CACHE;
-  if (cache)
+  /* Idempotency: bail when no cache is live, and null the global slot after
+   * release so a second finalize call (or finalize before any init) does not
+   * pfree(NULL) / double-free. */
+  if (! cache)
+    return;
+  for (uint32_t i = 0; i < cache->PROJSRSCacheCount; i++)
   {
-    for (uint32_t i = 0; i < cache->PROJSRSCacheCount; i++)
-    {
-      if (cache->MEOSPROJSRSCache[i].projection)
-        PROJSRSDestroyPJ(cache->MEOSPROJSRSCache[i].projection);
-    }
+    if (cache->MEOSPROJSRSCache[i].projection)
+      PROJSRSDestroyPJ(cache->MEOSPROJSRSCache[i].projection);
   }
   pfree(cache);
+  MEOS_PROJ_CACHE = NULL;
   return;
 }
 

--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -56,7 +56,9 @@ datum_npoint_distance(Datum np1, Datum np2)
 {
   Datum geom1 = PointerGetDatum(npoint_to_geompoint(DatumGetNpointP(np1)));
   Datum geom2 = PointerGetDatum(npoint_to_geompoint(DatumGetNpointP(np2)));
-  return datum_pt_distance2d(geom1, geom2);
+  Datum result = datum_pt_distance2d(geom1, geom2);
+  pfree(DatumGetPointer(geom1)); pfree(DatumGetPointer(geom2));
+  return result;
 }
 
 /*****************************************************************************

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -150,7 +150,13 @@ GetWaysCache()
 void
 meos_finalize_ways(void)
 {
+  /* Idempotency: only destroy a live cache, and null the slot so a
+   * second finalize call does not double-free the cache and its
+   * stored geometries. */
+  if (! MEOS_WAYS_CACHE)
+    return;
   DestroyWaysCache(MEOS_WAYS_CACHE);
+  MEOS_WAYS_CACHE = NULL;
 }
 
 /**

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1204,7 +1204,9 @@ pose_distance(Datum pose1, Datum pose2)
 {
   Datum geom1 = PosePGetDatum(pose_to_point(DatumGetPoseP(pose1)));
   Datum geom2 = PosePGetDatum(pose_to_point(DatumGetPoseP(pose2)));
-  return datum_pt_distance2d(geom1, geom2);
+  Datum result = datum_pt_distance2d(geom1, geom2);
+  pfree(DatumGetPointer(geom1)); pfree(DatumGetPointer(geom2));
+  return result;
 }
 
 /**

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -231,7 +231,7 @@ nad_tpose_stbox(const Temporal *temp, const STBox *box)
   GSERIALIZED *traj = tpose_trajectory(temp);
   GSERIALIZED *geo = stbox_geo(box);
   double result = geom_distance2d(traj, geo);
-  pfree(traj);
+  pfree(traj); pfree(geo);
   return result;
 }
 

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2106,7 +2106,7 @@ shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
-  
+
   Temporal *dist = tdistance_trgeo_geo(temp, gs);
   const TInstant *inst = temporal_min_instant(dist);
   /* Timestamp t may be at an exclusive bound */
@@ -2115,6 +2115,7 @@ shortestline_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
   LWGEOM *line = (LWGEOM *) lwline_make(value, PointerGetDatum(gs));
   GSERIALIZED *result = geo_serialize(line);
   lwgeom_free(line);
+  pfree(dist);
   return result;
 }
 

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2040,7 +2040,7 @@ nad_trgeo_stbox(const Temporal *temp, const STBox *box)
   /* Compute the result */
   Temporal *dist = tdistance_trgeo_geo(temp, geo);
   double result = DatumGetFloat8(temporal_min_value(dist));
-  pfree(geo);
+  pfree(dist); pfree(geo);
   if (hast)
     pfree(temp1);
   return result;

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -148,6 +148,11 @@ proj_initialize(void)
 static void
 proj_finalize(void)
 {
+  /* Idempotency: skip when the per-thread context is already gone. PROJ
+   * documents proj_context_destroy(NULL) as destroying the *default* PROJ
+   * context, which is not what we want on a second finalize call. */
+  if (! MEOS_PJ_CONTEXT)
+    return;
   proj_context_destroy(MEOS_PJ_CONTEXT);
   MEOS_PJ_CONTEXT = NULL;
   return;

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -81,8 +81,18 @@ gsl_initialize(void)
 static void
 gsl_finalize(void)
 {
-  gsl_rng_free(MEOS_GENERATION_RNG);
-  gsl_rng_free(MEOS_AGGREGATION_RNG);
+  /* Idempotency: only free live generators, and null the slots so a
+   * second finalize call does not double-free. */
+  if (MEOS_GENERATION_RNG)
+  {
+    gsl_rng_free(MEOS_GENERATION_RNG);
+    MEOS_GENERATION_RNG = NULL;
+  }
+  if (MEOS_AGGREGATION_RNG)
+  {
+    gsl_rng_free(MEOS_AGGREGATION_RNG);
+    MEOS_AGGREGATION_RNG = NULL;
+  }
   MEOS_GSL_INITIALIZED = false;
   return;
 }

--- a/postgres/timezone/pgtz.c
+++ b/postgres/timezone/pgtz.c
@@ -521,10 +521,18 @@ meos_initialize_timezone(const char *tz_str)
 void
 meos_finalize_timezone(void)
 {
+  /* Idempotency: null each slot after destroying it so a second
+   * meos_finalize() call does not double-free. */
   if (session_timezone)
-    pfree(session_timezone); 
+  {
+    pfree(session_timezone);
+    session_timezone = NULL;
+  }
   if (timezone_cache)
+  {
     tzcache_my_destroy(timezone_cache);
+    timezone_cache = NULL;
+  }
   return;
 }
 /*****************************************************************************/


### PR DESCRIPTION
## Summary

- Make `meos_finalize_projsrs`, `meos_finalize_timezone`, `proj_finalize`, `meos_finalize_ways`, and `gsl_finalize` idempotent (safe to call more than once, no double-free or use-after-free)
- `pfree` intermediate geometry/datum allocations in `pose_distance`, `nad_tpose_stbox`, `nad_trgeo_stbox`, `shortestline_trgeo_geo`, and `datum_npoint_distance` that were leaked on every call

These fixes were found by a valgrind sweep over the MEOS smoke-test suite.  Each commit is self-contained.

## Test plan

- [ ] CI green (all existing regression suites pass; no new valgrind "definitely lost" reports for the affected code paths)
- [ ] Idempotent: calling `meos_finalize()` twice must not crash (verified manually with a test harness)
