### PR TITLE
Agree the group of the box and span functions with their header

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1084,7 +1084,6 @@ extern SpanSet *union_span_date(const Span *s, DateADT d);
 extern SpanSet *union_span_float(const Span *s, double d);
 extern SpanSet *union_span_int(const Span *s, int i);
 extern SpanSet *union_span_span(const Span *s1, const Span *s2);
-extern Span *super_union_span_span(const Span *s1, const Span *s2);
 extern SpanSet *union_span_spanset(const Span *s, const SpanSet *ss);
 extern SpanSet *union_span_timestamptz(const Span *s, TimestampTz t);
 extern SpanSet *union_spanset_bigint(const SpanSet *ss, int64 i);

--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -877,6 +877,7 @@ extern Span *numspan_shift_scale(const Span *s, Datum shift, Datum width, bool h
 extern SpanSet *numspanset_shift_scale(const SpanSet *ss, Datum shift, Datum width, bool hasshift, bool haswidth);
 extern Set *set_compact(const Set *s);
 extern void span_expand(const Span *s1, Span *s2);
+extern Span *super_union_span_span(const Span *s1, const Span *s2);
 extern SpanSet *spanset_compact(const SpanSet *ss);
 extern TBox *tbox_expand_value(const TBox *box, Datum value, MeosType basetyp);
 extern Set *textcat_textset_text_common(const Set *s, const text *txt, bool invert);

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -890,7 +890,7 @@ tbox_hast(const TBox *box)
 }
 
 /**
- * @ingroup meos_internal_box_accessor
+ * @ingroup meos_box_accessor
  * @brief Return in the last argument the minimum X value of a temporal box as
  * a double
  * @param[in] box Box
@@ -990,7 +990,7 @@ tbox_xmin_inc(const TBox *box, bool *result)
 }
 
 /**
- * @ingroup meos_internal_box_accessor
+ * @ingroup meos_box_accessor
  * @brief Return in the last argument the maximum X value of a temporal box as
  * a double 
  * @param[in] box Box


### PR DESCRIPTION
Two functions state a doxygen group that their header contradicts, and the catalog the bindings are generated from reads the group, so each is either projected while documented internal or skipped while exported. They are the only two in the library: after this, no function tagged `@ingroup meos_internal_*` is declared in `meos.h`.

The minimum and maximum X value of a temporal box are read through three typed accessors, one per span type, and through `tbox_xmin` and `tbox_xmax`, which answer in a double whatever the box holds. The latter two are declared in `meos.h` and are what the SQL functions call, as one temporal box type carries the integer, big integer and float spans, so they belong to the public accessor group as their siblings `tbox_tmin`, `tbox_tmax` and the inclusive flags do.

The bounding union of two spans asserts its arguments instead of validating them, is called from the GiST and the aggregate code of the extension, and has `union_tbox_tbox` as its public counterpart, so it is internal as its group states and its declaration moves to `meos_internal.h`.