### PR TITLE
Read and write a PostGIS raster through its WKB representation

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -42,14 +42,16 @@ jobs:
             libgeos-dev \
             libproj-dev \
             libjson-c-dev \
-            libgsl-dev
+            libgsl-dev \
+            libgdal-dev
 
       - name: Build
         run: |
           mkdir build
           cd build
-          # Enable the optional types to be able to test them below
-          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DCBUFFER=on -DJSON=on -DPOSE=on -DRGEO=on ..
+          # Enable the optional types to be able to test them below. RASTER
+          # requires GDAL, installed above
+          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DCBUFFER=on -DJSON=on -DPOSE=on -DRGEO=on -DRASTER=on ..
           make -j $(nproc)
           sudo make install
 
@@ -98,6 +100,12 @@ jobs:
           ./merge_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o geo_test geo_test.c -L/usr/local/lib -lmeos
           ./geo_test
+          # The raster input and output functions are the only way a caller
+          # outside PostgreSQL reaches a Raster, so they are exercised here
+          # rather than through the PostgreSQL suite. The RASTER family is
+          # built and installed above.
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o raster_test raster_test.c -L/usr/local/lib -lmeos
+          ./raster_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o numeric_test numeric_test.c -L/usr/local/lib -lmeos
           ./numeric_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o setspan_test setspan_test.c -L/usr/local/lib -lmeos

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -109,6 +109,13 @@ extern uint64 raquet_hash_extended(const Raquet *rq, uint64 seed);
 
 typedef struct Raster Raster;
 
+/* Input and output functions for PostGIS rasters */
+
+extern Raster *raster_from_wkb(const uint8_t *wkb, size_t size);
+extern Raster *raster_from_hexwkb(const char *hexwkb);
+extern uint8_t *raster_as_wkb(const Raster *rast, size_t *size_out);
+extern char *raster_as_hexwkb(const Raster *rast, size_t *size_out);
+
 /* Accessor functions for PostGIS rasters */
 
 extern int raster_num_bands(const Raster *rast);

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -40,11 +40,185 @@
 
 #include "librtcore.h"
 
+/* C */
+#include <string.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
 #include <meos_raster.h>
 #include "temporal/temporal.h"
