### PR TITLE
Shrink the error sentinel and MEOS-only baselines to the findings that remain

### DIFF
--- a/tools/scripts/error_sentinels_baseline.txt
+++ b/tools/scripts/error_sentinels_baseline.txt
@@ -69,15 +69,6 @@ meos/src/temporal/set_meos.c:469: bigintset_start_value() validates with LONG_MA
 meos/src/temporal/set_meos.c:561: bigintset_end_value() returns int64 but documents INT_MAX, expected INT64_MAX
 meos/src/temporal/set_meos.c:561: bigintset_end_value() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
 meos/src/temporal/set_ops.c:186: contains_set_value() returns bool but validates with NULL, expected false
-meos/src/temporal/set_ops_meos.c:1538: distance_set_int() returns int but documents -1, expected INT_MAX
-meos/src/temporal/set_ops_meos.c:1538: distance_set_int() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/set_ops_meos.c:1554: distance_set_bigint() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/set_ops_meos.c:1554: distance_set_bigint() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/set_ops_meos.c:1586: distance_set_date() returns int but documents -1, expected INT_MAX
-meos/src/temporal/set_ops_meos.c:1586: distance_set_date() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/set_ops_meos.c:1620: distance_intset_intset() returns int but documents -1, expected INT_MAX
-meos/src/temporal/set_ops_meos.c:1636: distance_bigintset_bigintset() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/set_ops_meos.c:1668: distance_dateset_dateset() returns int but documents -1, expected INT_MAX
 meos/src/temporal/span.c:1467: timestamptz_shift() returns TimestampTz but documents `DT_NOEND`, expected DT_NOEND
 meos/src/temporal/span_meos.c:410: bigintspan_lower() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
 meos/src/temporal/span_meos.c:410: bigintspan_lower() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
@@ -87,18 +78,6 @@ meos/src/temporal/span_meos.c:577: intspan_width() returns int but documents -1,
 meos/src/temporal/span_meos.c:577: intspan_width() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/span_meos.c:592: bigintspan_width() returns int64 but documents -1, expected INT64_MAX
 meos/src/temporal/span_meos.c:592: bigintspan_width() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/span_ops_meos.c:1361: distance_span_int() returns int but documents -1, expected INT_MAX
-meos/src/temporal/span_ops_meos.c:1361: distance_span_int() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/span_ops_meos.c:1377: distance_span_bigint() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/span_ops_meos.c:1377: distance_span_bigint() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/span_ops_meos.c:1409: distance_span_date() returns int but documents -1, expected INT_MAX
-meos/src/temporal/span_ops_meos.c:1409: distance_span_date() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/span_ops_meos.c:1443: distance_intspan_intspan() returns int but documents -1, expected INT_MAX
-meos/src/temporal/span_ops_meos.c:1443: distance_intspan_intspan() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/span_ops_meos.c:1458: distance_bigintspan_bigintspan() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/span_ops_meos.c:1458: distance_bigintspan_bigintspan() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/span_ops_meos.c:1488: distance_datespan_datespan() returns int but documents -1, expected INT_MAX
-meos/src/temporal/span_ops_meos.c:1488: distance_datespan_datespan() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/spanset.c:519: spanset_mem_size() returns int but documents -1, expected INT_MAX
 meos/src/temporal/spanset.c:519: spanset_mem_size() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/spanset.c:574: spanset_lower_inc() returns bool but validates with NULL, expected false
@@ -119,24 +98,6 @@ meos/src/temporal/spanset_meos.c:538: bigintspanset_width() returns int64 but do
 meos/src/temporal/spanset_meos.c:538: bigintspanset_width() returns int64 but validates with -1, expected INT64_MAX
 meos/src/temporal/spanset_ops.c:697: overright_spanset_value() returns bool but validates with NULL, expected false
 meos/src/temporal/spanset_ops.c:80: contains_spanset_timestamptz() returns bool but validates with NULL, expected false
-meos/src/temporal/spanset_ops_meos.c:1280: distance_spanset_int() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1280: distance_spanset_int() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1296: distance_spanset_bigint() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/spanset_ops_meos.c:1296: distance_spanset_bigint() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/spanset_ops_meos.c:1329: distance_spanset_date() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1329: distance_spanset_date() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1363: distance_intspanset_intspan() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1363: distance_intspanset_intspan() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1379: distance_bigintspanset_bigintspan() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/spanset_ops_meos.c:1379: distance_bigintspanset_bigintspan() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/spanset_ops_meos.c:1411: distance_datespanset_datespan() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1411: distance_datespanset_datespan() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1445: distance_intspanset_intspanset() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1445: distance_intspanset_intspanset() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1460: distance_bigintspanset_bigintspanset() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/spanset_ops_meos.c:1460: distance_bigintspanset_bigintspanset() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/spanset_ops_meos.c:1490: distance_datespanset_datespanset() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset_ops_meos.c:1490: distance_datespanset_datespanset() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/tbox.c:170: tbox_make() returns TBox * but documents `NULL`, expected NULL
 meos/src/temporal/temporal.c:2283: temporal_value_n() returns bool but validates with NULL, expected false
 meos/src/temporal/temporal.c:2442: temporal_num_sequences() returns int but documents -1, expected INT_MAX

--- a/tools/scripts/meos_only_files_baseline.txt
+++ b/tools/scripts/meos_only_files_baseline.txt
@@ -36,9 +36,6 @@ meos/src/h3/h3index_sets.c:427: file-scope MEOS conditional: move the definition
 meos/src/json/jsonbset.c:353: file-scope MEOS conditional: move the definition to the module's _meos.c
 meos/src/npoint/npoint.c:48: file-scope MEOS conditional: move the definition to the module's _meos.c
 meos/src/pointcloud/schema_hook.c:18: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/quadbin/CMakeLists.txt: quadbinset_meos.c is compiled into the PG extension: list it inside if(MEOS), or drop the _meos suffix
-meos/src/quadbin/quadbinset_meos.c: quadbin_cell_to_children_set() is called from mobilitydb/src: the PG extension needs it, so it is not MEOS-only
-meos/src/quadbin/quadbinset_meos.c: quadbin_grid_disk() is called from mobilitydb/src: the PG extension needs it, so it is not MEOS-only
 meos/src/temporal/doublen.c:131: file-scope MEOS conditional: move the definition to the module's _meos.c
 meos/src/temporal/doublen.c:202: file-scope MEOS conditional: move the definition to the module's _meos.c
 meos/src/temporal/doublen.c:63: file-scope MEOS conditional: move the definition to the module's _meos.c


### PR DESCRIPTION
The error sentinel and MEOS-only baselines list 42 findings the code does not produce. Each checker fails on a baselined finding that is fixed, so that the baseline shrinks as the code improves rather than drifting into a list of claims about nothing, and both jobs therefore fail on every branch, master included.

`check_error_sentinels.py` reports 39 such entries: the int, int64 and date variants of the span, span set and set distance functions, which return the maximum of their return type. `check_meos_only_files.py` reports 3: the quadbin set functions the PG extension calls.

Regenerating both files with the `--rebaseline` flag each checker documents removes those entries and adds none, and both checkers report clean, at 131 and 68 baselined findings.