### PR TITLE
Serialize a Raquet tile through its Well-Known Binary representation

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3915,6 +3915,27 @@
 		</sect2>
 
 		<sect2>
+			<title>Serialización de Raquet</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raquet_asBinary"><varname>asBinary</varname></link>: Devolver la representación Well-Known Binary (WKB) de una tesela Raquet</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_asHexWKB"><varname>asHexWKB</varname></link>: Devolver la representación Well-Known Binary codificada en hexadecimal ASCII (HexWKB) de una tesela Raquet</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link>: Devolver una tesela Raquet a partir de su representación Well-Known Binary (WKB)</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link>: Devolver una tesela Raquet a partir de su representación Well-Known Binary codificada en hexadecimal ASCII (HexWKB)</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
 			<title>Accesores y Comparación de Raquet</title>
 			<itemizedlist>
 				<listitem>

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -211,6 +211,44 @@ GROUP BY t.tripid, t.trip;
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="raquet_serialization">
+		<title>Serialización de Raquet</title>
+
+		<para>Las funciones <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>raquet</varname>, y <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> y <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> lo reconstruyen. Una tesela lleva sus píxeles y su georreferenciación QUADBIN en un único valor, de modo que hace un viaje de ida y vuelta a través de una cadena de bytes portable sin intervención de ninguna extensión espacial, y la forma hexadecimal permite que una columna de teselas haga ese viaje mediante un <varname>COPY</varname> basado en texto. Ambas funciones de salida aceptan un argumento opcional de ordenación de bytes, <varname>NDR</varname> para little-endian o <varname>XDR</varname> para big-endian, cuyo valor predeterminado es la ordenación del servidor.</para>
+
+		<itemizedlist>
+			<listitem xml:id="raquet_asBinary">
+				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
+				<para>Devolver la representación Well-Known Binary (WKB) de una tesela Raquet</para>
+				<para><varname>asBinary(raquet,endianencoding text DEFAULT '') → bytea</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_asHexWKB">
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+				<para>Devolver la representación Well-Known Binary codificada en hexadecimal ASCII (HexWKB) de una tesela Raquet</para>
+				<para><varname>asHexWKB(raquet,endianencoding text DEFAULT '') → text</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquetFromBinary">
+				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
+				<para>Devolver una tesela Raquet a partir de su representación Well-Known Binary (WKB)</para>
+				<para><varname>raquetFromBinary(bytea) → raquet</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquetFromHexWKB">
+				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
+				<para>Devolver una tesela Raquet a partir de su representación Well-Known Binary codificada en hexadecimal ASCII (HexWKB)</para>
+				<para><varname>raquetFromHexWKB(text) → raquet</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
+  5193776270265024512, 'UINT8')))
+  = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8');
+-- true
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="raquet_accessors">
 		<title>Accesores y Comparación de Raquet</title>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3975,6 +3975,27 @@
 		</sect2>
 
 		<sect2>
