### PR TITLE
Name the packages the optional families need on RPM-based distributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ On Fedora and other RPM-based distributions, the same dependencies are installed
 dnf install gcc gcc-c++ cmake make postgresql-server-devel postgis geos-devel proj-devel json-c-devel gsl-devel
 ```
 
+The optional families that `-DALL=ON` enables need two more packages, `gdal-devel` for the raster operators and `h3-devel` for the H3 index type.
+
 Building & Installation
 -----------------------
 

--- a/doc/es/introduction.xml
+++ b/doc/es/introduction.xml
@@ -274,6 +274,9 @@ sudo apt-get install cmake gcc libgsl-dev
 sudo dnf install gcc gcc-c++ cmake make postgresql-server-devel postgis \
   geos-devel proj-devel json-c-devel gsl-devel
 </programlisting>
+			<para>
+				Las familias opcionales que habilita <varname>-DALL=ON</varname> requieren dos paquetes adicionales, <varname>gdal-devel</varname> para los operadores de rásteres y <varname>h3-devel</varname> para el tipo de índice H3.
+			</para>
 		</sect2>
 
 		<sect2 xml:id="configuring">

--- a/doc/introduction.xml
+++ b/doc/introduction.xml
@@ -275,6 +275,9 @@ sudo apt-get install cmake gcc libgsl-dev
 sudo dnf install gcc gcc-c++ cmake make postgresql-server-devel postgis \
   geos-devel proj-devel json-c-devel gsl-devel
 </programlisting>
+			<para>
+				The optional families enabled by <varname>-DALL=ON</varname> need two further packages, <varname>gdal-devel</varname> for the raster operators and <varname>h3-devel</varname> for the H3 index type.
+			</para>
 		</sect2>
 
 		<sect2 xml:id="configuring">


### PR DESCRIPTION
The RPM dependency command installs what the default build needs. Enabling the optional families with `-DALL=ON` also needs GDAL, which the raster operators link against, and libh3, which the H3 index type links against.

Without `gdal-devel`, a `-DALL=ON` configuration on a stock Fedora 44 stops at:

```
CMake Error at /usr/share/cmake/Modules/FindPackageHandleStandardArgs.cmake:290 (message):
  Could NOT find GDAL (missing: GDAL_LIBRARY GDAL_INCLUDE_DIR) (found version
  "GDAL_VERSION-NOTFOUND")
Call Stack (most recent call first):
  /usr/share/cmake/Modules/FindGDAL.cmake:231 (find_package_handle_standard_args)
  CMakeLists.txt:517 (find_package)
```

With `gdal-devel` and `h3-devel` added, `-DALL=ON` configures and builds on Fedora 44 (GDAL 3.12.4, libh3 in `/usr/include/h3` and `/usr/lib64/libh3.so`).
