### PR TITLE
Run the MEOS smoke and version CI on changes under pgtypes

### DIFF
--- a/.github/workflows/meos-smoke.yml
+++ b/.github/workflows/meos-smoke.yml
@@ -7,6 +7,7 @@ on:
       - '.github/workflows/meos-smoke.yml'
       - 'cmake/**'
       - 'meos/**'
+      - 'pgtypes/**'
       - 'CMakeLists.txt'
     branches-ignore:
       - gh-pages
@@ -15,6 +16,7 @@ on:
       - '.github/workflows/meos-smoke.yml'
       - 'cmake/**'
       - 'meos/**'
+      - 'pgtypes/**'
       - 'CMakeLists.txt'
     branches-ignore:
       - gh-pages

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -14,6 +14,7 @@ on:
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
+      - 'pgtypes/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
     branches-ignore:
@@ -24,6 +25,7 @@ on:
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
+      - 'pgtypes/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
     branches-ignore:


### PR DESCRIPTION
The MEOS valgrind smoke workflow and the PostgreSQL-version matrix triggered only on changes under meos and mobilitydb, so a change to the vendored pgtypes code MEOS is built on compiled but was neither smoke-tested nor run against the regression suite. Both workflows now also trigger on pgtypes, so a change to that foundational layer is exercised by the full test surface.