### PR TITLE
refactor(meos): rename tpose/trgeo conversion and distance functions for precision

### DIFF
--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -219,7 +219,7 @@ Temporal *tpose_in(const char *str);
  *****************************************************************************/
 
 extern Temporal *tpose_make(const Temporal *tpoint, const Temporal *tradius);
-extern Temporal *tpose_to_tpoint(const Temporal *temp);
+extern Temporal *tpose_to_tgeompoint(const Temporal *temp);
 
 /*****************************************************************************
  * Accessor functions
@@ -251,7 +251,7 @@ extern Temporal *tpose_minus_stbox(const Temporal *temp, const STBox *box, bool 
  *****************************************************************************/
 
 extern Temporal *tdistance_tpose_pose(const Temporal *temp, const Pose *pose);
-extern Temporal *tdistance_tpose_point(const Temporal *temp, const GSERIALIZED *gs);
+extern Temporal *tdistance_tpose_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tdistance_tpose_tpose(const Temporal *temp1, const Temporal *temp2);
 extern double nad_tpose_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern double nad_tpose_pose(const Temporal *temp, const Pose *pose);

--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -88,7 +88,7 @@ extern Temporal *geo_tpose_to_trgeo(const GSERIALIZED *gs, const Temporal *temp)
  *****************************************************************************/
 
 extern Temporal *trgeo_to_tpose(const Temporal *temp);
-extern Temporal *trgeo_to_tpoint(const Temporal *temp);
+extern Temporal *trgeo_to_tgeompoint(const Temporal *temp);
 
 /*****************************************************************************
  * Accessor functions

--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -395,11 +395,11 @@ tpose_make(const Temporal *tpoint, const Temporal *tradius)
 
 /**
  * @ingroup meos_pose_conversion
- * @brief Return a geometry point from a temporal pose
+ * @brief Return a temporal geometry point from a temporal pose
  * @param[in] temp Temporal pose
  */
 Temporal *
