### PR TITLE
Follow the database encoding when building the default builtin locale

### DIFF
--- a/pgtypes/utils/pg_locale_builtin.c
+++ b/pgtypes/utils/pg_locale_builtin.c
@@ -133,7 +133,22 @@ meos_create_pg_locale_builtin(Oid collid)
 
   if (collid == DEFAULT_COLLATION_OID)
   {
+    /*
+     * @p database_locale is the UTF-8 builtin locale, which the builtin
+     * provider only accepts on a UTF-8 database. A database in any other
+     * encoding — SQL_ASCII is what initdb chooses when it runs under the C
+     * locale — takes the plain "C" builtin instead. Both are deterministic and
+     * both compare with memcmp, so text ordering and text hashes keep the same
+     * values on either locale; only the ctype semantics change, and "C" is the
+     * correct ctype for a database that is not UTF-8. Validating
+     * @p database_locale against such a database instead reports
+     * 'encoding "SQL_ASCII" does not match locale "C.UTF-8"' and every
+     * operation on a text value fails.
+     */
     locstr = database_locale;
+    int required_encoding = meos_builtin_locale_encoding(locstr);
+    if (required_encoding >= 0 && required_encoding != GetDatabaseEncoding())
+      locstr = "C";
   }
   else
   {


### PR DESCRIPTION
The default collation is pinned to the builtin `C.UTF-8` locale (`pgtypes/utils/pg_locale.c:190`), which the builtin provider accepts only on a UTF-8 database. On a database in any other encoding — `SQL_ASCII` is what a cluster created under the C locale gets — `meos_create_pg_locale_builtin` validates that locale against the database encoding and reports

```
ERROR:  encoding "SQL_ASCII" does not match locale "C.UTF-8"
```

so every operation on a text value fails: `hash(ttext …)`, `set_hash(textset …)`, text comparison, ordering.

This takes the plain `"C"` builtin locale instead when the database encoding is not the one the pinned locale requires. Both locales are deterministic and both compare with memcmp, so text hashes and text ordering keep the same values; only the ctype semantics change, and `"C"` is the correct ctype for a database that is not UTF-8. An explicitly named collation still validates as before.

Measured on a stock Fedora 44 container with no UTF-8 langpack, so the test cluster is `SQL_ASCII` — same build, same flags, only the patch differs:

| | master | with this change |
|---|---|---|
| tests failing | 58 of 240 | 56 of 240 |
| output files carrying the error | present | 0 |
| flipped to passing | — | `001_set_tbl`, `022_temporal` |
| newly failing | — | none |

Their output matches the **committed** expected files, which come from a UTF-8 cluster — the same hash values on either locale.

The 56 that stay red are an unrelated defect: sixty SQL files carry a UTF-8 byte order mark, which psql only skips when the client encoding is UTF-8. That is a separate change.

On a UTF-8 host nothing changes, and the full local suite passes.
