### PR TITLE
Bring the npoint and pose base-type representation sections under the inherited SQL generator

### DIFF
--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -86,6 +86,85 @@ SELECT npoint 'Npoint(99999999, 1.0)';
 </programlisting>
 		<para>Damos a continuación las funciones y operadores para los tipos de redes estáticas.</para>
 
+		<sect2 xml:id="npoint_inout">
+			<title>Entrada y salida</title>
+
+			<itemizedlist>
+				<listitem xml:id="npoint_asText">
+					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
+					<para>Devuelve la representación de texto conocido (Well-Known Text o WKT) o la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
+					<para><varname>asText({npoint,npoint[]}) → {text,text[]}</varname></para>
+					<para><varname>asEWKT({npoint,npoint[]}) → {text,text[]}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(npoint 'SRID=5676;Npoint(1,0.5)');
+-- NPoint(1,0.5)
+SELECT asText(ARRAY[npoint 'Npoint(1,0.2)', 'Npoint(1,0.5)']);
+-- {"NPoint(1,0.2)","NPoint(1,0.5)"}
+SELECT asEWKT(npoint 'SRID=5676;Npoint(1,0.5)');
+-- SRID=5676;NPoint(1,0.5)
+SELECT asEWKT(ARRAY[npoint 'SRID=5676;Npoint(1,0.2)', 'SRID=5676;Npoint(1,0.5)']);
+-- {"SRID=5676;NPoint(1,0.2)","SRID=5676;NPoint(1,0.5)"}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="npoint_asBinary">
+					<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
+					<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
+					<para><varname>asBinary(npoint,endian text='') → bytea</varname></para>
+					<para><varname>asEWKB(npoint,endian text='') → bytea</varname></para>
+					<para><varname>asHexWKB(npoint,endian text='') → text</varname></para>
+					<para><varname>asHexEWKB(npoint,endian text='') → text</varname></para>
+					<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina. Un punto de red toma su SRID de la red de rutas subyacente, por lo que ambas formas hexadecimales lo incluyen y coinciden, mientras que la forma binaria simple <varname>asBinary</varname> lo omite.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asBinary(npoint 'SRID=5676;Npoint(1,0.5)');
+-- \x01010100000000000000000000000000e03f
+SELECT asEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
+-- \x01412c1600000100000000000000000000000000e03f
+SELECT asHexWKB(npoint 'SRID=5676;Npoint(1,0.5)');
+-- 01412C1600000100000000000000000000000000E03F
+SELECT asHexEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
+-- 01412C1600000100000000000000000000000000E03F
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="npointFromText">
+					<indexterm significance="normal"><primary><varname>npointFromText</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>npointFromEWKT</varname></primary></indexterm>
+					<para>Entrada desde la representación de texto conocido (Well-Known Text o WKT) o desde la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
+					<para><varname>npointFromText(text) → npoint</varname></para>
+					<para><varname>npointFromEWKT(text) → npoint</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(npointFromText(text 'Npoint(1,0.5)'));
+-- SRID=5676;NPoint(1,0.5)
+SELECT asEWKT(npointFromEWKT(text 'SRID=5676;Npoint(1,0.5)'));
+-- SRID=5676;NPoint(1,0.5)
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="npointFromBinary">
+					<indexterm significance="normal"><primary><varname>npointFromBinary</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>npointFromEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>npointFromHexEWKB</varname></primary></indexterm>
+					<para>Entrada desde la representación binaria conocida (Well-Known Binary o WKB), desde la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o desde la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
+					<para><varname>npointFromBinary(bytea) → npoint</varname></para>
+					<para><varname>npointFromEWKB(bytea) → npoint</varname></para>
+					<para><varname>npointFromHexEWKB(text) → npoint</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(npointFromEWKB(
+  '\x01412c1600000100000000000000000000000000e03f'));
+-- SRID=5676;NPoint(1,0.5)
+SELECT asEWKT(npointFromHexEWKB(
+  '01412C1600000100000000000000000000000000E03F'));
+-- SRID=5676;NPoint(1,0.5)
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="constructor_functions">
 			<title>Constructores</title>
 

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -116,10 +116,12 @@ SELECT asEWKT(ARRAY[pose 'Pose(SRID=5676;Point(0 0),1)', 'Pose(SRID=5676;Point(1
 				<listitem xml:id="pose_asBinary">
 					<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
-					<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
+					<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
 					<para><varname>asBinary(pose,endian text='') → bytea</varname></para>
 					<para><varname>asEWKB(pose,endian text='') → bytea</varname></para>
+					<para><varname>asHexWKB(pose,endian text='') → text</varname></para>
 					<para><varname>asHexEWKB(pose,endian text='') → text</varname></para>
 					<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -127,6 +129,8 @@ SELECT asBinary(pose 'Pose(Point(1 2),1)');
 -- \x0101000000000000f03f0000000000000040000000000000f03f
 SELECT asEWKB(pose 'SRID=7844;Pose(Point(1 2),1)');
 -- \x0141a41e0000000000000000f03f0000000000000040000000000000f03f
+SELECT asHexWKB(pose 'Pose(Point(1 2),1)');
+-- 0101000000000000F03F0000000000000040000000000000F03F
 SELECT asHexEWKB(pose 'SRID=3812;Pose(Point(1 2),1)');
 -- 0141E40E0000000000000000F03F0000000000000040000000000000F03F
 </programlisting>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -86,6 +86,85 @@ SELECT npoint 'Npoint(99999999, 1.0)';
 </programlisting>
 		<para>We give next the functions and operators for the static network types.</para>
 
+		<sect2 xml:id="npoint_inout">
+			<title>Input and Output</title>
+
+			<itemizedlist>
+				<listitem xml:id="npoint_asText">
+					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
+					<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
+					<para><varname>asText({npoint,npoint[]}) → {text,text[]}</varname></para>
+					<para><varname>asEWKT({npoint,npoint[]}) → {text,text[]}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(npoint 'SRID=5676;Npoint(1,0.5)');
+-- NPoint(1,0.5)
+SELECT asText(ARRAY[npoint 'Npoint(1,0.2)', 'Npoint(1,0.5)']);
+-- {"NPoint(1,0.2)","NPoint(1,0.5)"}
+SELECT asEWKT(npoint 'SRID=5676;Npoint(1,0.5)');
+-- SRID=5676;NPoint(1,0.5)
+SELECT asEWKT(ARRAY[npoint 'SRID=5676;Npoint(1,0.2)', 'SRID=5676;Npoint(1,0.5)']);
+-- {"SRID=5676;NPoint(1,0.2)","SRID=5676;NPoint(1,0.5)"}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="npoint_asBinary">
+					<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
+					<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB), the Hexadecimal Well-Known Binary (HexWKB), or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
+					<para><varname>asBinary(npoint,endian text='') → bytea</varname></para>
+					<para><varname>asEWKB(npoint,endian text='') → bytea</varname></para>
+					<para><varname>asHexWKB(npoint,endian text='') → text</varname></para>
+					<para><varname>asHexEWKB(npoint,endian text='') → text</varname></para>
+					<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used. A network point takes its SRID from the underlying route network, so both hexadecimal forms embed it and coincide, while the plain <varname>asBinary</varname> form omits it.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asBinary(npoint 'SRID=5676;Npoint(1,0.5)');
+-- \x01010100000000000000000000000000e03f
+SELECT asEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
+-- \x01412c1600000100000000000000000000000000e03f
+SELECT asHexWKB(npoint 'SRID=5676;Npoint(1,0.5)');
+-- 01412C1600000100000000000000000000000000E03F
+SELECT asHexEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
+-- 01412C1600000100000000000000000000000000E03F
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="npointFromText">
+					<indexterm significance="normal"><primary><varname>npointFromText</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>npointFromEWKT</varname></primary></indexterm>
+					<para>Input from the Well-Known Text (WKT) or from the Extended Well-Known Text (EWKT) representation</para>
+					<para><varname>npointFromText(text) → npoint</varname></para>
+					<para><varname>npointFromEWKT(text) → npoint</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(npointFromText(text 'Npoint(1,0.5)'));
+-- SRID=5676;NPoint(1,0.5)
+SELECT asEWKT(npointFromEWKT(text 'SRID=5676;Npoint(1,0.5)'));
+-- SRID=5676;NPoint(1,0.5)
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="npointFromBinary">
+					<indexterm significance="normal"><primary><varname>npointFromBinary</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>npointFromEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>npointFromHexEWKB</varname></primary></indexterm>
+					<para>Input from the Well-Known Binary (WKB), from the Extended Well-Known Binary (EWKB), or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
+					<para><varname>npointFromBinary(bytea) → npoint</varname></para>
+					<para><varname>npointFromEWKB(bytea) → npoint</varname></para>
+					<para><varname>npointFromHexEWKB(text) → npoint</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(npointFromEWKB(
+  '\x01412c1600000100000000000000000000000000e03f'));
+-- SRID=5676;NPoint(1,0.5)
+SELECT asEWKT(npointFromHexEWKB(
+  '01412C1600000100000000000000000000000000E03F'));
+-- SRID=5676;NPoint(1,0.5)
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="npoint_constructor_functions">
 			<title>Constructors</title>
 

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -123,10 +123,12 @@ SELECT asEWKT(ARRAY[pose 'Pose(SRID=5676;Point(0 0),1)', 'Pose(SRID=5676;Point(1
 				<listitem xml:id="pose_asBinary">
 					<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
-					<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB), or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
+					<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB), the Hexadecimal Well-Known Binary (HexWKB), or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
 					<para><varname>asBinary(pose,endian text='') → bytea</varname></para>
 					<para><varname>asEWKB(pose,endian text='') → bytea</varname></para>
+					<para><varname>asHexWKB(pose,endian text='') → text</varname></para>
 					<para><varname>asHexEWKB(pose,endian text='') → text</varname></para>
 					<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -134,6 +136,8 @@ SELECT asBinary(pose 'Pose(Point(1 2),1)');
 -- \x0101000000000000f03f0000000000000040000000000000f03f
 SELECT asEWKB(pose 'SRID=7844;Pose(Point(1 2),1)');
 -- \x0141a41e0000000000000000f03f0000000000000040000000000000f03f
+SELECT asHexWKB(pose 'Pose(Point(1 2),1)');
+-- 0101000000000000F03F0000000000000040000000000000F03F
 SELECT asHexEWKB(pose 'SRID=3812;Pose(Point(1 2),1)');
 -- 0141E40E0000000000000000F03F0000000000000040000000000000F03F
 </programlisting>

--- a/mobilitydb/sql/npoint/300_npoint.in.sql
+++ b/mobilitydb/sql/npoint/300_npoint.in.sql
@@ -97,6 +97,8 @@ CREATE TYPE nsegment (
   alignment = double
 );
 
+-- GENERATED-REPRESENTATIONS-BEGIN npoint_base — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.d/representation_families.yaml and re-run.
 /*****************************************************************************
  * Input/output from (E)WKT, (E)WKB and HexEWKB representation
  *****************************************************************************/
@@ -156,10 +158,17 @@ CREATE FUNCTION asEWKB(npoint, endianenconding text DEFAULT '')
   AS 'MODULE_PATHNAME', 'Npoint_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION asHexWKB(npoint, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Npoint_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION asHexEWKB(npoint, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Npoint_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END npoint_base
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/sql/pose/100_pose.in.sql
+++ b/mobilitydb/sql/pose/100_pose.in.sql
@@ -68,6 +68,8 @@ CREATE TYPE pose (
   alignment = double
 );
 
+-- GENERATED-REPRESENTATIONS-BEGIN pose_base — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.d/representation_families.yaml and re-run.
 /*****************************************************************************
  * Input/output from (E)WKT, (E)WKB, and HexEWKB
  *****************************************************************************/
@@ -149,10 +151,17 @@ CREATE FUNCTION asEWKB(pose, endianenconding text DEFAULT '')
   AS 'MODULE_PATHNAME', 'Pose_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION asHexWKB(pose, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Pose_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION asHexEWKB(pose, endianenconding text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Pose_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END pose_base
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/test/npoint/expected/300_npoint.test.out
+++ b/mobilitydb/test/npoint/expected/300_npoint.test.out
@@ -110,6 +110,12 @@ SELECT asEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
  \x01412c1600000100000000000000000000000000e03f
 (1 row)
 
+SELECT asHexWKB(npoint 'SRID=5676;Npoint(1,0.5)');
+                   ashexwkb                   
+----------------------------------------------
+ 01412C1600000100000000000000000000000000E03F
+(1 row)
+
 SELECT asHexEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
                   ashexewkb                   
 ----------------------------------------------
@@ -137,6 +143,12 @@ SELECT npointFromBinary(asBinary(npoint 'SRID=5676;Npoint(1,0.5)'));
 SELECT npointFromEWKB(asEWKB(npoint 'SRID=5676;Npoint(1,0.5)'));
  npointfromewkb 
 ----------------
+ NPoint(1,0.5)
+(1 row)
+
+SELECT npointFromHexEWKB(asHexWKB(npoint 'SRID=5676;Npoint(1,0.5)'));
+ npointfromhexewkb 
+-------------------
  NPoint(1,0.5)
 (1 row)
 

--- a/mobilitydb/test/npoint/queries/300_npoint.test.sql
+++ b/mobilitydb/test/npoint/queries/300_npoint.test.sql
@@ -63,12 +63,14 @@ SELECT asText(npoint 'SRID=5676;Npoint(1,0.5)');
 SELECT asEWKT(npoint 'SRID=5676;Npoint(1,0.5)');
 SELECT asBinary(npoint 'SRID=5676;Npoint(1,0.5)');
 SELECT asEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
+SELECT asHexWKB(npoint 'SRID=5676;Npoint(1,0.5)');
 SELECT asHexEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
 
 SELECT npointFromText(asText(npoint 'SRID=5676;Npoint(1,0.5)'));
 SELECT npointFromEWKT(asEWKT(npoint 'SRID=5676;Npoint(1,0.5)'));
 SELECT npointFromBinary(asBinary(npoint 'SRID=5676;Npoint(1,0.5)'));
 SELECT npointFromEWKB(asEWKB(npoint 'SRID=5676;Npoint(1,0.5)'));
+SELECT npointFromHexEWKB(asHexWKB(npoint 'SRID=5676;Npoint(1,0.5)'));
 SELECT npointFromHexEWKB(asHexEWKB(npoint 'SRID=5676;Npoint(1,0.5)'));
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -382,6 +382,20 @@ SELECT poseFromBinary(asBinary(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)'
  t
 (1 row)
 
+SELECT poseFromHexEWKB(asHexWKB(pose 'SRID=3812;Pose(Point(1 2),1)'))
+     = pose 'SRID=3812;Pose(Point(1 2),1)' AS hexwkb_roundtrip;
+ hexwkb_roundtrip 
+------------------
+ t
+(1 row)
+
+SELECT asHexWKB(pose 'SRID=3812;Pose(Point(1 2),1)')
+     = asHexEWKB(pose 'SRID=3812;Pose(Point(1 2),1)') AS hexwkb_eq_hexewkb;
+ hexwkb_eq_hexewkb 
+-------------------
+ t
+(1 row)
+
 SELECT hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
      = hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
  hash_canonical 

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -187,6 +187,10 @@ SELECT pose(0::float, 0::float, 0::float, 0.5::float, 0.5::float, 0.5::float, 0.
      = pose(0::float, 0::float, 0::float, -0.5::float, -0.5::float, -0.5::float, -0.5::float, 0) AS ctor_canonical;
 SELECT poseFromBinary(asBinary(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)'))
      = pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' AS wkb_canonical;
+SELECT poseFromHexEWKB(asHexWKB(pose 'SRID=3812;Pose(Point(1 2),1)'))
+     = pose 'SRID=3812;Pose(Point(1 2),1)' AS hexwkb_roundtrip;
+SELECT asHexWKB(pose 'SRID=3812;Pose(Point(1 2),1)')
+     = asHexEWKB(pose 'SRID=3812;Pose(Point(1 2),1)') AS hexwkb_eq_hexewkb;
 SELECT hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
      = hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
 SELECT pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' ~= pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)' AS approx_canonical;

--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -63,7 +63,6 @@ mobilitydb/sql/json/458_tjsonb_compops.in.sql
 mobilitydb/sql/json/460_tjsonb_topops.in.sql
 mobilitydb/sql/json/462_tjsonb_posops.in.sql
 mobilitydb/sql/json/466_tjsonb_indexes.in.sql
-mobilitydb/sql/npoint/300_npoint.in.sql
 mobilitydb/sql/npoint/304_tnpoint_compops.in.sql
 mobilitydb/sql/npoint/306_tnpoint_spatialfuncs.in.sql
 mobilitydb/sql/npoint/307_tnpoint_boxops.in.sql
@@ -89,7 +88,6 @@ mobilitydb/sql/pointcloud/443_tpcpoint_spatialrels.in.sql
 mobilitydb/sql/pointcloud/444_tpcpoint_tempspatialrels.in.sql
 mobilitydb/sql/pointcloud/445_tpcpoint_analytics.in.sql
 mobilitydb/sql/pointcloud/447_tpcpoint_distance.in.sql
-mobilitydb/sql/pose/100_pose.in.sql
 mobilitydb/sql/pose/104_tpose_compops.in.sql
 mobilitydb/sql/pose/105_tpose_spatialfuncs.in.sql
 mobilitydb/sql/pose/107_tpose_boxops.in.sql

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -403,3 +403,82 @@ representation_families:
     - - lit: "-- asHexEWKB: extended hex-WKB (WKB_EXTENDED flag, includes SRID) \u2014\n-- mirrors asEWKB() and is consistent with MobilityDuck asHexEWKB."
       - asHexEWKB
   - lit: /*****************************************************************************/
+- family: npoint_base
+  file: mobilitydb/sql/npoint/300_npoint.in.sql
+  reference: true
+  begin: "\n * Input/output from (E)WKT, (E)WKB and HexEWKB representation\n"
+  end: "\n * Constructors\n"
+  temps:
+  - temp: npoint
+    maxdd: true
+  syms:
+    FromText: Npoint_from_ewkt
+    FromEWKT: Npoint_from_ewkt
+    FromBinary: Npoint_from_wkb
+    FromEWKB: Npoint_from_wkb
+    FromHexEWKB: Npoint_from_hexwkb
+    asText: Npoint_as_text
+    asEWKT: Npoint_as_ewkt
+    asBinary: Npoint_as_wkb
+    asEWKB: Npoint_as_ewkb
+    asHexWKB: Npoint_as_hexwkb
+    asHexEWKB: Npoint_as_hexwkb
+  arrsyms:
+    asText: Spatialarr_as_text
+    asEWKT: Spatialarr_as_ewkt
+  blocks:
+  - lit: "/*****************************************************************************\n * Input/output from (E)WKT, (E)WKB and HexEWKB representation\n *****************************************************************************/"
+  - ops:
+    - FromText
+    - FromEWKT
+    - FromBinary
+    - FromEWKB
+    - FromHexEWKB
+  - lit: "/*****************************************************************************/"
+  - ops:
+    - asText
+    - asEWKT
+    - asBinary
+    - asEWKB
+    - asHexWKB
+    - asHexEWKB
+- family: pose_base
+  file: mobilitydb/sql/pose/100_pose.in.sql
+  reference: true
+  begin: "\n * Input/output from (E)WKT, (E)WKB, and HexEWKB\n"
+  end: "\n * Constructors\n"
+  temps:
+  - temp: pose
+    maxdd: true
+  syms:
+    FromText: Pose_from_ewkt
+    FromEWKT: Pose_from_ewkt
+    FromBinary: Pose_from_wkb
+    FromEWKB: Pose_from_wkb
+    FromHexEWKB: Pose_from_hexwkb
+    asText: Pose_as_text
+    asEWKT: Pose_as_ewkt
+    asBinary: Pose_as_wkb
+    asEWKB: Pose_as_ewkb
+    asHexWKB: Pose_as_hexwkb
+    asHexEWKB: Pose_as_hexwkb
+  arrsyms:
+    asText: Spatialarr_as_text
+    asEWKT: Spatialarr_as_ewkt
+  blocks:
+  - lit: "/*****************************************************************************\n * Input/output from (E)WKT, (E)WKB, and HexEWKB\n *****************************************************************************/"
+  - ops:
+    - FromText
+    - FromEWKT
+    - FromBinary
+    - FromEWKB
+    - FromHexEWKB
+  - lit: "/*****************************************************************************\n * OGC GeoPose JSON I/O — Basic-Quaternion + Basic-YPR conformance\n *****************************************************************************/\n\nCREATE FUNCTION poseFromGeoPose(text)\n  RETURNS pose\n  AS 'MODULE_PATHNAME', 'Pose_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- conformance: 0 = Basic-Quaternion (default), 1 = Basic-YPR\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(pose, conformance int4 DEFAULT 0,\n    maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Pose_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION applyPose(geometry, pose)\n  RETURNS geometry\n  AS 'MODULE_PATHNAME', 'Pose_apply_geo'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
+  - lit: "/*****************************************************************************/"
+  - ops:
+    - asText
+    - asEWKT
+    - asBinary
+    - asEWKB
+    - asHexWKB
+    - asHexEWKB


### PR DESCRIPTION
The base scalar npoint and pose types emit their (E)WKT/(E/Hex)WKB representation surface from the inherited SQL generator's representation_families manifest, which supplies asHexWKB(npoint) and asHexWKB(pose) alongside asBinary, asEWKB and asHexEWKB. Each base type has a single hex writer, so asHexWKB and asHexEWKB coincide byte-for-byte — a network point carries the SRID of its route network and a pose its own — while asBinary omits the SRID. The DocBook chapters in English and Spanish document the new function with real emitted values, and the npoint and pose regression suites round-trip it.