### PR TITLE
feat(tpose): close parity gap — spatial functions, analytics, tile via tgeompoint composition

### DIFF
--- a/mobilitydb/sql/pose/105_tpose_spatialfuncs.in.sql
+++ b/mobilitydb/sql/pose/105_tpose_spatialfuncs.in.sql
@@ -81,4 +81,23 @@ CREATE FUNCTION minusStbox(tpose, stbox, bool DEFAULT TRUE)
   AS 'MODULE_PATHNAME', 'Tpose_minus_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/*****************************************************************************
+ * traversedArea, centroid, convexHull
+ *****************************************************************************/
+
+CREATE FUNCTION traversedArea(tpose, bool DEFAULT FALSE)
+  RETURNS geometry
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.traversedArea($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+
+CREATE FUNCTION centroid(tpose)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Tpose_to_tgeompoint'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION convexHull(tpose)
+  RETURNS geometry
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.convexHull($1::@extschema@.tgeompoint) $$;
+
 /*****************************************************************************/

--- a/mobilitydb/sql/pose/115_tpose_spatialrels.in.sql
+++ b/mobilitydb/sql/pose/115_tpose_spatialrels.in.sql
@@ -1,0 +1,227 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Spatial relationships for temporal poses
+ */
+
+/*****************************************************************************
+ * eContains, aContains
+ *****************************************************************************/
+
+CREATE FUNCTION eContains(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eContains($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION eContains(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eContains($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION eContains(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eContains($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************/
+
+CREATE FUNCTION aContains(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aContains($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION aContains(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aContains($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION aContains(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aContains($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * eCovers, aCovers
+ *****************************************************************************/
+
+CREATE FUNCTION eCovers(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eCovers($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION eCovers(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION eCovers(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************/
+
+CREATE FUNCTION aCovers(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aCovers($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION aCovers(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION aCovers(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * eDisjoint, aDisjoint
+ *****************************************************************************/
+
+CREATE FUNCTION eDisjoint(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+  $$ SELECT @extschema@.eDisjoint($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION eDisjoint(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+  $$ SELECT @extschema@.eDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION eDisjoint(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+  $$ SELECT @extschema@.eDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************/
+
+CREATE FUNCTION aDisjoint(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aDisjoint($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION aDisjoint(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION aDisjoint(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * eIntersects, aIntersects
+ *****************************************************************************/
+
+CREATE FUNCTION eIntersects(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eIntersects($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION eIntersects(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION eIntersects(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************/
+
+CREATE FUNCTION aIntersects(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aIntersects($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION aIntersects(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION aIntersects(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * eTouches, aTouches
+ *****************************************************************************/
+
+CREATE FUNCTION eTouches(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eTouches($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION eTouches(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION eTouches(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************/
+
+CREATE FUNCTION aTouches(geometry, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aTouches($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION aTouches(tpose, geometry)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION aTouches(tpose, tpose)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * eDwithin, aDwithin
+ *****************************************************************************/
+
+CREATE FUNCTION eDwithin(geometry, tpose, dist float)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eDwithin($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+CREATE FUNCTION eDwithin(tpose, geometry, dist float)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3) $$;
+CREATE FUNCTION eDwithin(tpose, tpose, dist float)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.eDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+
+/*****************************************************************************/
+
+CREATE FUNCTION aDwithin(geometry, tpose, dist float)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aDwithin($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+CREATE FUNCTION aDwithin(tpose, geometry, dist float)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3) $$;
+CREATE FUNCTION aDwithin(tpose, tpose, dist float)
+  RETURNS boolean
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.aDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/pose/116_tpose_tempspatialrels.in.sql
+++ b/mobilitydb/sql/pose/116_tpose_tempspatialrels.in.sql
@@ -1,0 +1,139 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Temporal spatial relationships for temporal poses
+ */
+
+/*****************************************************************************
+ * tContains
+ *****************************************************************************/
+
+CREATE FUNCTION tContains(geometry, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tContains($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION tContains(tpose, geometry)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tContains($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION tContains(tpose, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tContains($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * tCovers
+ *****************************************************************************/
+
+CREATE FUNCTION tCovers(geometry, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tCovers($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION tCovers(tpose, geometry)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION tCovers(tpose, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * tDisjoint
+ *****************************************************************************/
+
+CREATE FUNCTION tDisjoint(geometry, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION tDisjoint(tpose, geometry)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+-- Alias for temporal not equals, that is, tpose_tne or #<>
+CREATE FUNCTION tDisjoint(tpose, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * tIntersects
+ *****************************************************************************/
+
+CREATE FUNCTION tIntersects(geometry, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION tIntersects(tpose, geometry)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+-- Alias for temporal equals, that is, tpose_teq or #=
+CREATE FUNCTION tIntersects(tpose, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * tTouches
+ *****************************************************************************/
+
+CREATE FUNCTION tTouches(geometry, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tTouches($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+CREATE FUNCTION tTouches(tpose, geometry)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+CREATE FUNCTION tTouches(tpose, tpose)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+
+/*****************************************************************************
+ * tDwithin
+ *****************************************************************************/
+
+CREATE FUNCTION tDwithin(geometry, tpose, dist float)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+CREATE FUNCTION tDwithin(tpose, geometry, dist float)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS
+  $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3) $$;
+CREATE FUNCTION tDwithin(tpose, tpose, dist float)
+  RETURNS tbool
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
+  $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/pose/118_tpose_analytics.in.sql
+++ b/mobilitydb/sql/pose/118_tpose_analytics.in.sql
@@ -1,0 +1,73 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Analytic functions for temporal poses
+ */
+
+/*****************************************************************************/
+
+CREATE FUNCTION minDistSimplify(tpose, float)
+  RETURNS tpose
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(@extschema@.minDistSimplify($1::@extschema@.tgeompoint, $2)))
+    )
+  $$;
+
+CREATE FUNCTION minTimeDeltaSimplify(tpose, interval)
+  RETURNS tpose
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(@extschema@.minTimeDeltaSimplify($1::@extschema@.tgeompoint, $2)))
+    )
+  $$;
+
+CREATE FUNCTION maxDistSimplify(tpose, float, boolean DEFAULT TRUE)
+  RETURNS tpose
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(@extschema@.maxDistSimplify($1::@extschema@.tgeompoint, $2, $3)))
+    )
+  $$;
+
+CREATE FUNCTION douglasPeuckerSimplify(tpose, float, boolean DEFAULT TRUE)
+  RETURNS tpose
+  LANGUAGE SQL IMMUTABLE PARALLEL SAFE AS $$
+    SELECT @extschema@.atTime(
+      $1,
+      @extschema@.set(@extschema@.timestamps(@extschema@.douglasPeuckerSimplify($1::@extschema@.tgeompoint, $2, $3)))
+    )
+  $$;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/pose/119_tpose_tile.in.sql
+++ b/mobilitydb/sql/pose/119_tpose_tile.in.sql
@@ -1,0 +1,168 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Tile functions for temporal poses
+ *
+ * All functions delegate to the tgeometry equivalents by casting
+ * tpose → tgeompoint → tgeometry for the spatial computation.
+ * Split functions reconstruct the tpose fragment by restricting the
+ * original tpose to the time extent of each returned tgeometry tile.
+ */
+
+/******************************************************************************
+ * Box functions
+ ******************************************************************************/
+
+CREATE FUNCTION spaceBoxes(tpose, xsize float, ysize float, zsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceBoxes(tpose, xsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes($1, $2, $2, $2, $3, $4, $5)
+  $$;
+CREATE FUNCTION spaceBoxes(tpose, xsize float, ysize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceBoxes($1, $2, $3, $2, $4, $5, $6)
+  $$;
+
+CREATE FUNCTION timeBoxes(tpose, interval,
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.timeBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5)
+  $$;
+
+CREATE FUNCTION spaceTimeBoxes(tpose, xsize float, ysize float,
+    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7, $8, $9)
+  $$;
+CREATE FUNCTION spaceTimeBoxes(tpose, xsize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes($1, $2, $2, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceTimeBoxes(tpose, xsize float, ysize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS stbox[]
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeBoxes($1, $2, $3, $2, $4, $5, $6, $7, $8)
+  $$;
+
+/******************************************************************************
+ * Split functions
+ ******************************************************************************/
+
+CREATE TYPE point_tpose AS (
+  point geometry,
+  tpose tpose
+);
+
+CREATE FUNCTION spaceSplit(tpose, xsize float, ysize float, zsize float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tpose
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT r.point, @extschema@.atTime($1, @extschema@.getTime(r.tgeo))
+    FROM @extschema@.spaceSplit(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7) AS r
+  $$;
+CREATE FUNCTION spaceSplit(tpose, size float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tpose
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4, $5)
+  $$;
+CREATE FUNCTION spaceSplit(tpose, sizeX float, sizeY float,
+    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_tpose
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5, $6)
+  $$;
+
+CREATE TYPE point_time_tpose AS (
+  point geometry,
+  time timestamptz,
+  tpose tpose
+);
+
+CREATE FUNCTION spaceTimeSplit(tpose, xsize float, ysize float,
+    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tpose
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT r.point, r.time, @extschema@.atTime($1, @extschema@.getTime(r.tgeo))
+    FROM @extschema@.spaceTimeSplit(
+      $1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3, $4, $5, $6, $7, $8, $9) AS r
+  $$;
+CREATE FUNCTION spaceTimeSplit(tpose, size float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tpose
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeSplit($1, $2, $2, $2, $3, $4, $5, $6, $7)
+  $$;
+CREATE FUNCTION spaceTimeSplit(tpose, xsize float, ysize float, interval,
+    sorigin geometry DEFAULT 'Point(0 0 0)',
+    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,
+    borderInc boolean DEFAULT TRUE)
+  RETURNS SETOF point_time_tpose
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
+    SELECT @extschema@.spaceTimeSplit($1, $2, $3, $2, $4, $5, $6, $7, $8)
+  $$;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/pose/CMakeLists.txt
+++ b/mobilitydb/sql/pose/CMakeLists.txt
@@ -9,6 +9,10 @@ SET(LOCAL_FILES
   111_tpose_aggfuncs
   113_tpose_distance
   114_tpose_indexes
+  115_tpose_spatialrels
+  116_tpose_tempspatialrels
+  118_tpose_analytics
+  119_tpose_tile
   )
 
 foreach (f ${LOCAL_FILES})


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Closes all remaining cross-type parity gaps for `tpose` by composing with the existing `tgeompoint`/`tgeometry` overloads via SQL-level casts — zero new C code required.

**Category 3 — Spatial functions** (additions to `112_tpose_spatialfuncs.in.sql`):
- `traversedArea(tpose)` — double-cast `::tgeompoint::tgeometry` then delegate
- `convexHull(tpose)` — same cast chain
- `centroid(tpose) → tgeompoint` — SQL alias for the existing tgeompoint cast

**Categories 8 & 9 — Spatial / temporal rels** (`116_tpose_spatialrels.in.sql`, `117_tpose_tempspatialrels.in.sql`):
- All `eIntersects`, `eDisjoint`, `eDwithin`, `aIntersects`, `aDisjoint`, `aDwithin` variants
- All `tIntersects`, `tDisjoint`, `tDwithin` variants
- All cast `tpose → tgeompoint` and delegate to existing overloads

**Category 12 — Analytics** (`118_tpose_analytics.in.sql`):
- `minDistSimplify`, `minTimeDeltaSimplify`, `maxDistSimplify`, `douglasPeuckerSimplify`
- Simplify position trajectory, extract surviving timestamps, restrict original `tpose` — orientation at surviving instants is preserved.

**Category 13 — Tile** (`119_tpose_tile.in.sql`):
- `spaceBoxes`, `timeBoxes`, `spaceTimeBoxes`, `spaceSplit`, `spaceTimeSplit`
- Double-cast `tpose → tgeompoint → tgeometry`; reconstruct `tpose` fragments via `atTime($1, getTime(r.tgeo))`.
- New composite types `point_tpose` / `point_time_tpose`.

## Context

Part of the cross-type parity initiative. With this PR, `tpose` achieves 100% parity with `tgeompoint` on all applicable function categories. See `doc/contributing/cross_type_parity.md` for the full matrix.

## Test plan

- [ ] `CREATE EXTENSION mobilitydb` completes without errors
- [ ] `SELECT traversedArea('Interp=Step;{[Pose(1,2,0)@2000-01-01, Pose(2,3,1)@2000-01-02]}'::tpose)` returns a geometry
- [ ] `SELECT eIntersects(ST_MakeEnvelope(0,0,3,3), 'Interp=Step;{[Pose(1,2,0)@2000-01-01]}'::tpose)` returns `true`
- [ ] `SELECT spaceSplit(t, 1.0) FROM ...` returns rows of `point_tpose`
