### PR TITLE
Add the aggregate functions for th3index and tquadbin

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3127,6 +3127,19 @@
 		</sect2>
 
 		<sect2>
+		<title>Agregaciones</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="th3_tCount"><varname>tCount</varname></link>: Conteo temporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="th3_wCount"><varname>wCount</varname></link>: Conteo de ventana</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
 			<title>Índices</title>
 			<itemizedlist>
 				<listitem>
@@ -3272,6 +3285,19 @@
 			<itemizedlist>
 				<listitem>
 					<para><link linkend="tquadbin_comparisons"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Agregaciones</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tquadbin_tCount"><varname>tCount</varname></link>: Conteo temporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tquadbin_wCount"><varname>wCount</varname></link>: Conteo de ventana</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -830,6 +830,43 @@ SELECT eContains(
 </programlisting>
 	</sect1>
 
+	<sect1 xml:id="th3_aggregations">
+		<title>Agregaciones</title>
+		<para>Las funciones de agregación para celdas H3 temporales se ilustran a continuación.</para>
+
+		<itemizedlist>
+			<listitem xml:id="th3_tCount">
+				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
+				<para>Conteo temporal</para>
+				<para><varname>tCount(th3index) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
+  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04)' UNION
+  SELECT th3index '[871fa44a8ffffff@2001-01-03, 871fa44a8ffffff@2001-01-05)' )
+SELECT tCount(Temp)
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="th3_wCount">
+				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
+				<para>Conteo en ventana</para>
+				<para><varname>wCount(th3index) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
+  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04)' UNION
+  SELECT th3index '[871fa44a8ffffff@2001-01-03, 871fa44a8ffffff@2001-01-05)' )
+SELECT wCount(Temp, interval '1 day')
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 3@2001-01-03, 2@2001-01-04, 1@2001-01-05, 1@2001-01-06)}
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="th3_indexing">
 		<title>Indexación</title>
 		<para>Las clases de operadores GiST y SP-GiST están definidas para que los operadores de caja envolvente de la sección anterior puedan ser utilizados con los índices correspondientes.</para>

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -370,6 +370,43 @@ SELECT round(quadbinCellArea(quadbin '48427fffffffffff')::numeric, 0);
 		<para>Los operadores de comparación de árbol B (<varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&lt;=</varname>, <varname>&gt;</varname>, <varname>&gt;=</varname>) y el operador hash están definidos sobre <varname>tquadbin</varname> a través de la maquinaria genérica de comparación temporal, ordenando por la secuencia de valores temporal subyacente. Soportan las clases de operadores <varname>tquadbin_btree_ops</varname> y <varname>tquadbin_hash_ops</varname> usadas por GROUP BY, DISTINCT, ORDER BY, y las uniones por mezcla / hash. Como con <varname>tbigint</varname>, el orden int64 de los identificadores QUADBIN no tiene significado geográfico — véase <xref linkend="quadbin_operational_notes"/>.</para>
 	</sect1>
 
+	<sect1 xml:id="tquadbin_aggregations">
+		<title>Agregaciones</title>
+		<para>Las funciones de agregación para celdas quadbin temporales se ilustran a continuación.</para>
+
+		<itemizedlist>
+			<listitem xml:id="tquadbin_tCount">
+				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
+				<para>Conteo temporal</para>
+				<para><varname>tCount(tquadbin) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03)' UNION
+  SELECT tquadbin '[48427fffffffffff@2001-01-02, 48427fffffffffff@2001-01-04)' UNION
+  SELECT tquadbin '[48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-05)' )
+SELECT tCount(Temp)
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tquadbin_wCount">
+				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
+				<para>Conteo en ventana</para>
+				<para><varname>wCount(tquadbin) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03)' UNION
+  SELECT tquadbin '[48427fffffffffff@2001-01-02, 48427fffffffffff@2001-01-04)' UNION
+  SELECT tquadbin '[48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-05)' )
+SELECT wCount(Temp, interval '1 day')
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 3@2001-01-03, 2@2001-01-04, 1@2001-01-05, 1@2001-01-06)}
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="tquadbin_indexing">
 		<title>Indexación</title>
 		<para>Se definen clases de operadores de árbol B y hash para que los operadores de comparación de la sección anterior puedan utilizarse con los índices correspondientes.</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3105,6 +3105,19 @@
 		</sect2>
 
 		<sect2>
+		<title>Aggregations</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="th3_tCount"><varname>tCount</varname></link>: Temporal count</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="th3_wCount"><varname>wCount</varname></link>: Window count</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
 			<title>Indexing</title>
 			<itemizedlist>
 				<listitem>
@@ -3250,6 +3263,19 @@
 			<itemizedlist>
 				<listitem>
 					<para><link linkend="tquadbin_comparisons"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
+		<title>Aggregations</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="tquadbin_tCount"><varname>tCount</varname></link>: Temporal count</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="tquadbin_wCount"><varname>wCount</varname></link>: Window count</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -848,6 +848,43 @@ SELECT eContains(
 </programlisting>
 	</sect1>
 
+	<sect1 xml:id="th3_aggregations">
+		<title>Aggregations</title>
+		<para>The aggregate functions for temporal H3 cells are illustrated next.</para>
+
+		<itemizedlist>
+			<listitem xml:id="th3_tCount">
+				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
+				<para>Temporal count</para>
+				<para><varname>tCount(th3index) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
+  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04)' UNION
+  SELECT th3index '[871fa44a8ffffff@2001-01-03, 871fa44a8ffffff@2001-01-05)' )
+SELECT tCount(Temp)
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="th3_wCount">
+				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
+				<para>Window count</para>
+				<para><varname>wCount(th3index) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
+  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04)' UNION
+  SELECT th3index '[871fa44a8ffffff@2001-01-03, 871fa44a8ffffff@2001-01-05)' )
+SELECT wCount(Temp, interval '1 day')
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 3@2001-01-03, 2@2001-01-04, 1@2001-01-05, 1@2001-01-06)}
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="th3_indexing">
 		<title>Indexing</title>
 		<para>GiST and SP-GiST operator classes are defined so the bounding-box operators of the previous section can be used with corresponding indexes.</para>

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -370,6 +370,43 @@ SELECT round(quadbinCellArea(quadbin '48427fffffffffff')::numeric, 0);
 		<para>The B-tree comparison operators (<varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&lt;=</varname>, <varname>&gt;</varname>, <varname>&gt;=</varname>) and the hash operator are defined on <varname>tquadbin</varname> through the generic temporal comparison machinery, ordering by the underlying temporal-value sequence. They support the <varname>tquadbin_btree_ops</varname> and <varname>tquadbin_hash_ops</varname> operator classes used by GROUP BY, DISTINCT, ORDER BY, and merge / hash joins. As with <varname>tbigint</varname>, the int64 ordering of QUADBIN identifiers carries no geographic meaning — see <xref linkend="quadbin_operational_notes"/>.</para>
 	</sect1>
 