+
+/*****************************************************************************
+ * Input and output functions
+ *
+ * A `Raster` is the serialized form, while the interchange representation of
+ * the PostGIS `raster` type is its WKB. The two are distinct byte streams, so
+ * these functions convert rather than cast: rt_core parses the WKB against the
+ * length it is given, and the resulting raster is then serialized.
+ *****************************************************************************/
+
+/**
+ * @brief Destroy an rt_core raster together with its bands
+ * @details rt_raster_destroy() releases the band registry but not the bands
+ * it points to, which the caller of a function producing them owns. The
+ * raster must carry its bands, that is, it must come from
+ * rt_raster_from_wkb(), rt_raster_from_hexwkb(), or a full
+ * rt_raster_deserialize(): after a header-only deserialization the registry
+ * is empty while the band count is not, and rt_raster_get_band() reads the
+ * registry without testing it
+ * @param[in] raster Raster
+ */
+static void
+raster_destroy(rt_raster raster)
+{
+  int numbands = rt_raster_get_num_bands(raster);
+  for (int i = 0; i < numbands; i++)
+    rt_band_destroy(rt_raster_get_band(raster, i));
+  rt_raster_destroy(raster);
+}
+
+/**
+ * @brief Return the serialized form of an rt_core raster, destroying the
+ * raster
+ * @param[in] raster Raster to serialize and destroy, may be @p NULL
+ * @return On error, return @p NULL
+ */
+static Raster *
+raster_serialize_destroy(rt_raster raster)
+{
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+      "Could not parse the Well-Known Binary (WKB) representation of a raster");
+    return NULL;
+  }
+  Raster *result = (Raster *) rt_raster_serialize(raster);
+  raster_destroy(raster);
+  if (! result)
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT, "Could not serialize raster");
+    return NULL;
+  }
+  return result;
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return a raster from its Well-Known Binary (WKB) representation
+ * @param[in] wkb WKB string
+ * @param[in] size Size of the string
+ * @return On error, return @p NULL
+ */
+Raster *
+raster_from_wkb(const uint8_t *wkb, size_t size)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(wkb, NULL);
+  /* rt_core takes the length as a uint32_t, which is also the widest raster it
+   * can serialize, its size field being a uint32_t varlena header */
+  if (size > UINT32_MAX)
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+      "The Well-Known Binary (WKB) representation of a raster must have at "
+      "most %u bytes: %zu", UINT32_MAX, size);
+    return NULL;
+  }
+  return raster_serialize_destroy(rt_raster_from_wkb(wkb, (uint32_t) size));
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return a raster from its ASCII hex-encoded Well-Known Binary
+ * (HexWKB) representation
+ * @param[in] hexwkb HexWKB string
+ * @return On error, return @p NULL
+ */
+Raster *
+raster_from_hexwkb(const char *hexwkb)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(hexwkb, NULL);
+  size_t size = strlen(hexwkb);
+  if (size > UINT32_MAX)
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_INPUT,
+      "The ASCII hex-encoded Well-Known Binary (HexWKB) representation of a "
+      "raster must have at most %u bytes: %zu", UINT32_MAX, size);
+    return NULL;
+  }
+  return raster_serialize_destroy(rt_raster_from_hexwkb(hexwkb,
+    (uint32_t) size));
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return the Well-Known Binary (WKB) representation of a raster
+ * @param[in] rast Raster
+ * @param[out] size_out Size of the output
+ * @return On error, return @p NULL
+ */
+uint8_t *
+raster_as_wkb(const Raster *rast, size_t *size_out)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rast, NULL); VALIDATE_NOT_NULL(size_out, NULL);
+  /* The bands are needed, so the raster is fully deserialized. It keeps
+   * pointers into `rast` without owning them, and is destroyed below before
+   * `rast` is handed back to the caller */
+  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not deserialize raster");
+    return NULL;
+  }
+  uint32_t wkb_size;
+  uint8_t *result = rt_raster_to_wkb(raster, 0, &wkb_size);
+  raster_destroy(raster);
+  if (! result)
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_OUTPUT,
+      "Could not output the Well-Known Binary (WKB) representation of a "
+      "raster");
+    return NULL;
+  }
+  *size_out = (size_t) wkb_size;
+  return result;
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return the ASCII hex-encoded Well-Known Binary (HexWKB)
+ * representation of a raster
+ * @param[in] rast Raster
+ * @param[out] size_out Size of the output, not counting the null terminator
+ * @return On error, return @p NULL
+ */
+char *
+raster_as_hexwkb(const Raster *rast, size_t *size_out)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rast, NULL); VALIDATE_NOT_NULL(size_out, NULL);
+  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not deserialize raster");
+    return NULL;
+  }
+  uint32_t hexwkb_size;
+  char *result = rt_raster_to_hexwkb(raster, 0, &hexwkb_size);
+  raster_destroy(raster);
+  if (! result)
+  {
+    meos_error(ERROR, MEOS_ERR_WKB_OUTPUT,
+      "Could not output the ASCII hex-encoded Well-Known Binary (HexWKB) "
+      "representation of a raster");
+    return NULL;
+  }
+  *size_out = (size_t) hexwkb_size;
+  return result;
+}
 
 /*****************************************************************************
  * Accessor functions

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -1,0 +1,168 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the input and output functions of the PostGIS
+ * raster type, and the band count read through them.
+ *
+ * A @p Raster is the serialized form of the PostGIS @p raster type. A
+ * PostgreSQL session reaches it by detoasting its own column, but every other
+ * binding holds the interchange representation instead, so
+ * #raster_num_bands() is reachable outside PostgreSQL only through
+ * #raster_from_wkb() / #raster_from_hexwkb(). This program exercises that path
+ * with no PostgreSQL involved, which is what makes the band count inheritable
+ * by the language bindings rather than a PostgreSQL-only operator.
+ *
+ * The two rasters below are the ASCII hex-encoded WKB of the two rasters the
+ * `numBands` case of mobilitydb/test/raster/queries/500_raster.test.sql builds
+ * with `ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+ * 4326), '32BF', 0.0, NULL)`, so that the two suites read the same values.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o raster_test raster_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_raster.h>
+
+/* A 3x3 raster with a single 32BF band */
+static const char *raster_one_band =
+  "0100000100000000000000f03f000000000000f0bf000000000000000000000000000008"
+  "4000000000000000000000000000000000e6100000030003000a00000000000000000000"
+  "000000000000000000000000000000000000000000000000000000000000";
+
+/* The same raster with a second 32BF band added */
+static const char *raster_two_bands =
+  "0100000200000000000000f03f000000000000f0bf000000000000000000000000000008"
+  "4000000000000000000000000000000000e6100000030003000a00000000000000000000"
+  "000000000000000000000000000000000000000000000000000000000000"
+  "0a0000000000000000000000000000000000000000000000000000000000000000000000"
+  "0000000000";
+
+/* Main program */
+int main(void)
+{
+  /* Initialize MEOS and install the error handler that reports through
+   * meos_errno instead of exiting */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  meos_initialize_noexit_error_handler();
+
+  /* The band count is read from the interchange representation alone, which is
+   * all a binding holds */
+  const char *hexwkbs[2] = {raster_one_band, raster_two_bands};
+  for (int i = 0; i < 2; i++)
+  {
+    meos_errno_reset();
+    Raster *rast = raster_from_hexwkb(hexwkbs[i]);
+    assert(rast != NULL);
+    assert(meos_errno() == 0);
+    int nbands = raster_num_bands(rast);
+    printf("raster_num_bands(raster_from_hexwkb(#%d)): %d\n", i + 1, nbands);
+    assert(nbands == i + 1);
+    assert(meos_errno() == 0);
+
+    /* The HexWKB output is read back into a raster with the same bands */
+    size_t hexwkb_size;
+    char *hexwkb = raster_as_hexwkb(rast, &hexwkb_size);
+    assert(hexwkb != NULL);
+    assert(hexwkb_size == strlen(hexwkb));
+    Raster *rast1 = raster_from_hexwkb(hexwkb);
+    assert(rast1 != NULL);
+    assert(raster_num_bands(rast1) == nbands);
+
+    /* The binary output round trips likewise, and the two representations
+     * encode the same bytes */
+    size_t wkb_size;
+    uint8_t *wkb = raster_as_wkb(rast, &wkb_size);
+    assert(wkb != NULL);
+    assert(wkb_size * 2 == hexwkb_size);
+    Raster *rast2 = raster_from_wkb(wkb, wkb_size);
+    assert(rast2 != NULL);
+    assert(raster_num_bands(rast2) == nbands);
+    assert(meos_errno() == 0);
+
+    free(hexwkb); free(wkb); free(rast); free(rast1); free(rast2);
+  }
+
+  /* A null argument is rejected rather than dereferenced */
+  size_t size;
+  meos_errno_reset();
+  assert(raster_from_wkb(NULL, 0) == NULL);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  assert(raster_from_hexwkb(NULL) == NULL);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  assert(raster_num_bands(NULL) == -1);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  assert(raster_as_wkb(NULL, &size) == NULL);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  assert(raster_as_hexwkb(NULL, &size) == NULL);
+  assert(meos_errno() != 0);
+
+  /* A raster is read against the length it is given, so every truncation of a
+   * valid representation is a parse failure and not a read past the end of the
+   * buffer. The size the header inside the bytes claims is never trusted */
+  size_t wkb_size;
+  Raster *rast = raster_from_hexwkb(raster_one_band);
+  assert(rast != NULL);
+  uint8_t *wkb = raster_as_wkb(rast, &wkb_size);
+  assert(wkb != NULL);
+  for (size_t trunc = 0; trunc < wkb_size; trunc++)
+  {
+    meos_errno_reset();
+    Raster *bad = raster_from_wkb(wkb, trunc);
+    assert(bad == NULL);
+    assert(meos_errno() != 0);
+  }
+  printf("raster_from_wkb(truncated to 0..%zu bytes): NULL\n", wkb_size - 1);
+  free(wkb); free(rast);
+
+  /* A string that is not hex-encoded WKB is a parse failure */
+  meos_errno_reset();
+  Raster *bad_hex = raster_from_hexwkb("this is not hex-encoded WKB");
+  printf("raster_from_hexwkb(bad HexWKB): %s, errno %d\n",
+    bad_hex ? "non-NULL" : "NULL", meos_errno());
+  assert(bad_hex == NULL);
+  assert(meos_errno() != 0);
+
+  meos_finalize();
+  printf("raster_test: all assertions passed\n");
+  return 0;
+}

