### PR TITLE
Report a planar pose asked for as GeoPose

### DIFF
--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -311,15 +311,26 @@ geopose_param_number(const char *str, double *out)
  * @brief Extract the position and orientation of a pose in the form every
  * GeoPose encoding needs: longitude, latitude and height in degrees and
  * metres, and a unit quaternion in Hamilton convention.
- * @details Every class the standard defines fixes a WGS-84 outer frame, so
- * this is also where the SRID is checked. A pose with SRID 0 is treated as
- * geographic.
+ * @details Every class the standard defines places its pose in a topocentric
+ * frame on the surface of the Earth, so this is where the frame of the pose
+ * is checked. A pose with SRID 0 is treated as geographic.
+ *
+ * That frame is geographic, which a planar pose does not have: its
+ * coordinates measure a plane rather than the ellipsoid, so writing them as a
+ * longitude and a latitude would assert something the value does not say. A
+ * planar pose is therefore reported here rather than encoded.
  * @return On error return false
  */
 static bool
 geopose_pose_components(const Pose *pose, double *lon, double *lat, double *h,
   double *W, double *X, double *Y, double *Z)
 {
+  if (! MEOS_FLAGS_GET_GEODETIC(pose->flags))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "GeoPose JSON requires a geodetic pose, got a planar one");
+    return false;
+  }
   int32_t srid = pose_srid(pose);
   if (! geopose_srid_is_geographic(srid))
   {

--- a/meos/test/geopose_test.c
+++ b/meos/test/geopose_test.c
@@ -174,7 +174,7 @@ int main(void)
    *------------------------------------------------------------------------*/
 
   meos_errno_reset();
-  Temporal *inst = tpose_in("Pose(Point(8 47), 0)@2026-01-01");
+  Temporal *inst = tpose_in("Geodpose(Point(8 47), 0)@2026-01-01");
   assert(inst != NULL);
   assert(meos_errno() == 0);
   out = tpose_as_geopose(inst, BASIC_QUATERNION, 6);
@@ -191,8 +191,8 @@ int main(void)
    * between its neighbours and the normalisation of the sequence keeps all
    * three: a Series carries as many poses as the value holds */
   meos_errno_reset();
-  Temporal *regular = tpose_in("[Pose(Point(0 0), 0)@2026-01-01, "
-    "Pose(Point(1 0), 0)@2026-01-02, Pose(Point(1 1), 0)@2026-01-03]");
+  Temporal *regular = tpose_in("[Geodpose(Point(0 0), 0)@2026-01-01, "
+    "Geodpose(Point(1 0), 0)@2026-01-02, Geodpose(Point(1 1), 0)@2026-01-03]");
   assert(regular != NULL);
   assert(meos_errno() == 0);
   s1 = temporal_out(regular, 6);
@@ -248,8 +248,8 @@ int main(void)
    *------------------------------------------------------------------------*/
 
   meos_errno_reset();
-  Temporal *irregular = tpose_in("[Pose(Point(0 0), 0)@2026-01-01, "
-    "Pose(Point(1 0), 0)@2026-01-02, Pose(Point(1 1), 0)@2026-01-05]");
+  Temporal *irregular = tpose_in("[Geodpose(Point(0 0), 0)@2026-01-01, "
+    "Geodpose(Point(1 0), 0)@2026-01-02, Geodpose(Point(1 1), 0)@2026-01-05]");
   assert(irregular != NULL);
   assert(meos_errno() == 0);
   s1 = temporal_out(irregular, 6);
@@ -318,9 +318,31 @@ int main(void)
   assert(bad == NULL);
   assert(meos_errno() != 0);
 
+  /* Every class of the standard places its pose in a topocentric frame on
+   * the surface of the Earth, which a planar pose does not have */
+  meos_errno_reset();
+  Pose *planar = pose_in("Pose(Point(1 1),0.5)");
+  assert(planar != NULL);
+  char *flat_json = pose_as_geopose(planar, BASIC_QUATERNION, 6);
+  printf("pose_as_geopose(planar pose): %s, errno %d\n",
+    flat_json ? "non-NULL" : "NULL", meos_errno());
+  assert(flat_json == NULL);
+  assert(meos_errno() != 0);
+  free(planar);
+
+  meos_errno_reset();
+  Temporal *planar_t = tpose_in("Pose(Point(8 47), 0)@2026-01-01");
+  assert(planar_t != NULL);
+  flat_json = tpose_as_geopose(planar_t, BASIC_QUATERNION, 6);
+  printf("tpose_as_geopose(planar pose): %s, errno %d\n",
+    flat_json ? "non-NULL" : "NULL", meos_errno());
+  assert(flat_json == NULL);
+  assert(meos_errno() != 0);
+  free(planar_t);
+
   /* An unknown conformance class */
   meos_errno_reset();
-  Pose *good = pose_in("Pose(Point(1 1),0.5)");
+  Pose *good = pose_in("Geodpose(Point(1 1),0.5)");
   assert(good != NULL);
   char *none = pose_as_geopose(good, 7, 6);
   printf("pose_as_geopose(conformance 7): %s, errno %d\n",

--- a/mobilitydb/test/pose/expected/103_pose_geopose.test.out
+++ b/mobilitydb/test/pose/expected/103_pose_geopose.test.out
@@ -149,48 +149,48 @@ SELECT poseFromGeoPose('{"position":{"lat":0,"lon":0,"h":0}}');
 ERROR:  GeoPose JSON requires either a 'quaternion' object (Basic-Quaternion) or an 'angles' object (Basic-YPR)
 SELECT poseFromGeoPose('{"position":{"lat":0,"lon":0,"h":0},"quaternion":{"x":0,"y":0,"z":0}}');
 ERROR:  GeoPose 'quaternion' must carry numeric 'w','x','y','z' members
-SELECT asGeoPose(pose 'Pose(Point(1 1),0.5)', 99, 6);
+SELECT asGeoPose(pose 'Geodpose(Point(1 1),0.5)', 99, 6);
 ERROR:  Unknown GeoPose conformance class 99 (0 = Basic-Quaternion, 1 = Basic-YPR)
-SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
+SELECT asGeoPose(pose 'SRID=5676;Geodpose(Point(1 1),0.5)', 0, 6);
 ERROR:  GeoPose JSON requires a WGS-84 geographic SRID (4326 or 4979), got 5676
-SELECT asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6);
+SELECT asGeoPose(tpose 'Geodpose(Point(8 47), 0)@2026-01-01', 0, 6);
                                                asgeopose                                                
 --------------------------------------------------------------------------------------------------------
  {"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1},"validTime":1767254400000}
 (1 row)
 
-SELECT asText(tposeFromGeoPose(asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
+SELECT asText(tposeFromGeoPose(asGeoPose(tpose 'Geodpose(Point(8 47), 0)@2026-01-01', 0, 6)));
                              astext                              
 -----------------------------------------------------------------
  GeodPose(POINT Z (8 47 0),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST
 (1 row)
 
-SELECT asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 0), 0.5)@2026-01-02]', 0, 6);
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0), 0)@2026-01-01, Geodpose(Point(0 0), 0.5)@2026-01-02]', 0, 6);
                                                                                                                                                                                                                                                                                                                 asgeopose                                                                                                                                                                                                                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"header":{"poseCount":2,"startInstant":1767254400000,"stopInstant":1767340800000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"interPoseDuration":86400000,"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameSeries":[{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.968912, 0, 0, 0.247404]"}],"trailer":{"poseCount":2}}
 (1 row)
 
-SELECT asText(round(tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 15)), 6));
+SELECT asText(round(tposeFromGeoPose(asGeoPose(tpose '[Geodpose(Point(0 0), 0)@2026-01-01, Geodpose(Point(0 1), 0)@2026-01-02]', 0, 15)), 6));
                                                               astext                                                              
 ----------------------------------------------------------------------------------------------------------------------------------
  [GeodPose(POINT Z (0 0 0),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (0 1 0),1,0,0,0)@Fri Jan 02 00:00:00 2026 PST]
 (1 row)
 
-SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01, Pose(Point(0 0 0), 0.707107, 0, 0, 0.707107)@2026-01-02]', 1, 6);
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01, Geodpose(Point(0 0 0), 0.707107, 0, 0, 0.707107)@2026-01-02]', 1, 6);
                                                                                                                                                                                                                                                                                                                 asgeopose                                                                                                                                                                                                                                                                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"header":{"poseCount":2,"startInstant":1767254400000,"stopInstant":1767340800000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"interPoseDuration":86400000,"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameSeries":[{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.707107, 0, 0, 0.707107]"}],"trailer":{"poseCount":2}}
 (1 row)
 
-SELECT asGeoPose(tpose '{[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01, Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02], [Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04, Pose(Point(0 0 600), 0.5, 0.5, 0.5, 0.5)@2026-01-05]}', 1, 4);
+SELECT asGeoPose(tpose '{[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01, Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02], [Geodpose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04, Geodpose(Point(0 0 600), 0.5, 0.5, 0.5, 0.5)@2026-01-05]}', 1, 4);
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         asgeopose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"header":{"poseCount":4,"startInstant":1767254400000,"stopInstant":1767600000000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameAndTimeSeries":[{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767254400000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 100]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767340800000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 300]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767513600000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 600]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767600000000}],"trailer":{"poseCount":4}}
 (1 row)
 
-SELECT tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 15)) =
-  tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 6)) AS same;
+SELECT tposeFromGeoPose(asGeoPose(tpose '[Geodpose(Point(0 0), 0)@2026-01-01, Geodpose(Point(0 1), 0)@2026-01-02]', 0, 15)) =
+  tposeFromGeoPose(asGeoPose(tpose '[Geodpose(Point(0 0), 0)@2026-01-01, Geodpose(Point(0 1), 0)@2026-01-02]', 0, 6)) AS same;
  same 
 ------
  f
