### PR TITLE
Write a pose as an OGC GeoPose Advanced document

### DIFF
--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -1258,7 +1258,7 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 
 	<sect1 xml:id="pose_ogc_geopose">
 		<title>Soporte de OGC GeoPose v1.0</title>
-		<para>El tipo <varname>pose</varname> implementa el modelo de datos que subyace al <ulink url="https://www.ogc.org/standards/geopose/">estándar OGC GeoPose v1.0</ulink>: una <varname>position</varname> más una <varname>orientation</varname> en un marco de referencia conocido, donde la orientación es un cuaternión unitario en la convención de Hamilton o, de forma equivalente, una terna yaw / pitch / roll bajo la convención Tait-Bryan intrínseca ZYX. Esta sección agrupa la superficie SQL que expone esa interoperabilidad: E/S JSON para las clases de conformidad Basic del estándar, una función auxiliar de renormalización explícita para quienes ejecutan composiciones largas, y los accesores de ángulos de Euler que esperan los consumidores Basic-YPR.</para>
+		<para>El tipo <varname>pose</varname> implementa el modelo de datos que subyace al <ulink url="https://www.ogc.org/standards/geopose/">estándar OGC GeoPose v1.0</ulink>: una <varname>position</varname> más una <varname>orientation</varname> en un marco de referencia conocido, donde la orientación es un cuaternión unitario en la convención de Hamilton o, de forma equivalente, una terna yaw / pitch / roll bajo la convención Tait-Bryan intrínseca ZYX. Esta sección agrupa la superficie SQL que expone esa interoperabilidad: E/S JSON para las clases de conformidad Basic y Advanced del estándar, una función auxiliar de renormalización explícita para quienes ejecutan composiciones largas, y los accesores de ángulos de Euler que esperan los consumidores Basic-YPR.</para>
 
 		<sect2 xml:id="pose_geopose_io">
 			<title>Entrada y salida JSON</title>
@@ -1266,21 +1266,24 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 				<listitem xml:id="pose_geopose_funcs">
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poseFromGeoPose</varname></primary></indexterm>
-					<para>Convertir hacia o desde la codificación JSON de OGC GeoPose v1.0 (clase de conformidad Basic-Quaternion o Basic-YPR)</para>
+					<para>Convertir hacia o desde la codificación JSON de OGC GeoPose v1.0 (clase de conformidad Basic-Quaternion, Basic-YPR o Advanced)</para>
 					<para><varname>asGeoPose(pose,conformance int4=0,maxdecimaldigits int4=-1) → text</varname></para>
 					<para><varname>poseFromGeoPose(text) → pose</varname></para>
-					<para>El argumento <varname>conformance</varname> selecciona la clase de salida: <varname>0</varname> = Basic-Quaternion (predeterminado, sin pérdida), <varname>1</varname> = Basic-YPR (yaw, pitch, roll en grados, Tait-Bryan intrínseco ZYX). El argumento <varname>maxdecimaldigits</varname> es el número de dígitos significativos que se conservan en los números JSON; <varname>-1</varname> utiliza el valor predeterminado sin pérdida de json-c. La función de entrada detecta automáticamente la clase de conformidad a partir de las claves JSON, donde el miembro <varname>quaternion</varname> implica Basic-Quaternion mientras que el miembro <varname>angles</varname> implica Basic-YPR. Las clases de conformidad Basic exigen un marco exterior geográfico; la implementación acepta el SRID 4326 (o 0, tratado como geográfico) y rechaza los SRID proyectados en el límite de la conversión.</para>
+					<para>El argumento <varname>conformance</varname> selecciona la clase de salida: <varname>0</varname> = Basic-Quaternion (predeterminado, sin pérdida), <varname>1</varname> = Basic-YPR (yaw, pitch, roll en grados, Tait-Bryan intrínseco ZYX), <varname>2</varname> = Advanced. El argumento <varname>maxdecimaldigits</varname> es el número de dígitos significativos que se conservan en los números JSON; <varname>-1</varname> utiliza el valor predeterminado sin pérdida de json-c. La función de entrada detecta automáticamente la clase de conformidad a partir de las claves JSON, donde el miembro <varname>frameSpecification</varname> implica Advanced, el miembro <varname>quaternion</varname> implica Basic-Quaternion y el miembro <varname>angles</varname> implica Basic-YPR.</para>
+					<para>Las clases Basic llevan la posición en un miembro <varname>position</varname> y dejan el marco implícito. La clase Advanced no tiene miembro de posición: nombra su marco exterior de forma explícita y la pose se sitúa en el origen de ese marco, de modo que las dos codificaciones de una misma pose se releen iguales. Todas las clases exigen un marco exterior geográfico, por lo que la pose debe ser geodésica; una pose planar se rechaza en el límite de la conversión, al igual que un SRID proyectado.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asGeoPose(pose 'Pose(Point(8 47 1500), 0.7071067811865476, 0, 0,
-  0.7071067811865475)', 0, 6);
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 0, 6);
 /* {"position":{"lat":47,"lon":8,"h":1500},"quaternion":{"x":0,"y":0,"z":0.707107,
     "w":0.707107}} */
-SELECT asGeoPose(pose 'Pose(Point(8 47 1500), 0.7071067811865476, 0, 0,
-  0.7071067811865475)', 1, 6);
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 1, 6);
 -- {"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 6);
+/* {"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":
+    "longitude=8&latitude=47&height=1500&crs=EPSG:4979"},
+   "quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}} */
 SELECT asEWKT(poseFromGeoPose(
-  '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'));
--- Pose(POINT Z (8 47 1500),0.7071067811865476,0,0,0.7071067811865475)
+  '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'), 6);
+-- SRID=4326;GeodPose(POINT Z (8 47 1500),0.707107,0,0,0.707107)
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -1345,7 +1348,7 @@ SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
 
 		<sect2 xml:id="pose_geopose_frames">
 			<title>Registro de metadatos de marcos</title>
-			<para>El estándar OGC GeoPose v1.0 distingue el <emphasis>marco exterior</emphasis> (la referencia global, por ejemplo, WGS-84 geográfico o ECEF) del <emphasis>marco interior</emphasis> (el marco del cuerpo cuya orientación es el cuaternión de la pose). Las clases de conformidad Basic exigen WGS-84 geográfico como marco exterior y un marco interior implícito de ejes de cuerpo dextrógiros; la clase Advanced admite pilas de marcos con nombre.</para>
+			<para>El estándar OGC GeoPose v1.0 distingue el <emphasis>marco exterior</emphasis> (la referencia global, por ejemplo, WGS-84 geográfico o ECEF) del <emphasis>marco interior</emphasis> (el marco del cuerpo cuya orientación es el cuaternión de la pose). Las clases de conformidad Basic exigen WGS-84 geográfico como marco exterior y un marco interior implícito de ejes de cuerpo dextrógiros; la clase Advanced nombra su marco exterior de forma explícita y sitúa la pose en el origen de ese marco.</para>
 			<para>En MobilityDB, el tipo <varname>pose</varname> codifica el marco exterior de forma implícita mediante su SRID y utiliza el marco interior convencional de ejes de cuerpo dextrógiros. La tabla <varname>geopose_frames</varname> registra esta correspondencia en un catálogo paralelo a la tabla <varname>pointcloud_formats</varname> de pgPointCloud. Las pilas de marcos de la clase Advanced no están admitidas.</para>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT frame_id, authority, code, name, is_geographic

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2620,7 +2620,7 @@
 				<title>JSON Input and Output</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="pose_geopose_funcs"><varname>asGeoPose</varname>, <varname>poseFromGeoPose</varname></link>: Convert to or from the OGC GeoPose v1.0 JSON encoding (Basic-Quaternion or Basic-YPR conformance class)</para>
