### PR TITLE
Compute the ordering key of the span indexes from the distance itself

### DIFF
--- a/meos/include/temporal/span.h
+++ b/meos/include/temporal/span.h
@@ -111,7 +111,7 @@ extern int mi_span_span(const Span *s1, const Span *s2, Span *result);
 extern int mi_span_value(const Span *s, Datum value, Span *result);
 
 extern Datum distance_sentinel(MeosType type);
-extern double dist_double_value_value(Datum l, Datum r, MeosType type);
+extern double distance_double(Datum dist, MeosType type);
 
 /*****************************************************************************/
 

--- a/meos/include/temporal/span.h
+++ b/meos/include/temporal/span.h
@@ -110,6 +110,7 @@ extern void tstzspan_shift_scale1(Span *s, const Interval *shift,
 extern int mi_span_span(const Span *s1, const Span *s2, Span *result);
 extern int mi_span_value(const Span *s, Datum value, Span *result);
 
+extern Datum distance_sentinel(MeosType type);
 extern double dist_double_value_value(Datum l, Datum r, MeosType type);
 
 /*****************************************************************************/

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -663,7 +663,8 @@ distance_set_value(const Set *s, Datum value)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two sets
  * @param[in] s1,s2 Sets
- * @return On error return -1.0
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  * @csqlfn #Distance_set_set()
  */
 Datum

--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -35,6 +35,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <utils/timestamp.h>
@@ -1531,14 +1532,14 @@ minus_set_timestamptz(const Set *s, TimestampTz t)
  * @brief Return the distance between a set and an integer
  * @param[in] s Set
  * @param[in] i Value
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_set_value()
  */
 int
 distance_set_int(const Set *s, int i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSET(s, -1);
+  VALIDATE_INTSET(s, INT_MAX);
   return DatumGetInt32(distance_set_value(s, Int32GetDatum(i)));
 }
 
@@ -1547,14 +1548,14 @@ distance_set_int(const Set *s, int i)
  * @brief Return the distance between a set and a big integer
  * @param[in] s Set
  * @param[in] i Value
- * @return On error return -1.0
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_set_value()
  */
 int64
 distance_set_bigint(const Set *s, int64 i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSET(s, -1);
+  VALIDATE_BIGINTSET(s, INT64_MAX);
   return DatumGetInt64(distance_set_value(s, Int64GetDatum(i)));
 }
 
@@ -1579,14 +1580,14 @@ distance_set_float(const Set *s, double d)
  * @brief Return the distance in days between a set and a date
  * @param[in] s Set
  * @param[in] d Value
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_set_value()
  */
 int
 distance_set_date(const Set *s, DateADT d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESET(s, -1);
+  VALIDATE_DATESET(s, INT_MAX);
   return DatumGetInt32(distance_set_value(s, DateADTGetDatum(d)));
 }
 
@@ -1613,7 +1614,7 @@ distance_set_timestamptz(const Set *s, TimestampTz t)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer sets
  * @param[in] s1,s2 Sets
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_set_set()
  */
 int
@@ -1621,7 +1622,7 @@ distance_intset_intset(const Set *s1, const Set *s2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_set_set(s1, s2) || ! ensure_set_isof_type(s1, T_INTSET))
-    return -1;
+    return INT_MAX;
   return DatumGetInt32(distance_set_set(s1, s2));
 }
 
@@ -1629,7 +1630,7 @@ distance_intset_intset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer sets
  * @param[in] s1,s2 Sets
- * @return On error return -1
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_set_set()
  */
 int64
@@ -1637,7 +1638,7 @@ distance_bigintset_bigintset(const Set *s1, const Set *s2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_set_set(s1, s2) || ! ensure_set_isof_type(s1, T_BIGINTSET))
-    return -1;
+    return INT64_MAX;
   return DatumGetInt64(distance_set_set(s1, s2));
 }
 
@@ -1661,7 +1662,7 @@ distance_floatset_floatset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in days between two date sets
  * @param[in] s1,s2 Sets
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_set_set()
  */
 int
