### PR TITLE
Cover the circular-buffer temporal relationships in the smoke tests

### DIFF
--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -688,16 +688,7 @@ TCBUFFER_CONFIG = dict(
     name_arg_map={
         r"tstzset": {"Set *": "tstzset1"},
     },
-    skip={
-        # Internal "Unknown compare function for type" / "type is not a
-        # span type" failures, surfacing real MEOS bugs in the cbuffer
-        # spanset path. Skip until fixed.
-        "re:^tdisjoint_(tcbuffer|cbuffer|geo)_":   "MEOS bug: Unknown compare function for type",
-        "re:^tintersects_(tcbuffer|cbuffer|geo)_": "MEOS bug: type is not a span type",
-        "re:^ttouches_(tcbuffer|cbuffer|geo)_":    "MEOS bug: spanset path issue",
-        "re:^tcontains_(tcbuffer|cbuffer|geo)_":   "MEOS bug: spanset path issue",
-        "re:^tcovers_(tcbuffer|cbuffer|geo)_":     "MEOS bug: spanset path issue",
-    },
+    skip={},
     common_inputs="""\
   TimestampTz tstz1 = timestamptz_in("2001-01-02", -1);
   Span *tstzspan1 = tstzspan_in("[2001-01-01, 2001-01-04]");


### PR DESCRIPTION
The temporal spatial-relationship functions over tcbuffer and cbuffer (tdisjoint, tintersects, ttouches, tcontains and tcovers, in every argument direction) run cleanly, so the smoke-test generator calls them instead of skipping them, bringing the circular-buffer relationship surface under the valgrind leak floor.