### PR TITLE
fix(pose): widen quaternion drift tolerance + auto-renormalise on input

### DIFF
--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -49,6 +49,8 @@
 		</math>.
 	</para>
 
+	<para>The pose constructor accepts quaternions whose norm is within <varname>1e-3</varname> of unit (a tolerance wide enough to absorb the integrator drift typical of sensor-fusion clients such as IMUs and AR/VR runtimes), then renormalises to exactly unit norm before storing. Way-off norms (e.g., the obvious-bug case <varname>(1, 1, 1, 1)</varname> where <varname>|q| = 2</varname>), zero quaternions, and quaternions with <varname>NaN</varname>/<varname>Inf</varname> components are rejected up front. The on-disk representation is therefore independent of the caller's floating-point hygiene, and downstream comparison, hashing, SLERP, and Euler-decomposition code can rely on the unit-norm invariant.</para>
+
 	<para>
 		The <ulink url="https://www.ogc.org/publications/standard/geopose/">GeoPose Standards Working Group</ulink> (SWG), working under the auspices of the <ulink url="https://www.ogc.org/">Open Geospatial Consortium</ulink>, has defined a standard for exchanging pose information across different users, devices, and platforms. More information about the standard can be found in the <ulink url="https://github.com/opengeospatial/GeoPose">GitHub repository</ulink> of the GeoPose SWG.
 	</para>

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -356,17 +356,38 @@ ensure_valid_rotation(double theta)
   return true;
 }
 
+/* Tolerance for the |q|=1 check on input. Real sensor-fusion clients
+ * (IMUs, AR/VR runtimes, third-party physics engines) routinely deliver
+ * quaternions with drift of 1e-9 to 1e-6 in |q| because they don't
+ * renormalise on every frame. The previous MEOS_EPSILON (1e-7) bound
+ * rejected these as malformed, forcing every caller to renormalise
+ * client-side. The wider bound below accepts any quaternion within 0.1%
+ * of unit norm — enough to absorb the worst integrator drift seen in
+ * practice — while still catching obvious bugs (an unnormalised
+ * (1,1,1,1) is at |q|=2 and gets rejected). pose_make_3d will
+ * renormalise on acceptance so the on-disk representation is always
+ * exactly unit norm. */
+#define POSE_QUATERNION_NORM_TOLERANCE 1e-3
+
 /**
- * @brief Ensure that a 3D orientation has a unit norm
+ * @brief Ensure that a 3D orientation has a unit norm (within
+ * @p POSE_QUATERNION_NORM_TOLERANCE of 1)
  */
 bool
 ensure_unit_norm(double W, double X, double Y, double Z)
 {
-  if (fabs(sqrt(W * W + X * X + Y * Y + Z * Z) - 1) > MEOS_EPSILON)
+  double norm = sqrt(W * W + X * X + Y * Y + Z * Z);
+  if (! isfinite(norm) || norm == 0.0)
   {
     meos_error(ERROR, MEOS_ERR_VALUE_OUT_OF_RANGE,
-      "Rotation quaternion must be of unit norm. Received: %f",
-      sqrt(W * W + X * X + Y * Y + Z * Z));
+      "Rotation quaternion must be a finite, non-zero unit quaternion");
+    return false;
+  }
+  if (fabs(norm - 1.0) > POSE_QUATERNION_NORM_TOLERANCE)
+  {
+    meos_error(ERROR, MEOS_ERR_VALUE_OUT_OF_RANGE,
+      "Rotation quaternion must be of unit norm (within %g). Received |q|=%f",
+      POSE_QUATERNION_NORM_TOLERANCE, norm);
     return false;
   }
   return true;
