### PR TITLE
Free the value strings leaked by the two-argument JSONB constructor

### DIFF
--- a/pgtypes/utils/jsonb.c
+++ b/pgtypes/utils/jsonb.c
@@ -799,8 +799,13 @@ pg_jsonb_make_two_arg(text **keys, text **values, int count)
   state.res = meos_pushJsonbValue(&state.parseState, WJB_END_OBJECT, NULL);
   Jsonb *result = JsonbValueToJsonb(state.res);
   for (int i = 0; i < count; ++i)
+  {
     pfree(keys_str[i]);
+    if (values_str[i]) /* MEOS */
+      pfree(values_str[i]); /* MEOS */
+  }
   pfree(keys_str);
+  pfree(values_str); /* MEOS */
   return result;
 }
 


### PR DESCRIPTION
pg_jsonb_make_two_arg converts every non-null values[i] text into a fresh C string in its values_str array, so its cleanup loop frees each values_str element and the array itself alongside keys_str, mirroring the sibling pg_jsonb_make whose interleaved keys_vals_str array is freed in full.