### PR TITLE
test(geo): add KNN index coverage tests for tgeo

### DIFF
--- a/mobilitydb/test/geo/expected/074_tgeo_indexes_tbl.test.out
+++ b/mobilitydb/test/geo/expected/074_tgeo_indexes_tbl.test.out
@@ -847,6 +847,46 @@ SELECT round(distance, 6) FROM test;
  40.799855
 (3 rows)
 
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(1 1)' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 6.265196
+ 7.507952
+ 9.033748
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 19.586468
+ 40.510493
+ 55.551683
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| tgeography 'SRID=7844;[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 1290835.878317
+ 1464882.971455
+ 2106194.521674
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geography 'SRID=7844;Point(1 1)' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round     
+---------------
+ 264041.061863
+ 694000.259746
+ 928935.040099
+(3 rows)
+
 DROP INDEX tbl_tgeometry_rtree_idx;
 DROP INDEX
 DROP INDEX tbl_tgeometry3D_rtree_idx;
@@ -879,6 +919,46 @@ SELECT round(distance, 6) FROM test;
  33.126948
  36.208515
  40.799855
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(1 1)' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 6.265196
+ 7.507952
+ 9.033748
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 19.586468
+ 40.510493
+ 55.551683
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| tgeography 'SRID=7844;[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 1290835.878317
+ 1464882.971455
+ 2106194.521674
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geography 'SRID=7844;Point(1 1)' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round     
+---------------
+ 264041.061863
+ 694000.259746
+ 928935.040099
 (3 rows)
 
 DROP INDEX tbl_tgeometry_quadtree_idx;

--- a/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
+++ b/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
@@ -847,6 +847,46 @@ SELECT round(distance, 6) FROM test;
   66.99836
 (3 rows)
 
+WITH test AS (
+  SELECT temp |=| geometry 'Point(1 1)' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+    7.6287
+ 11.516189
+ 11.516189
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 14.004276
+    31.366
+    32.332
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| tgeogpoint '[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 3787384.994748
+ 3787650.660488
+ 3817820.847674
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 3768425.182236
+ 3768425.182236
+ 3784781.353772
+(3 rows)
+
 DROP INDEX tbl_tgeompoint_rtree_idx;
 DROP INDEX
 DROP INDEX tbl_tgeompoint3D_rtree_idx;
@@ -879,6 +919,46 @@ SELECT round(distance, 6) FROM test;
  47.623706
  56.138497
   66.99836
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'Point(1 1)' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+    7.6287
+ 11.516189
+ 11.516189
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| stbox 'STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 14.004276
+    31.366
+    32.332
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| tgeogpoint '[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 3787384.994748
+ 3787650.660488
+ 3817820.847674
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+     round      
+----------------
+ 3768425.182236
+ 3768425.182236
+ 3784781.353772
 (3 rows)
 
 DROP INDEX tbl_tgeompoint_quadtree_idx;

--- a/mobilitydb/test/geo/queries/074_tgeo_indexes_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/074_tgeo_indexes_tbl.test.sql
@@ -248,6 +248,19 @@ WITH test AS (
   SELECT temp |=| tgeometry 'SRID=3812;[Point(-1 -1 -1)@2001-06-01, Point(-2 -2 -2)@2001-07-01]' AS distance FROM tbl_tgeometry3D ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(1 1)' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| tgeography 'SRID=7844;[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geography 'SRID=7844;Point(1 1)' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeometry_rtree_idx;
 DROP INDEX tbl_tgeometry3D_rtree_idx;
 
@@ -266,6 +279,19 @@ WITH test AS (
   SELECT temp |=| tgeometry 'SRID=3812;[Point(-1 -1 -1)@2001-06-01, Point(-2 -2 -2)@2001-07-01]' AS distance FROM tbl_tgeometry3D ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 
+WITH test AS (
+  SELECT temp |=| geometry 'SRID=3812;Point(1 1)' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'SRID=3812;STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeometry ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| tgeography 'SRID=7844;[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geography 'SRID=7844;Point(1 1)' AS distance FROM tbl_tgeography ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeometry_quadtree_idx;
 DROP INDEX tbl_tgeometry3D_quadtree_idx;
 

--- a/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
@@ -248,6 +248,19 @@ WITH test AS (
   SELECT temp |=| tgeompoint '[Point(-1 -1 -1)@2001-06-01, Point(-2 -2 -2)@2001-07-01]' AS distance FROM tbl_tgeompoint3D ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 
+WITH test AS (
+  SELECT temp |=| geometry 'Point(1 1)' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| tgeogpoint '[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeompoint_rtree_idx;
 DROP INDEX tbl_tgeompoint3D_rtree_idx;
 
@@ -266,6 +279,19 @@ WITH test AS (
   SELECT temp |=| tgeompoint '[Point(-1 -1 -1)@2001-06-01, Point(-2 -2 -2)@2001-07-01]' AS distance FROM tbl_tgeompoint3D ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 
+WITH test AS (
+  SELECT temp |=| geometry 'Point(1 1)' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| stbox 'STBOX XT(((1,1),(2,2)),[2001-06-01, 2001-07-01])' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+
+WITH test AS (
+  SELECT temp |=| tgeogpoint '[Point(1 1)@2001-06-01, Point(2 2)@2001-07-01]' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+WITH test AS (
+  SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeompoint_quadtree_idx;
 DROP INDEX tbl_tgeompoint3D_quadtree_idx;
 


### PR DESCRIPTION
## Summary

- Adds expected-output regression tests for KNN (`<->` operator with `ORDER BY ... LIMIT`) queries on tgeometry/tgeography SP-GiST and GiST indexes.
- Covers the previously untested index-assisted nearest-neighbour path.

## Test plan

- [ ] New KNN test files pass in the coverage build with RGEO enabled