+			<title>Raquet Serialization</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raquet_asBinary"><varname>asBinary</varname></link>: Return the Well-Known Binary (WKB) representation of a Raquet tile</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquet_asHexWKB"><varname>asHexWKB</varname></link>: Return the ASCII hex-encoded Well-Known Binary (HexWKB) representation of a Raquet tile</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link>: Return a Raquet tile from its Well-Known Binary (WKB) representation</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link>: Return a Raquet tile from its ASCII hex-encoded Well-Known Binary (HexWKB) representation</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
+		<sect2>
 			<title>Raquet Accessors and Comparison</title>
 			<itemizedlist>
 				<listitem>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -209,6 +209,44 @@ GROUP BY t.tripid, t.trip;
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="raquet_serialization">
+		<title>Raquet Serialization</title>
+
+		<para>The functions <varname>asBinary</varname> and <varname>asHexWKB</varname> serialize a <varname>raquet</varname> value, and <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> and <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> reconstruct it. A tile carries its pixels and its QUADBIN georeferencing in one value, so it round-trips through a portable byte string with no spatial extension involved, and the hexadecimal form lets a tile column round-trip through a text-based <varname>COPY</varname>. Both output functions accept an optional endianness argument, <varname>NDR</varname> for little-endian or <varname>XDR</varname> for big-endian, defaulting to the endianness of the server.</para>
+
+		<itemizedlist>
+			<listitem xml:id="raquet_asBinary">
+				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
+				<para>Return the Well-Known Binary (WKB) representation of a Raquet tile</para>
+				<para><varname>asBinary(raquet,endianencoding text DEFAULT '') → bytea</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquet_asHexWKB">
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+				<para>Return the ASCII hex-encoded Well-Known Binary (HexWKB) representation of a Raquet tile</para>
+				<para><varname>asHexWKB(raquet,endianencoding text DEFAULT '') → text</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquetFromBinary">
+				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
+				<para>Return a Raquet tile from its Well-Known Binary (WKB) representation</para>
+				<para><varname>raquetFromBinary(bytea) → raquet</varname></para>
+			</listitem>
+
+			<listitem xml:id="raquetFromHexWKB">
+				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
+				<para>Return a Raquet tile from its ASCII hex-encoded Well-Known Binary (HexWKB) representation</para>
+				<para><varname>raquetFromHexWKB(text) → raquet</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
+  5193776270265024512, 'UINT8')))
+  = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8');
+-- true
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="raquet_accessors">
 		<title>Raquet Accessors and Comparison</title>
 

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -1835,6 +1835,36 @@ bytes_to_wkb_buf(uint8_t *valptr, size_t size, uint8_t *buf, uint8_t variant)
 }
 
 /**
+ * @brief Write into the buffer an opaque byte payload in the Well-Known Binary
+ * (WKB) representation
+ * @details A payload such as a text string or the pixel array of a Raquet tile
+ * is a sequence of bytes, not a number, so it carries no byte order and is
+ * written in the order it is held whatever endianness is requested. Passing it
+ * to #bytes_to_wkb_buf() instead would reverse it as that function reverses a
+ * scalar, and the reader, which copies the payload verbatim, would not put it
+ * back.
+ */
+static uint8_t *
+payload_to_wkb_buf(const uint8_t *valptr, size_t size, uint8_t *buf,
+  uint8_t variant)
+{
+  if (variant & WKB_HEX)
+  {
+    for (size_t i = 0; i < size; i++)
+    {
+      uint8_t b = valptr[i];
+      /* Top four bits to 0-F */
+      buf[2*i] = HEXCHR[b >> 4];
+      /* Bottom four bits to 0-F */
+      buf[2*i + 1] = HEXCHR[b & 0x0F];
+    }
+    return buf + (2 * size);
+  }
+  memcpy(buf, valptr, size);
+  return buf + size;
+}
+
+/**
  * @brief Generic function to write a typed value to WKB buffer with size checking
  */
 static inline uint8_t *
@@ -1959,26 +1989,8 @@ text_to_wkb_buf(const text *txt, uint8_t *buf, uint8_t variant)
   /* Write the size first (this gets proper endian handling) */
   buf = int64_to_wkb_buf(size, buf, variant);
 
-  /* Write the text data - needs special handling to avoid swapping */
-  if (variant & WKB_HEX)
-  {
-    /* Convert to hex without swapping byte order */
-    for (size_t i = 0; i < size; i++)
-    {
-      uint8_t b = str[i];
-      /* Top four bits to 0-F */
-      buf[2*i] = HEXCHR[b >> 4];
-      /* Bottom four bits to 0-F */
-      buf[2*i + 1] = HEXCHR[b & 0x0F];
-    }
-    return buf + (2 * size);
-  }
-  else
-  {
-    /* Binary - direct copy without swapping */
-    memcpy(buf, str, size);
-    return buf + size;
-  }
+  /* Write the text data, which carries no byte order of its own */
+  return payload_to_wkb_buf((const uint8_t *) str, size, buf, variant);
 }
 
 /**
@@ -2248,8 +2260,8 @@ raquet_to_wkb_buf(const Raquet *rq, uint8_t *buf, uint8_t variant,
   buf = bytes_to_wkb_buf(&has_nodata, MEOS_WKB_BYTE_SIZE, buf, variant);
   buf = double_to_wkb_buf(rq->nodata, buf, variant);
   /* Write the row-major packed pixel bytes */
-  buf = bytes_to_wkb_buf((uint8_t *) rq->pixels, raquet_pixels_size(rq), buf,
-    variant);
+  buf = payload_to_wkb_buf((const uint8_t *) rq->pixels, raquet_pixels_size(rq),
+    buf, variant);
   return buf;
 }
 #endif /* RASTER */

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -90,6 +90,38 @@ CREATE TYPE raquet (
   alignment = double
 );
 
