### PR TITLE
Keep the terminator of the upper-case map in the vendored liblwgeom

### DIFF
--- a/postgis/liblwgeom/lwutil.c
+++ b/postgis/liblwgeom/lwutil.c
@@ -465,7 +465,12 @@ struct geomtype_struct geomtype_struct_array[] =
 * We could also count on PgSQL sending us *lower* case inputs, as it seems to do that
 * regardless of the case the user provides for the type arguments.
 */
-const char dumb_upper_map[128] = "................................................0123456789.......ABCDEFGHIJKLMNOPQRSTUVWXYZ......ABCDEFGHIJKLMNOPQRSTUVWXYZ.....";
+/* MEOS: the bound is left implicit so that the string keeps its terminator.
+ * The map holds one entry per code point 0 to 127, which is what dumb_toupper
+ * below indexes and the only thing anything reads; a [128] bound drops the
+ * terminating NUL, which GCC 15 reports as
+ * -Wunterminated-string-initialization. */
+const char dumb_upper_map[] = "................................................0123456789.......ABCDEFGHIJKLMNOPQRSTUVWXYZ......ABCDEFGHIJKLMNOPQRSTUVWXYZ.....";
 
 static char dumb_toupper(int in)
 {


### PR DESCRIPTION
GCC 15 and newer report the initializer of `dumb_upper_map` in the vendored liblwgeom:

```
postgis/liblwgeom/lwutil.c:468:34: warning: initializer-string for array of 'char'
  truncates NUL terminator but destination lacks 'nonstring' attribute
  (129 chars into 128 available) [-Wunterminated-string-initialization]
```

The map carries one entry per code point 0 to 127, so the string is exactly 128 characters and the `[128]` bound leaves no room for its terminator. Leaving the bound implicit gives the array its terminator and keeps every index where it is: `dumb_toupper`, which clamps its argument to 0..127, is the only reader, and no code takes the array's size — the symbol appears in `lwutil.c` and nowhere else in the tree.

Measured on a Fedora 44 container (GCC 16.1.1), building the `liblwgeom` target from master and then with this change, same configuration:

| | warnings |
|---|---|
| master | 1 |
| with this change | 0 |

`lwutil.c` appears in the second build log, so the object is recompiled rather than reused.

The vendored geometry libraries compile under the standard warning flags, and `-Wunterminated-string-initialization` arrives in GCC 15, so a toolchain older than that reports nothing here.
