### PR TITLE
Write a temporal pose as an OGC GeoPose Stream

### DIFF
--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -114,6 +114,8 @@ extern Pose *pose_from_geopose(const char *json);
 extern char *pose_as_geopose(const Pose *pose, int conformance, int precision);
 extern Temporal *tpose_from_geopose(const char *json);
 extern char *tpose_as_geopose(const Temporal *temp, int conformance, int precision);
+extern char *tpose_as_geopose_stream_header(const Temporal *temp, int precision);
+extern char *tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst, int precision);
 extern GSERIALIZED *pose_apply_geo(const Pose *pose, const GSERIALIZED *body);
 extern Temporal *tpose_apply_geo(const Temporal *temp, const GSERIALIZED *body);
 

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -986,6 +986,25 @@ geopose_outer_frame(const GeoPoseAnchor *anchor, int precision)
 }
 
 /**
+ * @brief Set the tangent point of a composite from the pose of its first
+ * instant.
+ * @details Requirements 26 and 31 make the outer frame the first frame of a
+ * series, and Requirement 34 the first frame of a stream, so one instant
+ * fixes the frame that every later pose is expressed against.
+ * @return On error return false
+ */
+static bool
+geopose_anchor_from_instant(const TInstant *inst, GeoPoseAnchor *anchor)
+{
+  double lon, lat, h, W, X, Y, Z;
+  if (! geopose_pose_components(DatumGetPoseP(tinstant_value_p(inst)),
+      &lon, &lat, &h, &W, &X, &Y, &Z))
+    return false;
+  geopose_anchor_set(anchor, GEOPOSE_DEG2RAD(lat), GEOPOSE_DEG2RAD(lon), h);
+  return true;
+}
+
+/**
  * @brief Build a SeriesHeader or SeriesTrailer `poseCount` bearing object.
  * @details `integrityCheck` is optional in both and is not emitted: the
  * standard leaves the digest input undefined, so any value this
@@ -1065,17 +1084,12 @@ tpose_to_geopose_series(const Temporal *temp, bool regular, int precision)
     return NULL;
   }
 
-  /* Requirements 26 and 31 make the outer frame the first frame of the
-   * series, so the tangent point is the position of the first pose. */
-  double lon, lat, h, W, X, Y, Z;
-  if (! geopose_pose_components(DatumGetPoseP(tinstant_value_p(instants[0])),
-      &lon, &lat, &h, &W, &X, &Y, &Z))
+  GeoPoseAnchor anchor;
+  if (! geopose_anchor_from_instant(instants[0], &anchor))
   {
     pfree(instants);
     return NULL;
   }
-  GeoPoseAnchor anchor;
-  geopose_anchor_set(&anchor, GEOPOSE_DEG2RAD(lat), GEOPOSE_DEG2RAD(lon), h);
 
   json_object *arr = json_object_new_array();
   for (int i = 0; i < count; i++)
@@ -1419,6 +1433,93 @@ tpose_as_geopose(const Temporal *temp, int conformance, int precision)
   char *res = pstrdup(json_object_to_json_string_ext(series,
     GEOPOSE_JSON_FLAGS));
   json_object_put(series);