-tpose_to_tpoint(const Temporal *temp)
+tpose_to_tgeompoint(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSE(temp, NULL);

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -51,16 +51,16 @@
  * @brief Return the temporal distance between a geometry and a temporal pose
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @csqlfn #Tdistance_tpose_point()
+ * @csqlfn #Tdistance_tpose_geo()
  */
 Temporal *
-tdistance_tpose_point(const Temporal *temp, const GSERIALIZED *gs)
+tdistance_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpose_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   Temporal *result = tdistance_tgeo_geo((const Temporal *) tpoint, gs);
   pfree(tpoint);
   return result;
@@ -81,7 +81,7 @@ tdistance_tpose_pose(const Temporal *temp, const Pose *pose)
     return NULL;
 
   GSERIALIZED *geom = pose_to_point(pose);
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   Temporal *result = tdistance_tgeo_geo(tpoint, geom);
   pfree(geom);
   return result;
@@ -100,8 +100,8 @@ tdistance_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
   if (! ensure_valid_tpose_tpose(temp1, temp2))
     return NULL;
 
-  Temporal *tpoint1 = tpose_to_tpoint(temp1);
-  Temporal *tpoint2 = tpose_to_tpoint(temp2);
+  Temporal *tpoint1 = tpose_to_tgeompoint(temp1);
+  Temporal *tpoint2 = tpose_to_tgeompoint(temp2);
   Temporal *result = tdistance_tgeo_tgeo(tpoint1, tpoint2);
   pfree(tpoint1); pfree(tpoint2);
   return result;
@@ -126,7 +126,7 @@ nai_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
   if (! ensure_valid_tpose_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   TInstant *resultgeom = nai_tgeo_geo(tpoint, gs);
   /* We do not call the function tgeompointinst_tposeinst to avoid
    * roundoff errors. The closest point may be at an exclusive bound. */
@@ -152,7 +152,7 @@ nai_tpose_pose(const Temporal *temp, const Pose *pose)
     return NULL;
 
   GSERIALIZED *geom = pose_to_point(pose);
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   TInstant *res = nai_tgeo_geo(tpoint, geom);
   /* We do not call the function tgeompointinst_tposeinst to avoid
    * roundoff errors. The closest point may be at an exclusive bound. */
@@ -337,8 +337,8 @@ shortestline_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
   if (! ensure_valid_tpose_tpose(temp1, temp2))
     return NULL;
 
-  Temporal *tpoint1 = tpose_to_tpoint(temp1);
-  Temporal *tpoint2 = tpose_to_tpoint(temp2);
+  Temporal *tpoint1 = tpose_to_tgeompoint(temp1);
+  Temporal *tpoint2 = tpose_to_tgeompoint(temp2);
   GSERIALIZED *result = shortestline_tgeo_tgeo(tpoint1, tpoint2);
   pfree(tpoint1); pfree(tpoint2);
   return result;

--- a/meos/src/pose/tpose_spatialfuncs.c
+++ b/meos/src/pose/tpose_spatialfuncs.c
@@ -62,7 +62,7 @@ tpose_trajectory(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSE(temp, NULL);
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   GSERIALIZED *result = tpoint_trajectory(tpoint, UNARY_UNION_NO);
   pfree(tpoint);
   return result;
@@ -87,7 +87,7 @@ tpose_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
   if (gserialized_is_empty(gs))
     return atfunc ? NULL : temporal_copy(temp);
 
-  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *tpoint = tpose_to_tgeompoint(temp);
   Temporal *res = tgeo_restrict_geom(tpoint, gs, atfunc);
   Temporal *result = NULL;
   if (res)
@@ -148,7 +148,7 @@ tpose_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
   if (! ensure_valid_tpose_stbox(temp, box))
     return NULL;
 
-  Temporal *tgeom = tpose_to_tpoint(temp);
+  Temporal *tgeom = tpose_to_tgeompoint(temp);
   Temporal *tgeomres = tgeo_restrict_stbox(tgeom, box, border_inc, atfunc);
   Temporal *result = NULL;
   if (tgeomres)

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -267,12 +267,11 @@ trgeo_to_tpose(const Temporal *temp)
 
 /**
  * @ingroup meos_rgeo_conversion
- * @brief Return a temporal point obtained from the points of the temporal
- * pose of a temporal rigid geometry
+ * @brief Return a temporal geometry point from a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
  */
 Temporal *
-trgeo_to_tpoint(const Temporal *temp)
+trgeo_to_tgeompoint(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);

--- a/mobilitydb/sql/pose/113_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/113_tpose_distance.in.sql
@@ -42,7 +42,7 @@ CREATE FUNCTION tDistance(pose, tpose)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDistance(tpose, geometry(Point))
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tdistance_tpose_point'
+  AS 'MODULE_PATHNAME', 'Tdistance_tpose_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tDistance(tpose, pose)
   RETURNS tfloat

--- a/mobilitydb/sql/rgeo/122_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/122_trgeo.in.sql
@@ -207,7 +207,7 @@ CREATE FUNCTION tpose(trgeometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tgeompoint(trgeometry)
   RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Trgeometry_to_tpoint'
+  AS 'MODULE_PATHNAME', 'Trgeometry_to_tgeompoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (trgeometry AS tpose) WITH FUNCTION tpose(trgeometry);

--- a/mobilitydb/src/pose/tpose.c
+++ b/mobilitydb/src/pose/tpose.c
@@ -134,7 +134,7 @@ Datum
 Tpose_to_tgeompoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = tpose_to_tpoint(temp);
+  Temporal *result = tpose_to_tgeompoint(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -61,7 +61,7 @@ Tdistance_point_tpose(PG_FUNCTION_ARGS)
 {
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
-  Temporal *result = tdistance_tpose_point(temp, gs);
+  Temporal *result = tdistance_tpose_geo(temp, gs);
   PG_FREE_IF_COPY(gs, 0);
   PG_FREE_IF_COPY(temp, 1);
   if (! result)
@@ -69,8 +69,8 @@ Tdistance_point_tpose(PG_FUNCTION_ARGS)
   PG_RETURN_TEMPORAL_P(result);
 }
 
-PGDLLEXPORT Datum Tdistance_tpose_point(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tdistance_tpose_point);
+PGDLLEXPORT Datum Tdistance_tpose_geo(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tdistance_tpose_geo);
 /**
  * @ingroup mobilitydb_pose_dist
  * @brief Return the temporal distance between a temporal pose and a geometry
@@ -79,11 +79,11 @@ PG_FUNCTION_INFO_V1(Tdistance_tpose_point);
  * @sqlop @p <->
  */
 Datum
-Tdistance_tpose_point(PG_FUNCTION_ARGS)
+Tdistance_tpose_geo(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
-  Temporal *result = tdistance_tpose_point(temp, gs);
+  Temporal *result = tdistance_tpose_geo(temp, gs);
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(gs, 1);
   if (! result)

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -416,18 +416,18 @@ Trgeometry_to_tpose(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PGDLLEXPORT Datum Trgeometry_to_tpoint(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Trgeometry_to_tpoint);
+PGDLLEXPORT Datum Trgeometry_to_tgeompoint(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Trgeometry_to_tgeompoint);
 /**
  * @ingroup mobilitydb_rgeo_conversion
  * @brief Convert a temporal rigid geometry into a temporal point 
  * @sqlfn tgeompoint()
  */
 Datum
-Trgeometry_to_tpoint(PG_FUNCTION_ARGS)
+Trgeometry_to_tgeompoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = trgeo_to_tpoint(temp);
+  Temporal *result = trgeo_to_tgeompoint(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);
 }


### PR DESCRIPTION
## Summary

- Renames a small set of `tpose` and `trgeo` MEOS-layer conversion and distance functions whose names were ambiguous or inconsistent with the naming convention used by other type families.
- 11 files, 32 insertions/33 deletions; purely a rename with no logic change.

## Test plan

- [ ] All existing regression tests pass unchanged
- [ ] PyMEOS / JMEOS bindings updated if they reference the old names (check meos.h diff)
