### PR TITLE
Default the geography Well-Known Binary SRID to 4326 on input

### DIFF
--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1753,10 +1753,14 @@ geo_from_wkb_state(meos_wkb_parse_state *s)
   }
   /* Advance the state by the number of bytes read for the geometry */
   s->pos += (s1.pos - s1.wkb);
-  /* Create the geometry. We cannot call gserialized_from_lwgeom since it does 
+  /* A geography is geodetic and in WGS84 (EPSG:4326) by definition, so default
+   * its SRID to 4326 when the Well-Known Binary carries none */
+  if (s->geodetic && geo->srid == SRID_UNKNOWN)
+    geo->srid = SRID_DEFAULT;
+  /* Create the geometry. We cannot call gserialized_from_lwgeom since it does
    * not set the geodetic flag. Therefore we need to call the corresponding
    * MEOS function for doing this */
-  GSERIALIZED *result = s->geodetic ? 
+  GSERIALIZED *result = s->geodetic ?
     geog_serialize(geo) : geom_serialize(geo);
   lwgeom_free(geo);
   return result;

--- a/mobilitydb/test/geo/expected/050_set_tbl.test.out
+++ b/mobilitydb/test/geo/expected/050_set_tbl.test.out
@@ -62,16 +62,16 @@ SELECT COUNT(*) FROM tbl_geomset WHERE geomsetFromBinary(asBinary(g)) <> g;
      0
 (1 row)
 
-SELECT COUNT(*) FROM tbl_geogset WHERE setSRID(geogsetFromBinary(asBinary(g)), 4326) <> g;
+SELECT COUNT(*) FROM tbl_geogset WHERE geogsetFromBinary(asBinary(g)) <> g;
  count 
 -------
      0
 (1 row)
 
-SELECT COUNT(*) FROM tbl_geogset WHERE SRID(geogsetFromBinary(asBinary(g))) <> 0;
- count 
--------
-     0
+SELECT SRID(geogsetFromBinary(asBinary(geogset '{Point(1 1), Point(2 2)}')));
+ srid 
+------
+ 4326
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geomset WHERE geomsetFromEWKB(asEWKB(g)) <> g;

--- a/mobilitydb/test/geo/queries/050_set_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/050_set_tbl.test.sql
@@ -55,10 +55,10 @@ SELECT MAX(length(asText(g))) FROM tbl_geogset;
 SELECT MAX(length(asEWKT(g))) FROM tbl_geomset;
 SELECT MAX(length(asEWKT(g))) FROM tbl_geogset;
 
--- asBinary emits plain WKB (no SRID); setSRID reapplies it before comparing
+-- asBinary emits plain WKB (no SRID); a geography defaults to SRID 4326
 SELECT COUNT(*) FROM tbl_geomset WHERE geomsetFromBinary(asBinary(g)) <> g;
-SELECT COUNT(*) FROM tbl_geogset WHERE setSRID(geogsetFromBinary(asBinary(g)), 4326) <> g;
-SELECT COUNT(*) FROM tbl_geogset WHERE SRID(geogsetFromBinary(asBinary(g))) <> 0;
+SELECT COUNT(*) FROM tbl_geogset WHERE geogsetFromBinary(asBinary(g)) <> g;
+SELECT SRID(geogsetFromBinary(asBinary(geogset '{Point(1 1), Point(2 2)}')));
 
 -- asEWKB preserves the SRID
 SELECT COUNT(*) FROM tbl_geomset WHERE geomsetFromEWKB(asEWKB(g)) <> g;


### PR DESCRIPTION
A geography is geodetic and in WGS84 by definition, so its Well-Known Binary input assigns the SRID 4326 when the representation carries none; a geometry keeps the unknown SRID. A round-trip regression test covers the geography default.