### PR TITLE
Document the RPM-based build dependencies and the supported version ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,9 +111,9 @@ Requirements
 ------------
 
 *   Linux (other UNIX-like systems may work, but remain untested)
-*   CMake >= 3.7
+*   CMake >= 3.12
 *   A C++17 compiler (e.g. GCC >= 7, Clang >= 5, MSVC >= 19.14) — required since the polygon Boolean engine was migrated to vendored Clipper2
-*   PostgreSQL >= 14
+*   PostgreSQL 16 to 19 (the build stops with an explicit error outside that range)
 *   PostGIS >= 3.0
 *   GEOS >= 3.8
 *   PROJ4 >= 6.1
@@ -124,6 +124,11 @@ Requirements
 For example, you can build the following command to install all MobilityDB build dependencies for Debian-based systems using PostgreSQL 16 and PostGIS 3:
 ```bash
 apt install build-essential cmake postgresql-server-dev-16 libgeos-dev libproj-dev libjson-c-dev libgsl-dev
+```
+
+On Fedora and other RPM-based distributions, the same dependencies are installed with the distribution packages, which already carry a supported PostgreSQL and PostGIS:
+```bash
+dnf install gcc gcc-c++ cmake make postgresql-server-devel postgis geos-devel proj-devel json-c-devel gsl-devel
 ```
 
 Building & Installation

--- a/doc/es/introduction.xml
+++ b/doc/es/introduction.xml
@@ -224,7 +224,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 				<listitem><para>Sistema de compilación multiplataforma <filename>CMake</filename>.</para></listitem>
 				<listitem><para>Compilador C <filename>gcc</filename> o <filename>clang</filename>. Se pueden usar otros compiladores ANSI C, pero pueden causar problemas al compilar algunas dependencias.</para></listitem>
 				<listitem><para>GNU Make (<filename>gmake</filename> o <filename>make</filename>) versión 3.1 o superior. Para muchos sistemas, GNU make es la versión predeterminada de make. Verifique la versión invocando <filename>make -v</filename>.</para></listitem>
-				<listitem><para>PostgreSQL versión 12 o superior. PostgreSQL está disponible en <ulink url="http://www.postgresql.org">http://www.postgresql.org</ulink>.</para></listitem>
+				<listitem><para>PostgreSQL versión 16 a 19. Fuera de ese rango, la configuración se detiene con un error explícito. PostgreSQL está disponible en <ulink url="http://www.postgresql.org">http://www.postgresql.org</ulink>.</para></listitem>
 				<listitem><para>PostGIS versión 3 o superior. PostGIS está disponible en <ulink url="https://postgis.net/">https://postgis.net/</ulink>.</para></listitem>
 				<listitem><para>Biblioteca científica GNU (GSL). GSL está disponible en <ulink url="https://www.gnu.org/software/gsl/">https://www.gnu.org/software/gsl/</ulink>. GSL se utiliza para los generadores de números aleatorios.</para></listitem>
 			</itemizedlist>
@@ -251,7 +251,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 			</itemizedlist>
 
 			<para>
-				<emphasis role="bold">Ejemplo: instalar dependencias en Linux</emphasis>
+				<emphasis role="bold">Ejemplo: instalar dependencias en distribuciones basadas en Debian</emphasis>
 			</para>
 
 			<para>Dependencias de base de datos</para>
@@ -261,6 +261,18 @@ sudo apt-get install postgresql-16 postgresql-server-dev-16 postgresql-16-postgi
 			<para>Dependencias de construcción</para>
 			<programlisting language="bash" xml:space="preserve">
 sudo apt-get install cmake gcc libgsl-dev
