### PR TITLE
Validate the GeoPose encoding against the OGC schemas and test it in MEOS

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -83,3 +83,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Check that the templatetypes table documents the type catalog
         run: python3 tools/scripts/check_templatetypes_doc.py
+
+  geopose_conformance_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Validate the GeoPose documents against the OGC schemas
+        run: python3 tools/scripts/check_geopose_conformance.py

--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -106,6 +106,8 @@ jobs:
           # built and installed above.
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o raster_test raster_test.c -L/usr/local/lib -lmeos
           ./raster_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o geopose_test geopose_test.c -L/usr/local/lib -lmeos
+          ./geopose_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o numeric_test numeric_test.c -L/usr/local/lib -lmeos
           ./numeric_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o setspan_test setspan_test.c -L/usr/local/lib -lmeos

--- a/meos/test/geopose_test.c
+++ b/meos/test/geopose_test.c
@@ -1,0 +1,348 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the OGC GeoPose encoding of poses and temporal
+ * poses.
+ *
+ * MobilityDB implements four of the eight conformance classes of OGC GeoPose
+ * v1.0 (OGC 21-056r11): Basic-YPR and Basic-Quaternion for a pose, and the
+ * Regular and Irregular Composite Sequence Series for a temporal pose. The
+ * program exercises each of them through the four functions the C API exposes,
+ * and covers the error paths that a malformed document reaches.
+ *
+ * The conformance class of a temporal pose follows its value: a single instant
+ * yields a Basic document, a sequence whose instants are equally spaced yields
+ * a Regular Series, and any other sequence yields an Irregular Series.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o geopose_test geopose_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_geo.h>
+#include <meos_pose.h>
+
+/* Conformance classes of a Basic document, as the second argument of the
+ * functions encoding a pose */
+#define BASIC_QUATERNION 0
+#define BASIC_YPR        1
+
+/**
+ * @brief Report a document and assert that it carries a member
+ */
+static void
+ensure_member(const char *what, const char *json, const char *member)
+{
+  printf("%s: %s\n", what, json);
+  assert(strstr(json, member) != NULL);
+  return;
+}
+
+/**
+ * @brief Report a document and assert that it carries no such member
+ */
+static void
+ensure_no_member(const char *what, const char *json, const char *member)
+{
+  printf("%s: carries no `%s`\n", what, member);
+  assert(strstr(json, member) == NULL);
+  return;
+}
+
+/* Main program */
+int main(void)
+{
+  /* Initialize MEOS and install the error handler that reports through
+   * meos_errno instead of exiting */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  meos_initialize_noexit_error_handler();
+
+  printf("****************************************************************\n");
+  printf("OGC GeoPose 1.0 encoding\n");
+  printf("****************************************************************\n");
+
+  /*--------------------------------------------------------------------------
+   * Basic-Quaternion, the class a pose takes by default
+   *------------------------------------------------------------------------*/
+
+  const char *quat_json = "{\"position\":{\"lat\":47,\"lon\":8,\"h\":1500},"
+    "\"quaternion\":{\"x\":0,\"y\":0,\"z\":0.7071067811865476,"
+    "\"w\":0.7071067811865476}}";
+
+  meos_errno_reset();
+  Pose *quat = pose_from_geopose(quat_json);
+  assert(quat != NULL);
+  assert(meos_errno() == 0);
+
+  char *out = pose_as_geopose(quat, BASIC_QUATERNION, 6);
+  assert(out != NULL);
+  ensure_member("Basic-Quaternion", out, "\"quaternion\"");
+  ensure_member("Basic-Quaternion", out, "\"position\"");
+  /* The position of a Basic document is always three-dimensional */
+  ensure_member("Basic-Quaternion", out, "\"h\"");
+  free(out);
+
+  /* The same pose seen as Basic-YPR carries the Euler angles instead */
+  out = pose_as_geopose(quat, BASIC_YPR, 6);
+  assert(out != NULL);
+  ensure_member("Basic-YPR view", out, "\"angles\"");
+  ensure_member("Basic-YPR view", out, "\"yaw\"");
+  ensure_no_member("Basic-YPR view", out, "\"quaternion\"");
+  free(out);
+
+  /* The round trip preserves the pose */
+  out = pose_as_geopose(quat, BASIC_QUATERNION, 15);
+  Pose *quat_back = pose_from_geopose(out);
+  assert(quat_back != NULL);
+  char *s1 = pose_out(quat, 6);
+  char *s2 = pose_out(quat_back, 6);
+  printf("round trip: %s -> %s\n", s1, s2);
+  assert(strcmp(s1, s2) == 0);
+  free(s1); free(s2); free(out); free(quat_back); free(quat);
+
+  /*--------------------------------------------------------------------------
+   * Basic-YPR, and the two-dimensional pose it also encodes
+   *------------------------------------------------------------------------*/
+
+  meos_errno_reset();
+  Pose *ypr = pose_from_geopose("{\"position\":{\"lat\":47,\"lon\":8,\"h\":0},"
+    "\"angles\":{\"yaw\":90,\"pitch\":0,\"roll\":0}}");
+  assert(ypr != NULL);
+  assert(meos_errno() == 0);
+  out = pose_as_geopose(ypr, BASIC_YPR, 6);
+  ensure_member("Basic-YPR", out, "\"angles\"");
+  free(out); free(ypr);
+
+  /* A yaw-only document without a height is the two-dimensional pose of a
+   * trajectory that tracks neither elevation nor tilt */
+  meos_errno_reset();
+  Pose *flat = pose_from_geopose("{\"position\":{\"lat\":0,\"lon\":0},"
+    "\"angles\":{\"yaw\":90,\"pitch\":0,\"roll\":0}}");
+  assert(flat != NULL);
+  assert(meos_errno() == 0);
+  s1 = pose_out(flat, 6);
+  printf("two-dimensional pose: %s\n", s1);
+  free(s1); free(flat);
+
+  /* The identity quaternion is the pose of a body aligned with its frame */
+  meos_errno_reset();
+  Pose *ident = pose_from_geopose("{\"position\":{\"lat\":0,\"lon\":0,\"h\":0},"
+    "\"quaternion\":{\"x\":0,\"y\":0,\"z\":0,\"w\":1}}");
+  assert(ident != NULL);
+  assert(meos_errno() == 0);
+  out = pose_as_geopose(ident, BASIC_QUATERNION, 6);
+  ensure_member("identity quaternion", out, "\"w\":1");
+  free(out); free(ident);
+
+  /*--------------------------------------------------------------------------
+   * A single instant yields a Basic document
+   *------------------------------------------------------------------------*/
+
+  meos_errno_reset();
+  Temporal *inst = tpose_in("Pose(Point(8 47), 0)@2026-01-01");
+  assert(inst != NULL);
+  assert(meos_errno() == 0);
+  out = tpose_as_geopose(inst, BASIC_QUATERNION, 6);
+  assert(out != NULL);
+  ensure_member("single instant", out, "\"quaternion\"");
+  ensure_no_member("single instant", out, "\"header\"");
+  free(out); free(inst);
+
+  /*--------------------------------------------------------------------------
+   * Equally spaced instants yield a Regular Series
+   *------------------------------------------------------------------------*/
+
+  /* The poses turn a corner, so that none of them lies on the segment
+   * between its neighbours and the normalisation of the sequence keeps all
+   * three: a Series carries as many poses as the value holds */
+  meos_errno_reset();
+  Temporal *regular = tpose_in("[Pose(Point(0 0), 0)@2026-01-01, "
+    "Pose(Point(1 0), 0)@2026-01-02, Pose(Point(1 1), 0)@2026-01-03]");
+  assert(regular != NULL);
+  assert(meos_errno() == 0);
+  s1 = temporal_out(regular, 6);
+  printf("Regular value: %s\n", s1);
+  free(s1);
+
+  out = tpose_as_geopose(regular, BASIC_QUATERNION, 6);
+  assert(out != NULL);
+  /* The four members the Series schema requires, and the duration that only
+   * the Regular class carries */
+  ensure_member("Regular Series", out, "\"header\"");
+  ensure_member("Regular Series", out, "\"outerFrame\"");
+  ensure_member("Regular Series", out, "\"innerFrameSeries\"");
+  ensure_member("Regular Series", out, "\"trailer\"");
+  ensure_member("Regular Series", out, "\"interPoseDuration\"");
+  /* The header of a Series holds the count, the bounds and the model of the
+   * transition between poses */
+  ensure_member("Regular Series", out, "\"poseCount\":3");
+  ensure_member("Regular Series", out, "\"startInstant\"");
+  ensure_member("Regular Series", out, "\"stopInstant\"");
+  ensure_member("Regular Series", out, "\"transitionModel\"");
+  /* A linear interpolation is the `interpolate` literal of the standard's
+   * TransitionModel enumeration */
+  ensure_member("Regular Series", out, "\"interpolate\"");
+
+  free(out);
+
+  /* The inner frames of a Series hold a rotation against its outer frame, so
+   * a two-dimensional pose comes back three-dimensional and the value read
+   * back is not the value written. What the round trip does preserve is the
+   * document: encoding the value read back reproduces it member for member,
+   * so nothing of the Series is lost on the way through.
+   *
+   * The reproduction holds up to eleven digits. A Series spends its digits on
+   * metres from the tangent point rather than on degrees, and the conversion
+   * through the geocentric frame and back leaves about a nanometre of
+   * floating-point round-off, which a twelfth digit exposes. */
+  out = tpose_as_geopose(regular, BASIC_QUATERNION, 6);
+  assert(out != NULL);
+  Temporal *regular_back = tpose_from_geopose(out);
+  assert(regular_back != NULL);
+  assert(meos_errno() == 0);
+  assert(temporal_num_instants(regular_back) == 3);
+  char *again = tpose_as_geopose(regular_back, BASIC_QUATERNION, 6);
+  assert(again != NULL);
+  printf("Regular re-encoding is stable: %s\n",
+    strcmp(out, again) == 0 ? "yes" : "no");
+  assert(strcmp(out, again) == 0);
+  free(again); free(out); free(regular_back); free(regular);
+
+  /*--------------------------------------------------------------------------
+   * Unequally spaced instants yield an Irregular Series
+   *------------------------------------------------------------------------*/
+
+  meos_errno_reset();
+  Temporal *irregular = tpose_in("[Pose(Point(0 0), 0)@2026-01-01, "
+    "Pose(Point(1 0), 0)@2026-01-02, Pose(Point(1 1), 0)@2026-01-05]");
+  assert(irregular != NULL);
+  assert(meos_errno() == 0);
+  s1 = temporal_out(irregular, 6);
+  printf("Irregular value: %s\n", s1);
+  free(s1);
+
+  out = tpose_as_geopose(irregular, BASIC_QUATERNION, 6);
+  assert(out != NULL);
+  ensure_member("Irregular Series", out, "\"header\"");
+  ensure_member("Irregular Series", out, "\"outerFrame\"");
+  ensure_member("Irregular Series", out, "\"innerFrameAndTimeSeries\"");
+  ensure_member("Irregular Series", out, "\"trailer\"");
+  /* Each element of an Irregular Series times its own frame */
+  ensure_member("Irregular Series", out, "\"validTime\"");
+  ensure_no_member("Irregular Series", out, "\"interPoseDuration\"");
+
+  free(out);
+
+  out = tpose_as_geopose(irregular, BASIC_QUATERNION, 6);
+  assert(out != NULL);
+  Temporal *irregular_back = tpose_from_geopose(out);
+  assert(irregular_back != NULL);
+  assert(meos_errno() == 0);
+  assert(temporal_num_instants(irregular_back) == 3);
+  again = tpose_as_geopose(irregular_back, BASIC_QUATERNION, 6);
+  assert(again != NULL);
+  printf("Irregular re-encoding is stable: %s\n",
+    strcmp(out, again) == 0 ? "yes" : "no");
+  assert(strcmp(out, again) == 0);
+  /* The instants a Series times are the instants of the value it came from */
+  s1 = temporal_out(irregular_back, 6);
+  printf("Irregular read back: %s\n", s1);
+  assert(strstr(s1, "2026-01-05") != NULL);
+  free(s1); free(again); free(out); free(irregular_back); free(irregular);
+
+  /*--------------------------------------------------------------------------
+   * The error paths
+   *------------------------------------------------------------------------*/
+
+  printf("****************************************************************\n");
+  printf("Error paths\n");
+  printf("****************************************************************\n");
+
+  /* A document that is not JSON at all */
+  meos_errno_reset();
+  Pose *bad = pose_from_geopose("this is not JSON");
+  printf("pose_from_geopose(not JSON): %s, errno %d\n",
+    bad ? "non-NULL" : "NULL", meos_errno());
+  assert(bad == NULL);
+  assert(meos_errno() != 0);
+
+  /* A document carrying neither a quaternion nor the Euler angles belongs to
+   * no Basic conformance class */
+  meos_errno_reset();
+  bad = pose_from_geopose("{\"position\":{\"lat\":0,\"lon\":0,\"h\":0}}");
+  printf("pose_from_geopose(no orientation): %s, errno %d\n",
+    bad ? "non-NULL" : "NULL", meos_errno());
+  assert(bad == NULL);
+  assert(meos_errno() != 0);
+
+  /* A document without a position */
+  meos_errno_reset();
+  bad = pose_from_geopose("{\"quaternion\":{\"x\":0,\"y\":0,\"z\":0,\"w\":1}}");
+  printf("pose_from_geopose(no position): %s, errno %d\n",
+    bad ? "non-NULL" : "NULL", meos_errno());
+  assert(bad == NULL);
+  assert(meos_errno() != 0);
+
+  /* An unknown conformance class */
+  meos_errno_reset();
+  Pose *good = pose_in("Pose(Point(1 1),0.5)");
+  assert(good != NULL);
+  char *none = pose_as_geopose(good, 7, 6);
+  printf("pose_as_geopose(conformance 7): %s, errno %d\n",
+    none ? "non-NULL" : "NULL", meos_errno());
+  assert(none == NULL);
+  assert(meos_errno() != 0);
+  free(good);
+
+  /* A Series whose header carries none of the members the schema requires */
+  meos_errno_reset();
+  Temporal *torn = tpose_from_geopose("{\"header\":{\"poseCount\":99}}");
+  printf("tpose_from_geopose(incomplete header): %s, errno %d\n",
+    torn ? "non-NULL" : "NULL", meos_errno());
+  assert(torn == NULL);
+  assert(meos_errno() != 0);
+
+  printf("****************************************************************\n");
+  printf("All GeoPose assertions hold\n");
+  printf("****************************************************************\n");
+
+  /* Finalize MEOS */
+  meos_finalize();
+
+  return 0;
+}

