### PR TITLE
Report a temporal point within a zero distance of a geometry as intersecting it

### DIFF
--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -1585,6 +1585,13 @@ tdwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
       if (supported)
         return tpoint_linear_dwithin_geom(temp, gs, dist);
     }
+    /* A zero distance is the intersection relationship, which the buffer below
+     * cannot express: the buffer of a geometry of a lower dimension than a
+     * surface by a zero distance is empty, and an empty geometry carries no
+     * relationship */
+    if (dist == 0.0)
+      return tinterrel_tgeo_geo(temp, gs, TINTERSECTS);
+
     GSERIALIZED *buffer = geom_buffer(gs, dist, "");
     Temporal *result = tinterrel_tgeo_geo(temp, buffer, TINTERSECTS);
     pfree(buffer);

--- a/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/geo/expected/072_tpoint_tempspatialrels.test.out
@@ -1339,6 +1339,54 @@ SELECT tDwithin(tgeompoint 'Point(1 1 1)@2000-01-01', tgeompoint 'Point(1 1)@200
  t@Sat Jan 01 00:00:00 2000 PST
 (1 row)
 
+SELECT tDwithin(tgeompoint 'Point(0 0)@2000-01-01', geometry 'Linestring(0 -5,0 5)', 0);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(geometry 'Linestring(0 -5,0 5)', tgeompoint 'Point(0 0)@2000-01-01', 0);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tgeompoint 'Point(0 0)@2000-01-01', geometry 'MultiPoint(0 0,1 1)', 0);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tgeompoint 'Point(0 0)@2000-01-01', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', 0);
+            tdwithin            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tDwithin(tgeompoint '{Point(-3 0)@2000-01-01, Point(0 0)@2000-01-02}', geometry 'Linestring(0 -5,0 5)', 0);
+                             tdwithin                             
+------------------------------------------------------------------
+ {f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST}
+(1 row)
+
+SELECT tDwithin(tgeompoint 'Interp=Step;[Point(-3 0)@2000-01-01, Point(0 0)@2000-01-03]', geometry 'Linestring(0 -5,0 5)', 0);
+                             tdwithin                             
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT tDwithin(tgeompoint '[Point(-3 0)@2000-01-01, Point(3 0)@2000-01-03]', geometry 'Linestring(0 -5,0 5)', 0);
+                                                               tdwithin                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tDwithin(tgeompoint 'Point(0 0)@2000-01-01', geometry 'Linestring(3 -5,3 5)', 2);
+            tdwithin            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tDwithin(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02], [Point(5 5)@2000-01-05, Point(7 7)@2000-01-07]}', tgeompoint '{Point(3 3)@2000-01-03, Point(4 4)@2000-01-04}', 1);
  tdwithin 
 ----------

--- a/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/072_tpoint_tempspatialrels.test.sql
@@ -384,6 +384,18 @@ SELECT tDwithin(tgeompoint 'Interp=Step;{[Point(1 1)@2000-01-01, Point(2 2)@2000
 -- Mixed 2D/3D
 SELECT tDwithin(tgeompoint 'Point(1 1 1)@2000-01-01', tgeompoint 'Point(1 1)@2000-01-01', 2);
 
+-- A zero distance is the intersection relationship, for every interpolation
+-- and for a geometry of any dimension
+SELECT tDwithin(tgeompoint 'Point(0 0)@2000-01-01', geometry 'Linestring(0 -5,0 5)', 0);
+SELECT tDwithin(geometry 'Linestring(0 -5,0 5)', tgeompoint 'Point(0 0)@2000-01-01', 0);
+SELECT tDwithin(tgeompoint 'Point(0 0)@2000-01-01', geometry 'MultiPoint(0 0,1 1)', 0);
+SELECT tDwithin(tgeompoint 'Point(0 0)@2000-01-01', geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', 0);
+SELECT tDwithin(tgeompoint '{Point(-3 0)@2000-01-01, Point(0 0)@2000-01-02}', geometry 'Linestring(0 -5,0 5)', 0);
+SELECT tDwithin(tgeompoint 'Interp=Step;[Point(-3 0)@2000-01-01, Point(0 0)@2000-01-03]', geometry 'Linestring(0 -5,0 5)', 0);
+SELECT tDwithin(tgeompoint '[Point(-3 0)@2000-01-01, Point(3 0)@2000-01-03]', geometry 'Linestring(0 -5,0 5)', 0);
+-- A strictly positive distance keeps the expanded geometry
+SELECT tDwithin(tgeompoint 'Point(0 0)@2000-01-01', geometry 'Linestring(3 -5,3 5)', 2);
+
 -- Coverage
 SELECT tDwithin(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02], [Point(5 5)@2000-01-05, Point(7 7)@2000-01-07]}', tgeompoint '{Point(3 3)@2000-01-03, Point(4 4)@2000-01-04}', 1);
 SELECT tDwithin(tgeompoint '{[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02),(Point(2 2)@2000-01-02, Point(3 3)@2000-01-03)}', tgeomPoint '{[Point(2.5 2.5)@2000-01-01, Point(2.5 2.5)@2000-01-02], [Point(2.5 2.5)@2000-01-03,Point(2.5 2.5)@2000-01-04]}', 1);


### PR DESCRIPTION
A temporal point against a geometry that is not a point resolves the within-distance relationship on a buffer of the geometry expanded by the distance, except for a linear temporal geometry point over a geometry the clip engine supports, which has a native path. The buffer of a geometry of a lower dimension than a surface by a zero distance is empty, and an empty geometry carries no relationship, so every value that reaches the buffer answers NULL.

`ST_IsEmpty(ST_Buffer(geometry 'Linestring(0 -5,0 5)', 0))` is true, and so is the same test on a multipoint, while a polygon is its own zero buffer. An instantaneous point lying on that line answers NULL where the same point against a polygon answers true, and the discrete and step interpolations answer alike.

A zero distance is the intersection relationship, which `tinterrel_tgeo_geo` states in the other direction, so the zero case resolves through it. The conversion sits after the native path of the linear interpolation, which keeps its own kernel and reproduces its answers.

The added cases are the only coverage of a zero distance against a geometry that is not a point, so no committed expectation moves.