+						<para><link linkend="pose_geopose_funcs"><varname>asGeoPose</varname>, <varname>poseFromGeoPose</varname></link>: Convert to or from the OGC GeoPose v1.0 JSON encoding (Basic-Quaternion, Basic-YPR or Advanced conformance class)</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2682,7 +2682,7 @@
 				<title>Temporal JSON I/O</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="pose_geopose_funcs"><varname>asGeoPose</varname>, <varname>tposeFromGeoPose</varname></link>: Convert a temporal pose to or from its OGC GeoPose v1.0 encoding: a Basic document for an instant, a Composite Sequence Series for a sequence</para>
+						<para><link linkend="pose_geopose_funcs"><varname>asGeoPose</varname>, <varname>tposeFromGeoPose</varname></link>: Convert a temporal pose to or from its OGC GeoPose v1.0 encoding: a Basic or Advanced document for an instant, a Composite Sequence Series for a sequence</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1267,7 +1267,7 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 
 	<sect1 xml:id="pose_ogc_geopose">
 		<title>OGC GeoPose v1.0 Support</title>
-		<para>The <varname>pose</varname> type implements the data model behind the <ulink url="https://www.ogc.org/standards/geopose/">OGC GeoPose v1.0 standard</ulink>: a <varname>position</varname> plus an <varname>orientation</varname> in a known reference frame, where the orientation is a unit quaternion in Hamilton convention or, equivalently, a yaw / pitch / roll triple under the ZYX intrinsic Tait-Bryan convention. This section groups the SQL surface that exposes that interoperability, JSON I/O for the standard's Basic conformance classes, an explicit renormalization helper for callers running long compositions, and the Euler-angle accessors that Basic-YPR consumers expect.</para>
+		<para>The <varname>pose</varname> type implements the data model behind the <ulink url="https://www.ogc.org/standards/geopose/">OGC GeoPose v1.0 standard</ulink>: a <varname>position</varname> plus an <varname>orientation</varname> in a known reference frame, where the orientation is a unit quaternion in Hamilton convention or, equivalently, a yaw / pitch / roll triple under the ZYX intrinsic Tait-Bryan convention. This section groups the SQL surface that exposes that interoperability, JSON I/O for the standard's Basic and Advanced conformance classes, an explicit renormalization helper for callers running long compositions, and the Euler-angle accessors that Basic-YPR consumers expect.</para>
 
 		<sect2 xml:id="pose_geopose_io">
 			<title>JSON Input and Output</title>
@@ -1275,21 +1275,24 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 				<listitem xml:id="pose_geopose_funcs">
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poseFromGeoPose</varname></primary></indexterm>
-					<para>Convert to or from the OGC GeoPose v1.0 JSON encoding (Basic-Quaternion or Basic-YPR conformance class)</para>
+					<para>Convert to or from the OGC GeoPose v1.0 JSON encoding (Basic-Quaternion, Basic-YPR or Advanced conformance class)</para>
 					<para><varname>asGeoPose(pose,conformance int4=0,maxdecimaldigits int4=-1) → text</varname></para>
 					<para><varname>poseFromGeoPose(text) → pose</varname></para>
-					<para>The <varname>conformance</varname> argument selects the output class: <varname>0</varname> = Basic-Quaternion (default, lossless), <varname>1</varname> = Basic-YPR (yaw, pitch, roll in degrees, ZYX intrinsic Tait-Bryan). The <varname>maxdecimaldigits</varname> argument is the number of significant digits to keep in the JSON numbers; <varname>-1</varname> uses json-c's lossless default. The input function auto-detects the conformance class from the JSON keys, where a <varname>quaternion</varname> member implies Basic-Quaternion while an <varname>angles</varname> member implies Basic-YPR. The Basic conformance classes mandate a geographic outer frame; the implementation accepts SRID 4326 (or 0, treated as geographic) and rejects projected SRIDs at the conversion boundary.</para>
+					<para>The <varname>conformance</varname> argument selects the output class: <varname>0</varname> = Basic-Quaternion (default, lossless), <varname>1</varname> = Basic-YPR (yaw, pitch, roll in degrees, ZYX intrinsic Tait-Bryan), <varname>2</varname> = Advanced. The <varname>maxdecimaldigits</varname> argument is the number of significant digits to keep in the JSON numbers; <varname>-1</varname> uses json-c's lossless default. The input function auto-detects the conformance class from the JSON keys, where a <varname>frameSpecification</varname> member implies Advanced, a <varname>quaternion</varname> member implies Basic-Quaternion, and an <varname>angles</varname> member implies Basic-YPR.</para>
+					<para>The Basic classes carry the position in a <varname>position</varname> member and leave the frame implicit. The Advanced class has no position member: it names its outer frame explicitly, and the pose sits at the origin of that frame, so the two encodings of one pose read back equal. Every class mandates a geographic outer frame, so the pose must be geodetic; a planar pose is rejected at the conversion boundary, as is a projected SRID.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asGeoPose(pose 'Pose(Point(8 47 1500), 0.7071067811865476, 0, 0,
-  0.7071067811865475)', 0, 6);
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 0, 6);
 /* {"position":{"lat":47,"lon":8,"h":1500},"quaternion":{"x":0,"y":0,"z":0.707107,
     "w":0.707107}} */
-SELECT asGeoPose(pose 'Pose(Point(8 47 1500), 0.7071067811865476, 0, 0,
-  0.7071067811865475)', 1, 6);
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 1, 6);
 -- {"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 6);
+/* {"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":
+    "longitude=8&latitude=47&height=1500&crs=EPSG:4979"},
+   "quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}} */
 SELECT asEWKT(poseFromGeoPose(
-  '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'));
--- Pose(POINT Z (8 47 1500),0.7071067811865476,0,0,0.7071067811865475)
+  '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'), 6);
+-- SRID=4326;GeodPose(POINT Z (8 47 1500),0.707107,0,0,0.707107)
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -1345,7 +1348,7 @@ SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
 
 		<sect2 xml:id="pose_geopose_frames">
 			<title>Frame Metadata Registry</title>
