### PR TITLE
fix(temporal): skiplist ownership, aggregate leaks, and heap-buffer-overflow in tinstant_make

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on ..
+          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DCBUFFER=on ..
           make -j $(nproc)
           sudo make install
 
@@ -65,6 +65,8 @@ jobs:
           ./geo_test
           gcc -Wall -g -I/usr/local/include -o npoint_test npoint_test.c -L/usr/local/lib -lmeos
           ./npoint_test
+          gcc -Wall -g -I/usr/local/include -o cbuffer_test cbuffer_test.c -L/usr/local/lib -lmeos
+          ./cbuffer_test
 
   threaded:
     name: Thread-safety (TSan)

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -3301,10 +3301,12 @@ mrr_distance_geos(GEOSGeometry *geom, bool geodetic)
         GEOSGeom_destroy(pt2);
         break;
       default:
+        GEOSGeom_destroy(mrr_geom);
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "Invalid geometry type for Minimum Rotated Rectangle");
         return -1.0;
     }
+    GEOSGeom_destroy(mrr_geom);
   }
   return result;
 }

--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -718,6 +718,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
       {
         void *newkey = palloc(list->key_size);
         memcpy(newkey, keys[i], list->key_size);
+        newelem->key = newkey;
       }
       else
         newelem->key = NULL;

--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -441,7 +441,7 @@ keyval_skiplist_common(SkipList *list, void **keys, void **values, int count,
   void *max_value = values[count - 1];
 
   /* Find the list values that are strictly before the span of new values */
-  memset(update, 0, sizeof(&update));
+  memset(update, 0, sizeof(int) * SKIPLIST_MAXLEVEL);
   int height = list->elems[0].height;
   SkipListElem *elem = &list->elems[0];
   int cur = 0;

--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -490,6 +490,9 @@ keyval_skiplist_merge(SkipList *list, void **keys1, void **values1,
   int count1, void **keys2, void **values2, int count2, int *newcount,
   void ***newkeys, void ***tofree, int *nfree)
 {
+  /* Convention: result, *newkeys, and *tofree are three distinct allocations.
+   * The caller (skiplist_splice) frees the merged elements + the *tofree shell
+   * via pfree_array, then frees the result and *newkeys shells separately. */
   void **result = palloc(sizeof(void *) * (count1 + count2));
   void **newkeys1 = palloc(sizeof(void *) * (count1 + count2));
   void **tofree1 = palloc(sizeof(void *) * Max(count1, count2));
@@ -589,6 +592,12 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
   /* Array keeping the new aggregated values that must be freed */
   void **tofree = NULL;
   int nfree = 0;
+  /* Shells returned by the merge helpers; freed after the insertion loop.
+   * The merge helpers guarantee these are distinct allocations from tofree,
+   * so we can pfree them unconditionally without double-freeing the elements
+   * (which are released via pfree_array(tofree, nfree)). */
+  void **newvalues_shell = NULL;
+  void **newkeys_shell = NULL;
 
   /* Remove from the list the elements that overlap with the new elements
    * (if any) and compute their aggregation */
@@ -671,6 +680,9 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
       keys = newkeys;
       values = newvalues;
       count = newcount;
+      /* Stash the merge-helper shells for release after the insertion loop. */
+      newvalues_shell = newvalues;
+      newkeys_shell = newkeys;
     }
   }
 
@@ -732,6 +744,13 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
   /* Free memory */
   if (spliced_count != 0)
     pfree_array((void **) tofree, nfree);