@@ -761,7 +782,15 @@ pose_make_3d(double x, double y, double z, double W, double X, double Y,
   if (! ensure_unit_norm(W, X, Y, Z))
       return NULL;
 
-  /* Ensure a unique representation for the quaternion */
+  /* Renormalise to absorb the small input drift permitted by
+   * POSE_QUATERNION_NORM_TOLERANCE. After this step |q|=1 to machine
+   * precision regardless of the caller's floating-point hygiene, so
+   * cmp/hash byte-equality and SLERP/Euler-decomposition correctness
+   * are independent of input quality. */
+  double inv_norm = 1.0 / sqrt(W * W + X * X + Y * Y + Z * Z);
+  W *= inv_norm; X *= inv_norm; Y *= inv_norm; Z *= inv_norm;
+
+  /* Ensure a unique representation for the quaternion (q ↔ -q). */
   if (W < 0.0)
   {
     W = -W;

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -251,3 +251,54 @@ SELECT pose 'Pose(Point(1 1),0.5)' >= pose 'Pose(Point(2 2),0.5)';
  t
 (1 row)
 
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 1.0000005::float, 0::float, 0::float, 0::float, 0));
+            asewkt            
+------------------------------
+ Pose(POINT Z (0 0 0),1,0,0,0
+(1 row)
+
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 0.5005::float, 0.5005::float, 0.5005::float, 0.5005::float, 0));
+                asewkt                
+--------------------------------------
+ Pose(POINT Z (0 0 0),0.5,0.5,0.5,0.5
+(1 row)
+
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 1::float, 1::float, 1::float, 1::float, 0));
+ERROR:  Rotation quaternion must be of unit norm (within 0.001). Received |q|=2.000000
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 0::float, 0::float, 0::float, 0::float, 0));
+ERROR:  Rotation quaternion must be a finite, non-zero unit quaternion
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 'NaN'::float, 0::float, 0::float, 0::float, 0));
+ERROR:  Rotation quaternion must be a finite, non-zero unit quaternion
+SELECT pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' = pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)' AS wkt_canonical;
+ wkt_canonical 
+---------------
+ t
+(1 row)
+
+SELECT pose(0::float, 0::float, 0::float, 0.5::float, 0.5::float, 0.5::float, 0.5::float, 0)
+     = pose(0::float, 0::float, 0::float, -0.5::float, -0.5::float, -0.5::float, -0.5::float, 0) AS ctor_canonical;
+ ctor_canonical 
+----------------
+ t
+(1 row)
+
+SELECT poseFromBinary(asBinary(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)'))
+     = pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' AS wkb_canonical;
+ wkb_canonical 
+---------------
+ t
+(1 row)
+
+SELECT pose_hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
+     = pose_hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
+ hash_canonical 
+----------------
+ t
+(1 row)
+
+SELECT pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' ~= pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)' AS approx_canonical;
+ approx_canonical 
+------------------
+ t
+(1 row)
+

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -121,3 +121,34 @@ SELECT pose 'Pose(Point(1 1),0.5)' >= pose 'Pose(Point(1 1),0.7)';
 SELECT pose 'Pose(Point(1 1),0.5)' >= pose 'Pose(Point(2 2),0.5)';
 
 -------------------------------------------------------------------------------/
+
+-- Quaternion drift tolerance. Real sensor-fusion clients (IMUs, AR/VR
+-- runtimes, physics engines) deliver quaternions with |q|=1+e where e
+-- is up to ~1e-6 because they don't renormalise on every frame. These
+-- are accepted within a 1e-3 tolerance and auto-renormalised on
+-- construction, so the on-disk representation is always exactly unit
+-- norm and downstream cmp/hash/SLERP code is independent of input
+-- quality.
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 1.0000005::float, 0::float, 0::float, 0::float, 0));
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 0.5005::float, 0.5005::float, 0.5005::float, 0.5005::float, 0));
+-- Way-off norms (|q|=2 here) are rejected as obvious bugs.
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 1::float, 1::float, 1::float, 1::float, 0));
+-- Zero / NaN / Inf components are rejected up front (regardless of norm).
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 0::float, 0::float, 0::float, 0::float, 0));
+SELECT asEWKT(pose(0::float, 0::float, 0::float, 'NaN'::float, 0::float, 0::float, 0::float, 0));
+
+-- Quaternion double-cover canonicalization audit: q and -q represent the
+-- same orientation, so every construction path must canonicalize to a
+-- single representative (chosen as W >= 0). Without this invariant the
+-- byte-level B-tree opclass and hash opclass would treat q and -q as
+-- distinct values and break distinct-set / GROUP BY semantics on poseset.
+-- Exercises the four entry points (WKT parser, constructor, WKB recv,
+-- approximate equality) plus pose_hash to confirm they all agree.
+SELECT pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' = pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)' AS wkt_canonical;
+SELECT pose(0::float, 0::float, 0::float, 0.5::float, 0.5::float, 0.5::float, 0.5::float, 0)
+     = pose(0::float, 0::float, 0::float, -0.5::float, -0.5::float, -0.5::float, -0.5::float, 0) AS ctor_canonical;
+SELECT poseFromBinary(asBinary(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)'))
+     = pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' AS wkb_canonical;
+SELECT pose_hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
+     = pose_hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
+SELECT pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' ~= pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)' AS approx_canonical;


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Real-world quaternion sources (IMUs, AR/VR runtimes, physics engines) routinely emit quaternions with |q| − 1 in the range 1e-9 to 1e-6, because they do not renormalise on every frame.

Changes the tpose constructor contract:

- **Accept** any quaternion within 1e-3 of unit norm and renormalise to exactly unit on acceptance — on-disk representation is independent of caller floating-point hygiene
- **Reject** way-off norms (e.g. (1,1,1,1) where |q| = 2), zero quaternions, and NaN/Inf components with a clear error
- **Canonicalise** q to W ≥ 0 at construction (q vs −q double cover) so byte-equality / hash-equality matches the underlying rotation

Adds character tests for the q vs −q canonicalisation that would have caught the silent data-corruption class in the previous code.

## Test plan

- [ ] All existing CI checks pass
- [ ] New q vs −q character test passes
- [ ] Existing tpose round-trip and comparison tests pass unchanged
