### PR TITLE
Free the instant array that the tpose sequence builder copies

### DIFF
--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -319,6 +319,7 @@ tposeseq_make(const TSequence *seq1, const TSequence *seq2)
   }
   TSequence *result = tsequence_make(instants, seq1->count,
     seq1->period.lower_inc, seq1->period.upper_inc, interp, NORMALIZE);
+  pfree_array((void **) instants, seq1->count);
   return result;
 }
 


### PR DESCRIPTION
tposeseq_make builds a temporary array of pose instants and hands it to tsequence_make, which copies them; free the array and its elements afterward, matching the sibling tposeseq_apply_geo builder.