### PR TITLE
Name the wrapper the value-first set and span-set operations register

### DIFF
--- a/meos/src/cbuffer/cbufferset_meos.c
+++ b/meos/src/cbuffer/cbufferset_meos.c
@@ -237,9 +237,9 @@ union_set_cbuffer(const Set *s, const Cbuffer *cb)
 /**
  * @ingroup meos_cbuffer_set_setops
  * @brief Return the union of a circular buffer and a set
- * @param[in] s Set
  * @param[in] cb Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_cbuffer_set(const Cbuffer *cb, const Set *s)
@@ -266,9 +266,9 @@ intersection_set_cbuffer(const Set *s, const Cbuffer *cb)
 /**
  * @ingroup meos_cbuffer_set_setops
  * @brief Return the intersection of a circular buffer and a set
- * @param[in] s Set
  * @param[in] cb Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_cbuffer_set(const Cbuffer *cb, const Set *s)

--- a/meos/src/geo/geoset_meos.c
+++ b/meos/src/geo/geoset_meos.c
@@ -299,9 +299,9 @@ union_set_geo(const Set *s, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_set_setops
  * @brief Return the union of a geometry/geography and a set
- * @param[in] s Set
  * @param[in] gs Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_geo_set(const GSERIALIZED *gs, const Set *s)
@@ -328,9 +328,9 @@ intersection_set_geo(const Set *s, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_set_setops
  * @brief Return the intersection of a geometry/geography and a set
- * @param[in] s Set
  * @param[in] gs Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_geo_set(const GSERIALIZED *gs, const Set *s)

--- a/meos/src/json/jsonbset.c
+++ b/meos/src/json/jsonbset.c
@@ -282,6 +282,7 @@ union_set_jsonb(const Set *s, const Jsonb *jb)
  * @brief Return the union of a JSONB value and a set
  * @param[in] jb Value
  * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_jsonb_set(const Jsonb *jb, const Set *s)
@@ -309,6 +310,7 @@ intersection_set_jsonb(const Set *s, const Jsonb *jb)
  * @brief Return the intersection of a JSONB value and a set
  * @param[in] jb Value
  * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_jsonb_set(const Jsonb *jb, const Set *s)

--- a/meos/src/npoint/npointset_meos.c
+++ b/meos/src/npoint/npointset_meos.c
@@ -268,9 +268,9 @@ union_set_npoint(const Set *s, const Npoint *np)
 /**
  * @ingroup meos_npoint_set_setops
  * @brief Return the union of a network point and a set
- * @param[in] s Set
  * @param[in] np Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_npoint_set(const Npoint *np, const Set *s)
@@ -297,9 +297,9 @@ intersection_set_npoint(const Set *s, const Npoint *np)
 /**
  * @ingroup meos_npoint_set_setops
  * @brief Return the intersection of a network point and a set
- * @param[in] s Set
  * @param[in] np Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_npoint_set(const Npoint *np, const Set *s)

--- a/meos/src/pose/poseset_meos.c
+++ b/meos/src/pose/poseset_meos.c
@@ -279,9 +279,9 @@ union_set_pose(const Set *s, const Pose *pose)
 /**
  * @ingroup meos_pose_set_setops
  * @brief Return the union of a pose and a set
- * @param[in] s Set
  * @param[in] pose Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_pose_set(const Pose *pose, const Set *s)
@@ -308,9 +308,9 @@ intersection_set_pose(const Set *s, const Pose *pose)
 /**
  * @ingroup meos_pose_set_setops
  * @brief Return the intersection of a pose and a set
- * @param[in] s Set
  * @param[in] pose Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_pose_set(const Pose *pose, const Set *s)

--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -1085,9 +1085,9 @@ union_set_timestamptz(const Set *s, const TimestampTz t)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the union of an integer and a set
- * @param[in] s Set
  * @param[in] i Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_int_set(int i, const Set *s)
@@ -1098,9 +1098,9 @@ union_int_set(int i, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the union of a big integer and a set
- * @param[in] s Set
  * @param[in] i Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_bigint_set(int64 i, const Set *s)
@@ -1111,9 +1111,9 @@ union_bigint_set(int64 i, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the union of a float and a set
- * @param[in] s Set
  * @param[in] d Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_float_set(double d, const Set *s)
@@ -1124,9 +1124,9 @@ union_float_set(double d, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the union of a text and a set
- * @param[in] s Set
  * @param[in] txt Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_text_set(const text *txt, const Set *s)
@@ -1137,9 +1137,9 @@ union_text_set(const text *txt, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the union of a date and a set
- * @param[in] s Set
  * @param[in] d Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_date_set(const DateADT d, const Set *s)
@@ -1150,9 +1150,9 @@ union_date_set(const DateADT d, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the union of a timestamptz and a set
- * @param[in] s Set
  * @param[in] t Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_timestamptz_set(const TimestampTz t, const Set *s)
@@ -1259,9 +1259,9 @@ intersection_set_timestamptz(const Set *s, TimestampTz t)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the intersection of an integer and a set
- * @param[in] s Set
  * @param[in] i Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_int_set(int i, const Set *s)
@@ -1272,9 +1272,9 @@ intersection_int_set(int i, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the intersection of a big integer and a set
- * @param[in] s Set
  * @param[in] i Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_bigint_set(int64 i, const Set *s)
@@ -1285,9 +1285,9 @@ intersection_bigint_set(int64 i, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the intersection of a float and a set
- * @param[in] s Set
  * @param[in] d Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_float_set(double d, const Set *s)
@@ -1298,9 +1298,9 @@ intersection_float_set(double d, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the intersection of a text and a set
- * @param[in] s Set
  * @param[in] txt Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_text_set(const text *txt, const Set *s)
@@ -1311,9 +1311,9 @@ intersection_text_set(const text *txt, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the intersection of a date and a set
- * @param[in] s Set
  * @param[in] d Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_date_set(const DateADT d, const Set *s)
@@ -1324,9 +1324,9 @@ intersection_date_set(const DateADT d, const Set *s)
 /**
  * @ingroup meos_setspan_set
  * @brief Return the intersection of a timestamptz and a set
- * @param[in] s Set
  * @param[in] t Value
- * @csqlfn #Union_set_value()
+ * @param[in] s Set
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_timestamptz_set(const TimestampTz t, const Set *s)

--- a/meos/src/temporal/spanset_ops_meos.c
+++ b/meos/src/temporal/spanset_ops_meos.c
@@ -880,10 +880,10 @@ overafter_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
 
 /**
  * @ingroup meos_setspan_set
- * @brief Return the union of a span set and an integer
- * @param[in] ss Span set
+ * @brief Return the union of an integer and a span set
  * @param[in] i Value
- * @csqlfn #Union_spanset_value()
+ * @param[in] ss Span set
+ * @csqlfn #Union_value_spanset()
  */
 SpanSet *
 union_int_spanset(int i, SpanSet *ss)
