### PR TITLE
Report a pixel type in the case the RaQuet specification writes it

### DIFF
--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -13,9 +13,9 @@
 
 	<para>La extensión <ulink url="https://postgis.net/docs/using_raster_dataman.html">ráster de PostGIS</ulink> almacena datos de cobertura en cuadrícula (elevación, temperatura, imágenes satelitales, …) en el tipo <varname>raster</varname>. Cada ráster tiene una o más bandas; una banda contiene un arreglo 2D de valores de píxel, una extensión espacial, un tamaño de píxel y un valor centinela opcional para datos nulos (<varname>nodata</varname>).</para>
 
-	<para>El operador de muestreo de ráster de MobilityDB evalúa una banda de ráster en los instantes de una trayectoria de punto móvil y devuelve un <varname>tfloat</varname>. Los instantes cuya posición cae fuera de la extensión del ráster o sobre un píxel <varname>nodata</varname> se descartan silenciosamente. Los operadores de muestreo son de valor doble sea cual sea el tipo de píxel de la banda, de modo que un tipo de píxel pertenece a la superficie de muestreo cuando todo valor que puede contener es exactamente representable en un número de doble precisión. Eso es lo que permite muestrear una banda de cualquier tipo en un único <varname>tfloat</varname>, y que una columna con teselas de varios tipos de píxel se lea con una sola consulta. Un tipo de píxel también se acepta con el nombre que le da el ráster de PostGIS, de modo que el tipo de banda que informa una llamada a <varname>ST_BandPixelType</varname> (<varname>8BUI</varname>, <varname>16BSI</varname>, <varname>32BF</varname>, …) se pasa a los constructores de teselas tal cual. El ráster de PostGIS no lleva flotantes de 16 bits ni enteros de 64 bits, así que <varname>FLOAT16</varname>, <varname>INT64</varname> y <varname>UINT64</varname> toman la grafía que da su gramática, <varname>16BF</varname>, <varname>64BSI</varname> y <varname>64BUI</varname>. Sus tipos <varname>1BB</varname>, <varname>2BUI</varname> y <varname>4BUI</varname> ocupan menos de un byte por píxel, para lo cual una tesela no tiene representación, y así lo indican. El nombre que informa una tesela es el que la especificación RaQuet da al tipo.
+	<para>El operador de muestreo de ráster de MobilityDB evalúa una banda de ráster en los instantes de una trayectoria de punto móvil y devuelve un <varname>tfloat</varname>. Los instantes cuya posición cae fuera de la extensión del ráster o sobre un píxel <varname>nodata</varname> se descartan silenciosamente. Los operadores de muestreo son de valor doble sea cual sea el tipo de píxel de la banda, de modo que un tipo de píxel pertenece a la superficie de muestreo cuando todo valor que puede contener es exactamente representable en un número de doble precisión. Eso es lo que permite muestrear una banda de cualquier tipo en un único <varname>tfloat</varname>, y que una columna con teselas de varios tipos de píxel se lea con una sola consulta. Un tipo de píxel también se acepta con el nombre que le da el ráster de PostGIS, de modo que el tipo de banda que informa una llamada a <varname>ST_BandPixelType</varname> (<varname>8BUI</varname>, <varname>16BSI</varname>, <varname>32BF</varname>, …) se pasa a los constructores de teselas tal cual. El ráster de PostGIS no lleva flotantes de 16 bits ni enteros de 64 bits, así que <varname>float16</varname>, <varname>int64</varname> y <varname>uint64</varname> toman la grafía que da su gramática, <varname>16BF</varname>, <varname>64BSI</varname> y <varname>64BUI</varname>. Sus tipos <varname>1BB</varname>, <varname>2BUI</varname> y <varname>4BUI</varname> ocupan menos de un byte por píxel, para lo cual una tesela no tiene representación, y así lo indican. El nombre que informa una tesela es el que la especificación RaQuet da al tipo.
 