+  /* Release the merge-helper pointer-array shells. These are allocated by
+   * temporal_skiplist_merge / keyval_skiplist_merge as separate allocations
+   * from tofree, so freeing them here does not double-free the elements. */
+  if (newvalues_shell)
+    pfree(newvalues_shell);
+  if (newkeys_shell)
+    pfree(newkeys_shell);
   return;
 }
 

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -395,7 +395,10 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
   int count2, datum_func2 func, int *newcount, void ***tofree, int *nfree)
 {
   TInstant **result = palloc(sizeof(TInstant *) * (count1 + count2));
-  void **tofree1 = palloc(sizeof(TInstant *) * Max(count1, count2));
+  /* Every result entry is a freshly-allocated copy/make and is owned by this
+   * function (the skiplist insertion at the call site makes its own copy via
+   * temporal_copy). Size tofree1 to the worst case: count1 + count2. */
+  void **tofree1 = palloc(sizeof(TInstant *) * (count1 + count2));
   int i = 0, j = 0, count = 0, nfree1 = 0;
   while (i < count1 && j < count2)
   {
@@ -437,6 +440,8 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
     else if (cmp < 0)
     {
       result[count++] = tinstant_copy(inst1);
+      if (tofree)
+        tofree1[nfree1++] = result[count - 1];
       i++;
     }
     else

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -103,21 +103,28 @@ datum_max_float8(Datum l, Datum r)
 }
 
 /**
- * @brief Return the minimum value of the two arguments
+ * @brief Return a fresh copy of the minimum value of the two arguments
+ * @note Returns a freshly-allocated Datum so that callers can always free the
+ * result without aliasing into one of the inputs. Required by the @p tagg
+ * paths, which free the per-element result Datum after copying it into a
+ * @p TInstant.
  */
  Datum
 datum_min_text(Datum l, Datum r)
 {
-  return text_cmp(DatumGetTextP(l), DatumGetTextP(r)) < 0 ? l : r;
+  Datum chosen = text_cmp(DatumGetTextP(l), DatumGetTextP(r)) < 0 ? l : r;
+  return datum_copy(chosen, T_TEXT);
 }
 
 /**
- * @brief Return the maximum value of the two arguments
+ * @brief Return a fresh copy of the maximum value of the two arguments
+ * @note See @ref datum_min_text for the always-fresh ownership contract.
  */
 Datum
 datum_max_text(Datum l, Datum r)
 {
-  return text_cmp(DatumGetTextP(l), DatumGetTextP(r)) > 0 ? l : r;
+  Datum chosen = text_cmp(DatumGetTextP(l), DatumGetTextP(r)) > 0 ? l : r;
+  return datum_copy(chosen, T_TEXT);
 }
 
 /**
@@ -399,8 +406,13 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
     {
       if (func)
       {
-        result[count++] = tinstant_make(func(tinstant_value_p(inst1),
-          tinstant_value_p(inst2)), inst1->temptype, inst1->t);
+        /* All @p datum_func2 implementations passed here return a freshly
+         * allocated Datum (or by-value); aliasing variants are wrapped at
+         * source. @p tinstant_make copies the value, so the result Datum can
+         * be released right after construction. */
+        Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
+        result[count++] = tinstant_make(value, inst1->temptype, inst1->t);
+        DATUM_FREE(value, temptype_basetype(inst1->temptype));
         if (tofree)
           tofree1[nfree1++] = result[count - 1];
       }
@@ -543,16 +555,20 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
   TSequence *syncseq1, *syncseq2;
   synchronize_tsequence_tsequence(seq1, seq2, &syncseq1, &syncseq2, crossings);
   TInstant **instants = palloc(sizeof(TInstant *) * syncseq1->count);