-			<para>The OGC GeoPose v1.0 standard distinguishes the <emphasis>outer frame</emphasis> (the global reference, e.g., WGS-84 geographic or ECEF) from the <emphasis>inner frame</emphasis> (the body frame whose orientation is the pose's quaternion). The Basic conformance classes mandate WGS-84 geographic as the outer frame and an implicit right-handed body-axes inner frame; the Advanced class supports stacks of named frames.</para>
+			<para>The OGC GeoPose v1.0 standard distinguishes the <emphasis>outer frame</emphasis> (the global reference, e.g., WGS-84 geographic or ECEF) from the <emphasis>inner frame</emphasis> (the body frame whose orientation is the pose's quaternion). The Basic conformance classes mandate WGS-84 geographic as the outer frame and an implicit right-handed body-axes inner frame; the Advanced class names its outer frame explicitly and places the pose at that frame's origin.</para>
 			<para>In MobilityDB the <varname>pose</varname> type encodes the outer frame implicitly via its SRID and uses the conventional right-handed body-axes inner frame. The <varname>geopose_frames</varname> table records this mapping in a registry parallel to pgPointCloud's <varname>pointcloud_formats</varname>. Advanced-class frame stacks are not supported.</para>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT frame_id, authority, code, name, is_geographic

--- a/meos/include/pose/pose_geopose.h
+++ b/meos/include/pose/pose_geopose.h
@@ -45,20 +45,25 @@
  *****************************************************************************/
 
 /**
- * @brief Orientation encodings of an OGC GeoPose Basic document.
- * @details The two Basic conformance classes differ only in how they carry
- * the orientation, so one value chooses between them. It is orthogonal to
- * the target conformance class, which follows from the value being written:
- * a pose and a single temporal instant are Basic documents, a temporal
- * sequence is a Composite Sequence Series. A Series carries a quaternion in
- * every inner frame and offers no such choice.
+ * @brief Conformance classes a single pose can be written as.
+ * @details The two Basic classes differ only in how they carry the
+ * orientation. The Advanced class differs in the frame: it names its outer
+ * frame explicitly where the Basic classes leave it implicit, and carries the
+ * position inside that frame, having no member of its own for it.
  *
- * The Advanced, Chain, Graph and Stream classes are not implemented.
+ * The class of a composite follows from the value instead of from this
+ * choice: a temporal sequence is a Composite Sequence Series, Regular or
+ * Irregular as its instants are spaced, and a Stream is written by the two
+ * entry points of its own. A Series carries a quaternion in every inner frame
+ * and offers no orientation choice.
+ *
+ * The Chain and Graph classes are not implemented.
  */
 typedef enum
 {
   GEOPOSE_BASIC_QUATERNION = 0,  /**< {position, quaternion} canonical form */
-  GEOPOSE_BASIC_YPR        = 1   /**< {position, angles} (yaw/pitch/roll) */
+  GEOPOSE_BASIC_YPR        = 1,  /**< {position, angles} (yaw/pitch/roll) */
+  GEOPOSE_ADVANCED         = 2   /**< {frameSpecification, quaternion} */
 } GeoPoseClass;
 
 /*****************************************************************************/

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -28,7 +28,7 @@
  *****************************************************************************/
 
 /**
- * @brief OGC GeoPose JSON I/O — Basic-YPR and Basic-Quaternion conformance.
+ * @brief OGC GeoPose JSON I/O — the classes a single pose is written as.
  *
  * Implements the OGC GeoPose v1.0 standard's two Basic conformance classes:
  *
@@ -51,10 +51,26 @@
  * implementation accepts only SRID 4326 inputs (or unknown SRID, treated as
  * geographic) and rejects projected SRIDs with a clear error.
  *
+ * The Advanced class carries the same pose with the frame named explicitly:
+ *
+ *   {
+ *     "frameSpecification": {
+ *       "authority": "/geopose/1.0",
+ *       "id": "LTP-ENU",
+ *       "parameters": "longitude=8&latitude=47&height=1500&crs=EPSG:4979"
+ *     },
+ *     "quaternion": { "x": 0.0, "y": 0.0, "z": 0.7071, "w": 0.7071 }
+ *   }
+ *
+ * The class has no position member, so the pose sits at the tangent point of
+ * the frame it names, which makes the two documents above describe the same
+ * pose and read back equal.
+ *
  * On input the parser auto-detects the conformance class from the keys
- * present (`quaternion` vs `angles`). On output the caller picks the class
- * via `GeoPoseClass`; the default chosen by the SQL surface is
- * Basic-Quaternion since it is lossless for our internal representation.
+ * present (`frameSpecification`, then `quaternion` vs `angles`). On output
+ * the caller picks the class via `GeoPoseClass`; the default chosen by the
+ * SQL surface is Basic-Quaternion since it is lossless for our internal
+ * representation.
  *
  * 2D poses (data = [x, y, theta]) are represented in JSON with `h: 0`,
  * `pitch: 0`, `roll: 0`, and yaw = theta. `theta` is stored in radians
@@ -69,7 +85,9 @@
  * objects each carrying a `validTime`, remains available for reading and
  * writing but is not an OGC conformance class.
  *
- * The Advanced, Chain, Graph and Stream classes are not implemented.
+ * A Stream is written by the two entry points of its own, one for the header
+ * that opens it and one per element. The Chain and Graph classes are not
+ * implemented.
  */
 
 /* C */
@@ -107,6 +125,13 @@
 #define GEOPOSE_SRID_WGS84_2D 4326
 #define GEOPOSE_SRID_WGS84_3D 4979
 #define GEOPOSE_GEOGRAPHIC_SRID GEOPOSE_SRID_WGS84_2D
+
+/* The authority and identifiers naming the two frames, as used by the
+ * encoding examples of OGC 21-056r11 Clause 9.2. The Advanced class names its
+ * outer frame and the composites name both, so these are shared. */
+#define GEOPOSE_AUTHORITY       "/geopose/1.0"
+#define GEOPOSE_ID_OUTER_FRAME  "LTP-ENU"
+#define GEOPOSE_ID_INNER_FRAME  "RotateTranslate"
 
 /**
  * @brief Return true if @p srid names the WGS-84 geographic frame the
@@ -377,6 +402,127 @@ geopose_new_double(double v, int precision)
  *****************************************************************************/
 
 /**
+ * @brief Read the `quaternion` member shared by the Basic-Quaternion and
+ * Advanced classes.
+ * @return On error return false
+ */
+static bool
+geopose_quaternion_from_json(json_object *jq, double *W, double *X, double *Y,
+  double *Z)
+{
+  if (! geopose_get_number(jq, "w", W) || ! geopose_get_number(jq, "x", X) ||
+      ! geopose_get_number(jq, "y", Y) || ! geopose_get_number(jq, "z", Z))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose 'quaternion' must carry numeric 'w','x','y','z' members");
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @brief Return whether a `crs` frame parameter names a WGS-84 geographic
+ * CRS, in the `EPSG:<code>` form the frames of this module carry and the
+ * form the Moving Features encoding names a CRS by.
+ */
+static bool
+geopose_crs_is_geographic(const char *crs)
+{
+  if (pg_strncasecmp(crs, "EPSG:", 5) != 0)
+    return false;
+  char *end;
+  long code = strtol(crs + 5, &end, 10);
+  return (end != crs + 5) && geopose_srid_is_geographic((int32_t) code);
+}
+
+/**
+ * @brief Build a pose from a parsed Advanced-class GeoPose JSON object.
+ * @details An Advanced document names its outer frame explicitly and has no
+ * `position` member, so the pose is placed by the frame: it sits at the
+ * tangent point the frame's `parameters` give. Requirement 9 leaves those
+ * parameters free-form and the standard registers no authority or id, so what
+ * is read here is what this module writes, which is also what the encoding
+ * examples of the standard use.
+ *
+ * A frame this module cannot place a pose in is reported rather than guessed
+ * at, and so is a missing coordinate: a pose whose position defaulted to zero
+ * would be accepted here and refused by every operation that followed.
+ * @return On error return @p NULL
+ */
+static Pose *
+pose_from_geopose_advanced(json_object *frame, json_object *root)
+{
+  if (! json_object_is_type(frame, json_type_object))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose 'frameSpecification' must be a FrameSpecification object");
+    return NULL;
+  }
+  json_object *jauth = geopose_find_member(frame, "authority");
+  json_object *jid = geopose_find_member(frame, "id");
+  json_object *jpar = geopose_find_member(frame, "parameters");
+  if (jauth == NULL || ! json_object_is_type(jauth, json_type_string) ||
+      jid == NULL || ! json_object_is_type(jid, json_type_string) ||
+      jpar == NULL || ! json_object_is_type(jpar, json_type_string))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose 'frameSpecification' requires string 'authority', 'id' and "
+      "'parameters' members");
+    return NULL;
+  }
+
+  const char *auth = json_object_get_string(jauth);
+  const char *id = json_object_get_string(jid);
+  if (strcmp(auth, GEOPOSE_AUTHORITY) != 0 ||
+      pg_strcasecmp(id, GEOPOSE_ID_OUTER_FRAME) != 0)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unsupported GeoPose outer frame '%s'/'%s'; the frame read is "
+      "'%s'/'%s', which carries the position of the pose in its parameters",
+      auth, id, GEOPOSE_AUTHORITY, GEOPOSE_ID_OUTER_FRAME);
+    return NULL;
+  }
+
+  const char *params = json_object_get_string(jpar);
+  double lon, lat, h;
+  if (! geopose_param_number(geopose_param_find(params, "longitude"), &lon) ||
+      ! geopose_param_number(geopose_param_find(params, "latitude"), &lat) ||
+      ! geopose_param_number(geopose_param_find(params, "height"), &h))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose 'frameSpecification' parameters must carry numeric "
+      "'longitude', 'latitude' and 'height'");
+    return NULL;
+  }
+
+  /* The frame may name the CRS its tangent point is given in. A projected one
+   * would place the pose off the ellipsoid the topocentric conversion is
+   * against, so only a geographic CRS is read. */
+  const char *crs = geopose_param_find(params, "crs");
+  if (crs != NULL && ! geopose_crs_is_geographic(crs))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose 'frameSpecification' parameter 'crs' must name a WGS-84 "
+      "geographic CRS as EPSG:%d or EPSG:%d", GEOPOSE_SRID_WGS84_2D,
+      GEOPOSE_SRID_WGS84_3D);
+    return NULL;
+  }
+
+  json_object *jq = geopose_find_member(root, "quaternion");
+  if (jq == NULL || ! json_object_is_type(jq, json_type_object))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose Advanced JSON missing required 'quaternion' object");
+    return NULL;
+  }
+  double W, X, Y, Z;
+  if (! geopose_quaternion_from_json(jq, &W, &X, &Y, &Z))
+    return NULL;
+  return pose_make_3d(lon, lat, h, W, X, Y, Z, true,
+    GEOPOSE_GEOGRAPHIC_SRID);
+}
+
+/**
  * @brief Build a pose from a parsed Basic-class GeoPose JSON object.
  * @details Used internally by @p pose_from_geopose (single-pose entry
  * point) and by the temporal-GeoPose entry points which iterate an
@@ -386,6 +532,12 @@ geopose_new_double(double v, int precision)
 static Pose *
 pose_from_geopose_object(json_object *root)
 {
+  /* An Advanced document names its outer frame explicitly and carries no
+   * `position`, the placement travelling in the frame instead. */
+  json_object *jframe = geopose_find_member(root, "frameSpecification");
+  if (jframe != NULL)
+    return pose_from_geopose_advanced(jframe, root);
+
   /* Position: {lat, lon, h} */
   json_object *jpos = geopose_find_member(root, "position");
   if (jpos == NULL || ! json_object_is_type(jpos, json_type_object))
