### PR TITLE
Widen a temporal point to a temporal geometry without converting its values

### DIFF
--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1462,7 +1462,7 @@ tgeompoint_to_tgeometry(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TGEOMPOINT(temp, NULL);
-  return tgeom_tgeog(temp, TPOINT_TO_TGEO);
+  return tgeo_tpoint(temp, TPOINT_TO_TGEO);
 }
 
 /**

--- a/mobilitydb/test/geo/expected/056_tgeo_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tgeo_spatialfuncs.test.out
@@ -981,6 +981,39 @@ SELECT asEWKT(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02
  SRID=4326;{[POINT(1.5 1.5)@Sat Jan 01 00:00:00 2000 PST, POINT(2.5 2.5)@Sun Jan 02 00:00:00 2000 PST, POINT(1.5 1.5)@Mon Jan 03 00:00:00 2000 PST], [POINT(3.5 3.5)@Tue Jan 04 00:00:00 2000 PST, POINT(3.5 3.5)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asEWKT(tgeompoint 'Point(1 1)@2000-01-01'::tgeometry);
+                 asewkt                  
+-----------------------------------------
+ POINT(1 1)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asEWKT(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}'::tgeometry);
+                                                           asewkt                                                            
+-----------------------------------------------------------------------------------------------------------------------------
+ {POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(2 2)@Sun Jan 02 00:00:00 2000 PST, POINT(1 1)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asEWKT(tgeompoint 'Interp=Step;[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]'::tgeometry);
+                                       asewkt                                       
+------------------------------------------------------------------------------------
+ [POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(2 2)@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT asEWKT(tgeompoint 'SRID=3812;Point(1 1)@2000-01-01'::tgeometry);
+                      asewkt                       
+---------------------------------------------------
+ SRID=3812;POINT(1 1)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asEWKT(tgeogpoint 'SRID=4326;Point(1 1)@2000-01-01'::tgeography);
+                      asewkt                       
+---------------------------------------------------
+ SRID=4326;POINT(1 1)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+/* Errors */
+SELECT asEWKT(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]'::tgeometry);
+ERROR:  The temporal type cannot have linear interpolation
 SELECT ST_AsText(traversedArea(tgeometry 'Point(1 1)@2000-01-01'));
  st_astext  
 ------------

--- a/mobilitydb/test/geo/queries/056_tgeo_spatialfuncs.test.sql
+++ b/mobilitydb/test/geo/queries/056_tgeo_spatialfuncs.test.sql
@@ -353,6 +353,17 @@ SELECT asEWKT(tgeography '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02,
 SELECT asEWKT(tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]'::tgeometry);
 SELECT asEWKT(tgeography '{[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03],[Point(3.5 3.5)@2000-01-04, Point(3.5 3.5)@2000-01-05]}'::tgeometry);
 
+-- A temporal point widened to a temporal geometry keeps its values and its
+-- SRID, including the unknown SRID
+SELECT asEWKT(tgeompoint 'Point(1 1)@2000-01-01'::tgeometry);
+SELECT asEWKT(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}'::tgeometry);
+SELECT asEWKT(tgeompoint 'Interp=Step;[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]'::tgeometry);
+SELECT asEWKT(tgeompoint 'SRID=3812;Point(1 1)@2000-01-01'::tgeometry);
+SELECT asEWKT(tgeogpoint 'SRID=4326;Point(1 1)@2000-01-01'::tgeography);
+
+/* Errors */
+SELECT asEWKT(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]'::tgeometry);
+
 --------------------------------------------------------
 
 -- 2D


### PR DESCRIPTION
Widening a temporal point to a temporal geometry changes the temporal type and nothing else: the values are already geometries. `tgeo_tpoint` carries exactly that conversion, and `tgeogpoint_to_tgeography` uses it. `tgeompoint_to_tgeometry` instead goes through `tgeom_tgeog`, which sends every value through `geog_to_geom`, the geography to geometry conversion, and that assigns the geography default SRID to a value whose SRID is unknown:

```sql
SELECT asEWKT(tgeompoint 'Point(1 1)@2000-01-01'::tgeometry);
--  SRID=4326;POINT(1 1)@Sat Jan 01 00:00:00 2000 PST
```

Every later operation between that value and a geometry of unknown SRID then reports mixed SRIDs. A temporal point carrying an explicit SRID keeps it, which is why the corpus does not show the substitution.

The two directions share the bare value `false` — `TPOINT_TO_TGEO` and `TGEOG_TO_TGEOM` are both `false` — so the wrong helper compiles silently.

This routes the conversion through `tgeo_tpoint`, so the values and the SRID pass through untouched, and a temporal point with linear interpolation reports the interpolation the target type cannot carry, as the temporal geography point conversion already does. The conversion block of `056_tgeo_spatialfuncs` gains the temporal point cases, in both SRID states, and the linear one among the errors; the rest of the suite is unchanged.