### PR TITLE
Expose asHexWKB for the tcbuffer, tpose and trgeometry types

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -319,10 +319,12 @@ SELECT asMFJSON(tcbuffer 'SRID=4326;[Cbuffer(Point(1 1),0.2)@2001-01-01,
 			<listitem xml:id="tcbuffer_asBinary">
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
-				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o la representación hexadecimal extendida binaria conocida (Extended Well-Known Binary o EWKB)</para>
+				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
 				<para><varname>asBinary(tcbuffer,endian text='') → bytea</varname></para>
 				<para><varname>asEWKB(tcbuffer,endian text='') → bytea</varname></para>
+				<para><varname>asHexWKB(tcbuffer,endian text='') → text</varname></para>
 				<para><varname>asHexEWKB(tcbuffer,endian text='') → text</varname></para>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -330,6 +332,8 @@ SELECT asBinary(tcbuffer 'Cbuffer(Point(1 2),1)@2001-01-01');
 -- \x013b0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
 SELECT asEWKB(tcbuffer 'SRID=7844;Cbuffer(Point(1 2),1)@2001-01-01');
 -- \x013b0041a41e0000000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
+SELECT asHexWKB(tcbuffer 'Cbuffer(Point(1 2),1)@2001-01-01');
+-- 013B0001000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
 SELECT asHexEWKB(tcbuffer 'SRID=3812;Cbuffer(Point(1 2),1)@2001-01-01');
 -- 013B0041E40E0000000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
 </programlisting>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -505,19 +505,23 @@ SELECT asMFJSON(tpose 'Pose(Point Z(1 2 3),1,0,0,0)@2001-01-01', 3);
 			<listitem xml:id="tpose_asBinary">
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
-				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
+				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
 				<para><varname>asBinary(tpose,endian text='') → bytea</varname></para>
 				<para><varname>asEWKB(tpose,endian text='') → bytea</varname></para>
+				<para><varname>asHexWKB(tpose,endian text='') → text</varname></para>
 				<para><varname>asHexEWKB(tpose,endian text='') → text</varname></para>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tpose 'Pose(Point(1 2),1)@2001-01-01');
--- \x013a0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
+-- \x0138000101000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
 SELECT asEWKB(tpose 'SRID=7844;Pose(Point(1 2),1)@2001-01-01');
--- \x013a0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
+-- \x01380041a41e000041a41e0000000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
+SELECT asHexWKB(tpose 'Pose(Point(1 2),1)@2001-01-01');
+-- 0138000101000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
 SELECT asHexEWKB(tpose 'SRID=3812;Pose(Point(1 2),1)@2001-01-01');
--- 013A0001000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
+-- 01380041E40E000041E40E0000000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
 </programlisting>
 			</listitem>
 

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -76,14 +76,20 @@ SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@20
 
 			<listitem xml:id="trgeometry_asEWKB">
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Devuelve la representación extendida binaria conocida (Extended Well-Known Binary o EWKB)</para>
 				<para><varname>asEWKB(trgeometry [, endian text]) → bytea</varname></para>
-				<para>La función complementaria <varname>asHexEWKB</varname> devuelve los mismos bytes como un texto codificado en hexadecimal.</para>
+				<para><varname>asHexWKB(trgeometry [, endian text]) → text</varname></para>
+				<para><varname>asHexEWKB(trgeometry [, endian text]) → text</varname></para>
+				<para>Las funciones complementarias <varname>asHexWKB</varname> y <varname>asHexEWKB</varname> devuelven los mismos bytes como un texto codificado en hexadecimal.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01'));
 -- 130
 -- The bytes round-trip through the matching input function.
 SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01')));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01')));
 -- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
 </programlisting>
 			</listitem>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -319,10 +319,12 @@ SELECT asMFJSON(tcbuffer 'SRID=4326;[Cbuffer(Point(1 1),0.2)@2001-01-01,
 			<listitem xml:id="tcbuffer_asBinary">
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
-				<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB) representation, or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
+				<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB) representation, the Hexadecimal Well-Known Binary (HexWKB) representation, or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
 				<para><varname>asBinary(tcbuffer,endian text='') → bytea</varname></para>
 				<para><varname>asEWKB(tcbuffer,endian text='') → bytea</varname></para>