@@ -209,56 +209,56 @@ SELECT pose '{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y"
  t
 (1 row)
 
-SELECT pose 'Pose(Point(8 47), 0)';
-                         pose                         
-------------------------------------------------------
- POSE (010100000000000000000020400000000000804740, 0)
+SELECT pose 'Geodpose(Point(8 47), 0)';
+                           pose                           
+----------------------------------------------------------
+ GEODPOSE (010100000000000000000020400000000000804740, 0)
 (1 row)
 
-SELECT asText(tpose (asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
+SELECT asText(tpose (asGeoPose(tpose 'Geodpose(Point(8 47), 0)@2026-01-01', 0, 6)));
                              astext                              
 -----------------------------------------------------------------
  GeodPose(POINT Z (8 47 0),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST
 (1 row)
 
-SELECT asText(tpose '{Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02}');
-                                                 astext                                                 
---------------------------------------------------------------------------------------------------------
- {Pose(POINT(8 47),0)@Thu Jan 01 00:00:00 2026 PST, Pose(POINT(9 48),0.5)@Fri Jan 02 00:00:00 2026 PST}
+SELECT asText(tpose '{Geodpose(Point(8 47), 0)@2026-01-01, Geodpose(Point(9 48), 0.5)@2026-01-02}');
+                                                     astext                                                     
+----------------------------------------------------------------------------------------------------------------
+ {GeodPose(POINT(8 47),0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT(9 48),0.5)@Fri Jan 02 00:00:00 2026 PST}
 (1 row)
 
-SELECT asText(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02], [Pose(Point(10 50), 1)@2026-01-04]}');
-                                                                            astext                                                                             
----------------------------------------------------------------------------------------------------------------------------------------------------------------
- {[Pose(POINT(8 47),0)@Thu Jan 01 00:00:00 2026 PST, Pose(POINT(9 48),0.5)@Fri Jan 02 00:00:00 2026 PST], [Pose(POINT(10 50),1)@Sun Jan 04 00:00:00 2026 PST]}
+SELECT asText(tpose '{[Geodpose(Point(8 47), 0)@2026-01-01, Geodpose(Point(9 48), 0.5)@2026-01-02], [Geodpose(Point(10 50), 1)@2026-01-04]}');
+                                                                                  astext                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[GeodPose(POINT(8 47),0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT(9 48),0.5)@Fri Jan 02 00:00:00 2026 PST], [GeodPose(POINT(10 50),1)@Sun Jan 04 00:00:00 2026 PST]}
 (1 row)
 
-SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6);
+SELECT asGeoPose(pose 'SRID=4979;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6);
                                     asgeopose                                    
 ---------------------------------------------------------------------------------
  {"position":{"lat":47,"lon":8,"h":1500},"quaternion":{"x":0,"y":0,"z":0,"w":1}}
 (1 row)
 
-SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) =
-  asGeoPose(pose 'SRID=4326;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) AS same;
+SELECT asGeoPose(pose 'SRID=4979;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) =
+  asGeoPose(pose 'SRID=4326;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) AS same;
  same 
 ------
  t
 (1 row)
 
 SELECT poseFromGeoPose(asGeoPose(
-  pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) =
+  pose 'SRID=4979;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) =
   poseFromGeoPose(asGeoPose(
-  pose 'SRID=4326;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) AS same;
+  pose 'SRID=4326;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) AS same;
  same 
 ------
  t
 (1 row)
 
-SELECT asGeoPose(tpose 'SRID=4979;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
-  asGeoPose(tpose 'SRID=4326;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) AS same;
+SELECT asGeoPose(tpose 'SRID=4979;[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
+  asGeoPose(tpose 'SRID=4326;[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) AS same;
  same 
 ------
  t
@@ -266,59 +266,75 @@ SELECT asGeoPose(tpose 'SRID=4979;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-0
 
 /* Errors */
 -- A projected SRID is not a GeoPose outer frame.
-SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
+SELECT asGeoPose(pose 'SRID=5676;Geodpose(Point(1 1),0.5)', 0, 6);
 ERROR:  GeoPose JSON requires a WGS-84 geographic SRID (4326 or 4979), got 5676
-SELECT asGeoPose(tpose 'SRID=5676;[Pose(Point(1 1),0.5)@2026-01-01,
-  Pose(Point(2 2),0.5)@2026-01-02]', 0, 6);
+SELECT asGeoPose(tpose 'SRID=5676;[Geodpose(Point(1 1),0.5)@2026-01-01,
+  Geodpose(Point(2 2),0.5)@2026-01-02]', 0, 6);
 ERROR:  GeoPose JSON requires a WGS-84 geographic SRID (4326 or 4979), got 5676
-SELECT asGeoPose(tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 6);
+SELECT asGeoPose(pose 'Pose(Point(1 1),0.5)', 0, 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one
+SELECT asGeoPose(pose 'SRID=4326;Pose(Point(8 47),0.5)', 0, 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one
+SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one
+SELECT asGeoPose(pose 'Pose(Point(8 47),0.5)', 1, 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one
+SELECT asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one
+SELECT asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01,
+  Pose(Point(0 1), 0)@2026-01-02]', 0, 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one
+SELECT asGeoPose(tpose '{Pose(Point(0 0), 0)@2026-01-01,
+  Pose(Point(0 1), 0)@2026-01-02}', 0, 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one
+SELECT asGeoPose(tpose 'Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 6);
                                                  asgeopose                                                 
 -----------------------------------------------------------------------------------------------------------
  {"position":{"lat":47,"lon":8,"h":1500},"quaternion":{"x":0,"y":0,"z":0,"w":1},"validTime":1767254400000}
 (1 row)
 
-SELECT asGeoPose(tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 1, 6);
+SELECT asGeoPose(tpose 'Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 1, 6);
                                                 asgeopose                                                 
 ----------------------------------------------------------------------------------------------------------
  {"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":0,"pitch":0,"roll":0},"validTime":1767254400000}
 (1 row)
 
-SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
-  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-03]', 0, 6);
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Geodpose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-03]', 0, 6);
                                                                                                                                                                                                                                                                                                                                                                               asgeopose                                                                                                                                                                                                                                                                                                                                                                               
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"header":{"poseCount":3,"startInstant":1767254400000,"stopInstant":1767427200000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"interPoseDuration":86400000,"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameSeries":[{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.5, 0.5, 0.5, 0.5]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 100]&rotation=[0.5, 0.5, 0.5, 0.5]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 300]&rotation=[0.5, 0.5, 0.5, 0.5]"}],"trailer":{"poseCount":3}}
 (1 row)
 
-SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
-  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-05]', 0, 6);
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Geodpose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-05]', 0, 6);
                                                                                                                                                                                                                                                                                                                                                                                                                          asgeopose                                                                                                                                                                                                                                                                                                                                                                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"header":{"poseCount":3,"startInstant":1767254400000,"stopInstant":1767600000000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameAndTimeSeries":[{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767254400000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 100]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767340800000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 300]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767600000000}],"trailer":{"poseCount":3}}
 (1 row)
 
-SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
-  asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 1, 6) AS same;
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
+  asGeoPose(tpose '[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 1, 6) AS same;
  same 
 ------
  t
 (1 row)
 
-SELECT asGeoPose(tpose '{[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02],
-  [Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04]}', 0, 6);
+SELECT asGeoPose(tpose '{[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02],
+  [Geodpose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04]}', 0, 6);
                                                                                                                                                                                                                                                                                                                                                                                                                          asgeopose                                                                                                                                                                                                                                                                                                                                                                                                                          
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  {"header":{"poseCount":3,"startInstant":1767254400000,"stopInstant":1767513600000,"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"}},"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"},"innerFrameAndTimeSeries":[{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767254400000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 100]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767340800000},{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 300]&rotation=[0.5, 0.5, 0.5, 0.5]"},"validTime":1767513600000}],"trailer":{"poseCount":3}}
 (1 row)
 
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
-  Pose(Point(10 49 1700), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
+  Geodpose(Point(10 49 1700), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
 SELECT (d->'header'->>'poseCount')::int = jsonb_array_length(d->'innerFrameAndTimeSeries')
   AND (d->'trailer'->>'poseCount')::int = jsonb_array_length(d->'innerFrameAndTimeSeries')
 FROM j;
@@ -327,8 +343,8 @@ FROM j;
  t
 (1 row)
 
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
 SELECT to_timestamp((d->'header'->>'startInstant')::bigint / 1000) AT TIME ZONE 'UTC',
        to_timestamp((d->'header'->>'stopInstant')::bigint / 1000) AT TIME ZONE 'UTC'
 FROM j;
@@ -337,36 +353,36 @@ FROM j;
  Thu Jan 01 08:00:00 2026 | Mon Jan 05 08:00:00 2026
 (1 row)
 
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
 SELECT to_timestamp((e->>'validTime')::bigint / 1000) AT TIME ZONE 'UTC'
 FROM j, jsonb_array_elements(d->'innerFrameAndTimeSeries') AS e;
  timezone 
 ----------
 (0 rows)
 
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01 00:00:00.123456,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01 00:00:00.123456,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
 SELECT (d->'header'->>'startInstant')::bigint % 1000 AS millisecond_kept FROM j;
  millisecond_kept 
 ------------------
               123
 (1 row)
 
-SELECT (asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb->>'interPoseDuration')::bigint;
+SELECT (asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb->>'interPoseDuration')::bigint;
    int8   
 ----------
  86400000
 (1 row)
 
 WITH j(interp, d) AS (VALUES
-  ('linear', asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
-  ('step', asGeoPose(tpose 'Interp=Step;[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
-  ('discrete', asGeoPose(tpose '{Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05}', 0, 6)::jsonb))
+  ('linear', asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
+  ('step', asGeoPose(tpose 'Interp=Step;[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
+  ('discrete', asGeoPose(tpose '{Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05}', 0, 6)::jsonb))
 SELECT interp,
   d->'header'->'transitionModel'->>'authority',
   d->'header'->'transitionModel'->>'id',
@@ -379,8 +395,8 @@ FROM j;
  discrete | /geopose/1.0 | none        | interpolation=Discrete
 (3 rows)
 
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
 SELECT d->'outerFrame'->>'authority', d->'outerFrame'->>'id',
   d->'outerFrame'->>'parameters'
 FROM j;
@@ -389,8 +405,8 @@ FROM j;
  /geopose/1.0 | LTP-ENU  | longitude=8&latitude=47&height=1500&crs=EPSG:4979
 (1 row)
 
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
 SELECT d->'innerFrameSeries'->0->>'authority', d->'innerFrameSeries'->0->>'id',
   split_part(d->'innerFrameSeries'->0->>'parameters', '&', 1)
 FROM j;
@@ -408,49 +424,49 @@ ORDER BY code;
 (2 rows)
 
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
-  tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 15)), 6));
+  tpose 'Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 15)), 6));
                                astext                               
 --------------------------------------------------------------------
  GeodPose(POINT Z (8 47 1500),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST
 (1 row)
 
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
-  tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
-    Pose(Point(10 47 1700), 1, 0, 0, 0)@2026-01-03]', 0, 15)), 6));
+  tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
+    Geodpose(Point(10 47 1700), 1, 0, 0, 0)@2026-01-03]', 0, 15)), 6));
                                                                                                     astext                                                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  [GeodPose(POINT Z (8 47 1500),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (9 48 1600),1,0,0,0)@Fri Jan 02 00:00:00 2026 PST, GeodPose(POINT Z (10 47 1700),1,0,0,0)@Sat Jan 03 00:00:00 2026 PST]
 (1 row)
 
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
-  tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 15)), 6));
+  tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 15)), 6));
                                                                   astext                                                                  
 ------------------------------------------------------------------------------------------------------------------------------------------
  [GeodPose(POINT Z (8 47 1500),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (9 48 1600),1,0,0,0)@Mon Jan 05 00:00:00 2026 PST]
 (1 row)
 
 SELECT interp(tposeFromGeoPose(asGeoPose(
-  tpose 'Interp=Step;[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 15)));
+  tpose 'Interp=Step;[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 15)));
  interp 
 --------
  Step
 (1 row)
 
 SELECT interp(tposeFromGeoPose(asGeoPose(
-  tpose '{Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02}', 0, 15)));
+  tpose '{Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02}', 0, 15)));
   interp  
 ----------
  Discrete
 (1 row)
 
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
-  tpose '{[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02],
-   [Pose(Point(10 50 1700), 1, 0, 0, 0)@2026-01-04]}', 0, 15)), 6));
+  tpose '{[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02],
+   [Geodpose(Point(10 50 1700), 1, 0, 0, 0)@2026-01-04]}', 0, 15)), 6));
                                                                                                     astext                                                                                                     
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  [GeodPose(POINT Z (8 47 1500),1,0,0,0)@Thu Jan 01 00:00:00 2026 PST, GeodPose(POINT Z (9 48 1600),1,0,0,0)@Fri Jan 02 00:00:00 2026 PST, GeodPose(POINT Z (10 50 1700),1,0,0,0)@Sun Jan 04 00:00:00 2026 PST]

--- a/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
+++ b/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
@@ -154,10 +154,10 @@ SELECT poseFromGeoPose('{"position":{"lat":0,"lon":0,"h":0}}');
 SELECT poseFromGeoPose('{"position":{"lat":0,"lon":0,"h":0},"quaternion":{"x":0,"y":0,"z":0}}');
 
 -- Unknown conformance class on output.
-SELECT asGeoPose(pose 'Pose(Point(1 1),0.5)', 99, 6);
+SELECT asGeoPose(pose 'Geodpose(Point(1 1),0.5)', 99, 6);
 
 -- Projected SRID is rejected by the GeoPose Basic classes.
-SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
+SELECT asGeoPose(pose 'SRID=5676;Geodpose(Point(1 1),0.5)', 0, 6);
 
 -------------------------------------------------------------------------------
 
@@ -170,29 +170,29 @@ SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
 -------------------------------------------------------------------------------
 
 -- TInstant tpose -> a Basic document carrying its validTime.
-SELECT asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6);
+SELECT asGeoPose(tpose 'Geodpose(Point(8 47), 0)@2026-01-01', 0, 6);
 -- Round-trip preserves subtype.
-SELECT asText(tposeFromGeoPose(asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
+SELECT asText(tposeFromGeoPose(asGeoPose(tpose 'Geodpose(Point(8 47), 0)@2026-01-01', 0, 6)));
 
 -- 2D linear-interp TSequence -> a Series. Its inner frames hold a rotation
 -- against the outer frame, so a 2D pose comes back three-dimensional.
-SELECT asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 0), 0.5)@2026-01-02]', 0, 6);
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0), 0)@2026-01-01, Geodpose(Point(0 0), 0.5)@2026-01-02]', 0, 6);
 -- Round-trip preserves the underlying pose values.
