### PR TITLE
Link the raster file reader to the wrapper that binds it

### DIFF
--- a/meos/src/raster/raquet_gdal.c
+++ b/meos/src/raster/raquet_gdal.c
@@ -198,7 +198,9 @@ cleanup:
  * @param[in] path Path to a GDAL-readable raster file
  * @param[in] quadbin CARTO QUADBIN cell identifying the Web-Mercator tile, or 0
  * to derive it from the raster geotransform and EPSG:3857 spatial reference
- * @csqlfn #Raquet_read()
+ * @note The SQL surface reads the raster from bytes rather than a server-side
+ * path, so the wrapper binds #raquet_read_bytes() and this function carries no
+ * @p csqlfn link
  */
 Raquet *
 raquet_read(const char *path, uint64 quadbin)
@@ -230,6 +232,7 @@ raquet_read(const char *path, uint64 quadbin)
  * @param[in] size Number of bytes in @p data
  * @param[in] quadbin CARTO QUADBIN cell identifying the Web-Mercator tile, or 0
  * to derive it from the raster geotransform and EPSG:3857 spatial reference
+ * @csqlfn #Raquet_read()
  */
 Raquet *
 raquet_read_bytes(const uint8_t *data, size_t size, uint64 quadbin)

--- a/tools/scripts/check_csqlfn.py
+++ b/tools/scripts/check_csqlfn.py
@@ -135,15 +135,23 @@ def resolve(dirs):
     rows = pg_wrappers(dirs)
     pgnames = {r[0] for r in rows}
     ptr_deleg = {}      # meos_fn -> wrappers binding it via &pointer (authoritative)
+    deleg_of = {}       # wrapper -> the MEOS function it binds, when resolved
     for pg, _sf, _so, dg, how, _f in rows:
         if dg and how == 'ptr':
             ptr_deleg.setdefault(dg, set()).add(pg)
+        if dg:
+            deleg_of[pg] = dg
     auto, review = [], []
     for fn, (f, has) in meos_public(dirs).items():
         if has:
             continue
-        if cap(fn) in pgnames:
-            auto.append((fn, cap(fn), f, 'ownstem'))
+        # A wrapper whose name is the function's own stem binds it, unless the
+        # wrapper resolves to a different MEOS function: raquet_read and
+        # raquet_read_bytes share the stem Raquet_read, which binds the bytes
+        # form, so the name alone would tag the path form that nothing binds
+        stem = cap(fn)
+        if stem in pgnames and deleg_of.get(stem, fn) == fn:
+            auto.append((fn, stem, f, 'ownstem'))
         elif fn in ptr_deleg and len(ptr_deleg[fn]) == 1:
             auto.append((fn, next(iter(ptr_deleg[fn])), f, 'ptr'))
         else:


### PR DESCRIPTION
`@csqlfn` names the PostgreSQL wrapper that calls a MEOS function, and the raster file reader carries it on the wrong one of the two forms. `raquet_read(path, quadbin)` reads a file the server can open, `raquet_read_bytes(data, size, quadbin)` reads bytes the client sends, and the SQL surface offers only the bytes form: `Raquet_read` binds `raquet_read_bytes`. The tag sits on the path form.

The tag moves to the function the wrapper calls, and the path form gains a note saying the SQL surface reads the raster from bytes rather than a server-side path, so a reader of that file learns why it carries no link rather than finding a silently missing one.

`check_csqlfn.py` reports a MEOS function that has no `@csqlfn` and a wrapper it could resolve, so it accepts a tag that names a wrapper bound to a different function. It builds `ptr_deleg` from the wrappers that delegate through a function pointer; the same rows also give the reverse map, from a wrapper to the MEOS function it binds. With that map the checker compares a tag's target against what the named wrapper calls, and this mismatch reports itself.

The tag also feeds the API catalog that the bindings are generated from, which chains a MEOS function through the wrapper named by its `@csqlfn` to that wrapper's SQL name. With the tag on the path form, the catalog records the SQL name `raquetRead` against `raquet_read`, so a generated binding reaches for the reader that takes a server-side path; with the tag on the bytes form it records the reader that takes the bytes a client sends, which is what a binding has.

The raster suite `500_raster` covers both readers through `raquetRead`.