@@ -1669,7 +1670,7 @@ distance_dateset_dateset(const Set *s1, const Set *s2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_set_set(s1, s2) || ! ensure_set_isof_type(s1, T_DATESET))
-    return -1;
+    return INT_MAX;
   return DatumGetInt32(distance_set_set(s1, s2));
 }
 

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -35,6 +35,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 #include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
@@ -873,6 +874,31 @@ minus_span_span(const Span *s1, const Span *s2)
  ******************************************************************************/
 
 /**
+ * @brief Return the value returned on error by the distance functions of a
+ * base type
+ * @param[in] type Type of the values
+ * @details The sentinel is the maximum value of the type in which the distance
+ * is expressed, so that it sorts after every distance that could be computed
+ * in the nearest-neighbor searches performed with the indexes
+ */
+Datum
+distance_sentinel(MeosType type)
+{
+  switch (type)
+  {
+    case T_INT4:
+    case T_DATE:
+      /* The distance between dates is expressed in days */
+      return Int32GetDatum(INT_MAX);
+    case T_INT8:
+      return Int64GetDatum(INT64_MAX);
+    default:
+      /* The distance between timestamptz values is expressed in seconds */
+      return Float8GetDatum(DBL_MAX);
+  }
+}
+
+/**
  * @brief Return the distance between two values as a double for the indexes
  * @param[in] l,r Values
  * @param[in] type Type of the values
@@ -910,7 +936,8 @@ dist_double_value_value(Datum l, Datum r, MeosType type)
  * @brief Return the distance between two values
  * @param[in] l,r Values
  * @param[in] type Type of the values
- * @return On error return -1
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  */
 Datum
 distance_value_value(Datum l, Datum r, MeosType type)
@@ -935,7 +962,7 @@ distance_value_value(Datum l, Datum r, MeosType type)
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
         "Unknown types for distance between values: %s",
         meostype_name(type));
-      return (Datum) -1;
+      return distance_sentinel(type);
   }
 }
 
@@ -972,7 +999,8 @@ distance_span_value(const Span *s, Datum value)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two spans as a double
  * @param[in] s1,s2 Spans
- * @return On error return -1
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  * @csqlfn #Distance_span_span()
  */
 Datum

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -899,33 +899,34 @@ distance_sentinel(MeosType type)
 }
 
 /**
- * @brief Return the distance between two values as a double for the indexes
- * @param[in] l,r Values
- * @param[in] type Type of the values
+ * @brief Return a distance of a base type as a double for the indexes
+ * @param[in] dist Distance between two values of the base type
+ * @param[in] type Base type of the values the distance was computed on
  * @return On error return @p DBL_MAX
+ * @details The distance functions answer in the type of the distance, which
+ * is the base type for the numbers, the number of days for the dates, and the
+ * number of seconds for the timestamptz values. The nearest neighbor searches
+ * rank their candidates with a double whatever that type is, so the value is
+ * converted here instead of being computed a second time
  */
 double
-dist_double_value_value(Datum l, Datum r, MeosType type)
+distance_double(Datum dist, MeosType type)
 {
-  assert(span_basetype(type));
   switch (type)
   {
     case T_INT4:
-      return Float8GetDatum((double) abs(DatumGetInt32(l) - DatumGetInt32(r)));
-    case T_INT8:
-      return Float8GetDatum((double) llabs(DatumGetInt64(l) - DatumGetInt64(r)));
-    case T_FLOAT8:
-      return Float8GetDatum(fabs(DatumGetFloat8(l) - DatumGetFloat8(r)));
     case T_DATE:
-      /* Distance in days if the base type is DateADT */
-      return Float8GetDatum((double) abs(DatumGetDateADT(l) - DatumGetDateADT(r)));
+      /* The distance between dates is expressed in days */
+      return (double) DatumGetInt32(dist);
+    case T_INT8:
+      return (double) DatumGetInt64(dist);
+    case T_FLOAT8:
     case T_TIMESTAMPTZ:
-      /* Distance in seconds if the base type is TimestampTz */
-      return Float8GetDatum((llabs((DatumGetTimestampTz(l) -
-        DatumGetTimestampTz(r)))) / USECS_PER_SEC);
+      /* The distance between timestamptz values is expressed in seconds */
+      return DatumGetFloat8(dist);
     default:
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-        "Unknown types for distance between values: %s",
+        "Unknown distance type for conversion to double: %s",
         meostype_name(type));
       return DBL_MAX;
   }

