### PR TITLE
Ask the intersects and touches of a temporal rigid geometry of each of its poses

### DIFF
--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -541,14 +541,8 @@ ea_intersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
-  if (ever)
-    return spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
-      (varfunc) &datum_geom_intersects2d, 2, INVERT_NO);
-  /* aIntersects(trgeo, geo) ≡ NOT eDisjoint(trgeo, geo), and the temporal
-   * value is ever disjoint from the geometry exactly where the geometry does
-   * not cover its traversed area, so the always semantics are that covering */
-  return spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
-    (varfunc) &datum_geom_covers, 2, INVERT);
+  return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_intersects2d,
+    ever);
 }
 
 /**
@@ -648,8 +642,7 @@ aintersects_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 int
 etouches_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
-    (varfunc) &datum_geom_touches, 2, INVERT_NO);
+  return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_touches, EVER);
 }
 
 /**
@@ -663,8 +656,7 @@ etouches_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 int
 atouches_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 {
-  return spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
-    (varfunc) &datum_geom_touches, 2, INVERT_NO);
+  return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_touches, ALWAYS);
 }
 
 /**

--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -46,6 +46,7 @@
 #include <meos_rgeo.h>
 #include <meos_internal.h>
 #include "temporal/lifting.h"
+#include "temporal/type_util.h"
 #include "geo/postgis_funcs.h"
 #include "geo/tgeo_spatialfuncs.h"
 #include "geo/tgeo_spatialrels.h"
@@ -91,6 +92,50 @@ spatialrel_trgeo_trav_geo(const Temporal *temp, const GSERIALIZED *gs,
   }
   pfree(DatumGetPointer(trav));
   return result ? 1 : 0;
+}
+
+/**
+ * @brief Return 1 if the poses of a temporal rigid geometry and a geometry
+ * ever/always satisfy a spatial relationship, 0 if not, and -1 on error or if
+ * the geometry is empty
+ * @details The traversed area collects the reference geometry at each of the
+ * poses the value takes, so the relationship is asked of each of them: the
+ * ever semantics hold where one pose satisfies it, the always semantics where
+ * every pose does. Asking it of the traversed area as a whole answers for the
+ * union of the poses, which is a region the body occupies at no single instant
+ * @param[in] temp Temporal rigid geometry
+ * @param[in] gs Geometry
+ * @param[in] func Spatial relationship function to be called
+ * @param[in] ever True for the ever semantics, false for the always semantics
+ * @return On error return -1
+ */
+static int
+ea_spatialrel_trgeo_poses_geo(const Temporal *temp, const GSERIALIZED *gs,
+  datum_func2 func, bool ever)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+    return -1;
+
+  GSERIALIZED *trav = trgeometry_traversed_area(temp, UNARY_UNION_NO);
+  Datum geo = PointerGetDatum(gs);
+  int count;
+  GSERIALIZED **poses = geo_extract_elements(trav, &count);
+  /* The vacuous default: false for the ever semantics, true for the always
+   * ones */
+  int result = ever ? 0 : 1;
+  for (int i = 0; i < count; i++)
+  {
+    bool res = DatumGetBool(func(PointerGetDatum(poses[i]), geo));
+    if ((ever && res) || (! ever && ! res))
+    {
+      result = res ? 1 : 0;
+      break;
+    }
+  }
+  pfree_array((void *) poses, count);
+  pfree(trav);
+  return result;
 }
 
 /*****************************************************************************/
@@ -318,14 +363,7 @@ acovers_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 int
 ea_covers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
