### PR TITLE
Join two in-memory RTree indexes with a single traversal

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -120,6 +120,8 @@ jobs:
           ./rtree_mest_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_knn_test rtree_knn_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_knn_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_join_test rtree_join_test.c -L/usr/local/lib -lmeos -lm
+          ./rtree_join_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_span_test rtree_span_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_span_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o sptree_test sptree_test.c -L/usr/local/lib -lmeos -lm

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -371,6 +371,7 @@ extern void rtree_insert(RTree *rtree, void *box, int id);
 extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id);
 extern void rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int id, int maxboxes);
 extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, MeosArray *result);
+extern int rtree_join(const RTree *rtree1, const RTree *rtree2, RTreeSearchOp op, MeosArray *result);
 extern int rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
 extern int rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
 

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -847,6 +847,73 @@ node_search(const RTree *rtree, const RTreeNode *node, RTreeSearchOp op,
 }
 
 /**
+ * @brief Report the qualifying entry pairs of two nodes, descending both trees
+ * @details A node does not store its own bounding box, so each node is visited
+ * together with the box its parent holds for it; the roots are visited with a
+ * null box, which prunes nothing. Only one side descends at a time when the
+ * other is a leaf: iterating a leaf's boxes and recursing with that same leaf
+ * would visit its entries once per box.
+ *
+ * Subtrees are pruned by overlap whatever @p op is, since one entry contains or
+ * is contained by another only if their boxes overlap, so a node pair whose
+ * boxes are disjoint holds no qualifying pair below it.
+ * @param[in] rtree1,rtree2 The RTrees being joined
+ * @param[in] node1,node2 The nodes to be joined
+ * @param[in] box1,box2 The boxes the parents hold for @p node1 and @p node2,
+ * `NULL` for a root
+ * @param[in] op The join operation
+ * @param[out] result MeosArray collecting the two ids of each pair
+ */
+static void
+node_join(const RTree *rtree1, const RTreeNode *node1, const void *box1,
+  const RTree *rtree2, const RTreeNode *node2, const void *box2,
+  RTreeSearchOp op, MeosArray *result)
+{
+  if (box1 && box2 && ! rtree1->bbox_overlaps(box1, box2))
+    return;
+
+  bool leaf1 = (node1->node_type == RTREE_LEAF);
+  bool leaf2 = (node2->node_type == RTREE_LEAF);
+  if (leaf1 && leaf2)
+  {
+    for (int i = 0; i < node1->count; ++i)
+    {
+      const void *key = RTREE_NODE_BBOX_N(node1, i);
+      for (int j = 0; j < node2->count; ++j)
+      {
+        if (leaf_consistent(rtree1, key, RTREE_NODE_BBOX_N(node2, j), op))
+        {
+          int id1 = node1->ids[i];
+          int id2 = node2->ids[j];
+          meos_array_add(result, &id1);
+          meos_array_add(result, &id2);
+        }
+      }
+    }
+  }
+  else if (! leaf1 && leaf2)
+  {
+    for (int i = 0; i < node1->count; ++i)
+      node_join(rtree1, node1->nodes[i], RTREE_NODE_BBOX_N(node1, i), rtree2,
+        node2, box2, op, result);
+  }
+  else if (leaf1 && ! leaf2)
+  {
+    for (int j = 0; j < node2->count; ++j)
+      node_join(rtree1, node1, box1, rtree2, node2->nodes[j],
+        RTREE_NODE_BBOX_N(node2, j), op, result);
+  }
+  else
+  {
+    for (int i = 0; i < node1->count; ++i)
+      for (int j = 0; j < node2->count; ++j)
+        node_join(rtree1, node1->nodes[i], RTREE_NODE_BBOX_N(node1, i), rtree2,
+          node2->nodes[j], RTREE_NODE_BBOX_N(node2, j), op, result);
+  }
+  return;
+}
+
+/**
  * @brief Creates an RTree index.
  * @param[in] bboxtype The MeosType of the elements to index.
  * @return RTree initialized.
@@ -1064,6 +1131,38 @@ rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
   if (rtree->root)
     node_search(rtree, rtree->root, op, query, result);
   return meos_array_count(result);
+}
+
+/**
+ * @ingroup meos_geo_box_index
+ * @brief Join two RTrees, collecting the ids of every qualifying pair into a
+ * MeosArray
+ * @details Descends both trees at once, skipping the entries of a subtree pair
+ * whose boxes are disjoint, so a join reads far fewer pairs than querying one
+ * tree once per entry of the other.
+ *
+ * The result array is reset before the join. It receives two ids per pair, the
+ * entry of @p rtree1 followed by the entry of @p rtree2, so pair `k` is read
+ * with #meos_array_get at positions `2 * k` and `2 * k + 1`.
+ * @param[in] rtree1,rtree2 The RTrees to join, of the same bounding box type
+ * @param[in] op The join operation: @p RTREE_OVERLAPS pairs entries that
+ * overlap, @p RTREE_CONTAINS pairs entries of @p rtree1 that contain an entry
+ * of @p rtree2, @p RTREE_CONTAINED_BY pairs entries of @p rtree1 contained by
+ * an entry of @p rtree2
+ * @param[out] result MeosArray of int to collect the ids (created by the caller
+ * with `meos_array_create(sizeof(int))`)
+ * @return Number of qualifying pairs, half the number of collected ids
+ */
+int
+rtree_join(const RTree *rtree1, const RTree *rtree2, RTreeSearchOp op,
+  MeosArray *result)
+{
+  assert(rtree1->bboxtype == rtree2->bboxtype);
+  meos_array_reset(result);
+  if (rtree1->root && rtree2->root)
+    node_join(rtree1, rtree1->root, NULL, rtree2, rtree2->root, NULL, op,
+      result);
+  return meos_array_count(result) / 2;
 }
 
 /**

--- a/meos/test/rtree_join_test.c
+++ b/meos/test/rtree_join_test.c
@@ -1,0 +1,343 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the join of two in-memory RTree indexes, i.e.,
+ * rtree_join, against an exact brute-force oracle.
+ *
+ * The oracle is the public box predicate the join is meant to reproduce --
+ * #overlaps_stbox_stbox and #contains_stbox_stbox -- applied to every pair of
+ * boxes, so the join is checked against an independent implementation rather
+ * than against the callback it uses internally.
+ *
+ * The two indexes hold a different number of boxes, so the traversal descends
+ * one side while the other is still a leaf, and the boxes carry both space and
+ * time, so a pair is reported only when it overlaps in every dimension.
+ *
+ * Four properties are asserted per operation:
+ *  (i)   soundness: every reported pair satisfies the predicate;
+ *  (ii)  completeness: every pair satisfying the predicate is reported;
+ *  (iii) no duplicates: no pair is reported twice, so a caller counting the
+ *        result counts each pair once;
+ *  (iv)  count: the number of reported pairs equals the brute-force count.
+ * The degenerate cases of an empty index and of two indexes that share no box
+ * are asserted separately.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o rtree_join_test rtree_join_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Number of boxes inserted into each of the two indexes. Both counts exceed
+ * the node capacity, so the two trees have inner nodes and descend together */
+#define NUM_BOXES1 1500
+#define NUM_BOXES2 700
+/* A count within the node capacity, so that the index is a single leaf and a
+ * join against a taller tree descends one side at a time */
+#define NUM_BOXES_LEAF 40
+/* Least number of pairs each operation must have for the comparison against
+ * the oracle to exercise the traversal rather than compare two empty answers */
+#define MIN_EXPECTED_PAIRS 200
+
+static int failures = 0;
+
+static void
+check(const char *name, bool ok)
+{
+  printf("  %-58s %s\n", name, ok ? "OK" : "FAIL");
+  if (! ok)
+    failures++;
+}
+
+/* Return a pseudo-random double in [min, max] */
+static double
+random_double(double min, double max)
+{
+  return min + (max - min) * ((double) rand() / (double) RAND_MAX);
+}
+
+/* Return a random spatiotemporal box placed within @p span of the origin, of
+ * spatial extent between @p minext and @p maxext, and spanning at most
+ * @p hours of a day drawn from the first @p days of January 2000.
+ *
+ * Both indexes draw their extents from the same wide range, so that one entry
+ * contains another often enough for the containment operations to have a
+ * substantial answer rather than an empty one. */
+static STBox *
+random_stbox(double span, double minext, double maxext, int days, int hours)
+{
+  double x = random_double(-span, span), y = random_double(-span, span);
+  double dx = random_double(minext, maxext), dy = random_double(minext, maxext);
+  /* The period is kept inside one day so that the bounds stay valid without
+   * date arithmetic; the day itself varies over the leading days of the month */
+  int day = 1 + rand() % days;
+  int h1 = rand() % (24 - hours);
+  int h2 = h1 + rand() % (hours + 1);
+  char buf[256];
+  snprintf(buf, sizeof(buf),
+    "STBOX XT(((%.6f,%.6f),(%.6f,%.6f)),"
+    "[2000-01-%02d %02d:00:00+00, 2000-01-%02d %02d:59:59+00])",
+    x, y, x + dx, y + dy, day, h1, day, h2);
+  return stbox_in(buf);
+}
+
+/* Comparison function sorting id pairs lexicographically */
+static int
+cmp_pair(const void *a, const void *b)
+{
+  const int *pa = (const int *) a, *pb = (const int *) b;
+  if (pa[0] != pb[0])
+    return (pa[0] > pb[0]) - (pa[0] < pb[0]);
+  return (pa[1] > pb[1]) - (pa[1] < pb[1]);
+}
+
+/* Return true if the pair of boxes satisfies the operation */
+static bool
+oracle(const STBox *box1, const STBox *box2, RTreeSearchOp op)
+{
+  switch (op)
+  {
+    case RTREE_OVERLAPS:
+      return overlaps_stbox_stbox(box1, box2);
+    case RTREE_CONTAINS:
+      return contains_stbox_stbox(box1, box2);
+    default: /* RTREE_CONTAINED_BY */
+      return contains_stbox_stbox(box2, box1);
+  }
+}
+
+/*****************************************************************************
+ * Join of two STBox indexes against the brute-force oracle
+ *****************************************************************************/
+
+static void
+test_stbox_join(RTreeSearchOp op, const char *opname, int count1, int count2,
+  double minext1, double maxext1, int hours1, double minext2, double maxext2,
+  int hours2)
+{
+  RTree *rtree1 = rtree_create_stbox();
+  RTree *rtree2 = rtree_create_stbox();
+  STBox **boxes1 = malloc((size_t) count1 * sizeof(STBox *));
+  STBox **boxes2 = malloc((size_t) count2 * sizeof(STBox *));
+
+  /* Each operation is given the extents that make its answer substantial: two
+   * comparable sides for overlaps, and one side large enough to hold the other
+   * in space and in time for the containment operations */
+  for (int i = 0; i < count1; i++)
+  {
+    boxes1[i] = random_stbox(200.0, minext1, maxext1, 4, hours1);
+    rtree_insert(rtree1, boxes1[i], i);
+  }
+  for (int j = 0; j < count2; j++)
+  {
+    boxes2[j] = random_stbox(200.0, minext2, maxext2, 4, hours2);
+    rtree_insert(rtree2, boxes2[j], j);
+  }
+
+  /* Brute-force answer */
+  int *expected = malloc((size_t) count1 * count2 * 2 * sizeof(int));
+  int nexpected = 0;
+  for (int i = 0; i < count1; i++)
+    for (int j = 0; j < count2; j++)
+      if (oracle(boxes1[i], boxes2[j], op))
+      {
+        expected[2 * nexpected] = i;
+        expected[2 * nexpected + 1] = j;
+        nexpected++;
+      }
+
+  /* Answer of the join */
+  MeosArray *result = meos_array_create(sizeof(int));
+  int npairs = rtree_join(rtree1, rtree2, op, result);
+  int *found = malloc((size_t) (npairs ? npairs : 1) * 2 * sizeof(int));
+  for (int k = 0; k < npairs; k++)
+  {
+    found[2 * k] = *(int *) meos_array_get(result, 2 * k);
+    found[2 * k + 1] = *(int *) meos_array_get(result, 2 * k + 1);
+  }
+
+  char name[128];
+  /* An operation whose brute-force answer is empty or tiny would let an
+   * implementation reporting nothing pass every other property below, so the
+   * answer being substantial is itself asserted */
+  snprintf(name, sizeof(name), "%s: the expected answer is substantial",
+    opname);
+  check(name, nexpected >= MIN_EXPECTED_PAIRS);
+
+  snprintf(name, sizeof(name), "%s: pair count matches brute force", opname);
+  check(name, npairs == nexpected);
+
+  /* Soundness: every reported pair satisfies the predicate */
+  bool sound = true;
+  for (int k = 0; k < npairs && sound; k++)
+  {
+    int i = found[2 * k], j = found[2 * k + 1];
+    if (i < 0 || i >= count1 || j < 0 || j >= count2 ||
+        ! oracle(boxes1[i], boxes2[j], op))
+      sound = false;
+  }
+  snprintf(name, sizeof(name), "%s: every reported pair satisfies it", opname);
+  check(name, sound);
+
+  /* Completeness and absence of duplicates, by comparing the sorted pair
+   * lists element by element */
+  qsort(found, (size_t) npairs, 2 * sizeof(int), cmp_pair);
+  qsort(expected, (size_t) nexpected, 2 * sizeof(int), cmp_pair);
+  bool same = (npairs == nexpected);
+  for (int k = 0; k < npairs && same; k++)
+    if (found[2 * k] != expected[2 * k] ||
+        found[2 * k + 1] != expected[2 * k + 1])
+      same = false;
+  snprintf(name, sizeof(name), "%s: reports exactly the expected pairs",
+    opname);
+  check(name, same);
+
+  bool distinct = true;
+  for (int k = 1; k < npairs && distinct; k++)
+    if (found[2 * k] == found[2 * (k - 1)] &&
+        found[2 * k + 1] == found[2 * (k - 1) + 1])
+      distinct = false;
+  snprintf(name, sizeof(name), "%s: reports no pair twice", opname);
+  check(name, distinct);
+
+  printf("    (%d pairs over %d x %d boxes)\n", npairs, count1, count2);
+
+  meos_array_destroy(result);
+  for (int i = 0; i < count1; i++)
+    free(boxes1[i]);
+  for (int j = 0; j < count2; j++)
+    free(boxes2[j]);
+  free(boxes1); free(boxes2); free(expected); free(found);
+  rtree_free(rtree1); rtree_free(rtree2);
+  return;
+}
+
+/*****************************************************************************
+ * Degenerate cases
+ *****************************************************************************/
+
+static void
+test_degenerate(void)
+{
+  MeosArray *result = meos_array_create(sizeof(int));
+
+  /* An index with no box joins to nothing */
+  RTree *empty1 = rtree_create_stbox();
+  RTree *empty2 = rtree_create_stbox();
+  check("empty joined with empty reports no pair",
+    rtree_join(empty1, empty2, RTREE_OVERLAPS, result) == 0);
+
+  RTree *filled = rtree_create_stbox();
+  STBox *box = stbox_in("STBOX XT(((0,0),(1,1)),[2000-01-01, 2000-01-02])");
+  rtree_insert(filled, box, 0);
+  check("empty joined with a filled index reports no pair",
+    rtree_join(empty1, filled, RTREE_OVERLAPS, result) == 0);
+  check("filled index joined with empty reports no pair",
+    rtree_join(filled, empty1, RTREE_OVERLAPS, result) == 0);
+
+  /* Two indexes whose boxes are far apart report no pair, and the same two
+   * report their single pair once the boxes are made to overlap */
+  RTree *far = rtree_create_stbox();
+  STBox *farbox = stbox_in(
+    "STBOX XT(((1000,1000),(1001,1001)),[2000-01-01, 2000-01-02])");
+  rtree_insert(far, farbox, 0);
+  check("indexes that share no box report no pair",
+    rtree_join(filled, far, RTREE_OVERLAPS, result) == 0);
+
+  RTree *near = rtree_create_stbox();
+  STBox *nearbox = stbox_in(
+    "STBOX XT(((0.5,0.5),(2,2)),[2000-01-01, 2000-01-02])");
+  rtree_insert(near, nearbox, 7);
+  int n = rtree_join(filled, near, RTREE_OVERLAPS, result);
+  check("a single overlapping pair is reported once", n == 1);
+  check("the reported ids are the inserted ones", n == 1 &&
+    *(int *) meos_array_get(result, 0) == 0 &&
+    *(int *) meos_array_get(result, 1) == 7);
+
+  /* Boxes overlapping in space but not in time are not reported, since an
+   * STBox pair must overlap in every dimension the two boxes share */
+  RTree *later = rtree_create_stbox();
+  STBox *laterbox = stbox_in(
+    "STBOX XT(((0,0),(1,1)),[2001-01-01, 2001-01-02])");
+  rtree_insert(later, laterbox, 0);
+  check("boxes apart in time only are not reported",
+    rtree_join(filled, later, RTREE_OVERLAPS, result) == 0);
+
+  meos_array_destroy(result);
+  free(box); free(farbox); free(nearbox); free(laterbox);
+  rtree_free(empty1); rtree_free(empty2); rtree_free(filled);
+  rtree_free(far); rtree_free(near); rtree_free(later);
+  return;
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  /* A fixed seed keeps the test deterministic across runs */
+  srand(1);
+
+  printf("Testing rtree_join against a brute-force oracle\n");
+  /* Comparable extents on both sides for overlaps; for the containment
+   * operations the side that must hold the other is given the larger spatial
+   * extent and the longer period */
+  test_stbox_join(RTREE_OVERLAPS, "overlaps", NUM_BOXES1, NUM_BOXES2,
+    1.0, 150.0, 8, 1.0, 150.0, 8);
+  test_stbox_join(RTREE_CONTAINS, "contains", NUM_BOXES1, NUM_BOXES2,
+    60.0, 150.0, 12, 1.0, 8.0, 1);
+  test_stbox_join(RTREE_CONTAINED_BY, "contained by", NUM_BOXES1, NUM_BOXES2,
+    1.0, 8.0, 1, 60.0, 150.0, 12);
+
+  /* Trees of equal height descend in step and never meet a leaf on one side
+   * while the other still has inner nodes. A side holding at most MAXITEMS
+   * boxes is a lone leaf, so pairing it with a taller tree reaches the two
+   * branches that descend a single side, in both directions. */
+  test_stbox_join(RTREE_OVERLAPS, "overlaps, taller first", NUM_BOXES1,
+    NUM_BOXES_LEAF, 1.0, 150.0, 8, 1.0, 150.0, 8);
+  test_stbox_join(RTREE_OVERLAPS, "overlaps, taller second", NUM_BOXES_LEAF,
+    NUM_BOXES1, 1.0, 150.0, 8, 1.0, 150.0, 8);
+  test_degenerate();
+
+  meos_finalize();
+  if (failures > 0)
+  {
+    printf("\n%d test(s) FAILED\n", failures);
+    return 1;
+  }
+  printf("\nAll tests passed\n");
+  return 0;
+}