--- a/meos/src/temporal/span_ops_meos.c
+++ b/meos/src/temporal/span_ops_meos.c
@@ -35,6 +35,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 #include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
@@ -1354,14 +1355,14 @@ minus_span_timestamptz(const Span *s, TimestampTz t)
  * @brief Return the distance between a span and an integer as a double
  * @param[in] s Span
  * @param[in] i Value
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_span_value()
  */
 int
 distance_span_int(const Span *s, int i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPAN(s, -1);
+  VALIDATE_INTSPAN(s, INT_MAX);
   return distance_span_value(s, Int32GetDatum(i));
 }
 
@@ -1370,14 +1371,14 @@ distance_span_int(const Span *s, int i)
  * @brief Return the distance between a span and a big integer as a double
  * @param[in] s Span
  * @param[in] i Value
- * @return On error return -1
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_span_value()
  */
 int64
 distance_span_bigint(const Span *s, int64 i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPAN(s, -1);
+  VALIDATE_BIGINTSPAN(s, INT64_MAX);
   return distance_span_value(s, Int64GetDatum(i));
 }
 
@@ -1402,14 +1403,14 @@ distance_span_float(const Span *s, double d)
  * @brief Return the distance in days between a span and a date as a double
  * @param[in] s Span
  * @param[in] d Value
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_span_value()
  */
 int
 distance_span_date(const Span *s, DateADT d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPAN(s, -1);
+  VALIDATE_DATESPAN(s, INT_MAX);
   return distance_span_value(s, DateADTGetDatum(d));
 }
 
@@ -1436,14 +1437,14 @@ distance_span_timestamptz(const Span *s, TimestampTz t)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer spans
  * @param[in] s1,s2 Spans
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_span_span()
  */
 int
 distance_intspan_intspan(const Span *s1, const Span *s2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPAN(s1, -1); VALIDATE_INTSPAN(s2, -1);
+  VALIDATE_INTSPAN(s1, INT_MAX); VALIDATE_INTSPAN(s2, INT_MAX);
   return DatumGetInt32(distance_span_span(s1, s2));
 }
 
@@ -1451,14 +1452,14 @@ distance_intspan_intspan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer spans
  * @param[in] s1,s2 Spans
- * @return On error return -1
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_span_span()
  */
 int64
 distance_bigintspan_bigintspan(const Span *s1, const Span *s2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPAN(s1, -1); VALIDATE_BIGINTSPAN(s2, -1);
+  VALIDATE_BIGINTSPAN(s1, INT64_MAX); VALIDATE_BIGINTSPAN(s2, INT64_MAX);
   return DatumGetInt64(distance_span_span(s1, s2));
 }
 
@@ -1481,14 +1482,14 @@ distance_floatspan_floatspan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two date spans
  * @param[in] s1,s2 Spans
- * @return On error return -1
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_span_span()
  */
 int
 distance_datespan_datespan(const Span *s1, const Span *s2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPAN(s1, -1); VALIDATE_DATESPAN(s2, -1);
+  VALIDATE_DATESPAN(s1, INT_MAX); VALIDATE_DATESPAN(s2, INT_MAX);
   return DatumGetInt32(distance_span_span(s1, s2));
 }
 

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -1306,7 +1306,8 @@ distance_spanset_value(const SpanSet *ss, Datum value)
  * @brief Return the distance between a span set and a span
  * @param[in] ss Span set
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  * @csqlfn #Distance_spanset_span()
  */
 Datum
@@ -1314,7 +1315,7 @@ distance_spanset_span(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_spanset_span(ss, s))
-    return false;
+    return distance_sentinel(ss ? ss->span.basetype : T_FLOAT8);
   return distance_span_span(&ss->span, s);
 }
 
@@ -1322,7 +1323,8 @@ distance_spanset_span(const SpanSet *ss, const Span *s)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two span sets
  * @param[in] ss1,ss2 Span sets
