### PR TITLE
Cover the effect of a band nodata value on raster sampling

### DIFF
--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -46,6 +46,26 @@ WITH rast AS (
   SELECT ST_SetValues(
     ST_AddBand(
       ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999.0::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, -9999.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2000-01-01,
+  POINT(1.5 2.5)@2000-01-02, POINT(0.5 0.5)@2000-01-03]', r)::text AS result
+FROM rast;
+                         result                         
+--------------------------------------------------------
+ {10@2000-01-01 00:00:00+00, 70@2000-01-03 00:00:00+00}
+(1 row)
+
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
       '32BF'::text, 0.0::float8, NULL::float8
     ),
     1, 1, 1,

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -79,6 +79,25 @@ SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2000-01-01,
   POINT(5.5 5.5)@2000-01-02, POINT(0.5 0.5)@2000-01-03]', r)::text AS result
 FROM rast;
 
+-- An instant on a nodata pixel is dropped, as one outside the extent is: the
+-- band declares -9999 as its nodata value and pixel(row=1,col=2) holds it.
+-- POINT(0.5 2.5) → 10; POINT(1.5 2.5) → nodata → dropped; POINT(0.5 0.5) → 70
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999.0::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, -9999.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2000-01-01,
+  POINT(1.5 2.5)@2000-01-02, POINT(0.5 0.5)@2000-01-03]', r)::text AS result
+FROM rast;
+
 -- All instants outside the raster → NULL.
 WITH rast AS (
   SELECT ST_SetValues(


### PR DESCRIPTION
The raster sampling functions skip a pixel holding the band nodata value, which is what the `raster_sample_fn` contract requires. No case exercises that: every sampling case passes `NULL` as the `ST_AddBand` nodata argument, so no pixel any of them reads is nodata.

The case added here declares `-9999` as the band nodata value, places it at pixel(row=1,col=2), and sends a trajectory across it, so the instant over that pixel is dropped exactly as an instant outside the raster extent is.
