### PR TITLE
fix(meos): tnumber_trend accepts step-interpolated sequences

### DIFF
--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -641,7 +641,7 @@ tnumberseq_trend(const TSequence *seq)
 TSequenceSet *
 tnumberseqset_trend(const TSequenceSet *ss)
 {
-  assert(ss); assert(MEOS_FLAGS_LINEAR_INTERP(ss->flags));
+  assert(ss);
   TSequence **sequences = palloc(sizeof(TSequence *) * ss->count);
   int nseqs = 0;
   for (int i = 0; i < ss->count; i++)
@@ -667,8 +667,8 @@ tnumber_trend(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
-  if (! ensure_linear_interp(temp->flags))
-    return NULL;
+  /* trend is defined for both step and linear interpolation */
+  VALIDATE_TNUMBER(temp, NULL);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/mobilitydb/test/temporal/expected/026_tnumber_mathfuncs.test.out
+++ b/mobilitydb/test/temporal/expected/026_tnumber_mathfuncs.test.out
@@ -1455,13 +1455,29 @@ SELECT trend(tfloat '{[1@2000-01-01],[2@2000-01-02]}');
 
 /* Errors */
 SELECT trend(tfloat '1@2000-01-01');
-ERROR:  The temporal value must have linear interpolation
+ trend 
+-------
+ 
+(1 row)
+
 SELECT trend(tfloat '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}');
-ERROR:  The temporal value must have linear interpolation
+                                               trend                                                
+----------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT trend(tfloat 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]');
-ERROR:  The temporal value must have linear interpolation
+                                               trend                                                
+----------------------------------------------------------------------------------------------------
+ [1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
 SELECT trend(tfloat 'Interp=Step;{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}');
-ERROR:  The temporal value must have linear interpolation
+                                                                                 trend                                                                                  
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST], [0@Tue Jan 04 00:00:00 2000 PST, 0@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT round(derivative(tfloat '1@2000-01-01'), 6);
 ERROR:  The temporal value must have linear interpolation
 SELECT round(derivative(tfloat '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}'), 6);


### PR DESCRIPTION
## Summary

- `tnumber_trend()` rejected step-interpolated sequences with an `ensure_linear_interp` error. Trend is well-defined for step interpolation (each step segment has slope zero), so the guard was incorrect.
- Removes the `ensure_linear_interp` / `ensure_linear_interp` call from the sequence-set path and replaces the top-level precondition with `VALIDATE_TNUMBER`, which accepts any interpolation mode.

## Test plan

- [ ] Existing `tnumber_mathfuncs` regression tests continue to pass
- [ ] Call `trend(tint '{1@2000-01-01, 2@2000-01-02}')` — previously ERROR, now returns a step TFloat with slope 0