-Los tipos <varname>UINT64</varname> e <varname>INT64</varname> contienen valores fuera de ese dominio: una tesela de cualquiera de ellos se almacena y se vuelve a leer exactamente, mientras que muestrear un píxel cuyo valor ningún número de doble precisión nombra genera un error en lugar de responder con un valor vecino. Esto permite consultas como <emphasis>¿qué perfil de elevación siguió cada vehículo?</emphasis> o <emphasis>¿qué viajes entraron en una banda de umbral de temperatura?</emphasis></para>
+Los tipos <varname>uint64</varname> e <varname>int64</varname> contienen valores fuera de ese dominio: una tesela de cualquiera de ellos se almacena y se vuelve a leer exactamente, mientras que muestrear un píxel cuyo valor ningún número de doble precisión nombra genera un error en lugar de responder con un valor vecino. Esto permite consultas como <emphasis>¿qué perfil de elevación siguió cada vehículo?</emphasis> o <emphasis>¿qué viajes entraron en una banda de umbral de temperatura?</emphasis></para>
 
 	<para>Para usar los operadores descritos aquí, MobilityDB debe ser compilado con <varname>-DRASTER=ON</varname>. En tal compilación, el archivo <filename>mobilitydb.control</filename> generado declara <varname>requires = 'postgis, postgis_raster'</varname>, por lo que un único <varname>CASCADE</varname> crea la pila completa:</para>
 	<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -108,7 +108,7 @@ FROM unnest(quadbins(traj, 8)) AS q;
 
 -- Step 2: sample each matching tile
 SELECT rasterTileValueQuadbin(traj,
-    band_data, width, height, quadbin, 'FLOAT32', nodata, true)
+    band_data, width, height, quadbin, 'float32', nodata, true)
 FROM elevation_raquet
 WHERE quadbin = ANY(quadbins(traj, 8));
 </programlisting>
@@ -136,18 +136,18 @@ ORDER BY tile_count DESC;
 				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
 				<para>Muestrear un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
 				<para><varname>rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,boolean) → tfloat</varname></para>
-				<para>Evalúa un arreglo de píxeles de banda única en orden de fila mayor en cada instante de <varname>traj</varname> (SRID 4326). La georreferenciación de la tesela (rectángulo delimitador, mapeo de píxel a coordenadas) se deriva únicamente de <varname>quadbin</varname> mediante la transformada de tesela deslizante Web-Mercator. El argumento <varname>pixtype</varname> debe ser uno de <varname>UINT8</varname>, <varname>INT8</varname>, <varname>UINT16</varname>, <varname>INT16</varname>, <varname>UINT32</varname>, <varname>INT32</varname>, <varname>UINT64</varname>, <varname>INT64</varname>, <varname>FLOAT16</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>. Cuando <varname>has_nodata</varname> es verdadero, los instantes cuyo píxel equivale a <varname>nodata</varname> se descartan silenciosamente. Devuelve <varname>NULL</varname> cuando ningún instante sobrevive.</para>
+				<para>Evalúa un arreglo de píxeles de banda única en orden de fila mayor en cada instante de <varname>traj</varname> (SRID 4326). La georreferenciación de la tesela (rectángulo delimitador, mapeo de píxel a coordenadas) se deriva únicamente de <varname>quadbin</varname> mediante la transformada de tesela deslizante Web-Mercator. El argumento <varname>pixtype</varname> debe ser uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Cuando <varname>has_nodata</varname> es verdadero, los instantes cuyo píxel equivale a <varname>nodata</varname> se descartan silenciosamente. Devuelve <varname>NULL</varname> cuando ningún instante sobrevive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample elevation tiles from a Raquet Parquet table
 -- for all ship trajectories
 SELECT t.tripid, rasterTileValueQuadbin(t.trip
-  r.band_data, r.width, r.height, r.quadbin, 'FLOAT32', r.nodata, true)
+  r.band_data, r.width, r.height, r.quadbin, 'float32', r.nodata, true)
 FROM trips t
 JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
 
 -- Average sea-surface temperature per trajectory
 SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
-  r.band_data, 256, 256, r.quadbin, 'INT16', -9999, true)) AS mean_sst
+  r.band_data, 256, 256, r.quadbin, 'int16', -9999, true)) AS mean_sst
 FROM trips t
 JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 </programlisting>
@@ -157,14 +157,14 @@ JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construir una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
 				<para><varname>raquet(bytea,integer,integer,bigint,text,float8) → raquet</varname></para>
