### PR TITLE
feat(tcbuffer): close parity gap — analytics + tile via tgeompoint composition

### DIFF
--- a/meos/include/meos_cbuffer.h
+++ b/meos/include/meos_cbuffer.h
@@ -232,6 +232,7 @@ extern Temporal *tcbuffer_make(const Temporal *tpoint, const Temporal *tfloat);
 extern Set *tcbuffer_points(const Temporal *temp);
 extern Set *tcbuffer_radius(const Temporal *temp);
 extern GSERIALIZED *tcbuffer_trav_area(const Temporal *temp, bool merge_union);
+extern GSERIALIZED *tcbuffer_convex_hull(const Temporal *temp);
 
 /*****************************************************************************
  * Conversion functions

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -692,4 +692,23 @@ tcbuffer_trav_area(const Temporal *temp, bool unary_union)
   }
 }
 
+/**
+ * @ingroup meos_cbuffer_spatial_accessor
+ * @brief Return the convex hull of the traversed area of a temporal circular buffer
+ * @param[in] temp Temporal circular buffer
+ * @return On error return NULL
+ * @csqlfn #Tcbuffer_convex_hull()
+ */
+GSERIALIZED *
+tcbuffer_convex_hull(const Temporal *temp)
+{
+  VALIDATE_TCBUFFER(temp, NULL);
+  GSERIALIZED *trav = tcbuffer_trav_area(temp, UNARY_UNION_NO);
+  if (! trav)
+    return NULL;
+  GSERIALIZED *result = geom_convex_hull(trav);
+  pfree(trav);
+  return result;
+}
+
 /*****************************************************************************/

--- a/mobilitydb/sql/cbuffer/155_tcbuffer_spatialfuncs.in.sql
+++ b/mobilitydb/sql/cbuffer/155_tcbuffer_spatialfuncs.in.sql
@@ -66,6 +66,16 @@ CREATE FUNCTION traversedArea(tcbuffer, bool DEFAULT true)
   AS 'MODULE_PATHNAME', 'Tcbuffer_traversed_area'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION centroid(tcbuffer)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Tcbuffer_to_tgeompoint'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION convexHull(tcbuffer)
+  RETURNS geometry
+  AS 'MODULE_PATHNAME', 'Tcbuffer_convex_hull'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************
  * AtGeometry and MinusGeometry
  *****************************************************************************/
@@ -90,15 +100,15 @@ CREATE FUNCTION minusGeometry(tcbuffer, geometry)
   AS 'MODULE_PATHNAME', 'Tcbuffer_minus_geom'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION atStbox(tcbuffer, stbox, bool DEFAULT TRUE)
-  -- RETURNS tcbuffer
-  -- AS 'MODULE_PATHNAME', 'Tcbuffer_at_stbox'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atStbox(tcbuffer, stbox, borderInc bool DEFAULT TRUE)
+  RETURNS tcbuffer
+  AS 'MODULE_PATHNAME', 'Tcbuffer_at_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION minusStbox(tcbuffer, stbox, bool DEFAULT TRUE)
-  -- RETURNS tcbuffer
-  -- AS 'MODULE_PATHNAME', 'Tcbuffer_minus_stbox'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusStbox(tcbuffer, stbox, borderInc bool DEFAULT TRUE)
+  RETURNS tcbuffer
+  AS 'MODULE_PATHNAME', 'Tcbuffer_minus_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/
 

--- a/mobilitydb/sql/cbuffer/167_tcbuffer_analytics.in.sql
+++ b/mobilitydb/sql/cbuffer/167_tcbuffer_analytics.in.sql
@@ -28,41 +28,50 @@
  *****************************************************************************/
 
 /**
- * @brief Temporal distance for temporal network points.
+ * @file
+ * @brief Analytic functions for temporal circular buffers
+ *
+ * All functions simplify the center-point trajectory (cast to tgeompoint),
+ * extract the surviving timestamps, and restrict the original tcbuffer to
+ * those timestamps — preserving the radius channel at each surviving instant.
  */
 
-#ifndef __TCBUFFER_SPATIALFUNCS_H__
-#define __TCBUFFER_SPATIALFUNCS_H__
-
-/* PostgreSQL */
-#include <postgres.h>
-/* MEOS */
-#include "temporal/temporal.h"
-#include "cbuffer/cbuffer.h"
-
 /*****************************************************************************/
 
-/* Traversed area functions */
+CREATE FUNCTION minDistSimplify(tcbuffer, float)
+  RETURNS tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(
+        @extschema@.minDistSimplify($1::@extschema@.tgeompoint, $2))))
+  $$;
 
