### PR TITLE
Cover the trgeometry moving-moving distance and dwithin surface in the smoke tests

### DIFF
--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -485,20 +485,6 @@ TRGEO_CONFIG = dict(
         # The generic emitter would allocate into geom_out_param and never free
         # it; the cleanup block below calls the function and frees the result.
         "trgeometry_value_n":         "out-param GSERIALIZED ** is exercised manually below",
-        # The moving-moving temporal-distance kernel (trgeometry against a
-        # temporal point or another trgeometry) is not implemented yet, so its
-        # distance / nearest-approach wrappers abort. The trgeometry-vs-geometry
-        # and trgeometry-vs-spatiotemporal-box variants are implemented and
-        # covered here.
-        "re:^tdistance_trgeometry_(tpoint|trgeometry)$":    "moving-moving trgeometry distance not implemented yet",
-        "re:^nad_trgeometry_(tpoint|trgeometry)$":          "depends on unimplemented moving-moving trgeometry distance",
-        "re:^nai_trgeometry_(tpoint|trgeometry)$":          "depends on unimplemented moving-moving trgeometry distance",
-        "re:^shortestline_trgeometry_(tpoint|trgeometry)$": "depends on unimplemented moving-moving trgeometry distance",
-        # dwithin between two trgeometries delegates to the continuous
-        # turning-point solver tdwithin_trgeosegm, which is a stub; the
-        # trgeometry-vs-geometry variants go through the traversed area and are
-        # covered here.
-        "re:^[ae]?dwithin_trgeometry_trgeometry$": "depends on unimplemented tdwithin_trgeosegm",
         # The function validates its argument as a geomset, but the
         # temporal_restrict_values() it delegates to rejects every
         # trgeometry/geomset pair ("Operation on mixed temporal and set types:


### PR DESCRIPTION
The temporal distance, nearest-approach distance, nearest-approach instant and shortest line of a temporal rigid geometry against a temporal point or another temporal rigid geometry, and the ever and always dwithin between two temporal rigid geometries, are exercised in the trgeometry smoke test. The trgeometry value-at-index out-parameter and the geomset restriction remain skipped.