### PR TITLE
Uniformize the distance error sentinel to the maximum of the return type

### DIFF
--- a/meos/include/temporal/span.h
+++ b/meos/include/temporal/span.h
@@ -110,6 +110,7 @@ extern void tstzspan_shift_scale1(Span *s, const Interval *shift,
 extern int mi_span_span(const Span *s1, const Span *s2, Span *result);
 extern int mi_span_value(const Span *s, Datum value, Span *result);
 
+extern Datum distance_sentinel(MeosType type);
 extern double dist_double_value_value(Datum l, Datum r, MeosType type);
 
 /*****************************************************************************/

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -663,7 +663,8 @@ distance_set_value(const Set *s, Datum value)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two sets
  * @param[in] s1,s2 Sets
- * @return On error return -1.0
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  * @csqlfn #Distance_set_set()
  */
 Datum

--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -35,6 +35,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <utils/timestamp.h>
@@ -1531,14 +1532,14 @@ minus_set_timestamptz(const Set *s, TimestampTz t)
  * @brief Return the distance between a set and an integer
  * @param[in] s Set
  * @param[in] i Value
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_set_value()
  */
 int
 distance_set_int(const Set *s, int i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSET(s, -1);
+  VALIDATE_INTSET(s, INT_MAX);
   return DatumGetInt32(distance_set_value(s, Int32GetDatum(i)));
 }
 
@@ -1547,14 +1548,14 @@ distance_set_int(const Set *s, int i)
  * @brief Return the distance between a set and a big integer
  * @param[in] s Set
  * @param[in] i Value
- * @return On error return -1.0
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_set_value()
  */
 int64
 distance_set_bigint(const Set *s, int64 i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSET(s, -1);
+  VALIDATE_BIGINTSET(s, INT64_MAX);
   return DatumGetInt64(distance_set_value(s, Int64GetDatum(i)));
 }
 
@@ -1579,14 +1580,14 @@ distance_set_float(const Set *s, double d)
  * @brief Return the distance in days between a set and a date
  * @param[in] s Set
  * @param[in] d Value
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_set_value()
  */
 int
 distance_set_date(const Set *s, DateADT d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESET(s, -1);
+  VALIDATE_DATESET(s, INT_MAX);
   return DatumGetInt32(distance_set_value(s, DateADTGetDatum(d)));
 }
 
@@ -1613,7 +1614,7 @@ distance_set_timestamptz(const Set *s, TimestampTz t)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer sets
  * @param[in] s1,s2 Sets
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_set_set()
  */
 int
@@ -1621,7 +1622,7 @@ distance_intset_intset(const Set *s1, const Set *s2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_set_set(s1, s2) || ! ensure_set_isof_type(s1, T_INTSET))
-    return -1;
+    return INT_MAX;
   return DatumGetInt32(distance_set_set(s1, s2));
 }
 
@@ -1629,7 +1630,7 @@ distance_intset_intset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer sets
  * @param[in] s1,s2 Sets
- * @return On error return -1
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_set_set()
  */
 int64
@@ -1637,7 +1638,7 @@ distance_bigintset_bigintset(const Set *s1, const Set *s2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_set_set(s1, s2) || ! ensure_set_isof_type(s1, T_BIGINTSET))
-    return -1;
+    return INT64_MAX;
   return DatumGetInt64(distance_set_set(s1, s2));
 }
 
@@ -1661,7 +1662,7 @@ distance_floatset_floatset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in days between two date sets
  * @param[in] s1,s2 Sets
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_set_set()
  */
 int
@@ -1669,7 +1670,7 @@ distance_dateset_dateset(const Set *s1, const Set *s2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_set_set(s1, s2) || ! ensure_set_isof_type(s1, T_DATESET))
-    return -1;
+    return INT_MAX;
   return DatumGetInt32(distance_set_set(s1, s2));
 }
 

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -35,6 +35,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 #include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
@@ -873,6 +874,31 @@ minus_span_span(const Span *s1, const Span *s2)
  ******************************************************************************/
 
 /**
+ * @brief Return the value returned on error by the distance functions of a
+ * base type
+ * @param[in] type Type of the values
+ * @details The sentinel is the maximum value of the type in which the distance
+ * is expressed, so that it sorts after every distance that could be computed
+ * in the nearest-neighbor searches performed with the indexes
+ */
+Datum
+distance_sentinel(MeosType type)
+{
+  switch (type)
+  {
+    case T_INT4:
+    case T_DATE:
+      /* The distance between dates is expressed in days */
+      return Int32GetDatum(INT_MAX);
+    case T_INT8:
+      return Int64GetDatum(INT64_MAX);
+    default:
+      /* The distance between timestamptz values is expressed in seconds */
+      return Float8GetDatum(DBL_MAX);
+  }
+}
+
+/**
  * @brief Return the distance between two values as a double for the indexes
  * @param[in] l,r Values
  * @param[in] type Type of the values
@@ -910,7 +936,8 @@ dist_double_value_value(Datum l, Datum r, MeosType type)
  * @brief Return the distance between two values
  * @param[in] l,r Values
  * @param[in] type Type of the values
- * @return On error return -1
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  */
 Datum
 distance_value_value(Datum l, Datum r, MeosType type)
