### PR TITLE
Run the tjsonb smoke suite under valgrind

### DIFF
--- a/meos/test/run_smoketests.sh
+++ b/meos/test/run_smoketests.sh
@@ -29,6 +29,7 @@ SUITES=(
   tcbuffer_smoketest
   tnpoint_smoketest
   tgeometry_smoketest
+  tjsonb_smoketest
 )
 
 # Self-contained family suites: a family drops meos/test/smoke/<family>.json and


### PR DESCRIPTION
gen_smoketest.py emits tjsonb_smoketest.c for the temporal JSONB public surface; list it in run_smoketests.sh so the harness builds and leak-checks it under the strict full check alongside the other leak-clean suites.