### PR TITLE
Declare the temporal JSONB MF-JSON subtype parsers in the internal header

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -1083,6 +1083,9 @@ extern TSequence *ttextseq_from_mfjson(json_object *mfjson);
 extern TSequence *ttextseq_in(const char *str, interpType interp);
 extern TSequenceSet *ttextseqset_from_mfjson(json_object *mfjson);
 extern TSequenceSet *ttextseqset_in(const char *str);
+extern TInstant *tjsonbinst_from_mfjson(json_object *mfjson);
+extern TSequence *tjsonbseq_from_mfjson(json_object *mfjson);
+extern TSequenceSet *tjsonbseqset_from_mfjson(json_object *mfjson);
 extern Temporal *temporal_from_mfjson(const char *mfjson, MeosType temptype);
 
 /*****************************************************************************/

--- a/meos/include/meos_json.h
+++ b/meos/include/meos_json.h
@@ -283,11 +283,8 @@ extern Temporal *tjsonb_in(const char *str);
 extern char *tjsonb_out(const Temporal *temp);
 
 // Internal
-extern TInstant *tjsonbinst_from_mfjson(json_object *mfjson);
 extern TInstant *tjsonbinst_in(const char *str);
-extern TSequence *tjsonbseq_from_mfjson(json_object *mfjson);
 extern TSequence *tjsonbseq_in(const char *str, interpType interp);
-extern TSequenceSet *tjsonbseqset_from_mfjson(json_object *mfjson);
 extern TSequenceSet *tjsonbseqset_in(const char *str);
 
 /*****************************************************************************


### PR DESCRIPTION
tjsonbinst_from_mfjson, tjsonbseq_from_mfjson, and tjsonbseqset_from_mfjson take a json-c json_object and produce the instant, sequence, and sequence-set subtypes that the public string parser tjsonb_from_mfjson dispatches to, so they are declared in meos_internal.h next to the base-type MF-JSON subtype parsers rather than on the public meos_json.h surface, which keeps the json_object type off the public API that the bindings are generated from.