### PR TITLE
Add the WKB representation surface to the circular buffer base type

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -46,6 +46,88 @@ SELECT cbuffer 'Cbuffer(Point(1 1), -2.0)';
 </programlisting>
 		<para>A continuación damos las funciones y operadores para el tipo de búfer circular.</para>
 
+		<sect2 xml:id="cbuffer_inout">
+			<title>Entrada y salida</title>
+
+			<itemizedlist>
+				<listitem xml:id="cbuffer_asText">
+					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
+					<para>Devuelve la representación de texto conocido (Well-Known Text o WKT) o la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
+					<para><varname>asText({cbuffer,cbuffer[]}) → {text,text[]}</varname></para>
+					<para><varname>asEWKT({cbuffer,cbuffer[]}) → {text,text[]}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(cbuffer 'Cbuffer(Point(1 1), 0.5)');
+-- Cbuffer(POINT(1 1),0.5)
+SELECT asText(ARRAY[cbuffer 'Cbuffer(Point(1 1),0.2)', 'Cbuffer(Point(1 1),0.5)']);
+-- {"Cbuffer(POINT(1 1),0.2)","Cbuffer(POINT(1 1),0.5)"}
+SELECT asEWKT(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- SRID=5676;Cbuffer(POINT(1 1),0.5)
+SELECT asEWKT(ARRAY[cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.2)', 'Cbuffer(SRID=5676;Point(1 1),0.5)']);
+-- {"SRID=5676;Cbuffer(POINT(1 1),0.2)","SRID=5676;Cbuffer(POINT(1 1),0.5)"}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="cbuffer_asBinary">
+					<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
+					<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
+					<para><varname>asBinary(cbuffer,endian text='') → bytea</varname></para>
+					<para><varname>asEWKB(cbuffer,endian text='') → bytea</varname></para>
+					<para><varname>asHexWKB(cbuffer,endian text='') → text</varname></para>
+					<para><varname>asHexEWKB(cbuffer,endian text='') → text</varname></para>
+					<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina. Un búfer circular toma su SRID de su punto subyacente, por lo que ambas formas hexadecimales lo incluyen y coinciden, mientras que la forma binaria simple <varname>asBinary</varname> lo omite.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asBinary(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- \x0100000000000000f03f000000000000f03f000000000000e03f
+SELECT asEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- \x01402c160000000000000000f03f000000000000f03f000000000000e03f
+SELECT asHexWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- 01402C160000000000000000F03F000000000000F03F000000000000E03F
+SELECT asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- 01402C160000000000000000F03F000000000000F03F000000000000E03F
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="cbufferFromText">
+					<indexterm significance="normal"><primary><varname>cbufferFromText</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>cbufferFromEWKT</varname></primary></indexterm>
+					<para>Entrada desde la representación de texto conocido (Well-Known Text o WKT) o desde la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
+					<para><varname>cbufferFromText(text) → cbuffer</varname></para>
+					<para><varname>cbufferFromEWKT(text) → cbuffer</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(cbufferFromText(text 'Cbuffer(Point(1 1),0.5)'));
+-- Cbuffer(POINT(1 1),0.5)
+SELECT asEWKT(cbufferFromEWKT(text 'SRID=5676;Cbuffer(Point(1 1),0.5)'));
+-- SRID=5676;Cbuffer(POINT(1 1),0.5)
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="cbufferFromBinary">
+					<indexterm significance="normal"><primary><varname>cbufferFromBinary</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>cbufferFromEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>cbufferFromHexEWKB</varname></primary></indexterm>
+					<para>Entrada desde la representación binaria conocida (Well-Known Binary o WKB), desde la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o desde la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
+					<para><varname>cbufferFromBinary(bytea) → cbuffer</varname></para>
+					<para><varname>cbufferFromEWKB(bytea) → cbuffer</varname></para>
+					<para><varname>cbufferFromHexEWKB(text) → cbuffer</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(cbufferFromBinary(
+  '\x0100000000000000f03f000000000000f03f000000000000e03f'));
+-- Cbuffer(POINT(1 1),0.5)
+SELECT asEWKT(cbufferFromEWKB(
+  '\x01402c160000000000000000f03f000000000000f03f000000000000e03f'));
+-- SRID=5676;Cbuffer(POINT(1 1),0.5)
+SELECT asEWKT(cbufferFromHexEWKB(
+  '01402C160000000000000000F03F000000000000F03F000000000000E03F'));
+-- SRID=5676;Cbuffer(POINT(1 1),0.5)
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="cbuffer_constructors">
 			<title>Constructores</title>
 			<itemizedlist>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -46,6 +46,88 @@ SELECT cbuffer 'Cbuffer(Point(1 1), -2.0)';
 </programlisting>
 		<para>We give next the functions and operators for the circular buffer type.</para>
 
+		<sect2 xml:id="cbuffer_inout">
+			<title>Input and Output</title>
+
+			<itemizedlist>
+				<listitem xml:id="cbuffer_asText">
+					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
+					<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
+					<para><varname>asText({cbuffer,cbuffer[]}) → {text,text[]}</varname></para>
+					<para><varname>asEWKT({cbuffer,cbuffer[]}) → {text,text[]}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(cbuffer 'Cbuffer(Point(1 1), 0.5)');
+-- Cbuffer(POINT(1 1),0.5)
+SELECT asText(ARRAY[cbuffer 'Cbuffer(Point(1 1),0.2)', 'Cbuffer(Point(1 1),0.5)']);
+-- {"Cbuffer(POINT(1 1),0.2)","Cbuffer(POINT(1 1),0.5)"}
+SELECT asEWKT(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- SRID=5676;Cbuffer(POINT(1 1),0.5)
+SELECT asEWKT(ARRAY[cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.2)', 'Cbuffer(SRID=5676;Point(1 1),0.5)']);
+-- {"SRID=5676;Cbuffer(POINT(1 1),0.2)","SRID=5676;Cbuffer(POINT(1 1),0.5)"}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="cbuffer_asBinary">
+					<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
+					<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB), the Hexadecimal Well-Known Binary (HexWKB), or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
+					<para><varname>asBinary(cbuffer,endian text='') → bytea</varname></para>
+					<para><varname>asEWKB(cbuffer,endian text='') → bytea</varname></para>
+					<para><varname>asHexWKB(cbuffer,endian text='') → text</varname></para>
+					<para><varname>asHexEWKB(cbuffer,endian text='') → text</varname></para>
+					<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used. A circular buffer takes its SRID from its underlying point, so both hexadecimal forms embed it and coincide, while the plain <varname>asBinary</varname> form omits it.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asBinary(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- \x0100000000000000f03f000000000000f03f000000000000e03f
+SELECT asEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- \x01402c160000000000000000f03f000000000000f03f000000000000e03f
+SELECT asHexWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- 01402C160000000000000000F03F000000000000F03F000000000000E03F
+SELECT asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+-- 01402C160000000000000000F03F000000000000F03F000000000000E03F
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="cbufferFromText">
+					<indexterm significance="normal"><primary><varname>cbufferFromText</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>cbufferFromEWKT</varname></primary></indexterm>
+					<para>Input from the Well-Known Text (WKT) or from the Extended Well-Known Text (EWKT) representation</para>
+					<para><varname>cbufferFromText(text) → cbuffer</varname></para>
+					<para><varname>cbufferFromEWKT(text) → cbuffer</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(cbufferFromText(text 'Cbuffer(Point(1 1),0.5)'));
+-- Cbuffer(POINT(1 1),0.5)
+SELECT asEWKT(cbufferFromEWKT(text 'SRID=5676;Cbuffer(Point(1 1),0.5)'));
+-- SRID=5676;Cbuffer(POINT(1 1),0.5)
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="cbufferFromBinary">
+					<indexterm significance="normal"><primary><varname>cbufferFromBinary</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>cbufferFromEWKB</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>cbufferFromHexEWKB</varname></primary></indexterm>
+					<para>Input from the Well-Known Binary (WKB), from the Extended Well-Known Binary (EWKB), or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
+					<para><varname>cbufferFromBinary(bytea) → cbuffer</varname></para>
+					<para><varname>cbufferFromEWKB(bytea) → cbuffer</varname></para>
+					<para><varname>cbufferFromHexEWKB(text) → cbuffer</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(cbufferFromBinary(
+  '\x0100000000000000f03f000000000000f03f000000000000e03f'));
+-- Cbuffer(POINT(1 1),0.5)
+SELECT asEWKT(cbufferFromEWKB(
+  '\x01402c160000000000000000f03f000000000000f03f000000000000e03f'));
+-- SRID=5676;Cbuffer(POINT(1 1),0.5)
+SELECT asEWKT(cbufferFromHexEWKB(
+  '01402C160000000000000000F03F000000000000F03F000000000000E03F'));
+-- SRID=5676;Cbuffer(POINT(1 1),0.5)
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="cbuffer_constructors">
 			<title>Constructors</title>
 			<itemizedlist>

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -2005,8 +2005,11 @@ cbuffer_to_wkb_buf(const Cbuffer *cb, uint8_t *buf, uint8_t variant,
   {
     /* Write the endian flag (byte) */
     buf = endian_to_wkb_buf(buf, variant);
-    /* Write the SRID flag */
-    uint8_t wkb_flags = (uint8_t) MEOS_WKB_SRIDFLAG;
+    /* Write the SRID flag, set only when the SRID will follow (matching the
+     * npoint/pose/h3index readers, which trust the flag bit to decide
+     * whether to consume the SRID bytes) */
+    uint8_t wkb_flags = spatial_wkb_needs_srid(cb->srid, variant) ?
+      (uint8_t) MEOS_WKB_SRIDFLAG : 0;
     buf = bytes_to_wkb_buf(&wkb_flags, MEOS_WKB_BYTE_SIZE, buf, variant);
     /* Write the SRID */
     if (spatial_wkb_needs_srid(cb->srid, variant))
@@ -2026,8 +2029,7 @@ cbuffer_to_wkb_buf(const Cbuffer *cb, uint8_t *buf, uint8_t variant,
  * representation
  * @details endian flag, SRID flag, optional SRID (WGS84, extended variant
  * only), then the cell id (int8). The SRID flag bit is set only when the SRID
- * is actually written — matching the npoint/pose readers (and unlike the
- * unconditional cbuffer flag).
+ * is actually written — matching the npoint/pose/cbuffer readers.
  */
 static uint8_t *
 h3index_to_wkb_buf(Datum value, uint8_t *buf, uint8_t variant)

--- a/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
@@ -70,7 +70,38 @@ CREATE TYPE cbuffer (
   alignment = double
 );
 
--- Input/output in WKT, WKB and HexWKB representation
+-- GENERATED-REPRESENTATIONS-BEGIN cbuffer_base — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.d/representation_families.yaml and re-run.
+/******************************************************************************
+ * Input/output in WKT, WKB and HexWKB representation
+ ******************************************************************************/
+
+CREATE FUNCTION cbufferFromText(text)
+  RETURNS cbuffer
+  AS 'MODULE_PATHNAME', 'Cbuffer_from_ewkt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cbufferFromEWKT(text)
+  RETURNS cbuffer
+  AS 'MODULE_PATHNAME', 'Cbuffer_from_ewkt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cbufferFromBinary(bytea)
+  RETURNS cbuffer
+  AS 'MODULE_PATHNAME', 'Cbuffer_from_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cbufferFromEWKB(bytea)
+  RETURNS cbuffer
+  AS 'MODULE_PATHNAME', 'Cbuffer_from_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cbufferFromHexEWKB(text)
+  RETURNS cbuffer
+  AS 'MODULE_PATHNAME', 'Cbuffer_from_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************/
 
 CREATE FUNCTION asText(cbuffer, maxdecimaldigits int4 DEFAULT 15)
   RETURNS text
@@ -89,6 +120,28 @@ CREATE FUNCTION asEWKT(cbuffer[], maxdecimaldigits int4 DEFAULT 15)
   RETURNS text[]
   AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asBinary(cbuffer, endianenconding text DEFAULT '')
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Cbuffer_as_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asEWKB(cbuffer, endianenconding text DEFAULT '')
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Cbuffer_as_ewkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexWKB(cbuffer, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Cbuffer_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexEWKB(cbuffer, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Cbuffer_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END cbuffer_base
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -186,6 +186,30 @@ Cbuffer_as_ewkt(PG_FUNCTION_ARGS)
 
 /*****************************************************************************/
 
+PGDLLEXPORT Datum Cbuffer_from_ewkt(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Cbuffer_from_ewkt);
+/**
+ * @ingroup mobilitydb_cbuffer_base_inout
+ * @brief Return a circular buffer from its Extended Well-Known Text (EWKT)
+ * representation
+ * @note This just does the same thing as the SQL function cbuffer_in, except
+ * it has to handle a 'text' input. First, unwrap the text into a cstring,
+ * then do as cbuffer_in
+ * @sqlfn cbufferFromText(), cbufferFromEWKT()
+ */
+Datum
+Cbuffer_from_ewkt(PG_FUNCTION_ARGS)
+{
+  text *wkt_text = PG_GETARG_TEXT_P(0);
+  char *wkt = text_to_cstring(wkt_text);
+  /* Copy the pointer since it will be advanced during parsing */
+  const char *wkt_ptr = wkt;
+  Cbuffer *result = cbuffer_parse(&wkt_ptr, true);
+  pfree(wkt);
+  PG_FREE_IF_COPY(wkt_text, 0);
+  PG_RETURN_CBUFFER_P(result);
+}
+
 PGDLLEXPORT Datum Cbuffer_from_wkb(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Cbuffer_from_wkb);
 /**
@@ -239,6 +263,23 @@ Cbuffer_as_wkb(PG_FUNCTION_ARGS)
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
   PG_RETURN_BYTEA_P(Datum_as_wkb(fcinfo, PointerGetDatum(cb), T_CBUFFER,
     false));
+}
+
+PGDLLEXPORT Datum Cbuffer_as_ewkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Cbuffer_as_ewkb);
+/**
+ * @ingroup mobilitydb_cbuffer_base_inout
+ * @brief Return the Extended Well-Known Binary (EWKB) representation of a
+ * circular buffer
+ * @note It is the WKB representation prefixed with the SRID
+ * @sqlfn asEWKB()
+ */
+Datum
+Cbuffer_as_ewkb(PG_FUNCTION_ARGS)
+{
+  Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
+  PG_RETURN_BYTEA_P(Datum_as_wkb(fcinfo, PointerGetDatum(cb), T_CBUFFER,
+    true));
 }
 
 PGDLLEXPORT Datum Cbuffer_as_hexwkb(PG_FUNCTION_ARGS);

--- a/mobilitydb/test/cbuffer/expected/200_cbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/200_cbuffer.test.out
@@ -40,6 +40,79 @@ SELECT cbuffer 'Cbuffer(Point(1 1),0.5)xxx';
 ERROR:  Could not parse cbuffer value: Extraneous characters at the end
 LINE 1: SELECT cbuffer 'Cbuffer(Point(1 1),0.5)xxx';
                        ^
+SELECT asEWKT(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+              asewkt               
+-----------------------------------
+ SRID=5676;Cbuffer(POINT(1 1),0.5)
+(1 row)
+
+SELECT asBinary(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+                        asbinary                        
+--------------------------------------------------------
+ \x0100000000000000f03f000000000000f03f000000000000e03f
+(1 row)
+
+SELECT asEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+                             asewkb                             
+----------------------------------------------------------------
+ \x01402c160000000000000000f03f000000000000f03f000000000000e03f
+(1 row)
+
+SELECT asHexWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+                           ashexwkb                           
+--------------------------------------------------------------
+ 01402C160000000000000000F03F000000000000F03F000000000000E03F
+(1 row)
+
+SELECT asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+                          ashexewkb                           
+--------------------------------------------------------------
+ 01402C160000000000000000F03F000000000000F03F000000000000E03F
+(1 row)
+
+SELECT asText(cbufferFromText(asText(cbuffer 'Cbuffer(Point(1 1),0.5)')));
+         astext          
+-------------------------
+ Cbuffer(POINT(1 1),0.5)
+(1 row)
+
+SELECT asEWKT(cbufferFromEWKT(asEWKT(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+              asewkt               
+-----------------------------------
+ SRID=5676;Cbuffer(POINT(1 1),0.5)
+(1 row)
+
+SELECT asEWKT(cbufferFromBinary(asBinary(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+         asewkt          
+-------------------------
+ Cbuffer(POINT(1 1),0.5)
+(1 row)
+
+SELECT asEWKT(cbufferFromEWKB(asEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+              asewkt               
+-----------------------------------
+ SRID=5676;Cbuffer(POINT(1 1),0.5)
+(1 row)
+
+SELECT asEWKT(cbufferFromHexEWKB(asHexWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+              asewkt               
+-----------------------------------
+ SRID=5676;Cbuffer(POINT(1 1),0.5)
+(1 row)
+
+SELECT asEWKT(cbufferFromHexEWKB(asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+              asewkt               
+-----------------------------------
+ SRID=5676;Cbuffer(POINT(1 1),0.5)
+(1 row)
+
+SELECT asHexWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')
+     = asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)') AS hexwkb_eq_hexewkb;
+ hexwkb_eq_hexewkb 
+-------------------
+ t
+(1 row)
+
 SELECT asText(cbuffer('Point(1 1)', 0.5));
          astext          
 -------------------------

--- a/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
@@ -43,6 +43,26 @@ SELECT cbuffer 'Cbuffer(Point(1 1),-1.5)';
 SELECT cbuffer 'Cbuffer(Point(1 1),0.5)xxx';
 
 -------------------------------------------------------------------------------
+-- Input/output in WKT, WKB and HexWKB representation
+-------------------------------------------------------------------------------
+
+SELECT asEWKT(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+SELECT asBinary(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+SELECT asEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+SELECT asHexWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+SELECT asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
+
+SELECT asText(cbufferFromText(asText(cbuffer 'Cbuffer(Point(1 1),0.5)')));
+SELECT asEWKT(cbufferFromEWKT(asEWKT(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+SELECT asEWKT(cbufferFromBinary(asBinary(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+SELECT asEWKT(cbufferFromEWKB(asEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+SELECT asEWKT(cbufferFromHexEWKB(asHexWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+SELECT asEWKT(cbufferFromHexEWKB(asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')));
+
+SELECT asHexWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)')
+     = asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)') AS hexwkb_eq_hexewkb;
+
+-------------------------------------------------------------------------------
 -- Constructors
 -------------------------------------------------------------------------------
 

--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -5,9 +5,8 @@
 # land unnoticed. The list is a ratchet: it may only shrink. Bring a file
 # under the manifest, then delete its line here.
 #
-# 126 of 185 files remain.
+# 125 of 185 files remain.
 
-mobilitydb/sql/cbuffer/200_cbuffer.in.sql
 mobilitydb/sql/cbuffer/204_tcbuffer_compops.in.sql
 mobilitydb/sql/cbuffer/205_tcbuffer_spatialfuncs.in.sql
 mobilitydb/sql/cbuffer/207_tcbuffer_boxops.in.sql

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -482,3 +482,42 @@ representation_families:
     - asEWKB
     - asHexWKB
     - asHexEWKB
+- family: cbuffer_base
+  file: mobilitydb/sql/cbuffer/200_cbuffer.in.sql
+  reference: true
+  begin: "\n * Input/output in WKT, WKB and HexWKB representation\n"
+  end: "\n * Constructors\n"
+  temps:
+  - temp: cbuffer
+    maxdd: true
+  syms:
+    FromText: Cbuffer_from_ewkt
+    FromEWKT: Cbuffer_from_ewkt
+    FromBinary: Cbuffer_from_wkb
+    FromEWKB: Cbuffer_from_wkb
+    FromHexEWKB: Cbuffer_from_hexwkb
+    asText: Cbuffer_as_text
+    asEWKT: Cbuffer_as_ewkt
+    asBinary: Cbuffer_as_wkb
+    asEWKB: Cbuffer_as_ewkb
+    asHexWKB: Cbuffer_as_hexwkb
+    asHexEWKB: Cbuffer_as_hexwkb
+  arrsyms:
+    asText: Spatialarr_as_text
+    asEWKT: Spatialarr_as_ewkt
+  blocks:
+  - lit: "/******************************************************************************\n * Input/output in WKT, WKB and HexWKB representation\n ******************************************************************************/"
+  - ops:
+    - FromText
+    - FromEWKT
+    - FromBinary
+    - FromEWKB
+    - FromHexEWKB
+  - lit: "/*****************************************************************************/"
+  - ops:
+    - asText
+    - asEWKT
+    - asBinary
+    - asEWKB
+    - asHexWKB
+    - asHexEWKB


### PR DESCRIPTION
The circular buffer base type carries the asBinary, asEWKB, asHexWKB and asHexEWKB accessors and the cbufferFromText, cbufferFromEWKT, cbufferFromBinary, cbufferFromEWKB and cbufferFromHexEWKB constructors, generated from a cbuffer_base family in the inherited SQL representation generator. The circular buffer WKB writer sets the SRID flag bit only when the SRID follows, matching the npoint, pose and h3index readers. Round-trip regression tests and the English and Spanish reference documentation cover the surface.