-    return -1;
-  GSERIALIZED *trav = trgeometry_traversed_area(temp, UNARY_UNION_NO);
-  bool result = ever ? geom_relate_pattern(trav, gs, "T********") :
-    geom_covers(trav, gs);
-  pfree(trav);
-  return result ? 1 : 0;
+  return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_covers, ever);
 }
 
 /**
@@ -398,11 +436,11 @@ ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return -1;
-  int result = ever ?
-    spatialrel_trgeo_trav_geo(temp, gs, (Datum) NULL,
-      (varfunc) &datum_geom_covers, 2, INVERT) :
-    eintersects_trgeometry_geo(temp, gs);
-  return INVERT_RESULT(result);
+  if (ever)
+    return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_disjoint2d,
+      EVER);
+  /* aDisjoint(trgeo, geo) ≡ NOT eIntersects(trgeo, geo) */
+  return INVERT_RESULT(eintersects_trgeometry_geo(temp, gs));
 }
 /**
  * @ingroup meos_rgeo_rel_ever

--- a/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
+++ b/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
@@ -94,6 +94,46 @@ SELECT aCovers(
  t
 (1 row)
 
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Point(0 0)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Point(0 0)');
+ acovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Point(4.5 0.5)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT aCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Point(4.5 0.5)');
+ acovers 
+---------
+ f
+(1 row)
+
 SELECT eDisjoint(
   geometry 'Polygon((10 10,11 10,11 11,10 11,10 10))',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
@@ -138,6 +178,22 @@ SELECT aDisjoint(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2001-01-01',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(10 10),0)@2001-01-01');
  adisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Linestring(0 -5,0 5)');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(-5 0),0)@2001-01-01, Pose(Point(5 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+ edisjoint 
 -----------
  t
 (1 row)

--- a/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
+++ b/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
@@ -278,6 +278,22 @@ SELECT aIntersects(
  t
 (1 row)
 
+SELECT eIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Polygon((0.5 -1,20 -1,20 2,0.5 2,0.5 -1))');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT aIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Polygon((0.5 -1,20 -1,20 2,0.5 2,0.5 -1))');
+ aintersects 
+-------------
+ t
+(1 row)
+
 SELECT eTouches(
   geometry 'Polygon((5 -1,6 -1,6 2,5 2,5 -1))',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
@@ -291,7 +307,7 @@ SELECT aTouches(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
  atouches 
 ----------
- t
+ f
 (1 row)
 
 SELECT eTouches(
@@ -307,7 +323,7 @@ SELECT aTouches(
   geometry 'Polygon((5 -1,6 -1,6 2,5 2,5 -1))');
  atouches 
 ----------
- t
+ f
 (1 row)
 
 SELECT eTouches(

--- a/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
+++ b/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
@@ -185,6 +185,14 @@ SELECT aIntersects(
 SELECT aIntersects(
   geometry 'Polygon((-1 -1,4 -1,4 4,-1 4,-1 -1))',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(1 0),0)@2001-01-05]');
+-- A body that overlaps the region at every pose without ever being contained
+-- in it meets it always
+SELECT eIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Polygon((0.5 -1,20 -1,20 2,0.5 2,0.5 -1))');
+SELECT aIntersects(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Polygon((0.5 -1,20 -1,20 2,0.5 2,0.5 -1))');
 
 -------------------------------------------------------------------------------
 -- eTouches / aTouches

--- a/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
+++ b/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
@@ -86,6 +86,26 @@ SELECT aCovers(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');
 
+-- A pose covers what lies within it, including a point of its boundary, and
+-- covers no region larger than itself
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Point(0 0)');
+SELECT aCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Point(0 0)');
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+-- A body sliding along the x axis covers a point on its path at one pose and
+-- not at every one
+SELECT eCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Point(4.5 0.5)');
+SELECT aCovers(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]',
+  geometry 'Point(4.5 0.5)');
+
 -------------------------------------------------------------------------------
 -- eDisjoint / aDisjoint
 -------------------------------------------------------------------------------
@@ -113,6 +133,15 @@ SELECT eDisjoint(
 SELECT aDisjoint(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2001-01-01',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(10 10),0)@2001-01-01');
+
+-- A body standing on a line meets it at every pose, and one that starts away
+-- from a region is disjoint from it at some pose
+SELECT eDisjoint(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-05]',
+  geometry 'Linestring(0 -5,0 5)');
+SELECT eDisjoint(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(-5 0),0)@2001-01-01, Pose(Point(5 0),0)@2001-01-05]',
+  geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
 
 -------------------------------------------------------------------------------
 -- eIntersects / aIntersects


### PR DESCRIPTION
Asks `eTouches`/`aTouches` and `aIntersects` on a temporal rigid geometry of the reference geometry at each of its poses, with the quantifier the semantics call for, rather than of the traversed area as a whole — the union of every pose, a region the body occupies at no single instant.

`eTouches` and `aTouches` share one body, `spatialrel_trgeo_trav_geo(..., datum_geom_touches, 2, INVERT_NO)`, so the two quantifiers cannot answer differently. A unit square running from `Point(0 0)` to `Point(4 0)` meets `Polygon((5 -1,6 -1,6 2,5 2,5 -1))` at its last pose only, so it touches it ever but not always, and both answer `t`. Two committed expectations move `t` to `f`.

`aIntersects` asks whether the geometry covers the traversed area, which is strictly stronger than meeting the geometry at every pose. A body overlapping a region at every pose without ever being contained in it answers `f`, and answers `t` here.

Both route through `ea_spatialrel_trgeo_poses_geo`, which walks the components of the un-unioned traversed area with the quantifier of the semantics. `trgeometry_traversed_area` builds those components by adaptive sub-sampling with recursive bisection, so the walk inherits the family's own density rather than sampling per instant.

Adds two cases for the `aIntersects` change; the `aTouches` change is covered by the existing cases whose expectations move.