@@ -413,15 +565,8 @@ pose_from_geopose_object(json_object *root)
   {
     /* Basic-Quaternion */
     double W, X, Y, Z;
-    if (! geopose_get_number(jq, "w", &W) ||
-        ! geopose_get_number(jq, "x", &X) ||
-        ! geopose_get_number(jq, "y", &Y) ||
-        ! geopose_get_number(jq, "z", &Z))
-    {
-      meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-        "GeoPose 'quaternion' must carry numeric 'w','x','y','z' members");
+    if (! geopose_quaternion_from_json(jq, &W, &X, &Y, &Z))
       return NULL;
-    }
     /* Note: any reasonable client emits a unit quaternion. We keep the
      * input verbatim — the canonicalization/normalization pass is a
      * separate phase. */
@@ -476,15 +621,19 @@ pose_from_geopose_object(json_object *root)
 /**
  * @ingroup meos_pose_base_geopose
  * @brief Return a pose from its OGC GeoPose JSON representation
- * @param[in] json GeoPose JSON string (Basic-YPR or Basic-Quaternion)
+ * @param[in] json GeoPose JSON string (Basic-YPR, Basic-Quaternion or
+ * Advanced)
  * @return On error return @p NULL
  * @details Auto-detects the conformance class from the JSON keys present:
  *
+ *   - `frameSpecification`: Advanced (returns a 3D pose placed at the
+ *     tangent point of the frame, which is where a class with no position
+ *     member of its own carries it).
  *   - `quaternion`: Basic-Quaternion (returns a 3D pose).
  *   - `angles`:     Basic-YPR (returns a 3D pose; or 2D if pitch=roll=0
  *     and h=0, since that is the canonical 2D representation).
  *
- * Position is parsed as `{lat, lon, h}` (degrees, degrees, metres). The
+ * A Basic position is parsed as `{lat, lon, h}` (degrees, degrees, metres). The
  * resulting pose has SRID 4326 (WGS-84). Projected SRIDs are not
  * supported by this entry point — use the WKT/WKB I/O for those.
  * @csqlfn #Pose_from_geopose()
@@ -523,8 +672,12 @@ pose_from_geopose(const char *json)
  * Output — internal helper that builds a single GeoPose object node
  *****************************************************************************/
 
+/* The Advanced class places its pose in an explicit topocentric frame, which
+ * the geodesy section below builds, so its document is assembled there. */
+static json_object *pose_to_geopose_advanced(const Pose *pose, int precision);
+
 /**
- * @brief Build the Basic-class GeoPose JSON object for a single pose.
+ * @brief Build the GeoPose JSON object for a single pose.
  * @details Used internally by @p pose_as_geopose (single-pose entry
  * point) and by the temporal-GeoPose entry points which embed the
  * per-instant object into an envelope's @p instants array. The caller
@@ -534,12 +687,15 @@ pose_from_geopose(const char *json)
 static json_object *
 pose_to_geopose_object(const Pose *pose, int conformance, int precision)
 {
+  if (conformance == GEOPOSE_ADVANCED)
+    return pose_to_geopose_advanced(pose, precision);
+
   if (conformance != GEOPOSE_BASIC_QUATERNION &&
       conformance != GEOPOSE_BASIC_YPR)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Unknown GeoPose conformance class %d "
-      "(0 = Basic-Quaternion, 1 = Basic-YPR)", conformance);
+      "(0 = Basic-Quaternion, 1 = Basic-YPR, 2 = Advanced)", conformance);
     return NULL;
   }
   /* Both classes start from a quaternion, and both place the position in
@@ -587,13 +743,20 @@ pose_to_geopose_object(const Pose *pose, int conformance, int precision)
  * @ingroup meos_pose_base_geopose
  * @brief Return the OGC GeoPose JSON representation of a pose
  * @param[in] pose Pose value
- * @param[in] conformance Conformance class to emit (Basic-Quaternion or Basic-YPR)
+ * @param[in] conformance Conformance class to emit
+ * (0 = Basic-Quaternion, 1 = Basic-YPR, 2 = Advanced)
  * @param[in] precision Decimal places to keep in the JSON numbers; pass
  * a negative value to use json-c's default
  * @return On error return @p NULL
- * @details The Basic conformance classes mandate a geographic outer
+ * @details Every conformance class mandates a geographic outer
  * frame. Poses with SRID 0 are treated as geographic; poses with
  * non-zero non-4326 SRIDs are rejected (use WKT/WKB instead).
+ *
+ * The Basic classes carry the position in a `position` member and leave the
+ * frame implicit; the Advanced class names the frame explicitly and carries
+ * the position in it, the class having no position member of its own. The
+ * frame it names is the one at the pose, so the two documents describe the
+ * same pose and read back equal.
  * @csqlfn #Pose_as_geopose()
  */
 char *