+				<para><varname>asHexWKB(tcbuffer,endian text='') → text</varname></para>
 				<para><varname>asHexEWKB(tcbuffer,endian text='') → text</varname></para>
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -330,6 +332,8 @@ SELECT asBinary(tcbuffer 'Cbuffer(Point(1 2),1)@2001-01-01');
 -- \x013b0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
 SELECT asEWKB(tcbuffer 'SRID=7844;Cbuffer(Point(1 2),1)@2001-01-01');
 -- \x013b0041a41e0000000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
+SELECT asHexWKB(tcbuffer 'Cbuffer(Point(1 2),1)@2001-01-01');
+-- 013B0001000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
 SELECT asHexEWKB(tcbuffer 'SRID=3812;Cbuffer(Point(1 2),1)@2001-01-01');
 -- 013B0041E40E0000000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
 </programlisting>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -512,19 +512,23 @@ SELECT asMFJSON(tpose 'Pose(Point Z(1 2 3),1,0,0,0)@2001-01-01', 3);
 			<listitem xml:id="tpose_asBinary">
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
-				<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB) representation, or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
+				<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB) representation, the Hexadecimal Well-Known Binary (HexWKB) representation, or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
 				<para><varname>asBinary(tpose,endian text='') → bytea</varname></para>
 				<para><varname>asEWKB(tpose,endian text='') → bytea</varname></para>
+				<para><varname>asHexWKB(tpose,endian text='') → text</varname></para>
 				<para><varname>asHexEWKB(tpose,endian text='') → text</varname></para>
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tpose 'Pose(Point(1 2),1)@2001-01-01');
--- \x013a0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
+-- \x0138000101000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
 SELECT asEWKB(tpose 'SRID=7844;Pose(Point(1 2),1)@2001-01-01');
--- \x013a0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
+-- \x01380041a41e000041a41e0000000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000
+SELECT asHexWKB(tpose 'Pose(Point(1 2),1)@2001-01-01');
+-- 0138000101000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
 SELECT asHexEWKB(tpose 'SRID=3812;Pose(Point(1 2),1)@2001-01-01');
--- 013A0001000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
+-- 01380041E40E000041E40E0000000000000000F03F0000000000000040000000000000F03F009C57D3C11C0000
 </programlisting>
 			</listitem>
 

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -76,14 +76,20 @@ SELECT asMFJSON(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@20
 
 			<listitem xml:id="trgeometry_asEWKB">
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Return the Extended Well-Known Binary (EWKB) representation</para>
 				<para><varname>asEWKB(trgeometry [, endian text]) → bytea</varname></para>
-				<para>Companion <varname>asHexEWKB</varname> returns the same bytes as a hex-encoded text.</para>
+				<para><varname>asHexWKB(trgeometry [, endian text]) → text</varname></para>
+				<para><varname>asHexEWKB(trgeometry [, endian text]) → text</varname></para>
+				<para>Companion <varname>asHexWKB</varname> and <varname>asHexEWKB</varname> return the same bytes as a hex-encoded text.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01'));
 -- 130
 -- The bytes round-trip through the matching input function.
 SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01')));
+-- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1), 0.5)@2001-01-01')));
 -- POLYGON((0 0,1 0,1 1,0 1,0 0));Pose(POINT(1 1),0.5)@2001-01-01
 </programlisting>
 			</listitem>