-				<para>Empaqueta un arreglo de píxeles <varname>pixels</varname> de banda única en orden de fila mayor de <varname>width</varname> × <varname>height</varname> píxeles de tipo <varname>pixtype</varname> (uno de <varname>UINT8</varname>, <varname>INT8</varname>, <varname>UINT16</varname>, <varname>INT16</varname>, <varname>UINT32</varname>, <varname>INT32</varname>, <varname>UINT64</varname>, <varname>INT64</varname>, <varname>FLOAT16</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>), georreferenciado por la celda <varname>quadbin</varname>, en un único valor <varname>raquet</varname> autodescriptivo. El argumento <varname>nodata</varname> es opcional; cuando se omite (<varname>NULL</varname>) la tesela no lleva valor centinela de nodata. Se genera un error cuando el arreglo <varname>pixels</varname> es menor que <varname>width</varname> × <varname>height</varname> × el tamaño del píxel. Los píxeles de más de un byte son little-endian, que es el orden de bytes que les da la especificación RaQuet sea cual sea el orden de bytes del servidor, de modo que una tesela conserva sus valores cuando se lee en otra máquina. Un <varname>raquet</varname> es un valor de longitud variable, libre de GDAL, con una representación portátil en texto Hex-WKB y binaria, distinto de y coexistente con el tipo <varname>raster</varname> de PostGIS usado por <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
+				<para>Empaqueta un arreglo de píxeles <varname>pixels</varname> de banda única en orden de fila mayor de <varname>width</varname> × <varname>height</varname> píxeles de tipo <varname>pixtype</varname> (uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>), georreferenciado por la celda <varname>quadbin</varname>, en un único valor <varname>raquet</varname> autodescriptivo. El argumento <varname>nodata</varname> es opcional; cuando se omite (<varname>NULL</varname>) la tesela no lleva valor centinela de nodata. Se genera un error cuando el arreglo <varname>pixels</varname> es menor que <varname>width</varname> × <varname>height</varname> × el tamaño del píxel. Los píxeles de más de un byte son little-endian, que es el orden de bytes que les da la especificación RaQuet sea cual sea el orden de bytes del servidor, de modo que una tesela conserva sus valores cuando se lee en otra máquina. Un <varname>raquet</varname> es un valor de longitud variable, libre de GDAL, con una representación portátil en texto Hex-WKB y binaria, distinto de y coexistente con el tipo <varname>raster</varname> de PostGIS usado por <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Empaquetar las columnas sueltas de una tabla Raquet en valores raquet
-SELECT raquet(band_data, width, height, quadbin, 'FLOAT32', nodata) AS tile
+SELECT raquet(band_data, width, height, quadbin, 'float32', nodata) AS tile
 FROM elevation_raquet;
 
 -- Una tesela UINT8 de 2 x 2 sin nodata
-SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8');
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 </programlisting>
 			</listitem>
 
@@ -243,8 +243,8 @@ GROUP BY t.tripid, t.trip;
 				<para><varname>raquetFromHexWKB(text) → raquet</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
-  5193776270265024512, 'UINT8')))
-  = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8');
+  5193776270265024512, 'uint8')))
+  = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 -- true
 </programlisting>
 			</listitem>
@@ -264,7 +264,7 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
 				<para>Devolver la celda QUADBIN de una tesela Raquet</para>
 				<para><varname>quadbin(raquet) → bigint</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 5193776270265024512
 </programlisting>
 			</listitem>
@@ -274,7 +274,7 @@ SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<para>Devolver el ancho en píxeles de una tesela Raquet</para>
 				<para><varname>width(raquet) → integer</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>
 			</listitem>
@@ -284,7 +284,7 @@ SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<para>Devolver el alto en píxeles de una tesela Raquet</para>
 				<para><varname>height(raquet) → integer</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>
 			</listitem>
@@ -295,10 +295,10 @@ SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<para><varname>nodata(raquet) → float8</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nodata(raquet('\x01020304'::bytea, 2, 2,
-  5193776270265024512, 'UINT8', 255));
+  5193776270265024512, 'uint8', 255));
 -- 255
 -- The sentinel defaults to 0 when the constructor omits it.
-SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 0
 </programlisting>
 			</listitem>
@@ -307,11 +307,11 @@ SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
 				<para>Devolver el nombre del tipo de dato de píxel de una tesela Raquet</para>
 				<para><varname>pixtype(raquet) → text</varname></para>
-				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>UINT8</varname>, <varname>INT8</varname>, <varname>UINT16</varname>, <varname>INT16</varname>, <varname>UINT32</varname>, <varname>INT32</varname>, <varname>UINT64</varname>, <varname>INT64</varname>, <varname>FLOAT16</varname>, <varname>FLOAT32</varname> o <varname>FLOAT64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela se acepta tal cual; el nombre devuelto aquí conserva las mayúsculas.</para>
+				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela se acepta tal cual; el nombre devuelto aquí conserva las mayúsculas.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Leer la disposición de una tesela empaquetada
 SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
-FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8') AS tile) t;
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS tile) t;
 -- 5193776270265024512 | 2 | 2 | UINT8 | 0
 </programlisting>
 			</listitem>
