### PR TITLE
Reject the tile dimensions that do not fit a raquet

### DIFF
--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -415,6 +415,23 @@ Raster_tile_value_quadbin(PG_FUNCTION_ARGS)
   float8 nodata = PG_GETARG_FLOAT8(6);
   bool has_nd = PG_GETARG_BOOL(7);
 
+  /* The dimensions reach the tile as an unsigned 16-bit width and height, so
+   * a value outside that range is rejected here instead of wrapping to a
+   * different tile than the one asked for */
+  if (width <= 0 || height <= 0)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The width and height of a raquet tile must be positive");
+    PG_RETURN_NULL();
+  }
+  if (width > UINT16_MAX || height > UINT16_MAX)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The width and height of a raquet tile must be at most %d: %d x %d",
+      UINT16_MAX, width, height);
+    PG_RETURN_NULL();
+  }
+
   const uint8_t *pixels = (const uint8_t *) VARDATA_ANY(pxbytea);
   size_t pixels_size = (size_t) VARSIZE_ANY_EXHDR(pxbytea);
   MeosPixType pixtype = text_to_pixtype(pixtype_t);

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -226,6 +226,18 @@ SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 10.0)@2024-01-01
   5193776270265024512::bigint, -- quadbin_tile_to_cell(1,0,1)
   'UINT8', 0.0, false);
 ERROR:  The pixel array has 2 bytes but 4 are required for a 2 x 2 tile
+SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 10.0)@2024-01-01}',
+  '\x01020304'::bytea, 65538::integer, 2::integer,
+  5193776270265024512::bigint, 'UINT8', 0.0, false);
+ERROR:  The width and height of a raquet tile must be at most 65535: 65538 x 2
+SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 10.0)@2024-01-01}',
+  '\x01020304'::bytea, 2::integer, -1::integer,
+  5193776270265024512::bigint, 'UINT8', 0.0, false);
+ERROR:  The width and height of a raquet tile must be positive
+SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 10.0)@2024-01-01}',
+  '\x01020304'::bytea, 0::integer, 2::integer,
+  5193776270265024512::bigint, 'UINT8', 0.0, false);
+ERROR:  The width and height of a raquet tile must be positive
 WITH t(traj) AS (
   SELECT tgeompoint 'SRID=4326;{Point(45.0 75.0)@2024-01-01, Point(135.0 75.0)@2024-01-02, Point(45.0 10.0)@2024-01-03, Point(-45.0 75.0)@2024-01-04}' )
 SELECT rasterTileValue(traj,

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -266,6 +266,20 @@ SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 10.0)@2024-01-01
   5193776270265024512::bigint, -- quadbin_tile_to_cell(1,0,1)
   'UINT8', 0.0, false);
 
+-- The dimensions reach the tile as an unsigned 16-bit width and height. A
+-- value outside that range raises an error rather than wrapping to a tile of
+-- another size: 65538 would otherwise sample a 2 pixel wide tile, and -1 a
+-- 65535 pixel wide one.
+SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 10.0)@2024-01-01}',
+  '\x01020304'::bytea, 65538::integer, 2::integer,
+  5193776270265024512::bigint, 'UINT8', 0.0, false);
+SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 10.0)@2024-01-01}',
+  '\x01020304'::bytea, 2::integer, -1::integer,
+  5193776270265024512::bigint, 'UINT8', 0.0, false);
+SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 10.0)@2024-01-01}',
+  '\x01020304'::bytea, 0::integer, 2::integer,
+  5193776270265024512::bigint, 'UINT8', 0.0, false);
+
 -------------------------------------------------------------------------------
 -- raquet type: construction, WKB round-trip, and typed sampling
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The `width` and `height` of `rasterTileValueQuadbin` are declared as integers and reach the tile as an unsigned 16-bit width and height, so a value outside that range wraps: a width of 65538 samples a tile 2 pixels wide, and one of -1 a tile 65535 pixels wide.

The pixel array is measured against the wrapped dimensions, so the call answers from a tile of a size nobody asked for instead of reporting the argument.

Both cases are rejected where the narrowing happens, as `raquet_make` rejects the same two for the same reason:

```
ERROR:  The width and height of a raquet tile must be at most 65535: 65538 x 2
ERROR:  The width and height of a raquet tile must be positive
```

The expected output is harvested from a run and adds three rows for those cases.
