### PR TITLE
Build every optional family in the MEOS workflow

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -43,15 +43,21 @@ jobs:
             libproj-dev \
             libjson-c-dev \
             libgsl-dev \
-            libgdal-dev
+            libgdal-dev \
+            libh3-dev \
+            libxml2-dev \
+            zlib1g-dev
 
       - name: Build
         run: |
           mkdir build
           cd build
-          # Enable the optional types to be able to test them below. RASTER
-          # requires GDAL, installed above
-          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DCBUFFER=on -DJSON=on -DPOSE=on -DRGEO=on -DRASTER=on ..
+          # ALL enables every optional family, so a family added later is
+          # covered here without editing this workflow: the list in
+          # CMakeLists.txt decides, not this line. The families carrying an
+          # external dependency take it from the packages installed above,
+          # H3 from libh3, RASTER from GDAL, POINTCLOUD from libxml2 + zlib.
+          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DALL=on ..
           make -j $(nproc)
           sudo make install
 


### PR DESCRIPTION
The workflow names the families it builds one flag at a time:

```
cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DCBUFFER=on -DJSON=on -DPOSE=on -DRGEO=on -DRASTER=on ..
```

That builds five of the nine, so H3, POINTCLOUD and QUADBIN have no
standalone-MEOS build coverage, and a family added later is absent until
someone remembers to extend the line. The omission is invisible: the job passes
either way.

`ALL` enables every family from the list in `CMakeLists.txt`, so that list stays
the single place a family is registered, present and future ones alike:

```
cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DALL=on ..
```

Configuring this way reports nine `Including` lines and no `Excluding` line.

The families carrying an external dependency take it from the install step:
H3 from `libh3`, POINTCLOUD from `libxml2` and `zlib`, which
`meos/src/pointcloud/CMakeLists.txt` takes through `find_package(... REQUIRED)`,
and RASTER from GDAL, already installed. The vendored pgPointCloud sources are
compiled by CMake directly, so no autotools are needed here.