@@ -895,10 +895,10 @@ union_int_spanset(int i, SpanSet *ss)
 
 /**
  * @ingroup meos_setspan_set
- * @brief Return the union of a span set and a big integer
- * @param[in] ss Span set
+ * @brief Return the union of a big integer and a span set
  * @param[in] i Value
- * @csqlfn #Union_spanset_value()
+ * @param[in] ss Span set
+ * @csqlfn #Union_value_spanset()
  */
 SpanSet *
 union_bigint_spanset(int64 i, SpanSet *ss)
@@ -910,10 +910,10 @@ union_bigint_spanset(int64 i, SpanSet *ss)
 
 /**
  * @ingroup meos_setspan_set
- * @brief Return the union of a span set and a float
- * @param[in] ss Span set
+ * @brief Return the union of a float and a span set
  * @param[in] d Value
- * @csqlfn #Union_spanset_value()
+ * @param[in] ss Span set
+ * @csqlfn #Union_value_spanset()
  */
 SpanSet *
 union_float_spanset(double d, SpanSet *ss)
@@ -925,10 +925,10 @@ union_float_spanset(double d, SpanSet *ss)
 
 /**
  * @ingroup meos_setspan_set
- * @brief Return the union of a span set and a date
- * @param[in] ss Span set
+ * @brief Return the union of a date and a span set
  * @param[in] d Value
- * @csqlfn #Union_spanset_value()
+ * @param[in] ss Span set
+ * @csqlfn #Union_value_spanset()
  */
 SpanSet *
 union_date_spanset(DateADT d, SpanSet *ss)
