### PR TITLE
Emit ISO Well-Known Binary on the non-extended path to preserve the Z ordinate

### DIFF
--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -162,7 +162,7 @@ SELECT asMFJSON(tgeompoint 'SRID=4326;
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asBinary(tgeompoint 'Point(1 2 3)@2001-01-01');
--- \x012e0011000000000000f03f00000000000000400000000000000840009c57d3c11c0000
+-- \x012e001101e9030000000000000000f03f00000000000000400000000000000840009c57d3c11c0000
 SELECT asEWKB(tgeogpoint 'SRID=7844;Point(1 2 3)@2001-01-01');
 -- \x012f0071a41e0000000000000000f03f00000000000000400000000000000840009c57d3c11c0000
 SELECT asHexEWKB(tgeompoint 'SRID=3812;Point(1 2 3)@2001-01-01');

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -162,7 +162,7 @@ SELECT asMFJSON(tgeompoint 'SRID=4326;
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tgeompoint 'Point(1 2 3)@2001-01-01');
--- \x012e0011000000000000f03f00000000000000400000000000000840009c57d3c11c0000
+-- \x012e001101e9030000000000000000f03f00000000000000400000000000000840009c57d3c11c0000
 SELECT asEWKB(tgeogpoint 'SRID=7844;Point(1 2 3)@2001-01-01');
 -- \x012f0071a41e0000000000000000f03f00000000000000400000000000000840009c57d3c11c0000
 SELECT asHexEWKB(tgeompoint 'SRID=3812;Point(1 2 3)@2001-01-01');

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -1247,8 +1247,11 @@ spatial_wkb_needs_srid(int32_t srid, uint8_t variant)
 static size_t
 geo_to_wkb_size(const GSERIALIZED *gs, uint8_t variant)
 {
+  /* On the non-extended path emit ISO WKB so the Z and M ordinates are encoded
+   * without the SRID; the extended path already carries both. */
+  uint8_t v = (variant & WKB_EXTENDED) ? variant : (variant | (uint8_t) WKB_ISO);
   LWGEOM *geo = lwgeom_from_gserialized(gs);
-  size_t result = lwgeom_to_wkb_size(geo, variant);
+  size_t result = lwgeom_to_wkb_size(geo, v);
   lwgeom_free(geo);
   return result;
 }
@@ -2005,8 +2008,11 @@ text_to_wkb_buf(const text *txt, uint8_t *buf, uint8_t variant)
 static uint8_t *
 geo_to_wkb_buf(const GSERIALIZED *gs, uint8_t *buf, uint8_t variant)
 {
+  /* On the non-extended path emit ISO WKB so the Z and M ordinates are encoded
+   * without the SRID; the extended path already carries both. */
+  uint8_t v = (variant & WKB_EXTENDED) ? variant : (variant | (uint8_t) WKB_ISO);
   LWGEOM *geo = lwgeom_from_gserialized(gs);
-  buf = lwgeom_to_wkb_buf(geo, buf, variant);
+  buf = lwgeom_to_wkb_buf(geo, buf, v);
   lwgeom_free(geo);
   return buf;
 }

--- a/mobilitydb/test/geo/expected/050_set_tbl.test.out
+++ b/mobilitydb/test/geo/expected/050_set_tbl.test.out
@@ -116,6 +116,12 @@ SELECT asText(geomsetFromHexWKB(asHexWKB(geomset '{"Point(1 1 1)"}')));
  {"POINT Z (1 1 1)"}
 (1 row)
 
+SELECT asText(geomsetFromBinary(asBinary(geomset '{"Point(1 1 1)"}')));
+       astext        
+---------------------
+ {"POINT Z (1 1 1)"}
+(1 row)
+
 SELECT asEWKT(ARRAY[geometry 'Point(1 1)', 'SRID=5676;Point(1 1)']);
                 asewkt                 
 ---------------------------------------

--- a/mobilitydb/test/geo/expected/053_tgeo_inout.test.out
+++ b/mobilitydb/test/geo/expected/053_tgeo_inout.test.out
@@ -682,6 +682,12 @@ SELECT asBinary(tgeometry 'Point(1 1)@2000-01-01', 'XDR');
  \x00003c0100000000013ff00000000000003ff000000000000000000006b49d2000
 (1 row)
 
+SELECT asText(tgeometryFromBinary(asBinary(tgeometry 'Point(1 2 3)@2001-01-01')));
+                    astext                    
+----------------------------------------------
+ POINT Z (1 2 3)@Mon Jan 01 00:00:00 2001 PST
+(1 row)
+
 SELECT asHexEWKB(tgeometry '[Point(1 1)@2000-01-01]');
                                   ashexewkb                                   
 ------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/expected/053_tpoint_inout.test.out
+++ b/mobilitydb/test/geo/expected/053_tpoint_inout.test.out
@@ -727,6 +727,12 @@ SELECT asBinary(tgeompoint 'Point(1 1)@2000-01-01', 'XDR');
  \x00002e0100000000013ff00000000000003ff000000000000000000006b49d2000
 (1 row)
 
+SELECT asText(tgeompointFromBinary(asBinary(tgeompoint 'Point(1 2 3)@2001-01-01')));
+                    astext                    
+----------------------------------------------
+ POINT Z (1 2 3)@Mon Jan 01 00:00:00 2001 PST
+(1 row)
+
 SELECT asHexEWKB(tgeompoint '[Point(1 1)@2000-01-01]');
                                   ashexewkb                                   
 ------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/queries/050_set_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/050_set_tbl.test.sql
@@ -71,6 +71,8 @@ SELECT COUNT(*) FROM tbl_geogset WHERE geogsetFromHexWKB(asHexEWKB(g)) <> g;
 
 -- Coverage
 SELECT asText(geomsetFromHexWKB(asHexWKB(geomset '{"Point(1 1 1)"}')));
+-- 3D round trip: Z must survive the plain (non-extended) WKB encoding
+SELECT asText(geomsetFromBinary(asBinary(geomset '{"Point(1 1 1)"}')));
 SELECT asEWKT(ARRAY[geometry 'Point(1 1)', 'SRID=5676;Point(1 1)']);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/queries/053_tgeo_inout.test.sql
+++ b/mobilitydb/test/geo/queries/053_tgeo_inout.test.sql
@@ -200,6 +200,8 @@ SELECT asMFJSON(tgeometry 'SRID=123456;Point(50.813810 4.384260)@2019-01-01 18:0
 SELECT asBinary(tgeometry 'Point(1 1)@2000-01-01');
 SELECT asBinary(tgeometry 'Point(1 1)@2000-01-01', 'NDR');
 SELECT asBinary(tgeometry 'Point(1 1)@2000-01-01', 'XDR');
+-- 3D round trip: Z must survive the plain (non-extended) WKB encoding
+SELECT asText(tgeometryFromBinary(asBinary(tgeometry 'Point(1 2 3)@2001-01-01')));
 SELECT asHexEWKB(tgeometry '[Point(1 1)@2000-01-01]');
 SELECT asHexEWKB(tgeometry '[Point(1 1)@2000-01-01]', 'NDR');
 SELECT asHexEWKB(tgeometry '[Point(1 1)@2000-01-01]', 'XDR');

--- a/mobilitydb/test/geo/queries/053_tpoint_inout.test.sql
+++ b/mobilitydb/test/geo/queries/053_tpoint_inout.test.sql
@@ -207,6 +207,8 @@ SELECT asMFJSON(tgeompoint 'SRID=123456;Point(50.813810 4.384260)@2019-01-01 18:
 SELECT asBinary(tgeompoint 'Point(1 1)@2000-01-01');
 SELECT asBinary(tgeompoint 'Point(1 1)@2000-01-01', 'NDR');
 SELECT asBinary(tgeompoint 'Point(1 1)@2000-01-01', 'XDR');
+-- 3D round trip: Z must survive the plain (non-extended) WKB encoding
+SELECT asText(tgeompointFromBinary(asBinary(tgeompoint 'Point(1 2 3)@2001-01-01')));
 SELECT asHexEWKB(tgeompoint '[Point(1 1)@2000-01-01]');
 SELECT asHexEWKB(tgeompoint '[Point(1 1)@2000-01-01]', 'NDR');
 SELECT asHexEWKB(tgeompoint '[Point(1 1)@2000-01-01]', 'XDR');


### PR DESCRIPTION
The plain Well-Known Binary representation of a geometry emits ISO WKB, encoding the Z and M ordinates in the geometry type code without the SRID; the extended representation carries both the ordinates and the SRID. Round-trip regression tests over three-dimensional values and the reference documentation cover the encoding.