### PR TITLE
Answer the point-in-polygon short-circuit in the direction the relationship asks

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1636,6 +1636,12 @@ gserialized_is_poly(const GSERIALIZED* gs)
 /**
  * @brief Return -1, 0, or 1 depending on whether a (multi)point is completely
  * outside, on the boundary, or completely inside a (multi)polygon
+ * @details The function selects the polygon and the point out of the pair
+ * whatever order they arrive in, and always answers in the direction of the
+ * polygon: whether the polygon intersects, contains, or covers the point. That
+ * is the relationship asked for @p INTERSECTS, which is symmetric, in either
+ * order. For @p CONTAINS and @p COVERS the caller must place the polygon
+ * first, since the reverse direction is a different question
  * @note This function is based PostGIS function @p pip_short_circuit bypassing
  * the cache
  */
@@ -1776,11 +1782,16 @@ geom_spatialrel(const GSERIALIZED *gs1, const GSERIALIZED *gs2, spatialRel rel)
 
   /*
    * short-circuit 2: if the geoms are a (multi)point and a (multi)polygon,
-   * call the meos_point_in_polygon function.
+   * call the meos_point_in_polygon function. That function answers in the
+   * direction of the polygon, so it settles INTERSECTS, which is symmetric,
+   * with the pair in either order, and CONTAINS and COVERS only when the
+   * polygon is the first argument. A (multi)point asked to contain or cover a
+   * (multi)polygon is a different question and keeps the general path below.
    */
-  if ((rel == INTERSECTS || rel == CONTAINS || rel == COVERS) && (
-      (gserialized_is_point(gs1) && gserialized_is_poly(gs2)) ||
-      (gserialized_is_poly(gs1) && gserialized_is_point(gs2))))
+  bool poly_point = gserialized_is_poly(gs1) && gserialized_is_point(gs2);
+  if ((rel == INTERSECTS && (poly_point ||
+        (gserialized_is_point(gs1) && gserialized_is_poly(gs2)))) ||
+      ((rel == CONTAINS || rel == COVERS) && poly_point))
     return meos_point_in_polygon(gs1, gs2, rel);
 
   /* Call GEOS function */

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -2024,8 +2024,8 @@ geo_is_poly(const GSERIALIZED *gs)
  * must lie in A's closure. Supports the geometry types the clip engine
  * extracts into edges: points, (multi)lines, (multi)polygons with holes,
  * triangles, circular strings, curve polygons, and collections of these.
- * The dispatch mirrors #geom_spatialrel: an empty operand and a
- * (multi)point/(multi)polygon pair are handled by the same native
+ * The dispatch mirrors #geom_spatialrel: an empty operand and a (multi)polygon
+ * covering a (multi)point are handled by the same native
  * #meos_point_in_polygon short-circuit, so only the general case replaces the
  * GEOS covers call.
  * @pre The arguments have the same SRID
@@ -2058,11 +2058,12 @@ geo_covers2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (gserialized_get_gbox_p(gs1, &box1) && gserialized_get_gbox_p(gs2, &box2) &&
       gbox_overlaps_2d(&box1, &box2) == LW_FALSE)
     return false;