@@ -324,7 +324,7 @@ FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8') AS 
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The footprint of a tile covering the north-eastern quadrant at zoom 1
 SELECT round(stbox(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
-  'UINT8')), 6);
+  'uint8')), 6);
 -- SRID=4326;STBOX X((0,0),(180,85.051129))
 
 -- Keep the tiles whose footprint overlaps a region of interest
@@ -365,8 +365,8 @@ WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
 				<para>Las funciones que respaldan estos operadores son <varname>eq</varname>, <varname>ne</varname>, <varname>lt</varname>, <varname>le</varname>, <varname>ge</varname> y <varname>gt</varname>, junto con <varname>cmp(raquet,raquet) → integer</varname>, que devuelve -1, 0 o 1.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Dos teselas con la misma celda, disposición y píxeles son iguales
-SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'UINT8') =
-       raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'UINT8');
+SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'uint8') =
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'uint8');
 -- true
 
 -- Deduplicar teselas, lo que permiten las clases de operadores btree y hash

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -13,9 +13,9 @@
 
 	<para>The <ulink url="https://postgis.net/docs/using_raster_dataman.html">PostGIS raster</ulink> extension stores gridded coverage data (elevation, temperature, satellite imagery, …) in the <varname>raster</varname> type. Each raster has one or more bands; a band holds a 2D array of pixel values, a spatial extent, a pixel size, and an optional nodata sentinel value.</para>
 
-	<para>MobilityDB's raster sampling operator evaluates a raster band at the instants of a moving-point trajectory and returns a <varname>tfloat</varname>. Instants whose position falls outside the raster extent or on a nodata pixel are silently dropped. The sampling operators are double-valued whatever the pixel type of the band, so a pixel type belongs to the sampling surface when every value it can hold is exactly representable in a double precision number. That is what lets a band of any type be sampled into one <varname>tfloat</varname>, and a column holding tiles of several pixel types be read by a single query. A pixel type is also accepted under the name PostGIS raster gives it, so the band type an <varname>ST_BandPixelType</varname> call reports (<varname>8BUI</varname>, <varname>16BSI</varname>, <varname>32BF</varname>, …) passes into the tile constructors as it stands. PostGIS raster carries no 16-bit float and no 64-bit integer, so <varname>FLOAT16</varname>, <varname>INT64</varname> and <varname>UINT64</varname> take the spelling its grammar gives them, <varname>16BF</varname>, <varname>64BSI</varname> and <varname>64BUI</varname>. Its <varname>1BB</varname>, <varname>2BUI</varname> and <varname>4BUI</varname> types carry less than a byte a pixel, which a tile has no representation for, and say so. The name a tile reports is the one the RaQuet specification gives the type.
+	<para>MobilityDB's raster sampling operator evaluates a raster band at the instants of a moving-point trajectory and returns a <varname>tfloat</varname>. Instants whose position falls outside the raster extent or on a nodata pixel are silently dropped. The sampling operators are double-valued whatever the pixel type of the band, so a pixel type belongs to the sampling surface when every value it can hold is exactly representable in a double precision number. That is what lets a band of any type be sampled into one <varname>tfloat</varname>, and a column holding tiles of several pixel types be read by a single query. A pixel type is also accepted under the name PostGIS raster gives it, so the band type an <varname>ST_BandPixelType</varname> call reports (<varname>8BUI</varname>, <varname>16BSI</varname>, <varname>32BF</varname>, …) passes into the tile constructors as it stands. PostGIS raster carries no 16-bit float and no 64-bit integer, so <varname>float16</varname>, <varname>int64</varname> and <varname>uint64</varname> take the spelling its grammar gives them, <varname>16BF</varname>, <varname>64BSI</varname> and <varname>64BUI</varname>. Its <varname>1BB</varname>, <varname>2BUI</varname> and <varname>4BUI</varname> types carry less than a byte a pixel, which a tile has no representation for, and say so. The name a tile reports is the one the RaQuet specification gives the type.
 
