### PR TITLE
Free the GeoJSON string in the temporal MF-JSON output

### DIFF
--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -889,6 +889,7 @@ tinstant_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst,
     const GSERIALIZED *gs = trgeoinst_geom_p(inst);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
     stringbuffer_append_len(sb, "\"values\":[", 10);
     pose_as_json_sb(sb, DatumGetPoseP(tinstant_value_p(inst)), precision);
   }
@@ -942,6 +943,7 @@ tsequence_as_mfjson_sb(stringbuffer_t *sb, const TSequence *seq,
     const GSERIALIZED *gs = trgeoseq_geom_p(seq);
     char *str = geo_as_geojson(gs, 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,\"values\":[", str);
+    pfree(str);
   }
 #endif /* RGEO */
   else
@@ -1048,6 +1050,7 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
     stringbuffer_append_len(sb, "\"geometry\":", 11);
     char *str = geo_as_geojson(trgeoseqset_geom_p(ss), 0, precision, NULL);
     stringbuffer_aprintf(sb, "%s,", str);
+    pfree(str);
   }
 #endif /* RGEO */
 
@@ -1078,8 +1081,8 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
         const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value_p(inst));
         /* Do not repeat the crs for the composing geometries */
         char *str = geo_as_geojson(gs, 0, precision, NULL);
-        stringbuffer_aprintf(sb, "%s", str);      
-        // pfree(str);
+        stringbuffer_aprintf(sb, "%s", str);
+        pfree(str);
       }
 #if CBUFFER
       else if (inst->temptype == T_TCBUFFER)


### PR DESCRIPTION
The MF-JSON writers for temporal geometry, geography and rigid geometry values pass the string returned by geo_as_geojson to the buffer without releasing it. tsequenceset_as_mfjson_sb leaks it for every composing tgeometry or tgeography instant, and the three rigid-geometry paths in tinstant_as_mfjson_sb, tsequence_as_mfjson_sb and tsequenceset_as_mfjson_sb leak the reference-geometry string once per value. Each site now frees the string after appending it, matching the tinstant and tsequence geometry paths that already do. The emitted MF-JSON is unchanged.