### PR TITLE
Read a pixel type name without regard to case

### DIFF
--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -305,7 +305,7 @@ SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
 				<para>Devolver el nombre del tipo de dato de píxel de una tesela Raquet</para>
 				<para><varname>pixtype(raquet) → text</varname></para>
-				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>.</para>
+				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela se acepta tal cual; el nombre devuelto aquí conserva las mayúsculas.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Leer la disposición de una tesela empaquetada
 SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -303,7 +303,7 @@ SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
 				<para>Return the name of the pixel data type of a Raquet tile</para>
 				<para><varname>pixtype(raquet) → text</varname></para>
-				<para>The returned name is the one the constructors accept, that is, one of <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>.</para>
+				<para>The returned name is the one the constructors accept, that is, one of <varname>UINT8</varname>, <varname>INT16</varname>, <varname>INT32</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>. The constructors read the name without regard to case, so the lower-case spelling the RaQuet specification gives a tile's <varname>type</varname> field is accepted as it stands; the name returned here keeps the upper case.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Read back the layout of a packaged tile
 SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -106,17 +106,21 @@ raquet_pixtype_size(MeosPixType pixtype)
  * @brief Return the pixel data type corresponding to a name
  * @param[in] str Pixel type name: UINT8, INT16, INT32, FLOAT32, or FLOAT64
  * @note This is the parser counterpart of #raquet_pixtype()
+ * @note The name is read without regard to case, so the lower-case spelling
+ * the RaQuet specification gives the `type` field of a tile carries straight
+ * through from a file into the constructors. The name #raquet_pixtype()
+ * returns keeps the upper case the SQL surface documents
  */
 MeosPixType
 raquet_pixtype_from_string(const char *str)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(str, MEOS_PT_UINT8);
-  if (strcmp(str, "UINT8") == 0)   return MEOS_PT_UINT8;
-  if (strcmp(str, "INT16") == 0)   return MEOS_PT_INT16;
-  if (strcmp(str, "INT32") == 0)   return MEOS_PT_INT32;
-  if (strcmp(str, "FLOAT32") == 0) return MEOS_PT_FLOAT32;
-  if (strcmp(str, "FLOAT64") == 0) return MEOS_PT_FLOAT64;
+  if (pg_strcasecmp(str, "UINT8") == 0)   return MEOS_PT_UINT8;
+  if (pg_strcasecmp(str, "INT16") == 0)   return MEOS_PT_INT16;
+  if (pg_strcasecmp(str, "INT32") == 0)   return MEOS_PT_INT32;
+  if (pg_strcasecmp(str, "FLOAT32") == 0) return MEOS_PT_FLOAT32;
+  if (pg_strcasecmp(str, "FLOAT64") == 0) return MEOS_PT_FLOAT64;
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
     "Unknown pixel type \"%s\": use UINT8, INT16, INT32, FLOAT32, or FLOAT64",
     str);

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -399,6 +399,29 @@ SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')
  UINT8   | INT16   | INT32   | FLOAT32 | FLOAT64
 (1 row)
 
+SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+  'uint8'));
+ pixtype 
+---------
+ UINT8
+(1 row)
+
+SELECT pixtype(raquet('\x0102030405060708'::bytea, 2, 1,
+  5193776270265024512::bigint, 'float32'));
+ pixtype 
+---------
+ FLOAT32
+(1 row)
+
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint8')
+       = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint12');
+ERROR:  Unknown pixel type "uint12": use UINT8, INT16, INT32, FLOAT32, or FLOAT64
 SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
   -9999.0));
  nodata 

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -450,6 +450,19 @@ SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')
        pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          'FLOAT64'));
 
+-- The pixel type name is read without regard to case, so the lower-case
+-- spelling the RaQuet specification gives a tile's type field is accepted as
+-- it stands. The name reported back keeps the documented upper case.
+SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+  'uint8'));
+SELECT pixtype(raquet('\x0102030405060708'::bytea, 2, 1,
+  5193776270265024512::bigint, 'float32'));
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint8')
+       = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
+
+-- An unknown name is still rejected, whatever its case.
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint12');
+
 -- The nodata sentinel supplied to the constructor is the one reported back.
 SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
   -9999.0));


### PR DESCRIPTION
The RaQuet specification spells a tile's pixel type in lower case in the `type`
field of its metadata. `raquet_pixtype_from_string` reads the name with
`pg_strcasecmp`, so a tile whose type comes from a conformant RaQuet producer is
accepted as it stands rather than rejected as an unknown pixel type.

`raquet_pixtype()` returns the upper-case name, so the output of the type is
untouched and `pixtype(t) = 'UINT8'` holds. This is the strict reader half of the
contract, not a change to what the library emits: MEOS has no RaQuet metadata
writer, so conformance here is an input-side question only.

The EN and ES manuals carry the sentence that says so, and the SQL test covers
each of the five names in the specification's spelling.