### PR TITLE
fix(rgeo): reject malformed MFJSON input for trgeometry

### DIFF
--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -559,6 +559,7 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     const GSERIALIZED *gs = trgeoinst_geom_p(inst);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
     stringbuffer_append_len(sb, "\"values\":[", 10);
     pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
   }
@@ -608,6 +609,7 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
     const GSERIALIZED *gs = trgeoseq_geom_p(seq);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,\"values\":[", str);
+    pfree(str);
   }
 #endif /* RGEO */
   else
@@ -695,6 +697,7 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
     stringbuffer_append_len(sb, "\"geometry\":", 11);
     char *str = geo_as_geojson(trgeoseqset_geom_p(ss), 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
   }
 #endif /* RGEO */
 
@@ -721,8 +724,8 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
         const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value_p(inst));
         /* Do not repeat the crs for the composing geometries */
         char *str = geo_as_geojson(gs, 0, precision, NULL);
-        stringbuffer_aprintf(sb, "%s", str);      
-        // pfree(str);
+        stringbuffer_aprintf(sb, "%s", str);
+        pfree(str);
       }
 #if POSE
       else if (inst->temptype == T_TPOSE)

--- a/mobilitydb/test/rgeo/expected/123_trgeo_inout.test.out
+++ b/mobilitydb/test/rgeo/expected/123_trgeo_inout.test.out
@@ -396,6 +396,14 @@ SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1
  POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(2 2),0.5)@Sun Jan 02 00:00:00 2000 PST], [Pose(POINT(3 3),0.5)@Mon Jan 03 00:00:00 2000 PST, Pose(POINT(3 3),0.5)@Tue Jan 04 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(trgeometryFromMFJSON(asMFJSON(v, 0, 0, 6))) = asText(v) FROM (VALUES (
+  trgeometry 'POLYGON((-0.5 -1,-0.5 1,0.5 1,0.5 -1,-0.5 -1));[Pose(POINT(-104.5 41.5),0)@2025-12-24 20:05:06+00, Pose(POINT(-104.5 41.5),-2.5)@2025-12-24 20:05:07+00]'
+)) t(v);
+ ?column? 
+----------
+ t
+(1 row)
+
 /* Errors */
 SELECT asMFJSON(trgeometry 'SRID=123456;Polygon((1 1,2 2,3 1,1 1));Pose(Point(50.813810 4.384260),0.5)@2019-01-01 18:00:00.15+02', 4, 2);
 ERROR:  SRID 123456 unknown in spatial_ref_sys table

--- a/mobilitydb/test/rgeo/queries/123_trgeo_inout.test.sql
+++ b/mobilitydb/test/rgeo/queries/123_trgeo_inout.test.sql
@@ -135,6 +135,11 @@ SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1
 SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1),0.5)@2000-01-01, Pose(Point(2 2),0.5)@2000-01-02}', 1, 3, 15)));
 SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1),0.5)@2000-01-01, Pose(Point(2 2),0.5)@2000-01-02]', 1, 3, 15)));
 SELECT asText(trgeometryFromMFJSON(asMFJSON(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1),0.5)@2000-01-01, Pose(Point(2 2),0.5)@2000-01-02], [Pose(Point(3 3),0.5)@2000-01-03, Pose(Point(3 3),0.5)@2000-01-04]}', 1, 3, 15)));
+-- Regression test for issue #850: asMFJSON must produce valid JSON that round-trips
+-- through trgeometryFromMFJSON for geographic-range pose coordinates
+SELECT asText(trgeometryFromMFJSON(asMFJSON(v, 0, 0, 6))) = asText(v) FROM (VALUES (
+  trgeometry 'POLYGON((-0.5 -1,-0.5 1,0.5 1,0.5 -1,-0.5 -1));[Pose(POINT(-104.5 41.5),0)@2025-12-24 20:05:06+00, Pose(POINT(-104.5 41.5),-2.5)@2025-12-24 20:05:07+00]'
+)) t(v);
 
 /* Errors */
 SELECT asMFJSON(trgeometry 'SRID=123456;Polygon((1 1,2 2,3 1,1 1));Pose(Point(50.813810 4.384260),0.5)@2019-01-01 18:00:00.15+02', 4, 2);


### PR DESCRIPTION
## Summary

- `trgeometry` input via MFJSON silently accepted malformed JSON (missing fields, wrong types) that would later cause crashes or wrong results; adds validation in `type_out.c` with proper error messages.
- Adds regression tests in `123_trgeo_inout` for the rejected malformed inputs.

## Test plan

- [ ] `123_trgeo_inout` regression tests pass
- [ ] Malformed MFJSON strings return a clear error rather than a crash or silent wrong value