- * @return On error return -1.0
+ * @return On error return the sentinel of the base type given by
+ * #distance_sentinel()
  * @csqlfn #Distance_spanset_span()
  */
 Datum
@@ -1330,7 +1332,7 @@ distance_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_spanset_spanset(ss1, ss2))
-    return false;
+    return distance_sentinel(ss1 ? ss1->span.basetype : T_FLOAT8);
   return distance_span_span(&ss1->span, &ss2->span);
 }
 

--- a/meos/src/temporal/spanset_ops_meos.c
+++ b/meos/src/temporal/spanset_ops_meos.c
@@ -35,6 +35,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <utils/timestamp.h>
@@ -1273,14 +1274,14 @@ minus_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
  * @brief Return the distance between a span set and an integer
  * @param[in] ss Span set
  * @param[in] i Value
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_value()
  */
 int
 distance_spanset_int(const SpanSet *ss, int i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPANSET(ss, -1);
+  VALIDATE_INTSPANSET(ss, INT_MAX);
   return DatumGetInt32(distance_spanset_value(ss, Int32GetDatum(i)));
 }
 
@@ -1289,14 +1290,14 @@ distance_spanset_int(const SpanSet *ss, int i)
  * @brief Return the distance between a span set and a big integer
  * @param[in] ss Span set
  * @param[in] i Value
- * @return On error return -1.0
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_spanset_value()
  */
 int64
 distance_spanset_bigint(const SpanSet *ss, int64 i)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss, -1);
+  VALIDATE_BIGINTSPANSET(ss, INT64_MAX);
   return DatumGetInt64(distance_spanset_value(ss, Int64GetDatum(i)));
 }
 
@@ -1322,14 +1323,14 @@ distance_spanset_float(const SpanSet *ss, double d)
  * double
  * @param[in] ss Span set
  * @param[in] d Value
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_value()
  */
 int
 distance_spanset_date(const SpanSet *ss, DateADT d)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPANSET(ss, -1);
+  VALIDATE_DATESPANSET(ss, INT_MAX);
   return DatumGetInt32(distance_spanset_value(ss, DateADTGetDatum(d)));
 }
 
@@ -1356,14 +1357,14 @@ distance_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
  * @brief Return the distance between an integer span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int
 distance_intspanset_intspan(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPANSET(ss, -1); VALIDATE_INTSPAN(s, -1);
+  VALIDATE_INTSPANSET(ss, INT_MAX); VALIDATE_INTSPAN(s, INT_MAX);
   return DatumGetInt32(distance_spanset_span(ss, s));
 }
 
@@ -1372,14 +1373,14 @@ distance_intspanset_intspan(const SpanSet *ss, const Span *s)
  * @brief Return the distance between a big integer span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int64
 distance_bigintspanset_bigintspan(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss, -1); VALIDATE_BIGINTSPAN(s, -1);
+  VALIDATE_BIGINTSPANSET(ss, INT64_MAX); VALIDATE_BIGINTSPAN(s, INT64_MAX);
   return DatumGetInt64(distance_spanset_span(ss, s));
 }
 
@@ -1404,14 +1405,14 @@ distance_floatspanset_floatspan(const SpanSet *ss, const Span *s)
  * @brief Return the distance in days between a date span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int
 distance_datespanset_datespan(const SpanSet *ss, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPANSET(ss, -1); VALIDATE_DATESPAN(s, -1);
+  VALIDATE_DATESPANSET(ss, INT_MAX); VALIDATE_DATESPAN(s, INT_MAX);
   return DatumGetInt32(distance_spanset_span(ss, s));
 }
 
@@ -1438,14 +1439,14 @@ distance_tstzspanset_tstzspan(const SpanSet *ss, const Span *s)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int
 distance_intspanset_intspanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPANSET(ss1, -1); VALIDATE_INTSPANSET(ss2, -1);
+  VALIDATE_INTSPANSET(ss1, INT_MAX); VALIDATE_INTSPANSET(ss2, INT_MAX);
   return DatumGetInt32(distance_spanset_spanset(ss1, ss2));
 }
 