@@ -935,7 +962,7 @@ distance_value_value(Datum l, Datum r, MeosType type)
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
         "Unknown types for distance between values: %s",
         meostype_name(type));
-      return (Datum) -1;
+      return distance_sentinel(type);
   }
 }
 
@@ -972,7 +999,8 @@ distance_span_value(const Span *s, Datum value)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two spans as a double
  * @param[in] s1,s2 Spans
- * @return On error return -1
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  * @csqlfn #Distance_span_span()
  */
 Datum

--- a/meos/src/temporal/span_ops_meos.c
+++ b/meos/src/temporal/span_ops_meos.c
@@ -35,6 +35,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 #include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
@@ -1354,14 +1355,14 @@ minus_span_timestamptz(const Span *s, TimestampTz t)
  * @brief Return the distance between a span and an integer as a double
  * @param[in] s Span
  * @param[in] i Value
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_span_value()
  */
 int
 distance_span_int(const Span *s, int i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPAN(s, -1);
+  VALIDATE_INTSPAN(s, INT_MAX);
   return distance_span_value(s, Int32GetDatum(i));
 }
 
@@ -1370,14 +1371,14 @@ distance_span_int(const Span *s, int i)
  * @brief Return the distance between a span and a big integer as a double
  * @param[in] s Span
  * @param[in] i Value
- * @return On error return -1
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_span_value()
  */
 int64
 distance_span_bigint(const Span *s, int64 i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPAN(s, -1);
+  VALIDATE_BIGINTSPAN(s, INT64_MAX);
   return distance_span_value(s, Int64GetDatum(i));
 }
 
@@ -1402,14 +1403,14 @@ distance_span_float(const Span *s, double d)
  * @brief Return the distance in days between a span and a date as a double
  * @param[in] s Span
  * @param[in] d Value
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_span_value()
  */
 int
 distance_span_date(const Span *s, DateADT d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPAN(s, -1);
+  VALIDATE_DATESPAN(s, INT_MAX);
   return distance_span_value(s, DateADTGetDatum(d));
 }
 
@@ -1436,14 +1437,14 @@ distance_span_timestamptz(const Span *s, TimestampTz t)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer spans
  * @param[in] s1,s2 Spans
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_span_span()
  */
 int
 distance_intspan_intspan(const Span *s1, const Span *s2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPAN(s1, -1); VALIDATE_INTSPAN(s2, -1);
+  VALIDATE_INTSPAN(s1, INT_MAX); VALIDATE_INTSPAN(s2, INT_MAX);
   return DatumGetInt32(distance_span_span(s1, s2));
 }
 
@@ -1451,14 +1452,14 @@ distance_intspan_intspan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer spans
  * @param[in] s1,s2 Spans
- * @return On error return -1
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_span_span()
  */
 int64
 distance_bigintspan_bigintspan(const Span *s1, const Span *s2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPAN(s1, -1); VALIDATE_BIGINTSPAN(s2, -1);
+  VALIDATE_BIGINTSPAN(s1, INT64_MAX); VALIDATE_BIGINTSPAN(s2, INT64_MAX);
   return DatumGetInt64(distance_span_span(s1, s2));
 }
 
@@ -1481,14 +1482,14 @@ distance_floatspan_floatspan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two date spans
  * @param[in] s1,s2 Spans
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_span_span()
  */
 int
 distance_datespan_datespan(const Span *s1, const Span *s2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPAN(s1, -1); VALIDATE_DATESPAN(s2, -1);
+  VALIDATE_DATESPAN(s1, INT_MAX); VALIDATE_DATESPAN(s2, INT_MAX);
   return DatumGetInt32(distance_span_span(s1, s2));
 }
 

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -1306,7 +1306,8 @@ distance_spanset_value(const SpanSet *ss, Datum value)
  * @brief Return the distance between a span set and a span
  * @param[in] ss Span set
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  * @csqlfn #Distance_spanset_span()
  */
 Datum
@@ -1314,7 +1315,7 @@ distance_spanset_span(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_spanset_span(ss, s))
-    return false;
+    return distance_sentinel(ss ? ss->span.basetype : T_FLOAT8);
   return distance_span_span(&ss->span, s);
 }
 
@@ -1322,7 +1323,8 @@ distance_spanset_span(const SpanSet *ss, const Span *s)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two span sets
  * @param[in] ss1,ss2 Span sets
- * @return On error return -1.0
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  * @csqlfn #Distance_spanset_span()
  */
 Datum
@@ -1330,7 +1332,7 @@ distance_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_spanset_spanset(ss1, ss2))
-    return false;
+    return distance_sentinel(ss1 ? ss1->span.basetype : T_FLOAT8);
   return distance_span_span(&ss1->span, &ss2->span);
 }
 