+  return res;
+}
+
+/**
+ * @ingroup meos_pose_base_geopose
+ * @brief Return the OGC GeoPose StreamHeader of a temporal pose
+ * @details A Stream is the open-ended member of the Composite Sequence
+ * classes: it carries the same frames as an Irregular Series but states
+ * neither how many poses there are nor when they end, since more may
+ * arrive. The standard splits it into two documents, and this is the one
+ * that "appears once at the beginning of a stream": the transition model
+ * of Requirement 35 and, per Requirement 34, the outer frame that every
+ * element is expressed against.
+ *
+ * The frame is anchored at the first pose of @p temp, so a producer that
+ * accumulates its value with @p temporal_append_tinstant writes the header
+ * from the same value it goes on to stream, and the elements it emits speak
+ * of the same tangent point.
+ * @param[in] temp Temporal pose
+ * @param[in] precision Significant digits in JSON numbers; -1 = lossless
+ * @return On error return @p NULL
+ */
+char *
+tpose_as_geopose_stream_header(const Temporal *temp, int precision)
+{
+  VALIDATE_TPOSE(temp, NULL);
+
+  const TInstant *first = (const TInstant *) temporal_start_instant(temp);
+  if (first == NULL)
+    return NULL;
+  GeoPoseAnchor anchor;
+  if (! geopose_anchor_from_instant(first, &anchor))
+    return NULL;
+
+  json_object *root = json_object_new_object();
+  json_object_object_add(root, "transitionModel",
+    geopose_transition_model(MEOS_FLAGS_GET_INTERP(temp->flags)));
+  json_object_object_add(root, "outerFrame",
+    geopose_outer_frame(&anchor, precision));
+  char *res = pstrdup(json_object_to_json_string_ext(root,
+    GEOPOSE_JSON_FLAGS));
+  json_object_put(root);
+  return res;
+}
+
+/**
+ * @ingroup meos_pose_base_geopose
+ * @brief Return the OGC GeoPose StreamElement of one instant of a temporal
+ * pose
+ * @details This is "the repeated information streamed at irregular times":
+ * the inner frame of @p inst and the instant it is valid at, wrapped as
+ * Requirement 36 asks. The frame is relative to the outer frame of the
+ * stream, which @p temp anchors at its first pose, so the same value that
+ * produced the header produces every element and the two agree.
+ * @param[in] temp Temporal pose the stream is written from
+ * @param[in] inst Instant to write
+ * @param[in] precision Significant digits in JSON numbers; -1 = lossless
+ * @return On error return @p NULL
+ */
+char *
+tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst,
+  int precision)
+{
+  VALIDATE_TPOSE(temp, NULL);
+  VALIDATE_NOT_NULL(inst, NULL);
+
+  const TInstant *first = (const TInstant *) temporal_start_instant(temp);
+  if (first == NULL)
+    return NULL;
+  GeoPoseAnchor anchor;
+  if (! geopose_anchor_from_instant(first, &anchor))
+    return NULL;
+
+  json_object *frame = geopose_inner_frame(&anchor,
+    DatumGetPoseP(tinstant_value_p(inst)), precision);
+  if (frame == NULL)
+    return NULL;
+  json_object *fat = json_object_new_object();
+  json_object_object_add(fat, "frame", frame);
+  json_object_object_add(fat, "validTime",
+    json_object_new_int64(geopose_instant_out(inst->t)));
+
+  json_object *root = json_object_new_object();
+  json_object_object_add(root, "streamElement", fat);
+  char *res = pstrdup(json_object_to_json_string_ext(root,
+    GEOPOSE_JSON_FLAGS));
+  json_object_put(root);
   return res;
 }
 

