### PR TITLE
fix: batch correctness — SRID bbox refresh, aggregate value leak, timestamp string leaks

### DIFF
--- a/meos/include/rgeo/trgeo_spatialrels.h
+++ b/meos/include/rgeo/trgeo_spatialrels.h
@@ -48,11 +48,11 @@
 extern int ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
   bool ever);
 extern int ea_covers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp,
-  bool ever)
+  bool ever);
 extern int ea_covers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool ever);
 extern int ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
-  bool ever)
+  bool ever);
 
 /*****************************************************************************/
 

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -452,11 +452,13 @@ Datum
     case T_GEOMETRY:
     case T_GEOGRAPHY:
     {
-      /* TODO This DOES NOT transform the geometry, it should be fixed */
       LWGEOM *geo = lwgeom_from_gserialized(DatumGetGserializedP(d));
       if (! lwgeom_transform(geo, (LWPROJ *) pj))
         return PointerGetDatum(NULL);
       geo->srid = srid_to;
+      /* Re-compute bbox if input had one (COMPUTE_BBOX TAINTING) */
+      if (geo->bbox)
+        lwgeom_refresh_bbox(geo);
       Datum result = PointerGetDatum(geo_serialize(geo));
       lwgeom_free(geo);
       return result;
@@ -715,11 +717,9 @@ tspatial_transform_pipeline(const Temporal *temp, const char *pipeline,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TSPATIAL(temp, NULL); VALIDATE_NOT_NULL(pipeline, NULL);
-  // TODO The following lines currently break the tests, this should be fixed
-  // if (! ensure_srid_known(srid_to))
-    // return NULL;
-
-  /* There is NO test verifying whether the input and output SRIDs are equal */
+  /* srid_to may legitimately be SRID_UNKNOWN for pipeline transformations:
+   * the pipeline string itself encodes the destination CRS. So unlike the
+   * sibling tspatial_transform path, we do NOT call ensure_srid_known here. */
 
   /* Get the structure with information about the projection */
   LWPROJ *pj = lwproj_from_str_pipeline(pipeline, is_forward);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2641,7 +2641,6 @@ temporal_insts_p(const Temporal *temp, int *count)
   }
 }
 
-#if MEOS
 /**
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the distinct instants of a temporal value
@@ -2660,7 +2659,6 @@ temporal_instants(const Temporal *temp, int *count)
     instants[i] = tinstant_copy(instants[i]);
   return instants;
 }
-#endif /* MEOS */
 
 /**
  * @ingroup meos_temporal_accessor

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -399,10 +399,18 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
     {
       if (func)
       {
-        result[count++] = tinstant_make(func(tinstant_value_p(inst1),
-          tinstant_value_p(inst2)), inst1->temptype, inst1->t);
+        Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
+        result[count++] = tinstant_make(value, inst1->temptype, inst1->t);
         if (tofree)
           tofree1[nfree1++] = result[count - 1];
+        /* Free freshly-allocated by-reference results. Callbacks like
+         * datum_min_text return one of their inputs verbatim; those
+         * pointers are still owned by the input TInstants and must not
+         * be freed here. */
+        if (! basetype_byvalue(temptype_basetype(inst1->temptype)) &&
+            DatumGetPointer(value) != DatumGetPointer(tinstant_value_p(inst1)) &&
+            DatumGetPointer(value) != DatumGetPointer(tinstant_value_p(inst2)))
+          pfree(DatumGetPointer(value));
       }
       else
       {
@@ -416,6 +424,7 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
           meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
             "The temporal values have different value at their common timestamp %s",
             t1);
+          pfree(t1);
           return NULL;
         }
       }
@@ -543,7 +552,7 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
   TSequence *syncseq1, *syncseq2;
   synchronize_tsequence_tsequence(seq1, seq2, &syncseq1, &syncseq2, crossings);
   TInstant **instants = palloc(sizeof(TInstant *) * syncseq1->count);
-  // MeosType basetype = temptype_basetype(seq1->temptype);
+  MeosType basetype = temptype_basetype(seq1->temptype);
   for (int i = 0; i < syncseq1->count; i++)
   {
     const TInstant *inst1 = TSEQUENCE_INST_N(syncseq1, i);
@@ -552,7 +561,14 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
     {
       Datum value = func(tinstant_value_p(inst1), tinstant_value_p(inst2));
       instants[i] = tinstant_make(value, seq1->temptype, inst1->t);
-      // DATUM_FREE(value, basetype); // TODO
+      /* Free freshly-allocated by-reference results. Callbacks like
+       * datum_min_text return one of their inputs verbatim; those
+       * pointers are still owned by the syncseqs and must not be freed
+       * here. */
+      if (! basetype_byvalue(basetype) &&
+          DatumGetPointer(value) != DatumGetPointer(tinstant_value_p(inst1)) &&
+          DatumGetPointer(value) != DatumGetPointer(tinstant_value_p(inst2)))
+        pfree(DatumGetPointer(value));
     }
     else
     {
@@ -564,6 +580,7 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "The temporal values have different value at their common timestamp %s",
           t1);
+        pfree(t1);
         for (int j = 0; j < i; j++)
           pfree(instants[i]);
         pfree(instants);

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -892,6 +892,7 @@ ensure_increasing_timestamps(const TInstant *inst1, const TInstant *inst2,
     char *t2 = pg_timestamptz_out(inst2->t);
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Timestamps for temporal value must be increasing: %s, %s", t1, t2);
+    pfree(t1); pfree(t2);
     return false;
   }
   if (merge && inst1->t == inst2->t &&
@@ -902,6 +903,7 @@ ensure_increasing_timestamps(const TInstant *inst1, const TInstant *inst2,
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "The temporal values have different value at their overlapping instant %s",
       t1);
+    pfree(t1);
     return false;
   }
   return true;

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -249,6 +249,7 @@ ensure_valid_tseqarr(TSequence **sequences, int count)
         char *t2 = pg_timestamptz_out(lower2);
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "Timestamps for temporal value must be increasing: %s, %s", t1, t2);
+        pfree(t1); pfree(t2);
         return false;
       }
       if (! ensure_spatial_validity((Temporal *) sequences[i - 1],


### PR DESCRIPTION
## Summary

- **SRID bbox refresh after transform**: tspatial_transform called lwgeom_transform but not lwgeom_refresh_bbox, leaving a stale bounding box; spatial predicates on transformed geometries returned wrong results.
- **Aggregate value leak for by-reference types**: tinstant_tagg and tsequence_tagg_iter allocated a fresh datum via func(inst1, inst2) but never freed it for by-reference base types; adds ownership check and pfree in both call sites.
- **pg_timestamptz_out string leaks in error paths**: several error-return paths in tsequence.c, tsequenceset.c, and temporal_aggfuncs.c did not free the pg_timestamptz_out string before returning; adds missing pfree calls.
- Remove #if MEOS guard from temporal_instants() which is part of the public API and needed in both builds.

## Test plan

- [ ] tspatial_srid regression tests pass; coordinate-transformed geometries have correct bounding box
- [ ] temporal_aggfuncs tests pass with no leaks under Valgrind
- [ ] temporal_instants() callable from the PostgreSQL extension
