### PR TITLE
Ask the temporal relationships of a zero-radius temporal circular buffer of the temporal point it is

### DIFF
--- a/meos/include/cbuffer/tcbuffer_spatialfuncs.h
+++ b/meos/include/cbuffer/tcbuffer_spatialfuncs.h
@@ -42,6 +42,12 @@
 
 /*****************************************************************************/
 
+/* Degenerate value functions */
+
+extern bool tcbuffer_is_tpoint(const Temporal *temp);
+
+/*****************************************************************************/
+
 /* Traversed area functions */
 
 extern GSERIALIZED *tcbufferinst_traversed_area(const TInstant *inst);

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -692,6 +692,31 @@ tcbuffer_traversed_area(const Temporal *temp, bool unary_union)
 }
 
 /**
+ * @brief Return true if every composing circular buffer of a temporal circular
+ * buffer has a zero radius, that is, the value is a temporal point
+ * @details A disc of a zero radius is the point at its centre, so such a value
+ * converts to a temporal geometry point without loss, and the temporal point
+ * of the geo family owns the relationships the disc kernels read from a disc
+ * boundary. The test is exact and applies to the whole value: a value holding
+ * a single disc of a strictly positive radius keeps the disc kernels
+ * @param[in] temp Temporal circular buffer
+ */
+bool
+tcbuffer_is_tpoint(const Temporal *temp)
+{
+  assert(temp); assert(temp->temptype == T_TCBUFFER);
+  int count;
+  const TInstant **instants = temporal_insts_p(temp, &count);
+  bool result = true;
+  for (int i = 0; i < count && result; i++)
+    result = (DatumGetCbufferP(tinstant_value_p(instants[i]))->radius == 0.0);
+  pfree(instants);
+  return result;
+}
+
+/*****************************************************************************/
+
+/**
  * @ingroup meos_cbuffer_accessor
  * @brief Return the convex hull of a temporal circular buffer
  * @param[in] temp Temporal circular buffer

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -1497,23 +1497,6 @@ aintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
- * @brief Return true if every composing circular buffer of a temporal circular
- * buffer has a zero radius, that is, the value is a temporal point
- */
-static bool
-tcbuffer_is_tpoint(const Temporal *temp)
-{
-  assert(temp); assert(temp->temptype == T_TCBUFFER);
-  int count;
-  const TInstant **instants = temporal_insts_p(temp, &count);
-  bool result = true;
-  for (int i = 0; i < count && result; i++)
-    result = (DatumGetCbufferP(tinstant_value_p(instants[i]))->radius == 0.0);
-  pfree(instants);
-  return result;
-}
-
-/**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry ever touch,
  * 0 if not, and -1 on error or if the geometry is empty

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -961,6 +961,21 @@ tinterrel_tcbuffer_geo_dist(const Temporal *temp, const GSERIALIZED *gs,
   if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
 
+  /* A value composed of discs of a zero radius is a temporal point, whose
+   * conversion is exact, and the temporal point relationships of the geo
+   * family resolve the contact at a zero clearance that the disc kernels below
+   * read from a disc boundary. A strictly positive distance reaches here only
+   * from `tdwithin`, which computes the intersection semantics */
+  if (tcbuffer_is_tpoint(temp))
+  {
+    Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
+    Temporal *result = (dist > 0.0) ?
+      tdwithin_tgeo_geo(tpoint, gs, dist) :
+      tinterrel_tgeo_geo(tpoint, gs, tinter);
+    pfree(tpoint);
+    return result;
+  }
+
   /* Bounding box test, expanding the temporal box by the distance */
   STBox box1, box1_exp, box2;
   tspatial_set_stbox(temp, &box1);

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
@@ -1119,3 +1119,69 @@ SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', tcbuffer 'Cbuff
 ERROR:  The geometry cannot have Z dimension
 LINE 1: SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-...
                                  ^
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Point(0 0)');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(geometry 'Point(0 0)', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Point(0 0)');
+                                                              tdisjoint                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sun Jan 02 00:00:00 2000 PST], (t@Sun Jan 02 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Linestring(0 -5,0 5)');
+                                                             tintersects                                                              
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Linestring(-5 0,5 0)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+                                                                             tintersects                                                                              
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 16:00:00 2000 PST, t@Sun Jan 02 08:00:00 2000 PST], (f@Sun Jan 02 08:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDisjoint(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]');
+                                                                              tdisjoint                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 16:00:00 2000 PST, f@Sun Jan 02 08:00:00 2000 PST], (t@Sun Jan 02 08:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-03]', geometry 'Point(1 1)');
+                            tintersects                             
+--------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Linestring(0 -5,0 5)', 2);
+                                                                               tdwithin                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:00:00 2000 PST, t@Sun Jan 02 16:00:00 2000 PST], (f@Sun Jan 02 16:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(geometry 'Linestring(0 -5,0 5)', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', 2);
+                                                                               tdwithin                                                                               
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 08:00:00 2000 PST, t@Sun Jan 02 16:00:00 2000 PST], (f@Sun Jan 02 16:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]', geometry 'Point(0 0)');
+                                                                                        tintersects                                                                                        
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 22:09:13.846154 2000 PST, t@Sun Jan 02 02:10:54.545455 2000 PST], (f@Sun Jan 02 02:10:54.545455 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+

--- a/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
@@ -350,3 +350,30 @@ SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', tcbuffer 'Cbuff
 SELECT tDwithin(tcbuffer 'Cbuffer(Point(1 1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 
 -------------------------------------------------------------------------------
+-- Discs of a zero radius: the value is a temporal point
+--
+-- A disc of a zero radius is the point at its centre, so the answers below are
+-- those of the temporal point the value converts to. The contact is at a zero
+-- clearance, which is the disc boundary the disc kernels read a touch from
+-------------------------------------------------------------------------------
+
+-- A point running through the position of a point geometry meets it at the
+-- single instant it passes through
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Point(0 0)');
+SELECT tIntersects(geometry 'Point(0 0)', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]');
+SELECT tDisjoint(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Point(0 0)');
+-- The same point crossing a line, and running along it
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Linestring(0 -5,0 5)');
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Linestring(-5 0,5 0)');
+-- Entering and leaving a polygon
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))');
+SELECT tDisjoint(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]');
+-- A point standing still on the position of a point geometry
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(1 1),0)@2000-01-01, Cbuffer(Point(1 1),0)@2000-01-03]', geometry 'Point(1 1)');
+-- Within a distance of a line the point approaches and leaves
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', geometry 'Linestring(0 -5,0 5)', 2);
+SELECT tDwithin(geometry 'Linestring(0 -5,0 5)', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', 2);
+-- A single disc of a strictly positive radius keeps the disc semantics
+SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]', geometry 'Point(0 0)');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
A disc of a zero radius is the point at its centre, so a temporal circular buffer whose discs all have a zero radius is a temporal point and converts to one without loss. The disc kernels read the relationship from the position of the disc centre with respect to the geometry and encode the interior disjointness in the radius, so at a zero radius a contact at a zero clearance falls on the disc boundary, and `tIntersects`, `tDisjoint` and `tDwithin` lose it.

A point running from `(-3 0)` to `(3 0)` passes through `Point(0 0)` at the middle instant, and `tIntersects` answers `f` throughout. The same value crossing the vertical line through the origin, entering and leaving the unit square, and running along a line it lies on answer alike, as do the geometry-first directions and the circular-buffer operand, which reach the same kernel.

The conversion applies to the whole value: a value holding a single disc of a strictly positive radius keeps the disc kernels, which the last added case pins.

`tinterrel_tcbuffer_geo_dist` carries `tIntersects`, `tDisjoint` and `tDwithin`, so the conversion sits there once, delegating to `tinterrel_tgeo_geo` and, for a strictly positive distance, to `tdwithin_tgeo_geo`. `tcbuffer_is_tpoint` moves from a static in the ever/always file to `tcbuffer_spatialfuncs.c`, where both engines reach it; the ever/always touches converts on the same test.

The added cases are the only coverage of a zero radius in this file, so no committed expectation moves.