+	<sect1 xml:id="tquadbin_aggregations">
+		<title>Aggregations</title>
+		<para>The aggregate functions for temporal quadbin cells are illustrated next.</para>
+
+		<itemizedlist>
+			<listitem xml:id="tquadbin_tCount">
+				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
+				<para>Temporal count</para>
+				<para><varname>tCount(tquadbin) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03)' UNION
+  SELECT tquadbin '[48427fffffffffff@2001-01-02, 48427fffffffffff@2001-01-04)' UNION
+  SELECT tquadbin '[48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-05)' )
+SELECT tCount(Temp)
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="tquadbin_wCount">
+				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
+				<para>Window count</para>
+				<para><varname>wCount(tquadbin) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03)' UNION
+  SELECT tquadbin '[48427fffffffffff@2001-01-02, 48427fffffffffff@2001-01-04)' UNION
+  SELECT tquadbin '[48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-05)' )
+SELECT wCount(Temp, interval '1 day')
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 3@2001-01-03, 2@2001-01-04, 1@2001-01-05, 1@2001-01-06)}
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="tquadbin_indexing">
 		<title>Indexing</title>
 		<para>B-tree and hash operator classes are defined so the comparison operators of the previous section can be used with corresponding indexes.</para>

--- a/mobilitydb/sql/h3/261_th3index_aggfuncs.in.sql
+++ b/mobilitydb/sql/h3/261_th3index_aggfuncs.in.sql
@@ -1,0 +1,195 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Aggregate functions for temporal H3 cells
+ */
+
+-- The function is not STRICT
+CREATE FUNCTION tspatial_extent_transfn(stbox, th3index)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'Tspatial_extent_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE extent(th3index) (
+  SFUNC = tspatial_extent_transfn,
+  STYPE = stbox,
+  COMBINEFUNC = stbox_extent_combinefn,
+  PARALLEL = safe
+);
+
+-- The function is not STRICT
+CREATE FUNCTION tcount_transfn(internal, th3index)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION th3index_tagg_finalfn(internal)
+  RETURNS th3index
+  AS 'MODULE_PATHNAME', 'Temporal_tagg_finalfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE AGGREGATE tCount(th3index) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+-- The function is not STRICT
+CREATE FUNCTION wcount_transfn(internal, th3index, interval)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE wCount(th3index, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_merge_transfn(internal, th3index)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE merge(th3index) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = th3index_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(th3index) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = th3index_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE FUNCTION temporal_app_tinst_transfn(th3index, th3index)
+  RETURNS th3index
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION temporal_app_tinst_transfn(th3index, th3index, interp text)
+  RETURNS th3index
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_app_tinst_transfn(th3index, th3index, interp text,
+    maxt interval)
+  RETURNS th3index
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION temporal_append_finalfn(th3index)
+  RETURNS th3index
+  AS 'MODULE_PATHNAME', 'Temporal_append_finalfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE AGGREGATE appendInstant(th3index) (
+  SFUNC = temporal_app_tinst_transfn(th3index, th3index),
+  STYPE = th3index,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(th3index) (
+  SFUNC = temporal_app_tinst_transfn(th3index, th3index),
+  STYPE = th3index,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+CREATE AGGREGATE appendInstant(th3index, interp text) (
+  SFUNC = temporal_app_tinst_transfn(th3index, th3index, text),
+  STYPE = th3index,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(th3index, interp text) (
+  SFUNC = temporal_app_tinst_transfn(th3index, th3index, text),
+  STYPE = th3index,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+CREATE AGGREGATE appendInstant(th3index, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(th3index, th3index, text, maxt),
+  STYPE = th3index,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(th3index, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(th3index, th3index, text, maxt),
+  STYPE = th3index,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+/*****************************************************************************/
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_app_tseq_transfn(th3index, th3index)
+  RETURNS th3index
+  AS 'MODULE_PATHNAME', 'Temporal_app_tseq_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE appendSequence(th3index) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = th3index,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(th3index) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = th3index,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+/*****************************************************************************/

--- a/mobilitydb/sql/h3/CMakeLists.txt
+++ b/mobilitydb/sql/h3/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(LOCAL_FILES
   257_th3index_boxops
   258_th3index_topops
   259_th3index_posops
+  261_th3index_aggfuncs
   262_th3index_spatialrels
   264_th3index_tempspatialrels
   272_th3index_gist

--- a/mobilitydb/sql/quadbin/361_tquadbin_aggfuncs.in.sql
+++ b/mobilitydb/sql/quadbin/361_tquadbin_aggfuncs.in.sql
@@ -1,0 +1,195 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Aggregate functions for temporal quadbin cells
+ */
+
+-- The function is not STRICT
+CREATE FUNCTION tspatial_extent_transfn(stbox, tquadbin)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'Tspatial_extent_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE extent(tquadbin) (
+  SFUNC = tspatial_extent_transfn,
+  STYPE = stbox,
+  COMBINEFUNC = stbox_extent_combinefn,
+  PARALLEL = safe
+);
+
+-- The function is not STRICT
+CREATE FUNCTION tcount_transfn(internal, tquadbin)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION tquadbin_tagg_finalfn(internal)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_tagg_finalfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE AGGREGATE tCount(tquadbin) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+-- The function is not STRICT
+CREATE FUNCTION wcount_transfn(internal, tquadbin, interval)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE wCount(tquadbin, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_merge_transfn(internal, tquadbin)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE merge(tquadbin) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tquadbin_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE mergeAgg(tquadbin) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tquadbin_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+CREATE FUNCTION temporal_app_tinst_transfn(tquadbin, tquadbin)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION temporal_app_tinst_transfn(tquadbin, tquadbin, interp text)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_app_tinst_transfn(tquadbin, tquadbin, interp text,
+    maxt interval)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION temporal_append_finalfn(tquadbin)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_append_finalfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE AGGREGATE appendInstant(tquadbin) (
+  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin),
+  STYPE = tquadbin,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tquadbin) (
+  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin),
+  STYPE = tquadbin,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+CREATE AGGREGATE appendInstant(tquadbin, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin, text),
+  STYPE = tquadbin,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tquadbin, interp text) (
+  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin, text),
+  STYPE = tquadbin,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+CREATE AGGREGATE appendInstant(tquadbin, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin, text, maxt),
+  STYPE = tquadbin,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendInstantAgg(tquadbin, interp text, maxt interval) (
+  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin, text, maxt),
+  STYPE = tquadbin,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+/*****************************************************************************/
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_app_tseq_transfn(tquadbin, tquadbin)
+  RETURNS tquadbin
+  AS 'MODULE_PATHNAME', 'Temporal_app_tseq_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE appendSequence(tquadbin) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tquadbin,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE appendSequenceAgg(tquadbin) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tquadbin,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+/*****************************************************************************/

--- a/mobilitydb/sql/quadbin/CMakeLists.txt
+++ b/mobilitydb/sql/quadbin/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(LOCAL_FILES
   357_tquadbin_boxops
   358_tquadbin_topops
   359_tquadbin_posops
+  361_tquadbin_aggfuncs
   362_tquadbin_spatialrels
   364_tquadbin_tempspatialrels
   372_tquadbin_gist

--- a/mobilitydb/test/h3/expected/261_th3index_aggfuncs.test.out
+++ b/mobilitydb/test/h3/expected/261_th3index_aggfuncs.test.out
@@ -1,0 +1,166 @@
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (NULL::th3index),
+  (th3index '831c02fffffffff@2001-01-01'),
+  (th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}')) t(temp);
+                                                                 round                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;GEODSTBOX XT(((-145.20901,49.268689),(-142.844448,50.533827)),[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (th3index '831c02fffffffff@2001-01-01'),
+  (th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}'),
+  (NULL)) t(temp);
+                                                                 round                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;GEODSTBOX XT(((-145.20901,49.268689),(-142.844448,50.533827)),[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (th3index '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]'),
+  ('{[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02], [871fa44a8ffffff@2001-01-03, 880326b885fffff@2001-01-04]}')) t(temp);
+                                                                round                                                                
+-------------------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;GEODSTBOX XT(((-145.20901,49.268689),(65.602001,89.583016)),[Mon Jan 01 00:00:00 2001 PST, Thu Jan 04 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(extent(temp), 6) FROM ( VALUES (th3index '831c02fffffffff@2001-01-01')) t(temp);
+                                                                 round                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;GEODSTBOX XT(((-145.20901,49.268689),(-143.772016,50.213164)),[Mon Jan 01 00:00:00 2001 PST, Mon Jan 01 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(extent(temp), 6) FROM ( VALUES (NULL::th3index)) t(temp);
+ round 
+-------
+ 
+(1 row)
+
+WITH Temp(temp) AS (
+  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03]' UNION
+  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04]' )
+SELECT tCount(Temp) FROM Temp;
+                                                                                tcount                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Mon Jan 01 00:00:00 2001 PST, 2@Tue Jan 02 00:00:00 2001 PST, 2@Wed Jan 03 00:00:00 2001 PST], (1@Wed Jan 03 00:00:00 2001 PST, 1@Thu Jan 04 00:00:00 2001 PST]}
+(1 row)
+
+WITH Temp(temp) AS (
+  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03]' UNION
+  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04]' )
+SELECT wCount(Temp, interval '2 days') FROM Temp;
+                                                                                wcount                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Mon Jan 01 00:00:00 2001 PST, 2@Tue Jan 02 00:00:00 2001 PST, 2@Fri Jan 05 00:00:00 2001 PST], (1@Fri Jan 05 00:00:00 2001 PST, 1@Sat Jan 06 00:00:00 2001 PST]}
+(1 row)
+
+SELECT merge(temp) FROM (VALUES
+  (th3index '831c02fffffffff@2001-01-01'),
+  (th3index '831c00fffffffff@2001-01-02')) t(temp);
+                                            merge                                             
+----------------------------------------------------------------------------------------------
+ {831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+SELECT mergeAgg(temp) FROM (VALUES
+  (th3index '831c02fffffffff@2001-01-01'),
+  (th3index '831c00fffffffff@2001-01-02')) t(temp);
+                                           mergeagg                                           
+----------------------------------------------------------------------------------------------
+ {831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-03' UNION
+  SELECT th3index '880326b885fffff@2001-01-04' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+                                                                                          astext                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST, 871fa44a8ffffff@Wed Jan 03 00:00:00 2001 PST, 880326b885fffff@Thu Jan 04 00:00:00 2001 PST]
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-03' UNION
+  SELECT th3index '880326b885fffff@2001-01-04' )
+SELECT asText(appendInstantAgg(inst ORDER BY inst)) FROM temp;
+                                                                                          astext                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST, 871fa44a8ffffff@Wed Jan 03 00:00:00 2001 PST, 880326b885fffff@Thu Jan 04 00:00:00 2001 PST]
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+                                                                   astext                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------
+ [831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST, 871fa44a8ffffff@Wed Jan 03 00:00:00 2001 PST]
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst, 'step')) FROM temp;
+                                                                   astext                                                                   
+--------------------------------------------------------------------------------------------------------------------------------------------
+ [831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST, 871fa44a8ffffff@Wed Jan 03 00:00:00 2001 PST]
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-04' UNION
+  SELECT th3index '880326b885fffff@2001-01-08' )
+SELECT asText(appendInstant(inst, 'step', interval '1 day' ORDER BY inst)) FROM temp;
+                                                                                             astext                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST], [871fa44a8ffffff@Thu Jan 04 00:00:00 2001 PST], [880326b885fffff@Mon Jan 08 00:00:00 2001 PST]}
+(1 row)
+
+/* Errors */
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-01' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+ERROR:  The temporal values have different value at their common timestamp Mon Jan 01 00:00:00 2001 PST
+WITH temp1(k, inst) AS (
+  SELECT 1, th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT 2, th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT 3, th3index '871fa44a8ffffff@2001-01-03' UNION
+  SELECT 4, th3index '880326b885fffff@2001-01-04' UNION
+  SELECT 5, th3index '880326b88dfffff@2001-01-05' UNION
+  SELECT 6, th3index '8a2a100d645ffff@2001-01-06' ),
+temp2(k, seq) AS (
+  SELECT (k - 1) / 2, appendInstant(inst ORDER BY inst)
+  FROM temp1
+  GROUP BY (k - 1) / 2)
+SELECT asText(appendSequence(seq ORDER BY seq)) FROM temp2;
+                                                                                                                                           astext                                                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST], [871fa44a8ffffff@Wed Jan 03 00:00:00 2001 PST, 880326b885fffff@Thu Jan 04 00:00:00 2001 PST], [880326b88dfffff@Fri Jan 05 00:00:00 2001 PST, 8a2a100d645ffff@Sat Jan 06 00:00:00 2001 PST]}
+(1 row)
+
+WITH temp1(k, inst) AS (
+  SELECT 1, th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT 2, th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT 3, th3index '871fa44a8ffffff@2001-01-03' UNION
+  SELECT 4, th3index '880326b885fffff@2001-01-04' UNION
+  SELECT 5, th3index '880326b88dfffff@2001-01-05' UNION
+  SELECT 6, th3index '8a2a100d645ffff@2001-01-06' ),
+temp2(k, seq) AS (
+  SELECT (k - 1) / 2, appendInstant(inst ORDER BY inst)
+  FROM temp1
+  GROUP BY (k - 1) / 2)
+SELECT asText(appendSequenceAgg(seq ORDER BY seq)) FROM temp2;
+                                                                                                                                           astext                                                                                                                                           
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[831c02fffffffff@Mon Jan 01 00:00:00 2001 PST, 831c00fffffffff@Tue Jan 02 00:00:00 2001 PST], [871fa44a8ffffff@Wed Jan 03 00:00:00 2001 PST, 880326b885fffff@Thu Jan 04 00:00:00 2001 PST], [880326b88dfffff@Fri Jan 05 00:00:00 2001 PST, 8a2a100d645ffff@Sat Jan 06 00:00:00 2001 PST]}
+(1 row)
+