-extern GSERIALIZED *tcbufferinst_trav_area(const TInstant *inst);
-extern GSERIALIZED *tcbufferseq_trav_area(const TSequence *seq);
-extern GSERIALIZED *tcbufferseqset_trav_area(const TSequenceSet *ss);
-extern GSERIALIZED *tcbuffersegm_trav_area(const TInstant *inst1,
-  const TInstant *inst2);
+CREATE FUNCTION minTimeDeltaSimplify(tcbuffer, interval)
+  RETURNS tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(
+        @extschema@.minTimeDeltaSimplify($1::@extschema@.tgeompoint, $2))))
+  $$;
 
-/* Spatial accessor functions */
+CREATE FUNCTION maxDistSimplify(tcbuffer, float, boolean DEFAULT TRUE)
+  RETURNS tcbuffer
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(
+        @extschema@.maxDistSimplify($1::@extschema@.tgeompoint, $2, $3))))
+  $$;
 
-extern GSERIALIZED *tcbuffer_convex_hull(const Temporal *temp);
-
-/* Restriction functions */
-
-extern Temporal *tcbuffer_restrict_cbuffer(const Temporal *temp,
-  const Cbuffer *cb, bool atfunc);
-extern Temporal *tcbuffer_restrict_stbox(const Temporal *temp,
- const STBox *box, bool border_inc, bool atfunc);
-extern Temporal *tcbuffer_restrict_geom(const Temporal *temp,
-  const GSERIALIZED *gs, bool atfunc);
+CREATE FUNCTION douglasPeuckerSimplify(tcbuffer, float, boolean DEFAULT TRUE)
+  RETURNS tcbuffer
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(
+        @extschema@.douglasPeuckerSimplify($1::@extschema@.tgeompoint, $2, $3))))
+  $$;
 
 /*****************************************************************************/
-
-#endif /* __TCBUFFER_SPATIALFUNCS_H__ */