@@ -791,11 +954,8 @@ geopose_anchor_rotation(const GeoPoseAnchor *anchor, double lat_rad,
  * OGC GeoPose Composite Sequence classes — JSON encoding
  *****************************************************************************/
 
-/* Normative authority and identifier strings, as used by the encoding
- * examples of OGC 21-056r11 Clause 9.2. */
-#define GEOPOSE_AUTHORITY       "/geopose/1.0"
-#define GEOPOSE_ID_OUTER_FRAME  "LTP-ENU"
-#define GEOPOSE_ID_INNER_FRAME  "RotateTranslate"
+/* The transition model identifiers, from the same encoding examples as the
+ * frame identifiers above. */
 #define GEOPOSE_ID_TM_NONE      "none"
 #define GEOPOSE_ID_TM_INTERP    "interpolate"
 /* Requirement 9 places the content of `parameters` outside the scope of
@@ -983,6 +1143,39 @@ geopose_outer_frame(const GeoPoseAnchor *anchor, int precision)
     "longitude=%s&latitude=%s&height=%s&crs=EPSG:%d",
     blon, blat, bh, GEOPOSE_SRID_WGS84_3D);
   return geopose_frame_spec(GEOPOSE_ID_OUTER_FRAME, params);
+}
+
+/**
+ * @brief Build the Advanced-class GeoPose JSON object for a single pose.
+ * @details Requirement 17, titled *Expression of outer frame*, makes
+ * `Advanced.frameSpecification` an explicit outer frame, and the class has no
+ * `position` member of its own, so the placement travels in that frame. The
+ * frame written here is the LTP-ENU frame at the pose's own position, which
+ * puts the pose at the origin of the frame it names. Its quaternion is then
+ * the orientation in that frame, unrotated, and the document carries exactly
+ * what the Basic-Quaternion document of the same pose carries.
+ * @return On error return @p NULL
+ */
+static json_object *
+pose_to_geopose_advanced(const Pose *pose, int precision)
+{
+  double lon, lat, h, W, X, Y, Z;
+  if (! geopose_pose_components(pose, &lon, &lat, &h, &W, &X, &Y, &Z))
+    return NULL;
+
+  GeoPoseAnchor anchor;
+  geopose_anchor_set(&anchor, GEOPOSE_DEG2RAD(lat), GEOPOSE_DEG2RAD(lon), h);
+
+  json_object *root = json_object_new_object();
+  json_object_object_add(root, "frameSpecification",
+    geopose_outer_frame(&anchor, precision));
+  json_object *jq = json_object_new_object();
+  json_object_object_add(jq, "x", geopose_new_double(X, precision));
+  json_object_object_add(jq, "y", geopose_new_double(Y, precision));
+  json_object_object_add(jq, "z", geopose_new_double(Z, precision));
+  json_object_object_add(jq, "w", geopose_new_double(W, precision));
+  json_object_object_add(root, "quaternion", jq);
+  return root;
 }
 
 /**
@@ -1362,7 +1555,7 @@ tpose_from_geopose_series(json_object *root, json_object *elements,
 
 
 /**
- * @brief Build the Basic-class document of a single temporal instant.
+ * @brief Build the single-pose document of a temporal instant.
  * @details The Basic classes carry no time, so the instant's own is added
  * under the name `validTime` that the Advanced, Chain, Graph, Series and
  * Stream classes all use, and with the type they all give it: a
@@ -1390,7 +1583,7 @@ tposeinst_as_geopose(const TInstant *inst, int conformance, int precision)
  * @ingroup meos_pose_geopose_accessor
  * @brief Return the OGC GeoPose JSON representation of a temporal pose
  * @details The class follows from the value, not from an argument. A
- * @p TInstant is a Basic document carrying the instant's @p validTime; a
+ * @p TInstant is a single-pose document carrying the instant's @p validTime; a
  * @p TSequence or @p TSequenceSet is a Composite Sequence Series, the
  * Regular one when its instants are equally spaced by a whole number of
  * milliseconds and the Irregular one otherwise. The outer frame of a Series
@@ -1399,11 +1592,11 @@ tposeinst_as_geopose(const TInstant *inst, int conformance, int precision)
  *
  * A Series flattens a @p TSequenceSet and drops bounds inclusivity, the
  * standard's model having neither gaps nor open bounds. @p conformance
- * chooses the orientation encoding of a Basic document and has no effect on
+ * chooses the class of a single-pose document and has no effect on
  * a Series, whose inner frames carry a quaternion and offer no choice.
  * @param[in] temp Temporal pose
- * @param[in] conformance Orientation encoding of a Basic document
- * (0 = Basic-Quaternion, 1 = Basic-YPR)
+ * @param[in] conformance Class of a single-pose document
+ * (0 = Basic-Quaternion, 1 = Basic-YPR, 2 = Advanced)
  * @param[in] precision Significant digits in JSON numbers; -1 = lossless
  * @return On error return @p NULL
  * @csqlfn #Tpose_as_geopose()
@@ -1524,7 +1717,7 @@ tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst,
 }
 
 /**
- * @brief Parse one element of an @p instants array (Basic-class object
+ * @brief Parse one element of an @p instants array (single-pose object
  * + @p validTime member) into a TInstant. Returns @p NULL on error.
  */
 static TInstant *
@@ -1547,8 +1740,8 @@ tposeinst_from_geopose_object(json_object *obj)
   else
   {
     meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
-      "A GeoPose Basic document needs a 'validTime' to read as a temporal "
-      "pose");
+      "A single-pose GeoPose document needs a 'validTime' to read as a "
+      "temporal pose");
     return NULL;
   }
   Pose *pose = pose_from_geopose_object(obj);
@@ -1639,9 +1832,13 @@ tpose_from_geopose(const char *json)
   }
   json_tokener_free(tok);
 
