### PR TITLE
Name the quadbin set functions after the build that compiles them

### DIFF
--- a/meos/include/quadbin/quadbinset.h
+++ b/meos/include/quadbin/quadbinset.h
@@ -45,8 +45,8 @@
  * lift is handled by the tquadbin layer.
  */
 
-#ifndef __QUADBINSET_MEOS_H__
-#define __QUADBINSET_MEOS_H__
+#ifndef __QUADBINSET_H__
+#define __QUADBINSET_H__
 
 /* PostgreSQL */
 #include <postgres.h>
@@ -74,4 +74,4 @@ extern Set *quadbin_grid_disk(Quadbin origin, int k);
 extern Set *quadbin_cell_to_children_set(Quadbin origin,
   int children_resolution);
 
-#endif /* __QUADBINSET_MEOS_H__ */
+#endif /* __QUADBINSET_H__ */

--- a/meos/src/quadbin/CMakeLists.txt
+++ b/meos/src/quadbin/CMakeLists.txt
@@ -1,7 +1,7 @@
 set(QUADBIN_SOURCES
   quadbin.c
   quadbin_geo.c
-  quadbinset_meos.c
+  quadbinset.c
   tquadbin_ops.c
   tquadbin.c
   tquadbin_boxops.c

--- a/meos/src/quadbin/quadbinset.c
+++ b/meos/src/quadbin/quadbinset.c
@@ -39,7 +39,7 @@
  *   4. Return the Set.
  */
 
-#include "quadbin/quadbinset_meos.h"
+#include "quadbin/quadbinset.h"
 
 /* PostgreSQL */
 #include <postgres.h>


### PR DESCRIPTION
The `_meos.c` suffix marks the typed functions that hide `Datum` from the bindings and that CMake compiles only for the MEOS library, so every family lists them inside `if(MEOS)`. The quadbin set file carries the suffix while its `CMakeLists.txt` lists it unconditionally, and the PG extension calls both of the functions it defines from `Quadbin_cell_to_children_set` and `Quadbin_grid_disk`, so its content is shared rather than MEOS-only. It is named `quadbinset.c`, next to `quadbin.c` and `quadbin_geo.c`, and the family is left without a MEOS-only file.