-  // MeosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
   for (int i = 0; i < syncseq1->count; i++)
   {
     const TInstant *inst1 = TSEQUENCE_INST_N(syncseq1, i);
     const TInstant *inst2 = TSEQUENCE_INST_N(syncseq2, i);
     if (func)
     {
+      /* All @p datum_func2 implementations passed here return a freshly
+       * allocated Datum (or by-value); aliasing variants are wrapped at
+       * source. @p tinstant_make copies the value, so the result Datum can
+       * be released right after construction. */
       Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
       instants[i] = tinstant_make(value, seq1->temptype, inst1->t);
-      // DATUM_FREE(value, basetype); // TODO
+      DATUM_FREE(value, basetype);
     }
     else
     {

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -293,7 +293,7 @@ temporal_skiplist_common(SkipList *list, void **values, int count,
   }
 
   /* Find the list values that are strictly before the span of new values */
-  memset(update, 0, sizeof(&update));
+  memset(update, 0, sizeof(int) * SKIPLIST_MAXLEVEL);
   int height = list->elems[0].height;
   SkipListElem *elem = &list->elems[0];
   int cur = 0;

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -346,6 +346,10 @@ temporal_skiplist_merge(void **spliced, int spliced_count, void **values,
   int count, datum_func2 func, bool crossings, int *newcount, void ***tofree,
   int *nfree)
 {
+  /* Convention: *tofree must be a distinct allocation from the returned
+   * newvalues shell. The caller (skiplist_splice) frees the elements + the
+   * tofree shell via pfree_array, then frees the newvalues shell separately.
+   * Aliasing the two would cause skiplist_splice to either leak or double-free. */
   *newcount = 0;
   void **newvalues;
   uint8 subtype = ((Temporal *) values[0])->subtype;
@@ -356,7 +360,12 @@ temporal_skiplist_merge(void **spliced, int spliced_count, void **values,
   {
     newvalues = (void **) tsequence_tagg((TSequence **) spliced, spliced_count,
       (TSequence **) values, count, func, crossings, newcount);
-    *tofree = newvalues;
+    /* Duplicate the pointer-array shell so *tofree is distinct from
+     * newvalues; both shells then hold the same TSequence* element pointers,
+     * which the elements-free pass in skiplist_splice will release exactly once. */
+    void **tofree1 = palloc(sizeof(TSequence *) * (*newcount));
+    memcpy(tofree1, newvalues, sizeof(TSequence *) * (*newcount));
+    *tofree = tofree1;
     *nfree = *newcount;
   }
   return newvalues;

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -433,6 +433,8 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
         if (tinstant_eq(inst1, inst2))
         {
           result[count++] = tinstant_copy(inst1);
+          if (tofree)
+            tofree1[nfree1++] = result[count - 1];
         }
         else
         {

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -440,6 +440,22 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
           meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
             "The temporal values have different value at their common timestamp %s",
             t1);
+          /* Mirror the caller's pfree_array teardown: when tofree was
+           * requested, every result[] entry was tracked in tofree1; otherwise
+           * walk result[] directly. Either way, release the partially built
+           * TInstants and both pointer-array shells before bailing. */
+          if (tofree)
+          {
+            for (int k = 0; k < nfree1; k++)
+              pfree(tofree1[k]);
+          }
+          else
+          {
+            for (int k = 0; k < count; k++)
+              pfree(result[k]);
+          }
+          pfree(tofree1);
+          pfree(result);
           return NULL;
         }
       }

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -1259,14 +1259,13 @@ temporal_transform_tcount(const Temporal *temp, int *count)
 SkipList *
 timestamptz_tcount_transfn(SkipList *state, TimestampTz t)
 {
+  /* Validate the existing skiplist's subtype *before* allocating instants,
+   * otherwise the early-return on subtype mismatch leaks the transform. */
+  if (state && ! ensure_same_skiplist_subtype(state, TINSTANT))
+    return NULL;
   TInstant **instants = timestamp_transform_tcount(t);
   if (! state)
     state = temporal_skiplist_make();
-  else
-  {
-    if (! ensure_same_skiplist_subtype(state, TINSTANT))
-      return NULL;
-  }
   temporal_skiplist_splice(state, (void **) instants, 1, &datum_sum_int32,
     CROSSINGS_NO);
   pfree_array((void **) instants, 1);
@@ -1290,14 +1289,13 @@ tstzset_tcount_transfn(SkipList *state, const Set *s)
   if (! ensure_set_isof_type(s, T_TSTZSET))
     return NULL;
 
+  /* Validate the existing skiplist's subtype *before* allocating instants,
+   * otherwise the early-return on subtype mismatch leaks the transform. */
+  if (state && ! ensure_same_skiplist_subtype(state, TINSTANT))
+    return NULL;
   TInstant **instants = tstzset_transform_tcount(s);
   if (! state)
     state = temporal_skiplist_make();
-  else
-  {
-    if (! ensure_same_skiplist_subtype(state, TINSTANT))
-      return NULL;
-  }
   temporal_skiplist_splice(state, (void **) instants, s->count, &datum_sum_int32,
     CROSSINGS_NO);
   pfree_array((void **) instants, s->count);
@@ -1321,14 +1319,13 @@ tstzspan_tcount_transfn(SkipList *state, const Span *s)
   if (! ensure_span_isof_type(s, T_TSTZSPAN))
     return NULL;
 
+  /* Validate the existing skiplist's subtype *before* allocating the
+   * transform, otherwise the early-return on subtype mismatch leaks it. */
+  if (state && ! ensure_same_skiplist_subtype(state, TSEQUENCE))
+    return NULL;
   TSequence *seq = tstzspan_transform_tcount(s);
   if (! state)
     state = temporal_skiplist_make();
-  else
-  {
-    if (! ensure_same_skiplist_subtype(state, TSEQUENCE))
-      return NULL;
-  }
   temporal_skiplist_splice(state, (void **) &seq, 1, &datum_sum_int32,
     CROSSINGS_NO);
   pfree(seq);
@@ -1353,14 +1350,13 @@ tstzspanset_tcount_transfn(SkipList *state, const SpanSet *ss)
   if (! ensure_spanset_isof_type(ss, T_TSTZSPANSET))
     return NULL;
 
+  /* Validate the existing skiplist's subtype *before* allocating the
+   * transform, otherwise the early-return on subtype mismatch leaks it. */
+  if (state && ! ensure_same_skiplist_subtype(state, TSEQUENCE))
+    return NULL;
   TSequence **sequences = tstzspanset_transform_tcount(ss);
   if (! state)
     state = temporal_skiplist_make();
-  else
-  {
-    if (! ensure_same_skiplist_subtype(state, TSEQUENCE))
-      return NULL;
-  }
   for (int i = 0; i < ss->count; i++)
   {
     temporal_skiplist_splice(state, (void **) &sequences[i], 1,

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -612,9 +612,15 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "The temporal values have different value at their common timestamp %s",
           t1);
+        /* Free the instants built so far in this loop (j is the loop var, not
+         * i) plus the synced sequences and any "before intersection" sequence
+         * already in sequences[0..nseqs-1]. */
         for (int j = 0; j < i; j++)
-          pfree(instants[i]);
+          pfree(instants[j]);
         pfree(instants);
+        pfree(syncseq1); pfree(syncseq2);
+        for (int j = 0; j < nseqs; j++)
+          pfree(sequences[j]);
         return -1;
       }
     }

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -220,6 +220,7 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
   size_t size = value_offset;
   /* Create the temporal instant */
   size_t value_size;
+  size_t value_copy_size;
   void *value_from;
   MeosType basetype = temptype_basetype(temptype);
   bool typbyval = basetype_byvalue(basetype);
@@ -228,6 +229,7 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
   {
     /* For base types passed by value */
     value_size = DOUBLE_PAD(sizeof(Datum));
+    value_copy_size = sizeof(Datum);
     value_from = &value;
   }
   else
@@ -235,13 +237,24 @@ tinstant_make(Datum value, MeosType temptype, TimestampTz t)
     /* For base types passed by reference */
     int16 typlen = meostype_length(basetype);
     value_from = DatumGetPointer(value);
-    value_size = (typlen != -1) ? DOUBLE_PAD((unsigned int) typlen) :
-      DOUBLE_PAD(VARSIZE(value_from));
+    if (typlen != -1)
+    {
+      value_size = DOUBLE_PAD((unsigned int) typlen);
+      value_copy_size = (unsigned int) typlen;
+    }
+    else
+    {
+      value_copy_size = VARSIZE(value_from);
+      value_size = DOUBLE_PAD(value_copy_size);
+    }
   }
   size += value_size;
   TInstant *result = palloc0(size);
   void *value_to = ((char *) result) + value_offset;
-  memcpy(value_to, value_from, value_size);
+  /* Copy only the actual value bytes; palloc0 already zeroed any DOUBLE_PAD
+   * trailing bytes in the destination, so reading past the source object
+   * (which may be a tightly-allocated varlena) is unnecessary and unsafe. */
+  memcpy(value_to, value_from, value_copy_size);
   /* Initialize fixed-size values */
   result->temptype = temptype;
   result->subtype = TINSTANT;

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -465,11 +465,17 @@ ensure_valid_tinstarr_gaps(TInstant **instants, int count, bool merge,
     if (! ensure_increasing_timestamps(instants[i - 1], instants[i], merge) ||
         ! ensure_spatial_validity((Temporal *) instants[i - 1],
           (Temporal *) instants[i]))
+    {
+      pfree(result);
       return NULL;
+    }
 #if NPOINT
     if (instants[i]->temptype == T_TNPOINT &&
         ! ensure_same_rid_tnpointinst(instants[i - 1], instants[i]))
+    {
+      pfree(result);
       return NULL;
+    }
 #endif
     /* Determine if there should be a split */
     bool split = false;


### PR DESCRIPTION
## Summary

Thirteen self-contained fixes for skiplist and aggregate code paths found by ASan/valgrind:

- **heap-buffer-overflow**: `tinstant_make` value `memcpy` used wrong size — fixed
- **skiplist ownership**: clean up `datum_func2` ownership contract in tagg paths; track `tinstant_copy` results in `tofree1`; normalise skiplist merge return convention to fix `newvalues` leak
- **aggregate leaks**: free `result` and `tofree1` on error-return in `tinstant_tagg`; track `cmp==0` eq-branch in `tofree1`; fix `newkey` assignment in `skiplist_splice`; correct `memset` size on update array in `skiplist_common`
- **geo**: destroy `GEOSMinimumRotatedRectangle` result in `mrr_distance_geos`
- **tsequence_tagg_iter**: free instants/syncs/sequences on error
- **tcount_transfn**: validate subtype before allocating transform
- **ensure_valid_tinstarr_gaps**: free splits array on validation failure
- **CI**: build MEOS with `-DCBUFFER=on` and run `cbuffer_test`

## Test plan

- [ ] CI green (all existing regression suites pass)
- [ ] ASan: no heap-buffer-overflow in `tinstant_make` value copy
- [ ] Valgrind: no new "definitely lost" in skiplist merge / tagg paths
