### PR TITLE
Answer the set-set relationships from an index over both sides

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -132,6 +132,8 @@ jobs:
           ./rtree_knn_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_join_test rtree_join_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_join_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o setset_pairs_test setset_pairs_test.c -L/usr/local/lib -lmeos -lm
+          ./setset_pairs_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_span_test rtree_span_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_span_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o sptree_test sptree_test.c -L/usr/local/lib -lmeos -lm

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -2207,6 +2207,55 @@ stbox_within_dist_space(const STBox *box1, const STBox *box2, double dist)
 }
 
 /**
+ * @brief Comparison function sorting index pairs lexicographically
+ */
+static int
+pair_cmp(const void *a, const void *b)
+{
+  const int *pa = (const int *) a, *pb = (const int *) b;
+  if (pa[0] != pb[0])
+    return (pa[0] > pb[0]) - (pa[0] < pb[0]);
+  return (pa[1] > pb[1]) - (pa[1] < pb[1]);
+}
+
+/**
+ * @brief Return the index pairs whose boxes overlap, in lexicographic order
+ * @details Indexes both sides and joins the two trees, so the pairs whose
+ * boxes are apart are never visited. The pairs are sorted so that the caller
+ * reports them in the order the pairwise comparison would.
+ * @param[in] bb1,bb2 Bounding boxes of the two sides
+ * @param[in] count1,count2 Number of boxes
+ * @param[out] npairs Number of pairs found
+ * @return Flattened array of @p npairs index pairs, or NULL when none overlap
+ */
+static int *
+setset_box_pairs(const STBox *bb1, int count1, const STBox *bb2, int count2,
+  int *npairs)
+{
+  RTree *rtree1 = rtree_create_stbox();
+  RTree *rtree2 = rtree_create_stbox();
+  for (int i = 0; i < count1; i++)
+    rtree_insert(rtree1, (void *) &bb1[i], i);
+  for (int j = 0; j < count2; j++)
+    rtree_insert(rtree2, (void *) &bb2[j], j);
+
+  MeosArray *found = meos_array_create(sizeof(int));
+  int n = rtree_join(rtree1, rtree2, RTREE_OVERLAPS, found);
+  int *result = NULL;
+  if (n > 0)
+  {
+    result = palloc((size_t) n * 2 * sizeof(int));
+    for (int k = 0; k < 2 * n; k++)
+      result[k] = *(int *) meos_array_get(found, k);
+    qsort(result, (size_t) n, 2 * sizeof(int), pair_cmp);
+  }
+  meos_array_destroy(found);
+  rtree_free(rtree1); rtree_free(rtree2);
+  *npairs = n;
+  return result;
+}
+
+/**
  * @brief Validate two arrays of temporal geos and materialise their STBoxes
  * @details Ensures both arrays are non-empty and that every element is a
  * non-NULL temporal geo sharing the SRID, dimensionality, and geodetic flag of
@@ -2261,6 +2310,126 @@ typedef enum
   SS_EDISJOINT, SS_ADISJOINT,
 } SetSetEAPred;
 
+/* Least number of pairs for which indexing both sides costs less than
+ * comparing every pair of boxes. Building the two trees is linear in the
+ * number of boxes while the comparison is quadratic, so the two meet a little
+ * over ten thousand pairs; the value sits above that, since below it the
+ * comparison is a few milliseconds either way. */
+#define SETSET_INDEX_MIN_PAIRS 100000.0
+
+/**
+ * @brief Return the exact ever/always relationship of a pair
+ * @param[in] temp1,temp2 Temporal geos
+ * @param[in] dist Distance, for the within-distance relationships
+ * @param[in] pred Relationship to apply
+ * @return 1 when the pair satisfies it, 0 when it does not, -1 on error
+ */
+static int
+setset_ea_exact(const Temporal *temp1, const Temporal *temp2, double dist,
+  SetSetEAPred pred)
+{
+  switch (pred)
+  {
+    case SS_EDWITHIN:
+      return ea_dwithin_tgeo_tgeo(temp1, temp2, dist, EVER);
+    case SS_ADWITHIN:
+      return ea_dwithin_tgeo_tgeo(temp1, temp2, dist, ALWAYS);
+    case SS_EINTERSECTS:
+      return ea_intersects_tgeo_tgeo(temp1, temp2, EVER);
+    case SS_AINTERSECTS:
+      return ea_intersects_tgeo_tgeo(temp1, temp2, ALWAYS);
+    case SS_ETOUCHES:
+      return ea_touches_tgeo_tgeo(temp1, temp2, EVER);
+    case SS_ATOUCHES:
+      return ea_touches_tgeo_tgeo(temp1, temp2, ALWAYS);
+    case SS_EDISJOINT:
+      /* Ever disjoint is the negation of always intersects */
+      return INVERT_RESULT(ea_intersects_tgeo_tgeo(temp1, temp2, ALWAYS));
+    default: /* SS_ADISJOINT: always disjoint is the negation of ever
+      intersects */
+      return INVERT_RESULT(ea_intersects_tgeo_tgeo(temp1, temp2, EVER));
+  }
+}
+
+/**
+ * @brief Run an ever/always set-set relationship over the pairs an index
+ * reports, rather than over every pair
+ * @details The relationships divide by what their bounding boxes decide:
+ * - the within-distance relationships need the pairs whose boxes are closer
+ *   than the distance, which is the overlap of the boxes of the first side
+ *   grown by it;
+ * - intersects and touches need the pairs whose boxes overlap, since boxes
+ *   apart can neither intersect nor touch;
+ * - the disjoint relationships report every pair sharing time whose boxes are
+ *   apart in space without an exact test, and test only the pairs whose boxes
+ *   overlap, so they need the pairs overlapping in time and the pairs
+ *   overlapping in space as a subset of them.
+ * @param[in] arr1,arr2 Arrays of temporal geos
+ * @param[in] count1,count2 Number of elements
+ * @param[in] bb1,bb2 Their bounding boxes
+ * @param[in] dist Distance, for the within-distance relationships
+ * @param[in] pred Relationship to apply
+ * @param[in] is_dwithin,is_disjoint Class of @p pred
+ * @param[out] count Number of pairs reported
+ * @return Flattened array of @p count index pairs, or NULL when none qualify
+ */
+static int *
+setset_ea_pairs_indexed(const Temporal **arr1, int count1,
+  const Temporal **arr2, int count2, const STBox *bb1, const STBox *bb2,
+  double dist, SetSetEAPred pred, bool is_dwithin, int *count)
+{
+  /* The within-distance relationships compare the boxes of the first side
+   * grown by the distance, which is what their prefilter tests */
+  STBox *grown = NULL;
+  const STBox *probe = bb1;
+  if (is_dwithin)
+  {
+    grown = palloc((size_t) count1 * sizeof(STBox));
+    for (int i = 0; i < count1; i++)
+    {
+      grown[i] = bb1[i];
+      grown[i].xmin -= dist; grown[i].xmax += dist;
+      grown[i].ymin -= dist; grown[i].ymax += dist;
+      if (MEOS_FLAGS_GET_Z(grown[i].flags))
+      {
+        grown[i].zmin -= dist; grown[i].zmax += dist;
+      }
+    }
+    probe = grown;
+  }
+
+  int nbox;
+  int *boxpairs = setset_box_pairs(probe, count1, bb2, count2, &nbox);
+  if (grown)
+    pfree(grown);
+
+  /* Only the pairs whose boxes qualify can satisfy the relationship */
+  if (nbox == 0)
+  {
+    *count = 0;
+    return NULL;
+  }
+  int *result = palloc((size_t) nbox * 2 * sizeof(int));
+  int nres = 0;
+  for (int k = 0; k < nbox; k++)
+  {
+    int i = boxpairs[2 * k], j = boxpairs[2 * k + 1];
+    if (setset_ea_exact(arr1[i], arr2[j], dist, pred) == 1)
+    {
+      result[2 * nres] = i; result[2 * nres + 1] = j; nres++;
+    }
+  }
+  pfree(boxpairs);
+
+  *count = nres;
+  if (nres == 0)
+  {
+    pfree(result);
+    return NULL;
+  }
+  return result;
+}
+
 /**
  * @brief Generic ever/always set-set spatial join driver
  * @details Runs the exact per-pair predicate selected by @p pred only on the
@@ -2288,6 +2457,23 @@ setset_ea_pairs(const Temporal **arr1, int count1, const Temporal **arr2,
   bool geodetic = MEOS_FLAGS_GET_GEODETIC(arr1[0]->flags);
   bool is_dwithin = (pred == SS_EDWITHIN || pred == SS_ADWITHIN);
   bool is_disjoint = (pred == SS_EDISJOINT || pred == SS_ADISJOINT);
+  /* Above this many pairs, indexing both sides and joining the trees reads
+   * fewer boxes than comparing every pair, and the answer is sized from the
+   * pairs that survive rather than from the number of pairs there could be.
+   *
+   * The geodetic case has no spatial prefilter to index. The disjoint
+   * relationships keep the comparison as well: they report the pairs sharing
+   * time whose boxes are apart, which is most of the pairs sharing time, and
+   * ordering that many pairs costs more than the comparison it replaces. */
+  if (! geodetic && ! is_disjoint &&
+      (double) count1 * (double) count2 >= SETSET_INDEX_MIN_PAIRS)
+  {
+    int *res = setset_ea_pairs_indexed(arr1, count1, arr2, count2, bb1, bb2,
+      dist, pred, is_dwithin, count);
+    pfree(bb1); pfree(bb2);
+    return res;
+  }
+
   int *result = palloc((size_t) count1 * count2 * 2 * sizeof(int));
   int nres = 0;
   for (int i = 0; i < count1; i++)