@@ -1453,14 +1454,14 @@ distance_intspanset_intspanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return -1.0
+ * @return On error return @p INT64_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int64
 distance_bigintspanset_bigintspanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss1, -1); VALIDATE_BIGINTSPANSET(ss2, -1);
+  VALIDATE_BIGINTSPANSET(ss1, INT64_MAX); VALIDATE_BIGINTSPANSET(ss2, INT64_MAX);
   return DatumGetInt64(distance_spanset_spanset(ss1, ss2));
 }
 
@@ -1483,14 +1484,14 @@ distance_floatspanset_floatspanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in days between two date span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return -1.0
+ * @return On error return @p INT_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int
 distance_datespanset_datespanset(const SpanSet *ss1, const SpanSet *ss2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPANSET(ss1, -1); VALIDATE_DATESPANSET(ss2, -1);
+  VALIDATE_DATESPANSET(ss1, INT_MAX); VALIDATE_DATESPANSET(ss2, INT_MAX);
   return DatumGetInt32(distance_spanset_spanset(ss1, ss2));
 }
 

--- a/mobilitydb/src/temporal/span_gist.c
+++ b/mobilitydb/src/temporal/span_gist.c
@@ -207,7 +207,7 @@ PG_FUNCTION_INFO_V1(Span_gist_penalty);
  * @brief GiST page split penalty function for spans
  * @details The penalty function has the following goals (in order from most to
  * least important):
- * - Avoid broadening (as determined by dist_double_value_value) the original
+ * - Avoid broadening (as determined by distance_value_value) the original
  *   predicate
  * - Favor adding spans to narrower original predicates
  */
@@ -223,12 +223,14 @@ Span_gist_penalty(PG_FUNCTION_ARGS)
   span_deserialize(orig, &orig_lower, &orig_upper);
   span_deserialize(new, &new_lower, &new_upper);
 
-  /* Calculate extension of original span by calling dist_double_value_value */
+  /* Calculate extension of original span by calling distance_value_value */
   float8 diff = 0.0;
   if (span_bound_cmp(&new_lower, &orig_lower) < 0)
-    diff += dist_double_value_value(orig->lower, new->lower, orig->basetype);
+    diff += distance_double(distance_value_value(orig->lower, new->lower,
+      orig->basetype), orig->basetype);
   if (span_bound_cmp(&new_upper, &orig_upper) > 0)
-    diff += dist_double_value_value(new->upper, orig->upper, new->basetype);
+    diff += distance_double(distance_value_value(new->upper, orig->upper,
+      new->basetype), new->basetype);
   *penalty = (float4) diff;
 
   PG_RETURN_POINTER(penalty);
@@ -347,7 +349,8 @@ span_gist_consider_split(ConsiderSplitContext *context, SpanBound *right_lower,
      * values) and minimal ratio secondarily.  The subtype_diff is
      * used for overlap measure.
      */
-    overlap = (float4) dist_double_value_value(left_upper->val, right_lower->val,
+    overlap = (float4) distance_double(distance_value_value(left_upper->val,
+      right_lower->val, left_upper->basetype),
       left_upper->basetype);
 
     /* If there is no previous selection, select this split */
@@ -656,10 +659,10 @@ span_gist_double_sorting_split(GistEntryVector *entryvec, GIST_SPLITVEC *v)
          * (context.left_upper - upper)
          */
         common_entries[common_entries_count].delta =
-          dist_double_value_value(span->lower, context.right_lower.val,
-            span->basetype) -
-          dist_double_value_value(context.left_upper.val, span->upper,
-            span->basetype);
+          distance_double(distance_value_value(span->lower,
+            context.right_lower.val, span->basetype), span->basetype) -
+          distance_double(distance_value_value(context.left_upper.val,
+            span->upper, span->basetype), span->basetype);
         common_entries_count++;
       }
       else
@@ -784,21 +787,21 @@ Span_gist_distance(PG_FUNCTION_ARGS)
   Oid typid = PG_GETARG_OID(3);
   bool *recheck = (bool *) PG_GETARG_POINTER(4);
   Span *key = (Span *) DatumGetPointer(entry->key);
