### PR TITLE
Emit the pcpoint padding bytes as zeros in the Well-Known Binary representation

### DIFF
--- a/meos/include/pointcloud/pcpoint.h
+++ b/meos/include/pointcloud/pcpoint.h
@@ -66,6 +66,7 @@ extern bool ensure_valid_pcpointset_pcpoint(const Set *s, const Pcpoint *pt);
  *****************************************************************************/
 
 extern Pcpoint *pcpoint_parse(const char **str, bool end);
+extern size_t pcpoint_meaningful_size(const Pcpoint *pt);
 
 /*****************************************************************************/
 

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -100,8 +100,11 @@ typedef struct
  *   In practice any well-formed pcpoint has VARSIZE >= 12 (header +
  *   pcid + at least 1 data byte from the data[1] placeholder) so the
  *   guard only protects against malformed input, not valid values.
+ * @note Exported (not `static`) so that the generic WKB path in
+ *   temporal/type_out.c (`pcpoint_to_wkb_buf`) can zero the same padding
+ *   bytes and stay byte-consistent with the hex-WKB path below.
  */
-static inline size_t
+size_t
 pcpoint_meaningful_size(const Pcpoint *pt)
 {
   size_t sz = VARSIZE(pt);

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -1341,15 +1341,20 @@ npoint_to_wkb_size(const Npoint *np, uint8_t variant, bool component)
  * in the Well-Known Binary (WKB) representation
  *
  * The encoding is intentionally minimal: the entire varlena body
- * (i.e. pcid + payload) is written length-prefixed, with the
- * trailing struct padding trimmed. The schema for the @c pcid is
- * resolved out-of-band (pgpointcloud's @c pointcloud_formats catalog,
- * via the @c meos_pc_schema_fn hook installed at backend startup),
- * so it is not embedded in the WKB. This makes the encoding fine for
- * @c COPY @c BINARY round-trips inside a database, but assumes the
- * receiver can resolve @c pcid against the same catalog. Cross-cluster
- * portability is a separate concern handled by an optional schema-
- * embedding flag bit (not yet implemented).
+ * (i.e. pcid + payload) is written length-prefixed. The full length is
+ * kept even for a pcpoint, whose trailing bytes are pgpointcloud's
+ * struct-tail padding (see the note in pointcloud/pcpoint.c): shrinking
+ * the length would make @c pcvarlena_from_wkb_state (type_in.c) allocate
+ * a varlena pgpointcloud's own point deserializer no longer recognizes.
+ * @c pcpoint_to_wkb_buf writes that padding as zeros instead, mirroring
+ * @c pcpoint_hex_out, so two byte-equal pcpoints always agree on their
+ * WKB. The schema for the @c pcid is resolved out-of-band (pgpointcloud's
+ * @c pointcloud_formats catalog, via the @c meos_pc_schema_fn hook
+ * installed at backend startup), so it is not embedded in the WKB. This
+ * makes the encoding fine for @c COPY @c BINARY round-trips inside a
+ * database, but assumes the receiver can resolve @c pcid against the
+ * same catalog. Cross-cluster portability is a separate concern handled
+ * by an optional schema-embedding flag bit (not yet implemented).
  */
 static size_t
 pcpoint_to_wkb_size(const Pcpoint *pt, uint8_t variant)
@@ -2206,15 +2211,30 @@ opaque_bytes_to_wkb_buf(const uint8_t *src, size_t body_len, uint8_t *buf,
  * Binary (WKB) representation: int32 body length + body bytes.
  *
  * The body comprises everything after the varlena header: pcid +
- * dimension payload, with the pgpointcloud tail padding trimmed.
+ * dimension payload. The trailing bytes past the meaningful prefix are
+ * pgpointcloud's struct-tail padding, which its constructor leaves
+ * uninitialized (see the note in pointcloud/pcpoint.c). They are
+ * written as zeros — mirroring @c pcpoint_hex_out — instead of copied
+ * verbatim, so that two pcpoints holding the same point always produce
+ * the same WKB. The full body length is still written, matching what
+ * @c pcvarlena_from_wkb_state (type_in.c) needs to rebuild a varlena of
+ * the size pgpointcloud's own deserializer expects.
  */
 static uint8_t *
 pcpoint_to_wkb_buf(const Pcpoint *pt, uint8_t *buf, uint8_t variant)
 {
   size_t body_len = VARSIZE(pt) - VARHDRSZ;
+  size_t meaningful_len = pcpoint_meaningful_size(pt) - VARHDRSZ;
+  assert(meaningful_len <= body_len);
   buf = int32_to_wkb_buf((int32) body_len, buf, variant);
-  return opaque_bytes_to_wkb_buf((const uint8_t *) VARDATA(pt), body_len,
+  buf = opaque_bytes_to_wkb_buf((const uint8_t *) VARDATA(pt), meaningful_len,
     buf, variant);
+  for (size_t i = meaningful_len; i < body_len; i++)
+  {
+    uint8_t zero = 0;
+    buf = opaque_bytes_to_wkb_buf(&zero, 1, buf, variant);
+  }
+  return buf;
 }
 static uint8_t *
 pcpatch_to_wkb_buf(const Pcpatch *pa, uint8_t *buf, uint8_t variant)

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -42,6 +42,32 @@ SELECT asText(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '20
  t
 (1 row)
 
+SELECT asText(tpcpointFromBinary(asBinary(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)))) = asText(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT asText(tpcpointFromHexWKB(asHexWKB(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)))) = asText(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT asHexWKB(tpcpoint(pcpoint(1, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz)) =
+  asHexWKB(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT asBinary(tpcpoint(pcpoint(1, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz)) =
+  asBinary(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT pcid(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  pcid 
 ------

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -72,6 +72,27 @@ SELECT array_length(asText(ARRAY[:inst1, :inst2]), 1);
 SELECT asText(ARRAY[:inst1, :inst2]) = ARRAY[asText(:inst1), asText(:inst2)];
 
 -------------------------------------------------------------------------------
+-- WKB / HexWKB output
+-------------------------------------------------------------------------------
+
+-- Round trip through the generic WKB path.
+SELECT asText(tpcpointFromBinary(asBinary(:inst1))) = asText(:inst1);
+SELECT asText(tpcpointFromHexWKB(asHexWKB(:inst1))) = asText(:inst1);
+
+-- Two independently-constructed byte-equal pcpoints produce identical WKB.
+-- pcpoint() and PC_MakePoint() are different function calls (so the
+-- planner cannot constant-fold one into the other) that build the same
+-- point, which is what exposes pgpointcloud's uninitialized struct-tail
+-- padding (see the note in pointcloud/pcpoint.c): the generic WKB path
+-- (pcpoint_to_wkb_buf in temporal/type_out.c) used to copy that padding
+-- verbatim, so the two calls below could disagree past the meaningful
+-- prefix even though the points they wrap are equal.
+SELECT asHexWKB(tpcpoint(pcpoint(1, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz)) =
+  asHexWKB(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT asBinary(tpcpoint(pcpoint(1, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz)) =
+  asBinary(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+
+-------------------------------------------------------------------------------
 -- pcid + subtype size
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The generic Well-Known Binary writer for a pointcloud point writes the struct-tail padding that pgpointcloud leaves uninitialized as zeros rather than copying it verbatim, so two points holding the same value serialize to identical binary and hexadecimal representations, matching the scalar hex representation. The pcpoint_meaningful_size measurement is shared between the two paths. A regression test covers two independently constructed equal points.