### PR TITLE
Ask the temporal relationships of two zero-radius temporal circular buffers of the temporal points they are

### DIFF
--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -1239,6 +1239,21 @@ tcontains_covers_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
     return NULL;
 
+  /* Two values composed of discs of a zero radius are temporal points, whose
+   * conversion is exact. The disc kernel below reads the containment from the
+   * clearance of the two disc boundaries, which a disc of a zero radius does
+   * not carry: a point contains and covers the point it coincides with */
+  if (tcbuffer_is_tpoint(temp1) && tcbuffer_is_tpoint(temp2))
+  {
+    Temporal *tpoint1 = tcbuffer_to_tgeompoint(temp1);
+    Temporal *tpoint2 = tcbuffer_to_tgeompoint(temp2);
+    Temporal *result = strict ?
+      tcontains_tgeo_tgeo(tpoint1, tpoint2) :
+      tcovers_tgeo_tgeo(tpoint1, tpoint2);
+    pfree(tpoint1); pfree(tpoint2);
+    return result;
+  }
+
   Temporal *sync1, *sync2;
   /* Synchronization without adding crossings; NULL when they share no time */
   if (! intersection_temporal_temporal(temp1, temp2, SYNCHRONIZE_NOCROSS,
@@ -2522,6 +2537,23 @@ ttouches_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
 Temporal *
 ttouches_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 {
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
+    return NULL;
+
+  /* Two values composed of discs of a zero radius are temporal points, whose
+   * conversion is exact. The disc kernel below reads a touch from the two disc
+   * boundaries meeting at the sum of the radii, which a pair of coinciding
+   * points meets at a zero distance while their interiors coincide */
+  if (tcbuffer_is_tpoint(temp1) && tcbuffer_is_tpoint(temp2))
+  {
+    Temporal *tpoint1 = tcbuffer_to_tgeompoint(temp1);
+    Temporal *tpoint2 = tcbuffer_to_tgeompoint(temp2);
+    Temporal *result = ttouches_tgeo_tgeo(tpoint1, tpoint2);
+    pfree(tpoint1); pfree(tpoint2);
+    return result;
+  }
+
   return tspatialrel_tcbuffer_tcbuffer(temp1, temp2, &datum_cbuffer_touches);
 }
 

--- a/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/214_tcbuffer_tempspatialrels.test.out
@@ -1251,6 +1251,66 @@ SELECT tContains(geometry 'Linestring(-5 0,5 0)', tcbuffer '[Cbuffer(Point(-3 0)
  {[t@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
+SELECT tTouches(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
+            ttouches            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tContains(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
+           tcontains            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tCovers(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
+            tcovers             
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tTouches(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(5 5),0)@2000-01-01');
+            ttouches            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tContains(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(5 5),0)@2000-01-01');
+           tcontains            
+--------------------------------
+ f@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tTouches(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(0 -3),0)@2000-01-01, Cbuffer(Point(0 3),0)@2000-01-03]');
+                             ttouches                             
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT tContains(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(0 -3),0)@2000-01-01, Cbuffer(Point(0 3),0)@2000-01-03]');
+                                                              tcontains                                                               
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tCovers(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(0 -3),0)@2000-01-01, Cbuffer(Point(0 3),0)@2000-01-03]');
+                                                               tcovers                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 00:00:00 2000 PST], (f@Sun Jan 02 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT tTouches(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(2 0),1)@2000-01-01');
+            ttouches            
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT tCovers(tcbuffer 'Cbuffer(Point(0 0),2)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01');
+            tcovers             
+--------------------------------
+ t@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]', geometry 'Point(0 0)');
                                                                                         tintersects                                                                                        
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

--- a/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/214_tcbuffer_tempspatialrels.test.sql
@@ -397,6 +397,21 @@ SELECT tCovers(geometry 'Point(0 0)', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-
 -- A line covers the point it carries, and contains it away from its end points
 SELECT tCovers(geometry 'Linestring(-5 0,5 0)', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]');
 SELECT tContains(geometry 'Linestring(-5 0,5 0)', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(5 0),0)@2000-01-03]');
+-- Two points that coincide do not touch, since their interiors coincide,
+-- while each contains and covers the other
+SELECT tTouches(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
+SELECT tContains(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
+SELECT tCovers(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
+SELECT tTouches(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(5 5),0)@2000-01-01');
+SELECT tContains(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(5 5),0)@2000-01-01');
+-- Two points crossing meet at a single instant, which they contain and cover
+-- each other at and touch at nowhere
+SELECT tTouches(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(0 -3),0)@2000-01-01, Cbuffer(Point(0 3),0)@2000-01-03]');
+SELECT tContains(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(0 -3),0)@2000-01-01, Cbuffer(Point(0 3),0)@2000-01-03]');
+SELECT tCovers(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0)@2000-01-03]', tcbuffer '[Cbuffer(Point(0 -3),0)@2000-01-01, Cbuffer(Point(0 3),0)@2000-01-03]');
+-- Discs of a strictly positive radius keep the disc kernels
+SELECT tTouches(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(2 0),1)@2000-01-01');
+SELECT tCovers(tcbuffer 'Cbuffer(Point(0 0),2)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01');
 -- A single disc of a strictly positive radius keeps the disc semantics
 SELECT tIntersects(tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]', geometry 'Point(0 0)');
 SELECT tContains(geometry 'Polygon((-1 -1,-1 1,1 1,1 -1,-1 -1))', tcbuffer '[Cbuffer(Point(-3 0),0)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]');


### PR DESCRIPTION
A disc of a zero radius is the point at its centre, so two temporal circular buffers whose discs all have a zero radius are temporal points and convert to ones without loss. The disc kernels read a touch from the two disc boundaries meeting at the sum of the radii and the containment from the clearance between them, neither of which a disc of a zero radius carries.

Two points that coincide meet at a zero distance, which the touch kernel reads as the boundaries meeting, so they touch where their interiors coincide, while `ST_Touches` of a point with itself is false. The containment kernel asks for a strictly positive clearance, so a point contains nothing, not even the point it coincides with, while `ST_Contains` of a point with itself is true.

Two points crossing meet at a single instant, which they contain and cover each other at and touch at nowhere.

The conversion applies to both values: a pair holding a disc of a strictly positive radius keeps the disc kernels, where two discs meeting at one point do touch.

`tcontains_covers_tcbuffer_tcbuffer` and `ttouches_tcbuffer_tcbuffer` carry the conversion, delegating to `tcontains_tgeo_tgeo`, `tcovers_tgeo_tgeo` and `ttouches_tgeo_tgeo`. The intersects, disjoint and within-distance relationships of two temporal points answer alike in both engines.

The added cases are the only coverage of a zero radius for these relationships, so no committed expectation moves.