### PR TITLE
Declare every function of the public headers as extern

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -696,7 +696,7 @@ extern Temporal **tpoint_make_simple(const Temporal *temp, int *count);
 
 /* SRID functions */
 
-int32_t tspatial_srid(const Temporal *temp);
+extern int32_t tspatial_srid(const Temporal *temp);
 extern Temporal *tspatial_set_srid(const Temporal *temp, int32_t srid);
 extern Temporal *tspatial_transform(const Temporal *temp, int32_t srid);
 extern Temporal *tspatial_transform_pipeline(const Temporal *temp, const char *pipelinestr, int32_t srid, bool is_forward);

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -222,7 +222,7 @@ extern Set *union_set_pose(const Set *s, const Pose *pose);
  *****************************************************************************/
 
 extern Temporal *tpose_from_mfjson(const char *str);
-Temporal *tpose_in(const char *str);
+extern Temporal *tpose_in(const char *str);
 
 /*****************************************************************************
  * Constructor functions

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -216,15 +216,14 @@ TInstant *
 tinstant_make(Datum value, MeosType temptype, TimestampTz t)
 {
   /* Ensure the validity of the arguments */
-  int32_t tspatial_srid;
   // TODO Should we bypass the tests on tnpoint ?
   if (tspatial_type(temptype) && temptype != T_TNPOINT)
   {
     MeosType basetype = temptype_basetype(temptype);
-    tspatial_srid = spatial_srid(value, basetype);
+    int32_t srid = spatial_srid(value, basetype);
     /* Ensure that the SRID is geodetic for geography */
-    if (tgeodetic_type(temptype) && tspatial_srid != SRID_UNKNOWN && 
-        ! ensure_srid_is_latlong(tspatial_srid))
+    if (tgeodetic_type(temptype) && srid != SRID_UNKNOWN &&
+        ! ensure_srid_is_latlong(srid))
       return NULL;
     /* Ensure that a geometry/geography is not empty */
     if (tgeo_type_all(temptype) && 


### PR DESCRIPTION
Two declarations of the public API omit the `extern` that every declaration around them carries: `tspatial_srid` in `meos_geo.h` and `tpose_in` in `meos_pose.h`. The keyword is what a function declaration means without it, so the omission changes nothing beyond making those two lines read as a different kind of declaration than their neighbours. With them, every function of `meos/include/meos*.h` is declared the same way.

The local holding the SRID in `tinstant_make` carries the name of the `tspatial_srid` function it shadows, which is what cppcheck reports as `shadowFunction`. It is named `srid` and declared where it is used, as its sibling in `set.c` names and scopes the same value.