--- a/meos/test/geopose_test.c
+++ b/meos/test/geopose_test.c
@@ -286,6 +286,55 @@ int main(void)
   free(s1); free(again); free(out); free(irregular_back); free(irregular);
 
   /*--------------------------------------------------------------------------
+   * A stream is written a piece at a time
+   *------------------------------------------------------------------------*/
+
+  /* A Stream is the open-ended member of the Composite Sequence classes. The
+   * standard splits it into two documents: a header that appears once, and an
+   * element repeated for every pose that arrives. A producer accumulating its
+   * value writes the header from that value and an element per instant, so
+   * both speak of the same outer frame. */
+  meos_errno_reset();
+  Temporal *stream = tpose_in("[Geodpose(Point(0 0), 0)@2026-01-01, "
+    "Geodpose(Point(1 0), 0)@2026-01-02, Geodpose(Point(1 1), 0)@2026-01-05]");
+  assert(stream != NULL);
+  assert(meos_errno() == 0);
+
+  char *sh = tpose_as_geopose_stream_header(stream, 6);
+  assert(sh != NULL);
+  ensure_member("Stream header", sh, "\"transitionModel\"");
+  ensure_member("Stream header", sh, "\"outerFrame\"");
+  /* The header states neither how many poses there are nor when they end:
+   * more may arrive, which is what distinguishes a stream from a series. */
+  ensure_no_member("Stream header", sh, "\"poseCount\"");
+  ensure_no_member("Stream header", sh, "\"stopInstant\"");
+  ensure_no_member("Stream header", sh, "\"trailer\"");
+
+  /* Every instant yields an element carrying its frame and its time */
+  int ninsts = temporal_num_instants(stream);
+  assert(ninsts == 3);
+  for (int i = 0; i < ninsts; i++)
+  {
+    TInstant *inst = temporal_instant_n(stream, i + 1);
+    assert(inst != NULL);
+    char *se = tpose_as_geopose_stream_element(stream, inst, 6);
+    assert(se != NULL);
+    ensure_member("Stream element", se, "\"streamElement\"");
+    ensure_member("Stream element", se, "\"frame\"");
+    ensure_member("Stream element", se, "\"validTime\"");
+    free(se); free(inst);
+  }
+
+  /* The first element sits at the tangent point the header anchors, so its
+   * frame is the identity translation */
+  TInstant *first = temporal_instant_n(stream, 1);
+  char *se1 = tpose_as_geopose_stream_element(stream, first, 6);
+  printf("Stream first element: %s\n", se1);
+  assert(strstr(se1, "translation=[0, 0, 0]") != NULL);
+  free(se1); free(first);
+  free(sh); free(stream);
+
+  /*--------------------------------------------------------------------------
    * The error paths
    *------------------------------------------------------------------------*/
 
@@ -317,6 +366,27 @@ int main(void)
     bad ? "non-NULL" : "NULL", meos_errno());
   assert(bad == NULL);
   assert(meos_errno() != 0);
+
+  /* A stream is anchored by the value it is written from, so a planar value
+   * has no frame to anchor and neither document can be written */
+  meos_errno_reset();
+  Temporal *planar_s = tpose_in("[Pose(Point(0 0), 0)@2026-01-01, "
+    "Pose(Point(1 0), 0)@2026-01-02]");
+  assert(planar_s != NULL);
+  char *bad_sh = tpose_as_geopose_stream_header(planar_s, 6);
+  printf("stream header(planar value): %s, errno %d\n",
+    bad_sh ? "non-NULL" : "NULL", meos_errno());
+  assert(bad_sh == NULL);
+  assert(meos_errno() != 0);
+
+  meos_errno_reset();
+  TInstant *planar_i = temporal_instant_n(planar_s, 1);
+  char *bad_se = tpose_as_geopose_stream_element(planar_s, planar_i, 6);
+  printf("stream element(planar value): %s, errno %d\n",
+    bad_se ? "non-NULL" : "NULL", meos_errno());
+  assert(bad_se == NULL);
+  assert(meos_errno() != 0);
+  free(planar_i); free(planar_s);
 
   /* Every class of the standard places its pose in a topocentric frame on
    * the surface of the Earth, which a planar pose does not have */

