### PR TITLE
Document the raster band count and link the raster functions to their wrappers

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3877,6 +3877,15 @@
 		</sect2>
 
 		<sect2>
+			<title>Accesores de Ráster</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raster_numBands"><varname>numBands</varname></link>: Devolver el número de bandas de un ráster</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
 			<title>Muestreo Raquet / QUADBIN</title>
 			<itemizedlist>
 				<listitem>

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -66,6 +66,33 @@ WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="raster_accessors">
+		<title>Accesores de Ráster</title>
+
+		<itemizedlist>
+			<listitem xml:id="raster_numBands">
+				<indexterm significance="normal"><primary><varname>numBands</varname></primary></indexterm>
+				<para>Devolver el número de bandas de un ráster</para>
+				<para><varname>numBands(raster) → integer</varname></para>
+				<para>El número de banda que aceptan <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> y los operadores construidos sobre él va de 1 hasta este valor.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH rast1 AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8
+  ) AS r
+), rast2 AS (
+  SELECT ST_AddBand(r, '32BF'::text, 0.0::float8, NULL::float8) AS r
+  FROM rast1
+)
+SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
+       numBands((SELECT r FROM rast2)) AS num_bands_two;
+-- 1 | 2
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="raquet_quadbin">
 		<title>Muestreo Raquet / QUADBIN</title>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3937,6 +3937,15 @@
 		</sect2>
 
 		<sect2>
+			<title>Raster Accessors</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raster_numBands"><varname>numBands</varname></link>: Return the number of bands of a raster</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
 			<title>Raquet / QUADBIN Sampling</title>
 			<itemizedlist>
 				<listitem>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -65,6 +65,33 @@ WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="raster_accessors">
+		<title>Raster Accessors</title>
+
+		<itemizedlist>
+			<listitem xml:id="raster_numBands">
+				<indexterm significance="normal"><primary><varname>numBands</varname></primary></indexterm>
+				<para>Return the number of bands of a raster</para>
+				<para><varname>numBands(raster) → integer</varname></para>
+				<para>The band number accepted by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> and by the operators built on it ranges from 1 to this value.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH rast1 AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8
+  ) AS r
+), rast2 AS (
+  SELECT ST_AddBand(r, '32BF'::text, 0.0::float8, NULL::float8) AS r
+  FROM rast1
+)
+SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
+       numBands((SELECT r FROM rast2)) AS num_bands_two;
+-- 1 | 2
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="raquet_quadbin">
 		<title>Raquet / QUADBIN Sampling</title>
 

--- a/meos/src/raster/raquet_gdal.c
+++ b/meos/src/raster/raquet_gdal.c
@@ -198,6 +198,7 @@ cleanup:
  * @param[in] path Path to a GDAL-readable raster file
  * @param[in] quadbin CARTO QUADBIN cell identifying the Web-Mercator tile, or 0
  * to derive it from the raster geotransform and EPSG:3857 spatial reference
