### PR TITLE
Ask the covers and disjoint of a temporal rigid geometry of each of its poses

### DIFF
--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -46,6 +46,7 @@
 #include <meos_rgeo.h>
 #include <meos_internal.h>
 #include "temporal/lifting.h"
+#include "temporal/type_util.h"
 #include "geo/postgis_funcs.h"
 #include "geo/tgeo_spatialfuncs.h"
 #include "geo/tgeo_spatialrels.h"
@@ -91,6 +92,50 @@ spatialrel_trgeo_trav_geo(const Temporal *temp, const GSERIALIZED *gs,
   }
   pfree(DatumGetPointer(trav));
   return result ? 1 : 0;
+}
+
+/**
+ * @brief Return 1 if the poses of a temporal rigid geometry and a geometry
+ * ever/always satisfy a spatial relationship, 0 if not, and -1 on error or if
+ * the geometry is empty
+ * @details The traversed area collects the reference geometry at each of the
+ * poses the value takes, so the relationship is asked of each of them: the
+ * ever semantics hold where one pose satisfies it, the always semantics where
+ * every pose does. Asking it of the traversed area as a whole answers for the
+ * union of the poses, which is a region the body occupies at no single instant
+ * @param[in] temp Temporal rigid geometry
+ * @param[in] gs Geometry
+ * @param[in] func Spatial relationship function to be called
+ * @param[in] ever True for the ever semantics, false for the always semantics
+ * @return On error return -1
+ */
+static int
+ea_spatialrel_trgeo_poses_geo(const Temporal *temp, const GSERIALIZED *gs,
+  datum_func2 func, bool ever)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+    return -1;
+
+  GSERIALIZED *trav = trgeometry_traversed_area(temp, UNARY_UNION_NO);
+  Datum geo = PointerGetDatum(gs);
+  int count;
+  GSERIALIZED **poses = geo_extract_elements(trav, &count);
+  /* The vacuous default: false for the ever semantics, true for the always
+   * ones */
+  int result = ever ? 0 : 1;
+  for (int i = 0; i < count; i++)
+  {
+    bool res = DatumGetBool(func(PointerGetDatum(poses[i]), geo));
+    if ((ever && res) || (! ever && ! res))
+    {
+      result = res ? 1 : 0;
+      break;
+    }
+  }
+  pfree_array((void *) poses, count);
+  pfree(trav);
+  return result;
 }
 
 /*****************************************************************************/
@@ -318,14 +363,7 @@ acovers_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 int
 ea_covers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
-    return -1;
-  GSERIALIZED *trav = trgeometry_traversed_area(temp, UNARY_UNION_NO);
-  bool result = ever ? geom_relate_pattern(trav, gs, "T********") :
-    geom_covers(trav, gs);
-  pfree(trav);
-  return result ? 1 : 0;
+  return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_covers, ever);
 }
 
 /**
@@ -398,11 +436,11 @@ ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
-  int result = ever ?
-    spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
-      (varfunc) &datum_geom_covers, 2, INVERT) :
-    eintersects_trgeometry_geo(temp, gs);
-  return INVERT_RESULT(result);
+  if (ever)
+    return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_disjoint2d,
+      EVER);
+  /* aDisjoint(trgeo, geo) ≡ NOT eIntersects(trgeo, geo) */
+  return INVERT_RESULT(eintersects_trgeometry_geo(temp, gs));
 }
 /**
  * @ingroup meos_rgeo_rel_ever

--- a/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
+++ b/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
@@ -94,6 +94,46 @@ SELECT aCovers(
  t
 (1 row)
 
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Point(0 0)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Point(0 0)');
+ acovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Point(4.5 0.5)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Point(4.5 0.5)');
+ acovers 
+---------
+ f
+(1 row)
+
 SELECT eDisjoint(
   geometry 'Polygon((10 10,11 10,11 11,10 11,10 10))',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
@@ -138,6 +178,22 @@ SELECT aDisjoint(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2001-01-01',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(10 10),0)@2001-01-01');
  adisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Linestring(0 -5,0 5)');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(-5 0),0)@2001-01-01, Pose(Point(5 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ edisjoint 
 -----------
  t
 (1 row)

--- a/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
+++ b/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
@@ -86,6 +86,26 @@ SELECT aCovers(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
 
+-- A pose covers what lies within it, including a point of its boundary, and
+-- covers no region larger than itself
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Point(0 0)');
+SELECT aCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Point(0 0)');
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+-- A body sliding along the x axis covers a point on its path at one pose and
+-- not at every one
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Point(4.5 0.5)');
+SELECT aCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Point(4.5 0.5)');
+
 -------------------------------------------------------------------------------
 -- eDisjoint / aDisjoint
 -------------------------------------------------------------------------------
@@ -113,6 +133,15 @@ SELECT eDisjoint(
 SELECT aDisjoint(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2001-01-01',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(10 10),0)@2001-01-01');
+
+-- A body standing on a line meets it at every pose, and one that starts away
+-- from a region is disjoint from it at some pose
+SELECT eDisjoint(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Linestring(0 -5,0 5)');
+SELECT eDisjoint(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(-5 0),0)@2001-01-01, Pose(Point(5 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
 
 -------------------------------------------------------------------------------
 -- eIntersects / aIntersects


### PR DESCRIPTION
The traversed area of a temporal rigid geometry collects the reference geometry at each of the poses the value takes. Asking a relationship of that collection as a whole answers for the union of the poses, a region the body occupies at no single instant, so the ever semantics hold where one pose satisfies the relationship and the always semantics where every pose does.

Covers asks the relate pattern of the *contains* relationship for the ever semantics and the covering of the whole collection for the always ones, so the two quantifiers run different relationships and the always answer can hold without the ever one:

```sql
-- a unit square standing on the origin, and a point of its own boundary
SELECT eCovers(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
  [Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
  geometry 'Point(0 0)');   -- t
SELECT aCovers(  -- the same operands
  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
  [Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
  geometry 'Point(0 0)');   -- t
```

Before this, `aCovers` answers true and `eCovers` false: the body always covers a point it never covered.

Disjoint asks whether the geometry covers the traversed area, which is the formula the temporal point uses, where a point is either inside the geometry or outside it. A body has extent: one standing on a line meets it at every pose, yet the geometry does not cover the body, so the value is reported as ever disjoint from a line it never leaves.

```sql
SELECT eDisjoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
  [Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
  geometry 'Linestring(0 -5,0 5)');   -- f
```

This walks the poses, with the quantifier of the semantics. Over eight predicates, seven poses and eleven geometry types the covers and disjoint answers agree with the temporal geometry the value casts to on every translating pose, and every always answer that holds is matched by the ever one.

No committed expectation moves: the suite holds no case where a pose and the union of the poses answer differently, which is what leaves this uncovered. The added cases are a body covering a point of its own boundary, one covering a point only at its last pose, one that cannot cover a region larger than itself, a body standing on a line, and one that starts away from a region and enters it.