--- a/mobilitydb/test/h3/queries/261_th3index_aggfuncs.test.sql
+++ b/mobilitydb/test/h3/queries/261_th3index_aggfuncs.test.sql
@@ -1,0 +1,141 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- extent(th3index): mixed temporal subtypes folded together, NULLs filtered
+-- round to 10 decimal places to suppress platform floating-point ULP differences
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (NULL::th3index),
+  (th3index '831c02fffffffff@2001-01-01'),
+  (th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}')) t(temp);
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (th3index '831c02fffffffff@2001-01-01'),
+  (th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}'),
+  (NULL)) t(temp);
+
+-- extent(th3index): linear sequence + step sequenceset over disjoint footprints
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (th3index '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]'),
+  ('{[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02], [871fa44a8ffffff@2001-01-03, 880326b885fffff@2001-01-04]}')) t(temp);
+
+-- extent(th3index): single row degenerate cases
+SELECT round(extent(temp), 6) FROM ( VALUES (th3index '831c02fffffffff@2001-01-01')) t(temp);
+SELECT round(extent(temp), 6) FROM ( VALUES (NULL::th3index)) t(temp);
+
+-------------------------------------------------------------------------------
+
+WITH Temp(temp) AS (
+  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03]' UNION
+  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04]' )
+SELECT tCount(Temp) FROM Temp;
+
+WITH Temp(temp) AS (
+  SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03]' UNION
+  SELECT th3index '[831c00fffffffff@2001-01-02, 831c00fffffffff@2001-01-04]' )
+SELECT wCount(Temp, interval '2 days') FROM Temp;
+
+-------------------------------------------------------------------------------
+
+SELECT merge(temp) FROM (VALUES
+  (th3index '831c02fffffffff@2001-01-01'),
+  (th3index '831c00fffffffff@2001-01-02')) t(temp);
+SELECT mergeAgg(temp) FROM (VALUES
+  (th3index '831c02fffffffff@2001-01-01'),
+  (th3index '831c00fffffffff@2001-01-02')) t(temp);
+
+-------------------------------------------------------------------------------
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-03' UNION
+  SELECT th3index '880326b885fffff@2001-01-04' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-03' UNION
+  SELECT th3index '880326b885fffff@2001-01-04' )
+SELECT asText(appendInstantAgg(inst ORDER BY inst)) FROM temp;
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst, 'step')) FROM temp;
+
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT th3index '871fa44a8ffffff@2001-01-04' UNION
+  SELECT th3index '880326b885fffff@2001-01-08' )
+SELECT asText(appendInstant(inst, 'step', interval '1 day' ORDER BY inst)) FROM temp;
+
+/* Errors */
+WITH temp(inst) AS (
+  SELECT th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT th3index '831c00fffffffff@2001-01-01' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+
+-------------------------------------------------------------------------------
+
+WITH temp1(k, inst) AS (
+  SELECT 1, th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT 2, th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT 3, th3index '871fa44a8ffffff@2001-01-03' UNION
+  SELECT 4, th3index '880326b885fffff@2001-01-04' UNION
+  SELECT 5, th3index '880326b88dfffff@2001-01-05' UNION
+  SELECT 6, th3index '8a2a100d645ffff@2001-01-06' ),
+temp2(k, seq) AS (
+  SELECT (k - 1) / 2, appendInstant(inst ORDER BY inst)
+  FROM temp1
+  GROUP BY (k - 1) / 2)
+SELECT asText(appendSequence(seq ORDER BY seq)) FROM temp2;
+
+WITH temp1(k, inst) AS (
+  SELECT 1, th3index '831c02fffffffff@2001-01-01' UNION
+  SELECT 2, th3index '831c00fffffffff@2001-01-02' UNION
+  SELECT 3, th3index '871fa44a8ffffff@2001-01-03' UNION
+  SELECT 4, th3index '880326b885fffff@2001-01-04' UNION
+  SELECT 5, th3index '880326b88dfffff@2001-01-05' UNION
+  SELECT 6, th3index '8a2a100d645ffff@2001-01-06' ),
+temp2(k, seq) AS (
+  SELECT (k - 1) / 2, appendInstant(inst ORDER BY inst)
+  FROM temp1
+  GROUP BY (k - 1) / 2)
+SELECT asText(appendSequenceAgg(seq ORDER BY seq)) FROM temp2;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/quadbin/expected/361_tquadbin_aggfuncs.test.out
+++ b/mobilitydb/test/quadbin/expected/361_tquadbin_aggfuncs.test.out
@@ -1,0 +1,164 @@
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (NULL::tquadbin),
+  (tquadbin '480fffffffffffff@2001-01-01'),
+  (tquadbin '{48427fffffffffff@2001-01-01, 480fffffffffffff@2001-01-02}')) t(temp);
+                                                        round                                                         
+----------------------------------------------------------------------------------------------------------------------
+ SRID=4326;STBOX XT(((-180,-85.051129),(180,85.051129)),[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (tquadbin '480fffffffffffff@2001-01-01'),
+  (tquadbin '{48427fffffffffff@2001-01-01, 480fffffffffffff@2001-01-02}'),
+  (NULL)) t(temp);
+                                                        round                                                         
+----------------------------------------------------------------------------------------------------------------------
+ SRID=4326;STBOX XT(((-180,-85.051129),(180,85.051129)),[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (tquadbin '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02]'),
+  ('{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02], [48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-04]}')) t(temp);
+                                                        round                                                         
+----------------------------------------------------------------------------------------------------------------------
+ SRID=4326;STBOX XT(((-180,-85.051129),(180,85.051129)),[Mon Jan 01 00:00:00 2001 PST, Thu Jan 04 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(extent(temp), 6) FROM ( VALUES (tquadbin '480fffffffffffff@2001-01-01')) t(temp);
+                                                        round                                                         
+----------------------------------------------------------------------------------------------------------------------
+ SRID=4326;STBOX XT(((-180,-85.051129),(180,85.051129)),[Mon Jan 01 00:00:00 2001 PST, Mon Jan 01 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(extent(temp), 6) FROM ( VALUES (NULL::tquadbin)) t(temp);
+ round 
+-------
+ 
+(1 row)
+
+WITH Temp(temp) AS (
+  SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03]' UNION
+  SELECT tquadbin '[48427fffffffffff@2001-01-02, 48427fffffffffff@2001-01-04]' )
+SELECT tCount(Temp) FROM Temp;
+                                                                                tcount                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Mon Jan 01 00:00:00 2001 PST, 2@Tue Jan 02 00:00:00 2001 PST, 2@Wed Jan 03 00:00:00 2001 PST], (1@Wed Jan 03 00:00:00 2001 PST, 1@Thu Jan 04 00:00:00 2001 PST]}
+(1 row)
+
+WITH Temp(temp) AS (
+  SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03]' UNION
+  SELECT tquadbin '[48427fffffffffff@2001-01-02, 48427fffffffffff@2001-01-04]' )
+SELECT wCount(Temp, interval '2 days') FROM Temp;
+                                                                                wcount                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Mon Jan 01 00:00:00 2001 PST, 2@Tue Jan 02 00:00:00 2001 PST, 2@Fri Jan 05 00:00:00 2001 PST], (1@Fri Jan 05 00:00:00 2001 PST, 1@Sat Jan 06 00:00:00 2001 PST]}
+(1 row)
+
+SELECT merge(temp) FROM (VALUES
+  (tquadbin '480fffffffffffff@2001-01-01'),
+  (tquadbin '48427fffffffffff@2001-01-02')) t(temp);
+                                             merge                                              
+------------------------------------------------------------------------------------------------
+ {480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+SELECT mergeAgg(temp) FROM (VALUES
+  (tquadbin '480fffffffffffff@2001-01-01'),
+  (tquadbin '48427fffffffffff@2001-01-02')) t(temp);
+                                            mergeagg                                            
+------------------------------------------------------------------------------------------------
+ {480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+                                                                    astext                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ [480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST, 48a6227affffffff@Wed Jan 03 00:00:00 2001 PST]
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-03' )
+SELECT asText(appendInstantAgg(inst ORDER BY inst)) FROM temp;
+                                                                    astext                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ [480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST, 48a6227affffffff@Wed Jan 03 00:00:00 2001 PST]
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+                                                                    astext                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ [480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST, 48a6227affffffff@Wed Jan 03 00:00:00 2001 PST]
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst, 'step')) FROM temp;
+                                                                    astext                                                                     
+-----------------------------------------------------------------------------------------------------------------------------------------------
+ [480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST, 48a6227affffffff@Wed Jan 03 00:00:00 2001 PST]
+(1 row)
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-04' UNION
+  SELECT tquadbin '480fffffffffffff@2001-01-08' )
+SELECT asText(appendInstant(inst, 'step', interval '1 day' ORDER BY inst)) FROM temp;
+                                                                                               astext                                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST], [48a6227affffffff@Thu Jan 04 00:00:00 2001 PST], [480fffffffffffff@Mon Jan 08 00:00:00 2001 PST]}
+(1 row)
+
+/* Errors */
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-01' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+ERROR:  The temporal values have different value at their common timestamp Mon Jan 01 00:00:00 2001 PST
+WITH temp1(k, inst) AS (
+  SELECT 1, tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT 2, tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT 3, tquadbin '48a6227affffffff@2001-01-03' UNION
+  SELECT 4, tquadbin '480fffffffffffff@2001-01-04' UNION
+  SELECT 5, tquadbin '48427fffffffffff@2001-01-05' UNION
+  SELECT 6, tquadbin '48a6227affffffff@2001-01-06' ),
+temp2(k, seq) AS (
+  SELECT (k - 1) / 2, appendInstant(inst ORDER BY inst)
+  FROM temp1
+  GROUP BY (k - 1) / 2)
+SELECT asText(appendSequence(seq ORDER BY seq)) FROM temp2;
+                                                                                                                                              astext                                                                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST], [48a6227affffffff@Wed Jan 03 00:00:00 2001 PST, 480fffffffffffff@Thu Jan 04 00:00:00 2001 PST], [48427fffffffffff@Fri Jan 05 00:00:00 2001 PST, 48a6227affffffff@Sat Jan 06 00:00:00 2001 PST]}
+(1 row)
+
+WITH temp1(k, inst) AS (
+  SELECT 1, tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT 2, tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT 3, tquadbin '48a6227affffffff@2001-01-03' UNION
+  SELECT 4, tquadbin '480fffffffffffff@2001-01-04' UNION
+  SELECT 5, tquadbin '48427fffffffffff@2001-01-05' UNION
+  SELECT 6, tquadbin '48a6227affffffff@2001-01-06' ),
+temp2(k, seq) AS (
+  SELECT (k - 1) / 2, appendInstant(inst ORDER BY inst)
+  FROM temp1
+  GROUP BY (k - 1) / 2)
+SELECT asText(appendSequenceAgg(seq ORDER BY seq)) FROM temp2;
+                                                                                                                                              astext                                                                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[480fffffffffffff@Mon Jan 01 00:00:00 2001 PST, 48427fffffffffff@Tue Jan 02 00:00:00 2001 PST], [48a6227affffffff@Wed Jan 03 00:00:00 2001 PST, 480fffffffffffff@Thu Jan 04 00:00:00 2001 PST], [48427fffffffffff@Fri Jan 05 00:00:00 2001 PST, 48a6227affffffff@Sat Jan 06 00:00:00 2001 PST]}
+(1 row)
+

