### PR TITLE
Free the world geometry that the pose apply builder serializes

### DIFF
--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -734,6 +734,7 @@ tposeseq_apply_geo(const TSequence *seq, const GSERIALIZED *body)
     }
     instants[i] = tinstant_make(GserializedPGetDatum(world), T_TGEOMPOINT,
       inst->t);
+    pfree(world);
   }
   TSequence *result = tsequence_make(instants, seq->count,
     seq->period.lower_inc, seq->period.upper_inc,


### PR DESCRIPTION
tposeseq_apply_geo serializes each instant's transformed body with pose_apply_geo and copies it into the tgeompoint instant via tinstant_make; free that intermediate GSERIALIZED once it has been copied.