--- a/postgis/rt_core/rt_wkb.c
+++ b/postgis/rt_core/rt_wkb.c
@@ -54,6 +54,12 @@ rt_band_from_wkb(
 		rterror("rt_band_from_wkb: Out of memory allocating rt_band during WKB parsing");
 		return NULL;
 	}
+	/* MEOS: the band is allocated uninitialized, and every error path below
+	 * destroys it before all of its fields have been read from the WKB.
+	 * rt_band_destroy() branches on `offline` and dereferences `data` to
+	 * decide what to release, so a malformed WKB would otherwise release two
+	 * indeterminate pointers */
+	memset(band, 0, sizeof (struct rt_band_t));
 	band->ownsdata = 0; /* assume we don't own data */
 
 	if (end - *ptr < 1) {


### PR DESCRIPTION
A `Raster` is the serialized form of the PostGIS `raster` type, and the only
function taking one, `raster_num_bands()`, has no producer. A PostgreSQL
session detoasts its own column to obtain one, so the gap is invisible there
and fatal everywhere else: a caller outside PostgreSQL holds the interchange
bytes and has no sanctioned way to reach the function.

This adds the input and output functions the sibling Raquet tile already has,
so that every caller reaches a raster the same way:

```c
extern Raster *raster_from_wkb(const uint8_t *wkb, size_t size);
extern Raster *raster_from_hexwkb(const char *hexwkb);
extern uint8_t *raster_as_wkb(const Raster *rast, size_t *size_out);
extern char *raster_as_hexwkb(const Raster *rast, size_t *size_out);
```

The serialized form and the WKB are distinct byte streams, so these convert
rather than cast: `rt_core` parses the WKB against the length it is given, and
the raster is then serialized. The length is never taken from the header
embedded in the bytes.

`rt_band_from_wkb()` allocates the band uninitialized and sets only its
`ownsdata` field, while every error path in the parser destroys the band
before reading the remaining fields from the WKB. `rt_band_destroy()` branches
on `offline` and dereferences `data` to decide what to release, so a malformed
WKB releases two indeterminate pointers. The first commit initializes the band.
This is the first MEOS caller of that parser, so the path becomes reachable
here.

`rt_raster_destroy()` releases the band registry but not the bands it points
to, which the caller owns, so the new functions release both.

## Tests

`meos/test/raster_test.c` reads the two rasters of the `numBands` case of the
PostgreSQL suite from their WKB, with no PostgreSQL involved, round trips them
through both representations, and checks that a null argument and every
truncation of a valid representation are rejected. It runs in `meos.yml`, whose
build gains `RASTER` and its GDAL dependency.

Under valgrind the suite reports 0 errors and 0 bytes lost.
