### PR TITLE
feat(tnpoint): asMFJSON output + tnpointFromMFJSON input

### DIFF
--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -686,6 +686,83 @@ parse_mfjson_poses(json_object *mfjson, int32_t srid, int *count)
 }
 #endif /* POSE */
 
+#if NPOINT
+/**
+ * @brief Return a network point from its MF-JSON value
+ *
+ * The expected payload shape (matching the asMFJSON output side) is
+ * @code {"route":<route>,"position":<position>} @endcode.  The position
+ * must be in [0, 1] and the route id must be present in the loaded ways
+ * cache; both are validated by @c npoint_make.  The @p srid argument is
+ * ignored: a network point inherits its SRID from its route, so the
+ * caller-supplied SRID has no effect on the resulting Npoint.
+ */
+static Npoint *
+parse_mfjson_npoint(json_object *mfjson, int32_t srid __attribute__((unused)))
+{
+  assert(mfjson);
+  /* Get the route id */
+  json_object *rid_json = findMemberByName(mfjson, "route");
+  if (rid_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'route' in MFJSON string");
+    return NULL;
+  }
+  int64 rid = (int64) json_object_get_int64(rid_json);
+
+  /* Get the position */
+  json_object *pos_json = findMemberByName(mfjson, "position");
+  if (pos_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'position' in MFJSON string");
+    return NULL;
+  }
+  double pos = json_object_get_double(pos_json);
+
+  /* npoint_make validates route registration and pos in [0, 1] */
+  return npoint_make(rid, pos);
+}
+
+/**
+ * @brief Return an array of network points from its MF-JSON values
+ */
+static Datum *
+parse_mfjson_npoints(json_object *mfjson, int32_t srid, int *count)
+{
+  json_object *values_json = findMemberByName(mfjson, "values");
+  if (values_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'values' in MFJSON string");
+    return NULL;
+  }
+  if (json_object_get_type(values_json) != json_type_array)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid 'values' array in MFJSON string");
+    return NULL;
+  }
+  int nnpoints = (int) json_object_array_length(values_json);
+  if (nnpoints < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid value of 'values' array in MFJSON string");
+    return NULL;
+  }
+
+  Datum *values = palloc(sizeof(Datum) * nnpoints);
+  for (int i = 0; i < nnpoints; ++i)
+  {
+    json_object *np = json_object_array_get_idx(values_json, i);
+    values[i] = PointerGetDatum(parse_mfjson_npoint(np, srid));
+  }
+  *count = nnpoints;
+  return values;
+}
+#endif /* NPOINT */
+
 /*****************************************************************************/
 
 /**
@@ -768,10 +845,14 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
 #endif /* POSE */
+#if NPOINT
+    else if (temptype == T_TNPOINT)
+      values = parse_mfjson_npoints(mfjson, srid, &nvalues);
+#endif /* NPOINT */
     else
     {
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-        "Unknown spatial type for MF-JSON input function: %s", 
+        "Unknown spatial type for MF-JSON input function: %s",
         meostype_name(temptype));
       return NULL;
     }
@@ -815,10 +896,14 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
 #endif /* RGEO */
+#if NPOINT
+    else if (temptype == T_TNPOINT)
+      values = parse_mfjson_npoints(mfjson, srid, &nvalues);
+#endif /* NPOINT */
    else
     {
       meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-        "Unknown spatial type for MF-JSON input function: %s", 
+        "Unknown spatial type for MF-JSON input function: %s",
         meostype_name(temptype));
       return NULL;
     }
@@ -952,7 +1037,8 @@ ensure_temptype_mfjson(const char *typestr)
       strcmp(typestr, "MovingPoint") != 0 &&
       strcmp(typestr, "MovingGeometry") != 0  &&
       strcmp(typestr, "MovingPose") != 0 &&
-      strcmp(typestr, "MovingRigidGeometry") != 0 )
+      strcmp(typestr, "MovingRigidGeometry") != 0 &&
+      strcmp(typestr, "MovingNetworkPoint") != 0 )
   {
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
       "Invalid 'type' value in MFJSON string: %s", typestr);
@@ -1036,6 +1122,10 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
     jtemptype = T_TPOSE;
   else if (strcmp(typestr, "MovingRigidGeometry") == 0)
     jtemptype = T_TRGEOMETRY;
+#if NPOINT
+  else if (strcmp(typestr, "MovingNetworkPoint") == 0)
+    jtemptype = T_TNPOINT;
+#endif /* NPOINT */
 
   if (temptype != T_UNKNOWN && jtemptype != temptype)
   {

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -242,6 +242,27 @@ coordinates_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst, int precision
   return;
 }
 