-  /* A (multi)point/(multi)polygon pair (in either order) is resolved by the
-   * native point-in-polygon test, exactly as #geom_spatialrel does before
-   * delegating to GEOS */
-  if ((geo_is_point(gs1) && geo_is_poly(gs2)) ||
-      (geo_is_poly(gs1) && geo_is_point(gs2)))
+  /* A (multi)polygon covering a (multi)point is resolved by the native
+   * point-in-polygon test, exactly as #geom_spatialrel does before delegating
+   * to GEOS. That test answers in the direction of the polygon, so the reverse
+   * pair, a (multi)point asked to cover a (multi)polygon, keeps the general
+   * path below */
+  if (geo_is_poly(gs1) && geo_is_point(gs2))
     return meos_point_in_polygon(gs1, gs2, COVERS);
 
   /* Extract the edges of both geometries */

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
@@ -46,6 +46,30 @@ SELECT eContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(1 
  f
 (1 row)
 
+SELECT aContains(tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ acontains 
+-----------
+ f
+(1 row)
+
+SELECT aContains(tgeometry '[Point(2 2)@2000-01-01, Point(4 4)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ acontains 
+-----------
+ f
+(1 row)
+
+SELECT aContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]');
+ acontains 
+-----------
+ t
+(1 row)
+
+SELECT aContains(tgeometry '[Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-01, Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-02]', geometry 'Point(2 2)');
+ acontains 
+-----------
+ t
+(1 row)
+
 SELECT eContains(geometry 'Point empty', tgeometry 'Point(1 1)@2000-01-01');
  econtains 
 -----------
@@ -123,6 +147,42 @@ SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(1 4)
  ecovers 
 ---------
  f
+(1 row)
+
+SELECT eCovers(tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT aCovers(tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ acovers 
+---------
+ f
+(1 row)
+
+SELECT eCovers(tgeometry '[Point(2 2)@2000-01-01, Point(4 4)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tgeometry '[Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-01, Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-02]', geometry 'Point(2 2)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(tgeometry '[Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-01, Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-02]', geometry 'Point(2 2)');
+ acovers 
+---------
+ t
 (1 row)
 
 SELECT eCovers(geometry 'Point empty', tgeometry 'Point(1 1)@2000-01-01');

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -19,7 +19,7 @@ SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eContains(temp, g);
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aContains(temp, g);
  count 
 -------
-    31
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eContains(t1.temp, t2.temp);
@@ -49,13 +49,13 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aCovers(g, temp);
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eCovers(temp, g);
  count 
 -------
-   439
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aCovers(temp, g);
  count 
 -------
-    31
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eCovers(t1.temp, t2.temp);

--- a/mobilitydb/test/geo/queries/070_tgeo_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tgeo_spatialrels.test.sql
@@ -28,7 +28,7 @@
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
--- eContains
+-- eContains, aContains
 -------------------------------------------------------------------------------
 
 SELECT eContains(geometry 'Point(1 1)', tgeometry 'Point(1 1)@2000-01-01');
@@ -41,6 +41,14 @@ SELECT eContains(geometry 'Linestring(1 1,3 3,1 1)', tgeometry '[Point(4 2)@2000
 SELECT eContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(0 1)@2000-01-01, Point(4 1)@2000-01-02]');
 SELECT eContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(1 4)@2000-01-01, Point(4 1)@2000-01-02]');
 
+-- A temporal geometry holding point values never contains a polygon, whichever
+-- side of the polygon its values are on
+SELECT aContains(tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+SELECT aContains(tgeometry '[Point(2 2)@2000-01-01, Point(4 4)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+-- The polygon does contain the points, in the direction that asks it
+SELECT aContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]');
+SELECT aContains(tgeometry '[Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-01, Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-02]', geometry 'Point(2 2)');
+
 SELECT eContains(geometry 'Point empty', tgeometry 'Point(1 1)@2000-01-01');
 SELECT eContains(geometry 'Point empty', tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
 SELECT eContains(geometry 'Point empty', tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
@@ -52,7 +60,7 @@ SELECT eContains(geometry 'Point(1 1 1)', tgeometry 'Point(1 1)@2000-01-01');
 SELECT eContains(geometry 'Point(1 1)', tgeometry 'Point(1 1 1)@2000-01-01');
 
 -------------------------------------------------------------------------------
--- eCovers
+-- eCovers, aCovers
 -------------------------------------------------------------------------------
 
 SELECT eCovers(geometry 'Point(1 1)', tgeometry 'Point(1 1)@2000-01-01');
@@ -64,6 +72,16 @@ SELECT eCovers(geometry 'Linestring(1 1,3 3)', tgeometry '[Point(4 2)@2000-01-01
 SELECT eCovers(geometry 'Linestring(1 1,3 3,1 1)', tgeometry '[Point(4 2)@2000-01-01, Point(2 4)@2000-01-02]');
 SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(0 1)@2000-01-01, Point(4 1)@2000-01-02]');
 SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(1 4)@2000-01-01, Point(4 1)@2000-01-02]');
+
+-- A temporal geometry holding point values never covers a polygon, whichever
+-- side of the polygon its values are on
+SELECT eCovers(tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+SELECT aCovers(tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+SELECT eCovers(tgeometry '[Point(2 2)@2000-01-01, Point(4 4)@2000-01-02]', geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');
+-- The polygon does cover the points, in the direction that asks it
+SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]');
+SELECT eCovers(tgeometry '[Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-01, Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-02]', geometry 'Point(2 2)');
+SELECT aCovers(tgeometry '[Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-01, Polygon((1 1,1 3,3 3,3 1,1 1))@2000-01-02]', geometry 'Point(2 2)');
 
 SELECT eCovers(geometry 'Point empty', tgeometry 'Point(1 1)@2000-01-01');
 SELECT eCovers(geometry 'Point empty', tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');


### PR DESCRIPTION
A (multi)point/(multi)polygon pair takes a native point-in-polygon test instead of GEOS, in `geom_spatialrel` and in the native `geo_covers2d`. That test picks the polygon and the point out of the pair whatever order they arrive in, and always answers in the direction of the polygon. Intersects is symmetric, so either order reaches the same answer. Contains and covers are not: a point asked whether it covers a polygon receives the answer to whether the polygon covers the point, which holds whenever the point lies inside.

```
geom_contains(Point(0 0), Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1)))          -> t
ST_Relate(Point(0 0), Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1)), 'T*****FF*') -> f
```

This restricts the short-circuit to the polygon-first pair for contains and covers, and leaves the reverse pair to the general path, which resolves it from the edges and reports that a point covers no polygon. Intersects keeps both orders.

The relationships that carry the inverted answer are `eCovers`, `aCovers` and `aContains` of a temporal geometry holding point values against a polygon:

```sql
SELECT eCovers(tgeometry '[Point(2 2)@2000-01-01, Point(2.5 2.5)@2000-01-02]',
  geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))');   -- f
```

`eContains` is unaffected, since its ever semantics ask for the relate pattern of the traversed area rather than for containment. Over the geo tables the three counts drop to zero, and the reverse direction, a polygon against a temporal geometry, is unchanged.

The `(tgeometry, geometry)` direction of covers and contains has no test coverage, which is what lets the inversion go unseen; this adds it, in both the direction that holds and the one that does not.