--- a/meos/src/temporal/spanset_ops_meos.c
+++ b/meos/src/temporal/spanset_ops_meos.c
@@ -35,6 +35,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <utils/timestamp.h>
@@ -1273,14 +1274,14 @@ minus_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
  * @brief Return the distance between a span set and an integer
  * @param[in] ss Span set
  * @param[in] i Value
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_value()
  */
 int
 distance_spanset_int(const SpanSet *ss, int i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPANSET(ss, -1);
+  VALIDATE_INTSPANSET(ss, INT_MAX);
   return DatumGetInt32(distance_spanset_value(ss, Int32GetDatum(i)));
 }
 
@@ -1289,14 +1290,14 @@ distance_spanset_int(const SpanSet *ss, int i)
  * @brief Return the distance between a span set and a big integer
  * @param[in] ss Span set
  * @param[in] i Value
- * @return On error return -1.0
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_spanset_value()
  */
 int64
 distance_spanset_bigint(const SpanSet *ss, int64 i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss, -1);
+  VALIDATE_BIGINTSPANSET(ss, INT64_MAX);
   return DatumGetInt64(distance_spanset_value(ss, Int64GetDatum(i)));
 }
 
@@ -1322,14 +1323,14 @@ distance_spanset_float(const SpanSet *ss, double d)
  * double
  * @param[in] ss Span set
  * @param[in] d Value
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_value()
  */
 int
 distance_spanset_date(const SpanSet *ss, DateADT d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPANSET(ss, -1);
+  VALIDATE_DATESPANSET(ss, INT_MAX);
   return DatumGetInt32(distance_spanset_value(ss, DateADTGetDatum(d)));
 }
 
@@ -1356,14 +1357,14 @@ distance_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
  * @brief Return the distance between an integer span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int
 distance_intspanset_intspan(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPANSET(ss, -1); VALIDATE_INTSPAN(s, -1);
+  VALIDATE_INTSPANSET(ss, INT_MAX); VALIDATE_INTSPAN(s, INT_MAX);
   return DatumGetInt32(distance_spanset_span(ss, s));
 }
 
@@ -1372,14 +1373,14 @@ distance_intspanset_intspan(const SpanSet *ss, const Span *s)
  * @brief Return the distance between a big integer span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int64
 distance_bigintspanset_bigintspan(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss, -1); VALIDATE_BIGINTSPAN(s, -1);
+  VALIDATE_BIGINTSPANSET(ss, INT64_MAX); VALIDATE_BIGINTSPAN(s, INT64_MAX);
   return DatumGetInt64(distance_spanset_span(ss, s));
 }
 
@@ -1404,14 +1405,14 @@ distance_floatspanset_floatspan(const SpanSet *ss, const Span *s)
  * @brief Return the distance in days between a date span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int
 distance_datespanset_datespan(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPANSET(ss, -1); VALIDATE_DATESPAN(s, -1);
+  VALIDATE_DATESPANSET(ss, INT_MAX); VALIDATE_DATESPAN(s, INT_MAX);
   return DatumGetInt32(distance_spanset_span(ss, s));
 }
 
@@ -1438,14 +1439,14 @@ distance_tstzspanset_tstzspan(const SpanSet *ss, const Span *s)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int
 distance_intspanset_intspanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPANSET(ss1, -1); VALIDATE_INTSPANSET(ss2, -1);
+  VALIDATE_INTSPANSET(ss1, INT_MAX); VALIDATE_INTSPANSET(ss2, INT_MAX);
   return DatumGetInt32(distance_spanset_spanset(ss1, ss2));
 }
 
@@ -1453,14 +1454,14 @@ distance_intspanset_intspanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return -1.0
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int64
 distance_bigintspanset_bigintspanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss1, -1); VALIDATE_BIGINTSPANSET(ss2, -1);
+  VALIDATE_BIGINTSPANSET(ss1, INT64_MAX); VALIDATE_BIGINTSPANSET(ss2, INT64_MAX);
   return DatumGetInt64(distance_spanset_spanset(ss1, ss2));
 }
 
@@ -1483,14 +1484,14 @@ distance_floatspanset_floatspanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in days between two date span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int
 distance_datespanset_datespanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPANSET(ss1, -1); VALIDATE_DATESPANSET(ss2, -1);
+  VALIDATE_DATESPANSET(ss1, INT_MAX); VALIDATE_DATESPANSET(ss2, INT_MAX);
   return DatumGetInt32(distance_spanset_spanset(ss1, ss2));
 }
 


### PR DESCRIPTION
The distance functions of the set, span, and span set types returned -1 on error, while their float siblings already returned `DBL_MAX`. They now return `INT_MAX`, `INT64_MAX`, or `DBL_MAX` according to their return type, so the sentinel is out of the domain of the distances and sorts after every distance that can be computed, as the nearest neighbor searches performed with the indexes require.

The documentation of `distance_set_bigint`, of `distance_set_date`, and of the span set distance functions stated a float sentinel for an integer return; the sentinel and the documentation now agree with the return type. The distance between a span set and a span or between two span sets returned zero on error, that is, the smallest possible distance.