### PR TITLE
Check the MEOS-only file selection and the error sentinels in CI

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -68,6 +68,14 @@ jobs:
       - name: Reject <-> operators that btree_gist owns
         run: python3 tools/scripts/check_btree_gist_operators.py
 
+  meos_only_files_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check that MEOS-only code is selected by file, not by #if MEOS
+        run: python3 tools/scripts/check_meos_only_files.py
+
   binding_io_ownership_check:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -76,6 +76,14 @@ jobs:
       - name: Check that MEOS-only code is selected by file, not by #if MEOS
         run: python3 tools/scripts/check_meos_only_files.py
 
+  error_sentinels_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check that every error sentinel is the maximum of the return type
+        run: python3 tools/scripts/check_error_sentinels.py
+
   binding_io_ownership_check:
     runs-on: ubuntu-latest
     steps:

--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: PostgreSQL
+#
+# BINDING-HEADER-PARSE-OK: CI source guard under tools/scripts/, in the
+# shape of check_csqlfn.py. It reads meos/src/**.c to compare a function
+# signature with its own error sentinel; it extracts no API surface and
+# generates nothing.
+#
+# Check that every error sentinel is the maximum of the return type.
+#
+# Why
+# ---
+# A MEOS function that cannot compute its result reports the failure
+# through `meos_error()` and returns a sentinel value. Every binding
+# derives its null guard from that sentinel, and the guard must be a
+# pure function of the C return type so the generator can emit it
+# without a per-function table:
+#
+#   int     -> INT_MAX      double -> DBL_MAX
+#   int64   -> INT64_MAX    T *    -> NULL
+#   bool    -> false
+#
+# Rust makes the reason concrete. `distance_set_bigint` projects to
+# `-> Option<i64>` and the generated guard reads
+# `if raw == i64::MAX { None } else { Some(raw) }`. A sentinel outside
+# the return type cannot be written there at all: `f64::MAX` does not
+# inhabit an `i64`, and widening the signature to `f64` makes the
+# round trip lossy above 2^53 -- a wrong answer rather than a type
+# error. `-1` does inhabit it, which is worse: it is a legal distance
+# in the eyes of the type system and it collides with the `< 0` guard
+# of the three-valued integer predicates.
+#
+# The ordering matters as much as the typing. A nearest-neighbour scan
+# ranks candidates by distance, so a sentinel that sorts BEFORE real
+# distances -- any negative one -- hands the top of the result set to
+# the entries whose distance could not be computed. The maximum of the
+# type sorts last, in every type, in every host.
+#
+# `LONG_MAX` is rejected as an int64 sentinel: `long` is 32 bits on
+# LLP64 Windows, which this project builds (windows_msys2.yml), so
+# `LONG_MAX` silently becomes `INT32_MAX` there. `INT64_MAX` is the
+# portable spelling.
+#
+# What is checked, per function whose body has a VALIDATE_* guard or
+# whose doxygen carries an `@return On error return X` line:
+#
+#   * the sentinel of the VALIDATE_* macro matches the return type
+#   * the documented sentinel matches the return type
+#   * the two agree with each other
+#
+# Usage:
+#   python3 tools/scripts/check_error_sentinels.py              # check
+#   python3 tools/scripts/check_error_sentinels.py --report     # list all
+#   python3 tools/scripts/check_error_sentinels.py --rebaseline # regen
+#
+# Run from the repo root.
+"""Check that every MEOS error sentinel is the maximum of its return type."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+BASELINE_PATH = REPO_ROOT / "tools" / "scripts" / "error_sentinels_baseline.txt"
+
+# The sentinel each return type must use
+EXPECTED = {
+    "int": "INT_MAX",
+    "int32": "INT_MAX",
+    "int64": "INT64_MAX",
+    "double": "DBL_MAX",
+    "float8": "DBL_MAX",
+    "bool": "false",
+    "DateADT": "DATEVAL_NOEND",
+    "TimestampTz": "DT_NOEND",
+}
+# Spellings that resolve to the right value but are not the canonical one
+ALIASES = {
+    "LONG_MAX": "INT64_MAX",
+    "PG_INT64_MAX": "INT64_MAX",
+    "PG_INT32_MAX": "INT_MAX",
+    "infinity": "DBL_MAX",
+}
+# `long` is 32 bits on LLP64 Windows, which this project builds
+# (.github/workflows/windows_msys2.yml), so LONG_MAX silently becomes
+# INT32_MAX there. INT64_MAX is the portable spelling.
+NON_PORTABLE = {"LONG_MAX", "ULONG_MAX"}
+# The relationship predicates answer with three-valued logic -- 1 true,
+# 0 false, -1 unknown -- so -1 is their canonical sentinel, not a maximum.
+# It is out of their value domain, which is what the rule actually asks for.
+PREDICATE = re.compile(
+    r"^(ever|always)_|"
+    r"^[ea](contains|covers|coveredby|crosses|disjoint|dwithin|equals|"
+    r"intersects|overlaps|touches|within)_")
+# A pointer return: any sentinel other than NULL is wrong
+POINTER = re.compile(r"\*\s*$")
+
+FUNC_DEF = re.compile(r"^([a-z_][a-z0-9_]*)\s*\(")
+RET_TYPE = re.compile(r"^((?:const\s+)?[A-Za-z_][A-Za-z0-9_]*(?:\s*\*+)?)\s*$")
+VALIDATE = re.compile(r"\bVALIDATE_[A-Z0-9_]+\s*\([^,]+,\s*([^)]+?)\s*\)")
+DOC_RETURN = re.compile(r"@return\s+On error return\s+(?:@p\s+)?([^\s,.]+)")
+
+
+def sentinel_for(rettype: str) -> str | None:
+    """Return the sentinel the given return type must use, if it has one."""
+    rettype = rettype.strip()
+    if POINTER.search(rettype):
+        return "NULL"
+    return EXPECTED.get(rettype.replace("const ", "").strip())
+
+
+def normalize(token: str) -> str:
+    """Return the canonical spelling of a sentinel token."""
+    token = token.strip().rstrip(";")
+    return ALIASES.get(token, token)
+
+
+def scan(path: Path, rel: str) -> list[str]:
+    """Return the sentinel findings of one source file."""
+    findings = []
+    lines = path.read_text().splitlines()
+    for i, line in enumerate(lines):
+        m = FUNC_DEF.match(line)
+        if not m or i == 0:
+            continue
+        rt = RET_TYPE.match(lines[i - 1].strip())
+        if not rt or lines[i - 1].strip().startswith("static"):
+            continue
+        name, rettype = m.group(1), rt.group(1)
+        want = sentinel_for(rettype)
+        if want == "INT_MAX" and PREDICATE.match(name):
+            want = "-1"
+        if want is None:
+            continue
+
+        # the doxygen block sits above the return type
+        doc = []
+        j = i - 2
+        while j >= 0 and not lines[j].lstrip().startswith("/**"):
+            doc.append(lines[j])
+            j -= 1
+            if i - j > 40:
+                break
+        documented = documented_raw = None
+        for dl in doc:
+            d = DOC_RETURN.search(dl)
+            if d:
+                documented_raw = d.group(1).strip().rstrip(";")
+                documented = normalize(d.group(1))
+                break
+
+        # the body runs to the first line that closes it at column 0
+        body = []
+        k = i + 1
+        while k < len(lines) and lines[k] != "}":
+            body.append(lines[k])
+            k += 1
+        validated = validated_raw = None
+        for bl in body:
+            v = VALIDATE.search(bl)
+            if v:
+                validated_raw = v.group(1).strip().rstrip(";")
+                validated = normalize(v.group(1))
+                break
+
+        for raw, where in ((validated_raw, "validates with"),
+                           (documented_raw, "documents")):
+            if raw in NON_PORTABLE:
+                findings.append(f"{rel}:{i + 1}: {name}() {where} {raw}, which "
+                                f"is 32 bits on LLP64 Windows: use INT64_MAX")
+
+        if validated is not None and validated != want:
+            findings.append(f"{rel}:{i + 1}: {name}() returns {rettype} but "
+                            f"validates with {validated}, expected {want}")
+        if documented is not None and documented != want:
+            findings.append(f"{rel}:{i + 1}: {name}() returns {rettype} but "
+                            f"documents {documented}, expected {want}")
+    return findings
+
+
+def collect(root: Path) -> list[str]:
+    """Return every sentinel finding under meos/src."""
+    findings = []
+    for path in sorted(root.glob("meos/src/**/*.c")):
+        findings.extend(scan(path, path.relative_to(root).as_posix()))
+    return sorted(findings)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rebaseline", action="store_true",
+                        help="write the current findings as the new baseline")
+    parser.add_argument("--report", action="store_true",
+                        help="print every finding, baselined ones included")
+    args = parser.parse_args()
+
+    findings = collect(REPO_ROOT)
+
+    if args.rebaseline:
+        header = ("# Findings of tools/scripts/check_error_sentinels.py that are\n"
+                  "# grandfathered in. The list only shrinks: a new mismatch\n"
+                  "# fails the check. Regenerate with --rebaseline after a fix.\n")
+        BASELINE_PATH.write_text(header + "\n".join(findings) + "\n")
+        print(f"wrote {len(findings)} findings to "
+              f"{BASELINE_PATH.relative_to(REPO_ROOT)}")
+        return 0
+
+    if args.report:
+        for line in findings:
+            print(line)
+        print(f"\n{len(findings)} sentinel mismatch(es)")
+        return 0
+
+    baseline = set()
+    if BASELINE_PATH.exists():
+        baseline = {ln for ln in BASELINE_PATH.read_text().splitlines()
+                    if ln and not ln.startswith("#")}
+
+    new = [ln for ln in findings if ln not in baseline]
+    if new:
+        print("An error sentinel must be the maximum of the return type "
+              "(int INT_MAX, int64 INT64_MAX, double DBL_MAX, pointer NULL):\n")
+        for line in new:
+            print(f"  {line}")
+        return 1
+
+    stale = sorted(baseline - set(findings))
+    if stale:
+        print(f"{len(stale)} baselined finding(s) are fixed. "
+              f"Run --rebaseline to shrink the baseline:\n")
+        for line in stale:
+            print(f"  {line}")
+        return 1
+
+    print(f"error-sentinels: clean ({len(baseline)} baselined).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/check_meos_only_files.py
+++ b/tools/scripts/check_meos_only_files.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: PostgreSQL
+#
+# BINDING-HEADER-PARSE-OK: this is a CI source guard under tools/scripts/,
+# not a binding generator. It scans meos/src/**.c and CMakeLists.txt for a
+# build-layout rule and extracts no API surface, exactly as its siblings
+# check_csqlfn.py and check_btree_gist_operators.py scan sources and SQL.
+#
+# Enforce the file-selection rule for MEOS-only code.
+#
+# Why
+# ---
+# `Datum` is a PostgreSQL type that no binding (PyMEOS, JMEOS, GoMEOS,
+# meos-rs, MEOS.NET, MEOS.js) can construct, so it appears only in
+# `meos_internal.h`. Every operation the PG extension implements
+# generically through a single Datum-taking function therefore needs
+# typed instantiations for the public MEOS surface, and those live in
+# `<module>_meos.c` files that CMake compiles only for the MEOS
+# library:
+#
+#   if(MEOS)
+#     list(APPEND <FAM>_SOURCES <module>_meos.c)
+#   endif()
+#
+# The selection is made by the FILE, never by a `#if MEOS` inside a C
+# file: a source that is compiled at all is compiled whole. Two ways
+# to break that, both of which this tool rejects:
+#
+#   * a `*_meos.c` that CMake compiles into the PG extension -- either
+#     because it is listed outside `if(MEOS)`, or because the PG side
+#     calls a function it defines. Content the extension needs is not
+#     MEOS-only and belongs in a file without the `_meos` suffix.
+#
+#   * a `#if MEOS` block at file scope in a shared source. The block
+#     holds the MEOS-only definitions of that module, so it belongs in
+#     the module's `_meos.c` file instead.
+#
+# The late-binding dispatchers are the one exception: they resolve a
+# type at run time over every family, so they carry `#if <FAMILY>`
+# conditionals by construction and are listed in EXEMPT_FILES.
+#
+# Blocks that sit INSIDE a function body are a different animal: they
+# select a PG-specific detail of a shared implementation (an aggregate
+# memory context, an allocation limit) rather than a whole definition,
+# so moving them would duplicate the function. They are reported for
+# the record but do not fail the check.
+#
+# Usage:
+#   python3 tools/scripts/check_meos_only_files.py              # check
+#   python3 tools/scripts/check_meos_only_files.py --report     # list all
+#   python3 tools/scripts/check_meos_only_files.py --rebaseline # regen
+#
+# Run from the repo root.
+"""Check that MEOS-only code is selected by file rather than by `#if MEOS`."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+BASELINE_PATH = REPO_ROOT / "tools" / "scripts" / "meos_only_files_baseline.txt"
+
+# The late-binding dispatchers, which need `#if <FAMILY>` by construction.
+# This exempts them from the conditional scan of THIS tool only; it neither
+# skips nor filters any public API function.  # SOURCE-GAP-ACK
+EXEMPT_FILES = {
+    "meos/src/temporal/type_in.c",
+    "meos/src/temporal/type_out.c",
+    "meos/src/temporal/type_util.c",
+}
+
+MEOS_IF = re.compile(r"^#if\s+!?\s*MEOS\b|^#ifn?def\s+MEOS\b")
+# A function definition in the house style: the return type sits on its own
+# line and the name starts at column 0
+FUNC_DEF = re.compile(r"^([a-z_][a-z0-9_]*)\s*\(")
+CMAKE_IF_MEOS = re.compile(r"^\s*if\s*\(\s*MEOS\s*\)")
+CMAKE_ELSE_ENDIF = re.compile(r"^\s*(else|elseif|endif)\s*\(")
+SOURCE_ENTRY = re.compile(r"([A-Za-z0-9_./]+\.c)\b")
+
+
+def strip_code(line: str) -> str:
+    """Return the line without string literals and line comments."""
+    return re.sub(r"//.*|\"(?:\\.|[^\"\\])*\"|'(?:\\.|[^'\\])'", "", line)
+
+
+def strip_comments(text: str) -> str:
+    """Return C source text without its comments.
+
+    A doxygen line such as `@sqlfn intset_in(), floatset_in()` names MEOS
+    functions without calling them, so the comments have to go before the
+    text is searched for callers.
+    """
+    return re.sub(r"/\*.*?\*/|//[^\n]*", "", text, flags=re.DOTALL)
+
+
+def ungated_meos_sources(root: Path) -> list[tuple[str, str]]:
+    """Return the (cmakelists, source) pairs listing a `_meos.c` outside if(MEOS)."""
+    found = []
+    for cml in sorted(root.glob("meos/src/**/CMakeLists.txt")):
+        gated = False
+        for raw in cml.read_text().splitlines():
+            line = raw.split("#", 1)[0]
+            if CMAKE_IF_MEOS.match(line):
+                gated = True
+                continue
+            if CMAKE_ELSE_ENDIF.match(line):
+                gated = False
+                continue
+            if gated:
+                continue
+            for src in SOURCE_ENTRY.findall(line):
+                if src.endswith("_meos.c"):
+                    found.append((cml.relative_to(root).as_posix(), src))
+    return found
+
+
+def meos_only_definitions(path: Path) -> list[str]:
+    """Return the names of the non-static functions defined in a `_meos.c`."""
+    names = []
+    lines = path.read_text().splitlines()
+    for i, line in enumerate(lines):
+        m = FUNC_DEF.match(line)
+        if not m or i == 0:
+            continue
+        prev = lines[i - 1].strip()
+        # the previous line is the return type; a `static` one is not exported
+        if not prev or prev.startswith("static") or prev.endswith((";", ",", "{")):
+            continue
+        if not re.match(r"^[A-Za-z_][A-Za-z0-9_ ]*\**$", prev):
+            continue
+        names.append(m.group(1))
+    return names
+
+
+def conditionals(path: Path) -> tuple[list[int], list[int]]:
+    """Return the (file-scope, in-function) line numbers of MEOS conditionals."""
+    top, inside, depth = [], [], 0
+    for n, line in enumerate(path.read_text().splitlines(), start=1):
+        if MEOS_IF.match(line):
+            (top if depth == 0 else inside).append(n)
+        code = strip_code(line)
+        depth = max(0, depth + code.count("{") - code.count("}"))
+    return top, inside
+
+
+def collect(root: Path) -> tuple[list[str], list[str]]:
+    """Return the (failing, informational) findings, each as one text line."""
+    fail, info = [], []
+
+    for cml, src in ungated_meos_sources(root):
+        fail.append(f"{cml}: {src} is compiled into the PG extension: "
+                    f"list it inside if(MEOS), or drop the _meos suffix")
+
+    # BINDING-HEADER-PARSE-OK: CI source guard, scans .c files for a build
+    # rule; no headers are read and no API surface is extracted
+    pg_sources = strip_comments("\n".join(
+        p.read_text() for p in sorted(root.glob("mobilitydb/src/**/*.c"))))
+    # A name that a shared source defines too has a PG counterpart -- the
+    # npoint family builds ways.c instead of ways_meos.c through the else()
+    # branch -- so a call from the extension resolves there, not here
+    shared = set()
+    for path in sorted(root.glob("meos/src/**/*.c")):
+        if not path.name.endswith("_meos.c"):
+            shared.update(meos_only_definitions(path))
+
+    for path in sorted(root.glob("meos/src/**/*_meos.c")):
+        rel = path.relative_to(root).as_posix()
+        for name in meos_only_definitions(path):
+            if name in shared:
+                continue
+            if re.search(rf"\b{re.escape(name)}\s*\(", pg_sources):
+                fail.append(f"{rel}: {name}() is called from mobilitydb/src: "
+                            f"the PG extension needs it, so it is not MEOS-only")
+        top, _ = conditionals(path)
+        for n in top:
+            fail.append(f"{rel}:{n}: MEOS conditional inside a MEOS-only file")
+
+    for path in sorted(root.glob("meos/src/**/*.c")):
+        rel = path.relative_to(root).as_posix()
+        if rel.endswith("_meos.c") or rel in EXEMPT_FILES:
+            continue
+        top, inside = conditionals(path)
+        for n in top:
+            fail.append(f"{rel}:{n}: file-scope MEOS conditional: "
+                        f"move the definition to the module's _meos.c")
+        for n in inside:
+            info.append(f"{rel}:{n}: MEOS conditional inside a function body")
+
+    return sorted(fail), sorted(info)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rebaseline", action="store_true",
+                        help="write the current findings as the new baseline")
+    parser.add_argument("--report", action="store_true",
+                        help="print every finding, baselined ones included")
+    args = parser.parse_args()
+
+    fail, info = collect(REPO_ROOT)
+
+    if args.rebaseline:
+        header = ("# Findings of tools/scripts/check_meos_only_files.py that are\n"
+                  "# grandfathered in. The list only shrinks: a new violation\n"
+                  "# fails the check. Regenerate with --rebaseline after a split.\n")
+        BASELINE_PATH.write_text(header + "\n".join(fail) + "\n")
+        print(f"wrote {len(fail)} findings to "
+              f"{BASELINE_PATH.relative_to(REPO_ROOT)}")
+        return 0
+
+    if args.report:
+        for line in fail:
+            print(f"split needed: {line}")
+        for line in info:
+            print(f"in-function : {line}")
+        print(f"\n{len(fail)} to split, {len(info)} in-function (informational)")
+        return 0
+
+    baseline = set()
+    if BASELINE_PATH.exists():
+        baseline = {ln for ln in BASELINE_PATH.read_text().splitlines()
+                    if ln and not ln.startswith("#")}
+
+    new = [ln for ln in fail if ln not in baseline]
+    if new:
+        print("MEOS-only code must be selected by file, not by #if MEOS:\n")
+        for line in new:
+            print(f"  {line}")
+        print(f"\n{len(new)} new violation(s). Move the definitions into the "
+              f"module's _meos.c (gated by if(MEOS) in CMake), or, when the PG "
+              f"extension needs them, into a file without the _meos suffix.")
+        return 1
+
+    stale = sorted(baseline - set(fail))
+    if stale:
+        print(f"{len(stale)} baselined finding(s) are fixed. "
+              f"Run --rebaseline to shrink the baseline:\n")
+        for line in stale:
+            print(f"  {line}")
+        return 1
+
+    print(f"meos-only-files: clean ({len(baseline)} baselined, "
+          f"{len(info)} in-function conditionals reported by --report).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/error_sentinels_baseline.txt
+++ b/tools/scripts/error_sentinels_baseline.txt
@@ -1,0 +1,173 @@
+# Findings of tools/scripts/check_error_sentinels.py that are
+# grandfathered in. The list only shrinks: a new mismatch
+# fails the check. Regenerate with --rebaseline after a fix.
+meos/src/cbuffer/cbuffer.c:1408: cbuffer_cmp() returns int but validates with false, expected INT_MAX
+meos/src/cbuffer/tcbuffer_spatialrels.c:147: spatialrel_geo_geo() returns int but documents -1, expected INT_MAX
+meos/src/geo/postgis_funcs.c:1490: geo_num_points() returns int but documents -1, expected INT_MAX
+meos/src/geo/postgis_funcs.c:1490: geo_num_points() returns int but validates with -1, expected INT_MAX
+meos/src/geo/postgis_funcs.c:1509: geo_num_geos() returns int but documents -1, expected INT_MAX
+meos/src/geo/postgis_funcs.c:1509: geo_num_geos() returns int but validates with -1, expected INT_MAX
+meos/src/geo/postgis_funcs.c:2578: geo_equals() returns int but validates with -1, expected INT_MAX
+meos/src/geo/postgis_funcs.c:4740: line_locate_point() returns double but documents -1, expected DBL_MAX
+meos/src/geo/postgis_funcs.c:4877: line_numpoints() returns int but documents -1, expected INT_MAX
+meos/src/geo/postgis_funcs.c:4877: line_numpoints() returns int but validates with -1, expected INT_MAX
+meos/src/geo/postgis_funcs.c:543: geo_is_empty() returns bool but validates with NULL, expected false
+meos/src/geo/stbox.c:2191: before_stbox_stbox() returns bool but validates with NULL, expected false
+meos/src/geo/stbox.c:2209: overbefore_stbox_stbox() returns bool but validates with NULL, expected false
+meos/src/geo/stbox.c:2226: after_stbox_stbox() returns bool but validates with NULL, expected false
+meos/src/geo/stbox.c:2244: overafter_stbox_stbox() returns bool but validates with NULL, expected false
+meos/src/geo/stbox.c:2499: stbox_cmp() returns int but validates with false, expected INT_MAX
+meos/src/geo/tgeo_compops.c:63: eacomp_tgeo_geo() returns int but validates with -1, expected INT_MAX
+meos/src/geo/tgeo_compops.c:81: eacomp_tgeo_tgeo() returns int but validates with -1, expected INT_MAX
+meos/src/geo/tgeo_distance.c:2970: stbox_spatial_distance() returns double but validates with false, expected DBL_MAX
+meos/src/geo/tgeo_spatialfuncs.c:1115: tgeominst_tgeoginst() returns TInstant * but documents `NULL`, expected NULL
+meos/src/geo/tgeo_spatialfuncs.c:1147: tgeomseq_tgeogseq() returns TSequence * but documents `NULL`, expected NULL
+meos/src/geo/tgeo_spatialfuncs.c:1175: tgeomseqset_tgeogseqset() returns TSequenceSet * but documents `NULL`, expected NULL
+meos/src/geo/tgeo_spatialfuncs.c:1205: tgeom_tgeog() returns Temporal * but documents `NULL`, expected NULL
+meos/src/geo/tgeo_spatialfuncs.c:1231: tgeometry_to_tgeography() returns Temporal * but documents `NULL`, expected NULL
+meos/src/geo/tgeo_spatialfuncs.c:1246: tgeography_to_tgeometry() returns Temporal * but documents `NULL`, expected NULL
+meos/src/geo/tgeo_spatialfuncs.c:1406: tgeo_tpoint() returns Temporal * but documents `NULL`, expected NULL
+meos/src/geo/tgeo_spatialfuncs.c:1752: tgeo_convex_hull() returns GSERIALIZED * but documents `NULL`, expected NULL
+meos/src/geo/tgeo_spatialrels.c:435: spatialrel_tgeo_tgeo() returns int but documents -1, expected INT_MAX
+meos/src/geo/tpoint_spatialfuncs.c:1422: tpoint_tfloat_to_geomeas() returns bool but validates with NULL, expected false
+meos/src/geo/tspatial_tempspatialrels.c:595: tspatialrel_tspatial_base() returns Temporal * but documents `NULL`, expected NULL
+meos/src/geo/tspatial_tempspatialrels.c:651: tspatialrel_tspatial_tspatial() returns Temporal * but documents `NULL`, expected NULL
+meos/src/npoint/npoint.c:1069: npoint_route() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/npoint/npoint.c:1098: nsegment_route() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/npoint/npoint.c:1207: npoint_cmp() returns int but validates with false, expected INT_MAX
+meos/src/npoint/npoint.c:1312: nsegment_cmp() returns int but validates with false, expected INT_MAX
+meos/src/npoint/tnpoint.c:833: tnpoint_route() returns int64 but documents INT_MAX, expected INT64_MAX
+meos/src/npoint/tnpoint_compops.c:57: eacomp_tnpoint_npoint() returns int but validates with -1, expected INT_MAX
+meos/src/npoint/tnpoint_compops.c:74: eacomp_tnpoint_tnpoint() returns int but validates with -1, expected INT_MAX
+meos/src/npoint/tnpoint_routeops.c:107: overlaps_rid_tnpoint_bigintset() returns bool but validates with NULL, expected false
+meos/src/npoint/tnpoint_routeops.c:123: contains_rid_tnpoint_bigintset() returns bool but validates with NULL, expected false
+meos/src/npoint/tnpoint_routeops.c:151: same_rid_tnpoint_bigintset() returns bool but validates with NULL, expected false
+meos/src/npoint/tnpoint_routeops.c:61: contains_rid_tnpoint_bigint() returns bool but validates with NULL, expected false
+meos/src/npoint/tnpoint_routeops.c:88: same_rid_tnpoint_bigint() returns bool but validates with NULL, expected false
+meos/src/npoint/tnpoint_spatialfuncs.c:203: npoint_same() returns bool but validates with NULL, expected false
+meos/src/pointcloud/pcpatch.c:331: pcpatch_cmp() returns int but validates with false, expected INT_MAX
+meos/src/pointcloud/pcpoint.c:366: pcpoint_cmp() returns int but validates with false, expected INT_MAX
+meos/src/pointcloud/tpcbox.c:1047: tpcbox_cmp() returns int but validates with false, expected INT_MAX
+meos/src/pose/pose.c:1863: pose_eq() returns bool but validates with NULL, expected false
+meos/src/pose/pose.c:1905: pose_same() returns bool but validates with NULL, expected false
+meos/src/pose/pose.c:1947: pose_cmp() returns int but validates with false, expected INT_MAX
+meos/src/raster/raquet.c:666: raquet_width() returns int but validates with -1, expected INT_MAX
+meos/src/raster/raquet.c:679: raquet_height() returns int but validates with -1, expected INT_MAX
+meos/src/raster/raquet.c:692: raquet_nodata() returns double but validates with 0.0, expected DBL_MAX
+meos/src/raster/raquet.c:802: raquet_cmp() returns int but validates with false, expected INT_MAX
+meos/src/raster/raquet_gdal.c:510: eraster_value_gdal() returns int but validates with -1, expected INT_MAX
+meos/src/raster/raquet_gdal.c:540: araster_value_gdal() returns int but validates with -1, expected INT_MAX
+meos/src/raster/raster_quadbin.c:583: eraster_value() returns int but validates with -1, expected INT_MAX
+meos/src/raster/raster_quadbin.c:616: araster_value() returns int but validates with -1, expected INT_MAX
+meos/src/raster/raster_rtcore.c:235: raster_num_bands() returns int but validates with -1, expected INT_MAX
+meos/src/rgeo/trgeo_spatialrels.c:72: spatialrel_trgeo_trav_geo() returns int but documents -1, expected INT_MAX
+meos/src/temporal/set.c:672: set_mem_size() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/set.c:686: set_num_values() returns int but documents -1, expected INT_MAX
+meos/src/temporal/set.c:686: set_num_values() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/set_meos.c:469: bigintset_start_value() returns int64 but documents INT_MAX, expected INT64_MAX
+meos/src/temporal/set_meos.c:469: bigintset_start_value() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/set_meos.c:561: bigintset_end_value() returns int64 but documents INT_MAX, expected INT64_MAX
+meos/src/temporal/set_meos.c:561: bigintset_end_value() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/set_ops.c:186: contains_set_value() returns bool but validates with NULL, expected false
+meos/src/temporal/set_ops_meos.c:1538: distance_set_int() returns int but documents -1, expected INT_MAX
+meos/src/temporal/set_ops_meos.c:1538: distance_set_int() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/set_ops_meos.c:1554: distance_set_bigint() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/set_ops_meos.c:1554: distance_set_bigint() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/set_ops_meos.c:1586: distance_set_date() returns int but documents -1, expected INT_MAX
+meos/src/temporal/set_ops_meos.c:1586: distance_set_date() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/set_ops_meos.c:1620: distance_intset_intset() returns int but documents -1, expected INT_MAX
+meos/src/temporal/set_ops_meos.c:1636: distance_bigintset_bigintset() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/set_ops_meos.c:1668: distance_dateset_dateset() returns int but documents -1, expected INT_MAX
+meos/src/temporal/span.c:1467: timestamptz_shift() returns TimestampTz but documents `DT_NOEND`, expected DT_NOEND
+meos/src/temporal/span_meos.c:410: bigintspan_lower() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/span_meos.c:410: bigintspan_lower() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/span_meos.c:487: bigintspan_upper() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/span_meos.c:487: bigintspan_upper() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/span_meos.c:577: intspan_width() returns int but documents -1, expected INT_MAX
+meos/src/temporal/span_meos.c:577: intspan_width() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/span_meos.c:592: bigintspan_width() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/span_meos.c:592: bigintspan_width() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/span_ops_meos.c:1361: distance_span_int() returns int but documents -1, expected INT_MAX
+meos/src/temporal/span_ops_meos.c:1361: distance_span_int() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/span_ops_meos.c:1377: distance_span_bigint() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/span_ops_meos.c:1377: distance_span_bigint() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/span_ops_meos.c:1409: distance_span_date() returns int but documents -1, expected INT_MAX
+meos/src/temporal/span_ops_meos.c:1409: distance_span_date() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/span_ops_meos.c:1443: distance_intspan_intspan() returns int but documents -1, expected INT_MAX
+meos/src/temporal/span_ops_meos.c:1443: distance_intspan_intspan() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/span_ops_meos.c:1458: distance_bigintspan_bigintspan() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/span_ops_meos.c:1458: distance_bigintspan_bigintspan() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/span_ops_meos.c:1488: distance_datespan_datespan() returns int but documents -1, expected INT_MAX
+meos/src/temporal/span_ops_meos.c:1488: distance_datespan_datespan() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset.c:519: spanset_mem_size() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset.c:519: spanset_mem_size() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset.c:574: spanset_lower_inc() returns bool but validates with NULL, expected false
+meos/src/temporal/spanset.c:588: spanset_upper_inc() returns bool but validates with NULL, expected false
+meos/src/temporal/spanset.c:690: datespanset_num_dates() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset.c:690: datespanset_num_dates() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset.c:788: tstzspanset_num_timestamps() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset.c:788: tstzspanset_num_timestamps() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset.c:948: spanset_num_spans() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset.c:948: spanset_num_spans() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset_meos.c:382: bigintspanset_lower() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/spanset_meos.c:382: bigintspanset_lower() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/spanset_meos.c:459: bigintspanset_upper() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/spanset_meos.c:459: bigintspanset_upper() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/spanset_meos.c:522: intspanset_width() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset_meos.c:522: intspanset_width() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset_meos.c:538: bigintspanset_width() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/spanset_meos.c:538: bigintspanset_width() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/spanset_ops.c:697: overright_spanset_value() returns bool but validates with NULL, expected false
+meos/src/temporal/spanset_ops.c:80: contains_spanset_timestamptz() returns bool but validates with NULL, expected false
+meos/src/temporal/spanset_ops_meos.c:1280: distance_spanset_int() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1280: distance_spanset_int() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1296: distance_spanset_bigint() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/spanset_ops_meos.c:1296: distance_spanset_bigint() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/spanset_ops_meos.c:1329: distance_spanset_date() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1329: distance_spanset_date() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1363: distance_intspanset_intspan() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1363: distance_intspanset_intspan() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1379: distance_bigintspanset_bigintspan() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/spanset_ops_meos.c:1379: distance_bigintspanset_bigintspan() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/spanset_ops_meos.c:1411: distance_datespanset_datespan() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1411: distance_datespanset_datespan() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1445: distance_intspanset_intspanset() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1445: distance_intspanset_intspanset() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1460: distance_bigintspanset_bigintspanset() returns int64 but documents -1, expected INT64_MAX
+meos/src/temporal/spanset_ops_meos.c:1460: distance_bigintspanset_bigintspanset() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/spanset_ops_meos.c:1490: distance_datespanset_datespanset() returns int but documents -1, expected INT_MAX
+meos/src/temporal/spanset_ops_meos.c:1490: distance_datespanset_datespanset() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/tbox.c:170: tbox_make() returns TBox * but documents `NULL`, expected NULL
+meos/src/temporal/temporal.c:2283: temporal_value_n() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal.c:2442: temporal_num_sequences() returns int but documents -1, expected INT_MAX
+meos/src/temporal/temporal.c:2442: temporal_num_sequences() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/temporal.c:2667: temporal_num_instants() returns int but documents -1, expected INT_MAX
+meos/src/temporal/temporal.c:2667: temporal_num_instants() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/temporal.c:2875: temporal_num_timestamps() returns int but documents -1, expected INT_MAX
+meos/src/temporal/temporal.c:2875: temporal_num_timestamps() returns int but validates with -1, expected INT_MAX
+meos/src/temporal/temporal.c:2953: temporal_timestamptz_n() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_analytics.c:1773: temporal_hausdorff_distance() returns double but documents `DBL_MAX`, expected DBL_MAX
+meos/src/temporal/temporal_boxops_meos.c:101: contains_temporal_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:119: contained_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:135: contained_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:150: contained_temporal_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:168: overlaps_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:184: overlaps_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:198: overlaps_temporal_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:216: same_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:232: same_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:246: same_temporal_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:264: adjacent_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:280: adjacent_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:294: adjacent_temporal_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:70: contains_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_boxops_meos.c:86: contains_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_posops_meos.c:105: overafter_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_posops_meos.c:123: before_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_posops_meos.c:138: overbefore_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_posops_meos.c:153: after_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_posops_meos.c:168: overafter_temporal_tstzspan() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_posops_meos.c:60: before_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_posops_meos.c:75: overbefore_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_posops_meos.c:90: after_tstzspan_temporal() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal_tile.c:127: bigint_get_bin() returns int64 but documents INT_MAX, expected INT64_MAX

--- a/tools/scripts/meos_only_files_baseline.txt
+++ b/tools/scripts/meos_only_files_baseline.txt
@@ -1,0 +1,74 @@
+# Findings of tools/scripts/check_meos_only_files.py that are
+# grandfathered in. The list only shrinks: a new violation
+# fails the check. Regenerate with --rebaseline after a split.
+meos/src/geo/postgis_funcs.c:66: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/geo/tgeo_spatialfuncs.c:790: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/geo/tspatial.c:353: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/geo/tspatial_transform_meos.c:213: MEOS conditional inside a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c:236: MEOS conditional inside a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c:30: MEOS conditional inside a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c:36: MEOS conditional inside a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c:653: MEOS conditional inside a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c:676: MEOS conditional inside a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c:97: MEOS conditional inside a MEOS-only file
+meos/src/h3/h3index.c:106: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:120: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:558: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:643: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:753: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:771: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:789: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:808: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:826: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:845: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:864: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:888: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index.c:92: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:111: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:153: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:201: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:242: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:278: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:315: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:365: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:394: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/h3/h3index_sets.c:427: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/json/jsonbset.c:353: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/npoint/npoint.c:48: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/pointcloud/schema_hook.c:18: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/quadbin/CMakeLists.txt: quadbinset_meos.c is compiled into the PG extension: list it inside if(MEOS), or drop the _meos suffix
+meos/src/quadbin/quadbinset_meos.c: quadbin_cell_to_children_set() is called from mobilitydb/src: the PG extension needs it, so it is not MEOS-only
+meos/src/quadbin/quadbinset_meos.c: quadbin_grid_disk() is called from mobilitydb/src: the PG extension needs it, so it is not MEOS-only
+meos/src/temporal/doublen.c:131: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/doublen.c:202: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/doublen.c:63: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/error.c:153: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/error.c:226: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/error.c:42: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/error.c:68: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos.c:137: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos.c:186: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos.c:215: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos.c:82: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos_catalog.c:1083: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos_catalog.c:1285: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos_catalog.c:1331: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos_catalog.c:1402: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos_catalog.c:811: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos_catalog.c:869: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/meos_catalog.c:904: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/set.c:804: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/skiplist.c:186: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/skiplist.c:413: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/skiplist.c:49: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/skiplist.c:575: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/skiplist.c:60: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/skiplist.c:762: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/spanset.c:1068: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/temporal.c:1643: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/temporal.c:284: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/temporal.c:343: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/temporal_aggfuncs.c:62: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/temporal_boxops.c:695: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/tsequence.c:1253: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/temporal/tsequenceset.c:1400: file-scope MEOS conditional: move the definition to the module's _meos.c


### PR DESCRIPTION
Two checks in the shape of the one for the `meos_error` return-or-not contract: a ratchet over a baseline of the current findings, so a new violation fails the build and the baseline only shrinks.

`check_meos_only_files.py` — the typed functions that hide `Datum` from the bindings live in `<module>_meos.c` files that CMake compiles only for the MEOS library, so a source that is compiled at all is compiled whole. It rejects a `_meos.c` that the extension compiles or calls into, and a file-scope `#if MEOS` block in a shared source, which holds definitions belonging in the module `_meos.c` file. The late-binding dispatchers `type_in.c`, `type_out.c` and `type_util.c` are the exception, as they need their `#if <FAMILY>` conditionals by construction. It grandfathers 71 findings and reports 30 more conditionals that sit inside a function body, which select a PostgreSQL-specific detail of a shared implementation rather than a whole definition.

`check_error_sentinels.py` — a function that cannot compute its result reports the failure through `meos_error()` and returns a sentinel, and every binding derives its null guard from it, so the guard has to be a pure function of the C return type: `INT_MAX` for `int`, `INT64_MAX` for `int64`, `DBL_MAX` for `double`, `NULL` for a pointer, `false` for a boolean, `DATEVAL_NOEND` and `DT_NOEND` for the two time types. The relationship predicates are the documented exception, as -1 is the unknown of their three-valued logic. It compares the return type of each function with the sentinel of its `VALIDATE_` guard and with the one its documentation states, and rejects `LONG_MAX`, which is 32 bits on the LLP64 Windows builds. It grandfathers 170 findings, among them comparison functions that answer "equal" and a spatial distance that answers zero when their arguments are invalid.