--- a/mobilitydb/test/quadbin/queries/361_tquadbin_aggfuncs.test.sql
+++ b/mobilitydb/test/quadbin/queries/361_tquadbin_aggfuncs.test.sql
@@ -1,0 +1,139 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- extent(tquadbin): mixed temporal subtypes folded together, NULLs filtered
+-- round to 10 decimal places to suppress platform floating-point ULP differences
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (NULL::tquadbin),
+  (tquadbin '480fffffffffffff@2001-01-01'),
+  (tquadbin '{48427fffffffffff@2001-01-01, 480fffffffffffff@2001-01-02}')) t(temp);
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (tquadbin '480fffffffffffff@2001-01-01'),
+  (tquadbin '{48427fffffffffff@2001-01-01, 480fffffffffffff@2001-01-02}'),
+  (NULL)) t(temp);
+
+-- extent(tquadbin): linear sequence + step sequenceset over disjoint footprints
+SELECT round(extent(temp), 6) FROM ( VALUES
+  (tquadbin '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02]'),
+  ('{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02], [48a6227affffffff@2001-01-03, 48a6227affffffff@2001-01-04]}')) t(temp);
+
+-- extent(tquadbin): single row degenerate cases
+SELECT round(extent(temp), 6) FROM ( VALUES (tquadbin '480fffffffffffff@2001-01-01')) t(temp);
+SELECT round(extent(temp), 6) FROM ( VALUES (NULL::tquadbin)) t(temp);
+
+-------------------------------------------------------------------------------
+
+WITH Temp(temp) AS (
+  SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03]' UNION
+  SELECT tquadbin '[48427fffffffffff@2001-01-02, 48427fffffffffff@2001-01-04]' )
+SELECT tCount(Temp) FROM Temp;
+
+WITH Temp(temp) AS (
+  SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03]' UNION
+  SELECT tquadbin '[48427fffffffffff@2001-01-02, 48427fffffffffff@2001-01-04]' )
+SELECT wCount(Temp, interval '2 days') FROM Temp;
+
+-------------------------------------------------------------------------------
+
+SELECT merge(temp) FROM (VALUES
+  (tquadbin '480fffffffffffff@2001-01-01'),
+  (tquadbin '48427fffffffffff@2001-01-02')) t(temp);
+SELECT mergeAgg(temp) FROM (VALUES
+  (tquadbin '480fffffffffffff@2001-01-01'),
+  (tquadbin '48427fffffffffff@2001-01-02')) t(temp);
+
+-------------------------------------------------------------------------------
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-03' )
+SELECT asText(appendInstantAgg(inst ORDER BY inst)) FROM temp;
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-03' )
+SELECT asText(appendInstant(inst ORDER BY inst, 'step')) FROM temp;
+
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT tquadbin '48a6227affffffff@2001-01-04' UNION
+  SELECT tquadbin '480fffffffffffff@2001-01-08' )
+SELECT asText(appendInstant(inst, 'step', interval '1 day' ORDER BY inst)) FROM temp;
+
+/* Errors */
+WITH temp(inst) AS (
+  SELECT tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT tquadbin '48427fffffffffff@2001-01-01' )
+SELECT asText(appendInstant(inst ORDER BY inst)) FROM temp;
+
+-------------------------------------------------------------------------------
+
+WITH temp1(k, inst) AS (
+  SELECT 1, tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT 2, tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT 3, tquadbin '48a6227affffffff@2001-01-03' UNION
+  SELECT 4, tquadbin '480fffffffffffff@2001-01-04' UNION
+  SELECT 5, tquadbin '48427fffffffffff@2001-01-05' UNION
+  SELECT 6, tquadbin '48a6227affffffff@2001-01-06' ),
+temp2(k, seq) AS (
+  SELECT (k - 1) / 2, appendInstant(inst ORDER BY inst)
+  FROM temp1
+  GROUP BY (k - 1) / 2)
+SELECT asText(appendSequence(seq ORDER BY seq)) FROM temp2;
+
+WITH temp1(k, inst) AS (
+  SELECT 1, tquadbin '480fffffffffffff@2001-01-01' UNION
+  SELECT 2, tquadbin '48427fffffffffff@2001-01-02' UNION
+  SELECT 3, tquadbin '48a6227affffffff@2001-01-03' UNION
+  SELECT 4, tquadbin '480fffffffffffff@2001-01-04' UNION
+  SELECT 5, tquadbin '48427fffffffffff@2001-01-05' UNION
+  SELECT 6, tquadbin '48a6227affffffff@2001-01-06' ),
+temp2(k, seq) AS (
+  SELECT (k - 1) / 2, appendInstant(inst ORDER BY inst)
+  FROM temp1
+  GROUP BY (k - 1) / 2)
+SELECT asText(appendSequenceAgg(seq ORDER BY seq)) FROM temp2;
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -225,7 +225,7 @@ Two more reference chapters carry inherited surface:
 
 | chapter → `<sect1>` | prefix | generated? | notes |
 |---|---|---|---|
