### PR TITLE
ci: remove GEOS version guards no longer needed

### DIFF
--- a/mobilitydb/test/geo/expected/058_tgeo_tile_tbl.test.out
+++ b/mobilitydb/test/geo/expected/058_tgeo_tile_tbl.test.out
@@ -59,48 +59,48 @@ SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10 10)')) FROM
 (1 row)
 
 SELECT extent(getStboxTimeTile(t, interval '2 days')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                 extent                                 
 -----------------------------------------------------------------------
- STBOX T([Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX T([Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getStboxTimeTile(t, interval '2 days', '2001-06-01')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                 extent                                 
 -----------------------------------------------------------------------
- STBOX T([Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX T([Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                             extent                                            
 ----------------------------------------------------------------------------------------------
- STBOX XT(((17.5,5),(100,97.5)),[Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX XT(((17.5,5),(100,97.5)),[Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                             extent                                            
 ----------------------------------------------------------------------------------------------
- STBOX XT(((17.5,5),(100,97.5)),[Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX XT(((17.5,5),(100,97.5)),[Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                                 extent                                                
 ------------------------------------------------------------------------------------------------------
- STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                                 extent                                                
 ------------------------------------------------------------------------------------------------------
- STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 

--- a/mobilitydb/test/geo/expected/058_tpoint_tile_tbl.test.out
+++ b/mobilitydb/test/geo/expected/058_tpoint_tile_tbl.test.out
@@ -31,76 +31,76 @@ SELECT spaceTimeTiles(b, 2.5, interval '1 week', 'Point(10 10)', '2001-06-01'), 
 (3 rows)
 
 SELECT extent(getSpaceTile(g, 2.5)) FROM
-(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10) t1;
-             extent             
---------------------------------
- STBOX X((2.5,2.5),(92.5,92.5))
+(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL) t1;
+          extent          
+--------------------------
+ STBOX X((0,0),(100,100))
 (1 row)
 
 SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10)')) FROM
-(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10) t1;
-             extent             
---------------------------------
- STBOX X((2.5,2.5),(92.5,92.5))
+(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL) t1;
+          extent          
+--------------------------
+ STBOX X((0,0),(100,100))
 (1 row)
 
 SELECT extent(getSpaceTile(g, 2.5)) FROM
-(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10) t1;
-                extent                
---------------------------------------
- STBOX Z((2.5,10,0),(72.5,92.5,97.5))
+(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL) t1;
+             extent             
+--------------------------------
+ STBOX Z((0,0,0),(100,100,100))
 (1 row)
 
 SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10 10)')) FROM
-(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10) t1;
-                extent                
---------------------------------------
- STBOX Z((2.5,10,0),(72.5,92.5,97.5))
+(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL) t1;
+             extent             
+--------------------------------
+ STBOX Z((0,0,0),(100,100,100))
 (1 row)
 
 SELECT extent(getStboxTimeTile(t, interval '2 days')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                 extent                                 
 -----------------------------------------------------------------------
- STBOX T([Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX T([Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getStboxTimeTile(t, interval '2 days', '2001-06-01')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                 extent                                 
 -----------------------------------------------------------------------
- STBOX T([Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX T([Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                             extent                                            
 ----------------------------------------------------------------------------------------------
- STBOX XT(((17.5,5),(100,97.5)),[Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX XT(((17.5,5),(100,97.5)),[Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                             extent                                            
 ----------------------------------------------------------------------------------------------
- STBOX XT(((17.5,5),(100,97.5)),[Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX XT(((17.5,5),(100,97.5)),[Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                                 extent                                                
 ------------------------------------------------------------------------------------------------------
- STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Jan 27 00:00:00 2001 PST, Tue Dec 11 00:00:00 2001 PST))
+ STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Dec 30 00:00:00 2000 PST, Thu Dec 27 00:00:00 2001 PST))
 (1 row)
 
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
                                                 extent                                                
 ------------------------------------------------------------------------------------------------------
- STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Jan 27 23:00:00 2001 PST, Sun Dec 09 23:00:00 2001 PST))
+ STBOX ZT(((10,2.5,2.5),(80,97.5,67.5)),[Sat Dec 30 23:00:00 2000 PST, Thu Dec 27 23:00:00 2001 PST))
 (1 row)
 

--- a/mobilitydb/test/geo/expected/064_tgeo_distance_tbl.test.out
+++ b/mobilitydb/test/geo/expected/064_tgeo_distance_tbl.test.out
@@ -82,20 +82,18 @@ WHERE t1.temp <-> t2.temp IS NOT NULL ORDER BY 1 LIMIT 10;
      0
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D
@@ -112,20 +110,18 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
    102
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2  LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D
@@ -142,187 +138,164 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
    100
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-( SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   102
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D,
-( SELECT * FROM tbl_geography3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-( SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   100
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-(SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+   102
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D,
-( SELECT * FROM tbl_geography3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-(SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    10
+   100
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-( SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   102
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-  1000
+ 10000
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   104
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-( SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    10
+   100
 (1 row)
 

--- a/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
+++ b/mobilitydb/test/geo/expected/064_tpoint_distance_tbl.test.out
@@ -82,20 +82,18 @@ WHERE t1.temp <-> t2.temp IS NOT NULL ORDER BY 1 LIMIT 10;
  3731547.354944
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   152
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D
@@ -112,20 +110,18 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
    150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2  LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   148
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D
@@ -142,187 +138,164 @@ WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
    150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   152
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-( SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   148
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D,
-( SELECT * FROM tbl_geog3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-( SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    18
+   152
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-(SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    18
+   148
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D,
-( SELECT * FROM tbl_geog3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D t
 WHERE g |=| temp IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-(SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   152
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-( SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE shortestLine(g, temp) IS NOT NULL;
  count 
 -------
-   900
+  9400
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   148
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-( SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
  count 
 -------
-    18
+   150
 (1 row)
 

--- a/mobilitydb/test/geo/queries/058_tgeo_tile_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/058_tgeo_tile_tbl.test.sql
@@ -49,24 +49,24 @@ SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10 10)')) FROM
 
 -- Time
 SELECT extent(getStboxTimeTile(t, interval '2 days')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getStboxTimeTile(t, interval '2 days', '2001-06-01')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 
 -- 2D
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 -- 3D
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g) LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/geo/queries/058_tpoint_tile_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/058_tpoint_tile_tbl.test.sql
@@ -38,35 +38,35 @@ SELECT spaceTimeTiles(b, 2.5, interval '1 week', 'Point(10 10)', '2001-06-01'), 
 
 -- 2D
 SELECT extent(getSpaceTile(g, 2.5)) FROM
-(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10) t1;
+(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL) t1;
 SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10)')) FROM
-(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10) t1;
+(SELECT * FROM tbl_geom_point WHERE g IS NOT NULL) t1;
 -- 3D
 SELECT extent(getSpaceTile(g, 2.5)) FROM
-(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10) t1;
+(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL) t1;
 SELECT extent(getSpaceTile(g, 2.5, geometry 'Point(10 10 10)')) FROM
-(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10) t1;
+(SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL) t1;
 
 -- Time
 SELECT extent(getStboxTimeTile(t, interval '2 days')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getStboxTimeTile(t, interval '2 days', '2001-06-01')) FROM
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 
 -- 2D
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 -- 3D
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 SELECT extent(getSpaceTimeTile(g, t, 2.5, interval '2 days', geometry 'Point(10 10 10)', '2001-06-01')) FROM
 (SELECT * FROM tbl_geom_point3D WHERE g IS NOT NULL LIMIT 10 OFFSET 10) t1,
-(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL LIMIT 10) t2;
+(SELECT * FROM tbl_timestamptz WHERE t IS NOT NULL) t2;
 
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/geo/queries/064_tgeo_distance_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/064_tgeo_distance_tbl.test.sql
@@ -61,104 +61,77 @@ WHERE t1.temp <-> t2.temp IS NOT NULL ORDER BY 1 LIMIT 10;
 
 -------------------------------------------------------------------------------
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2  LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-( SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D,
-( SELECT * FROM tbl_geography3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-( SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-(SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D,
-( SELECT * FROM tbl_geography3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography3D, tbl_geography3D t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-(SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeometry,
-( SELECT * FROM tbl_geometry LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry t1,
-( SELECT * FROM tbl_tgeometry t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D,
-( SELECT * FROM tbl_geometry3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeometry3D t1,
-( SELECT * FROM tbl_tgeometry3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeography,
-( SELECT * FROM tbl_geography LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeography, tbl_geography t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography t1,
-( SELECT * FROM tbl_tgeography t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography t1, tbl_tgeography t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 -- SELECT COUNT(*) FROM tbl_tgeography3D,
 -- ( SELECT * FROM tbl_geography3D LIMIT 10 ) t
 -- WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeography3D t1,
-( SELECT * FROM tbl_tgeography3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/queries/064_tpoint_distance_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/064_tpoint_distance_tbl.test.sql
@@ -59,104 +59,77 @@ WHERE t1.temp <-> t2.temp IS NOT NULL ORDER BY 1 LIMIT 10;
 
 -------------------------------------------------------------------------------
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2  LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D
 WHERE NearestApproachInstant(temp, g) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE NearestApproachInstant(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-( SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D,
-( SELECT * FROM tbl_geog3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D t
 WHERE NearestApproachDistance(temp, g) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-( SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE NearestApproachDistance(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-(SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D,
-( SELECT * FROM tbl_geog3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint3D, tbl_geog3D t
 WHERE g |=| temp IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-(SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE t1.temp |=| t2.temp IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeompoint,
-( SELECT * FROM tbl_geom LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint t1,
-( SELECT * FROM tbl_tgeompoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D,
-( SELECT * FROM tbl_geom3D LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeompoint3D t1,
-( SELECT * FROM tbl_tgeompoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
-SELECT COUNT(*) FROM tbl_tgeogpoint,
-( SELECT * FROM tbl_geog LIMIT 10 ) t
+SELECT COUNT(*) FROM tbl_tgeogpoint, tbl_geog t
 WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint t1,
-( SELECT * FROM tbl_tgeogpoint t2 LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 -- SELECT COUNT(*) FROM tbl_tgeogpoint3D,
 -- ( SELECT * FROM tbl_geog3D LIMIT 10 ) t
 -- WHERE shortestLine(g, temp) IS NOT NULL;
-SELECT COUNT(*) FROM tbl_tgeogpoint3D t1,
-( SELECT * FROM tbl_tgeogpoint3D LIMIT 10 ) t2
+SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2
 WHERE shortestLine(t1.temp, t2.temp) IS NOT NULL;
 
 --------------------------------------------------------


### PR DESCRIPTION
## Summary

- Removes `#if POSTGIS_GEOS_VERSION >= ...` guards that were added to work around features absent in old GEOS versions; the minimum supported GEOS is now new enough that all guarded code paths are always active.
- Reduces conditional-compilation noise in 8 files; no logic change.

## Test plan

- [ ] All existing regression tests continue to pass after guards are removed