+-- GENERATED-REPRESENTATIONS-BEGIN raquet_base — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.d/representation_families.yaml and re-run.
+/******************************************************************************
+ * Well-Known Binary representations
+ *
+ * The tile carries its pixels and its QUADBIN georeferencing in one value, so
+ * these round-trip a tile through a portable byte string with no spatial
+ * extension involved, as the sibling h3index cell does.
+ ******************************************************************************/
+
+CREATE FUNCTION raquetFromBinary(bytea)
+  RETURNS raquet
+  AS 'MODULE_PATHNAME', 'Raquet_from_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION raquetFromHexWKB(text)
+  RETURNS raquet
+  AS 'MODULE_PATHNAME', 'Raquet_from_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asBinary(raquet, endianenconding text DEFAULT '')
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Raquet_as_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexWKB(raquet, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Raquet_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END raquet_base
+
 /******************************************************************************
  * raquet constructor
  ******************************************************************************/

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -498,6 +498,75 @@ Raquet_send(PG_FUNCTION_ARGS)
   PG_RETURN_BYTEA_P(result);
 }
 
+PGDLLEXPORT Datum Raquet_from_wkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_from_wkb);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a Raquet tile from its Well-Known Binary (WKB) representation
+ * @sqlfn raquetFromBinary()
+ */
+Datum
+Raquet_from_wkb(PG_FUNCTION_ARGS)
+{
+  bytea *bytea_wkb = PG_GETARG_BYTEA_P(0);
+  uint8_t *wkb = (uint8_t *) VARDATA(bytea_wkb);
+  Raquet *result = raquet_from_wkb(wkb, VARSIZE(bytea_wkb) - VARHDRSZ);
+  PG_FREE_IF_COPY(bytea_wkb, 0);
+  PG_RETURN_RAQUET_P(result);
+}
+
+PGDLLEXPORT Datum Raquet_from_hexwkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_from_hexwkb);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a Raquet tile from its ASCII hex-encoded Well-Known Binary
+ * (HexWKB) representation
+ * @sqlfn raquetFromHexWKB()
+ */
+Datum
+Raquet_from_hexwkb(PG_FUNCTION_ARGS)
+{
+  text *hexwkb_text = PG_GETARG_TEXT_P(0);
+  char *hexwkb = text_to_cstring(hexwkb_text);
+  Raquet *result = raquet_from_hexwkb(hexwkb);
+  pfree(hexwkb);
+  PG_FREE_IF_COPY(hexwkb_text, 0);
+  PG_RETURN_RAQUET_P(result);
+}
+
+PGDLLEXPORT Datum Raquet_as_wkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_as_wkb);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the Well-Known Binary (WKB) representation of a Raquet tile
+ * @sqlfn asBinary()
+ */
+Datum
+Raquet_as_wkb(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  bytea *result = Datum_as_wkb(fcinfo, RaquetPGetDatum(rq), T_RAQUET, false);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_BYTEA_P(result);
+}
+
+PGDLLEXPORT Datum Raquet_as_hexwkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_as_hexwkb);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the ASCII hex-encoded Well-Known Binary (HexWKB)
+ * representation of a Raquet tile
+ * @sqlfn asHexWKB()
+ */
+Datum
+Raquet_as_hexwkb(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  text *result = Datum_as_hexwkb(fcinfo, RaquetPGetDatum(rq), T_RAQUET, false);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_TEXT_P(result);
+}
+
 PGDLLEXPORT Datum Raquet_constructor(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Raquet_constructor);
 /**

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -347,6 +347,39 @@ FROM t;
 SELECT raquetRead(
   decode('49492a00080000000b000001030001000000020000000101030001000000020000000201030001000000080000000301030001000000010000000601030001000000010000001101040001000000920000001501030001000000010000001601030001000000020000001701040001000000040000001c01030001000000010000005301030001000000010000000000000001020304', 'hex'));
 ERROR:  Raster has no geotransform; cannot derive its QUADBIN cell: in-memory raster
+SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
+         5193776270265024512::bigint, 'UINT8')))
+       = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x0102030405060708'::bytea, 2, 2,
+         5193776270265024512::bigint, 'INT16', -9999.0)))
+       = raquet('\x0102030405060708'::bytea, 2, 2, 5193776270265024512::bigint,
+         'INT16', -9999.0);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
+         5193776270265024512::bigint, 'UINT8'), 'XDR'))
+       = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
+         5193776270265024512::bigint, 'UINT8'), 'NDR'))
+       = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
 FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
         'UINT8') AS tile) t;

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -407,6 +407,32 @@ SELECT raquetRead(
   decode('49492a00080000000b000001030001000000020000000101030001000000020000000201030001000000080000000301030001000000010000000601030001000000010000001101040001000000920000001501030001000000010000001601030001000000020000001701040001000000040000001c01030001000000010000005301030001000000010000000000000001020304', 'hex'));
 
 -------------------------------------------------------------------------------
+-- raquet (Hex)WKB round trip
+--
+-- The tile carries its pixels and its QUADBIN georeferencing in one value, so
+-- it round-trips through a portable byte string with no spatial extension
+-- involved, exactly as the sibling h3index cell does.
+-------------------------------------------------------------------------------
+
+SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
+         5193776270265024512::bigint, 'UINT8')))
+       = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x0102030405060708'::bytea, 2, 2,
+         5193776270265024512::bigint, 'INT16', -9999.0)))
+       = raquet('\x0102030405060708'::bytea, 2, 2, 5193776270265024512::bigint,
+         'INT16', -9999.0);
+
+-- The endianness argument is accepted on both output forms.
+SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
+         5193776270265024512::bigint, 'UINT8'), 'XDR'))
+       = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
+         5193776270265024512::bigint, 'UINT8'), 'NDR'))
+       = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+
+-------------------------------------------------------------------------------
 -- raquet accessors
 -------------------------------------------------------------------------------
 

--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -106,7 +106,6 @@ mobilitydb/sql/quadbin/359_tquadbin_posops.in.sql
 mobilitydb/sql/quadbin/362_tquadbin_spatialrels.in.sql
 mobilitydb/sql/quadbin/372_tquadbin_gist.in.sql
 mobilitydb/sql/quadbin/373_tquadbin_spgist.in.sql
-mobilitydb/sql/raster/500_raster.in.sql
 mobilitydb/sql/rgeo/154_trgeo_compops.in.sql
 mobilitydb/sql/rgeo/156_trgeo_spatialfuncs.in.sql
 mobilitydb/sql/rgeo/160_trgeo_boxops.in.sql

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -521,3 +521,22 @@ representation_families:
     - asEWKB
     - asHexWKB
     - asHexEWKB
+- family: raquet_base
+  file: mobilitydb/sql/raster/500_raster.in.sql
+  reference: true
+  begin: "\n * Well-Known Binary representations\n"
+  end: "\n * raquet constructor\n"
+  temps:
+  - temp: raquet
+  syms:
+    FromBinary: Raquet_from_wkb
+    FromHexWKB: Raquet_from_hexwkb
+    asBinary: Raquet_as_wkb
+    asHexWKB: Raquet_as_hexwkb
+  blocks:
+  - lit: "/******************************************************************************\n * Well-Known Binary representations\n *\n * The tile carries its pixels and its QUADBIN georeferencing in one value, so\n * these round-trip a tile through a portable byte string with no spatial\n * extension involved, as the sibling h3index cell does.\n ******************************************************************************/"
+  - ops:
+    - FromBinary
+    - FromHexWKB
+    - asBinary
+    - asHexWKB