@@ -940,10 +940,10 @@ union_date_spanset(DateADT d, SpanSet *ss)
 
 /**
  * @ingroup meos_setspan_set
- * @brief Return the union of a span set and a timestamptz
- * @param[in] ss Span set
+ * @brief Return the union of a timestamptz and a span set
  * @param[in] t Value
- * @csqlfn #Union_spanset_value()
+ * @param[in] ss Span set
+ * @csqlfn #Union_value_spanset()
  */
 SpanSet *
 union_timestamptz_spanset(TimestampTz t, SpanSet *ss)


### PR DESCRIPTION
`union_int_set(int i, const Set *s)` takes its value first and delegates to
`union_set_int(s, i)`, which takes it second. Each order is a separate
PostgreSQL wrapper:

```sql
CREATE FUNCTION setUnion(integer, intset) ... 'Union_value_set'
CREATE FUNCTION setUnion(intset, integer) ... 'Union_set_value'
```

Every value-first set and span-set union and intersection named the *set-first*
wrapper, so the catalog gave them the reversed signature — `union_int_set`
published as `setUnion(intset, integer)`.

The intersection functions had a second defect on top of it. They named
`Union_set_value`, a wrapper for a different operation, so `intersection_int_set`
was published under `setUnion`. Anything projecting the catalog would have wired
intersection's body to union's overloads.

Two more in the same blocks: `union_jsonb_set` and `intersection_jsonb_set`
carried no `@csqlfn` at all, and the `@param` order (and, for the span sets, the
`@brief`) described the delegate rather than the function — `union_int_spanset`
reads "the union of a span set and an integer" while taking `(int, SpanSet *)`.

This is the convention these same files already follow a few functions earlier:
`contained_int_set` names `#Contained_value_set()`, `left_int_span` names
`#Left_value_span()`, and `union_int_span` — the span sibling of the very
function being fixed — already names `#Union_value_span()`.

### Measured

Deriving the catalog from master `6bfc894703` and from this branch, same
MEOS-API commit both sides:

- 5538 functions, unchanged; 27 change, and nothing outside `union_*` /
  `intersection_*` moves
- **10 functions move from `setUnion` to `setIntersection`** — the six numeric
  and text set intersections plus geo, cbuffer, npoint and pose
- 15 keep their SQL name and take their own argument order:
  `union_int_set` goes from `setUnion(intset, integer)` to
  `setUnion(integer, intset)`, `union_int_spanset` from
  `spansetUnion(intspanset, integer)` to `spansetUnion(integer, intspanset)`
- `union_jsonb_set` and `intersection_jsonb_set` gain their first name and
  signature — `setUnion(jsonb, jsonbset)` and `setIntersection(jsonb, jsonbset)`

`tools/scripts/check_csqlfn.py --gaps` reports 0 auto-resolvable gaps on both
sides, and its needs-review count falls 680 → 678 — the two JSONB tags.

### Left out

`union_pcpoint_set`, `union_pcpatch_set`, `intersection_pcpoint_set` and
`intersection_pcpatch_set` have exactly the same defect. Pointcloud work is
reserved to its own session, so they are reported here rather than fixed.

There is a wider version of this: 79 PostgreSQL wrappers that carry an `@sqlfn`
are the argument-swap of a wrapper some MEOS function claims, yet no MEOS
function claims them — 171 SQL overloads, `NAD_stbox_tgeo` among them. Some, like
these, are a tag naming the wrong twin; the rest have no MEOS symbol at all and
want the one-line swap wrapper the spatial-relationship grid already uses. This
change is the first slice.