-| `temporal_types_aggregation.xml` → Aggregation | `temporal_`/`tnumber_` | ✓ **GEN** | `aggregates.sql.tmpl` + `aggregate_families`, **9 entries** all `reference: true`, `whole_file: true` (temporal, cbuffer, geo, json, npoint, pointcloud, pose, rgeo, tpoint) — tCount/extent/tMin/tMax/tSum/tAvg/merge/appendInstant; `--gaps`: 16/18, missing th3index, tquadbin |
+| `temporal_types_aggregation.xml` → Aggregation | `temporal_`/`tnumber_` | ✓ **GEN** | `aggregates.sql.tmpl` + `aggregate_families`, **11 entries** all `reference: true`, `whole_file: true` (temporal, cbuffer, geo, json, npoint, pointcloud, pose, rgeo, tpoint, th3index, quadbin) — tCount/extent/tMin/tMax/tSum/tAvg/merge/appendInstant; `--gaps`: 18/18, full coverage |
 | → Indexing | (index) | ✓ **GEN** | GiST/SP-GiST via `gist/spgist/indexes.sql.tmpl` |
 | → Statistics and Selectivity | (selectivity) | ✗ HAND | |
 | `temporal_types_analytics.xml` → Simplification / Reduction / Similarity / Extended Kalman Filter / Splitting | `temporal_`/`tgeo_` | ✗ HAND | analytics; no template |
