### PR TITLE
Reject the tile dimensions in the function every binding calls

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -173,7 +173,7 @@ extern int araster_value_gdal(const Temporal *traj, const char *path, int band,
   const Span *vspan);
 
 extern Temporal *raster_tile_value_quadbin(const Temporal *traj,
-  const uint8_t *pixels, size_t pixels_size, uint16_t width, uint16_t height,
+  const uint8_t *pixels, size_t pixels_size, int32 width, int32 height,
   uint64 quadbin, MeosPixType pixtype, double nodata, bool has_nodata);
 
 extern Temporal *raster_tile_value(const Temporal *traj, const Raquet *rq);

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -332,11 +332,28 @@ read_pixel(const uint8_t *pixels, int col, int row, int width,
  */
 Temporal *
 raster_tile_value_quadbin(const Temporal *traj, const uint8_t *pixels,
-  size_t pixels_size, uint16_t width, uint16_t height, uint64 quadbin,
+  size_t pixels_size, int32 width, int32 height, uint64 quadbin,
   MeosPixType pixtype, double nodata, bool has_nodata)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(pixels, NULL);
+  /* The dimensions are taken in the type the SQL surface uses and validated
+   * before the narrowing to the tile's uint16 fields, so that a value outside
+   * that range is rejected here instead of wrapping to a different tile than
+   * the one asked for */
+  if (width <= 0 || height <= 0)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The width and height of a raquet tile must be positive");
+    return NULL;
+  }
+  if (width > UINT16_MAX || height > UINT16_MAX)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The width and height of a raquet tile must be at most %d: %d x %d",
+      UINT16_MAX, width, height);
+    return NULL;
+  }
   size_t need = (size_t) width * height * raquet_pixtype_size(pixtype);
   if (pixels_size < need)
   {

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -56,6 +56,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <meos.h>
+#include <meos_geo.h>
 #include <meos_raster.h>
 
 /* A 3x3 raster with a single 32BF band */
@@ -161,6 +162,29 @@ int main(void)
     bad_hex ? "non-NULL" : "NULL", meos_errno());
   assert(bad_hex == NULL);
   assert(meos_errno() != 0);
+
+  /* The tile dimensions are taken in the type the SQL surface uses and the
+   * range is rejected by the MEOS function, so a caller outside PostgreSQL
+   * gets the same answer as a PostgreSQL one. Passing a value that does not
+   * fit the tile's unsigned 16-bit fields would otherwise sample a tile of a
+   * different size: 65538 a two pixel wide one, -1 a 65535 pixel wide one */
+  Temporal *traj = tgeompoint_in("SRID=4326;{Point(45.0 10.0)@2024-01-01}");
+  assert(traj != NULL);
+  const uint8_t tile_pixels[4] = {1, 2, 3, 4};
+  const int32 bad_dims[][2] = {{65538, 2}, {2, -1}, {0, 2}, {2, 65536}};
+  for (size_t i = 0; i < sizeof(bad_dims) / sizeof(bad_dims[0]); i++)
+  {
+    meos_errno_reset();
+    Temporal *tile = raster_tile_value_quadbin(traj, tile_pixels,
+      sizeof(tile_pixels), bad_dims[i][0], bad_dims[i][1],
+      5193776270265024512ULL, MEOS_PT_UINT8, 0.0, false);
+    printf("raster_tile_value_quadbin(%d x %d): %s, errno %d\n",
+      bad_dims[i][0], bad_dims[i][1], tile ? "non-NULL" : "NULL",
+      meos_errno());
+    assert(tile == NULL);
+    assert(meos_errno() != 0);
+  }
+  free(traj);
 
   meos_finalize();
   printf("raster_test: all assertions passed\n");

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -415,30 +415,12 @@ Raster_tile_value_quadbin(PG_FUNCTION_ARGS)
   float8 nodata = PG_GETARG_FLOAT8(6);
   bool has_nd = PG_GETARG_BOOL(7);
 
-  /* The dimensions reach the tile as an unsigned 16-bit width and height, so
-   * a value outside that range is rejected here instead of wrapping to a
-   * different tile than the one asked for */
-  if (width <= 0 || height <= 0)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "The width and height of a raquet tile must be positive");
-    PG_RETURN_NULL();
-  }
-  if (width > UINT16_MAX || height > UINT16_MAX)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "The width and height of a raquet tile must be at most %d: %d x %d",
-      UINT16_MAX, width, height);
-    PG_RETURN_NULL();
-  }
-
   const uint8_t *pixels = (const uint8_t *) VARDATA_ANY(pxbytea);
   size_t pixels_size = (size_t) VARSIZE_ANY_EXHDR(pxbytea);
   MeosPixType pixtype = text_to_pixtype(pixtype_t);
 
   Temporal *result = raster_tile_value_quadbin(traj, pixels, pixels_size,
-    (uint16_t) width, (uint16_t) height, (uint64) quadbin,
-    pixtype, nodata, has_nd);
+    width, height, (uint64) quadbin, pixtype, nodata, has_nd);
 
   PG_FREE_IF_COPY(traj, 0);
   if (result == NULL)


### PR DESCRIPTION
`raster_tile_value_quadbin` takes the tile dimensions as `uint16_t`, and the
range is tested in the PostgreSQL wrapper, which narrows `int32` to that type
with a cast. The guard therefore covers the SQL surface and no other caller: a
binding passing 65538 samples a two pixel wide tile, and one passing -1 a 65535
pixel wide one, in both cases silently.

The function takes the dimensions in the type the SQL surface uses, `int32`, and
tests the range itself before the narrowing to the tile's `uint16` fields:

```c
if (width <= 0 || height <= 0) ...
if (width > UINT16_MAX || height > UINT16_MAX) ...
```

That is the shape, the comment and the error text the sibling `raquet_make`
already carries for the same defect, so the two agree. The wrapper passes the
dimensions through and does wiring only.

`int32` widens `uint16_t`, so a caller already passing a small positive value
keeps compiling and gains the rejection.

## Tests

The error text is the one the wrapper raises, so the PostgreSQL cases keep their
expected output.

`meos/test/raster_test.c` covers the rejection from a MEOS caller, with no
PostgreSQL involved, which is where the guard is absent: `65538 x 2`, `2 x -1`,
`0 x 2`, and `2 x 65536` for the bound itself. Each returns `NULL` and sets
`MEOS_ERR_INVALID_ARG_VALUE`.
