### PR TITLE
Drop the UTF-8 byte order mark from the SQL files

### DIFF
--- a/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
+++ b/mobilitydb/datagen/geo/create_test_tables_tpoint.sql
@@ -1,4 +1,4 @@
-﻿/*****************************************************************************
+/*****************************************************************************
  *
  * This MobilityDB code is provided under The PostgreSQL License.
  * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/200_cbuffer_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/200_cbuffer_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/204_tcbuffer_compops.test.sql
+++ b/mobilitydb/test/cbuffer/queries/204_tcbuffer_compops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/204_tcbuffer_compops_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/204_tcbuffer_compops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/208_tcbuffer_topops.test.sql
+++ b/mobilitydb/test/cbuffer/queries/208_tcbuffer_topops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/208_tcbuffer_topops_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/208_tcbuffer_topops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/209_tcbuffer_posops.test.sql
+++ b/mobilitydb/test/cbuffer/queries/209_tcbuffer_posops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/209_tcbuffer_posops_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/209_tcbuffer_posops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/h3/queries/271_th3index_ops_tbl.test.sql
+++ b/mobilitydb/test/h3/queries/271_th3index_ops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/h3/queries/272_th3index_indexes_tbl.test.sql
+++ b/mobilitydb/test/h3/queries/272_th3index_indexes_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/h3/queries/290_th3index_spatialrels_tbl.test.sql
+++ b/mobilitydb/test/h3/queries/290_th3index_spatialrels_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/452_tjsonb.test.sql
+++ b/mobilitydb/test/json/queries/452_tjsonb.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/452_tjsonb_text.test.sql
+++ b/mobilitydb/test/json/queries/452_tjsonb_text.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/454_tjsonb_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/454_tjsonb_jsonfuncs.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/456_tjsonb_op.test.sql
+++ b/mobilitydb/test/json/queries/456_tjsonb_op.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/458_tjsonb_compops.test.sql
+++ b/mobilitydb/test/json/queries/458_tjsonb_compops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/458_tjsonb_compops_tbl.test.sql
+++ b/mobilitydb/test/json/queries/458_tjsonb_compops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/460_tjsonb_topops.test.sql
+++ b/mobilitydb/test/json/queries/460_tjsonb_topops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/460_tjsonb_topops_tbl.test.sql
+++ b/mobilitydb/test/json/queries/460_tjsonb_topops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/462_tjsonb_posops.test.sql
+++ b/mobilitydb/test/json/queries/462_tjsonb_posops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/json/queries/462_tjsonb_posops_tbl.test.sql
+++ b/mobilitydb/test/json/queries/462_tjsonb_posops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/300_npoint.test.sql
+++ b/mobilitydb/test/npoint/queries/300_npoint.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/300_npoint_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/300_npoint_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/302_tnpoint.test.sql
+++ b/mobilitydb/test/npoint/queries/302_tnpoint.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/302_tnpoint_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/302_tnpoint_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/304_tnpoint_compops.test.sql
+++ b/mobilitydb/test/npoint/queries/304_tnpoint_compops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/304_tnpoint_compops_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/304_tnpoint_compops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/306_tnpoint_spatialfuncs.test.sql
+++ b/mobilitydb/test/npoint/queries/306_tnpoint_spatialfuncs.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/306_tnpoint_spatialfuncs_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/306_tnpoint_spatialfuncs_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/308_tnpoint_topops.test.sql
+++ b/mobilitydb/test/npoint/queries/308_tnpoint_topops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/308_tnpoint_topops_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/308_tnpoint_topops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/309_tnpoint_posops.test.sql
+++ b/mobilitydb/test/npoint/queries/309_tnpoint_posops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/309_tnpoint_posops_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/309_tnpoint_posops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/310_tnpoint_routeops_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/310_tnpoint_routeops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/312_tnpoint_distance.test.sql
+++ b/mobilitydb/test/npoint/queries/312_tnpoint_distance.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/312_tnpoint_distance_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/312_tnpoint_distance_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/npoint/queries/314_tnpoint_aggfuncs_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/314_tnpoint_aggfuncs_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/100_pose_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/102_tpose.test.sql
+++ b/mobilitydb/test/pose/queries/102_tpose.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/104_tpose_compops.test.sql
+++ b/mobilitydb/test/pose/queries/104_tpose_compops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/104_tpose_compops_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/104_tpose_compops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/108_tpose_topops.test.sql
+++ b/mobilitydb/test/pose/queries/108_tpose_topops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/108_tpose_topops_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/108_tpose_topops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/109_tpose_posops.test.sql
+++ b/mobilitydb/test/pose/queries/109_tpose_posops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/pose/queries/109_tpose_posops_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/109_tpose_posops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/quadbin/queries/357_tquadbin_ops_tbl.test.sql
+++ b/mobilitydb/test/quadbin/queries/357_tquadbin_ops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/quadbin/queries/362_tquadbin_spatialrels_tbl.test.sql
+++ b/mobilitydb/test/quadbin/queries/362_tquadbin_spatialrels_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/quadbin/queries/372_tquadbin_indexes_tbl.test.sql
+++ b/mobilitydb/test/quadbin/queries/372_tquadbin_indexes_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/rgeo/queries/152_trgeo_compops.test.sql
+++ b/mobilitydb/test/rgeo/queries/152_trgeo_compops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/rgeo/queries/152_trgeo_compops_tbl.test.sql
+++ b/mobilitydb/test/rgeo/queries/152_trgeo_compops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/rgeo/queries/156_trgeo_topops.test.sql
+++ b/mobilitydb/test/rgeo/queries/156_trgeo_topops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/rgeo/queries/156_trgeo_topops_tbl.test.sql
+++ b/mobilitydb/test/rgeo/queries/156_trgeo_topops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/rgeo/queries/157_trgeo_posops.test.sql
+++ b/mobilitydb/test/rgeo/queries/157_trgeo_posops.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB

--- a/mobilitydb/test/rgeo/queries/157_trgeo_posops_tbl.test.sql
+++ b/mobilitydb/test/rgeo/queries/157_trgeo_posops_tbl.test.sql
@@ -1,4 +1,4 @@
-﻿-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
 --
 -- This MobilityDB code is provided under The PostgreSQL License.
 -- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB


### PR DESCRIPTION
Sixty SQL files start with a UTF-8 byte order mark — fifty-nine test queries under `mobilitydb/test/*/queries` and `mobilitydb/datagen/geo/create_test_tables_tpoint.sql`.

psql skips that mark only when the client encoding is UTF-8. On a database in another encoding the three bytes sit in front of the first line, so the leading `---` reads as SQL rather than as a comment, psql echoes the whole licence header into the output, and the test diverges from its expected result.

The mark carries no information here: every file is ASCII apart from the two accented names in the licence header, which UTF-8 encodes the same way with or without it. Each file loses exactly three bytes and keeps the rest of its content, so the suite reads the same on any database encoding.

Measured on a stock Fedora 44 container with no UTF-8 langpack, where a cluster created under the C locale is `SQL_ASCII` — same build, same flags, only the marks differ:

| | with the marks | without them |
|---|---|---|
| tests failing | 58 of 240 | **2** of 240 |

The two that remain are `001_set_tbl` and `022_temporal`, whose default-locale error is the subject of https://github.com/MobilityDB/MobilityDB/pull/1903; with both changes the suite is 240/240 on an `SQL_ASCII` cluster.

On a UTF-8 host nothing changes, and the full local suite passes.