@@ -469,18 +469,17 @@ plain = the file exists but is still hand-maintained.
 | npoint (300) | **304** | 306 | **308** | **309** | 312 | **314** | **320** | **322** | **316** | 307 |
 | pose (100) | **104** | 105 | **108** | **109** | 110 | **111** | 112 | **114** | **116** | 107 |
 | rgeo (150) | **154** | 156 | **161** | **162** | 164 | **168** | 170 | **172** | **173** | 160 |
-| h3 (250) | **254** | 255 | **258** | **259** | — | — | **262** | **264** | **272**·**273** | **257** |
-| quadbin (350) | **354** | 355 | **358** | **359** | — | — | **362** | **364** | **372**·**373** | **357** |
+| h3 (250) | **254** | 255 | **258** | **259** | — | **261** | **262** | **264** | **272**·**273** | **257** |
+| quadbin (350) | **354** | 355 | **358** | **359** | — | **361** | **362** | **364** | **372**·**373** | **357** |
 
 Reading the table:
 - **`compops`/`topops`/`posops`/`idx` are generated for every derived family** via the
   `subtypes:` `files:` track (§3): cbuffer, npoint, pose, rgeo (`[compops, topops,
   posops, indexes]`) and h3, quadbin (`[compops, posops, topops, spatialrels, gist,
   spgist]`).
