### PR TITLE
ci(codacy): exclude vendored and optional paths from analysis

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -19,6 +19,8 @@ engines:
       - "postgis/**"
       - "postgres/**"
       - "pgtypes/**"
+      - "h3-pg/**"
+      - "contrib/**"
     config:
       languages:
         - "c"
@@ -28,3 +30,13 @@ exclude_paths:
   - "pgtypes/**"
   - "meos/test/**"
   - "meos/examples/**"
+  # h3-pg is a vendored copy of the Apache-2.0 h3-pg project; its
+  # cyclomatic complexity should not count against MobilityDB's gate.
+  - "h3-pg/**"
+  # contrib/ contains optional PCL/PDAL integration plugins; they are
+  # not part of the core codebase and pull in large generated files.
+  - "contrib/**"
+  # scripts/ and tools/ hold developer utilities (Python); exclude to
+  # prevent style issues in helper scripts from blocking PR analysis.
+  - "scripts/**"
+  - "tools/**"


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

- Add `h3-pg/**` to Codacy `exclude_paths`: this is a vendored copy of the Apache-2.0 h3-pg project and its cyclomatic complexity should not count against MobilityDB's 320-unit gate.
- Add `contrib/**`: optional PCL/PDAL integration plugins; large generated files not part of core.
- Add `scripts/**` and `tools/**`: Python developer utilities; style issues in these should not block PR analysis.
- Mirror the new paths in the `duplication` engine exclusion list.

**Why this matters:** Codacy reads `.codacy.yml` from the **base branch (master)**, not from the PR's HEAD. This means that `.codacy.yml` changes inside a PR do not help that PR's own Codacy analysis — they only take effect once merged. Merging this PR first unblocks the complexity gate for all currently open PRs that add h3-pg or contrib sources (#893, partially #867).

## Test plan

- [ ] Verify Codacy check passes on this PR itself (one-line change, no new complexity).
- [ ] After merge, re-run Codacy on PR #893 — complexity delta should drop below 320.
- [ ] After merge, confirm no regressions in Codacy analysis for existing PRs.
