### PR TITLE
Check the derivation links of every family

### DIFF
--- a/meos/src/json/jsonbset_jsonfuncs.c
+++ b/meos/src/json/jsonbset_jsonfuncs.c
@@ -146,6 +146,7 @@ concat_jsonbset_jsonb(const Set *set, const Jsonb *jb, bool invert)
  * @param[in] idx Index
  * @param[in] astext True when the output is a text set
  * @param[in] null_handle States the null value treatment
+ * @csqlfn #Jsonbset_array_element()
  */
 Set *
 jsonbset_array_element(const Set *set, int idx, bool astext,
@@ -314,6 +315,7 @@ jsonbset_exists_array(const Set *set, text **keys, int count, bool any,
  * @param[in] null_handle States the null value treatment, which must be one of
  * 'raise_exception', 'use_json_null', 'delete_key', or 'return_target'
  * @param[in] lax True when the lax mode is used
+ * @csqlfn #Jsonbset_set()
  */
 Set *
 jsonbset_set(const Set *set, text **keys, int count, const Jsonb *newjb,
@@ -522,6 +524,7 @@ jsonbset_delete_path(const Set *set, text **path_elems, int path_len)
  * @param[in] path_len Number of elements in the input array
  * @param[in] astext True when the output is a text set
  * @param[in] null_handle States the null value treatment
+ * @csqlfn #Jsonbset_extract_path()
  */
 Set *
 jsonbset_extract_path(const Set *set, text **path_elems, int path_len,
@@ -679,6 +682,7 @@ jsonbset_path_match(const Set *set, const JsonPath *jp, const Jsonb *vars,
  * numeric errors, when false, no errors are suppressed
  * @param[in] tz When true, support comparisons of date/time values that
  * require timezone-aware conversions, false otherwise
+ * @csqlfn #Jsonbset_path_query_array()
  */
 Set *
 jsonbset_path_query_array(const Set *set, const JsonPath *jp,
@@ -714,6 +718,7 @@ jsonbset_path_query_array(const Set *set, const JsonPath *jp,
  * numeric errors, when false, no errors are suppressed
  * @param[in] tz When true, support comparisons of date/time values that
  * require timezone-aware conversions, false otherwise
+ * @csqlfn #Jsonbset_path_query_first()
  */
 Set *
 jsonbset_path_query_first(const Set *set, const JsonPath *jp,

--- a/meos/src/json/tjsonb_jsonfuncs.c
+++ b/meos/src/json/tjsonb_jsonfuncs.c
@@ -717,6 +717,7 @@ contains_tjsonb_tjsonb(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Temporal JSON value
  * @param[in] idx Index
  * @param[in] null_handle States the null value treatment
+ * @csqlfn #Tjson_array_element()
  */
 Temporal *
 tjson_array_element(const Temporal *temp, int idx, nullHandleType null_handle)
@@ -742,6 +743,7 @@ tjson_array_element(const Temporal *temp, int idx, nullHandleType null_handle)
  * @param[in] idx Index
  * @param[in] astext True when the output is a temporal text
  * @param[in] null_handle States the null value treatment
+ * @csqlfn #Tjsonb_array_element()
  */
 Temporal *
 tjsonb_array_element(const Temporal *temp, int idx, bool astext,
@@ -946,6 +948,7 @@ tjsonb_exists_all(const Temporal *temp, text **keys, int count)
  * @param[in] null_handle States the null value treatment, which must be one of
  * 'raise_exception', 'use_json_null', 'delete_key', or 'return_target'
  * @param[in] lax True when the lax mode is used
+ * @csqlfn #Tjsonb_set()
  */
 Temporal *
 tjsonb_set(const Temporal *temp, text **keys, int count, const Jsonb *newjb,
@@ -1383,6 +1386,7 @@ tjsonb_delete_path(const Temporal *temp, text **path_elems, int path_len)
  * @param[in] path_elems Keys
  * @param[in] path_len Number of elements in the input array
  * @param[in] null_handle States the null value treatment
+ * @csqlfn #Tjson_extract_path()
  */
 Temporal *
 tjson_extract_path(const Temporal *temp, text **path_elems, int path_len,
@@ -1413,6 +1417,7 @@ tjson_extract_path(const Temporal *temp, text **path_elems, int path_len,
  * @param[in] path_len Number of elements in the input array
  * @param[in] astext True when the output is a temporal text
  * @param[in] null_handle States the null value treatment
+ * @csqlfn #Tjsonb_extract_path()
  */
 Temporal *
 tjsonb_extract_path(const Temporal *temp, text **path_elems, int path_len,
@@ -1497,6 +1502,7 @@ tjsonb_insert(const Temporal *temp, text **path_elems, int path_len,
  * numeric errors, when false, no errors are suppressed
  * @param[in] tz When true, support comparisons of date/time values that
  * require timezone-aware conversions, false otherwise
+ * @csqlfn #Tjsonb_path_exists()
  */
 Temporal *
 tjsonb_path_exists(const Temporal *temp, const JsonPath *jp, const Jsonb *vars,
@@ -1533,6 +1539,7 @@ tjsonb_path_exists(const Temporal *temp, const JsonPath *jp, const Jsonb *vars,
  * numeric errors, when false, no errors are suppressed
  * @param[in] tz When true, support comparisons of date/time values that
  * require timezone-aware conversions, false otherwise
+ * @csqlfn #Tjsonb_path_match()
  */
 Temporal *
 tjsonb_path_match(const Temporal *temp, const JsonPath *jp, const Jsonb *vars,
@@ -1568,6 +1575,7 @@ tjsonb_path_match(const Temporal *temp, const JsonPath *jp, const Jsonb *vars,
  * numeric errors, when false, no errors are suppressed
  * @param[in] tz When true, support comparisons of date/time values that
  * require timezone-aware conversions, false otherwise
+ * @csqlfn #Tjsonb_path_query_array()
  */
 Temporal *
 tjsonb_path_query_array(const Temporal *temp, const JsonPath *jp,
@@ -1604,6 +1612,7 @@ tjsonb_path_query_array(const Temporal *temp, const JsonPath *jp,
  * numeric errors, when false, no errors are suppressed
  * @param[in] tz When true, support comparisons of date/time values that
  * require timezone-aware conversions, false otherwise
+ * @csqlfn #Tjsonb_path_query_first()
  */
 Temporal *
 tjsonb_path_query_first(const Temporal *temp, const JsonPath *jp,

--- a/meos/src/quadbin/tquadbin_compops.c
+++ b/meos/src/quadbin/tquadbin_compops.c
@@ -105,6 +105,7 @@ eacomp_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2,
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if a temporal QUADBIN cell is ever equal to a base
  * QUADBIN cell.
+ * @csqlfn #Ever_eq_tquadbin_quadbin()
  */
 int
 ever_eq_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
@@ -116,6 +117,7 @@ ever_eq_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if a base QUADBIN cell is ever equal to a temporal
  * QUADBIN cell.
+ * @csqlfn #Ever_eq_quadbin_tquadbin()
  */
 int
 ever_eq_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
@@ -127,6 +129,7 @@ ever_eq_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if a temporal QUADBIN cell is ever not equal to a base
  * QUADBIN cell.
+ * @csqlfn #Ever_ne_tquadbin_quadbin()
  */
 int
 ever_ne_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
@@ -138,6 +141,7 @@ ever_ne_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if a base QUADBIN cell is ever not equal to a temporal
  * QUADBIN cell.
+ * @csqlfn #Ever_ne_quadbin_tquadbin()
  */
 int
 ever_ne_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
@@ -149,6 +153,7 @@ ever_ne_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if a temporal QUADBIN cell is always equal to a base
  * QUADBIN cell.
+ * @csqlfn #Always_eq_tquadbin_quadbin()
  */
 int
 always_eq_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
@@ -160,6 +165,7 @@ always_eq_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if a base QUADBIN cell is always equal to a temporal
  * QUADBIN cell.
+ * @csqlfn #Always_eq_quadbin_tquadbin()
  */
 int
 always_eq_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
@@ -171,6 +177,7 @@ always_eq_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if a temporal QUADBIN cell is always not equal to a base
  * QUADBIN cell.
+ * @csqlfn #Always_ne_tquadbin_quadbin()
  */
 int
 always_ne_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
@@ -182,6 +189,7 @@ always_ne_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if a base QUADBIN cell is always not equal to a temporal
  * QUADBIN cell.
+ * @csqlfn #Always_ne_quadbin_tquadbin()
  */
 int
 always_ne_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
@@ -197,6 +205,7 @@ always_ne_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if two temporal QUADBIN cells are ever equal at some
  * shared instant.
+ * @csqlfn #Ever_eq_tquadbin_tquadbin()
  */
 int
 ever_eq_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
@@ -208,6 +217,7 @@ ever_eq_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if two temporal QUADBIN cells are ever unequal at some
  * shared instant.
+ * @csqlfn #Ever_ne_tquadbin_tquadbin()
  */
 int
 ever_ne_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
@@ -219,6 +229,7 @@ ever_ne_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if two temporal QUADBIN cells are always equal across
  * their shared time axis.
+ * @csqlfn #Always_eq_tquadbin_tquadbin()
  */
 int
 always_eq_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
@@ -230,6 +241,7 @@ always_eq_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_quadbin_comp_ever
  * @brief Return `true` if two temporal QUADBIN cells are always unequal across
  * their shared time axis.
+ * @csqlfn #Always_ne_tquadbin_tquadbin()
  */
 int
 always_ne_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
@@ -273,6 +285,7 @@ tcomp_quadbin_tquadbin(Quadbin cell, const Temporal *temp,
  * @ingroup meos_quadbin_comp_temp
  * @brief Return the temporal equality between a temporal QUADBIN cell and a
  * base QUADBIN cell.
+ * @csqlfn #Teq_tquadbin_quadbin()
  */
 Temporal *
 teq_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
@@ -284,6 +297,7 @@ teq_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
  * @ingroup meos_quadbin_comp_temp
  * @brief Return the temporal equality between a base QUADBIN cell and a
  * temporal QUADBIN cell.
+ * @csqlfn #Teq_quadbin_tquadbin()
  */
 Temporal *
 teq_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
@@ -295,6 +309,7 @@ teq_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
  * @ingroup meos_quadbin_comp_temp
  * @brief Return the temporal inequality between a temporal QUADBIN cell and a
  * base QUADBIN cell.
+ * @csqlfn #Tne_tquadbin_quadbin()
  */
 Temporal *
 tne_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
@@ -306,6 +321,7 @@ tne_tquadbin_quadbin(const Temporal *temp, Quadbin cell)
  * @ingroup meos_quadbin_comp_temp
  * @brief Return the temporal inequality between a base QUADBIN cell and a
  * temporal QUADBIN cell.
+ * @csqlfn #Tne_quadbin_tquadbin()
  */
 Temporal *
 tne_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
@@ -317,6 +333,7 @@ tne_quadbin_tquadbin(Quadbin cell, const Temporal *temp)
  * @ingroup meos_quadbin_comp_temp
  * @brief Return the temporal equality of two temporal QUADBIN cells across
  * their shared time axis.
+ * @csqlfn #Teq_tquadbin_tquadbin()
  */
 Temporal *
 teq_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
@@ -330,6 +347,7 @@ teq_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_quadbin_comp_temp
  * @brief Return the temporal inequality of two temporal QUADBIN cells across
  * their shared time axis.
+ * @csqlfn #Tne_tquadbin_tquadbin()
  */
 Temporal *
 tne_tquadbin_tquadbin(const Temporal *temp1, const Temporal *temp2)

--- a/tools/scripts/check_csqlfn.py
+++ b/tools/scripts/check_csqlfn.py
@@ -175,11 +175,21 @@ def add_tag(meos_dir_glob, fn, pg):
     return False
 
 
+def families():
+    """Every family directory under mobilitydb/src, discovered not listed.
+
+    A hardcoded subset silently drops a family: json, quadbin and raster were
+    absent, so the gaps in them went unreported however often the check ran.
+    Reading the directory keeps a family added later covered on its first run.
+    """
+    src = f'{ROOT}/mobilitydb/src'
+    return sorted(d for d in os.listdir(src) if os.path.isdir(f'{src}/{d}'))
+
+
 def main():
     """Dispatch on the mode argument and report the @csqlfn coverage."""
     mode = sys.argv[1] if len(sys.argv) > 1 else '--gaps'
-    dirs = sys.argv[2:] or ['temporal', 'geo', 'cbuffer', 'npoint', 'pose', 'rgeo',
-                            'h3', 'pointcloud']
+    dirs = sys.argv[2:] or families()
     rows, auto, review = resolve(dirs)
     if mode == '--table':
         for pg, sf, so, dg, _how, _f in sorted(rows):


### PR DESCRIPTION
`@csqlfn` is the reverse link from a MEOS function to the PG wrapper that binds
it, which the binding generators read to derive the SQL function of each MEOS
API function. `check_csqlfn.py --gaps` reports a MEOS function that has a
wrapper and no link, and CI runs it on every push.

The checker takes its families from a list naming eight of the eleven
directories under `mobilitydb/src`. `json`, `quadbin` and `raster` are absent
from that list, so a missing link in those three is reported by no run.

## The links

Thirty-two functions in the two unexamined families carry a wrapper and no
link, all of them resolved by the checker itself:

- json, fourteen: the `jsonbset` and `tjsonb` path and set accessors.
- quadbin, eighteen: the `ever`, `always` and temporal comparisons.

They come from `check_csqlfn.py --fix json quadbin`. The diff is additions only
and every added line is a `@csqlfn`; each target is a declared
`PG_FUNCTION_INFO_V1` wrapper.

## The check

The families come from the directories under `mobilitydb/src`, the way the
build detects what is present, rather than from a list. A family added later is
covered on its first run, and the three the list omits are covered. The default
run reports 0 gaps.

The two commits are ordered so that each stands on its own: the links, then the
wider check that would otherwise report them.
