### PR TITLE
Consume the visited-pixel counter of the raster summary statistics

### DIFF
--- a/postgis/rt_core/rt_statistics.c
+++ b/postgis/rt_core/rt_statistics.c
@@ -339,6 +339,7 @@ rt_band_get_summary_stats(
 			z++;
 		}
 	}
+	(void) j; /* MEOS */
 
 	RASTER_DEBUG(3, "sampling complete");
 


### PR DESCRIPTION
Casts the visited-pixel counter of the raster summary statistics to void so the vendored rt_core compiles warning-free under the standard warning flags. The sampling loop keeps two counters: k counts the pixels that enter the statistics, while j counts every pixel the sampler visits, including the ones a nodata test or a failed read rejects; nothing reads j afterwards, so GCC reports rt_statistics.c:133 as a variable set but not used. The cast is the idiom the neighbouring vendored files already use, and it keeps the counter available to a reader of the sampling logic. The warning needs RASTER, which -DALL=ON turns on, so a default build never reports it; on a Fedora 44 container with GCC 16.1.1 the librtcore target goes from one warning to none with rt_statistics.c recompiled in both builds, and a full -DALL=ON build of the tree then reports no compiler warnings at all.
