### PR TITLE
Read the reference pose as a borrowed value when converting a temporal rigid geometry to a temporal geometry

### DIFF
--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -1140,7 +1140,7 @@ trgeometry_to_tgeometry(const Temporal *temp)
   {
     const TInstant *inst = (const TInstant *) temp;
     GSERIALIZED *poly = geom_apply_pose(ref,
-      DatumGetPoseP(tinstant_value(inst)));
+      DatumGetPoseP(tinstant_value_p(inst)));
     TInstant *res = tinstant_make(PointerGetDatum(poly), T_TGEOMETRY,
       inst->t);
     pfree(poly);
@@ -1154,7 +1154,7 @@ trgeometry_to_tgeometry(const Temporal *temp)
     {
       const TInstant *inst = TSEQUENCE_INST_N(seq, i);
       GSERIALIZED *poly = geom_apply_pose(ref,
-        DatumGetPoseP(tinstant_value(inst)));
+        DatumGetPoseP(tinstant_value_p(inst)));
       insts[i] = tinstant_make(PointerGetDatum(poly), T_TGEOMETRY,
         inst->t);
       pfree(poly);
@@ -1174,7 +1174,7 @@ trgeometry_to_tgeometry(const Temporal *temp)
     {
       const TInstant *inst = TSEQUENCE_INST_N(seq, i);
       GSERIALIZED *poly = geom_apply_pose(ref,
-        DatumGetPoseP(tinstant_value(inst)));
+        DatumGetPoseP(tinstant_value_p(inst)));
       insts[i] = tinstant_make(PointerGetDatum(poly), T_TGEOMETRY,
         inst->t);
       pfree(poly);


### PR DESCRIPTION
The pose of each instant is read with the borrowed accessor when applying it to the reference geometry, so the conversion to a temporal geometry no longer copies a pose it does not free.