+</programlisting>
+
+			<para>
+				<emphasis role="bold">Ejemplo: instalar dependencias en distribuciones basadas en RPM</emphasis>
+			</para>
+
+			<para>
+				En Fedora, Red Hat Enterprise Linux y sus derivados, los paquetes de la distribución incluyen una versión compatible de PostgreSQL y de PostGIS, por lo que un solo comando cubre tanto las dependencias de base de datos como las de construcción.
+			</para>
+			<programlisting language="bash" xml:space="preserve">
+sudo dnf install gcc gcc-c++ cmake make postgresql-server-devel postgis \
+  geos-devel proj-devel json-c-devel gsl-devel
 </programlisting>
 		</sect2>
 

--- a/doc/introduction.xml
+++ b/doc/introduction.xml
@@ -225,7 +225,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 				<listitem><para><filename>CMake</filename> cross-platform build system.</para></listitem>
 				<listitem><para>C compiler <filename>gcc</filename> or <filename>clang</filename>. Other ANSI C compilers can be used but may cause problems compiling some dependencies.</para></listitem>
 				<listitem><para>GNU Make (<filename>gmake</filename> or <filename>make</filename>) version 3.1 or higher. For many systems, GNU make is the default version of make. Check the version by invoking <filename>make -v</filename>.</para></listitem>
-				<listitem><para>PostgreSQL version 12 or higher. PostgreSQL is available from <ulink url="http://www.postgresql.org">http://www.postgresql.org</ulink>.</para></listitem>
+				<listitem><para>PostgreSQL version 16 to 19. Outside that range the configuration stops with an explicit error. PostgreSQL is available from <ulink url="http://www.postgresql.org">http://www.postgresql.org</ulink>.</para></listitem>
 				<listitem><para>PostGIS version 3 or higher. PostGIS is available from <ulink url="https://postgis.net/">https://postgis.net/</ulink>.</para></listitem>
 				<listitem><para>GNU Scientific Library (GSL). GSL is available from <ulink url="https://www.gnu.org/software/gsl/">https://www.gnu.org/software/gsl/</ulink>. GSL is used for the random number generators.</para></listitem>
 			</itemizedlist>
@@ -252,7 +252,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 			</itemizedlist>
 
 			<para>
-				<emphasis role="bold">Example: Installing dependencies on Linux</emphasis>
+				<emphasis role="bold">Example: Installing dependencies on Debian-based distributions</emphasis>
 			</para>
 
 			<para>Database dependencies</para>
@@ -262,6 +262,18 @@ sudo apt-get install postgresql-16 postgresql-server-dev-16 postgresql-16-postgi
 			<para>Build dependencies</para>
 			<programlisting language="bash" xml:space="preserve" format="linespecific">
 sudo apt-get install cmake gcc libgsl-dev
+</programlisting>
+
+			<para>
+				<emphasis role="bold">Example: Installing dependencies on RPM-based distributions</emphasis>
+			</para>
+
+			<para>
+				On Fedora, Red Hat Enterprise Linux, and their derivatives the distribution packages carry a supported PostgreSQL and PostGIS, so a single command covers both the database and the build dependencies.
+			</para>
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
+sudo dnf install gcc gcc-c++ cmake make postgresql-server-devel postgis \
+  geos-devel proj-devel json-c-devel gsl-devel
 </programlisting>
 		</sect2>
 


### PR DESCRIPTION
The stated requirements do not match what the build accepts, and the dependency example covers Debian-based distributions only.

* `CMakeLists.txt` requires CMake 3.12, not 3.7.
* `mobilitydb/CMakeLists.txt` accepts PostgreSQL 16 to 19 (`PG_MIN_MAJOR_VERSION` / `PG_MAX_MAJOR_VERSION`) and stops with an explicit `FATAL_ERROR` outside that range; the README announces `>= 14` and the manual `12 or higher`.
* Fedora, RHEL, and their derivatives have no package list in the documentation.

This states the ranges the build enforces and adds the `dnf` command that installs the dependencies from the distribution packages, in the README and in both the English and the Spanish manual.

The package list is the one that builds and installs master on a stock Fedora 44 container (GCC 16.1.1, CMake 4.3.0, PostgreSQL 18.4, PostGIS 3.6.4, GEOS 3.14.1, PROJ 9.8.1) with zero compiler warnings.
