### PR TITLE
Answer false where GEOS reports that it could not evaluate a relationship

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1714,7 +1714,7 @@ GEOS2POSTGIS(GEOSGeom geom, char want3d)
  * @brief Transform two @p GSERIALIZED geometries into @p GEOSGeometry and
  * call the GEOS function passed as argument
  */
-static char
+static bool
 meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   char (*func)(GEOSContextHandle_t ctx, const GEOSGeometry *geos1,
     const GEOSGeometry *geos2))
@@ -1727,7 +1727,7 @@ meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "First argument geometry could not be converted to GEOS");
-    return 2;
+    return false;
   }
   GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
   if (! geos2)
@@ -1735,16 +1735,24 @@ meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
     GEOSGeom_destroy_r(ctx, geos1);
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "Second argument geometry could not be converted to GEOS");
-    return 2;
+    return false;
   }
 
   char result = func(ctx, geos1, geos2);
 
   GEOSGeom_destroy_r(ctx, geos1); GEOSGeom_destroy_r(ctx, geos2);
+  /* GEOS reports a failure as 2, which is the relationship reporting nothing.
+   * The answer is false, the one every other failure of these functions gives;
+   * an error handler that returns, which is the handler a language binding
+   * installs, would otherwise read a relationship that was never evaluated as
+   * holding */
   if (result == 2)
+  {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOS returned error");
-  return result;
+    return false;
+  }
+  return (bool) result;
 }
 
 /**
@@ -1800,13 +1808,13 @@ geom_spatialrel(const GSERIALIZED *gs1, const GSERIALIZED *gs2, spatialRel rel)
   switch (rel)
   {
     case INTERSECTS:
-      return (bool) meos_call_geos2(gs1, gs2, &GEOSIntersects_r);
+      return meos_call_geos2(gs1, gs2, &GEOSIntersects_r);
     case CONTAINS:
-      return (bool) meos_call_geos2(gs1, gs2, &GEOSContains_r);
+      return meos_call_geos2(gs1, gs2, &GEOSContains_r);
     case TOUCHES:
-      return (bool) meos_call_geos2(gs1, gs2, &GEOSTouches_r);
+      return meos_call_geos2(gs1, gs2, &GEOSTouches_r);
     case COVERS:
-      return (bool) meos_call_geos2(gs1, gs2, &GEOSCovers_r);
+      return meos_call_geos2(gs1, gs2, &GEOSCovers_r);
     default:
       /* keep compiler quiet */
       return false;
@@ -1938,9 +1946,14 @@ geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *p)
   GEOSGeom_destroy_r(ctx, geos1);
   GEOSGeom_destroy_r(ctx, geos2);
 
+  /* GEOS reports a failure as 2, which is the pattern reporting nothing. The
+   * answer is false, the one every other failure of this function gives */
   if (result == 2)
+  {
     meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
       "GEOSRelatePattern returned error");
+    return false;
+  }
   return (bool) result;
 }
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -135,6 +135,38 @@ int main(void)
   assert(strcmp(str_srid, "BOX3D(1 1 1,5 5 5)") == 0);
   free(str_srid); free(box_srid);
 
+  /* A geometry relationship that GEOS cannot evaluate reports the failure and
+   * answers false. GEOS rejects a collection of mixed dimensions, and under
+   * this handler the relationship returns rather than ending the process, so
+   * the value it gives is the one a language binding reads. A line far from
+   * the collection must not come back as containing it */
+  GSERIALIZED *coll = geom_in(
+    "GeometryCollection(Point(0 0),Linestring(2 2,3 3))", -1);
+  assert(coll != NULL);
+  GSERIALIZED *away = geom_in("Linestring(10 10,20 20)", -1);
+  assert(away != NULL);
+  char patt[10] = "T********";
+  meos_errno_reset();
+  bool rel = geom_relate_pattern(away, coll, patt);
+  int rel_errno = meos_errno();
+  printf("geom_relate_pattern(away, collection): %d, errno %d\n", rel,
+    rel_errno);
+  assert(rel == false);
+  assert(rel_errno != 0);
+  /* A pair GEOS does evaluate keeps its answer: a line through the collection
+   * meets it in their interiors */
+  GSERIALIZED *through = geom_in("Linestring(0 0,3 3)", -1);
+  assert(through != NULL);
+  meos_errno_reset();
+  bool rel_ok = geom_relate_pattern(through, coll, patt);
+  int errno_ok = meos_errno();
+  printf("geom_relate_pattern(through, collection): %d, errno %d\n", rel_ok,
+    errno_ok);
+  assert(rel_ok == true);
+  assert(errno_ok == 0);
+  free(coll); free(away); free(through);
+  meos_errno_reset();
+
   /* A malformed box3d returns NULL and sets the error status */
   meos_errno_reset();
   BOX3D *bad_box3d = box3d_in("BOX3D(1 2 3)");


### PR DESCRIPTION
GEOS returns `2` from a relationship it could not evaluate. `geom_relate_pattern` raises the error and then returns `(bool) result`, and `(bool) 2` is true. `meos_call_geos2`, which backs the intersects, contains, touches and covers branches of `geom_spatialrel`, returns `2` from both of its conversion failures and passes GEOS's own `2` through to four callers that cast it the same way. Every other failure of these functions answers false.

The default error handler ends the process at that error, and PostgreSQL leaves the call through its own error path, so the value reaches a caller only under the handler that returns — the one every language binding installs. There a relationship that GEOS never evaluated comes back as holding:

```
geom_relate_pattern(Linestring(10 10,20 20),
  GeometryCollection(Point(0 0),Linestring(2 2,3 3)), "T********")   -> t, errno 2
```

GEOS rejects that collection for its mixed dimensions, and the answer is true for two geometries nowhere near each other. Through the temporal relationship that reads the same pattern:

```
econtains_tgeo_geo([Point(10 10)@2000-01-01, Point(20 20)@2000-01-02], that collection) = 1
eintersects_tgeo_geo(same operands)                                                     = 0
```

a moving point that never approaches the collection counts as containing it.

This reports the failure and answers false. A pair GEOS does evaluate keeps its answer: the same pattern against a line that runs through the collection stays true with no error, which is the second case added to the geometry test program. `geom_equals` already returns its own error value on the sentinel rather than casting it, and it is the only other place in `meos/src` that reads the convention.

The regression lives in `meos/test/geo_test.c`, which the MEOS workflow already compiles and runs. Compiled against a build of this branch it exits 0; against a build of master it stops at `Assertion 'rel == false' failed`.