--- a/mobilitydb/test/pose/schemas/GeoPose.Basic.Quaternion.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Basic.Quaternion.Schema.json
@@ -1,0 +1,60 @@
+{
+  "description": "Basic-Quaternion: Basic GeoPose using quaternion to specify orientation",
+  "definitions": {
+    "Position": {
+      "type": "object",
+      "properties": {
+        "lat": {
+          "type": "number"
+        },
+        "lon": {
+          "type": "number"
+        },
+        "h": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "lat",
+        "lon",
+        "h"
+      ]
+    },
+    "Quaternion": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        },
+        "w": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z",
+        "w"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "position": {
+      "$ref": "#/definitions/Position"
+    },
+    "quaternion": {
+      "$ref": "#/definitions/Quaternion"
+    }
+  },
+  "required": [
+    "position",
+    "quaternion"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/GeoPose.Basic.YPR.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Basic.YPR.Schema.json
@@ -1,0 +1,56 @@
+{
+  "description": "Basic-YPR: Basic GeoPose using yaw, pitch, and roll to specify orientation",
+  "definitions": {
+    "angles": {
+      "type": "object",
+      "properties": {
+        "yaw": {
+          "type": "number"
+        },
+        "pitch": {
+          "type": "number"
+        },
+        "roll": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "yaw",
+        "pitch",
+        "roll"
+      ]
+    },
+    "Position": {
+      "type": "object",
+      "properties": {
+        "lat": {
+          "type": "number"
+        },
+        "lon": {
+          "type": "number"
+        },
+        "h": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "lat",
+        "lon",
+        "h"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "position": {
+      "$ref": "#/definitions/Position"
+    },
+    "angles": {
+      "$ref": "#/definitions/angles"
+    }
+  },
+  "required": [
+    "position",
+    "angles"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.Series.Irregular.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.Series.Irregular.Schema.json
@@ -1,0 +1,131 @@
+{
+  "description": "Irregular Series: Irregular GeoPose time series with variable inter-pose duration.",
+  "definitions": {
+    "FrameAndTime": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "frame": {
+          "$ref": "#/definitions/FrameSpecification"
+        },
+        "validTime": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "frame"
+      ]
+    },
+    "FrameSpecification": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    },
+    "SeriesHeader": {
+      "type": "object",
+      "properties": {
+        "poseCount": {
+          "type": "integer"
+        },
+        "integrityCheck": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "startInstant": {
+          "type": "integer"
+        },
+        "stopInstant": {
+          "type": "integer"
+        },
+        "transitionModel": {
+          "$ref": "#/definitions/TransitionModel"
+        }
+      },
+      "required": [
+        "poseCount",
+        "startInstant",
+        "stopInstant",
+        "transitionModel"
+      ]
+    },
+    "SeriesTrailer": {
+      "type": "object",
+      "properties": {
+        "poseCount": {
+          "type": "integer"
+        },
+        "integrityCheck": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "poseCount"
+      ]
+    },
+    "TransitionModel": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "header": {
+      "$ref": "#/definitions/SeriesHeader"
+    },
+    "outerFrame": {
+      "$ref": "#/definitions/FrameSpecification"
+    },
+    "innerFrameAndTimeSeries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FrameAndTime"
+      },
+      "minItems": 1
+    },
+    "trailer": {
+      "$ref": "#/definitions/SeriesTrailer"
+    }
+  },
+  "required": [
+    "header",
+    "outerFrame",
+    "innerFrameAndTimeSeries",
+    "trailer"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.Series.Regular.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.Series.Regular.Schema.json
@@ -1,0 +1,140 @@
+{
+  "description": "Regular Series: Regular GeoPose time series with constant inter-pose duration.",
+  "definitions": {
+    "FrameSpecification": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    },
+    "FrameSpecification-1": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    },
+    "SeriesHeader": {
+      "type": "object",
+      "properties": {
+        "poseCount": {
+          "type": "integer"
+        },
+        "integrityCheck": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "startInstant": {
+          "type": "integer"
+        },
+        "stopInstant": {
+          "type": "integer"
+        },
+        "transitionModel": {
+          "$ref": "#/definitions/TransitionModel"
+        }
+      },
+      "required": [
+        "poseCount",
+        "startInstant",
+        "stopInstant",
+        "transitionModel"
+      ]
+    },
+    "SeriesTrailer": {
+      "type": "object",
+      "properties": {
+        "poseCount": {
+          "type": "integer"
+        },
+        "integrityCheck": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "poseCount"
+      ]
+    },
+    "TransitionModel": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "header": {
+      "$ref": "#/definitions/SeriesHeader"
+    },
+    "interPoseDuration": {
+      "type": "integer"
+    },
+    "outerFrame": {
+      "$ref": "#/definitions/FrameSpecification"
+    },
+    "innerFrameSeries": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FrameSpecification-1"
+      },
+      "minItems": 1
+    },
+    "trailer": {
+      "$ref": "#/definitions/SeriesTrailer"
+    }
+  },
+  "required": [
+    "header",
+    "interPoseDuration",
+    "outerFrame",
+    "innerFrameSeries",
+    "trailer"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/LICENSE
+++ b/mobilitydb/test/pose/schemas/LICENSE
@@ -1,0 +1,77 @@
+OGC Software Notice
+https://www.ogc.org/license/
+
+The JSON schemas in this directory are the normative schemas of OGC GeoPose
+1.0 (OGC 21-056r11), copyright (c) Open Geospatial Consortium. They are held
+here unmodified, byte for byte as retrieved from
+https://schemas.opengis.net/geopose/1.0/schemata/, and are covered by the
+notice below.
+
+Permission is hereby granted by the Open Geospatial Consortium, (“Licensor”),
+free of charge and subject to the terms set forth below, to any person
+obtaining a copy of this Intellectual Property and any associated
+documentation, to deal in the Intellectual Property without restriction
+(except as set forth below), including without limitation the rights to
+implement, use, copy, modify, merge, publish, distribute, and/or sublicense
+copies of the Intellectual Property, and to permit persons to whom the
+Intellectual Property is furnished to do so, provided that all copyright
+notices on the intellectual property are retained intact and that each person
+to whom the Intellectual Property is furnished agrees to the terms of this
+Agreement.
+
+If you modify the Intellectual Property, all copies of the modified
+Intellectual Property must include, in addition to the above copyright notice,
+a notice that the Intellectual Property includes modifications that have not
+been approved or adopted by LICENSOR.
+
+THIS LICENSE IS A COPYRIGHT LICENSE ONLY, AND DOES NOT CONVEY ANY RIGHTS UNDER
+ANY PATENTS THAT MAY BE IN FORCE ANYWHERE IN THE WORLD. THE INTELLECTUAL
+PROPERTY IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NONINFRINGEMENT OF THIRD PARTY RIGHTS.
+THE COPYRIGHT HOLDER OR HOLDERS INCLUDED IN THIS NOTICE DO NOT WARRANT THAT
+THE FUNCTIONS CONTAINED IN THE INTELLECTUAL PROPERTY WILL MEET YOUR
+REQUIREMENTS OR THAT THE OPERATION OF THE INTELLECTUAL PROPERTY WILL BE
+UNINTERRUPTED OR ERROR FREE. ANY USE OF THE INTELLECTUAL PROPERTY SHALL BE
+MADE ENTIRELY AT THE USER’S OWN RISK. IN NO EVENT SHALL THE COPYRIGHT HOLDER
+OR ANY CONTRIBUTOR OF INTELLECTUAL PROPERTY RIGHTS TO THE INTELLECTUAL
+PROPERTY BE LIABLE FOR ANY CLAIM, OR ANY DIRECT, SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES, OR ANY DAMAGES WHATSOEVER RESULTING FROM ANY ALLEGED
+INFRINGEMENT OR ANY LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF
+CONTRACT, NEGLIGENCE OR UNDER ANY OTHER LEGAL THEORY, ARISING OUT OF OR IN
+CONNECTION WITH THE IMPLEMENTATION, USE, COMMERCIALIZATION OR PERFORMANCE OF
+THIS INTELLECTUAL PROPERTY.
+
+This license is effective until terminated. You may terminate it at any time
+by destroying the Intellectual Property together with all copies in any form.
+The license will also terminate if you fail to comply with any term or
+condition of this Agreement. Except as provided in the following sentence, no
+such termination of this license shall require the termination of any third
+party end-user sublicense to the Intellectual Property which is in force as of
+the date of notice of such termination. In addition, should the Intellectual
+Property, or the operation of the Intellectual Property, infringe, or in
+LICENSOR’s sole opinion be likely to infringe, any patent, copyright,
+trademark or other right of a third party, you agree that LICENSOR, in its
+sole discretion, may terminate this license without any compensation or
+liability to you, your licensees or any other party. You agree upon
+termination of any kind to destroy or cause to be destroyed the Intellectual
+Property together with all copies in any form, whether held by you or by any
+third party.
+
+Except as contained in this notice, the name of LICENSOR or of any other
+holder of a copyright in all or part of the Intellectual Property shall not be
+used in advertising or otherwise to promote the sale, use or other dealings in
+this Intellectual Property without prior written authorization of LICENSOR or
+such copyright holder. LICENSOR is and shall at all times be the sole entity
+that may authorize you or any third party to use certification marks,
+trademarks or other special designations to indicate compliance with any
+LICENSOR standards or specifications. This Agreement is governed by the laws
+of the Commonwealth of Massachusetts. The application to this Agreement of the
+United Nations Convention on Contracts for the International Sale of Goods is
+hereby expressly excluded. In the event any provision of this Agreement shall
+be deemed unenforceable, void or invalid, such provision shall be modified so
+as to make it valid and enforceable, and as so modified the entire Agreement
+shall remain in full force and effect. No decision, action or inaction by
+LICENSOR shall be construed to be a waiver of any rights or remedies available
+to it.
+

--- a/mobilitydb/test/pose/schemas/README.md
+++ b/mobilitydb/test/pose/schemas/README.md
@@ -1,0 +1,34 @@
+# OGC GeoPose 1.0 schemas
+
+The normative JSON schemas of the OGC GeoPose 1.0 conformance classes that
+MobilityDB implements, retrieved on 2026-08-14 from
+
+    https://schemas.opengis.net/geopose/1.0/schemata/
+
+| File | Conformance class |
+|---|---|
+| `GeoPose.Basic.YPR.Schema.json` | Basic-YPR |
+| `GeoPose.Basic.Quaternion.Schema.json` | Basic-Quaternion |
+| `GeoPose.Composite.Sequence.Series.Regular.Schema.json` | Regular Time Series |
+| `GeoPose.Composite.Sequence.Series.Irregular.Schema.json` | Irregular Time Series |
+
+The schemas are those of OGC GeoPose 1.0 (OGC 21-056r11) and belong to the
+Open Geospatial Consortium, which licenses them for redistribution under the
+OGC Software Notice reproduced in `LICENSE` beside them, as `clipper2` and
+`h3-pg` carry the notice of what they vendor. That notice asks for the
+copyright to be retained and for any modification to be declared, so the files
+are held here unmodified, byte for byte as retrieved, with these digests:
+
+    5508d26aed6f…  GeoPose.Basic.YPR.Schema.json
+    ce15e01a2ea8…  GeoPose.Basic.Quaternion.Schema.json
+    2c23b154da01…  GeoPose.Composite.Sequence.Series.Regular.Schema.json
+    69f49530f65f…  GeoPose.Composite.Sequence.Series.Irregular.Schema.json
+
+`tools/scripts/check_geopose_conformance.py` validates against them the GeoPose
+documents that `expected/103_pose_geopose.test.out` holds. Keeping a copy here
+rather than fetching at run time makes the check depend on nothing outside the
+repository, so it gives the same verdict in a network-less build as in CI.
+
+The four remaining conformance classes -- Advanced, Chain, Graph and Stream --
+have schemas at the same place, and belong here as soon as MobilityDB emits a
+document of one of them.

--- a/tools/scripts/check_geopose_conformance.py
+++ b/tools/scripts/check_geopose_conformance.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+#
+# This MobilityDB code is provided under The PostgreSQL License.
+# Copyright (c) 2016-2025, Universite libre de Bruxelles and MobilityDB
+# contributors
+#
+"""Validate the emitted GeoPose documents against the normative OGC schemas.
+
+MobilityDB implements four of the eight conformance classes of OGC GeoPose
+v1.0 (OGC 21-056r11): Basic-YPR, Basic-Quaternion, and the Regular and
+Irregular Composite Sequence Series.  Each class has a normative JSON schema,
+published under
+
+    https://schemas.opengis.net/geopose/1.0/schemata/
+
+A round-trip test proves that MobilityDB reads back what it writes, which
+holds just as well for a document no other implementation accepts.  Agreement
+with the schema is what a conformance claim rests on, so this check reads the
+documents the tests emit and validates each one against the schema of its
+class.
+
+The documents come from the expected output of the regression tests, so no
+database is needed: the file holds the exact bytes the implementation
+produces, and a change to the encoding that breaks conformance changes that
+file and fails here.
+
+The schemas use eight keywords -- `$ref`, `definitions`, `description`,
+`items`, `minItems`, `properties`, `required` and `type` -- with every `$ref`
+local to `#/definitions`.  Validating that subset takes little code and keeps
+the check free of any third-party dependency, which is why it is spelled out
+below rather than delegated to a JSON Schema library.
+
+Usage:
+  check_geopose_conformance.py           validate every document (CI guard)
+  check_geopose_conformance.py --list    print the documents and their class
+
+Exit status is non-zero when a document does not satisfy its schema, or when
+a conformance class emits no document at all.
+"""
+
+import json
+import os
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# The normative schemas, retrieved from schemas.opengis.net.
+SCHEMA_DIR = os.path.join(ROOT, 'mobilitydb', 'test', 'pose', 'schemas')
+
+# The expected output holding the emitted documents.
+EXPECTED = os.path.join(ROOT, 'mobilitydb', 'test', 'pose', 'expected',
+    '103_pose_geopose.test.out')
+
+# A document is recognised by the member that only its class carries, tried in
+# this order so that a Series is never mistaken for the Basic document of its
+# inner frames.
+CLASSES = [
+    ('innerFrameSeries', 'Regular Series',
+        'GeoPose.Composite.Sequence.Series.Regular.Schema.json'),
+    ('innerFrameAndTimeSeries', 'Irregular Series',
+        'GeoPose.Composite.Sequence.Series.Irregular.Schema.json'),
+    ('quaternion', 'Basic-Quaternion',
+        'GeoPose.Basic.Quaternion.Schema.json'),
+    ('angles', 'Basic-YPR',
+        'GeoPose.Basic.YPR.Schema.json'),
+]
+
+TYPES = {
+    'object': dict,
+    'array': list,
+    'string': str,
+    'boolean': bool,
+}
+
+
+def one_type_ok(value, expected):
+    """Return whether @p value has the single JSON Schema type @p expected."""
+    if expected == 'null':
+        return value is None
+    if expected in ('number', 'integer'):
+        # A JSON boolean is not a number, while Python bool derives from int.
+        if isinstance(value, bool):
+            return False
+        if expected == 'integer':
+            return isinstance(value, int)
+        return isinstance(value, (int, float))
+    return isinstance(value, TYPES[expected])
+
+
+def type_ok(value, expected):
+    """Return whether @p value has the JSON Schema type @p expected.
+    @details The type of a member that the schemas leave optional is a list
+    holding `null` beside the type the member has when it is present.
+    """
+    if isinstance(expected, list):
+        return any(one_type_ok(value, e) for e in expected)
+    return one_type_ok(value, expected)
+
+
+def validate(value, schema, root, path, errors):
+    """Collect into @p errors the ways @p value departs from @p schema."""
+    ref = schema.get('$ref')
+    if ref is not None:
+        # Every reference in these schemas is local to `#/definitions`.
+        target = root
+        for step in ref.lstrip('#/').split('/'):
+            target = target[step]
+        validate(value, target, root, path, errors)
+        return
+
+    expected = schema.get('type')
+    if expected is not None and not type_ok(value, expected):
+        errors.append('%s: expected %s, found %s' %
+            (path or '(document)', expected, type(value).__name__))
+        return
+
+    # A member the schema leaves optional is absent as JSON `null`, and then
+    # carries neither the members nor the constraints of its object type.
+    if isinstance(value, dict):
+        for name in schema.get('required', []):
+            if name not in value:
+                errors.append('%s: missing required member `%s`' %
+                    (path or '(document)', name))
+
+        for name, sub in schema.get('properties', {}).items():
+            if name in value:
+                validate(value[name], sub, root, '%s.%s' % (path, name),
+                    errors)
+
+    items = schema.get('items')
+    if items is not None and isinstance(value, list):
+        for i, elem in enumerate(value):
+            validate(elem, items, root, '%s[%d]' % (path, i), errors)
+
+    least = schema.get('minItems')
+    if least is not None and isinstance(value, list) and len(value) < least:
+        errors.append('%s: holds %d items, %d required' %
+            (path, len(value), least))
+
+
+def classify(doc):
+    """Return the conformance class of @p doc, or None when it has none."""
+    for member, name, schema in CLASSES:
+        if member in doc:
+            return name, schema
+    return None, None
+
+
+def documents(path):
+    """Yield every JSON document emitted as a result row of the tests."""
+    with open(path, encoding='utf-8') as f:
+        for line in f:
+            # A result row is indented by one space; a query echoed back
+            # carries the document inside a quoted literal.
+            if not line.startswith(' {'):
+                continue
+            try:
+                doc = json.loads(line.strip())
+            except ValueError:
+                continue
+            if isinstance(doc, dict):
+                yield doc
+
+
+def main():
+    listing = '--list' in sys.argv[1:]
+
+    if not os.path.isfile(EXPECTED):
+        print('check_geopose_conformance: no expected output at %s' %
+            os.path.relpath(EXPECTED, ROOT))
+        return 1
+
+    schemas = {}
+    for _, name, filename in CLASSES:
+        path = os.path.join(SCHEMA_DIR, filename)
+        if not os.path.isfile(path):
+            print('check_geopose_conformance: no schema at %s' %
+                os.path.relpath(path, ROOT))
+            return 1
+        with open(path, encoding='utf-8') as f:
+            schemas[name] = json.load(f)
+
+    total = 0
+    failed = 0
+    seen = {}
+    for doc in documents(EXPECTED):
+        name, _ = classify(doc)
+        if name is None:
+            continue
+        total += 1
+        seen[name] = seen.get(name, 0) + 1
+        errors = []
+        validate(doc, schemas[name], schemas[name], '', errors)
+        if listing:
+            print('  %-18s %s' % (name, 'ok' if not errors else 'INVALID'))
+        if errors:
+            failed += 1
+            print('check_geopose_conformance: a %s document is not '
+                'conformant' % name)
+            for e in errors:
+                print('    %s' % e)
+            print('    %s' % json.dumps(doc)[:200])
+
+    if not total:
+        print('check_geopose_conformance: no GeoPose document found in %s' %
+            os.path.relpath(EXPECTED, ROOT))
+        return 1
+
+    missing = [name for _, name, _ in CLASSES if name not in seen]
+    if missing:
+        print('check_geopose_conformance: no document emitted for %s' %
+            ', '.join(missing))
+        return 1
+
+    if failed:
+        print('check_geopose_conformance: %d of %d documents are not '
+            'conformant.' % (failed, total))
+        return 1
+
+    print('check_geopose_conformance: %d documents conform to the OGC '
+        'GeoPose 1.0 schemas (%s).' % (total,
+        ', '.join('%s %d' % (n, c) for n, c in sorted(seen.items()))))
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
MobilityDB implements four of the eight conformance classes of OGC GeoPose 1.0 (OGC 21-056r11): Basic-YPR, Basic-Quaternion, and the Regular and Irregular Composite Sequence Series. A round-trip test proves that MobilityDB reads back what it writes, which holds just as well for a document no other implementation accepts.

`tools/scripts/check_geopose_conformance.py` reads the GeoPose documents the regression tests emit and validates each against the normative schema of its conformance class, so agreement with the standard is checked rather than assumed. It reports 25 documents across the four classes. The schemas use eight keywords with every reference local to the document, so validating that subset needs no third-party dependency and gives the same verdict in a network-less build as in CI.

The four schemas are held beside the tests under the OGC Software Notice, which licenses them for redistribution provided the copyright is retained and any modification declared; they are unmodified, and the README records their digests, as `clipper2` and `h3-pg` carry the notice of what they vendor.

`meos/test/geopose_test.c` covers the same surface through the C API, which the regression tests reach only from PostgreSQL. It exercises the two Basic classes, both Series classes and five error paths, and asserts rather than printing, so a wrong value fails the job.

Three properties of the encoding the test pins down:

- a Series carries as many poses as the value holds, so a fixture whose poses are collinear and equally spaced encodes fewer of them than it lists, the redundant instants having been normalised away;
- the inner frames of a Series hold a rotation against its outer frame, so a two-dimensional pose comes back three-dimensional and the value read back is not the value written;
- what the round trip preserves is the document, and it does so up to eleven digits: the conversion through the geocentric frame and back leaves about a nanometre of floating-point round-off, which a twelfth digit exposes.
