### PR TITLE
Validate the pixel band inside raquet_make

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -85,8 +85,9 @@ extern char *raquet_as_hexwkb(const Raquet *rq, uint8_t variant, size_t *size_ou
 
 /* Constructor functions for Raquet tiles */
 
-extern Raquet *raquet_make(uint64 quadbin, uint16_t width, uint16_t height,
-  MeosPixType pixtype, double nodata, bool has_nodata, const uint8_t *pixels);
+extern Raquet *raquet_make(uint64 quadbin, int32 width, int32 height,
+  MeosPixType pixtype, double nodata, bool has_nodata, const uint8_t *pixels,
+  size_t pixels_size);
 extern Raquet *raquet_copy(const Raquet *rq);
 extern Raquet *raquet_read(const char *path, uint64 quadbin);
 extern Raquet *raquet_read_bytes(const uint8_t *data, size_t size, uint64 quadbin);

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -232,23 +232,44 @@ raquet_as_hexwkb(const Raquet *rq, uint8_t variant, size_t *size_out)
  * @param[in] has_nodata Whether nodata filtering is active
  * @param[in] pixels Row-major packed pixel bytes (`width * height *
  * raquet_pixtype_size(pixtype)` bytes)
+ * @param[in] pixels_size Number of bytes available at @p pixels
  * @csqlfn #Raquet_constructor()
  */
 Raquet *
-raquet_make(uint64 quadbin, uint16 width, uint16 height, MeosPixType pixtype,
-  double nodata, bool has_nodata, const uint8_t *pixels)
+raquet_make(uint64 quadbin, int32 width, int32 height, MeosPixType pixtype,
+  double nodata, bool has_nodata, const uint8_t *pixels, size_t pixels_size)
 {
   VALIDATE_NOT_NULL(pixels, NULL);
   if (! ensure_valid_pixtype((uint8) pixtype))
     return NULL;
-  if (width == 0 || height == 0)
+  /* The dimensions are taken in the type the SQL surface uses and validated
+   * before the narrowing to the uint16 fields below, so that a negative value
+   * is rejected here instead of wrapping to a large positive one */
+  if (width <= 0 || height <= 0)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "The width and height of a raquet tile must be positive");
     return NULL;
   }
+  if (width > UINT16_MAX || height > UINT16_MAX)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The width and height of a raquet tile must be at most %d: %d x %d",
+      UINT16_MAX, width, height);
+    return NULL;
+  }
 
   size_t npixels = (size_t) width * height * raquet_pixtype_size(pixtype);
+  /* The band arrives as a bare pointer, so its length must be given: without it
+   * the memcpy below reads past the end of a buffer shorter than the dimensions
+   * claim. Mirrors the check in #raster_tile_value_quadbin() */
+  if (pixels_size < npixels)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The pixel array has %zu bytes but %zu are required for a %d x %d tile",
+      pixels_size, npixels, width, height);
+    return NULL;
+  }
   size_t size = offsetof(struct Raquet, pixels) + npixels;
   Raquet *result = palloc0(size);
   SET_VARSIZE(result, size);

--- a/meos/src/raster/raquet_gdal.c
+++ b/meos/src/raster/raquet_gdal.c
@@ -179,8 +179,8 @@ raquet_from_gdal_dataset(GDALDatasetH ds, uint64 quadbin, const char *label)
     goto cleanup;
   }
 
-  result = raquet_make(quadbin, (uint16) xsize, (uint16) ysize, pixtype,
-    nodata, (bool) has_nodata, buf);
+  result = raquet_make(quadbin, xsize, ysize, pixtype,
+    nodata, (bool) has_nodata, buf, nbytes);
 
 cleanup:
   if (buf)

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1989,7 +1989,7 @@ raquet_from_wkb_state(meos_wkb_parse_state *s)
   /* Check that there is enough data to read the pixel payload */
   wkb_parse_state_check(s, npixels);
   Raquet *result = raquet_make(quadbin, width, height, (MeosPixType) pixtype,
-    nodata, has_nodata, s->pos);
+    nodata, has_nodata, s->pos, npixels);
   s->pos += npixels;
   return PointerGetDatum(result);
 }

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -509,19 +509,9 @@ Raquet_constructor(PG_FUNCTION_ARGS)
   float8      nodata    = has_nd ? PG_GETARG_FLOAT8(5) : 0.0;
   MeosPixType pixtype   = text_to_pixtype(pixtype_t);
 
-  if (width <= 0 || height <= 0)
-    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-      errmsg("The width and height of a raquet tile must be positive")));
-  size_t need = (size_t) width * height * raquet_pixtype_size(pixtype);
-  if ((size_t) VARSIZE_ANY_EXHDR(pxbytea) < need)
-    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-      errmsg("The pixel array has %zu bytes but %zu are required for a "
-        "%d x %d tile", (size_t) VARSIZE_ANY_EXHDR(pxbytea), need, width,
-        height)));
-
   const uint8_t *pixels = (const uint8_t *) VARDATA_ANY(pxbytea);
-  Raquet *result = raquet_make((uint64) quadbin, (uint16_t) width,
-    (uint16_t) height, pixtype, nodata, has_nd, pixels);
+  Raquet *result = raquet_make((uint64) quadbin, width, height, pixtype,
+    nodata, has_nd, pixels, (size_t) VARSIZE_ANY_EXHDR(pxbytea));
   PG_RETURN_RAQUET_P(result);
 }
 


### PR DESCRIPTION
`raquet_make()` validates the pixel band it is given. It takes the buffer length
as `pixels_size` and rejects a buffer shorter than
`width * height * raquet_pixtype_size(pixtype)`, so the bounds check holds for
every consumer of the MEOS API rather than being repeated by each host.
`raster_tile_value_quadbin()`, the other entry point taking a bare band, carries
the same argument and the same check.

### Dimensions

The dimensions are `int32`, the type the SQL surface uses, and are validated
before the narrowing to the tile's `uint16` fields: a non-positive value and a
value beyond the `uint16` range are both rejected.

### Callers

The PostgreSQL wrapper `Raquet_constructor` passes the bytea length. The GDAL
ingest path and the WKB reader pass the length each of them computes.

`raquet('\x0102'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')` reports:

```
ERROR:  The pixel array has 2 bytes but 4 are required for a 2 x 2 tile
```