### PR DESCRIPTION
`meos_raster.h` exports `raquet_from_wkb`, `raquet_from_hexwkb`, `raquet_as_wkb`
and `raquet_as_hexwkb`, and the MEOS side names the wrappers that bind them,
`@csqlfn #Raquet_from_wkb()` and its three siblings. None of those four wrappers
exists, so each tag points at nothing and no SQL function reaches the four
exports. The `raquet` type is documented as having a portable Hex-WKB text and
binary representation that it cannot produce.

The wrappers bind the four exports, and `raquet` joins the representation
manifest so the declarations come from the generator that owns this surface for
every other type. The names are the ones the sibling `h3index` cell carries:

```sql
raquetFromBinary(bytea) → raquet
raquetFromHexWKB(text) → raquet
asBinary(raquet, endianenconding text DEFAULT '') → bytea
asHexWKB(raquet, endianenconding text DEFAULT '') → text
```

`asBinary` and `asHexWKB` go through the shared `Datum_as_wkb` and
`Datum_as_hexwkb`, so the endianness argument behaves as it does for every other
type. Every binding derives its surface from these exports, so the four reach
each of them under one canonical name.

## The payload writer

`bytes_to_wkb_buf` reverses the bytes it writes when the requested endianness
differs from the machine, which is what a scalar needs. The pixel array of a
tile passes through it, and a pixel array is a sequence of bytes with no byte
order, so `XDR` reverses the payload while the reader, which copies it verbatim,
does not put it back:

```sql
SELECT raquetFromBinary(asBinary(tile, 'XDR')) = tile;
-- f
```

The first commit writes such a payload through a function that never reverses
it. The `text` payload carried this logic inline, with a comment saying it needs
special handling to avoid swapping, and both share it. The reach of the defect
is `raquet_as_wkb`, a public export, so a binding asking for `XDR` meets it;
`raquet_send` passes `WKB_NDR` and does not.

## Tests

`500_raster.test.sql` round-trips a tile through both representations, and
through each with an explicit `NDR` and `XDR`, the last being the case the
payload fix answers.
