### PR TITLE
Free the temporary endpoints of the 3D shortest line

### DIFF
--- a/postgis/liblwgeom/measures3d.c
+++ b/postgis/liblwgeom/measures3d.c
@@ -103,7 +103,9 @@ create_v_line(const LWGEOM *lwgeom, double x, double y, int32_t srid)
 	lwpoints[0] = lwpoint_make3dz(srid, x, y, gbox.zmin);
 	lwpoints[1] = lwpoint_make3dz(srid, x, y, gbox.zmax);
 
-	return (LWGEOM *)lwline_from_ptarray(srid, 2, lwpoints);
+	LWGEOM *result = (LWGEOM *)lwline_from_ptarray(srid, 2, lwpoints);
+	lwpoint_free(lwpoints[0]); lwpoint_free(lwpoints[1]); // MEOS
+	return result;
 }
 
 LWGEOM *
@@ -223,6 +225,7 @@ lw_dist3d_distanceline(const LWGEOM *lw1, const LWGEOM *lw2, int32_t srid, int m
 		lwpoints[1] = lwpoint_make3dz(srid, x2, y2, z2);
 
 		result = (LWGEOM *)lwline_from_ptarray(srid, 2, lwpoints);
+		lwpoint_free(lwpoints[0]); lwpoint_free(lwpoints[1]); // MEOS
 	}
 
 	return result;


### PR DESCRIPTION
lw_dist3d_distanceline and create_v_line build two LWPOINT endpoints and pass them to lwline_from_ptarray, which copies their coordinates into a new point array without taking ownership of the wrappers, then discard them. Each now frees the two points once the line is built, matching the 2D lw_dist2d_distanceline. This releases the memory that geom_shortestline3d and the 3D distance functions leaked.