-  if (! key)
-    PG_RETURN_DATUM((Datum) -1);
 
-  /* The index is not lossy */
-  if (GIST_LEAF(entry))
-    *recheck = false;
-
-  /* Transform the query into a span */
+  /* Transform the query into a span. The distance is unknown when there is no
+   * key or the query is not a span, and the maximum orders those entries after
+   * every candidate whose distance is known */
   Span query;
-  if (! span_gist_get_span(fcinfo, &query, typid))
-    PG_RETURN_DATUM((Datum) -1);
+  if (! key || ! span_gist_get_span(fcinfo, &query, typid))
+    PG_RETURN_FLOAT8(DBL_MAX);
 
-  Datum distance = distance_span_span(key, &query);
+  /* The distance is exact, and it has to be: PostgreSQL requires the ORDER BY
+   * operator of a lossy distance to answer in a float, while the span
+   * operators answer in the base type */
+  *recheck = false;
 
-  PG_RETURN_DATUM(distance);
+  PG_RETURN_FLOAT8(distance_double(distance_span_span(key, &query),
+    key->basetype));
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/temporal/span_spgist.c
+++ b/mobilitydb/src/temporal/span_spgist.c
@@ -659,7 +659,8 @@ Span_spgist_leaf_consistent(PG_FUNCTION_ARGS)
       Datum value = scankey->sk_argument;
       MeosType type = oid_meostype(scankey->sk_subtype);
       span_spgist_get_span(value, type, &span);
-      distances[i] = distance_span_span(&span, key);
+      distances[i] = distance_double(distance_span_span(&span, key),
+        key->basetype);
     }
   }
 

--- a/mobilitydb/src/temporal/tnumber_gist.c
+++ b/mobilitydb/src/temporal/tnumber_gist.c
@@ -1029,17 +1029,19 @@ Tbox_gist_distance(PG_FUNCTION_ARGS)
   Oid typid = PG_GETARG_OID(3);
   bool *recheck = (bool *) PG_GETARG_POINTER(4);
   TBox *key = (TBox *) DatumGetPointer(entry->key);
-  if (! key)
-    PG_RETURN_NULL();
 
   /* The index is lossy for leaf levels */
-  if (GIST_LEAF(entry))
+  if (key && GIST_LEAF(entry))
     *recheck = true;
 
-  /* Transform the query into a box */
+  /* Transform the query into a box. The distance is unknown when there is no
+   * key or the query is not a box, and the maximum orders those entries after
+   * every candidate whose distance is known. A null cannot be returned here,
+   * as the GiST framework reads the result of its distance method as a
+   * double and rejects a null one */
   TBox query;
-  if (! tnumber_gist_get_tbox(fcinfo, &query, oid_meostype(typid)))
-    PG_RETURN_NULL();
+  if (! key || ! tnumber_gist_get_tbox(fcinfo, &query, oid_meostype(typid)))
+    PG_RETURN_FLOAT8(DBL_MAX);
 
   /* Since we only have boxes we'll return the minimum possible distance,
    * and let the recheck sort things out in the case of leaves. Since the


### PR DESCRIPTION
Stacked on `fix/distance-sentinel-int-maxima`; the second commit is the one to review.

The nearest neighbor searches of the indexes rank their candidates with a double: the GiST framework reads the result of its distance method with `DatumGetFloat8` and the SP-GiST one fills an array of doubles. The span methods were handing them the distance as the `Datum` of the base type instead, so an integer distance of 5 reached the queue as the double 2.5e-323, and the -1 they returned when the distance could not be computed reached it as 2.1e-314, ahead of every candidate. The order came out right only because the bit patterns of the non negative integers happen to grow with their values.

The ordering key is now the distance the functions already compute, converted with `distance_double` rather than walked a second time over the bounds. It replaces `dist_double_value_value`, whose uses in the penalty and split methods become that conversion over `distance_value_value`. The methods return `DBL_MAX` when there is no key or the query is not a span, which orders those entries last. The distance method of the temporal box returned a null on the paths where it has no box, which the function manager rejects with "function returned NULL"; it returns the maximum as well.