### PR TITLE
Free the by-reference elements a parsed set copies

### DIFF
--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -558,7 +558,11 @@ set_parse(const char **str, MeosType settype)
       spatial_set_srid(values[i], basetype, set_srid);
   }
   result = set_make(values, array->count, basetype, ORDER);
-  if (meostype_length(basetype) < 0)
+  /* set_make copies each value into the set, so the parsed values are ours to
+   * free. A by-reference base type (varlena or fixed-length like npoint) owns
+   * a heap allocation per element; a by-value type stores the value inline in
+   * the Datum and only the array needs freeing. */
+  if (! basetype_byvalue(basetype))
     pfree_array((void **) values, array->count);
   else
     pfree(values);


### PR DESCRIPTION
set_parse hands its parsed values to set_make, which copies each into the set, then frees the originals only when the base type is variable-length. A fixed-length by-reference base type such as npoint also owns a per-element allocation, so key the element free on basetype_byvalue instead, freeing the elements of every by-reference set and leaving by-value sets to free just the array.