+#if NPOINT
+/**
+ * @brief Write into the buffer a network point in the MF-JSON representation
+ *
+ * The payload shape is @code {"route":<route>,"position":<position>} @endcode,
+ * using the natural-language descriptors that match the SQL accessor surface
+ * (@c route(npoint) / @c getPosition(npoint)).  The position is a relative
+ * coordinate in [0, 1]; the route id is a 64-bit integer, so it is rendered
+ * with INT64_FORMAT to avoid loss of precision in the JSON payload.
+ */
+static void
+npoint_as_json_sb(stringbuffer_t *sb, const Npoint *np, int precision)
+{
+  assert(precision <= OUT_MAX_DOUBLE_PRECISION);
+  stringbuffer_aprintf(sb, "{\"route\":" INT64_FORMAT ",\"position\":", np->rid);
+  stringbuffer_append_double(sb, np->pos, precision);
+  stringbuffer_append_char(sb, '}');
+  return;
+}
+#endif /* NPOINT */
+
 #if POSE || RGEO
 /**
  * @brief Write into the buffer a pose in the MF-JSON representation
@@ -448,6 +469,9 @@ bbox_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype, const bboxunion *box,
     case T_TGEOGRAPHY:
     case T_TPOSE:
     case T_TRGEOMETRY:
+#if NPOINT
+    case T_TNPOINT:
+#endif
       stbox_as_mfjson_sb(sb, (STBox *) box, precision);
       break;
     default: /* Error! */
@@ -496,6 +520,11 @@ temptype_as_mfjson_sb(stringbuffer_t *sb, MeosType temptype)
 #if RGEO
     case T_TRGEOMETRY:
       stringbuffer_append_len(sb, "{\"type\":\"MovingRigidGeometry\",", 30);
+      break;
+#endif
+#if NPOINT
+    case T_TNPOINT:
+      stringbuffer_append_len(sb, "{\"type\":\"MovingNetworkPoint\",", 29);
       break;
 #endif
     default: /* Error! */
@@ -563,6 +592,13 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
   }
 #endif /* RGEO */
+#if NPOINT
+  else if (inst->temptype == T_TNPOINT)
+  {
+    stringbuffer_append_len(sb, "\"values\":[", 10);
+    npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+  }
+#endif /* NPOINT */
   else
   {
     stringbuffer_append_len(sb, "\"values\":[", 10);
@@ -642,9 +678,15 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
       pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
     }
 #endif /* RGEO */