@@ -2310,30 +2496,7 @@ setset_ea_pairs(const Temporal **arr1, int count1, const Temporal **arr2,
           ! stbox_overlaps_space(&bb1[i], &bb2[j]))
           continue;
       }
-      int r;
-      switch (pred)
-      {
-        case SS_EDWITHIN:
-          r = ea_dwithin_tgeo_tgeo(arr1[i], arr2[j], dist, EVER); break;
-        case SS_ADWITHIN:
-          r = ea_dwithin_tgeo_tgeo(arr1[i], arr2[j], dist, ALWAYS); break;
-        case SS_EINTERSECTS:
-          r = ea_intersects_tgeo_tgeo(arr1[i], arr2[j], EVER); break;
-        case SS_AINTERSECTS:
-          r = ea_intersects_tgeo_tgeo(arr1[i], arr2[j], ALWAYS); break;
-        case SS_ETOUCHES:
-          r = ea_touches_tgeo_tgeo(arr1[i], arr2[j], EVER); break;
-        case SS_ATOUCHES:
-          r = ea_touches_tgeo_tgeo(arr1[i], arr2[j], ALWAYS); break;
-        case SS_EDISJOINT:
-          /* Ever disjoint is the negation of always intersects */
-          r = INVERT_RESULT(ea_intersects_tgeo_tgeo(arr1[i], arr2[j], ALWAYS));
-          break;
-        default: /* SS_ADISJOINT: always disjoint is the negation of ever
-          intersects */
-          r = INVERT_RESULT(ea_intersects_tgeo_tgeo(arr1[i], arr2[j], EVER));
-          break;
-      }
+      int r = setset_ea_exact(arr1[i], arr2[j], dist, pred);
       if (r == 1)
       {
         result[2 * nres] = i; result[2 * nres + 1] = j; nres++;

--- a/meos/test/setset_pairs_test.c
+++ b/meos/test/setset_pairs_test.c
@@ -1,0 +1,291 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the ever/always set-set relationships over
+ * arrays of temporal geos, i.e., the `*_tgeoarr_tgeoarr` functions, against
+ * the scalar relationship applied to every pair.
+ *
+ * The oracle is the scalar relationship of the same name, so the array
+ * function is checked against the per-pair answer it is meant to reproduce,
+ * including the cases its bounding box prefilter decides without an exact
+ * test. A pair with no common time is excluded, matching the drivers.
+ *
+ * The array sizes straddle the number of pairs above which the drivers index
+ * both sides and join the trees rather than comparing every pair, so both
+ * paths are exercised and asserted to give the same answer.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o setset_pairs_test setset_pairs_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Sizes below the number of pairs at which the drivers switch to the index */
+#define SMALL1 120
+#define SMALL2 120
+/* Sizes above it */
+#define LARGE1 500
+#define LARGE2 400
+/* Distance used by the within-distance relationships */
+#define DIST 3.0
+
+static int failures = 0;
+
+static void
+check(const char *name, bool ok)
+{
+  printf("  %-58s %s\n", name, ok ? "OK" : "FAIL");
+  if (! ok)
+    failures++;
+}
+
+/* Return a pseudo-random double in [min, max] */
+static double
+random_double(double min, double max)
+{
+  return min + (max - min) * ((double) rand() / (double) RAND_MAX);
+}
+
+/* Return a temporal geo moving between two random points of a grid over a
+ * random hour of a random day, so that the two coordinates and the period
+ * select different pairs */
+static Temporal *
+random_tgeo(void)
+{
+  double x = random_double(0, 40), y = random_double(0, 40);
+  double dx = random_double(-4, 4), dy = random_double(-4, 4);
+  int day = 1 + rand() % 5;
+  int h = rand() % 20;
+  char buf[512];
+  snprintf(buf, sizeof(buf),
+    "[POINT(%.4f %.4f)@2000-01-%02d %02d:00:00+00, "
+    "POINT(%.4f %.4f)@2000-01-%02d %02d:00:00+00]",
+    x, y, day, h, x + dx, y + dy, day, h + 3);
+  return (Temporal *) tgeompoint_in(buf);
+}
+
+/* Return a temporal geometry holding a unit square of a grid over a random
+ * hour of a random day. Squares of a grid share edges and corners, so the
+ * touches relationships hold for real pairs, which they never do for points:
+ * touching needs boundaries to meet and a point has none. */
+static Temporal *
+random_tgeometry(void)
+{
+  int gx = rand() % 12, gy = rand() % 12;
+  int day = 1 + rand() % 5;
+  int h = rand() % 20;
+  char buf[768];
+  snprintf(buf, sizeof(buf),
+    "Interp=Step;[Polygon((%d %d,%d %d,%d %d,%d %d,%d %d))"
+    "@2000-01-%02d %02d:00:00+00, "
+    "Polygon((%d %d,%d %d,%d %d,%d %d,%d %d))@2000-01-%02d %02d:00:00+00]",
+    gx, gy, gx + 1, gy, gx + 1, gy + 1, gx, gy + 1, gx, gy, day, h,
+    gx, gy, gx + 1, gy, gx + 1, gy + 1, gx, gy + 1, gx, gy, day, h + 3);
+  return (Temporal *) tgeometry_in(buf);
+}
+
+/* The relationships under test, each with its array function and the scalar
+ * the oracle applies to every pair */
+typedef enum
+{
+  P_EDWITHIN, P_ADWITHIN, P_EINTERSECTS, P_AINTERSECTS,
+  P_ETOUCHES, P_ATOUCHES, P_EDISJOINT, P_ADISJOINT,
+} Pred;
+
+static const char *PRED_NAME[] = {
+  "eDwithin", "aDwithin", "eIntersects", "aIntersects",
+  "eTouches", "aTouches", "eDisjoint", "aDisjoint",
+};
+
+static int *
+pred_array(Pred p, const Temporal **a1, int c1, const Temporal **a2, int c2,
+  int *count)
+{
+  switch (p)
+  {
+    case P_EDWITHIN:
+      return edwithin_tgeoarr_tgeoarr(a1, c1, a2, c2, DIST, count);
+    case P_ADWITHIN:
+      return adwithin_tgeoarr_tgeoarr(a1, c1, a2, c2, DIST, count);
+    case P_EINTERSECTS:
+      return eintersects_tgeoarr_tgeoarr(a1, c1, a2, c2, count);
+    case P_AINTERSECTS:
+      return aintersects_tgeoarr_tgeoarr(a1, c1, a2, c2, count);
+    case P_ETOUCHES:
+      return etouches_tgeoarr_tgeoarr(a1, c1, a2, c2, count);
+    case P_ATOUCHES:
+      return atouches_tgeoarr_tgeoarr(a1, c1, a2, c2, count);
+    case P_EDISJOINT:
+      return edisjoint_tgeoarr_tgeoarr(a1, c1, a2, c2, count);
+    default:
+      return adisjoint_tgeoarr_tgeoarr(a1, c1, a2, c2, count);
+  }
+}
+
+static int
+pred_scalar(Pred p, const Temporal *t1, const Temporal *t2)
+{
+  switch (p)
+  {
+    case P_EDWITHIN:    return edwithin_tgeo_tgeo(t1, t2, DIST);
+    case P_ADWITHIN:    return adwithin_tgeo_tgeo(t1, t2, DIST);
+    case P_EINTERSECTS: return eintersects_tgeo_tgeo(t1, t2);
+    case P_AINTERSECTS: return aintersects_tgeo_tgeo(t1, t2);
+    case P_ETOUCHES:    return etouches_tgeo_tgeo(t1, t2);
+    case P_ATOUCHES:    return atouches_tgeo_tgeo(t1, t2);
+    case P_EDISJOINT:   return edisjoint_tgeo_tgeo(t1, t2);
+    default:            return adisjoint_tgeo_tgeo(t1, t2);
+  }
+}
+
+/* Run one relationship over one pair of arrays and compare with the oracle */
+static void
+test_pred(Pred p, const Temporal **a1, int c1, const Temporal **a2, int c2,
+  const char *sizelabel)
+{
+  int nres = 0;
+  int *res = pred_array(p, a1, c1, a2, c2, &nres);
+
+  /* Oracle: the scalar relationship on every pair sharing time */
+  int *expected = malloc((size_t) c1 * c2 * 2 * sizeof(int));
+  int nexp = 0;
+  Span **periods1 = malloc((size_t) c1 * sizeof(Span *));
+  Span **periods2 = malloc((size_t) c2 * sizeof(Span *));
+  for (int i = 0; i < c1; i++)
+    periods1[i] = temporal_to_tstzspan(a1[i]);
+  for (int j = 0; j < c2; j++)
+    periods2[j] = temporal_to_tstzspan(a2[j]);
+  for (int i = 0; i < c1; i++)
+  {
+    for (int j = 0; j < c2; j++)
+    {
+      if (! overlaps_span_span(periods1[i], periods2[j]))
+        continue;
+      if (pred_scalar(p, a1[i], a2[j]) == 1)
+      {
+        expected[2 * nexp] = i; expected[2 * nexp + 1] = j; nexp++;
+      }
+    }
+  }
+
+  char name[160];
+  snprintf(name, sizeof(name), "%s %s: pair count matches the scalar",
+    PRED_NAME[p], sizelabel);
+  check(name, nres == nexp);
+
+  bool same = (nres == nexp);
+  for (int k = 0; k < nres && same; k++)
+    if (res[2 * k] != expected[2 * k] || res[2 * k + 1] != expected[2 * k + 1])
+      same = false;
+  snprintf(name, sizeof(name), "%s %s: same pairs in the same order",
+    PRED_NAME[p], sizelabel);
+  check(name, same);
+
+  printf("    (%d pairs over %d x %d)\n", nres, c1, c2);
+
+  if (res)
+    free(res);
+  for (int i = 0; i < c1; i++) free(periods1[i]);
+  for (int j = 0; j < c2; j++) free(periods2[j]);
+  free(expected); free(periods1); free(periods2);
+  return;
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  srand(1);
+
+  const Temporal **small1 = malloc(SMALL1 * sizeof(Temporal *));
+  const Temporal **small2 = malloc(SMALL2 * sizeof(Temporal *));
+  const Temporal **large1 = malloc(LARGE1 * sizeof(Temporal *));
+  const Temporal **large2 = malloc(LARGE2 * sizeof(Temporal *));
+  for (int i = 0; i < SMALL1; i++) small1[i] = random_tgeo();
+  for (int j = 0; j < SMALL2; j++) small2[j] = random_tgeo();
+  for (int i = 0; i < LARGE1; i++) large1[i] = random_tgeo();
+  for (int j = 0; j < LARGE2; j++) large2[j] = random_tgeo();
+
+  /* Two points drawn at random are never at one place at one instant, so the
+   * intersects and touches relationships would hold for no pair at all and
+   * their comparison against the scalar would compare two empty answers. Every
+   * third element of the second side repeats one of the first, which the
+   * relationships do hold for. */
+  for (int j = 0; j < SMALL2; j += 3)
+  {
+    free((void *) small2[j]);
+    small2[j] = temporal_copy(small1[j % SMALL1]);
+  }
+  for (int j = 0; j < LARGE2; j += 3)
+  {
+    free((void *) large2[j]);
+    large2[j] = temporal_copy(large1[j % LARGE1]);
+  }
+
+  /* Squares of a grid, for the relationships that need boundaries to meet */
+  const Temporal **poly1 = malloc(LARGE1 * sizeof(Temporal *));
+  const Temporal **poly2 = malloc(LARGE2 * sizeof(Temporal *));
+  for (int i = 0; i < LARGE1; i++) poly1[i] = random_tgeometry();
+  for (int j = 0; j < LARGE2; j++) poly2[j] = random_tgeometry();
+
+  printf("Testing the set-set relationships against the scalar relationship\n");
+  for (int p = 0; p < 8; p++)
+  {
+    test_pred((Pred) p, small1, SMALL1, small2, SMALL2, "points pairwise");
+    test_pred((Pred) p, large1, LARGE1, large2, LARGE2, "points indexed");
+    test_pred((Pred) p, poly1, LARGE1, poly2, LARGE2, "squares indexed");
+  }
+
+  for (int i = 0; i < LARGE1; i++) free((void *) poly1[i]);
+  for (int j = 0; j < LARGE2; j++) free((void *) poly2[j]);
+  free(poly1); free(poly2);
+
+  for (int i = 0; i < SMALL1; i++) free((void *) small1[i]);
+  for (int j = 0; j < SMALL2; j++) free((void *) small2[j]);
+  for (int i = 0; i < LARGE1; i++) free((void *) large1[i]);
+  for (int j = 0; j < LARGE2; j++) free((void *) large2[j]);
+  free(small1); free(small2); free(large1); free(large2);
+
+  meos_finalize();
+  if (failures > 0)
+  {
+    printf("\n%d test(s) FAILED\n", failures);
+    return 1;
+  }
+  printf("\nAll tests passed\n");
+  return 0;
+}


### PR DESCRIPTION
The ever/always relationships over two arrays of temporal geos compare every pair of bounding boxes before running the exact test on the pairs that survive, so the prefilter grows with the product of the two array sizes even when few pairs qualify.

This indexes both sides and joins the two trees with `rtree_join`, once the arrays are large enough for the two builds to cost less than the comparison. The pairs the join reports are sorted, so they are reported in the order the comparison would, and the answer is sized from the pairs that survive rather than from the number of pairs there could be.

Which relationships it serves follows from what their bounding boxes decide:

- the within-distance relationships join the boxes of the first side grown by the distance, which is exactly what `stbox_within_dist_space` tests;
- intersects and touches join the boxes directly, since boxes apart can neither intersect nor touch;
- the disjoint relationships keep the comparison. They report the pairs sharing time whose boxes are apart, which is most of the pairs sharing time, so ordering that many pairs costs more than the comparison it replaces;
- the geodetic case has no spatial prefilter to index.

### Measurements

Two arrays of 8000 temporal points, 64 million pairs, processor time, three runs each, both builds reporting the same answer:

| | comparison | index |
| --- | --- | --- |
| eIntersects | 1.45 / 1.45 / 1.72 s | **0.11 / 0.12 / 0.13 s** |
| eDisjoint | 1.59 / 1.92 / 1.65 s | unchanged, it keeps the comparison |

### Tests

`meos/test/setset_pairs_test.c` compares every relationship against the scalar relationship of the same name applied to each pair, so the array function is checked against the per-pair answer it reproduces, including the pairs its prefilter decides without an exact test.

The arrays sit either side of the size at which the index takes over, so both paths are asserted to give the same answer, in the same order. Every relationship is also run over temporal geometries holding squares of a grid: two points are never at one place at one instant and a point has no boundary, so over points the intersects and touches answers are empty and would compare two empty answers. Over squares they are not.