-  /* A Basic document holds one pose. With a `validTime` it is a temporal
-   * instant, which is what a temporal pose of that subtype writes. */
-  if (geopose_find_member(root, "position") != NULL)
+  /* A single-pose document holds one pose. With a `validTime` it is a
+   * temporal instant, which is what a temporal pose of that subtype writes.
+   * A Basic document is recognized by its `position` and an Advanced one by
+   * the frame it carries it in; a Series names its outer frame by a member of
+   * its own, so neither is mistaken for the other. */
+  if (geopose_find_member(root, "position") != NULL ||
+      geopose_find_member(root, "frameSpecification") != NULL)
   {
     TInstant *inst = tposeinst_from_geopose_object(root);
     json_object_put(root);

--- a/meos/test/geopose_test.c
+++ b/meos/test/geopose_test.c
@@ -56,10 +56,14 @@
 #include <meos_geo.h>
 #include <meos_pose.h>
 
-/* Conformance classes of a Basic document, as the second argument of the
- * functions encoding a pose */
+/* Conformance classes of a single-pose document, as the second argument of
+ * the functions encoding a pose */
 #define BASIC_QUATERNION 0
 #define BASIC_YPR        1
+#define ADVANCED         2
+
+/* The frame an Advanced document names, and the authority naming it */
+#define GEOPOSE_FRAME_ID "LTP-ENU"
 
 /**
  * @brief Report a document and assert that it carries a member
@@ -168,6 +172,74 @@ int main(void)
   out = pose_as_geopose(ident, BASIC_QUATERNION, 6);
   ensure_member("identity quaternion", out, "\"w\":1");
   free(out); free(ident);
+
+  /*--------------------------------------------------------------------------
+   * Advanced, the class that names its outer frame
+   *------------------------------------------------------------------------*/
+
+  meos_errno_reset();
+  Pose *adv = pose_from_geopose(quat_json);
+  assert(adv != NULL);
+  assert(meos_errno() == 0);
+
+  out = pose_as_geopose(adv, ADVANCED, 15);
+  assert(out != NULL);
+  ensure_member("Advanced", out, "\"frameSpecification\"");
+  ensure_member("Advanced", out, "\"quaternion\"");
+  /* The class has no position member: the pose sits at the tangent point of
+   * the frame it names, which is what carries the placement */
+  ensure_no_member("Advanced", out, "\"position\"");
+  ensure_member("Advanced", out, "\"" GEOPOSE_FRAME_ID "\"");
+  ensure_member("Advanced", out, "longitude=8");
+  ensure_member("Advanced", out, "latitude=47");
+  ensure_member("Advanced", out, "height=1500");
+
+  /* It reads back as the pose it was written from */
+  Pose *adv_back = pose_from_geopose(out);
+  assert(adv_back != NULL);
+  assert(meos_errno() == 0);
+  s1 = pose_out(adv, 6);
+  s2 = pose_out(adv_back, 6);
+  printf("Advanced round trip: %s -> %s\n", s1, s2);
+  assert(strcmp(s1, s2) == 0);
+  free(s1); free(s2); free(adv_back); free(out);
+
+  /* The Basic and Advanced documents of one pose say the same thing, the
+   * frame of the Advanced one standing where the position member stood */
+  out = pose_as_geopose(adv, BASIC_QUATERNION, 15);
+  Pose *basic_back = pose_from_geopose(out);
+  assert(basic_back != NULL);
+  s1 = pose_out(adv, 6);
+  s2 = pose_out(basic_back, 6);
+  printf("Basic and Advanced agree: %s == %s\n", s1, s2);
+  assert(strcmp(s1, s2) == 0);
+  free(s1); free(s2); free(basic_back); free(out); free(adv);
+
+  /* A temporal instant written Advanced carries its time, as it does in
+   * every other class that has a validTime. The pose is three-dimensional so
+   * that the round trip below is an equality: a GeoPose position is always
+   * `{lat, lon, h}`, so a two-dimensional pose comes back three-dimensional
+   * whichever class writes it, and it carries the SRID a document reads back
+   * as, an unknown one being geographic on the way out and 4326 on the way
+   * in */
+  meos_errno_reset();
+  Temporal *adv_inst = tpose_in("SRID=4326;"
+    "Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)@2026-01-01");
+  assert(adv_inst != NULL);
+  out = tpose_as_geopose(adv_inst, ADVANCED, 6);
+  assert(out != NULL);
+  ensure_member("Advanced instant", out, "\"frameSpecification\"");
+  ensure_member("Advanced instant", out, "\"validTime\"");
+  ensure_no_member("Advanced instant", out, "\"position\"");
+
+  /* and reads back as the instant it was written from */
+  Temporal *adv_inst_back = tpose_from_geopose(out);
+  assert(adv_inst_back != NULL);
+  s1 = temporal_out(adv_inst, 6);
+  s2 = temporal_out(adv_inst_back, 6);
+  printf("Advanced instant round trip: %s -> %s\n", s1, s2);
+  assert(strcmp(s1, s2) == 0);
+  free(s1); free(s2); free(adv_inst_back); free(out); free(adv_inst);
 
   /*--------------------------------------------------------------------------
    * A single instant yields a Basic document
@@ -363,6 +435,52 @@ int main(void)
   meos_errno_reset();
   bad = pose_from_geopose("{\"quaternion\":{\"x\":0,\"y\":0,\"z\":0,\"w\":1}}");
   printf("pose_from_geopose(no position): %s, errno %d\n",
+    bad ? "non-NULL" : "NULL", meos_errno());
+  assert(bad == NULL);
+  assert(meos_errno() != 0);
+
+  /* An Advanced document places its pose by the frame it names, so a frame
+   * this implementation cannot place a pose in is reported rather than
+   * guessed at */
+  meos_errno_reset();
+  bad = pose_from_geopose("{\"frameSpecification\":{\"authority\":\"EPSG\","
+    "\"id\":\"4979\",\"parameters\":\"\"},"
+    "\"quaternion\":{\"x\":0,\"y\":0,\"z\":0,\"w\":1}}");
+  printf("pose_from_geopose(unplaceable frame): %s, errno %d\n",
+    bad ? "non-NULL" : "NULL", meos_errno());
+  assert(bad == NULL);
+  assert(meos_errno() != 0);
+
+  /* A coordinate the frame does not carry is an error and not a zero: a pose
+   * defaulted to the origin would be accepted here and refused by every
+   * operation that followed */
+  meos_errno_reset();
+  bad = pose_from_geopose("{\"frameSpecification\":{\"authority\":"
+    "\"/geopose/1.0\",\"id\":\"LTP-ENU\",\"parameters\":\"longitude=8\"},"
+    "\"quaternion\":{\"x\":0,\"y\":0,\"z\":0,\"w\":1}}");
+  printf("pose_from_geopose(frame without a latitude): %s, errno %d\n",
+    bad ? "non-NULL" : "NULL", meos_errno());
+  assert(bad == NULL);
+  assert(meos_errno() != 0);
+
+  /* The frame may name the CRS its tangent point is given in, and a projected
+   * one would place the pose off the ellipsoid the conversion is against */
+  meos_errno_reset();
+  bad = pose_from_geopose("{\"frameSpecification\":{\"authority\":"
+    "\"/geopose/1.0\",\"id\":\"LTP-ENU\",\"parameters\":\"longitude=8&"
+    "latitude=47&height=0&crs=EPSG:3857\"},"
+    "\"quaternion\":{\"x\":0,\"y\":0,\"z\":0,\"w\":1}}");
+  printf("pose_from_geopose(projected frame CRS): %s, errno %d\n",
+    bad ? "non-NULL" : "NULL", meos_errno());
+  assert(bad == NULL);
+  assert(meos_errno() != 0);
+
+  /* An Advanced document still needs its orientation */
+  meos_errno_reset();
+  bad = pose_from_geopose("{\"frameSpecification\":{\"authority\":"
+    "\"/geopose/1.0\",\"id\":\"LTP-ENU\",\"parameters\":\"longitude=8&"
+    "latitude=47&height=0\"}}");
+  printf("pose_from_geopose(Advanced without a quaternion): %s, errno %d\n",
     bad ? "non-NULL" : "NULL", meos_errno());
   assert(bad == NULL);
   assert(meos_errno() != 0);

--- a/mobilitydb/sql/pose/100_pose.in.sql
+++ b/mobilitydb/sql/pose/100_pose.in.sql
@@ -100,7 +100,7 @@ CREATE FUNCTION poseFromHexEWKB(text)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
- * OGC GeoPose JSON I/O — Basic-Quaternion + Basic-YPR conformance
+ * OGC GeoPose JSON I/O — Basic-Quaternion, Basic-YPR and Advanced
  *****************************************************************************/
 
 CREATE FUNCTION poseFromGeoPose(text)
@@ -108,7 +108,7 @@ CREATE FUNCTION poseFromGeoPose(text)
   AS 'MODULE_PATHNAME', 'Pose_from_geopose'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- conformance: 0 = Basic-Quaternion (default), 1 = Basic-YPR
+-- conformance: 0 = Basic-Quaternion (default), 1 = Basic-YPR, 2 = Advanced
 -- maxdecimaldigits: significant digits to keep; -1 = lossless
 CREATE FUNCTION asGeoPose(pose, conformance int4 DEFAULT 0,
     maxdecimaldigits int4 DEFAULT -1)

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -111,7 +111,7 @@ CREATE FUNCTION tposeFromGeoPose(text)
   AS 'MODULE_PATHNAME', 'Tpose_from_geopose'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- conformance:      0 = Basic-Quaternion (default), 1 = Basic-YPR
+-- conformance:      0 = Basic-Quaternion (default), 1 = Basic-YPR, 2 = Advanced
 -- maxdecimaldigits: significant digits to keep; -1 = lossless
 CREATE FUNCTION asGeoPose(tpose, conformance int4 DEFAULT 0,
     maxdecimaldigits int4 DEFAULT -1)

--- a/mobilitydb/test/pose/expected/103_pose_geopose.test.out
+++ b/mobilitydb/test/pose/expected/103_pose_geopose.test.out
@@ -150,7 +150,7 @@ ERROR:  GeoPose JSON requires either a 'quaternion' object (Basic-Quaternion) or
 SELECT poseFromGeoPose('{"position":{"lat":0,"lon":0,"h":0},"quaternion":{"x":0,"y":0,"z":0}}');
 ERROR:  GeoPose 'quaternion' must carry numeric 'w','x','y','z' members
 SELECT asGeoPose(pose 'Geodpose(Point(1 1),0.5)', 99, 6);
-ERROR:  Unknown GeoPose conformance class 99 (0 = Basic-Quaternion, 1 = Basic-YPR)
+ERROR:  Unknown GeoPose conformance class 99 (0 = Basic-Quaternion, 1 = Basic-YPR, 2 = Advanced)
 SELECT asGeoPose(pose 'SRID=5676;Geodpose(Point(1 1),0.5)', 0, 6);
 ERROR:  GeoPose JSON requires a WGS-84 geographic SRID (4326 or 4979), got 5676
 SELECT asGeoPose(tpose 'Geodpose(Point(8 47), 0)@2026-01-01', 0, 6);
@@ -532,7 +532,7 @@ SELECT asText(tposeFromGeoPose('{"type":"TemporalGeoPose","version":"1.0",
 -- A Basic document without a validTime is a pose, not a temporal pose.
 SELECT tposeFromGeoPose(
   '{"position":{"lat":47,"lon":8,"h":0},"quaternion":{"x":0,"y":0,"z":0,"w":1}}');
-ERROR:  A GeoPose Basic document needs a 'validTime' to read as a temporal pose
+ERROR:  A single-pose GeoPose document needs a 'validTime' to read as a temporal pose
 SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
   "stopInstant": 0, "transitionModel": {"authority": "/geopose/1.0",
   "id": "none", "parameters": ""}},
@@ -567,3 +567,68 @@ SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
     "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"}],
   "trailer": {"poseCount": 1}}');
 ERROR:  GeoPose Regular Series missing required integer 'interPoseDuration'
