### PR TITLE
Order the raster family gate alphabetically in the generic temporal I/O

### DIFF
--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -78,12 +78,12 @@
   #include <meos_quadbin.h>
   #include "quadbin/quadbin.h"
 #endif
+#if RASTER
+  #include <meos_raster.h>
+#endif
 #if RGEO
   #include <meos_rgeo.h>
   #include "rgeo/trgeo.h"
-#endif
-#if RASTER
-  #include <meos_raster.h>
 #endif
 
 #include <utils/jsonb.h>


### PR DESCRIPTION
The RASTER include block sits between QUADBIN and RGEO in meos/src/temporal/type_in.c, so every optional-family gate in the file is reached by name in one pass, as the dispatch blocks further down the same file already are.

Behaviour-neutral: the block moves, its contents are unchanged.