### PR TITLE
Retry a package download that a stalled mirror leaves hanging

### DIFF
--- a/.github/actions/apt-resilient/action.yml
+++ b/.github/actions/apt-resilient/action.yml
@@ -1,0 +1,25 @@
+# SPDX-License-Identifier: PostgreSQL
+
+name: Resilient apt
+description: >
+  Give apt a retry count and a transfer timeout, so that a package mirror which
+  stalls mid-download fails the transfer and is retried instead of holding the
+  job until the runner is killed. The settings land in an apt configuration
+  file, so every apt call the job makes afterwards reads them, including the
+  ones inside other actions.
+
+runs:
+  using: composite
+  steps:
+    - name: Configure apt retries and timeouts
+      shell: bash
+      run: |
+        # A stalled mirror is the failure mode this addresses, and a retry count
+        # alone does not reach it: apt waits on the socket forever, so there is
+        # no failure to retry. The timeout is what turns the stall into one.
+        sudo tee /etc/apt/apt.conf.d/99-ci-resilient > /dev/null <<'CONF'
+        Acquire::Retries "3";
+        Acquire::http::Timeout "30";
+        Acquire::https::Timeout "30";
+        Acquire::ftp::Timeout "30";
+        CONF

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -38,6 +38,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - uses: ./.github/actions/apt-resilient
+
       - name: Install Requirements
         run: |
           sudo apt install -y licensecheck

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -42,6 +42,8 @@ jobs:
           echo "PGIS=3" >> $GITHUB_ENV
           echo "PGPORT=5432" >> $GITHUB_ENV
 
+      - uses: ./.github/actions/apt-resilient
+
       - name: Add PostgreSQL APT repository
         run: |
           sudo apt-get install curl ca-certificates gnupg

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -55,6 +55,8 @@ jobs:
         # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
+    - uses: ./.github/actions/apt-resilient
+
     - name: Add PostgreSQL APT repository
       run: |
         sudo apt-get install curl ca-certificates gnupg

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -41,6 +41,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/apt-resilient
+
       - name: Add the PostgreSQL APT repository
         # Provides libh3-dev and the postgresql-server-dev package that the
         # vendored pgPointCloud build below needs for pg_config.

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -25,6 +25,8 @@ jobs:
           sparse-checkout: doc
 
       # Install dblatex
+      - uses: ./.github/actions/apt-resilient
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/meos-smoke.yml
+++ b/.github/workflows/meos-smoke.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/apt-resilient
+
       - name: Install dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -35,6 +35,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/apt-resilient
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -152,6 +154,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/apt-resilient
+
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -198,6 +202,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/apt-resilient
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/meos_locale.yml
+++ b/.github/workflows/meos_locale.yml
@@ -45,6 +45,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/apt-resilient
+
       - name: Install build deps and de_DE.UTF-8 locale
         run: |
           sudo apt-get update

--- a/.github/workflows/meos_utf8_smoke.yml
+++ b/.github/workflows/meos_utf8_smoke.yml
@@ -50,6 +50,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - uses: ./.github/actions/apt-resilient
+
       - name: Install build deps
         run: |
           sudo apt-get update

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -66,6 +66,8 @@ jobs:
           PGP=5432
           echo "PGPORT=${PGP}" >> $GITHUB_ENV        
 
+      - uses: ./.github/actions/apt-resilient
+
       - name: Add PostgreSQL APT repository
         run: |
           sudo apt-get install curl ca-certificates gnupg


### PR DESCRIPTION
Retry a package download that a stalled mirror leaves hanging

A job that installs its dependencies from the Ubuntu archive holds until the
runner is killed when the mirror stops mid-download: apt waits on the socket
with no timeout, so the transfer neither completes nor fails, and the run has
to be cancelled by hand. It happened three times in one day on the Azure
archive, each time inside the dependency install of a different workflow.

A composite action writes an apt configuration file giving apt a transfer
timeout and a retry count, and every job that installs packages runs it after
the checkout. The timeout is the part that reaches the failure: a retry count
alone never fires, because a stalled transfer produces nothing to retry. With
the timeout the stall becomes a failed transfer, and the retry then takes
another mirror.

The settings live in a configuration file rather than on a command line, so
every apt call the job makes afterwards reads them, including the ones inside
other actions, and a job that gains a package install later inherits the
behaviour without a change of its own.