+SELECT asGeoPose(pose 'SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 6);
+                                                                                        asgeopose                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=1500&crs=EPSG:4979"},"quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}}
+(1 row)
+
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 0, 6);
+                                           asgeopose                                           
+-----------------------------------------------------------------------------------------------
+ {"position":{"lat":47,"lon":8,"h":1500},"quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}}
+(1 row)
+
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 1, 6);
+                                    asgeopose                                    
+---------------------------------------------------------------------------------
+ {"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}
+(1 row)
+
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 6);
+                                                                                        asgeopose                                                                                         
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=1500&crs=EPSG:4979"},"quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}}
+(1 row)
+
+SELECT asEWKT(poseFromGeoPose(
+  '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'), 6);
+                            asewkt                             
+---------------------------------------------------------------
+ SRID=4326;GeodPose(POINT Z (8 47 1500),0.707107,0,0,0.707107)
+(1 row)
+
+SELECT asEWKT(poseFromGeoPose(
+  '{"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=1500&crs=EPSG:4979"},"quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}}'), 6);
+                            asewkt                             
+---------------------------------------------------------------
+ SRID=4326;GeodPose(POINT Z (8 47 1500),0.707107,0,0,0.707107)
+(1 row)
+
+SELECT poseFromGeoPose(asGeoPose(pose 'SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 15)) =
+  poseFromGeoPose(asGeoPose(pose 'SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 0, 15));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT asGeoPose(tpose 'SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)@2026-01-01', 2, 6);
+                                                                                                     asgeopose                                                                                                      
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=1500&crs=EPSG:4979"},"quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107},"validTime":1767254400000}
+(1 row)
+
+SELECT poseFromGeoPose('{"frameSpecification":{"authority":"EPSG","id":"4979",
+  "parameters":""},"quaternion":{"x":0,"y":0,"z":0,"w":1}}');
+ERROR:  Unsupported GeoPose outer frame 'EPSG'/'4979'; the frame read is '/geopose/1.0'/'LTP-ENU', which carries the position of the pose in its parameters
+SELECT poseFromGeoPose('{"frameSpecification":{"authority":"/geopose/1.0",
+  "id":"LTP-ENU","parameters":"longitude=8"},
+  "quaternion":{"x":0,"y":0,"z":0,"w":1}}');
+ERROR:  GeoPose 'frameSpecification' parameters must carry numeric 'longitude', 'latitude' and 'height'
+SELECT poseFromGeoPose('{"frameSpecification":{"authority":"/geopose/1.0",
+  "id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=0&crs=EPSG:3857"},
+  "quaternion":{"x":0,"y":0,"z":0,"w":1}}');
+ERROR:  GeoPose 'frameSpecification' parameter 'crs' must name a WGS-84 geographic CRS as EPSG:4326 or EPSG:4979
+SELECT poseFromGeoPose('{"frameSpecification":{"authority":"/geopose/1.0",
+  "id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=0"}}');
+ERROR:  GeoPose Advanced JSON missing required 'quaternion' object

--- a/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
+++ b/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
@@ -27,7 +27,7 @@
 --
 -------------------------------------------------------------------------------
 
--- OGC GeoPose v1.0 JSON I/O — Basic-Quaternion + Basic-YPR conformance.
+-- OGC GeoPose v1.0 JSON I/O — Basic-Quaternion, Basic-YPR and Advanced.
 
 -------------------------------------------------------------------------------
 -- Input: Basic-Quaternion conformance class
@@ -503,5 +503,52 @@ SELECT tposeFromGeoPose('{"header": {"poseCount": 1, "startInstant": 0,
   "innerFrameSeries": [{"authority": "/geopose/1.0",
     "id": "RotateTranslate", "parameters": "translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"}],
   "trailer": {"poseCount": 1}}');
+
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Advanced
+--
+-- The Advanced class names its outer frame explicitly and has no position
+-- member of its own, so the pose sits at the tangent point of the frame.
+-------------------------------------------------------------------------------
+
+SELECT asGeoPose(pose 'SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 6);
+
+-- The examples the manual shows, so that they are what the implementation
+-- prints rather than what it once printed.
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 0, 6);
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 1, 6);
+SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 6);
+SELECT asEWKT(poseFromGeoPose(
+  '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'), 6);
+SELECT asEWKT(poseFromGeoPose(
+  '{"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=1500&crs=EPSG:4979"},"quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}}'), 6);
+
+-- The same pose written Basic and Advanced reads back the same, the frame
+-- standing where the position member stood.
+SELECT poseFromGeoPose(asGeoPose(pose 'SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 15)) =
+  poseFromGeoPose(asGeoPose(pose 'SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 0, 15));
+
+-- A temporal instant written Advanced carries its validTime.
+SELECT asGeoPose(tpose 'SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)@2026-01-01', 2, 6);
+
+-- A frame no pose can be placed in.
+SELECT poseFromGeoPose('{"frameSpecification":{"authority":"EPSG","id":"4979",
+  "parameters":""},"quaternion":{"x":0,"y":0,"z":0,"w":1}}');
+
+-- A frame missing one of the coordinates that place the pose.
+SELECT poseFromGeoPose('{"frameSpecification":{"authority":"/geopose/1.0",
+  "id":"LTP-ENU","parameters":"longitude=8"},
+  "quaternion":{"x":0,"y":0,"z":0,"w":1}}');
+
+-- A frame whose tangent point is given in a projected CRS.
+SELECT poseFromGeoPose('{"frameSpecification":{"authority":"/geopose/1.0",
+  "id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=0&crs=EPSG:3857"},
+  "quaternion":{"x":0,"y":0,"z":0,"w":1}}');
+
+-- An Advanced document without its orientation.
+SELECT poseFromGeoPose('{"frameSpecification":{"authority":"/geopose/1.0",
+  "id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=0"}}');
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/schemas/GeoPose.Advanced.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Advanced.Schema.json
@@ -1,0 +1,63 @@
+{
+  "description": "Advanced: Advanced GeoPose allowing flexible outer frame specification, quaternion orientation, and valid time.",
+  "definitions": {
+    "FrameSpecification": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    },
+    "Quaternion": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        },
+        "w": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z",
+        "w"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "frameSpecification": {
+      "$ref": "#/definitions/FrameSpecification"
+    },
+    "quaternion": {
+      "$ref": "#/definitions/Quaternion"
+    },
+    "validTime": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "frameSpecification",
+    "quaternion"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/README.md
+++ b/mobilitydb/test/pose/schemas/README.md
@@ -9,8 +9,11 @@ MobilityDB implements, retrieved on 2026-08-14 from
 |---|---|
 | `GeoPose.Basic.YPR.Schema.json` | Basic-YPR |
 | `GeoPose.Basic.Quaternion.Schema.json` | Basic-Quaternion |
+| `GeoPose.Advanced.Schema.json` | Advanced |
 | `GeoPose.Composite.Sequence.Series.Regular.Schema.json` | Regular Time Series |
 | `GeoPose.Composite.Sequence.Series.Irregular.Schema.json` | Irregular Time Series |
+| `GeoPose.Composite.Sequence.StreamHeader.Schema.json` | Stream, the document opening one |
+| `GeoPose.Composite.Sequence.StreamElement.Schema.json` | Stream, the document repeated in one |
 
 The schemas are those of OGC GeoPose 1.0 (OGC 21-056r11) and belong to the
 Open Geospatial Consortium, which licenses them for redistribution under the
@@ -21,14 +24,17 @@ are held here unmodified, byte for byte as retrieved, with these digests:
 
     5508d26aed6f…  GeoPose.Basic.YPR.Schema.json
     ce15e01a2ea8…  GeoPose.Basic.Quaternion.Schema.json
