### PR TITLE
Resolve the touches of a zero-radius temporal circular buffer as a point

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -1497,9 +1497,33 @@ aintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
+ * @brief Return true if every composing circular buffer of a temporal circular
+ * buffer has a zero radius, that is, the value is a temporal point
+ */
+static bool
+tcbuffer_is_tpoint(const Temporal *temp)
+{
+  assert(temp); assert(temp->temptype == T_TCBUFFER);
+  int count;
+  const TInstant **instants = temporal_insts_p(temp, &count);
+  bool result = true;
+  for (int i = 0; i < count && result; i++)
+    result = (DatumGetCbufferP(tinstant_value_p(instants[i]))->radius == 0.0);
+  pfree(instants);
+  return result;
+}
+
+/**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry ever touch,
  * 0 if not, and -1 on error or if the geometry is empty
+ * @details Touching is a contact of the two whose interiors stay disjoint. A
+ * disc of a strictly positive radius carries an interior, and the paths below
+ * read the disjointness from the position of its centre with respect to the
+ * geometry. A disc of radius zero is a point, whose interior is the point
+ * itself: it touches the geometry exactly where it lies on the boundary of the
+ * geometry, and a value composed of such discs is a temporal point, which
+ * reaches that relationship through its own conversion
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -1511,6 +1535,18 @@ ea_touches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
+
+  /* A value composed of discs of a zero radius is a temporal point, whose
+   * conversion is exact, and the temporal point relationship resolves the
+   * contact with the boundary of the geometry that the paths below read from
+   * a disc boundary */
+  if (tcbuffer_is_tpoint(temp))
+  {
+    Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
+    int result = ea_touches_tpoint_geo(tpoint, gs, ever);
+    pfree(tpoint);
+    return result;
+  }
 
   /* Bounding box test: a moving disk whose radius-aware bounding box is
    * disjoint from the geometry never reaches it, so it cannot touch. This is a

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -622,6 +622,90 @@ SELECT eTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)
  f
 (1 row)
 
+SELECT eTouches(tcbuffer '[Cbuffer(Point(-5 0),0)@2000-01-01, Cbuffer(Point(5 0),0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(tcbuffer '[Cbuffer(Point(-5 0),0)@2000-01-01, Cbuffer(Point(5 0),0)@2000-01-02]', geometry 'Linestring(-1 -1,1 1)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer '[Cbuffer(Point(-3 -3),0)@2000-01-01, Cbuffer(Point(-1 -1),0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(tcbuffer '[Cbuffer(Point(-1 -1),0)@2000-01-01, Cbuffer(Point(-1 1),0)@2000-01-02]', geometry 'CurvePolygon(CircularString(-1 0,0 1,1 0,0 -1,-1 0))');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT aTouches(tcbuffer '[Cbuffer(Point(-5 0),0)@2000-01-01, Cbuffer(Point(5 0),0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ atouches 
+----------
+ f
+(1 row)
+
+SELECT aTouches(tcbuffer '[Cbuffer(Point(-1 -1),0)@2000-01-01, Cbuffer(Point(-1 1),0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ atouches 
+----------
+ t
+(1 row)
+
+SELECT aTouches(tcbuffer '[Cbuffer(Point(-1 -1),0)@2000-01-01, Cbuffer(Point(-1 1),0)@2000-01-02]', geometry 'Triangle((-1 -1,-1 1,1 1,-1 -1))');
+ atouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]', geometry 'Linestring(-1 -1,1 1)');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eTouches(tgeompoint '[Point(-3 -3)@2000-01-01, Point(-1 -1)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT eTouches(tgeompoint '[Point(-1 -1)@2000-01-01, Point(-1 1)@2000-01-02]', geometry 'CurvePolygon(CircularString(-1 0,0 1,1 0,0 -1,-1 0))');
+ etouches 
+----------
+ t
+(1 row)
+
+SELECT aTouches(tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ atouches 
+----------
+ f
+(1 row)
+
+SELECT aTouches(tgeompoint '[Point(-1 -1)@2000-01-01, Point(-1 1)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ atouches 
+----------
+ t
+(1 row)
+
+SELECT aTouches(tgeompoint '[Point(-1 -1)@2000-01-01, Point(-1 1)@2000-01-02]', geometry 'Triangle((-1 -1,-1 1,1 1,-1 -1))');
+ atouches 
+----------
+ t
+(1 row)
+
 /* Errors */
 SELECT eTouches(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -235,6 +235,27 @@ SELECT aTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0)
 -- The disc stays away from the ring
 SELECT eTouches(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(10 0),1)@2000-01-01, Cbuffer(Point(10 10),1)@2000-01-03]');
 
