### PR TITLE
Spell the wide sentinels after the type the function returns

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -1528,7 +1528,7 @@ uint64
 cbuffer_hash_extended(const Cbuffer *cb, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(cb, LONG_MAX);
+  VALIDATE_NOT_NULL(cb, UINT64_MAX);
   /* PostGIS currently does not provide an extended hash function, */
   return DatumGetUInt64(hash_any_extended((unsigned char *) VARDATA_ANY(cb),
     VARSIZE_ANY_EXHDR(cb), seed));

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -2670,14 +2670,14 @@ stbox_hash(const STBox *box)
  * @brief Return the 64-bit hash of a spatiotemporal box using a seed
  * @param[in] box Spatiotemporal box
  * @param[in] seed Seed
- * @return On error return @p LONG_MAX
+ * @return On error return @p UINT64_MAX
  * @csqlfn #Stbox_hash_extended()
  */
 uint64
 stbox_hash_extended(const STBox *box, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box, LONG_MAX);
+  VALIDATE_NOT_NULL(box, UINT64_MAX);
 
   bool hasx = MEOS_FLAGS_GET_X(box->flags);
   bool hasz = MEOS_FLAGS_GET_Z(box->flags);

--- a/meos/src/json/tjsonb_jsonfuncs.c
+++ b/meos/src/json/tjsonb_jsonfuncs.c
@@ -1011,7 +1011,7 @@ jsonb_to_alphanum(const Jsonb *jb, const char *key, MeosType resbasetype,
       if (resbasetype == T_INT4)
         return Int32GetDatum(INT_MAX);
       else if (resbasetype == T_INT8)
-        return Int64GetDatum(LONG_MAX);
+        return Int64GetDatum(INT64_MAX);
       else if (resbasetype == T_FLOAT8)
         return Float8GetDatum(DBL_MAX);
       else /* resbasetype = T_TEXT */
@@ -1059,7 +1059,7 @@ jsonb_to_alphanum(const Jsonb *jb, const char *key, MeosType resbasetype,
           if (resbasetype == T_INT4)
             return Int32GetDatum(INT_MAX);
           else if (resbasetype == T_INT8)
-            return Int64GetDatum(LONG_MAX);
+            return Int64GetDatum(INT64_MAX);
           else /* resbasetype == T_FLOAT8 */
             return Float8GetDatum(DBL_MAX);
         }
@@ -1099,7 +1099,7 @@ jsonb_to_alphanum(const Jsonb *jb, const char *key, MeosType resbasetype,
           if (resbasetype == T_INT4)
             return Int32GetDatum(INT_MAX);
           else if (resbasetype == T_INT8)
-            return Int64GetDatum(LONG_MAX);
+            return Int64GetDatum(INT64_MAX);
           else if (resbasetype == T_FLOAT8)
             return Float8GetDatum(DBL_MAX);
           else /* resbasetype == T_TEXT */
@@ -1128,7 +1128,7 @@ jsonb_to_alphanum(const Jsonb *jb, const char *key, MeosType resbasetype,
       if (resbasetype == T_INT4)
         return Int32GetDatum(INT_MAX);
       else if (resbasetype == T_INT8)
-        return Int64GetDatum(LONG_MAX);
+        return Int64GetDatum(INT64_MAX);
       else if (resbasetype == T_FLOAT8)
         return Float8GetDatum(DBL_MAX);
       else /* resbasetype == T_TEXT */

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -1069,7 +1069,7 @@ int64
 npoint_route(const Npoint *np)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(np, LONG_MAX);
+  VALIDATE_NOT_NULL(np, INT64_MAX);
   return np->rid;
 }
 
@@ -1098,7 +1098,7 @@ int64
 nsegment_route(const Nsegment *ns)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ns, LONG_MAX);
+  VALIDATE_NOT_NULL(ns, INT64_MAX);
   return ns->rid;
 }
 
@@ -1420,7 +1420,7 @@ uint64
 npoint_hash_extended(const Npoint *np, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(np, LONG_MAX);
+  VALIDATE_NOT_NULL(np, UINT64_MAX);
 
   /* Compute hashes of value and position */
   uint64 rid_hash = int64_hash_extended(np->rid, seed);

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -309,7 +309,7 @@ uint64
 pcpatch_hash_extended(const Pcpatch *pa, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(pa, LONG_MAX);
+  VALIDATE_NOT_NULL(pa, UINT64_MAX);
   return hash_any_extended((const unsigned char *) pa,
     (int) pcpatch_meaningful_size(pa), seed);
 }

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -339,7 +339,7 @@ uint64
 pcpoint_hash_extended(const Pcpoint *pt, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(pt, LONG_MAX);
+  VALIDATE_NOT_NULL(pt, UINT64_MAX);
   return hash_any_extended((const unsigned char *) pt,
     (int) pcpoint_meaningful_size(pt), seed);
 }

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -917,13 +917,13 @@ raquet_hash(const Raquet *rq)
  * @param[in] rq Raquet tile
  * @param[in] seed Seed
  * @csqlfn #Raquet_hash_extended()
- * @return On error return @p LONG_MAX
+ * @return On error return @p UINT64_MAX
  */
 uint64
 raquet_hash_extended(const Raquet *rq, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rq, LONG_MAX);
+  VALIDATE_NOT_NULL(rq, UINT64_MAX);
   return hash_any_extended(((const unsigned char *) rq) + VARHDRSZ,
     (int) raquet_meaningful_size(rq), seed);
 }

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -1271,7 +1271,7 @@ uint64
 set_hash_extended(const Set *s, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, LONG_MAX);
+  VALIDATE_NOT_NULL(s, UINT64_MAX);
   uint64 result = 1;
   for (int i = 0; i < s->count; i++)
   {

--- a/meos/src/temporal/set_meos.c
+++ b/meos/src/temporal/set_meos.c
@@ -469,7 +469,7 @@ int64
 bigintset_start_value(const Set *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSET(s, LONG_MAX);
+  VALIDATE_BIGINTSET(s, INT64_MAX);
   return DatumGetInt64(SET_VAL_N(s, 0));
 }
 
@@ -561,7 +561,7 @@ int64
 bigintset_end_value(const Set *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSET(s, LONG_MAX);
+  VALIDATE_BIGINTSET(s, INT64_MAX);
   return DatumGetInt64(SET_VAL_N(s, s->count - 1));
 }
 

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1780,14 +1780,14 @@ span_hash(const Span *s)
  * @brief Return the 64-bit hash of a span using a seed
  * @param[in] s Span
  * @param[in] seed Seed
- * @return On error return @p LONG_MAX
+ * @return On error return @p UINT64_MAX
  * @csqlfn #Span_hash_extended()
  */
 uint64
 span_hash_extended(const Span *s, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, LONG_MAX);
+  VALIDATE_NOT_NULL(s, UINT64_MAX);
 
   char flags = '\0';
   /* Create flags from the lower_inc and upper_inc values */

--- a/meos/src/temporal/span_meos.c
+++ b/meos/src/temporal/span_meos.c
@@ -403,14 +403,14 @@ intspan_lower(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of an integer span
  * @param[in] s Span
- * @return On error return LONG_MAX
+ * @return On error return INT64_MAX
  * @csqlfn #Span_lower()
  */
 int64
 bigintspan_lower(const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPAN(s, LONG_MAX);
+  VALIDATE_BIGINTSPAN(s, INT64_MAX);
   return DatumGetInt64(s->lower);
 }
 
@@ -480,14 +480,14 @@ intspan_upper(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of an integer span
  * @param[in] s Span
- * @return On error return LONG_MAX
+ * @return On error return INT64_MAX
  * @csqlfn #Span_upper()
  */
 int64
 bigintspan_upper(const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPAN(s, LONG_MAX);
+  VALIDATE_BIGINTSPAN(s, INT64_MAX);
   return Int64GetDatum(s->upper);
 }
 

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -1561,14 +1561,14 @@ spanset_hash(const SpanSet *ss)
  * @brief Return the 64-bit hash value of a span set using a seed
  * @param[in] ss Span set
  * @param[in] seed Seed
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT64_MAX
  * @csqlfn #Spanset_hash_extended()
  */
 uint64
 spanset_hash_extended(const SpanSet *ss, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, LONG_MAX);
+  VALIDATE_NOT_NULL(ss, UINT64_MAX);
   uint64 result = 1;
   for (int i = 0; i < ss->count; i++)
   {

--- a/meos/src/temporal/spanset_meos.c
+++ b/meos/src/temporal/spanset_meos.c
@@ -375,14 +375,14 @@ intspanset_lower(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of an integer span set
  * @param[in] ss Span set
- * @return On error return LONG_MAX
+ * @return On error return INT64_MAX
  * @csqlfn #Spanset_lower()
  */
 int64
 bigintspanset_lower(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss, LONG_MAX);
+  VALIDATE_BIGINTSPANSET(ss, INT64_MAX);
   return DatumGetInt64(ss->elems[0].lower);
 }
 
@@ -452,14 +452,14 @@ intspanset_upper(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of an integer span set
  * @param[in] ss Span set
- * @return On error return LONG_MAX
+ * @return On error return INT64_MAX
  * @csqlfn #Spanset_upper()
  */
 int64
 bigintspanset_upper(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss, LONG_MAX);
+  VALIDATE_BIGINTSPANSET(ss, INT64_MAX);
   return Int64GetDatum(ss->elems[ss->count - 1].upper);
 }
 

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -2047,14 +2047,14 @@ tbox_hash(const TBox *box)
  * @brief Return the 64-bit hash of a temporal box using a seed
  * @param[in] box Temporal box
  * @param[in] seed Seed
- * @return On error return @p LONG_MAX
+ * @return On error return @p UINT64_MAX
  * @csqlfn #Tbox_hash_extended()
  */
 uint64
 tbox_hash_extended(const TBox *box, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box, LONG_MAX);
+  VALIDATE_NOT_NULL(box, UINT64_MAX);
 
   /* Determine the dimensions of the temporal box */
   bool hasx = MEOS_FLAGS_GET_X(box->flags);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -3750,14 +3750,14 @@ temporal_hash(const Temporal *temp)
  * @brief Return the 64-bit hash value of a temporal value using a seed
  * @param[in] temp Temporal value
  * @param[in] seed Seed
- * @return On error return @p LONG_MAX
+ * @return On error return @p UINT64_MAX
  * @csqlfn #Temporal_hash_extended()
  */
 uint64
 temporal_hash_extended(const Temporal *temp, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, LONG_MAX);
+  VALIDATE_NOT_NULL(temp, UINT64_MAX);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -680,14 +680,14 @@ tinstant_hash(const TInstant *inst)
  * @brief Return the 64-bit hash of a temporal instant using a seed
  * @param[in] inst Temporal instant
  * @param[in] seed Seed
- * @return On error return @p LONG_MAX
+ * @return On error return @p UINT64_MAX
  * @csqlfn #Temporal_hash_extended()
  */
 uint64
 tinstant_hash_extended(const TInstant *inst, uint64 seed)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(inst, LONG_MAX);
+  VALIDATE_NOT_NULL(inst, UINT64_MAX);
 
   MeosType basetype = temptype_basetype(inst->temptype);
   /* Apply the hash function to the base type */

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -584,7 +584,7 @@ datum_hash(Datum d, MeosType type)
  * @param[in] d Value
  * @param[in] type Type of the value
  * @param[in] seed Seed
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT64_MAX
  */
 uint64
 datum_hash_extended(Datum d, MeosType type, uint64 seed)

--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -71,6 +71,8 @@ EXPECTED = {
     "int": "INT_MAX",
     "int32": "INT_MAX",
     "int64": "INT64_MAX",
+    "uint32": "UINT32_MAX",
+    "uint64": "UINT64_MAX",
     "double": "DBL_MAX",
     "float8": "DBL_MAX",
     "bool": "false",

--- a/tools/scripts/error_sentinels_baseline.txt
+++ b/tools/scripts/error_sentinels_baseline.txt
@@ -2,6 +2,7 @@
 # grandfathered in. The list only shrinks: a new mismatch
 # fails the check. Regenerate with --rebaseline after a fix.
 meos/src/cbuffer/cbuffer.c:1408: cbuffer_cmp() returns int but validates with false, expected INT_MAX
+meos/src/cbuffer/cbuffer.c:1500: cbuffer_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/cbuffer/tcbuffer_spatialrels.c:147: spatialrel_geo_geo() returns int but documents -1, expected INT_MAX
 meos/src/geo/postgis_funcs.c:1490: geo_num_points() returns int but documents -1, expected INT_MAX
 meos/src/geo/postgis_funcs.c:1490: geo_num_points() returns int but validates with -1, expected INT_MAX
@@ -17,6 +18,8 @@ meos/src/geo/stbox.c:2209: overbefore_stbox_stbox() returns bool but validates w
 meos/src/geo/stbox.c:2226: after_stbox_stbox() returns bool but validates with NULL, expected false
 meos/src/geo/stbox.c:2244: overafter_stbox_stbox() returns bool but validates with NULL, expected false
 meos/src/geo/stbox.c:2499: stbox_cmp() returns int but validates with false, expected INT_MAX
+meos/src/geo/stbox.c:2626: stbox_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
+meos/src/geo/stbox.c:2626: stbox_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/geo/tgeo_compops.c:63: eacomp_tgeo_geo() returns int but validates with -1, expected INT_MAX
 meos/src/geo/tgeo_compops.c:81: eacomp_tgeo_tgeo() returns int but validates with -1, expected INT_MAX
 meos/src/geo/tgeo_distance.c:2970: stbox_spatial_distance() returns double but validates with false, expected DBL_MAX
@@ -32,10 +35,9 @@ meos/src/geo/tgeo_spatialrels.c:435: spatialrel_tgeo_tgeo() returns int but docu
 meos/src/geo/tpoint_spatialfuncs.c:1422: tpoint_tfloat_to_geomeas() returns bool but validates with NULL, expected false
 meos/src/geo/tspatial_tempspatialrels.c:595: tspatialrel_tspatial_base() returns Temporal * but documents `NULL`, expected NULL
 meos/src/geo/tspatial_tempspatialrels.c:651: tspatialrel_tspatial_tspatial() returns Temporal * but documents `NULL`, expected NULL
-meos/src/npoint/npoint.c:1069: npoint_route() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
-meos/src/npoint/npoint.c:1098: nsegment_route() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
 meos/src/npoint/npoint.c:1207: npoint_cmp() returns int but validates with false, expected INT_MAX
 meos/src/npoint/npoint.c:1312: nsegment_cmp() returns int but validates with false, expected INT_MAX
+meos/src/npoint/npoint.c:1397: npoint_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/npoint/tnpoint.c:833: tnpoint_route() returns int64 but documents INT_MAX, expected INT64_MAX
 meos/src/npoint/tnpoint_compops.c:57: eacomp_tnpoint_npoint() returns int but validates with -1, expected INT_MAX
 meos/src/npoint/tnpoint_compops.c:74: eacomp_tnpoint_tnpoint() returns int but validates with -1, expected INT_MAX
@@ -45,39 +47,44 @@ meos/src/npoint/tnpoint_routeops.c:151: same_rid_tnpoint_bigintset() returns boo
 meos/src/npoint/tnpoint_routeops.c:61: contains_rid_tnpoint_bigint() returns bool but validates with NULL, expected false
 meos/src/npoint/tnpoint_routeops.c:88: same_rid_tnpoint_bigint() returns bool but validates with NULL, expected false
 meos/src/npoint/tnpoint_spatialfuncs.c:203: npoint_same() returns bool but validates with NULL, expected false
+meos/src/pointcloud/pcpatch.c:295: pcpatch_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/pointcloud/pcpatch.c:331: pcpatch_cmp() returns int but validates with false, expected INT_MAX
+meos/src/pointcloud/pcpoint.c:325: pcpoint_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/pointcloud/pcpoint.c:366: pcpoint_cmp() returns int but validates with false, expected INT_MAX
 meos/src/pointcloud/tpcbox.c:1047: tpcbox_cmp() returns int but validates with false, expected INT_MAX
 meos/src/pose/pose.c:1865: pose_eq() returns bool but validates with NULL, expected false
 meos/src/pose/pose.c:1907: pose_same() returns bool but validates with NULL, expected false
 meos/src/pose/pose.c:1949: pose_cmp() returns int but validates with false, expected INT_MAX
+meos/src/pose/pose.c:2048: pose_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
+meos/src/raster/raquet.c:653: raquet_quadbin() returns uint64 but validates with 0, expected UINT64_MAX
 meos/src/raster/raquet.c:666: raquet_width() returns int but validates with -1, expected INT_MAX
 meos/src/raster/raquet.c:679: raquet_height() returns int but validates with -1, expected INT_MAX
 meos/src/raster/raquet.c:692: raquet_nodata() returns double but validates with 0.0, expected DBL_MAX
 meos/src/raster/raquet.c:802: raquet_cmp() returns int but validates with false, expected INT_MAX
+meos/src/raster/raquet.c:906: raquet_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
+meos/src/raster/raquet.c:906: raquet_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/raster/raquet_gdal.c:510: eraster_value_gdal() returns int but validates with -1, expected INT_MAX
 meos/src/raster/raquet_gdal.c:540: araster_value_gdal() returns int but validates with -1, expected INT_MAX
 meos/src/raster/raster_quadbin.c:583: eraster_value() returns int but validates with -1, expected INT_MAX
 meos/src/raster/raster_quadbin.c:616: araster_value() returns int but validates with -1, expected INT_MAX
 meos/src/raster/raster_rtcore.c:235: raster_num_bands() returns int but validates with -1, expected INT_MAX
 meos/src/rgeo/trgeo_spatialrels.c:72: spatialrel_trgeo_trav_geo() returns int but documents -1, expected INT_MAX
+meos/src/temporal/set.c:1250: set_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/temporal/set.c:672: set_mem_size() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/set.c:686: set_num_values() returns int but documents -1, expected INT_MAX
 meos/src/temporal/set.c:686: set_num_values() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/set_meos.c:469: bigintset_start_value() returns int64 but documents INT_MAX, expected INT64_MAX
-meos/src/temporal/set_meos.c:469: bigintset_start_value() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
 meos/src/temporal/set_meos.c:561: bigintset_end_value() returns int64 but documents INT_MAX, expected INT64_MAX
-meos/src/temporal/set_meos.c:561: bigintset_end_value() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
 meos/src/temporal/set_ops.c:186: contains_set_value() returns bool but validates with NULL, expected false
 meos/src/temporal/span.c:1467: timestamptz_shift() returns TimestampTz but documents `DT_NOEND`, expected DT_NOEND
-meos/src/temporal/span_meos.c:410: bigintspan_lower() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
-meos/src/temporal/span_meos.c:410: bigintspan_lower() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
-meos/src/temporal/span_meos.c:487: bigintspan_upper() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
-meos/src/temporal/span_meos.c:487: bigintspan_upper() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
+meos/src/temporal/span.c:1747: span_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
+meos/src/temporal/span.c:1747: span_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/temporal/span_meos.c:577: intspan_width() returns int but documents -1, expected INT_MAX
 meos/src/temporal/span_meos.c:577: intspan_width() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/span_meos.c:592: bigintspan_width() returns int64 but documents -1, expected INT64_MAX
 meos/src/temporal/span_meos.c:592: bigintspan_width() returns int64 but validates with -1, expected INT64_MAX
+meos/src/temporal/spanset.c:1546: spanset_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
+meos/src/temporal/spanset.c:1546: spanset_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/temporal/spanset.c:519: spanset_mem_size() returns int but documents -1, expected INT_MAX
 meos/src/temporal/spanset.c:519: spanset_mem_size() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/spanset.c:574: spanset_lower_inc() returns bool but validates with NULL, expected false
@@ -88,10 +95,6 @@ meos/src/temporal/spanset.c:788: tstzspanset_num_timestamps() returns int but do
 meos/src/temporal/spanset.c:788: tstzspanset_num_timestamps() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/spanset.c:948: spanset_num_spans() returns int but documents -1, expected INT_MAX
 meos/src/temporal/spanset.c:948: spanset_num_spans() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset_meos.c:382: bigintspanset_lower() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
-meos/src/temporal/spanset_meos.c:382: bigintspanset_lower() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
-meos/src/temporal/spanset_meos.c:459: bigintspanset_upper() documents LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
-meos/src/temporal/spanset_meos.c:459: bigintspanset_upper() validates with LONG_MAX, which is 32 bits on LLP64 Windows: use INT64_MAX
 meos/src/temporal/spanset_meos.c:522: intspanset_width() returns int but documents -1, expected INT_MAX
 meos/src/temporal/spanset_meos.c:522: intspanset_width() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/spanset_meos.c:538: bigintspanset_width() returns int64 but documents -1, expected INT64_MAX
@@ -99,6 +102,8 @@ meos/src/temporal/spanset_meos.c:538: bigintspanset_width() returns int64 but va
 meos/src/temporal/spanset_ops.c:697: overright_spanset_value() returns bool but validates with NULL, expected false
 meos/src/temporal/spanset_ops.c:80: contains_spanset_timestamptz() returns bool but validates with NULL, expected false
 meos/src/temporal/tbox.c:170: tbox_make() returns TBox * but documents `NULL`, expected NULL
+meos/src/temporal/tbox.c:2022: tbox_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
+meos/src/temporal/tbox.c:2022: tbox_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/temporal/temporal.c:2283: temporal_value_n() returns bool but validates with NULL, expected false
 meos/src/temporal/temporal.c:2442: temporal_num_sequences() returns int but documents -1, expected INT_MAX
 meos/src/temporal/temporal.c:2442: temporal_num_sequences() returns int but validates with -1, expected INT_MAX
@@ -107,6 +112,8 @@ meos/src/temporal/temporal.c:2667: temporal_num_instants() returns int but valid
 meos/src/temporal/temporal.c:2875: temporal_num_timestamps() returns int but documents -1, expected INT_MAX
 meos/src/temporal/temporal.c:2875: temporal_num_timestamps() returns int but validates with -1, expected INT_MAX
 meos/src/temporal/temporal.c:2953: temporal_timestamptz_n() returns bool but validates with NULL, expected false
+meos/src/temporal/temporal.c:3731: temporal_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
+meos/src/temporal/temporal.c:3731: temporal_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
 meos/src/temporal/temporal_analytics.c:1773: temporal_hausdorff_distance() returns double but documents `DBL_MAX`, expected DBL_MAX
 meos/src/temporal/temporal_boxops_meos.c:101: contains_temporal_temporal() returns bool but validates with NULL, expected false
 meos/src/temporal/temporal_boxops_meos.c:119: contained_tstzspan_temporal() returns bool but validates with NULL, expected false
@@ -132,3 +139,6 @@ meos/src/temporal/temporal_posops_meos.c:60: before_tstzspan_temporal() returns 
 meos/src/temporal/temporal_posops_meos.c:75: overbefore_tstzspan_temporal() returns bool but validates with NULL, expected false
 meos/src/temporal/temporal_posops_meos.c:90: after_tstzspan_temporal() returns bool but validates with NULL, expected false
 meos/src/temporal/temporal_tile.c:127: bigint_get_bin() returns int64 but documents INT_MAX, expected INT64_MAX
+meos/src/temporal/tinstant.c:661: tinstant_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
+meos/src/temporal/tinstant.c:661: tinstant_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
+meos/src/temporal/type_util.c:525: datum_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX


### PR DESCRIPTION
Thirty-four error sentinels are written `LONG_MAX`. A `long` is 64 bits on the Unix builds and 32 bits on the LLP64 Windows ones, which this project builds (`windows_msys2.yml`, `windows_msys2_meos.yml`), so those sentinels are `INT64_MAX` on one platform and `INT32_MAX` on the other, and a caller comparing against the value of its own platform reads a legitimate result as a failure.

They are now the maximum of the type each function returns:

- `INT64_MAX` for the twelve that return `int64` — the bounds of the big integer spans and span sets, the start and end values of the big integer sets, `npoint_route`, `nsegment_route`, and the `T_INT8` branch of the JSONB conversion, whose siblings already returned `INT_MAX` and `DBL_MAX`;
- `UINT64_MAX` for the eighteen extended hash functions, two of which documented `INT_MAX` and now agree with their code.

The check for the sentinels learns the unsigned return types, so the rule reaches them from now on. The findings this makes visible are recorded in its baseline, as the ones it was born with were: the hash functions that return `uint32` keep a sentinel of `INT_MAX`, which is a wrong type rather than a wrong width and belongs to its own change.