### PR TITLE
Read the first instant through a view in the geopose stream

### DIFF
--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -1653,7 +1653,7 @@ tpose_as_geopose_stream_header(const Temporal *temp, int precision)
 {
   VALIDATE_TPOSE(temp, NULL);
 
-  const TInstant *first = (const TInstant *) temporal_start_instant(temp);
+  const TInstant *first = temporal_start_inst(temp);
   if (first == NULL)
     return NULL;
   GeoPoseAnchor anchor;
@@ -1692,7 +1692,7 @@ tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst,
   VALIDATE_TPOSE(temp, NULL);
   VALIDATE_NOT_NULL(inst, NULL);
 
-  const TInstant *first = (const TInstant *) temporal_start_instant(temp);
+  const TInstant *first = temporal_start_inst(temp);
   if (first == NULL)
     return NULL;
   GeoPoseAnchor anchor;


### PR DESCRIPTION
The geopose stream header and element take the first instant of the temporal pose only to read its anchor pose; use the temporal_start_inst view instead of the owned temporal_start_instant copy, which the accessors never freed.