-The types <varname>UINT64</varname> and <varname>INT64</varname> hold values beyond that domain: a tile of either is stored and read back exactly, while sampling a pixel whose value no double precision number names raises an error rather than answering with a neighbouring value. This enables queries such as <emphasis>what elevation profile did each vehicle follow?</emphasis> or <emphasis>which trips entered a temperature threshold band?</emphasis></para>
+The types <varname>uint64</varname> and <varname>int64</varname> hold values beyond that domain: a tile of either is stored and read back exactly, while sampling a pixel whose value no double precision number names raises an error rather than answering with a neighbouring value. This enables queries such as <emphasis>what elevation profile did each vehicle follow?</emphasis> or <emphasis>which trips entered a temperature threshold band?</emphasis></para>
 
 	<para>To use the operators described here, MobilityDB must be built with <varname>-DRASTER=ON</varname>. On such a build the generated <filename>mobilitydb.control</filename> declares <varname>requires = 'postgis, postgis_raster'</varname>, so a single <varname>CASCADE</varname> creates the full stack:</para>
 	<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -106,7 +106,7 @@ SELECT DISTINCT q
 FROM unnest(quadbins(traj, 8)) AS q;
 
 -- Step 2: sample each matching tile
-SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'FLOAT32',
+SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'float32',
   nodata, true)
 FROM elevation_raquet
 WHERE quadbin = ANY(quadbins(traj, 8));
@@ -135,18 +135,18 @@ ORDER BY tile_count DESC;
 				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
 				<para>Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
 				<para><varname>rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,boolean) → tfloat</varname></para>
-				<para>Evaluates a row-major single-band pixel array at each instant of <varname>traj</varname> (SRID 4326). The tile georeferencing (bounding box, pixel-to-coordinate mapping) is derived from <varname>quadbin</varname> alone via the Web-Mercator slippy-tile transform. The <varname>pixtype</varname> argument must be one of <varname>UINT8</varname>, <varname>INT8</varname>, <varname>UINT16</varname>, <varname>INT16</varname>, <varname>UINT32</varname>, <varname>INT32</varname>, <varname>UINT64</varname>, <varname>INT64</varname>, <varname>FLOAT16</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>. When <varname>has_nodata</varname> is true, instants whose pixel equals <varname>nodata</varname> are silently dropped. Returns <varname>NULL</varname> when no instant survives.</para>
+				<para>Evaluates a row-major single-band pixel array at each instant of <varname>traj</varname> (SRID 4326). The tile georeferencing (bounding box, pixel-to-coordinate mapping) is derived from <varname>quadbin</varname> alone via the Web-Mercator slippy-tile transform. The <varname>pixtype</varname> argument must be one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. When <varname>has_nodata</varname> is true, instants whose pixel equals <varname>nodata</varname> are silently dropped. Returns <varname>NULL</varname> when no instant survives.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample elevation tiles from a Raquet Parquet table
 -- for all ship trajectories
 SELECT t.tripid, rasterTileValueQuadbin(t.trip, r.band_data, r.width, r.height,
-  r.quadbin, 'FLOAT32', r.nodata, true)
+  r.quadbin, 'float32', r.nodata, true)
 FROM trips t
 JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
 
 -- Average sea-surface temperature per trajectory
 SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
-  r.band_data, 256, 256, r.quadbin, 'INT16', -9999, true)) AS mean_sst
+  r.band_data, 256, 256, r.quadbin, 'int16', -9999, true)) AS mean_sst
 FROM trips t
 JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 </programlisting>
@@ -156,14 +156,14 @@ JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
 				<para><varname>raquet(bytea,integer,integer,bigint,text,float8) → raquet</varname></para>
-				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>UINT8</varname>, <varname>INT8</varname>, <varname>UINT16</varname>, <varname>INT16</varname>, <varname>UINT32</varname>, <varname>INT32</varname>, <varname>UINT64</varname>, <varname>INT64</varname>, <varname>FLOAT16</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. Pixels of more than one byte are little-endian, which is the byte order the RaQuet specification gives them whatever the byte order of the server, so that a tile keeps its values when it is read on another machine. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
+				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. Pixels of more than one byte are little-endian, which is the byte order the RaQuet specification gives them whatever the byte order of the server, so that a tile keeps its values when it is read on another machine. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Package the loose tile columns of a Raquet table into raquet values
-SELECT raquet(band_data, width, height, quadbin, 'FLOAT32', nodata) AS tile
+SELECT raquet(band_data, width, height, quadbin, 'float32', nodata) AS tile
 FROM elevation_raquet;
 
 -- A 2 x 2 UINT8 tile with no nodata
-SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8');
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 </programlisting>
 			</listitem>
 
@@ -241,8 +241,8 @@ GROUP BY t.tripid, t.trip;
 				<para><varname>raquetFromHexWKB(text) → raquet</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
-  5193776270265024512, 'UINT8')))
-  = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8');
+  5193776270265024512, 'uint8')))
+  = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 -- true
 </programlisting>
 			</listitem>
