### PR TITLE
Meet the point a temporal point stands on while it does not move

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -553,6 +553,9 @@ point_in_polygon(double x, double y, Edge **edges, int nedges)
 /**
  * @brief Compute the intersection intervals of a trajectory segment with an
  * array of point edges
+ * @details A segment that does not move carries no direction to solve the
+ * parameter along, and meets a point edge exactly where it stands, for the
+ * whole of its extent
  */
 static void
 intervals_from_points(const POINT2D *a, const POINT2D *b, Edge **edges,
@@ -570,9 +573,26 @@ intervals_from_points(const POINT2D *a, const POINT2D *b, Edge **edges,
     ((fabs(dx) > FP_TOLERANCE) ? 1.0 / dx : 0.0) :
     ((fabs(dy) > FP_TOLERANCE) ? 1.0 / dy : 0.0);
 
+  /* The segment stands still */
   if (inv == 0.0)
+  {
+    for (int i = 0; i < nedges; i++)
+    {
+      const Edge *e = edges[i];
+      if (e->etype != EDGE_POINT)
+        continue;
+      if (fabs(a->x - e->x1) < FP_TOLERANCE &&
+          fabs(a->y - e->y1) < FP_TOLERANCE)
+      {
+        Span in;
+        span_set(Float8GetDatum(0.0), Float8GetDatum(1.0), true, true,
+          T_FLOAT8, T_FLOATSPAN, &in);
+        meos_array_add(intervals, &in);
+      }
+    }
     return;
-  
+  }
+
   /* Iterate through the points */
   for (int i = 0; i < nedges; i++)
   {

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
@@ -439,6 +439,42 @@ SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2000-01-01, P
  t
 (1 row)
 
+SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02, Point(1 1)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(geometry 'MultiPoint(1 1,2 2)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eDisjoint(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eIntersects(geometry 'Point(2 2)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');
+ eintersects 
+-------------
+ f
+(1 row)
+
+SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02, Point(3 3)@2000-01-03]');
+ eintersects 
+-------------
+ t
+(1 row)
+
 SELECT eIntersects(geometry 'Point empty', tgeompoint 'Point(1 1)@2000-01-01');
  eintersects 
 -------------

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
@@ -420,6 +420,24 @@ SELECT tIntersects(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, P
  {[t@Sat Jan 01 00:00:00 2000 PST], (f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST], [f@Tue Jan 04 00:00:00 2000 PST, f@Wed Jan 05 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tIntersects(tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]', geometry 'Point(1 1)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02, Point(3 3)@2000-01-03]', geometry 'Point(1 1)');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]', geometry 'Point(2 2)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT tIntersects(tgeompoint '[Point(0 1)@2000-01-01, Point(2 1)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
                                             tintersects                                             
 ----------------------------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tpoint_spatialrels.test.sql
@@ -159,6 +159,14 @@ SELECT eIntersects(geometry 'Point(1 1)', tgeompoint 'Point(1 1)@2000-01-01');
 SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');
 SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]');
 SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}');
+-- A temporal point that stands still meets the point it stands on, and no other
+SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');
+SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02, Point(1 1)@2000-01-03]');
+SELECT eIntersects(geometry 'MultiPoint(1 1,2 2)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');
+SELECT eDisjoint(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');
+SELECT eIntersects(geometry 'Point(2 2)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');
+-- Standing still for one segment and moving on the next
+SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02, Point(3 3)@2000-01-03]');
 -- Empty
 SELECT eIntersects(geometry 'Point empty', tgeompoint 'Point(1 1)@2000-01-01');
 SELECT eIntersects(geometry 'Point empty', tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}');

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
@@ -146,6 +146,12 @@ SELECT tIntersects(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Po
 SELECT tIntersects(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', geometry 'Point(1 1)');
 SELECT tIntersects(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03], [Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}', geometry 'Point(1 1)');
 
+-- A temporal point that stands still meets the point it stands on for the
+-- whole of the time it stands there
+SELECT tIntersects(tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]', geometry 'Point(1 1)');
+SELECT tIntersects(tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02, Point(3 3)@2000-01-03]', geometry 'Point(1 1)');
+SELECT tIntersects(tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]', geometry 'Point(2 2)');
+
 SELECT tIntersects(tgeompoint '[Point(0 1)@2000-01-01, Point(2 1)@2000-01-04]', geometry 'Linestring(1 0,1 1,2 1,2 0)');
 SELECT tIntersects(tgeompoint '[Point(0 0)@2000-01-01, Point(1 1)@2000-01-04)', geometry 'Linestring(1 1,2 1)');
 SELECT tIntersects(tgeompoint '[Point(1 1)@2000-01-01, Point(0 0)@2000-01-04)', geometry 'Linestring(0 0,1 1)');


### PR DESCRIPTION
The clip engine solves a trajectory segment against a point edge along the segment's direction, dividing by the longer of its two components. A segment whose two instants hold the same point has neither component, so the division is guarded and the function returns with no interval at all — which reads as the segment meeting no point of the geometry.

A temporal point that stands still therefore misses the very point it stands on:

```sql
SELECT eIntersects(geometry 'Point(1 1)',
  tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');   -- t
SELECT eDisjoint(geometry 'Point(1 1)',
  tgeompoint '[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02]');   -- f
```

Before this, both answer false, which no non-empty temporal value can satisfy at once. Every other reading of the same value — an instant, a discrete sequence, step interpolation — answers true, since only the linear path builds a segment, and a polygon or a line containing that position answers true too, through the paths that need no direction. `tIntersects` reads the same intervals and carries the same gap.

A segment that does not move meets a point edge exactly where it stands, and for the whole of its extent, so the guarded branch reports the point edges carrying its position over the whole parameter range instead of reporting nothing.

Over five predicates, thirteen trajectory shapes and nineteen geometry types, the answers of the geo and the circular-buffer engines differ on four of the cases before and none after. The tables hold no standing segment against a point geometry, which is what leaves this uncovered, so their counts do not move; the added cases pair a standing value with the point it stands on, a point it does not, a multipoint carrying its position, and a value that stands still for one segment and then moves away.