--- a/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.StreamElement.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.StreamElement.Schema.json
@@ -1,0 +1,47 @@
+{
+  "description": "Stream Element: The repeated information streamed at irregular times.",
+  "definitions": {
+    "FrameAndTime": {
+      "type": "object",
+      "properties": {
+        "frame": {
+          "$ref": "#/definitions/FrameSpecification"
+        },
+        "validTime": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "frame"
+      ]
+    },
+    "FrameSpecification": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "streamElement": {
+      "$ref": "#/definitions/FrameAndTime"
+    }
+  },
+  "required": [
+    "streamElement"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.StreamHeader.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.StreamHeader.Schema.json
@@ -1,0 +1,56 @@
+{
+  "description": "Composite: StreamHeader - appears once at the beginning of a stream.",
+  "definitions": {
+    "FrameSpecification": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    },
+    "TransitionModel": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "transitionModel": {
+      "$ref": "#/definitions/TransitionModel"
+    },
+    "outerFrame": {
+      "$ref": "#/definitions/FrameSpecification"
+    }
+  },
+  "required": [
+    "transitionModel",
+    "outerFrame"
+  ]
+}

--- a/tools/scripts/check_geopose_conformance.py
+++ b/tools/scripts/check_geopose_conformance.py
@@ -59,11 +59,27 @@ CLASSES = [
         'GeoPose.Composite.Sequence.Series.Regular.Schema.json'),
     ('innerFrameAndTimeSeries', 'Irregular Series',
         'GeoPose.Composite.Sequence.Series.Irregular.Schema.json'),
+    # A stream is written as two documents: the header once, then one element
+    # per pose. `outerFrame` comes after the two Series members because a
+    # Series carries an outer frame as well, and its own member names it more
+    # precisely; a stream header is what is left holding only an outer frame.
+    ('streamElement', 'Stream element',
+        'GeoPose.Composite.Sequence.StreamElement.Schema.json'),
+    ('outerFrame', 'Stream header',
+        'GeoPose.Composite.Sequence.StreamHeader.Schema.json'),
     ('quaternion', 'Basic-Quaternion',
         'GeoPose.Basic.Quaternion.Schema.json'),
     ('angles', 'Basic-YPR',
         'GeoPose.Basic.YPR.Schema.json'),
 ]
+
+# The classes the SQL surface writes, and which the expected output therefore
+# has to contain for this check to mean anything. The two stream documents are
+# written through the C API alone -- a stream is emitted a piece at a time by a
+# producer, which a query is not -- so they are validated wherever they appear
+# rather than demanded here; `meos/test/geopose_test.c` is what exercises them.
+REQUIRED = ('Regular Series', 'Irregular Series', 'Basic-Quaternion',
+    'Basic-YPR')
 
 TYPES = {
     'object': dict,
@@ -206,7 +222,7 @@ def main():
             os.path.relpath(EXPECTED, ROOT))
         return 1
 
-    missing = [name for _, name, _ in CLASSES if name not in seen]
+    missing = [name for name in REQUIRED if name not in seen]
     if missing:
         print('check_geopose_conformance: no document emitted for %s' %
             ', '.join(missing))


### PR DESCRIPTION
A Stream is the open-ended member of the Composite Sequence classes of OGC GeoPose 1.0: it carries the frames of an Irregular Series but states neither how many poses there are nor when they end, since more may arrive. The standard describes it as an

> open-ended sequence of time-stamped GeoPoses

and writes it as two documents with a normative schema each — a `StreamHeader` that "appears once at the beginning of a stream", carrying the transition model of Requirement 35 and the outer frame of Requirement 34, and a `StreamElement` holding "the repeated information streamed at irregular times" as Requirement 36 asks. A temporal pose is written the same way:

```c
extern char *tpose_as_geopose_stream_header(const Temporal *temp, int precision);
extern char *tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst, int precision);
```

The value carries the state, as it does for the append that accumulates it. Both documents are written from the temporal pose, which anchors the outer frame at its first instant, so a producer appending with `temporal_append_tinstant` writes a header and elements that speak of the same tangent point while holding nothing else between calls. That keeps the encoder free of any handle to create, thread and release.

The tangent point of a composite is set in one place, which the series shares.

The two schemas join the ones `check_geopose_conformance.py` validates, and the check names the classes the SQL surface writes: the stream documents are written through the C API alone, a stream being emitted a piece at a time by a producer rather than by a query, so they are validated wherever they appear and `meos/test/geopose_test.c` exercises them. The header is covered for the members it carries and for the counts and bounds it does not, an element for every instant of a sequence, the first element for the identity translation that places it at the tangent point, and both entry points for the planar value they report.

This adds the Stream class to Basic-YPR, Basic-Quaternion and the Regular and Irregular Series, which is five of the eight conformance classes and all three of the Sequence ones.