@@ -262,7 +262,7 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
 				<para>Return the QUADBIN cell of a Raquet tile</para>
 				<para><varname>quadbin(raquet) → bigint</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 5193776270265024512
 </programlisting>
 			</listitem>
@@ -272,7 +272,7 @@ SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<para>Return the width in pixels of a Raquet tile</para>
 				<para><varname>width(raquet) → integer</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>
 			</listitem>
@@ -282,7 +282,7 @@ SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<para>Return the height in pixels of a Raquet tile</para>
 				<para><varname>height(raquet) → integer</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>
 			</listitem>
@@ -293,10 +293,10 @@ SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<para><varname>nodata(raquet) → float8</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nodata(raquet('\x01020304'::bytea, 2, 2,
-  5193776270265024512, 'UINT8', 255));
+  5193776270265024512, 'uint8', 255));
 -- 255
 -- The sentinel defaults to 0 when the constructor omits it.
-SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 0
 </programlisting>
 			</listitem>
@@ -305,11 +305,11 @@ SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
 				<para>Return the name of the pixel data type of a Raquet tile</para>
 				<para><varname>pixtype(raquet) → text</varname></para>
-				<para>The returned name is the one the constructors accept, that is, one of <varname>UINT8</varname>, <varname>INT8</varname>, <varname>UINT16</varname>, <varname>INT16</varname>, <varname>UINT32</varname>, <varname>INT32</varname>, <varname>UINT64</varname>, <varname>INT64</varname>, <varname>FLOAT16</varname>, <varname>FLOAT32</varname>, or <varname>FLOAT64</varname>. The constructors read the name without regard to case, so the lower-case spelling the RaQuet specification gives a tile's <varname>type</varname> field is accepted as it stands; the name returned here keeps the upper case.</para>
+				<para>The returned name is the one the constructors accept, that is, one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. The constructors read the name without regard to case, so the lower-case spelling the RaQuet specification gives a tile's <varname>type</varname> field is accepted as it stands; the name returned here keeps the upper case.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Read back the layout of a packaged tile
 SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
-FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8') AS tile) t;
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS tile) t;
 -- 5193776270265024512 | 2 | 2 | UINT8 | 0
 </programlisting>
 			</listitem>
@@ -320,7 +320,7 @@ FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8') AS 
 				<para><varname>pixels(raquet) → bytea</varname></para>
 				<para>The bytes are row-major and packed, <varname>width</varname> × <varname>height</varname> pixels of the size of <varname>pixtype</varname> each, little-endian when a pixel is wider than one byte, which is the layout the constructors accept. A tile therefore round trips through its own accessors.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
+SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- \x01020304
 </programlisting>
 			</listitem>
@@ -333,7 +333,7 @@ SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'UINT8'));
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The footprint of a tile covering the north-eastern quadrant at zoom 1
 SELECT round(stbox(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
-  'UINT8')), 6);
+  'uint8')), 6);
 -- SRID=4326;STBOX X((0,0),(180,85.051129))
 
 -- Keep the tiles whose footprint overlaps a region of interest
@@ -374,8 +374,8 @@ WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
 				<para>The functions backing these operators are <varname>eq</varname>, <varname>ne</varname>, <varname>lt</varname>, <varname>le</varname>, <varname>ge</varname> and <varname>gt</varname>, together with <varname>cmp(raquet,raquet) → integer</varname>, which returns -1, 0, or 1.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Two tiles with the same cell, layout and pixels are equal
-SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'UINT8') =
-       raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'UINT8');
+SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'uint8') =
+       raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'uint8');
 -- true
 
 -- Deduplicate tiles, which the btree and hash operator classes support

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -91,17 +91,17 @@ typedef struct
  */
 static const pixtype_catalog_struct MEOS_PIXTYPE_CATALOG[] =
 {
-  [MEOS_PT_UINT8]   = { "UINT8",   "8BUI",  1 },
-  [MEOS_PT_INT16]   = { "INT16",   "16BSI", 2 },
-  [MEOS_PT_INT32]   = { "INT32",   "32BSI", 4 },
-  [MEOS_PT_FLOAT32] = { "FLOAT32", "32BF",  4 },
-  [MEOS_PT_FLOAT64] = { "FLOAT64", "64BF",  8 },
-  [MEOS_PT_INT8]    = { "INT8",    "8BSI",  1 },
-  [MEOS_PT_UINT16]  = { "UINT16",  "16BUI", 2 },
-  [MEOS_PT_UINT32]  = { "UINT32",  "32BUI", 4 },
-  [MEOS_PT_INT64]   = { "INT64",   "64BSI", 8 },
-  [MEOS_PT_UINT64]  = { "UINT64",  "64BUI", 8 },
-  [MEOS_PT_FLOAT16] = { "FLOAT16", "16BF",  2 },
+  [MEOS_PT_UINT8]   = { "uint8",   "8BUI",  1 },
+  [MEOS_PT_INT16]   = { "int16",   "16BSI", 2 },
+  [MEOS_PT_INT32]   = { "int32",   "32BSI", 4 },
+  [MEOS_PT_FLOAT32] = { "float32", "32BF",  4 },
+  [MEOS_PT_FLOAT64] = { "float64", "64BF",  8 },
+  [MEOS_PT_INT8]    = { "int8",    "8BSI",  1 },
+  [MEOS_PT_UINT16]  = { "uint16",  "16BUI", 2 },
+  [MEOS_PT_UINT32]  = { "uint32",  "32BUI", 4 },
+  [MEOS_PT_INT64]   = { "int64",   "64BSI", 8 },
+  [MEOS_PT_UINT64]  = { "uint64",  "64BUI", 8 },
+  [MEOS_PT_FLOAT16] = { "float16", "16BF",  2 },
 };
 
 /**
@@ -412,12 +412,12 @@ raquet_pixels_from_host(uint8 *pixels, size_t count, MeosPixType pixtype)
 /**
  * @ingroup meos_raster_base_accessor
  * @brief Return the pixel data type corresponding to a name
- * @param[in] str Pixel type name: UINT8, INT8, UINT16, INT16, UINT32, INT32, UINT64, INT64, FLOAT16, FLOAT32, or FLOAT64
+ * @param[in] str Pixel type name: uint8, int8, uint16, int16, uint32, int32, uint64, int64, float16, float32, or float64
  * @note This is the parser counterpart of #raquet_pixtype()
- * @note The name is read without regard to case, so the lower-case spelling
- * the RaQuet specification gives the `type` field of a tile carries straight
- * through from a file into the constructors. The name #raquet_pixtype()
- * returns keeps the upper case the SQL surface documents
+ * @note The name is read without regard to case, so a name written either way
+ * carries into the constructors. The name #raquet_pixtype() returns is the one
+ * the RaQuet specification writes, in lower case, so it compares equal to the
+ * `type` field of the tile a file holds
  * @note The name PostGIS raster gives a pixel type is accepted for the same
  * type, so the band type an `ST_BandPixelType` call reports carries into the
  * constructors as it stands. The types PostGIS carries in less than a byte a
@@ -701,8 +701,10 @@ raquet_nodata(const Raquet *rq)
  * @brief Return the name of the pixel data type of a Raquet tile
  * @param[in] rq Raquet tile
  * @return On error return @p NULL
- * @note The returned name is the one accepted by the tile constructors, that
- * is, one of UINT8, INT8, UINT16, INT16, UINT32, INT32, UINT64, INT64, FLOAT16, FLOAT32, or FLOAT64
+ * @note The returned name is the one the RaQuet specification writes for the
+ * type, that is, one of uint8, int8, uint16, int16, uint32, int32, uint64,
+ * int64, float16, float32, or float64, so it compares equal to the `type`
+ * field of the tile a RaQuet file holds
  * @csqlfn #Raquet_pixtype()
  */
 char *

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -179,7 +179,7 @@ CREATE OR REPLACE FUNCTION rasterValue(
  * @param[in] width Tile width in pixels
  * @param[in] height Tile height in pixels
  * @param[in] quadbin CARTO QUADBIN cell identifier
- * @param[in] pixtype Pixel type: UINT8, INT8, UINT16, INT16, UINT32, INT32, UINT64, INT64, FLOAT16, FLOAT32, or FLOAT64
+ * @param[in] pixtype Pixel type: uint8, int8, uint16, int16, uint32, int32, uint64, int64, float16, float32, or float64
  * @param[in] nodata Nodata sentinel value
  * @param[in] has_nodata Enable nodata filtering
  */

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -398,7 +398,7 @@ PG_FUNCTION_INFO_V1(Raster_tile_value_quadbin);
  * @param[in] width Tile width in pixels
  * @param[in] height Tile height in pixels
  * @param[in] quadbin CARTO QUADBIN cell (bigint)
- * @param[in] pixtype Pixel type name: UINT8, INT8, UINT16, INT16, UINT32, INT32, UINT64, INT64, FLOAT16, FLOAT32, or FLOAT64
+ * @param[in] pixtype Pixel type name: uint8, int8, uint16, int16, uint32, int32, uint64, int64, float16, float32, or float64
  * @param[in] nodata Nodata sentinel value
  * @param[in] has_nodata  Enable nodata filtering
  * @sqlfn rasterTileValueQuadbin()
@@ -577,7 +577,7 @@ PG_FUNCTION_INFO_V1(Raquet_constructor);
  * @param[in] width    Tile width in pixels
  * @param[in] height   Tile height in pixels
  * @param[in] quadbin  CARTO QUADBIN cell (bigint)
- * @param[in] pixtype  Pixel type name: UINT8, INT8, UINT16, INT16, UINT32, INT32, UINT64, INT64, FLOAT16, FLOAT32, or FLOAT64
+ * @param[in] pixtype  Pixel type name: uint8, int8, uint16, int16, uint32, int32, uint64, int64, float16, float32, or float64
  * @param[in] nodata   Nodata sentinel value (NULL disables nodata filtering)
  * @sqlfn raquet()
  */

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -385,7 +385,7 @@ FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
         'UINT8') AS tile) t;
        quadbin       | width | height | pixtype | nodata 
 ---------------------+-------+--------+---------+--------
