### PR TITLE
Free the reference geometry and temporal pose parsed from the MF-JSON of a temporal rigid geometry

### DIFF
--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1517,7 +1517,11 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
   json_object_put(poObj);
 #if RGEO
   if (temptype_orig == T_TRGEOMETRY && temptype == T_TPOSE)
-    return geometry_tpose_to_trgeometry(gs, result);
+  {
+    Temporal *trgeo = geometry_tpose_to_trgeometry(gs, result);
+    pfree(gs); pfree(result);
+    return trgeo;
+  }
 #endif /* RGEO */
   return result;
 }


### PR DESCRIPTION
The reference geometry and the temporal pose parsed from the MF-JSON of a temporal rigid geometry are copied into the result by geometry_tpose_to_trgeometry, so they are freed after the conversion, matching the well-known-binary reader.