### PR TITLE
Keep the JSONB iterator in sync when a key cannot be replaced

### DIFF
--- a/pgtypes/utils/jsonfuncs.c
+++ b/pgtypes/utils/jsonfuncs.c
@@ -3199,7 +3199,16 @@ setPathObject(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
         {
           meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
             "cannot replace existing key");
-          return; // TODO
+          /* meos_error() may return control to the caller (e.g. under the
+           * no-exit error handler used for host-embedded MEOS). Skip the
+           * value paired with the key already consumed above and keep
+           * draining the object instead of returning mid-iteration, so the
+           * JsonbIterator stays in sync for the caller's subsequent
+           * WJB_END_OBJECT read; an unsynced iterator makes setPath() push
+           * a stray WJB_VALUE with a NULL JsonbValue, which crashes in
+           * appendValue() */ // MEOS
+          (void) JsonbIteratorNext(it, &v, true); // MEOS
+          continue; // MEOS
         }
 
         r = JsonbIteratorNext(it, &v, true);  /* skip value */


### PR DESCRIPTION
setPathObject reports that an existing key cannot be replaced through meos_error and then returned mid-iteration. Because meos_error returns to its caller under the embedding-safe error handler, the JSONB iterator was left pointing at the value paired with that key, so setPath read it as the object terminator and pushed a value token with a null payload, crashing in appendValue. It now drains that value and continues draining the object, keeping the iterator in sync so the caller reaches the object end cleanly.