### PR TITLE
Declare the interval array of a clip segment before the jump that skips it

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1118,12 +1118,14 @@ tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
     intervals_from_arcs(a, b, sel_edges, sel_nedges);
     intervals_from_polygons(a, b, sel_edges, sel_nedges, edges, nedges, rtree,
       srid, xmax);
+    /* The array is declared before the jump below, which would otherwise skip
+     * its initializer while `next_segment` reads it */
+    Span *intervarr = NULL;
     if (intervals->count == 0)
       goto next_segment;
 
     /* Normalize the intervals */
     int count;
-    Span *intervarr = NULL;
     if (intervals->count > 1)
       intervarr = spanarr_normalize(intervals->elems, intervals->count,
         ORDER_NO, &count);
@@ -2664,13 +2666,15 @@ tpointseq_dwithin_edges(const TSequence *seq, Edge **edges, int nedges,
     intervals->count = 0;
     intervals_within_edges(a, b, sel_edges, sel_nedges, edges, nedges, dist,
       rtree, srid, xmax);
+    /* The array is declared before the jump below, which would otherwise skip
+     * its initializer while `next_segment` reads it */
+    Span *intervarr = NULL;
     if (intervals->count == 0)
       goto next_segment;
 
     /* Normalize the intervals (sort: the midpoint intervals and the isolated
      * within points are appended in two separate passes, not globally sorted) */
     int count;
-    Span *intervarr = NULL;
     if (intervals->count > 1)
       intervarr = spanarr_normalize(intervals->elems, intervals->count,
         ORDER, &count);


### PR DESCRIPTION
The two clipping loops of `tpoint_geom_clip.c` leave a segment early when it meets no edge:

```c
if (intervals->count == 0)
  goto next_segment;
...
Span *intervarr = NULL;
...
next_segment:
  if (intervarr && intervals->count > 1)
    pfree(intervarr);
```

The jump crosses the declaration, so the initializer never runs, and the label reads a value the segment never assigns. The `pfree` is out of reach on that path, the second operand being false whenever the jump is taken, but the read itself is undefined and sits one edit away from freeing a pointer that carries no value.

Declaring the array above the jump gives it a value on every path into the label. Only the declaration moves: no call changes place, so the point at which anything is computed, and the error path with it, stays where it is.

Both loops carry the shape, and gcc reports both under `-Wmaybe-uninitialized` in the coverage build, which compiles with `-fprofile-arcs -ftest-coverage` and `CASSERT=ON`.