-- **`aggfuncs` is generated for cbuffer, npoint, pose, rgeo** via the whole-file
-  `aggregate_families` axis (§4b), not the `subtypes:` track; h3/quadbin have no
-  `aggfuncs` file at all (`--gaps`: `aggregate_families` 16/18, missing th3index,
-  tquadbin).
+- **`aggfuncs` is generated for cbuffer, npoint, pose, rgeo, h3, quadbin** via the
+  whole-file `aggregate_families` axis (§4b), not the `subtypes:` track (`--gaps`:
+  `aggregate_families` 18/18, full coverage).
 - **`tempsp.rels` is generated for cbuffer, npoint, pose, rgeo, h3, quadbin** via
   `tempspatialrel_families` (§3/§5) — native for cbuffer, cast-delegated for the
   other five (`--gaps`: `tempspatialrel_families` 10/10, full `tspatial`-class
@@ -521,8 +520,6 @@ Reading the table:
   rgeo). npoint has no native kernel by design — its ever/always relationships
   cast-delegate to `tgeometry` at the SQL level instead (§3, §6, `subtypes:`
   `spatialrels` bullet below), so it needs none.
-- `aggregate_families`: th3index, tquadbin (today: temporal, cbuffer, geo, json,
-  npoint, pointcloud, pose, rgeo, tpoint — 16/18 temporal types).
 - `conversion_families`: tgeography, tpcpoint, tpcpatch (today: 15/18 temporal
   types, via 8 family entries).
 - `comparison_families` (Traditional comparisons): tpcpoint, tpcpatch (today:

--- a/tools/codegen/inherited/manifest.d/aggregate_families.yaml
+++ b/tools/codegen/inherited/manifest.d/aggregate_families.yaml
@@ -493,3 +493,79 @@ aggregate_families:
     - {sig: "temporal_app_tseq_transfn(tpcpoint, tpcpoint)", ret: "tpcpoint", sym: "Temporal_app_tseq_transfn", strict: false, pre: "-- The function is not STRICT\n"}
     - {sig: "temporal_app_tseq_transfn(tpcpatch, tpcpatch)", ret: "tpcpatch", sym: "Temporal_app_tseq_transfn", strict: false}
   - lit: "\nCREATE AGGREGATE appendSequence(tpcpoint) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tpcpoint,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendSequenceAgg(tpcpoint) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tpcpoint,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendSequence(tpcpatch) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tpcpatch,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendSequenceAgg(tpcpatch) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tpcpatch,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/*****************************************************************************/\n"
+
+- family: th3index
+  file: mobilitydb/sql/h3/261_th3index_aggfuncs.in.sql
+  reference: true
+  begin: "@brief Aggregate functions for temporal H3 cells"
+  whole_file: true
+  blocks:
+  - lit: "/**\n * @file\n * @brief Aggregate functions for temporal H3 cells\n */\n\n"
+  - fns:
+    - {sig: "tspatial_extent_transfn(stbox, th3index)", ret: "stbox", sym: "Tspatial_extent_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\nCREATE AGGREGATE extent(th3index) (\n  SFUNC = tspatial_extent_transfn,\n  STYPE = stbox,\n  COMBINEFUNC = stbox_extent_combinefn,\n  PARALLEL = safe\n);\n\n"
+  - fns:
+    - {sig: "tcount_transfn(internal, th3index)", ret: "internal", sym: "Temporal_tcount_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\n"
+  - fns:
+    - {sig: "th3index_tagg_finalfn(internal)", ret: "th3index", sym: "Temporal_tagg_finalfn"}
+  - lit: "\nCREATE AGGREGATE tCount(th3index) (\n  SFUNC = tcount_transfn,\n  STYPE = internal,\n  COMBINEFUNC = tcount_combinefn,\n  FINALFUNC = tint_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = SAFE\n);\n\n"
+  - fns:
+    - {sig: "wcount_transfn(internal, th3index, interval)", ret: "internal", sym: "Temporal_wcount_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\nCREATE AGGREGATE wCount(th3index, interval) (\n  SFUNC = wcount_transfn,\n  STYPE = internal,\n  COMBINEFUNC = tint_tsum_combinefn,\n  FINALFUNC = tint_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = SAFE\n);\n\n"
+  - fns:
+    - {sig: "temporal_merge_transfn(internal, th3index)", ret: "internal", sym: "Temporal_merge_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\nCREATE AGGREGATE merge(th3index) (\n  SFUNC = temporal_merge_transfn,\n  STYPE = internal,\n  COMBINEFUNC = temporal_merge_combinefn,\n  FINALFUNC = th3index_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE mergeAgg(th3index) (\n  SFUNC = temporal_merge_transfn,\n  STYPE = internal,\n  COMBINEFUNC = temporal_merge_combinefn,\n  FINALFUNC = th3index_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = safe\n);\n\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(th3index, th3index)", ret: "th3index", sym: "Temporal_app_tinst_transfn"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(th3index, th3index, interp text)", ret: "th3index", sym: "Temporal_app_tinst_transfn"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(th3index, th3index, interp text,\n    maxt interval)", ret: "th3index", sym: "Temporal_app_tinst_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_append_finalfn(th3index)", ret: "th3index", sym: "Temporal_append_finalfn"}
+  - lit: "\nCREATE AGGREGATE appendInstant(th3index) (\n  SFUNC = temporal_app_tinst_transfn(th3index, th3index),\n  STYPE = th3index,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendInstantAgg(th3index) (\n  SFUNC = temporal_app_tinst_transfn(th3index, th3index),\n  STYPE = th3index,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendInstant(th3index, interp text) (\n  SFUNC = temporal_app_tinst_transfn(th3index, th3index, text),\n  STYPE = th3index,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendInstantAgg(th3index, interp text) (\n  SFUNC = temporal_app_tinst_transfn(th3index, th3index, text),\n  STYPE = th3index,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendInstant(th3index, interp text, maxt interval) (\n  SFUNC = temporal_app_tinst_transfn(th3index, th3index, text, maxt),\n  STYPE = th3index,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendInstantAgg(th3index, interp text, maxt interval) (\n  SFUNC = temporal_app_tinst_transfn(th3index, th3index, text, maxt),\n  STYPE = th3index,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/*****************************************************************************/\n\n"
+  - fns:
+    - {sig: "temporal_app_tseq_transfn(th3index, th3index)", ret: "th3index", sym: "Temporal_app_tseq_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\nCREATE AGGREGATE appendSequence(th3index) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = th3index,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendSequenceAgg(th3index) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = th3index,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/*****************************************************************************/\n"
+
+- family: quadbin
+  file: mobilitydb/sql/quadbin/361_tquadbin_aggfuncs.in.sql
+  reference: true
+  begin: "@brief Aggregate functions for temporal quadbin cells"
+  whole_file: true
+  blocks:
+  - lit: "/**\n * @file\n * @brief Aggregate functions for temporal quadbin cells\n */\n\n"
+  - fns:
+    - {sig: "tspatial_extent_transfn(stbox, tquadbin)", ret: "stbox", sym: "Tspatial_extent_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\nCREATE AGGREGATE extent(tquadbin) (\n  SFUNC = tspatial_extent_transfn,\n  STYPE = stbox,\n  COMBINEFUNC = stbox_extent_combinefn,\n  PARALLEL = safe\n);\n\n"
+  - fns:
+    - {sig: "tcount_transfn(internal, tquadbin)", ret: "internal", sym: "Temporal_tcount_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\n"
+  - fns:
+    - {sig: "tquadbin_tagg_finalfn(internal)", ret: "tquadbin", sym: "Temporal_tagg_finalfn"}
+  - lit: "\nCREATE AGGREGATE tCount(tquadbin) (\n  SFUNC = tcount_transfn,\n  STYPE = internal,\n  COMBINEFUNC = tcount_combinefn,\n  FINALFUNC = tint_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = SAFE\n);\n\n"
+  - fns:
+    - {sig: "wcount_transfn(internal, tquadbin, interval)", ret: "internal", sym: "Temporal_wcount_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\nCREATE AGGREGATE wCount(tquadbin, interval) (\n  SFUNC = wcount_transfn,\n  STYPE = internal,\n  COMBINEFUNC = tint_tsum_combinefn,\n  FINALFUNC = tint_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = SAFE\n);\n\n"
+  - fns:
+    - {sig: "temporal_merge_transfn(internal, tquadbin)", ret: "internal", sym: "Temporal_merge_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\nCREATE AGGREGATE merge(tquadbin) (\n  SFUNC = temporal_merge_transfn,\n  STYPE = internal,\n  COMBINEFUNC = temporal_merge_combinefn,\n  FINALFUNC = tquadbin_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE mergeAgg(tquadbin) (\n  SFUNC = temporal_merge_transfn,\n  STYPE = internal,\n  COMBINEFUNC = temporal_merge_combinefn,\n  FINALFUNC = tquadbin_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = safe\n);\n\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(tquadbin, tquadbin)", ret: "tquadbin", sym: "Temporal_app_tinst_transfn"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(tquadbin, tquadbin, interp text)", ret: "tquadbin", sym: "Temporal_app_tinst_transfn"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(tquadbin, tquadbin, interp text,\n    maxt interval)", ret: "tquadbin", sym: "Temporal_app_tinst_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_append_finalfn(tquadbin)", ret: "tquadbin", sym: "Temporal_append_finalfn"}
+  - lit: "\nCREATE AGGREGATE appendInstant(tquadbin) (\n  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin),\n  STYPE = tquadbin,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendInstantAgg(tquadbin) (\n  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin),\n  STYPE = tquadbin,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendInstant(tquadbin, interp text) (\n  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin, text),\n  STYPE = tquadbin,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendInstantAgg(tquadbin, interp text) (\n  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin, text),\n  STYPE = tquadbin,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendInstant(tquadbin, interp text, maxt interval) (\n  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin, text, maxt),\n  STYPE = tquadbin,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendInstantAgg(tquadbin, interp text, maxt interval) (\n  SFUNC = temporal_app_tinst_transfn(tquadbin, tquadbin, text, maxt),\n  STYPE = tquadbin,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/*****************************************************************************/\n\n"
+  - fns:
+    - {sig: "temporal_app_tseq_transfn(tquadbin, tquadbin)", ret: "tquadbin", sym: "Temporal_app_tseq_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\nCREATE AGGREGATE appendSequence(tquadbin) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tquadbin,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\nCREATE AGGREGATE appendSequenceAgg(tquadbin) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tquadbin,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/*****************************************************************************/\n"


### PR DESCRIPTION
Aggregates the temporal cell index types, giving th3index and tquadbin the aggregate functions their sibling temporal types carry.

`261_th3index_aggfuncs.in.sql` and `361_tquadbin_aggfuncs.in.sql` declare the extent and the temporal aggregates of each family, and each `CMakeLists.txt` loads the file after the family's own type file. The declarations are a projection of the generator: the manifest entry that emits them names the aggregate file as its target, and `aggregate_families` reaches every temporal type.

The documentation of both families gains the functions in English and Spanish, and the tests cover the aggregates over the temporal subtypes and the degenerate single-row cases.
