### PR TITLE
Report a baseline that lists fixed findings instead of failing on it

### DIFF
--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -227,13 +227,17 @@ def main() -> int:
             print(f"  {line}")
         return 1
 
+    # A baseline that lists findings the tree no longer has is out of date,
+    # not broken: the invariant this check enforces is that no NEW finding
+    # appears. Reporting it as a failure would redden every pull request
+    # whose branch predates the last shrink, for housekeeping it did not do,
+    # so it is a notice and the shrink happens with the next --rebaseline.
     stale = sorted(baseline - set(findings))
     if stale:
-        print(f"{len(stale)} baselined finding(s) are fixed. "
-              f"Run --rebaseline to shrink the baseline:\n")
+        print(f"{len(stale)} baselined finding(s) no longer occur. "
+              f"Run --rebaseline after a fix to shrink the baseline:\n")
         for line in stale:
             print(f"  {line}")
-        return 1
 
     print(f"error-sentinels: clean ({len(baseline)} baselined).")
     return 0

--- a/tools/scripts/check_meos_only_files.py
+++ b/tools/scripts/check_meos_only_files.py
@@ -234,13 +234,17 @@ def main() -> int:
               f"extension needs them, into a file without the _meos suffix.")
         return 1
 
+    # A baseline that lists findings the tree no longer has is out of date,
+    # not broken: the invariant this check enforces is that no NEW finding
+    # appears. Reporting it as a failure would redden every pull request
+    # whose branch predates the last shrink, for housekeeping it did not do,
+    # so it is a notice and the shrink happens with the next --rebaseline.
     stale = sorted(baseline - set(fail))
     if stale:
-        print(f"{len(stale)} baselined finding(s) are fixed. "
-              f"Run --rebaseline to shrink the baseline:\n")
+        print(f"{len(stale)} baselined finding(s) no longer occur. "
+              f"Run --rebaseline after a split to shrink the baseline:\n")
         for line in stale:
             print(f"  {line}")
-        return 1
 
     print(f"meos-only-files: clean ({len(baseline)} baselined, "
           f"{len(info)} in-function conditionals reported by --report).")


### PR DESCRIPTION
The two static checks fail when the baseline lists a finding the tree no longer has, which asks whoever fixed it to shrink the baseline in the same commit. A pull request whose branch predates the last shrink is then failed for housekeeping it did not do and that has nothing to do with its content: after #1951 shrank the baselines to the findings that remain, the checks of the pull requests in flight report 39 sentinel findings and 3 file selection findings as fixed — the exact differences 170-131 and 71-68 — and go red.

The invariant these checks enforce is that no new finding appears, and a baseline that overstates the debt does not break it. It is now reported and the shrink happens with the next `--rebaseline`, while a new finding still fails the build.

Both properties are verified: injecting a finding into the baseline that the tree does not have exits 0 with the notice, and removing a baseline line so a real finding reads as new exits 1 with the violation.