### PR TITLE
Ask whether the tile has a value size with a comparison

### DIFF
--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -649,7 +649,7 @@ tbox_tile_state_make(const Temporal *temp, const TBox *box, Datum vsize,
   state->ntiles = 1;
   Datum start_bin, end_bin;
   /* Set the value dimension of the state box*/
-  if (datum_double(vsize, box->span.basetype))
+  if (datum_gt(vsize, 0, box->span.basetype))
   {
     /* The given vsize is greater than 0 */
     state->vsize = vsize;

--- a/meos/src/temporal/temporal_tile_meos.c
+++ b/meos/src/temporal/temporal_tile_meos.c
@@ -82,7 +82,7 @@ tbox_value_time_tiles(const TBox *box, Datum vsize, const Interval *duration,
   int nrows = 1, ncols = 1;
   Datum start_bin, end_bin;
   /* Determine the number of value bins */
-  if (datum_double(vsize, box->span.basetype))
+  if (datum_gt(vsize, 0, box->span.basetype))
     nrows = span_num_bins(&box->span, vsize, vorigin, &start_bin, &end_bin);
   /* Determine the number of time bins */
   int64 tunits = duration ? interval_units(duration) : 0;


### PR DESCRIPTION
The two functions that build a tiling state decide whether the grid has a value dimension by converting the size to a double and reading it as a truth value. The conversion is there to answer a question about the size that a comparison answers directly, and it answers it loosely: any size other than zero is true, a negative one included, while the comment on the parameter and the assertion of the enclosing function both say the size is greater than zero.

They now ask `datum_gt`, which `tbox_tile_state_make` already asserts with two lines above the test.