### PR TITLE
Fix geodetic-pose 3D WKT output dropping its closing parenthesis

### DIFF
--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -558,7 +558,7 @@ pose_wkt_out(const Pose *pose, bool extended, int maxdd)
     X = float8_out(pose->data[4], maxdd);
     Y = float8_out(pose->data[5], maxdd);
     Z = float8_out(pose->data[6], maxdd);
-    len += strlen(W) + strlen(X) + strlen(Y) + strlen(Z) + 3; // Three ','
+    len += strlen(W) + strlen(X) + strlen(Y) + strlen(Z) + 4; // Four ','
   }
   else
   {


### PR DESCRIPTION
`pose_wkt_out` sizes the output buffer for the 3D pose form `GeodPose(point,W,X,Y,Z)` / `Pose(point,W,X,Y,Z)` but the comma budget counted only 3 of the 4 commas separating the five values, leaving the buffer one byte short so `snprintf` truncated the trailing `)`. Output was e.g. `GeodPose(POINT Z (1 1 1),1,0,0,0` (no closing paren). Count 4 commas.

Surfaced by the POSE coverage tests (opt-in, not in the default CI matrix).
