### PR TITLE
ci(cbuffer): re-enable 160_tcbuffer_distance_tbl regression test

### DIFF
--- a/mobilitydb/test/cbuffer/CMakeLists.txt
+++ b/mobilitydb/test/cbuffer/CMakeLists.txt
@@ -18,7 +18,6 @@ list(SORT testfiles)
 # of the underlying functions. Re-enable once the expected output is
 # regenerated.
 set(SKIP_TESTS
-  160_tcbuffer_distance_tbl         # NearestApproachDistance / |=| count drift
   162_tcbuffer_spatialrels          # spatialrels output drift
   162_tcbuffer_spatialrels_tbl      # spatialrels output drift (table form)
   164_tcbuffer_tempspatialrels      # tempspatialrels output drift


### PR DESCRIPTION
## Summary

- Removes `160_tcbuffer_distance_tbl` from `SKIP_TESTS` in the cbuffer test CMakeLists; the underlying NearestApproachDistance / `|=|` count drift has been resolved.
- One-line change; the expected output file already matches current output.

## Test plan

- [ ] `160_tcbuffer_distance_tbl` passes in the coverage build