--- a/mobilitydb/sql/cbuffer/168_tcbuffer_tile.in.sql
+++ b/mobilitydb/sql/cbuffer/168_tcbuffer_tile.in.sql
@@ -1,0 +1,169 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Tile functions for temporal circular buffers
+ *
+ * All functions delegate to the tgeometry equivalents by casting
+ * tcbuffer → tgeompoint → tgeometry for the spatial computation.
+ * Split functions reconstruct the tcbuffer fragment by restricting the
+ * original tcbuffer to the time extent of each returned tgeometry tile,
+ * preserving the radius channel at each surviving instant.
+ */
+
+/******************************************************************************
+ * Box functions
+ ******************************************************************************/
+
+CREATE FUNCTION spaceBoxes(tcbuffer, xsize float, ysize float, zsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceBoxes(tcbuffer, xsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes($1, $2, $2, $2, $3, $4, $5)
+  $$;
+CREATE FUNCTION spaceBoxes(tcbuffer, xsize float, ysize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes($1, $2, $3, $2, $4, $5, $6)
+  $$;
+
+CREATE FUNCTION timeBoxes(tcbuffer, interval,
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.timeBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5)
+  $$;
+
+CREATE FUNCTION spaceTimeBoxes(tcbuffer, xsize float, ysize float,
+    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7, $8, $9)
+  $$;
+CREATE FUNCTION spaceTimeBoxes(tcbuffer, xsize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes($1, $2, $2, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceTimeBoxes(tcbuffer, xsize float, ysize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes($1, $2, $3, $2, $4, $5, $6, $7, $8)
+  $$;
+
+/******************************************************************************
+ * Split functions
+ ******************************************************************************/
+
+CREATE TYPE point_tcbuffer AS (
+  point geometry,
+  tcbuffer tcbuffer
+);
+
+CREATE FUNCTION spaceSplit(tcbuffer, xsize float, ysize float, zsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT r.point, @extschema@.atTime($1, @extschema@.getTime(r.tgeo))
+    FROM @extschema@.spaceSplit(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7) AS r
+  $$;
+CREATE FUNCTION spaceSplit(tcbuffer, size float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4, $5)
+  $$;
+CREATE FUNCTION spaceSplit(tcbuffer, sizeX float, sizeY float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5, $6)
+  $$;
+
+CREATE TYPE point_time_tcbuffer AS (
+  point geometry,
+  time timestamptz,
+  tcbuffer tcbuffer
+);
+
+CREATE FUNCTION spaceTimeSplit(tcbuffer, xsize float, ysize float,
+    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT r.point, r.time, @extschema@.atTime($1, @extschema@.getTime(r.tgeo))
+    FROM @extschema@.spaceTimeSplit(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7, $8, $9) AS r
+  $$;
+CREATE FUNCTION spaceTimeSplit(tcbuffer, size float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeSplit($1, $2, $2, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceTimeSplit(tcbuffer, xsize float, ysize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tcbuffer
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeSplit($1, $2, $3, $2, $4, $5, $6, $7, $8)
+  $$;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/cbuffer/CMakeLists.txt
+++ b/mobilitydb/sql/cbuffer/CMakeLists.txt
@@ -12,6 +12,8 @@ SET(LOCAL_FILES
   162_tcbuffer_spatialrels
   164_tcbuffer_tempspatialrels
   166_tcbuffer_indexes
+  167_tcbuffer_analytics
+  168_tcbuffer_tile
   )
 
 foreach (f ${LOCAL_FILES})

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -300,6 +300,24 @@ Tcbuffer_traversed_area(PG_FUNCTION_ARGS)
   PG_RETURN_TEMPORAL_P(result);
 }
 
+PGDLLEXPORT Datum Tcbuffer_convex_hull(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tcbuffer_convex_hull);
+/**
+ * @ingroup mobilitydb_cbuffer_accessor
+ * @brief Return the convex hull of the traversed area of a temporal circular buffer
+ * @sqlfn convexHull()
+ */
+Datum
+Tcbuffer_convex_hull(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  GSERIALIZED *result = tcbuffer_convex_hull(temp);
+  PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
 /*****************************************************************************
  * Restriction functions
  *****************************************************************************/
@@ -362,7 +380,8 @@ Tcbuffer_restrict_stbox(FunctionCallInfo fcinfo, bool atfunc)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   STBox *box = PG_GETARG_STBOX_P(1);
-  Temporal *result = tcbuffer_restrict_stbox(temp, box, false, atfunc);
+  bool border_inc = PG_GETARG_BOOL(2);
+  Temporal *result = tcbuffer_restrict_stbox(temp, box, border_inc, atfunc);
   PG_FREE_IF_COPY(temp, 0);
   if (! result)
     PG_RETURN_NULL();
@@ -372,10 +391,9 @@ Tcbuffer_restrict_stbox(FunctionCallInfo fcinfo, bool atfunc)
 PGDLLEXPORT Datum Tcbuffer_at_stbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tcbuffer_at_stbox);
 /**
- * @ingroup mobilitydb_geo_restrict
- * @brief Return a temporal circular buffer restricted to a circular buffer
- * @note Only 2D is supported
- * @sqlfn atValue()
+ * @ingroup mobilitydb_cbuffer_restrict
+ * @brief Return a temporal circular buffer restricted to a spatiotemporal box
+ * @sqlfn atStbox()
  */
 inline Datum
 Tcbuffer_at_stbox(PG_FUNCTION_ARGS)
@@ -386,10 +404,10 @@ Tcbuffer_at_stbox(PG_FUNCTION_ARGS)
 PGDLLEXPORT Datum Tcbuffer_minus_stbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tcbuffer_minus_stbox);
 /**
- * @ingroup mobilitydb_geo_restrict
+ * @ingroup mobilitydb_cbuffer_restrict
  * @brief Return a temporal circular buffer restricted to the complement of a
- * circular buffer
- * @sqlfn minusValue()
+ * spatiotemporal box
+ * @sqlfn minusStbox()
  */
 inline Datum
 Tcbuffer_minus_stbox(PG_FUNCTION_ARGS)


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Closes the last two cross-type parity gaps for `tcbuffer` by composing with the existing `tgeompoint` overloads via an SQL-level cast — zero new C code required.

**Category 12 — Analytics** (`167_tcbuffer_analytics.in.sql`):
- `minDistSimplify`, `minTimeDeltaSimplify`, `maxDistSimplify`, `douglasPeuckerSimplify`
- Cast center trajectory to `tgeompoint`, simplify, extract surviving timestamps, restrict original `tcbuffer` — the radius channel at surviving instants is preserved.

**Category 13 — Tile** (`168_tcbuffer_tile.in.sql`):
- `spaceBoxes`, `timeBoxes`, `spaceTimeBoxes`, `spaceSplit`, `spaceTimeSplit`
- Double-cast `tcbuffer → tgeompoint → tgeometry` for the spatial computation; reconstruct `tcbuffer` fragments via `atTime($1, getTime(r.tgeo))`.
- New composite types `point_tcbuffer` / `point_time_tcbuffer` mirror the `tgeo` pattern.

## Context

Part of the cross-type parity initiative. With this PR, `tcbuffer` achieves 100% parity with `tgeometry` on all applicable function categories. See `doc/contributing/cross_type_parity.md` for the full matrix.

## Test plan

- [ ] `CREATE EXTENSION mobilitydb` completes without errors
- [ ] `SELECT minDistSimplify(t, 0.5) FROM (SELECT 'Interp=Step;{[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(1 1),2)@2000-01-02]}'::tcbuffer) s(t)` returns a tcbuffer
- [ ] `SELECT spaceSplit(t, 1.0) FROM ...` returns rows of `point_tcbuffer`
