### PR TITLE
Repair the geometry set validity macros

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -76,7 +76,7 @@ typedef enum
 #else
   #define VALIDATE_GEOMSET(set, ret) \
     do { \
-      assert(temp); \
+      assert(set); \
       assert((set)->settype == T_GEOMSET); \
     } while (0)
 #endif /* MEOS */
@@ -85,7 +85,7 @@ typedef enum
  * @brief Macro ensuring that a set is a geography set
  */
 #if MEOS
-  #define VALIDATE_GEOGSET(set, ret) ( \
+  #define VALIDATE_GEOGSET(set, ret) \
     do { \
           if (! ensure_not_null((void *) (set)) || \
               ! ensure_set_isof_type(set, T_GEOGSET) ) \
@@ -94,7 +94,7 @@ typedef enum
 #else
   #define VALIDATE_GEOGSET(set, ret) \
     do { \
-      assert(temp); \
+      assert(set); \
       assert((set)->settype == T_GEOGSET); \
     } while (0)
 #endif /* MEOS */
@@ -112,8 +112,8 @@ typedef enum
 #else
   #define VALIDATE_GEOSET(set, ret) \
     do { \
-      assert(temp); \
-      assert(geoset_type((set)->settype); \
+      assert(set); \
+      assert(geoset_type((set)->settype)); \
     } while (0)
 #endif /* MEOS */
 


### PR DESCRIPTION
Four defects in the set validity macros of `meos/include/meos_geo.h`:

* the assert branch of `VALIDATE_GEOMSET`, `VALIDATE_GEOGSET` and `VALIDATE_GEOSET` tests `temp`, while the parameter is named `set`;
* `VALIDATE_GEOGSET` opens its MEOS branch with a stray parenthesis, `#define VALIDATE_GEOGSET(set, ret) ( \`, so it does not compile in either build;
* the second assert of `VALIDATE_GEOSET` is missing its closing parenthesis.

`VALIDATE_SPATIALSET`, immediately below them, is the same macro written correctly, and this change makes the three match it.

No caller reaches the broken text today, which is why nothing reports it: `VALIDATE_GEOMSET` and `VALIDATE_GEOGSET` have no callers at all, and `VALIDATE_GEOSET`'s five callers are all in `meos/src/geo/geoset_meos.c`, which `meos/src/geo/CMakeLists.txt` compiles under `if(MEOS)` — the branch that is correct. The first caller of any of them in an extension translation unit gets a compile error instead.

Compiling the three macro bodies as they stand, copied verbatim and given stub types, reports:

```
error: ‘temp’ undeclared (first use in this function)        [VALIDATE_GEOMSET]
error: ‘temp’ undeclared (first use in this function)        [VALIDATE_GEOSET]
error: unterminated argument list invoking macro "assert"    [VALIDATE_GEOSET]
```
