### PR TITLE
Return the singleton-set restriction instead of recomputing it

### DIFF
--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -268,7 +268,7 @@ temporal_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
 
   /* Singleton set */
   if (s->count == 1)
-    temporal_restrict_value(temp, SET_VAL_N(s, 0), atfunc);
+    return temporal_restrict_value(temp, SET_VAL_N(s, 0), atfunc);
 
   /* Bounding box test */
   interpType interp = MEOS_FLAGS_GET_INTERP(temp->flags);


### PR DESCRIPTION
temporal_restrict_values computes the restriction of a one-element set through the single-value fast path but discarded the result and fell through to the general path, leaking the fast-path value and restricting twice. Return it.