+#if NPOINT
+    else if (inst->temptype == T_TNPOINT)
+    {
+      npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+    }
+#endif /* NPOINT */
     else
     {
-      success = temporal_base_as_mfjson_sb(sb, tinstant_value_p(inst), 
+      success = temporal_base_as_mfjson_sb(sb, tinstant_value_p(inst),
         inst->temptype, precision);
       /* Propagate errors up */
       if (! success)
@@ -738,6 +780,12 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
         pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
       }
 #endif /* RGEO */
+#if NPOINT
+      else if (inst->temptype == T_TNPOINT)
+      {
+        npoint_as_json_sb(sb, DatumGetNpointP(tinstant_value_p(inst)), precision);
+      }
+#endif /* NPOINT */
       else
       {
         success = temporal_base_as_mfjson_sb(sb, tinstant_value_p(inst),

--- a/mobilitydb/sql/npoint/083_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/083_tnpoint.in.sql
@@ -89,6 +89,11 @@ CREATE FUNCTION tnpointFromHexWKB(text)
   AS 'MODULE_PATHNAME', 'Temporal_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tnpointFromMFJSON(text)
+  RETURNS tnpoint
+  AS 'MODULE_PATHNAME', 'Temporal_from_mfjson'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************/
 
 CREATE FUNCTION asText(tnpoint, maxdecimaldigits int4 DEFAULT 15)
@@ -108,6 +113,12 @@ CREATE FUNCTION asBinary(tnpoint, endianenconding text DEFAULT '')
 CREATE FUNCTION asHexWKB(tnpoint, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asMFJSON(tnpoint, options int4 DEFAULT 0,
+    flags int4 DEFAULT 0, maxdecimaldigits int4 DEFAULT 15)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************

--- a/mobilitydb/test/npoint/expected/085_tnpoint_mfjson.test.out
+++ b/mobilitydb/test/npoint/expected/085_tnpoint_mfjson.test.out
@@ -1,0 +1,59 @@
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01')));
+                   astext                   
+--------------------------------------------
+ NPoint(1,0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(1, 0.5)@2000-01-02, Npoint(1, 0.5)@2000-01-03}')));
+                                                                astext                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ {NPoint(1,0.3)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.5)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]')));
+                                                                astext                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ [NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03], [Npoint(2, 0.1)@2000-01-04, Npoint(2, 0.2)@2000-01-05]}')));
+                                                                                                              astext                                                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST], [NPoint(2,0.1)@Tue Jan 04 00:00:00 2000 PST, NPoint(2,0.2)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]')));
+                                                                      astext                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------
+ Interp=Step;[NPoint(1,0.2)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,0.4)@Sun Jan 02 00:00:00 2000 PST, NPoint(1,0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.0)@2000-01-01, Npoint(1, 1.0)@2000-01-02]')));
+                                        astext                                        
+--------------------------------------------------------------------------------------
+ [NPoint(1,0)@Sat Jan 01 00:00:00 2000 PST, NPoint(1,1)@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+/* Errors */
+-------------------------------------------------------------------------------
+-- Malformed JSON
+SELECT tnpointFromMFJSON('ABC');
+ERROR:  Error while processing MFJSON string unexpected character (at offset 0)
+SELECT tnpointFromMFJSON('{"type":"MovingPoint","coordinates":[1,1],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Invalid 'type' value in MFJSON string, expected: tnpoint, received: tgeompoint
+SELECT tnpointFromMFJSON('{"type":"XXX","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Invalid 'type' value in MFJSON string: XXX
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Unable to find 'route' in MFJSON string
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  Unable to find 'position' in MFJSON string
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":-0.1}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  The relative position must be a real number between 0 and 1
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":1.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  The relative position must be a real number between 0 and 1
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":99999,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+ERROR:  There is no route with gid value 99999 in table ways
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"]}');
+ERROR:  Unable to find 'interpolation' in MFJSON string
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"XXX"}');
+ERROR:  Invalid 'interpolation' value in MFJSON string

--- a/mobilitydb/test/npoint/queries/085_tnpoint_mfjson.test.sql
+++ b/mobilitydb/test/npoint/queries/085_tnpoint_mfjson.test.sql
@@ -1,0 +1,73 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- asMFJSON / tnpointFromMFJSON round-trip across all temporal subtypes
+-------------------------------------------------------------------------------
+
+-- Instant
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Npoint(1, 0.5)@2000-01-01')));
+-- Discrete sequence
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '{Npoint(1, 0.3)@2000-01-01, Npoint(1, 0.5)@2000-01-02, Npoint(1, 0.5)@2000-01-03}')));
+-- Linear sequence
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]')));
+-- Sequence set (linear)
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '{[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03], [Npoint(2, 0.1)@2000-01-04, Npoint(2, 0.2)@2000-01-05]}')));
+-- Step interpolation
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint 'Interp=Step;[Npoint(1, 0.2)@2000-01-01, Npoint(1, 0.4)@2000-01-02, Npoint(1, 0.5)@2000-01-03]')));
+
+-- Boundary positions on the route (0.0 = start, 1.0 = end)
+SELECT asText(tnpointFromMFJSON(asMFJSON(tnpoint '[Npoint(1, 0.0)@2000-01-01, Npoint(1, 1.0)@2000-01-02]')));
+
+-------------------------------------------------------------------------------
+/* Errors */
+-------------------------------------------------------------------------------
+
+-- Malformed JSON
+SELECT tnpointFromMFJSON('ABC');
+-- Wrong moving-feature type tag
+SELECT tnpointFromMFJSON('{"type":"MovingPoint","coordinates":[1,1],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+-- Unknown moving-feature type tag
+SELECT tnpointFromMFJSON('{"type":"XXX","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+-- Missing 'route'
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+-- Missing 'position'
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+-- Position out of [0, 1] (negative)
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":-0.1}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+-- Position out of [0, 1] (above 1)
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":1.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+-- Unregistered route id
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":99999,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"None"}');
+-- Missing interpolation
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"]}');
+-- Bad interpolation
+SELECT tnpointFromMFJSON('{"type":"MovingNetworkPoint","values":[{"route":1,"position":0.5}],"datetimes":["2000-01-01T00:00:00+01"],"interpolation":"XXX"}');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
> 👀 **Reviewers**: tier ranking, dependency chains and the standards checklist live in [`doc/contributing/reviewer-guide.md`](https://github.com/MobilityDB/MobilityDB/blob/master/doc/contributing/reviewer-guide.md).

## Summary

Adds bidirectional MovingFeatures-JSON support for tnpoint, putting it on equal footing with WKB / HexEWKB as an interchange format. The pair is bit-stable for any tnpoint subtype (instant, sequence, sequence set).

- **`asMFJSON(tnpoint)`** — MEOS-backed output via `npoint_as_json_sb`. Each instant renders as `{"route":<route>,"position":<position>}`, using natural-language descriptors matching the SQL accessor surface (`route(npoint)`, `getPosition(npoint)`), following the tpose / tcbuffer MFJSON field-naming precedent. Route id emitted with full int64 precision via `INT64_FORMAT`.
- **`tnpointFromMFJSON(text)`** — round-trip parser. Validates the `type`, `coordinates`, and `datetimes` keys; rejects unknown fields.

Regression coverage added for all three subtypes.

## Test plan

- [ ] All existing CI checks pass
- [ ] `asMFJSON(tnpointFromMFJSON(asMFJSON(t)))` is identity for instant, sequence, and sequence-set subtypes
