### PR TITLE
Report a temporal rigid geometry as always intersecting where it does

### DIFF
--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -506,10 +506,11 @@ ea_intersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   if (ever)
     return spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
       (varfunc) &datum_geom_intersects2d, 2, INVERT_NO);
-  /* aIntersects(trgeo, geo) ≡ NOT eDisjoint(trgeo, geo) */
-  int result = spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
+  /* aIntersects(trgeo, geo) ≡ NOT eDisjoint(trgeo, geo), and the temporal
+   * value is ever disjoint from the geometry exactly where the geometry does
+   * not cover its traversed area, so the always semantics are that covering */
+  return spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
     (varfunc) &datum_geom_covers, 2, INVERT);
-  return INVERT_RESULT(result);
 }
 
 /**

--- a/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
+++ b/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
@@ -155,7 +155,7 @@ SELECT aIntersects(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
  aintersects 
 -------------
- t
+ f
 (1 row)
 
 SELECT eIntersects(
@@ -171,7 +171,7 @@ SELECT aIntersects(
   geometry 'Polygon((-1 -1,2 -1,2 2,-1 2,-1 -1))');
  aintersects 
 -------------
- t
+ f
 (1 row)
 
 SELECT eIntersects(
@@ -185,6 +185,38 @@ SELECT eIntersects(
 SELECT aIntersects(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
+ aintersects 
+-------------
+ t
+(1 row)
+
+SELECT eIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(20 20),0)@2001-01-01, Pose(Point(30 30),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,2 -1,2 2,-1 2,-1 -1))');
+ eintersects 
+-------------
+ f
+(1 row)
+
+SELECT aIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(20 20),0)@2001-01-01, Pose(Point(30 30),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,2 -1,2 2,-1 2,-1 -1))');
+ aintersects 
+-------------
+ f
+(1 row)
+
+SELECT aIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(1 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,4 -1,4 4,-1 4,-1 -1))');
+ aintersects 
+-------------
+ t
+(1 row)
+
+SELECT aIntersects(
+  geometry 'Polygon((-1 -1,4 -1,4 4,-1 4,-1 -1))',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(1 0),0)@2001-01-05]');
  aintersects 
 -------------
  t

--- a/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
+++ b/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
@@ -142,6 +142,21 @@ SELECT aIntersects(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
 
+-- A body that never reaches the geometry does not always intersect it, and one
+-- that stays within the geometry throughout does
+SELECT eIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(20 20),0)@2001-01-01, Pose(Point(30 30),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,2 -1,2 2,-1 2,-1 -1))');
+SELECT aIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(20 20),0)@2001-01-01, Pose(Point(30 30),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,2 -1,2 2,-1 2,-1 -1))');
+SELECT aIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(1 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,4 -1,4 4,-1 4,-1 -1))');
+SELECT aIntersects(
+  geometry 'Polygon((-1 -1,4 -1,4 4,-1 4,-1 -1))',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(1 0),0)@2001-01-05]');
+
 -------------------------------------------------------------------------------
 -- eTouches / aTouches
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The always semantics of intersects are the complement of the ever disjoint, as the comment on the branch states, and a temporal rigid geometry is ever disjoint from a geometry exactly where that geometry does not cover its traversed area. The branch computes that covering and then applies `INVERT_RESULT`, giving `! covers(gs, trav)` — which is character for character the body of `ea_disjoint_trgeo_geo`. So `aIntersects` carries the value of `eDisjoint` rather than its complement:

```sql
SELECT eIntersects(
  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(20 20),0)@2001-01-01, Pose(Point(30 30),0)@2001-01-05]',
  geometry 'Polygon((-1 -1,2 -1,2 2,-1 2,-1 -1))');   -- f
SELECT aIntersects(  -- same operands
  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(20 20),0)@2001-01-01, Pose(Point(30 30),0)@2001-01-05]',
  geometry 'Polygon((-1 -1,2 -1,2 2,-1 2,-1 -1))');   -- f
```

Before this the second answers true: a body that never comes near the geometry is reported as always intersecting it, while the ever form correctly answers false.

Against the temporal geometry the value casts to through `trgeometry_to_tgeometry` — which the geo family resolves — the answers disagree on 44 cases over five predicates, seven poses and eleven geometry types, and the always answer holds without the ever one on 40 of them.

This returns the covering. Two committed expectations move, both from true to false, and both are the body sliding from `(0 0)` to `(4 0)` against a box that reaches `x = 2`: the body leaves the box before the end of its period, so it intersects at some instant and not at every one. The added cases pair a body that never reaches the geometry with one that stays inside it throughout, in both argument orders.