+-- A temporal circular buffer whose discs have a zero radius is a temporal
+-- point, and touches a geometry wherever that point does: crossing a polygon
+-- meets its boundary, crossing the interior of a line does not touch it, and
+-- ending on a vertex or on a tangency to an arc does touch
+SELECT eTouches(tcbuffer '[Cbuffer(Point(-5 0),0)@2000-01-01, Cbuffer(Point(5 0),0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+SELECT eTouches(tcbuffer '[Cbuffer(Point(-5 0),0)@2000-01-01, Cbuffer(Point(5 0),0)@2000-01-02]', geometry 'Linestring(-1 -1,1 1)');
+SELECT eTouches(tcbuffer '[Cbuffer(Point(-3 -3),0)@2000-01-01, Cbuffer(Point(-1 -1),0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+SELECT eTouches(tcbuffer '[Cbuffer(Point(-1 -1),0)@2000-01-01, Cbuffer(Point(-1 1),0)@2000-01-02]', geometry 'CurvePolygon(CircularString(-1 0,0 1,1 0,0 -1,-1 0))');
+SELECT aTouches(tcbuffer '[Cbuffer(Point(-5 0),0)@2000-01-01, Cbuffer(Point(5 0),0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+-- Running along an edge of the polygon touches it at every instant
+SELECT aTouches(tcbuffer '[Cbuffer(Point(-1 -1),0)@2000-01-01, Cbuffer(Point(-1 1),0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+SELECT aTouches(tcbuffer '[Cbuffer(Point(-1 -1),0)@2000-01-01, Cbuffer(Point(-1 1),0)@2000-01-02]', geometry 'Triangle((-1 -1,-1 1,1 1,-1 -1))');
+-- the same four relationships asked of the trajectory as a temporal point
+SELECT eTouches(tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+SELECT eTouches(tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]', geometry 'Linestring(-1 -1,1 1)');
+SELECT eTouches(tgeompoint '[Point(-3 -3)@2000-01-01, Point(-1 -1)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+SELECT eTouches(tgeompoint '[Point(-1 -1)@2000-01-01, Point(-1 1)@2000-01-02]', geometry 'CurvePolygon(CircularString(-1 0,0 1,1 0,0 -1,-1 0))');
+SELECT aTouches(tgeompoint '[Point(-5 0)@2000-01-01, Point(5 0)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+SELECT aTouches(tgeompoint '[Point(-1 -1)@2000-01-01, Point(-1 1)@2000-01-02]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+SELECT aTouches(tgeompoint '[Point(-1 -1)@2000-01-01, Point(-1 1)@2000-01-02]', geometry 'Triangle((-1 -1,-1 1,1 1,-1 -1))');
+
 /* Errors */
 SELECT eTouches(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01');
 SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)');


### PR DESCRIPTION
Touching is a contact whose interiors stay disjoint. The two paths that resolve a temporal circular buffer against a geometry read that disjointness from a disc: the native path from the signed distance of the centre to the edges together with the side of the geometry the centre lies on, the traversed-area path from the swept region of each segment.

A disc of radius zero is a point. It has no interior to keep disjoint, and it touches the geometry exactly where it lies on the boundary of the geometry, which neither reading reports. The native path takes any contact with a line as a touch, since a geometry with no area leaves the centre always outside:

```sql
-- the trajectory crosses the line at (0 0), in the interior of the line
SELECT eTouches(tcbuffer '[Cbuffer(Point(-5 0),0)@2000-01-01, Cbuffer(Point(5 0),0)@2000-01-02]',
  geometry 'Linestring(-1 -1,1 1)');   -- f
```

and it drops a contact at a vertex or at a tangency to an arc, where the centre lies on the ring and the point-in-polygon test places it inside:

```sql
-- the trajectory ends on the corner of the square
SELECT eTouches(tcbuffer '[Cbuffer(Point(-3 -3),0)@2000-01-01, Cbuffer(Point(-1 -1),0)@2000-01-02]',
  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');   -- t
```

The traversed-area path is not the answer either: it asks the relationship of the swept region of the whole trajectory, so a trajectory that crosses a polygon reports no touch even though it meets the boundary.

A value whose discs all have a zero radius is a temporal point, and `tcbuffer_to_tgeompoint` keeps the centres exactly, so this routes it to the temporal point relationship. A disc of a strictly positive radius keeps both paths unchanged.

Over five trajectories and eleven geometry types, the answers for a radius-0 buffer and for the corresponding temporal point differ on eleven of the ever-predicate cases and on five of the always-predicate ones, and on none of either after. `aIntersects`, `aDisjoint`, `aContains` and `aCovers` are already equivalent at radius zero; touches is the only divergence on that side.

The cbuffer tables hold no zero-radius buffer, which is what leaves this uncovered, so their counts do not move. The added cases pair each radius-0 buffer with the same trajectory as a temporal point, for a crossing, a line interior, a vertex, an arc tangency, and a run along an edge.