--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -157,9 +157,14 @@ CREATE FUNCTION asEWKB(tcbuffer, endianenconding text DEFAULT '')
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(tcbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tcbuffer, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexEWKB(tcbuffer, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- GENERATED-REPRESENTATIONS-END cbuffer

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -175,9 +175,14 @@ CREATE FUNCTION asEWKB(tpose, endianenconding text DEFAULT '')
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(tpose, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tpose, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexEWKB(tpose, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- GENERATED-REPRESENTATIONS-END pose

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -157,9 +157,14 @@ CREATE FUNCTION asEWKB(trgeometry, endianenconding text DEFAULT '')
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(trgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(trgeometry, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexEWKB(trgeometry, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- GENERATED-REPRESENTATIONS-END rgeo

--- a/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
@@ -322,6 +322,54 @@ SELECT asText(tcbufferFromHexEWKB(asHexEWKB(tcbuffer 'Interp=Step;{[Cbuffer(Poin
  Interp=Step;{[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Cbuffer(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Cbuffer(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01')));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}')));
+                                                                               astext                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Cbuffer(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]')));
+                                                                               astext                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}')));
+                                                                                                                                       astext                                                                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Cbuffer(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Cbuffer(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Interp=Step;[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]')));
+                                                                                     astext                                                                                     
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Interp=Step;[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05] }')));
+                                                                                                                                             astext                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Interp=Step;{[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Cbuffer(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Cbuffer(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 'NDR')));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 'XDR')));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT asMFJSON(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01');
                                                                asmfjson                                                                
 ---------------------------------------------------------------------------------------------------------------------------------------

--- a/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
@@ -105,6 +105,16 @@ SELECT asText(tcbufferFromHexEWKB(asHexEWKB(tcbuffer '{[Cbuffer(Point(1 1), 0.2)
 SELECT asText(tcbufferFromHexEWKB(asHexEWKB(tcbuffer 'Interp=Step;[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', 'XDR')));
 SELECT asText(tcbufferFromHexEWKB(asHexEWKB(tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05] }', 'XDR')));
 
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01')));
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}')));
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]')));
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}')));
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Interp=Step;[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]')));
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Interp=Step;{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05] }')));
+
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 'NDR')));
+SELECT asText(tcbufferFromHexEWKB(asHexWKB(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 'XDR')));
+
 -------------------------------------------------------------------------------
 -- Input/output in MF-JSON format
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/expected/102_tpose.test.out
+++ b/mobilitydb/test/pose/expected/102_tpose.test.out
@@ -322,6 +322,54 @@ SELECT asText(tposeFromHexEWKB(asHexEWKB(tpose 'Interp=Step;{[Pose(Point(1 1), 0
  Interp=Step;{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Pose(Point(1 1), 0.5)@2000-01-01')));
+                      astext                       
+---------------------------------------------------
+ Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}')));
+                                                                          astext                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ {Pose(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')));
+                                                                          astext                                                                           
+-----------------------------------------------------------------------------------------------------------------------------------------------------------
+ [Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}')));
+                                                                                                                               astext                                                                                                                                
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')));
+                                                                                astext                                                                                 
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Interp=Step;[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Interp=Step;{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05] }')));
+                                                                                                                                     astext                                                                                                                                      
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ Interp=Step;{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', 'NDR')));
+                      astext                       
+---------------------------------------------------
+ Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', 'XDR')));
+                      astext                       
+---------------------------------------------------
+ Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT asText(tpose('Pose(Point(1 1),0)'::pose, '2012-01-01'::timestamp));
                      astext                      
 -------------------------------------------------

--- a/mobilitydb/test/pose/queries/102_tpose.test.sql
+++ b/mobilitydb/test/pose/queries/102_tpose.test.sql
@@ -105,6 +105,16 @@ SELECT asText(tposeFromHexEWKB(asHexEWKB(tpose '{[Pose(Point(1 1), 0.2)@2000-01-
 SELECT asText(tposeFromHexEWKB(asHexEWKB(tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', 'XDR')));
 SELECT asText(tposeFromHexEWKB(asHexEWKB(tpose 'Interp=Step;{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05] }', 'XDR')));
 
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Pose(Point(1 1), 0.5)@2000-01-01')));
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose '{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}')));
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')));
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose '{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}')));
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')));
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Interp=Step;{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05] }')));
+
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', 'NDR')));
+SELECT asText(tposeFromHexEWKB(asHexWKB(tpose 'Pose(Point(1 1), 0.5)@2000-01-01', 'XDR')));
+
 -------------------------------------------------------------------------------
 -- Constructors
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/expected/150_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/150_trgeo.test.out
@@ -430,6 +430,54 @@ SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Interp=Step;Polygon((1
  POLYGON((1 1,2 2,3 1,1 1));Interp=Step;{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01')));
+                                    astext                                    
+------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}')));
+                                                                                        astext                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')));
+                                                                                        astext                                                                                        
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}')));
+                                                                                                                                             astext                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Interp=Step;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')));
+                                                                                              astext                                                                                              
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Interp=Step;[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Interp=Step;Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}')));
+                                                                                                                                                   astext                                                                                                                                                   
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Interp=Step;{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST], [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', 'NDR')));
+                                    astext                                    
+------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', 'XDR')));
+                                    astext                                    
+------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT asText(trgeometry('Polygon((1 1,2 2,3 1,1 1))', tpose(pose 'Pose(Point(1 1),0)', timestamp '2012-01-01')));
                                    astext                                   
 ----------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
@@ -130,6 +130,16 @@ SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Polygon((1 1,2 2,3 1,1
 SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Interp=Step;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', 'XDR')));
 SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry 'Interp=Step;Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', 'XDR')));
 
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01')));
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}')));
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')));
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}')));
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Interp=Step;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]')));
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Interp=Step;Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}')));
+
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', 'NDR')));
+SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', 'XDR')));
+
 -------------------------------------------------------------------------------
 -- Constructors
 -------------------------------------------------------------------------------

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -86,6 +86,7 @@ representation_families:
     asText: Tspatial_as_text
     asEWKT: Tspatial_as_ewkt
     asEWKB: Tspatial_as_ewkb
+    asHexEWKB: Tspatial_as_hexewkb
   arrsyms:
     asText: Spatialarr_as_text
     asEWKT: Spatialarr_as_ewkt
@@ -105,6 +106,7 @@ representation_families:
     - asMFJSON
     - asBinary
     - asEWKB
+    - asHexWKB
     - asHexEWKB
 - family: npoint
   file: mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -144,6 +146,7 @@ representation_families:
     asText: Trgeometry_as_text
     asEWKT: Trgeometry_as_ewkt
     asEWKB: Tspatial_as_ewkb
+    asHexEWKB: Tspatial_as_hexewkb
   arrsyms:
     asText: Spatialarr_as_text
     asEWKT: Spatialarr_as_ewkt
@@ -163,6 +166,7 @@ representation_families:
     - asMFJSON
     - asBinary
     - asEWKB
+    - asHexWKB
     - asHexEWKB
 - family: h3
   file: mobilitydb/sql/h3/253_th3index.in.sql
@@ -253,6 +257,7 @@ representation_families:
     asText: Tspatial_as_text
     asEWKT: Tspatial_as_ewkt
     asEWKB: Tspatial_as_ewkb
+    asHexEWKB: Tspatial_as_hexewkb
   arrsyms:
     asText: Spatialarr_as_text
     asEWKT: Spatialarr_as_ewkt
@@ -274,6 +279,7 @@ representation_families:
     - asMFJSON
     - asBinary
     - asEWKB
+    - asHexWKB
     - asHexEWKB
 - family: pointcloud
   file: mobilitydb/sql/pointcloud/420_tpcpoint.in.sql


### PR DESCRIPTION
The temporal circular buffer, pose and rigid geometry types expose the asHexWKB and asHexEWKB hexadecimal Well-Known Binary accessors carried by the other temporal types, bound to the Temporal_as_hexwkb and Tspatial_as_hexewkb kernels through the representation generator manifest. Round-trip regression tests and the English and Spanish reference documentation cover both accessors.