+ * @csqlfn #Raquet_read()
  */
 Raquet *
 raquet_read(const char *path, uint64 quadbin)

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -328,6 +328,7 @@ read_pixel(const uint8_t *pixels, int col, int row, int width,
  * @param[in] nodata Nodata sentinel value
  * @param[in] has_nodata Whether nodata filtering is active
  * @return tfloat instant set, or NULL
+ * @csqlfn #Raster_tile_value_quadbin()
  */
 Temporal *
 raster_tile_value_quadbin(const Temporal *traj, const uint8_t *pixels,
@@ -638,6 +639,7 @@ araster_value(const Temporal *traj, const STBox *box,
  * @param[in] zoom Raquet zoom level (0–15)
  * @param[out] count Number of distinct cells returned
  * @return Palloc'd array of QUADBIN cell identifiers
+ * @csqlfn #Trajectory_quadbins()
  */
 uint64 *
 trajectory_quadbins(const Temporal *traj, uint32_t zoom, int *count)

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -229,6 +229,7 @@ raster_as_hexwkb(const Raster *rast, size_t *size_out)
  * @brief Return the number of bands of a raster
  * @param[in] rast Raster
  * @return On error, return -1
+ * @csqlfn #Raster_num_bands()
  */
 int
 raster_num_bands(const Raster *rast)

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -106,7 +106,6 @@ CREATE FUNCTION raquet(pixels bytea, width integer, height integer,
  * @param[in] rasterfile Raster file bytes in any GDAL-supported format
  * @param[in] quadbin CARTO QUADBIN cell, or NULL to derive it from the raster
  * geotransform and EPSG:3857 spatial reference
- * @csqlfn #Raquet_read()
  */
 CREATE FUNCTION raquetRead(
     rasterfile bytea,
@@ -126,7 +125,6 @@ CREATE FUNCTION raquetRead(
  * @param[in] traj Trajectory
  * @param[in] rast Raster
  * @param[in] band Band number (1-based, default 1)
- * @csqlfn #rasterValue()
  */
 CREATE OR REPLACE FUNCTION rasterValue(
     traj  tgeompoint,
@@ -152,7 +150,6 @@ CREATE OR REPLACE FUNCTION rasterValue(
  * @param[in] pixtype Pixel type: UINT8, INT16, INT32, FLOAT32, or FLOAT64
  * @param[in] nodata Nodata sentinel value
  * @param[in] has_nodata Enable nodata filtering
- * @csqlfn #Raster_tile_value_quadbin()
  */
 CREATE OR REPLACE FUNCTION rasterTileValueQuadbin(
     traj       tgeompoint,
@@ -176,7 +173,6 @@ CREATE OR REPLACE FUNCTION rasterTileValueQuadbin(
  * @brief Sample a raquet raster tile at the instants of a trajectory
  * @param[in] traj Trajectory
  * @param[in] rast Raquet tile
- * @csqlfn #Raster_tile_value()
  */
 CREATE FUNCTION rasterTileValue(
     traj tgeompoint,
@@ -191,7 +187,6 @@ CREATE FUNCTION rasterTileValue(
  * trajectory, keeping the value of the tile of highest zoom where tiles overlap
  * @param[in] traj Trajectory
  * @param[in] rast Array of raquet tiles
- * @csqlfn #Raster_tile_value_array()
  */
 CREATE FUNCTION rasterTileValue(
     traj tgeompoint,
@@ -210,7 +205,6 @@ CREATE FUNCTION rasterTileValue(
  * trajectory, suitable as a WHERE-clause join key against a Raquet table
  * @param[in] traj Trajectory (SRID 4326)
  * @param[in] zoom  QUADBIN zoom level (0–15)
- * @csqlfn #Trajectory_quadbins()
  */
 CREATE OR REPLACE FUNCTION quadbins(
     traj  tgeompoint,
@@ -231,7 +225,6 @@ CREATE OR REPLACE FUNCTION quadbins(
  * @param[in] rast Raster
  * @param[in] vspan Float value range (inclusive bounds)
  * @param[in] band Band number (1-based, default 1)
- * @csqlfn #atRasterValue()
  */
 CREATE OR REPLACE FUNCTION atRasterValue(traj tgeompoint, rast raster,
     vspan floatspan, band integer DEFAULT 1)
@@ -251,7 +244,6 @@ CREATE OR REPLACE FUNCTION atRasterValue(traj tgeompoint, rast raster,
  * @param[in] rast Raster
  * @param[in] vspan Float value range to exclude
  * @param[in] band Band number (1-based, default 1)
- * @csqlfn #minusRasterValue()
  */
 CREATE OR REPLACE FUNCTION minusRasterValue(traj tgeompoint, rast raster,
     vspan floatspan, band integer DEFAULT 1)
@@ -271,7 +263,6 @@ CREATE OR REPLACE FUNCTION minusRasterValue(traj tgeompoint, rast raster,
  * @param[in] rast Raster
  * @param[in] vspan Float value range
  * @param[in] band Band number (1-based, default 1)
- * @csqlfn #eRasterValue()
  */
 CREATE OR REPLACE FUNCTION eRasterValue(traj tgeompoint, rast raster,
     vspan floatspan, band integer DEFAULT 1)
@@ -291,7 +282,6 @@ CREATE OR REPLACE FUNCTION eRasterValue(traj tgeompoint, rast raster,
  * @param[in] rast Raster
  * @param[in] vspan Float value range
  * @param[in] band Band number (1-based, default 1)
- * @csqlfn #aRasterValue()
  */
 CREATE OR REPLACE FUNCTION aRasterValue(traj tgeompoint, rast raster,
     vspan floatspan, band integer DEFAULT 1) RETURNS boolean
@@ -306,7 +296,6 @@ CREATE OR REPLACE FUNCTION aRasterValue(traj tgeompoint, rast raster,
  * @ingroup mobilitydb_raster
  * @brief Return the number of bands of a raster
  * @param[in] rast Raster
- * @csqlfn #numBands()
  */
 CREATE FUNCTION numBands(raster)
   RETURNS integer


### PR DESCRIPTION
Two comment-and-documentation corrections around the raster band count.

## Document `numBands`

`numBands(raster)` is defined in the SQL, wrapped in the extension and covered
by the raster suite, but has no entry in the manual, so the only public raster
accessor cannot be found from the documentation.

It gets a `Raster Accessors` section beside `Sampling Operator`, in the shape
the Raquet path already has for its own accessors, and the matching line in the
reference index, in English and Spanish. The example is the one the suite
already runs, whose result is fixed by `500_raster.test.out`.

## Link the raster MEOS functions to their wrappers

`@csqlfn` is the reverse link from a MEOS function to the PG wrapper that binds
it, which the binding generators read to derive the SQL function of each MEOS
API function. `check_csqlfn.py` reads it from `meos/src`.

`500_raster.in.sql` is the only `.in.sql` in the tree carrying any `@csqlfn`,
eleven of them, and none is read: the checker globs `meos/src` and
`mobilitydb/src`, Doxygen has no `*.sql` in `FILE_PATTERNS`, and the SQL stub
generator synthesizes its own comments rather than copying these. Six of the
eleven name the very SQL function they sit above, so they link nothing.

Meanwhile four raster MEOS functions have a wrapper and no link, which the
checker reports as auto-resolvable gaps:

```
auto-resolvable @csqlfn GAPS: 4
  raquet_gdal.c      raquet_read                -> #Raquet_read
  raster_rtcore.c    raster_num_bands           -> #Raster_num_bands
  raster_quadbin.c   raster_tile_value_quadbin  -> #Raster_tile_value_quadbin
  raster_quadbin.c   trajectory_quadbins        -> #Trajectory_quadbins
```

Those four are added in `meos/src` and the eleven stranded tags are dropped,
which reports 0 gaps and leaves the family in the shape the other ten have.

The change is comments only; no SQL declaration or C code is touched.