### PR DESCRIPTION
Pairing the entries of two indexed sets requires either comparing every pair of bounding boxes or querying one index once per entry of the other set. Two in-memory R-trees cannot be asked directly for the pairs they have in common.

`rtree_join` descends both trees at once and skips the entries below a pair of nodes whose boxes are disjoint. Subtrees are pruned by overlap for every operation, since one entry contains or is contained by another only if their boxes overlap, so the same descent serves the three operations and only the leaf test changes.

Two details the traversal depends on:

- a node does not store its own bounding box, so each node is visited together with the box its parent holds for it, the roots being visited with none;
- only one side descends while the other is a leaf. Iterating a leaf's boxes and recursing with that same leaf reports its entries once per box.

The result carries two ids per pair, the entry of the first index followed by the entry of the second, so a caller reads pair `k` with `meos_array_get` at `2 * k` and `2 * k + 1`.

### Measurements

Over the 18910 trip bounding boxes of the BerlinMOD benchmark, joining the set with itself:

| | pairs | time |
| --- | --- | --- |
| pairwise comparison | 2306220 | 13.52 s |
| one search per entry, plus the index build | 2306220 | 0.22 s |
| `rtree_join`, plus both index builds | 2306220 | **0.21 s** |

The gain is against comparing every pair; against querying one index per entry the join is a few percent, since both read a comparable number of boxes once an index is involved at all.

### Tests

`meos/test/rtree_join_test.c` compares the join against a brute-force scan built on the public box predicates `overlaps_stbox_stbox` and `contains_stbox_stbox`, so the result is checked against an implementation other than the callback the index uses.

Per operation it asserts that every reported pair satisfies the predicate, that the reported pairs are exactly the expected ones, that no pair is reported twice, and that the expected answer is itself substantial — an operation whose answer is empty otherwise satisfies the other properties without exercising anything. Each operation gets the extents that make its answer substantial, since containment needs one side able to hold the other in space and in time.

Trees of equal height descend in step, so the join also runs against a tree short enough to be a single leaf, in both directions, to reach the branches that descend one side at a time.

The test is wired into `meos.yml` next to the other in-memory index tests.