### PR TITLE
Quantify the collection members of a spatial relationship as it requires

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -113,9 +113,29 @@ spatialrel_geo_geo_simple(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
 }
 
 /**
+ * @brief Set the quantifier each argument of a spatial relationship carries
+ * over the members of a collection
+ * @details A geometry covers or contains a collection only when it covers or
+ * contains every one of its members, and two geometries are disjoint only
+ * when every pair of their members is disjoint. The remaining relationships
+ * are satisfied by a single member
+ * @param[in] func Spatial relationship function
+ * @param[out] all1,all2 True when the corresponding argument of the
+ * relationship is universally quantified
+ */
+static void
+spatialrel_quantifiers(varfunc func, bool *all1, bool *all2)
+{
+  *all1 = (func == (varfunc) (&datum_geom_disjoint2d));
+  *all2 = *all1 || func == (varfunc) (&datum_geom_covers) ||
+    func == (varfunc) (&datum_geom_contains);
+}
+
+/**
  * @brief Return 1 if two geometries satisfy a spatial relationship
  * @details The function iterates for every member of a collection if one or
- * the two geometries are collections
+ * the two geometries are collections, with the quantifier that the
+ * relationship carries over each of its arguments
  * @param[in] gs1,gs2 Geometry
  * @param[in] param Parameter
  * @param[in] func PostGIS function to be called
@@ -131,19 +151,32 @@ spatialrel_geo_geo(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   int count1, count2;
   GSERIALIZED **elems1 = geo_extract_elements(gs1, &count1);
   GSERIALIZED **elems2 = geo_extract_elements(gs2, &count2);
+  /* The quantifiers apply to the arguments of the relationship, which are the
+   * two geometries in the order they are passed to it */
+  bool allarg1, allarg2;
+  spatialrel_quantifiers(func, &allarg1, &allarg2);
+  bool all1 = invert ? allarg2 : allarg1;
+  bool all2 = invert ? allarg1 : allarg2;
   /* Perform the iterations for the elements in the collections if any */
-  int result = 0;
+  int result = all1 ? 1 : 0;
   for (int i = 0; i < count1; i++)
   {
+    int res = all2 ? 1 : 0;
     for (int j = 0; j < count2; j++)
     {
-      result = spatialrel_geo_geo_simple(elems1[i], elems2[j], param, func,
+      int res1 = spatialrel_geo_geo_simple(elems1[i], elems2[j], param, func,
         numparam, invert);
-      if (result)
+      if (all2 ? ! res1 : res1)
+      {
+        res = res1;
         break;
+      }
     }
-    if (result)
+    if (all1 ? ! res : res)
+    {
+      result = res;
       break;
+    }
   }
   /* Clean up and return */
   pfree_array((void *) elems1, count1);

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -124,6 +124,18 @@ SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2)
  t
 (1 row)
 
+SELECT aContains(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,0.5 0.5)');
+ acontains 
+-----------
+ t
+(1 row)
+
+SELECT aContains(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,100 100)');
+ acontains 
+-----------
+ f
+(1 row)
+
 /* Errors */
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 ERROR:  Operation on mixed SRID
@@ -203,6 +215,36 @@ SELECT aCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))
  acovers 
 ---------
  t
+(1 row)
+
+SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,0.5 0.5)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,100 100)');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiLinestring((-1 0,1 0),(100 100,101 101))');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'GeometryCollection(Point(0 0),Linestring(100 100,101 101))');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT aCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,100 100)');
+ acovers 
+---------
+ f
 (1 row)
 
 /* Errors */

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -13,7 +13,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eContains(temp, g);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aContains(temp, g);
  count 
 -------
-    21
+     3
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eContains(cb, temp);
@@ -61,13 +61,13 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aCovers(g, temp);
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eCovers(temp, g);
  count 
 -------
-  1565
+   240
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aCovers(temp, g);
  count 
 -------
-    21
+     3
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eCovers(cb, temp);

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -66,6 +66,12 @@ SELECT eContains(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT eContains(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1)@2000-01-02]', tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02]');
 
+-- A multipart geometry is contained only when every one of its parts is. The
+-- disc of radius 1 sweeps the strip between (-5 0) and (5 0), which contains
+-- the parts near the origin and none of the far ones
+SELECT aContains(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,0.5 0.5)');
+SELECT aContains(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,100 100)');
+
 /* Errors */
 SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');
 
@@ -92,6 +98,15 @@ SELECT eCovers(tcbuffer '[Cbuffer(Point(1 1),1)@2000-01-01, Cbuffer(Point(2 2),1
 SELECT eCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer 'Cbuffer(Point(4.5 0),0.5)@2000-01-01');
 SELECT eCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(8 0),0.5)@2000-01-03]');
 SELECT aCovers(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');
+
+-- A multipart geometry is covered only when every one of its parts is. The
+-- disc of radius 1 sweeps the strip between (-5 0) and (5 0), which covers the
+-- parts near the origin and none of the far ones
+SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,0.5 0.5)');
+SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,100 100)');
+SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiLinestring((-1 0,1 0),(100 100,101 101))');
+SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'GeometryCollection(Point(0 0),Linestring(100 100,101 101))');
+SELECT aCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]', geometry 'MultiPoint(0 0,100 100)');
 
 /* Errors */
 SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),1)@2000-01-01', geometry 'SRID=3812;Point(1 1)');


### PR DESCRIPTION
The temporal circular buffer relationships resolve a collection operand by splitting it into its members and applying the relationship to each pair, because GEOS does not take a geometry collection. The member loops report the relationship as satisfied on the first pair that satisfies it, which is the quantifier intersects asks for. Covers and contains quantify their second argument universally, and disjoint quantifies both, so a swept area covering one part of a multipart geometry counts as covering all of it:

```sql
-- a disc of radius 1 sweeping from (-5 0) to (5 0)
SELECT eCovers(tcbuffer '[Cbuffer(Point(-5 0),1)@2000-01-01, Cbuffer(Point(5 0),1)@2000-01-02]',
  geometry 'MultiPoint(0 0,100 100)');   -- f
```

This gives each argument of the relationship the quantifier it carries, and maps those to the two element lists through the inversion flag, so the loop over the universally quantified side stops on the first member that fails instead of the first that holds.

Over the cbuffer tables `eCovers` of a temporal buffer against a geometry goes from 1565 to 240 pairs, `aCovers` and `aContains` from 21 to 3. The whole of the reduction sits on the multipart geometries: the pairs whose geometry has a single part number 239 of the 240 and cannot move, since a single member makes the two quantifiers the same. `eIntersects`, `eDisjoint`, `eContains` and `eTouches` are unchanged.