### PR TITLE
Keep the temporal geography point argument used when the asserts are gone

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -214,6 +214,7 @@ typedef enum
     do { \
       assert(temp); \
       assert((temp)->temptype == T_TGEOGPOINT); \
+      (void) (temp); \
     } while (0)
 #endif /* MEOS */
 


### PR DESCRIPTION
In the extension build `VALIDATE_TGEOGPOINT` expands to two asserts, and a Release build strips them, so a function whose whole body is that macro leaves its argument unused:

```
meos/src/h3/th3index.c:119:73: warning: unused parameter 'temp2' [-Wunused-parameter]
```

`ensure_valid_th3index_tgeogpoint` is that function — its body is `VALIDATE_TH3INDEX(temp1, false); VALIDATE_TGEOGPOINT(temp2, false);` and nothing else. Every other caller of the macro reads its argument afterwards, which is why none of them warns. `temp1` survives because the sibling macro `VALIDATE_TH3INDEX` already carries a `(void) (temp);` for exactly this reason; this adds the same cast to `VALIDATE_TGEOGPOINT`.

Reproducing it needs `-DH3=ON` together with a Release build. The only CI job that enables H3 also passes `-DCASSERT=ON`, which keeps the asserts and therefore keeps the argument used — that combination is why the warning stays out of sight.

Measured on the `h3` target, `-DMEOS=OFF -DCMAKE_BUILD_TYPE=Release -DH3=ON`: 1 warning before, 0 after.