+    236887312bee…  GeoPose.Advanced.Schema.json
     2c23b154da01…  GeoPose.Composite.Sequence.Series.Regular.Schema.json
     69f49530f65f…  GeoPose.Composite.Sequence.Series.Irregular.Schema.json
+    ee3b1944912b…  GeoPose.Composite.Sequence.StreamHeader.Schema.json
+    01791c205790…  GeoPose.Composite.Sequence.StreamElement.Schema.json
 
 `tools/scripts/check_geopose_conformance.py` validates against them the GeoPose
 documents that `expected/103_pose_geopose.test.out` holds. Keeping a copy here
 rather than fetching at run time makes the check depend on nothing outside the
 repository, so it gives the same verdict in a network-less build as in CI.
 
-The four remaining conformance classes -- Advanced, Chain, Graph and Stream --
-have schemas at the same place, and belong here as soon as MobilityDB emits a
-document of one of them.
+The two remaining conformance classes, Chain and Graph, have schemas at the
+same place, and belong here as soon as MobilityDB emits a document of one of
+them.

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -267,7 +267,7 @@ representation_families:
     - FromText
     - FromEWKT
     - FromMFJSON
-  - lit: "CREATE FUNCTION tposeFromGeoPose(text)\n  RETURNS tpose\n  AS 'MODULE_PATHNAME', 'Tpose_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- conformance:      0 = Basic-Quaternion (default), 1 = Basic-YPR\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(tpose, conformance int4 DEFAULT 0,\n    maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tpose_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION applyPose(geometry, tpose)\n  RETURNS tgeompoint\n  AS 'MODULE_PATHNAME', 'Tpose_apply_geo'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
+  - lit: "CREATE FUNCTION tposeFromGeoPose(text)\n  RETURNS tpose\n  AS 'MODULE_PATHNAME', 'Tpose_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- conformance:      0 = Basic-Quaternion (default), 1 = Basic-YPR, 2 = Advanced\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(tpose, conformance int4 DEFAULT 0,\n    maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tpose_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION applyPose(geometry, tpose)\n  RETURNS tgeompoint\n  AS 'MODULE_PATHNAME', 'Tpose_apply_geo'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
   - ops:
     - FromBinary
     - FromEWKB
@@ -473,7 +473,7 @@ representation_families:
     - FromBinary
     - FromEWKB
     - FromHexEWKB
-  - lit: "/*****************************************************************************\n * OGC GeoPose JSON I/O — Basic-Quaternion + Basic-YPR conformance\n *****************************************************************************/\n\nCREATE FUNCTION poseFromGeoPose(text)\n  RETURNS pose\n  AS 'MODULE_PATHNAME', 'Pose_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- conformance: 0 = Basic-Quaternion (default), 1 = Basic-YPR\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(pose, conformance int4 DEFAULT 0,\n    maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Pose_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION applyPose(geometry, pose)\n  RETURNS geometry\n  AS 'MODULE_PATHNAME', 'Pose_apply_geo'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
+  - lit: "/*****************************************************************************\n * OGC GeoPose JSON I/O — Basic-Quaternion, Basic-YPR and Advanced\n *****************************************************************************/\n\nCREATE FUNCTION poseFromGeoPose(text)\n  RETURNS pose\n  AS 'MODULE_PATHNAME', 'Pose_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- conformance: 0 = Basic-Quaternion (default), 1 = Basic-YPR, 2 = Advanced\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(pose, conformance int4 DEFAULT 0,\n    maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Pose_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION applyPose(geometry, pose)\n  RETURNS geometry\n  AS 'MODULE_PATHNAME', 'Pose_apply_geo'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
   - lit: "/*****************************************************************************/"
   - ops:
     - asText

--- a/tools/scripts/check_geopose_conformance.py
+++ b/tools/scripts/check_geopose_conformance.py
@@ -6,10 +6,10 @@
 #
 """Validate the emitted GeoPose documents against the normative OGC schemas.
 
-MobilityDB implements four of the eight conformance classes of OGC GeoPose
-v1.0 (OGC 21-056r11): Basic-YPR, Basic-Quaternion, and the Regular and
-Irregular Composite Sequence Series.  Each class has a normative JSON schema,
-published under
+MobilityDB implements six of the eight conformance classes of OGC GeoPose
+v1.0 (OGC 21-056r11): Basic-YPR, Basic-Quaternion, Advanced, the Regular and
+Irregular Composite Sequence Series, and the Stream.  Each class has a
+normative JSON schema, published under
 
     https://schemas.opengis.net/geopose/1.0/schemata/
 
@@ -67,6 +67,11 @@ CLASSES = [
         'GeoPose.Composite.Sequence.StreamElement.Schema.json'),
     ('outerFrame', 'Stream header',
         'GeoPose.Composite.Sequence.StreamHeader.Schema.json'),
+    # An Advanced document carries its position inside the frame it names, so
+    # `frameSpecification` is what distinguishes it from a Basic one; both
+    # carry a quaternion, so this comes first.
+    ('frameSpecification', 'Advanced',
+        'GeoPose.Advanced.Schema.json'),
     ('quaternion', 'Basic-Quaternion',
         'GeoPose.Basic.Quaternion.Schema.json'),
     ('angles', 'Basic-YPR',
@@ -79,7 +84,7 @@ CLASSES = [
 # producer, which a query is not -- so they are validated wherever they appear
 # rather than demanded here; `meos/test/geopose_test.c` is what exercises them.
 REQUIRED = ('Regular Series', 'Irregular Series', 'Basic-Quaternion',
-    'Basic-YPR')
+    'Basic-YPR', 'Advanced')
 
 TYPES = {
     'object': dict,


### PR DESCRIPTION
The Advanced class of OGC GeoPose 1.0 differs from the Basic ones in the frame, not in the pose. Requirement 17, titled *Expression of outer frame*, states that

> The `Advanced.frameSpecification` attribute shall represent an explicit frame specification with the `ExplicitFrameSpec` object

and the normative schema describes itself as allowing a flexible outer frame, while an overview sentence says instead that the two classes differ in the inner frame. A normative requirement outranks descriptive prose, so the frame that varies is the outer one.

The class has no `position` member, so the placement travels in that frame:

```json
{
  "frameSpecification": {
    "authority": "/geopose/1.0",
    "id": "LTP-ENU",
    "parameters": "longitude=8&latitude=47&height=1500&crs=EPSG:4979"
  },
  "quaternion": { "x": 0, "y": 0, "z": 0.707107, "w": 0.707107 }
}
```

The frame written is the LTP-ENU frame at the pose's own position, which puts the pose at the origin of the frame it names and leaves its quaternion the orientation in that frame, unrotated. The Basic-Quaternion and Advanced documents of one pose then carry the same thing and read back equal, which the tests assert directly. The tangent point is built by the helper the composites already use, so one place defines the parameter grammar.

```sql
asGeoPose(pose, 2, maxdecimaldigits)
```

selects it, alongside `0` for Basic-Quaternion and `1` for Basic-YPR, and a document is recognised on the way back in by the frame it names. Since the standard fixes neither the parameter syntax nor the authority and id vocabulary, the reader is strict where it cannot be sure: a frame no pose can be placed in is reported rather than guessed at, as is a missing coordinate and a tangent point given in a projected CRS. A pose whose position quietly defaults to the origin would be accepted at the boundary and refused by every operation that follows it.

The normative schema joins the ones `check_geopose_conformance.py` validates, which reports 27 conformant documents across the five classes the SQL surface writes, and the README beside the schemas lists all seven, the two stream ones included.

Every class of the standard requires a geodetic pose and refuses a planar one, so the GeoPose examples of both manuals are written from a geodetic pose, bounded to six digits, and are the queries the regression tests run, output included.

This adds Advanced to Basic-YPR, Basic-Quaternion, the Regular and Irregular Series and the Stream, which is six of the eight conformance classes.