- 5193776270265024512 |     2 |      2 | UINT8   |      0
+ 5193776270265024512 |     2 |      2 | uint8   |      0
 (1 row)
 
 SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')),
@@ -404,7 +404,7 @@ SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')
        pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT16'));
  pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype 
 ---------+---------+---------+---------+---------+---------+---------+---------+---------+---------+---------
- UINT8   | INT16   | INT32   | FLOAT32 | FLOAT64 | INT8    | UINT16  | UINT32  | INT64   | UINT64  | FLOAT16
+ uint8   | int16   | int32   | float32 | float64 | int8    | uint16  | uint32  | int64   | uint64  | float16
 (1 row)
 
 SELECT raquet('\x0102030405060708'::bytea, 2, 1, 5193776270265024512::bigint,
@@ -422,14 +422,14 @@ SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
   'uint8'));
  pixtype 
 ---------
- UINT8
+ uint8
 (1 row)
 
 SELECT pixtype(raquet('\x0102030405060708'::bytea, 2, 1,
   5193776270265024512::bigint, 'float32'));
  pixtype 
 ---------
- FLOAT32
+ float32
 (1 row)
 
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint8')
@@ -449,14 +449,14 @@ SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, '8BUI'))
          '64BSI'));
  pixtype | pixtype | pixtype | pixtype | pixtype | pixtype 
 ---------+---------+---------+---------+---------+---------
- UINT8   | INT16   | FLOAT32 | FLOAT64 | FLOAT16 | INT64
+ uint8   | int16   | float32 | float64 | float16 | int64
 (1 row)
 
 SELECT pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint,
   ST_BandPixelType(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '32BF'), 1)));
  pixtype 
 ---------
- FLOAT32
+ float32
 (1 row)
 
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '8BUI')
@@ -469,7 +469,7 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '8BUI')
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '4BUI');
 ERROR:  Pixel type "4BUI" carries less than a byte a pixel, which a Raquet band has no representation for
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint12');
-ERROR:  Unknown pixel type "uint12": use UINT8, INT16, INT32, FLOAT32, FLOAT64, INT8, UINT16, UINT32, INT64, UINT64, or FLOAT16, or the name PostGIS raster gives one of them
+ERROR:  Unknown pixel type "uint12": use uint8, int16, int32, float32, float64, int8, uint16, uint32, int64, uint64, or float16, or the name PostGIS raster gives one of them
 SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
   -9999.0));
  nodata 


### PR DESCRIPTION
Report a pixel type in the case the RaQuet specification writes it

RaQuet is the standard a tile implements, and it writes a pixel data type in
lower case: the `type` field of a band reads "uint8" or "float32", and the
eleven valid values are named that way throughout the specification. A tile
reports the name in upper case, so what a tile says of itself does not compare
equal to the field of the file it came from, and the standard is followed in
the value but not in the spelling.

A tile reports the name as the specification writes it, so

  pixtype(tile) = <the type field of the RaQuet band>

holds as it reads. The name is still read without regard to case, and the name
PostGIS raster gives a type is still accepted, so every place a name is
supplied carries on unchanged; only what a tile answers moves.

The names the manuals give and the enumeration the error message builds follow
the catalog, so they read in the same case without an edit of their own.