-SELECT asText(round(tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 15)), 6));
+SELECT asText(round(tposeFromGeoPose(asGeoPose(tpose '[Geodpose(Point(0 0), 0)@2026-01-01, Geodpose(Point(0 1), 0)@2026-01-02]', 0, 15)), 6));
 
 -- A 3D yaw-only TSequence. A Series carries a quaternion whichever
 -- orientation encoding is asked for.
-SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01, Pose(Point(0 0 0), 0.707107, 0, 0, 0.707107)@2026-01-02]', 1, 6);
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01, Geodpose(Point(0 0 0), 0.707107, 0, 0, 0.707107)@2026-01-02]', 1, 6);
 
 -- TSequenceSet -> one flattened Series.
-SELECT asGeoPose(tpose '{[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01, Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02], [Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04, Pose(Point(0 0 600), 0.5, 0.5, 0.5, 0.5)@2026-01-05]}', 1, 4);
+SELECT asGeoPose(tpose '{[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01, Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02], [Geodpose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04, Geodpose(Point(0 0 600), 0.5, 0.5, 0.5, 0.5)@2026-01-05]}', 1, 4);
 
 -- A Series spends its digits on metres from the tangent point rather than on
 -- degrees, so the precision it is written at bounds how well a position far
 -- from that point survives: fifteen digits carry a degree of latitude back
 -- exactly, six do not.
