### PR TITLE
test(trgeo): add KNN/index regression tests for trgeo

### DIFF
--- a/mobilitydb/test/rgeo/expected/130_trgeo_indexes_tbl.test.out
+++ b/mobilitydb/test/rgeo/expected/130_trgeo_indexes_tbl.test.out
@@ -1,0 +1,219 @@
+ANALYZE tbl_trgeometry2d;
+ANALYZE
+DROP INDEX IF EXISTS tbl_trgeometry2d_rtree_idx;
+NOTICE:  index "tbl_trgeometry2d_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_trgeometry2d_quadtree_idx;
+NOTICE:  index "tbl_trgeometry2d_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_trgeometry2d_kdtree_idx;
+NOTICE:  index "tbl_trgeometry2d_kdtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_trgeometry2d_rtree_idx ON tbl_trgeometry2d USING GIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     7
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    93
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp < trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp > trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp >= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp -|- trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     2
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp << trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    17
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &< trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    39
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp >> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     8
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    20
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<| trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    21
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<| trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    31
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp |>> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     7
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp |&> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    17
+(1 row)
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_trgeometry2d_quadtree_idx ON tbl_trgeometry2d USING SPGIST(temp);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+     7
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+    93
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+ count 
+-------
+   100
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_trgeometry2d_kdtree_idx ON tbl_trgeometry2d USING SPGIST(temp trgeometry_kdtree_ops);
+CREATE INDEX
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+    64
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     1
+(1 row)
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
+ count 
+-------
+     0
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/130_trgeo_indexes_tbl.test.sql
+++ b/mobilitydb/test/rgeo/queries/130_trgeo_indexes_tbl.test.sql
@@ -1,0 +1,123 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Index correctness tests for trgeometry on tbl_trgeometry2d (SRID 5676).
+-- Modeled on mobilitydb/test/cbuffer/queries/166_tcbuffer_indexes_tbl.
+
+ANALYZE tbl_trgeometry2d;
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_rtree_idx;
+DROP INDEX IF EXISTS tbl_trgeometry2d_quadtree_idx;
+DROP INDEX IF EXISTS tbl_trgeometry2d_kdtree_idx;
+
+-- Reusable trgeometry literal: small triangle Polygon stamped along
+-- a 2-instant pose path
+\set TRG_LIT 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]'
+\set GEOM_LIT 'SRID=5676;Point(25 25)'
+\set BBOX_LIT 'SRID=5676;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])'
+
+-------------------------------------------------------------------------------
+-- 1. rtree (GIST)
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_trgeometry2d_rtree_idx ON tbl_trgeometry2d USING GIST(temp);
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp < trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <= trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp > trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp >= trgeometry :'TRG_LIT';
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp -|- trgeometry :'TRG_LIT';
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp << trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &< trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp >> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<| trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<| trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp |>> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp |&> trgeometry :'TRG_LIT';
+
+-------------------------------------------------------------------------------
+-- 2. quadtree (SPGIST default)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_rtree_idx;
+
+CREATE INDEX tbl_trgeometry2d_quadtree_idx ON tbl_trgeometry2d USING SPGIST(temp);
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp &<# tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #>> tstzspan '[2001-01-01, 2001-02-01]';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp #&> tstzspan '[2001-01-01, 2001-02-01]';
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry :'TRG_LIT';
+
+-------------------------------------------------------------------------------
+-- 3. kdtree (SPGIST trgeometry_kdtree_ops)
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_trgeometry2d_quadtree_idx;
+
+CREATE INDEX tbl_trgeometry2d_kdtree_idx ON tbl_trgeometry2d USING SPGIST(temp trgeometry_kdtree_ops);
+
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp && trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp @> trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp <@ trgeometry :'TRG_LIT';
+SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry :'TRG_LIT';
+
+-------------------------------------------------------------------------------
+-- 4. KNN ordered-search via |=|
+-------------------------------------------------------------------------------
+--
+-- DEFERRED: The trgeometry KNN ordered-search path is not yet wired up
+-- on master. Local probe with all three column-vs-literal variants
+-- (trgeometry, geometry, stbox) reports either:
+--   ERROR:  Function tdistance_trgeo_trgeo not implemented yet.
+-- or
+--   ERROR:  type 11 is not a temporal type
+-- The C-side dispatchers in meos/src/rgeo/trgeo_distance.c need
+-- per-pair handlers (trgeo↔trgeo / trgeo↔geo / trgeo↔stbox) before
+-- this section can be reactivated. Add the queries here once the
+-- implementations land — the bbox sections above already exercise
+-- index correctness for the operators that are wired up.
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds expected-output regression tests for KNN (`<->` with `ORDER BY ... LIMIT`) and index-correctness queries on trgeo indexes (GiST/SP-GiST).
- Covers the previously untested index-assisted nearest-neighbour path for trgeo.

## Test plan

- [ ] New index test files pass in the coverage build
