### PR TITLE
Read the pixel bytes of a Raquet tile from SQL

### DIFF
--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3989,6 +3989,10 @@
 				</listitem>
 
 				<listitem>
+					<para><link linkend="raquet_pixels"><varname>pixels</varname></link>: Return the pixel bytes of a Raquet tile</para>
+				</listitem>
+
+				<listitem>
 					<para><link linkend="raquet_to_stbox"><varname>stbox</varname></link>: Convert a Raquet tile into a spatiotemporal box</para>
 				</listitem>
 

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -247,6 +247,17 @@ FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8') AS 
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raquet_pixels">
+				<indexterm significance="normal"><primary><varname>pixels</varname></primary></indexterm>
+				<para>Return the pixel bytes of a Raquet tile</para>
+				<para><varname>pixels(raquet) → bytea</varname></para>
+				<para>The bytes are row-major and packed, <varname>width</varname> × <varname>height</varname> pixels of the size of <varname>pixtype</varname> each, which is the layout the constructors accept. A tile therefore round trips through its own accessors.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+-- \x01020304
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raquet_to_stbox">
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convert a Raquet tile into a spatiotemporal box</para>

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -399,6 +399,7 @@ raquet_pixtype(const Raquet *rq)
  * @note The bytes are row-major and packed, @p width * @p height pixels of
  * @p raquet_pixtype_size() bytes each, which is the layout the tile
  * constructors accept
+ * @csqlfn #Raquet_pixels()
  */
 uint8_t *
 raquet_pixels(const Raquet *rq, size_t *size_out)

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -337,6 +337,10 @@ CREATE FUNCTION pixtype(raquet)
   RETURNS text
   AS 'MODULE_PATHNAME', 'Raquet_pixtype'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION pixels(raquet)
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Raquet_pixels'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
  * Comparison of raquet tiles

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -737,6 +737,27 @@ Raquet_pixtype(PG_FUNCTION_ARGS)
   PG_RETURN_TEXT_P(result);
 }
 
+PGDLLEXPORT Datum Raquet_pixels(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_pixels);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the pixel bytes of a Raquet tile
+ * @sqlfn pixels()
+ */
+Datum
+Raquet_pixels(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  size_t size;
+  uint8_t *pixels = raquet_pixels(rq, &size);
+  bytea *result = palloc(VARHDRSZ + size);
+  SET_VARSIZE(result, VARHDRSZ + size);
+  memcpy(VARDATA(result), pixels, size);
+  pfree(pixels);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_BYTEA_P(result);
+}
+
 /*****************************************************************************
  * Raquet type: comparison
  *****************************************************************************/

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -361,6 +361,29 @@ SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8'
   -9999
 (1 row)
 
+SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+  'UINT8'));
+   pixels   
+------------
+ \x01020304
+(1 row)
+
+SELECT raquet(pixels(tile), width(tile), height(tile), quadbin(tile),
+         pixtype(tile), nodata(tile)) = tile AS round_trips
+FROM (SELECT raquet('\x0102030405060708'::bytea, 2, 2,
+        5193776270265024512::bigint, 'INT16', -9999.0) AS tile) t;
+ round_trips 
+-------------
+ t
+(1 row)
+
+SELECT length(pixels(raquet('\x0102030405060708'::bytea, 2, 1,
+  5193776270265024512::bigint, 'FLOAT32')));
+ length 
+--------
+      8
+(1 row)
+
 SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') =
        raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') AS eq,
        raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8') <>

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -414,6 +414,20 @@ SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')
 SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
   -9999.0));
 
+-- The pixel bytes are returned in the layout the constructor accepts, so a
+-- tile rebuilt from its own accessors equals the tile it came from.
+SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+  'UINT8'));
+
+SELECT raquet(pixels(tile), width(tile), height(tile), quadbin(tile),
+         pixtype(tile), nodata(tile)) = tile AS round_trips
+FROM (SELECT raquet('\x0102030405060708'::bytea, 2, 2,
+        5193776270265024512::bigint, 'INT16', -9999.0) AS tile) t;
+
+-- A wider pixel type returns the whole band, not the pixel count.
+SELECT length(pixels(raquet('\x0102030405060708'::bytea, 2, 1,
+  5193776270265024512::bigint, 'FLOAT32')));
+
 -------------------------------------------------------------------------------
 -- raquet comparison
 -------------------------------------------------------------------------------


### PR DESCRIPTION
Of the six Raquet accessors, five reach SQL as `quadbin`, `width`, `height`,
`nodata` and `pixtype`, while `raquet_pixels` has no SQL function and no caller
anywhere in the tree. A tile therefore reports the layout of its band but not
the band that layout describes, and the value cannot be taken apart into the
arguments its own constructor accepts.

This adds `pixels(raquet) → bytea`, returning the bytes in the row-major packed
layout the constructors take, and closes the accessor group.

## Tests

The tile round trips through its own accessors:

```sql
SELECT raquet(pixels(tile), width(tile), height(tile), quadbin(tile),
         pixtype(tile), nodata(tile)) = tile AS round_trips
FROM (SELECT raquet('\x0102030405060708'::bytea, 2, 2,
        5193776270265024512::bigint, 'INT16', -9999.0) AS tile) t;
-- t
```

A case with a wider pixel type covers the whole band rather than the pixel
count: a 2 × 1 `FLOAT32` tile returns 8 bytes.