-SELECT tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 15)) =
-  tposeFromGeoPose(asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01, Pose(Point(0 1), 0)@2026-01-02]', 0, 6)) AS same;
+SELECT tposeFromGeoPose(asGeoPose(tpose '[Geodpose(Point(0 0), 0)@2026-01-01, Geodpose(Point(0 1), 0)@2026-01-02]', 0, 15)) =
+  tposeFromGeoPose(asGeoPose(tpose '[Geodpose(Point(0 0), 0)@2026-01-01, Geodpose(Point(0 1), 0)@2026-01-02]', 0, 6)) AS same;
 
 -------------------------------------------------------------------------------
 -- Reading a GeoPose document as a value of the type
@@ -204,15 +204,15 @@ SELECT pose '{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y"
   poseFromGeoPose('{"position":{"lat":1.0,"lon":1.0,"h":1.0},"quaternion":{"x":0.5,"y":0.5,"z":0.5,"w":0.5}}') AS same;
 
 -- The text form of a pose reads as before.
-SELECT pose 'Pose(Point(8 47), 0)';
+SELECT pose 'Geodpose(Point(8 47), 0)';
 
 -- A temporal pose reads a GeoPose document too.
-SELECT asText(tpose (asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6)));
+SELECT asText(tpose (asGeoPose(tpose 'Geodpose(Point(8 47), 0)@2026-01-01', 0, 6)));
 
 -- A brace opens a sequence set as well, and one still reads as such: neither a
 -- set of instants nor a set of sequences is a GeoPose document.
-SELECT asText(tpose '{Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02}');
-SELECT asText(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2026-01-02], [Pose(Point(10 50), 1)@2026-01-04]}');
+SELECT asText(tpose '{Geodpose(Point(8 47), 0)@2026-01-01, Geodpose(Point(9 48), 0.5)@2026-01-02}');
+SELECT asText(tpose '{[Geodpose(Point(8 47), 0)@2026-01-01, Geodpose(Point(9 48), 0.5)@2026-01-02], [Geodpose(Point(10 50), 1)@2026-01-04]}');
 
 -------------------------------------------------------------------------------
 -- Geographic SRIDs accepted at the GeoPose boundary
@@ -223,27 +223,42 @@ SELECT asText(tpose '{[Pose(Point(8 47), 0)@2026-01-01, Pose(Point(9 48), 0.5)@2
 -- bytes.
 -------------------------------------------------------------------------------
 
-SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6);
+SELECT asGeoPose(pose 'SRID=4979;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6);
 
-SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) =
-  asGeoPose(pose 'SRID=4326;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) AS same;
+SELECT asGeoPose(pose 'SRID=4979;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) =
+  asGeoPose(pose 'SRID=4326;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6) AS same;
 
 SELECT poseFromGeoPose(asGeoPose(
-  pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) =
+  pose 'SRID=4979;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) =
   poseFromGeoPose(asGeoPose(
-  pose 'SRID=4326;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) AS same;
+  pose 'SRID=4326;Geodpose(Point(8 47 1500), 1, 0, 0, 0)', 0, 15)) AS same;
 
-SELECT asGeoPose(tpose 'SRID=4979;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
-  asGeoPose(tpose 'SRID=4326;[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) AS same;
+SELECT asGeoPose(tpose 'SRID=4979;[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
+  asGeoPose(tpose 'SRID=4326;[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) AS same;
 
 /* Errors */
 
 -- A projected SRID is not a GeoPose outer frame.
-SELECT asGeoPose(pose 'SRID=5676;Pose(Point(1 1),0.5)', 0, 6);
-SELECT asGeoPose(tpose 'SRID=5676;[Pose(Point(1 1),0.5)@2026-01-01,
-  Pose(Point(2 2),0.5)@2026-01-02]', 0, 6);
+SELECT asGeoPose(pose 'SRID=5676;Geodpose(Point(1 1),0.5)', 0, 6);
+SELECT asGeoPose(tpose 'SRID=5676;[Geodpose(Point(1 1),0.5)@2026-01-01,
+  Geodpose(Point(2 2),0.5)@2026-01-02]', 0, 6);
+
+-- Every class of the standard places its pose in a topocentric frame on the
+-- surface of the Earth. A planar pose has no such frame: its coordinates
+-- measure a plane, so writing them as a longitude and a latitude would say
+-- something the value does not. A planar pose is reported, whatever its SRID
+-- and whichever entry point is asked.
+SELECT asGeoPose(pose 'Pose(Point(1 1),0.5)', 0, 6);
+SELECT asGeoPose(pose 'SRID=4326;Pose(Point(8 47),0.5)', 0, 6);
+SELECT asGeoPose(pose 'SRID=4979;Pose(Point(8 47 1500), 1, 0, 0, 0)', 0, 6);
+SELECT asGeoPose(pose 'Pose(Point(8 47),0.5)', 1, 6);
+SELECT asGeoPose(tpose 'Pose(Point(8 47), 0)@2026-01-01', 0, 6);
+SELECT asGeoPose(tpose '[Pose(Point(0 0), 0)@2026-01-01,
+  Pose(Point(0 1), 0)@2026-01-02]', 0, 6);
+SELECT asGeoPose(tpose '{Pose(Point(0 0), 0)@2026-01-01,
+  Pose(Point(0 1), 0)@2026-01-02}', 0, 6);
 
 -------------------------------------------------------------------------------
 -- The conformance class follows from the value
@@ -256,78 +271,78 @@ SELECT asGeoPose(tpose 'SRID=5676;[Pose(Point(1 1),0.5)@2026-01-01,
 -------------------------------------------------------------------------------
 
 -- A temporal instant is a Basic document plus validTime.
-SELECT asGeoPose(tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 6);
-SELECT asGeoPose(tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 1, 6);
+SELECT asGeoPose(tpose 'Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 6);
+SELECT asGeoPose(tpose 'Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 1, 6);
 
 -- Equally spaced instants give a Regular Series: the spacing is stated once
 -- as interPoseDuration and the inner frames carry no time.
-SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
-  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-03]', 0, 6);
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Geodpose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-03]', 0, 6);
 
 -- Unequally spaced instants give an Irregular Series: every inner frame
 -- carries its own validTime.
-SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
-  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-05]', 0, 6);
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Geodpose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-05]', 0, 6);
 
 -- A Series carries a quaternion in every inner frame, so the orientation
 -- encoding argument makes no difference to it.
-SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
-  asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 1, 6) AS same;
+SELECT asGeoPose(tpose '[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 0, 6) =
+  asGeoPose(tpose '[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02]', 1, 6) AS same;
 
 -- A sequence set is a Series too, flattened.
-SELECT asGeoPose(tpose '{[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
-  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02],
-  [Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04]}', 0, 6);
+SELECT asGeoPose(tpose '{[Geodpose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Geodpose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02],
+  [Geodpose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-04]}', 0, 6);
 
 -------------------------------------------------------------------------------
 -- Series header and trailer
 -------------------------------------------------------------------------------
 
 -- poseCount agrees with the length of the inner frame array in both.
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
-  Pose(Point(10 49 1700), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
+  Geodpose(Point(10 49 1700), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
 SELECT (d->'header'->>'poseCount')::int = jsonb_array_length(d->'innerFrameAndTimeSeries')
   AND (d->'trailer'->>'poseCount')::int = jsonb_array_length(d->'innerFrameAndTimeSeries')
 FROM j;
 
 -- startInstant and stopInstant are the temporal extent, in Unix milliseconds.
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
 SELECT to_timestamp((d->'header'->>'startInstant')::bigint / 1000) AT TIME ZONE 'UTC',
        to_timestamp((d->'header'->>'stopInstant')::bigint / 1000) AT TIME ZONE 'UTC'
 FROM j;
 
 -- Each validTime is the instant's Unix time in milliseconds.
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
 SELECT to_timestamp((e->>'validTime')::bigint / 1000) AT TIME ZONE 'UTC'
 FROM j, jsonb_array_elements(d->'innerFrameAndTimeSeries') AS e;
 
 -- A millisecond of the extent survives; a microsecond does not.
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01 00:00:00.123456,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01 00:00:00.123456,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb AS d)
 SELECT (d->'header'->>'startInstant')::bigint % 1000 AS millisecond_kept FROM j;
 
 -- interPoseDuration is the spacing in milliseconds.
-SELECT (asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb->>'interPoseDuration')::bigint;
+SELECT (asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb->>'interPoseDuration')::bigint;
 
 -------------------------------------------------------------------------------
 -- Transition model: the interpolation of the temporal value
 -------------------------------------------------------------------------------
 
 WITH j(interp, d) AS (VALUES
-  ('linear', asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
-  ('step', asGeoPose(tpose 'Interp=Step;[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
-  ('discrete', asGeoPose(tpose '{Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-     Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05}', 0, 6)::jsonb))
+  ('linear', asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
+  ('step', asGeoPose(tpose 'Interp=Step;[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 6)::jsonb),
+  ('discrete', asGeoPose(tpose '{Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+     Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05}', 0, 6)::jsonb))
 SELECT interp,
   d->'header'->'transitionModel'->>'authority',
   d->'header'->'transitionModel'->>'id',
@@ -339,15 +354,15 @@ FROM j;
 -------------------------------------------------------------------------------
 
 -- The outer frame is the LTP-ENU frame at the tangent point of the first pose.
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
 SELECT d->'outerFrame'->>'authority', d->'outerFrame'->>'id',
   d->'outerFrame'->>'parameters'
 FROM j;
 
 -- The first inner frame sits at the origin of the outer frame.
-WITH j AS (SELECT asGeoPose(tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-  Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
+WITH j AS (SELECT asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb AS d)
 SELECT d->'innerFrameSeries'->0->>'authority', d->'innerFrameSeries'->0->>'id',
   split_part(d->'innerFrameSeries'->0->>'parameters', '&', 1)
 FROM j;
@@ -362,35 +377,35 @@ ORDER BY code;
 
 -- A temporal instant round-trips through its Basic document.
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
-  tpose 'Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 15)), 6));
+  tpose 'Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 15)), 6));
 
 -- A Regular Series round-trips to the same value, to the emitted precision.
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
-  tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
-    Pose(Point(10 47 1700), 1, 0, 0, 0)@2026-01-03]', 0, 15)), 6));
+  tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02,
+    Geodpose(Point(10 47 1700), 1, 0, 0, 0)@2026-01-03]', 0, 15)), 6));
 
 -- An Irregular Series round-trips its uneven spacing too.
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
-  tpose '[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 15)), 6));
+  tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-05]', 0, 15)), 6));
 
 -- Step interpolation survives the transition model.
 SELECT interp(tposeFromGeoPose(asGeoPose(
-  tpose 'Interp=Step;[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 15)));
+  tpose 'Interp=Step;[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 15)));
 
 -- Discrete interpolation does too.
 SELECT interp(tposeFromGeoPose(asGeoPose(
-  tpose '{Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02}', 0, 15)));
+  tpose '{Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02}', 0, 15)));
 
 -- A Series has neither gaps nor open bounds, so a sequence set flattens into
 -- one closed sequence.
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
-  tpose '{[Pose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
-    Pose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02],
-   [Pose(Point(10 50 1700), 1, 0, 0, 0)@2026-01-04]}', 0, 15)), 6));
+  tpose '{[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+    Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02],
+   [Geodpose(Point(10 50 1700), 1, 0, 0, 0)@2026-01-04]}', 0, 15)), 6));
 
 -- A document written by another implementation reads as well. This is the
 -- Irregular Series example of the standard; its poseCount states the length


### PR DESCRIPTION
Every conformance class of OGC GeoPose 1.0 places its pose in a topocentric frame on the surface of the Earth. The standard defines a GeoPose as a

> pose whose associated outer frame … is a topocentric frame … related to the ephemeris object planet Earth

and a planar pose has no such frame: its coordinates measure a plane rather than the ellipsoid, so writing them as a longitude and a latitude asserts something the value does not say.

The frame of a pose is checked where every encoding path already reads its position, so a planar pose is reported whatever its SRID and whichever entry point is asked, rather than yielding a document that places it somewhere it is not:

```
ERROR:  GeoPose JSON requires a geodetic pose, got a planar one
```

The reader needs nothing: it builds a geodetic pose at every site, so it never produced a planar one.

The tests carry the geodetic poses the classes describe, and the documents they emit are identical to the ones the planar cases emitted: the expected output differs only in the spelling of the values echoed back and in the added rejections. The rejection is covered from `pose` and `tpose`, under both orientation encodings, for an instant, a sequence and a sequence set, and with an unset, a geographic and a projected SRID, and through the C API in `meos/test/geopose_test.c`. A projected SRID keeps its own rejection, written with a geodetic pose so that it reaches the frame check.
