### PR TITLE
Key the baselines of the static checks by what the finding is about

### DIFF
--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -120,8 +120,14 @@ def normalize(token: str) -> str:
     return ALIASES.get(token, token)
 
 
-def scan(path: Path, rel: str) -> list[str]:
-    """Return the sentinel findings of one source file."""
+def scan(path: Path, rel: str) -> list[tuple[str, str]]:
+    """Return the sentinel findings of one source file.
+
+    Each finding is a stable key and the text a reader sees. The key names the
+    file, the function and the sentinel, never the line: an edit anywhere above
+    a finding moves its line, and a baseline keyed by line would read every
+    finding below an inserted line as new.
+    """
     findings = []
     lines = path.read_text().splitlines()
     for i, line in enumerate(lines):
@@ -171,24 +177,27 @@ def scan(path: Path, rel: str) -> list[str]:
         for raw, where in ((validated_raw, "validates with"),
                            (documented_raw, "documents")):
             if raw in NON_PORTABLE:
-                findings.append(f"{rel}:{i + 1}: {name}() {where} {raw}, which "
-                                f"is 32 bits on LLP64 Windows: use INT64_MAX")
+                findings.append((f"{rel}\t{name}\t{where} {raw}",
+                                 f"{rel}:{i + 1}: {name}() {where} {raw}, which "
+                                 f"is 32 bits on LLP64 Windows: use INT64_MAX"))
 
         if validated is not None and validated != want:
-            findings.append(f"{rel}:{i + 1}: {name}() returns {rettype} but "
-                            f"validates with {validated}, expected {want}")
+            findings.append((f"{rel}\t{name}\tvalidates with {validated}",
+                             f"{rel}:{i + 1}: {name}() returns {rettype} but "
+                             f"validates with {validated}, expected {want}"))
         if documented is not None and documented != want:
-            findings.append(f"{rel}:{i + 1}: {name}() returns {rettype} but "
-                            f"documents {documented}, expected {want}")
+            findings.append((f"{rel}\t{name}\tdocuments {documented}",
+                             f"{rel}:{i + 1}: {name}() returns {rettype} but "
+                             f"documents {documented}, expected {want}"))
     return findings
 
 
-def collect(root: Path) -> list[str]:
+def collect(root: Path) -> list[tuple[str, str]]:
     """Return every sentinel finding under meos/src."""
     findings = []
     for path in sorted(root.glob("meos/src/**/*.c")):
         findings.extend(scan(path, path.relative_to(root).as_posix()))
-    return sorted(findings)
+    return sorted(findings, key=lambda f: f[1])
 
 
 def main() -> int:
@@ -203,15 +212,17 @@ def main() -> int:
 
     if args.rebaseline:
         header = ("# Findings of tools/scripts/check_error_sentinels.py that are\n"
-                  "# grandfathered in. The list only shrinks: a new mismatch\n"
-                  "# fails the check. Regenerate with --rebaseline after a fix.\n")
-        BASELINE_PATH.write_text(header + "\n".join(findings) + "\n")
+                  "# grandfathered in, keyed by file, function and sentinel so that\n"
+                  "# an edit above a finding does not read as a new one. The list only\n"
+                  "# shrinks: a new mismatch fails the check. Regenerate with\n"
+                  "# --rebaseline after a fix.\n")
+        BASELINE_PATH.write_text(header + "\n".join(k for k, _ in findings) + "\n")
         print(f"wrote {len(findings)} findings to "
               f"{BASELINE_PATH.relative_to(REPO_ROOT)}")
         return 0
 
     if args.report:
-        for line in findings:
+        for _, line in findings:
             print(line)
         print(f"\n{len(findings)} sentinel mismatch(es)")
         return 0
@@ -221,7 +232,7 @@ def main() -> int:
         baseline = {ln for ln in BASELINE_PATH.read_text().splitlines()
                     if ln and not ln.startswith("#")}
 
-    new = [ln for ln in findings if ln not in baseline]
+    new = [text for key, text in findings if key not in baseline]
     if new:
         print("An error sentinel must be the maximum of the return type "
               "(int INT_MAX, int64 INT64_MAX, double DBL_MAX, pointer NULL):\n")
@@ -234,7 +245,7 @@ def main() -> int:
     # appears. Reporting it as a failure would redden every pull request
     # whose branch predates the last shrink, for housekeeping it did not do,
     # so it is a notice and the shrink happens with the next --rebaseline.
-    stale = sorted(baseline - set(findings))
+    stale = sorted(baseline - {key for key, _ in findings})
     if stale:
         print(f"{len(stale)} baselined finding(s) no longer occur. "
               f"Run --rebaseline after a fix to shrink the baseline:\n")

--- a/tools/scripts/check_meos_only_files.py
+++ b/tools/scripts/check_meos_only_files.py
@@ -135,6 +135,27 @@ def meos_only_definitions(path: Path) -> list[str]:
     return names
 
 
+def anchor(path: Path, n: int) -> str:
+    """Return what the conditional at line n guards, as a stable name for it.
+
+    A line number moves with any edit above it, so the baseline names the first
+    thing the block declares instead; that survives the file growing elsewhere.
+    """
+    lines = path.read_text().splitlines()
+    window = lines[n:n + 10]
+    # the declarator names the block; the line before it holds the return type
+    # alone, which several blocks in a file share
+    for ln in window:
+        text = ln.strip()
+        if re.match(r"^[A-Za-z_][A-Za-z0-9_]*\s*\(", text):
+            return text[:70]
+    for ln in window:
+        text = ln.strip()
+        if text and not text.startswith(("*", "/*", "//")):
+            return text[:70]
+    return f"line {n}"
+
+
 def conditionals(path: Path) -> tuple[list[int], list[int]]:
     """Return the (file-scope, in-function) line numbers of MEOS conditionals."""
     top, inside, depth = [], [], 0
@@ -151,8 +172,9 @@ def collect(root: Path) -> tuple[list[str], list[str]]:
     fail, info = [], []
 
     for cml, src in ungated_meos_sources(root):
-        fail.append(f"{cml}: {src} is compiled into the PG extension: "
-                    f"list it inside if(MEOS), or drop the _meos suffix")
+        fail.append((f"{cml}\t{src}\tungated",
+                     f"{cml}: {src} is compiled into the PG extension: "
+                     f"list it inside if(MEOS), or drop the _meos suffix"))
 
     # BINDING-HEADER-PARSE-OK: CI source guard, scans .c files for a build
     # rule; no headers are read and no API surface is extracted
@@ -172,11 +194,13 @@ def collect(root: Path) -> tuple[list[str], list[str]]:
             if name in shared:
                 continue
             if re.search(rf"\b{re.escape(name)}\s*\(", pg_sources):
-                fail.append(f"{rel}: {name}() is called from mobilitydb/src: "
-                            f"the PG extension needs it, so it is not MEOS-only")
+                fail.append((f"{rel}\t{name}\tcalled from the extension",
+                             f"{rel}: {name}() is called from mobilitydb/src: "
+                             f"the PG extension needs it, so it is not MEOS-only"))
         top, _ = conditionals(path)
         for n in top:
-            fail.append(f"{rel}:{n}: MEOS conditional inside a MEOS-only file")
+            fail.append((f"{rel}\t{anchor(path, n)}\tconditional in a MEOS-only file",
+                         f"{rel}:{n}: MEOS conditional inside a MEOS-only file"))
 
     for path in sorted(root.glob("meos/src/**/*.c")):
         rel = path.relative_to(root).as_posix()
@@ -184,8 +208,9 @@ def collect(root: Path) -> tuple[list[str], list[str]]:
             continue
         top, inside = conditionals(path)
         for n in top:
-            fail.append(f"{rel}:{n}: file-scope MEOS conditional: "
-                        f"move the definition to the module's _meos.c")
+            fail.append((f"{rel}\t{anchor(path, n)}\tfile-scope conditional",
+                         f"{rel}:{n}: file-scope MEOS conditional: "
+                         f"move the definition to the module's _meos.c"))
         for n in inside:
             info.append(f"{rel}:{n}: MEOS conditional inside a function body")
 
@@ -206,13 +231,13 @@ def main() -> int:
         header = ("# Findings of tools/scripts/check_meos_only_files.py that are\n"
                   "# grandfathered in. The list only shrinks: a new violation\n"
                   "# fails the check. Regenerate with --rebaseline after a split.\n")
-        BASELINE_PATH.write_text(header + "\n".join(fail) + "\n")
+        BASELINE_PATH.write_text(header + "\n".join(k for k, _ in fail) + "\n")
         print(f"wrote {len(fail)} findings to "
               f"{BASELINE_PATH.relative_to(REPO_ROOT)}")
         return 0
 
     if args.report:
-        for line in fail:
+        for _, line in fail:
             print(f"split needed: {line}")
         for line in info:
             print(f"in-function : {line}")
@@ -224,7 +249,7 @@ def main() -> int:
         baseline = {ln for ln in BASELINE_PATH.read_text().splitlines()
                     if ln and not ln.startswith("#")}
 
-    new = [ln for ln in fail if ln not in baseline]
+    new = [text for key, text in fail if key not in baseline]
     if new:
         print("MEOS-only code must be selected by file, not by #if MEOS:\n")
         for line in new:
@@ -239,7 +264,7 @@ def main() -> int:
     # appears. Reporting it as a failure would redden every pull request
     # whose branch predates the last shrink, for housekeeping it did not do,
     # so it is a notice and the shrink happens with the next --rebaseline.
-    stale = sorted(baseline - set(fail))
+    stale = sorted(baseline - {key for key, _ in fail})
     if stale:
         print(f"{len(stale)} baselined finding(s) no longer occur. "
               f"Run --rebaseline after a split to shrink the baseline:\n")

--- a/tools/scripts/error_sentinels_baseline.txt
+++ b/tools/scripts/error_sentinels_baseline.txt
@@ -1,144 +1,146 @@
 # Findings of tools/scripts/check_error_sentinels.py that are
-# grandfathered in. The list only shrinks: a new mismatch
-# fails the check. Regenerate with --rebaseline after a fix.
-meos/src/cbuffer/cbuffer.c:1408: cbuffer_cmp() returns int but validates with false, expected INT_MAX
-meos/src/cbuffer/cbuffer.c:1500: cbuffer_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/cbuffer/tcbuffer_spatialrels.c:147: spatialrel_geo_geo() returns int but documents -1, expected INT_MAX
-meos/src/geo/postgis_funcs.c:1490: geo_num_points() returns int but documents -1, expected INT_MAX
-meos/src/geo/postgis_funcs.c:1490: geo_num_points() returns int but validates with -1, expected INT_MAX
-meos/src/geo/postgis_funcs.c:1509: geo_num_geos() returns int but documents -1, expected INT_MAX
-meos/src/geo/postgis_funcs.c:1509: geo_num_geos() returns int but validates with -1, expected INT_MAX
-meos/src/geo/postgis_funcs.c:2578: geo_equals() returns int but validates with -1, expected INT_MAX
-meos/src/geo/postgis_funcs.c:4740: line_locate_point() returns double but documents -1, expected DBL_MAX
-meos/src/geo/postgis_funcs.c:4877: line_numpoints() returns int but documents -1, expected INT_MAX
-meos/src/geo/postgis_funcs.c:4877: line_numpoints() returns int but validates with -1, expected INT_MAX
-meos/src/geo/postgis_funcs.c:543: geo_is_empty() returns bool but validates with NULL, expected false
-meos/src/geo/stbox.c:2191: before_stbox_stbox() returns bool but validates with NULL, expected false
-meos/src/geo/stbox.c:2209: overbefore_stbox_stbox() returns bool but validates with NULL, expected false
-meos/src/geo/stbox.c:2226: after_stbox_stbox() returns bool but validates with NULL, expected false
-meos/src/geo/stbox.c:2244: overafter_stbox_stbox() returns bool but validates with NULL, expected false
-meos/src/geo/stbox.c:2499: stbox_cmp() returns int but validates with false, expected INT_MAX
-meos/src/geo/stbox.c:2626: stbox_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
-meos/src/geo/stbox.c:2626: stbox_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/geo/tgeo_compops.c:63: eacomp_tgeo_geo() returns int but validates with -1, expected INT_MAX
-meos/src/geo/tgeo_compops.c:81: eacomp_tgeo_tgeo() returns int but validates with -1, expected INT_MAX
-meos/src/geo/tgeo_distance.c:2970: stbox_spatial_distance() returns double but validates with false, expected DBL_MAX
-meos/src/geo/tgeo_spatialfuncs.c:1115: tgeominst_tgeoginst() returns TInstant * but documents `NULL`, expected NULL
-meos/src/geo/tgeo_spatialfuncs.c:1147: tgeomseq_tgeogseq() returns TSequence * but documents `NULL`, expected NULL
-meos/src/geo/tgeo_spatialfuncs.c:1175: tgeomseqset_tgeogseqset() returns TSequenceSet * but documents `NULL`, expected NULL
-meos/src/geo/tgeo_spatialfuncs.c:1205: tgeom_tgeog() returns Temporal * but documents `NULL`, expected NULL
-meos/src/geo/tgeo_spatialfuncs.c:1231: tgeometry_to_tgeography() returns Temporal * but documents `NULL`, expected NULL
-meos/src/geo/tgeo_spatialfuncs.c:1246: tgeography_to_tgeometry() returns Temporal * but documents `NULL`, expected NULL
-meos/src/geo/tgeo_spatialfuncs.c:1406: tgeo_tpoint() returns Temporal * but documents `NULL`, expected NULL
-meos/src/geo/tgeo_spatialfuncs.c:1752: tgeo_convex_hull() returns GSERIALIZED * but documents `NULL`, expected NULL
-meos/src/geo/tgeo_spatialrels.c:435: spatialrel_tgeo_tgeo() returns int but documents -1, expected INT_MAX
-meos/src/geo/tpoint_spatialfuncs.c:1422: tpoint_tfloat_to_geomeas() returns bool but validates with NULL, expected false
-meos/src/geo/tspatial_tempspatialrels.c:595: tspatialrel_tspatial_base() returns Temporal * but documents `NULL`, expected NULL
-meos/src/geo/tspatial_tempspatialrels.c:651: tspatialrel_tspatial_tspatial() returns Temporal * but documents `NULL`, expected NULL
-meos/src/npoint/npoint.c:1207: npoint_cmp() returns int but validates with false, expected INT_MAX
-meos/src/npoint/npoint.c:1312: nsegment_cmp() returns int but validates with false, expected INT_MAX
-meos/src/npoint/npoint.c:1397: npoint_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/npoint/tnpoint.c:833: tnpoint_route() returns int64 but documents INT_MAX, expected INT64_MAX
-meos/src/npoint/tnpoint_compops.c:57: eacomp_tnpoint_npoint() returns int but validates with -1, expected INT_MAX
-meos/src/npoint/tnpoint_compops.c:74: eacomp_tnpoint_tnpoint() returns int but validates with -1, expected INT_MAX
-meos/src/npoint/tnpoint_routeops.c:107: overlaps_rid_tnpoint_bigintset() returns bool but validates with NULL, expected false
-meos/src/npoint/tnpoint_routeops.c:123: contains_rid_tnpoint_bigintset() returns bool but validates with NULL, expected false
-meos/src/npoint/tnpoint_routeops.c:151: same_rid_tnpoint_bigintset() returns bool but validates with NULL, expected false
-meos/src/npoint/tnpoint_routeops.c:61: contains_rid_tnpoint_bigint() returns bool but validates with NULL, expected false
-meos/src/npoint/tnpoint_routeops.c:88: same_rid_tnpoint_bigint() returns bool but validates with NULL, expected false
-meos/src/npoint/tnpoint_spatialfuncs.c:203: npoint_same() returns bool but validates with NULL, expected false
-meos/src/pointcloud/pcpatch.c:295: pcpatch_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/pointcloud/pcpatch.c:331: pcpatch_cmp() returns int but validates with false, expected INT_MAX
-meos/src/pointcloud/pcpoint.c:325: pcpoint_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/pointcloud/pcpoint.c:366: pcpoint_cmp() returns int but validates with false, expected INT_MAX
-meos/src/pointcloud/tpcbox.c:1047: tpcbox_cmp() returns int but validates with false, expected INT_MAX
-meos/src/pose/pose.c:1865: pose_eq() returns bool but validates with NULL, expected false
-meos/src/pose/pose.c:1907: pose_same() returns bool but validates with NULL, expected false
-meos/src/pose/pose.c:1949: pose_cmp() returns int but validates with false, expected INT_MAX
-meos/src/pose/pose.c:2048: pose_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/raster/raquet.c:653: raquet_quadbin() returns uint64 but validates with 0, expected UINT64_MAX
-meos/src/raster/raquet.c:666: raquet_width() returns int but validates with -1, expected INT_MAX
-meos/src/raster/raquet.c:679: raquet_height() returns int but validates with -1, expected INT_MAX
-meos/src/raster/raquet.c:692: raquet_nodata() returns double but validates with 0.0, expected DBL_MAX
-meos/src/raster/raquet.c:802: raquet_cmp() returns int but validates with false, expected INT_MAX
-meos/src/raster/raquet.c:906: raquet_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
-meos/src/raster/raquet.c:906: raquet_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/raster/raquet_gdal.c:510: eraster_value_gdal() returns int but validates with -1, expected INT_MAX
-meos/src/raster/raquet_gdal.c:540: araster_value_gdal() returns int but validates with -1, expected INT_MAX
-meos/src/raster/raster_quadbin.c:583: eraster_value() returns int but validates with -1, expected INT_MAX
-meos/src/raster/raster_quadbin.c:616: araster_value() returns int but validates with -1, expected INT_MAX
-meos/src/raster/raster_rtcore.c:235: raster_num_bands() returns int but validates with -1, expected INT_MAX
-meos/src/rgeo/trgeo_spatialrels.c:72: spatialrel_trgeo_trav_geo() returns int but documents -1, expected INT_MAX
-meos/src/temporal/set.c:1250: set_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/temporal/set.c:672: set_mem_size() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/set.c:686: set_num_values() returns int but documents -1, expected INT_MAX
-meos/src/temporal/set.c:686: set_num_values() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/set_meos.c:469: bigintset_start_value() returns int64 but documents INT_MAX, expected INT64_MAX
-meos/src/temporal/set_meos.c:561: bigintset_end_value() returns int64 but documents INT_MAX, expected INT64_MAX
-meos/src/temporal/set_ops.c:186: contains_set_value() returns bool but validates with NULL, expected false
-meos/src/temporal/span.c:1467: timestamptz_shift() returns TimestampTz but documents `DT_NOEND`, expected DT_NOEND
-meos/src/temporal/span.c:1747: span_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
-meos/src/temporal/span.c:1747: span_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/temporal/span_meos.c:577: intspan_width() returns int but documents -1, expected INT_MAX
-meos/src/temporal/span_meos.c:577: intspan_width() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/span_meos.c:592: bigintspan_width() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/span_meos.c:592: bigintspan_width() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/spanset.c:1546: spanset_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
-meos/src/temporal/spanset.c:1546: spanset_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/temporal/spanset.c:519: spanset_mem_size() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset.c:519: spanset_mem_size() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset.c:574: spanset_lower_inc() returns bool but validates with NULL, expected false
-meos/src/temporal/spanset.c:588: spanset_upper_inc() returns bool but validates with NULL, expected false
-meos/src/temporal/spanset.c:690: datespanset_num_dates() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset.c:690: datespanset_num_dates() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset.c:788: tstzspanset_num_timestamps() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset.c:788: tstzspanset_num_timestamps() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset.c:948: spanset_num_spans() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset.c:948: spanset_num_spans() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset_meos.c:522: intspanset_width() returns int but documents -1, expected INT_MAX
-meos/src/temporal/spanset_meos.c:522: intspanset_width() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/spanset_meos.c:538: bigintspanset_width() returns int64 but documents -1, expected INT64_MAX
-meos/src/temporal/spanset_meos.c:538: bigintspanset_width() returns int64 but validates with -1, expected INT64_MAX
-meos/src/temporal/spanset_ops.c:697: overright_spanset_value() returns bool but validates with NULL, expected false
-meos/src/temporal/spanset_ops.c:80: contains_spanset_timestamptz() returns bool but validates with NULL, expected false
-meos/src/temporal/tbox.c:170: tbox_make() returns TBox * but documents `NULL`, expected NULL
-meos/src/temporal/tbox.c:2022: tbox_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
-meos/src/temporal/tbox.c:2022: tbox_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/temporal/temporal.c:2283: temporal_value_n() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal.c:2442: temporal_num_sequences() returns int but documents -1, expected INT_MAX
-meos/src/temporal/temporal.c:2442: temporal_num_sequences() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/temporal.c:2667: temporal_num_instants() returns int but documents -1, expected INT_MAX
-meos/src/temporal/temporal.c:2667: temporal_num_instants() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/temporal.c:2875: temporal_num_timestamps() returns int but documents -1, expected INT_MAX
-meos/src/temporal/temporal.c:2875: temporal_num_timestamps() returns int but validates with -1, expected INT_MAX
-meos/src/temporal/temporal.c:2953: temporal_timestamptz_n() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal.c:3731: temporal_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
-meos/src/temporal/temporal.c:3731: temporal_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/temporal/temporal_analytics.c:1773: temporal_hausdorff_distance() returns double but documents `DBL_MAX`, expected DBL_MAX
-meos/src/temporal/temporal_boxops_meos.c:101: contains_temporal_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:119: contained_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:135: contained_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:150: contained_temporal_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:168: overlaps_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:184: overlaps_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:198: overlaps_temporal_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:216: same_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:232: same_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:246: same_temporal_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:264: adjacent_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:280: adjacent_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:294: adjacent_temporal_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:70: contains_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_boxops_meos.c:86: contains_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_posops_meos.c:105: overafter_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_posops_meos.c:123: before_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_posops_meos.c:138: overbefore_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_posops_meos.c:153: after_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_posops_meos.c:168: overafter_temporal_tstzspan() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_posops_meos.c:60: before_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_posops_meos.c:75: overbefore_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_posops_meos.c:90: after_tstzspan_temporal() returns bool but validates with NULL, expected false
-meos/src/temporal/temporal_tile.c:127: bigint_get_bin() returns int64 but documents INT_MAX, expected INT64_MAX
-meos/src/temporal/tinstant.c:661: tinstant_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
-meos/src/temporal/tinstant.c:661: tinstant_hash() returns uint32 but validates with INT_MAX, expected UINT32_MAX
-meos/src/temporal/type_util.c:525: datum_hash() returns uint32 but documents INT_MAX, expected UINT32_MAX
+# grandfathered in, keyed by file, function and sentinel so that
+# an edit above a finding does not read as a new one. The list only
+# shrinks: a new mismatch fails the check. Regenerate with
+# --rebaseline after a fix.
+meos/src/cbuffer/cbuffer.c	cbuffer_cmp	validates with false
+meos/src/cbuffer/cbuffer.c	cbuffer_hash	validates with INT_MAX
+meos/src/cbuffer/tcbuffer_spatialrels.c	spatialrel_geo_geo	documents -1
+meos/src/geo/postgis_funcs.c	geo_num_points	documents -1
+meos/src/geo/postgis_funcs.c	geo_num_points	validates with -1
+meos/src/geo/postgis_funcs.c	geo_num_geos	documents -1
+meos/src/geo/postgis_funcs.c	geo_num_geos	validates with -1
+meos/src/geo/postgis_funcs.c	geo_equals	validates with -1
+meos/src/geo/postgis_funcs.c	line_locate_point	documents -1
+meos/src/geo/postgis_funcs.c	line_numpoints	documents -1
+meos/src/geo/postgis_funcs.c	line_numpoints	validates with -1
+meos/src/geo/postgis_funcs.c	geo_is_empty	validates with NULL
+meos/src/geo/stbox.c	before_stbox_stbox	validates with NULL
+meos/src/geo/stbox.c	overbefore_stbox_stbox	validates with NULL
+meos/src/geo/stbox.c	after_stbox_stbox	validates with NULL
+meos/src/geo/stbox.c	overafter_stbox_stbox	validates with NULL
+meos/src/geo/stbox.c	stbox_cmp	validates with false
+meos/src/geo/stbox.c	stbox_hash	documents INT_MAX
+meos/src/geo/stbox.c	stbox_hash	validates with INT_MAX
+meos/src/geo/tgeo_compops.c	eacomp_tgeo_geo	validates with -1
+meos/src/geo/tgeo_compops.c	eacomp_tgeo_tgeo	validates with -1
+meos/src/geo/tgeo_distance.c	stbox_spatial_distance	validates with false
+meos/src/geo/tgeo_spatialfuncs.c	tgeominst_tgeoginst	documents `NULL`
+meos/src/geo/tgeo_spatialfuncs.c	tgeomseq_tgeogseq	documents `NULL`
+meos/src/geo/tgeo_spatialfuncs.c	tgeomseqset_tgeogseqset	documents `NULL`
+meos/src/geo/tgeo_spatialfuncs.c	tgeom_tgeog	documents `NULL`
+meos/src/geo/tgeo_spatialfuncs.c	tgeometry_to_tgeography	documents `NULL`
+meos/src/geo/tgeo_spatialfuncs.c	tgeography_to_tgeometry	documents `NULL`
+meos/src/geo/tgeo_spatialfuncs.c	tgeo_tpoint	documents `NULL`
+meos/src/geo/tgeo_spatialfuncs.c	tgeo_convex_hull	documents `NULL`
+meos/src/geo/tgeo_spatialrels.c	spatialrel_tgeo_tgeo	documents -1
+meos/src/geo/tpoint_spatialfuncs.c	tpoint_tfloat_to_geomeas	validates with NULL
+meos/src/geo/tspatial_tempspatialrels.c	tspatialrel_tspatial_base	documents `NULL`
+meos/src/geo/tspatial_tempspatialrels.c	tspatialrel_tspatial_tspatial	documents `NULL`
+meos/src/npoint/npoint.c	npoint_cmp	validates with false
+meos/src/npoint/npoint.c	nsegment_cmp	validates with false
+meos/src/npoint/npoint.c	npoint_hash	validates with INT_MAX
+meos/src/npoint/tnpoint.c	tnpoint_route	documents INT_MAX
+meos/src/npoint/tnpoint_compops.c	eacomp_tnpoint_npoint	validates with -1
+meos/src/npoint/tnpoint_compops.c	eacomp_tnpoint_tnpoint	validates with -1
+meos/src/npoint/tnpoint_routeops.c	overlaps_rid_tnpoint_bigintset	validates with NULL
+meos/src/npoint/tnpoint_routeops.c	contains_rid_tnpoint_bigintset	validates with NULL
+meos/src/npoint/tnpoint_routeops.c	same_rid_tnpoint_bigintset	validates with NULL
+meos/src/npoint/tnpoint_routeops.c	contains_rid_tnpoint_bigint	validates with NULL
+meos/src/npoint/tnpoint_routeops.c	same_rid_tnpoint_bigint	validates with NULL
+meos/src/npoint/tnpoint_spatialfuncs.c	npoint_same	validates with NULL
+meos/src/pointcloud/pcpatch.c	pcpatch_hash	validates with INT_MAX
+meos/src/pointcloud/pcpatch.c	pcpatch_cmp	validates with false
+meos/src/pointcloud/pcpoint.c	pcpoint_hash	validates with INT_MAX
+meos/src/pointcloud/pcpoint.c	pcpoint_cmp	validates with false
+meos/src/pointcloud/tpcbox.c	tpcbox_cmp	validates with false
+meos/src/pose/pose.c	pose_eq	validates with NULL
+meos/src/pose/pose.c	pose_same	validates with NULL
+meos/src/pose/pose.c	pose_cmp	validates with false
+meos/src/pose/pose.c	pose_hash	validates with INT_MAX
+meos/src/raster/raquet.c	raquet_quadbin	validates with 0
+meos/src/raster/raquet.c	raquet_width	validates with -1
+meos/src/raster/raquet.c	raquet_height	validates with -1
+meos/src/raster/raquet.c	raquet_nodata	validates with 0.0
+meos/src/raster/raquet.c	raquet_cmp	validates with false
+meos/src/raster/raquet.c	raquet_hash	documents INT_MAX
+meos/src/raster/raquet.c	raquet_hash	validates with INT_MAX
+meos/src/raster/raquet_gdal.c	eraster_value_gdal	validates with -1
+meos/src/raster/raquet_gdal.c	araster_value_gdal	validates with -1
+meos/src/raster/raster_quadbin.c	eraster_value	validates with -1
+meos/src/raster/raster_quadbin.c	araster_value	validates with -1
+meos/src/raster/raster_rtcore.c	raster_num_bands	validates with -1
+meos/src/rgeo/trgeo_spatialrels.c	spatialrel_trgeo_trav_geo	documents -1
+meos/src/temporal/set.c	set_hash	validates with INT_MAX
+meos/src/temporal/set.c	set_mem_size	validates with -1
+meos/src/temporal/set.c	set_num_values	documents -1
+meos/src/temporal/set.c	set_num_values	validates with -1
+meos/src/temporal/set_meos.c	bigintset_start_value	documents INT_MAX
+meos/src/temporal/set_meos.c	bigintset_end_value	documents INT_MAX
+meos/src/temporal/set_ops.c	contains_set_value	validates with NULL
+meos/src/temporal/span.c	timestamptz_shift	documents `DT_NOEND`
+meos/src/temporal/span.c	span_hash	documents INT_MAX
+meos/src/temporal/span.c	span_hash	validates with INT_MAX
+meos/src/temporal/span_meos.c	intspan_width	documents -1
+meos/src/temporal/span_meos.c	intspan_width	validates with -1
+meos/src/temporal/span_meos.c	bigintspan_width	documents -1
+meos/src/temporal/span_meos.c	bigintspan_width	validates with -1
+meos/src/temporal/spanset.c	spanset_hash	documents INT_MAX
+meos/src/temporal/spanset.c	spanset_hash	validates with INT_MAX
+meos/src/temporal/spanset.c	spanset_mem_size	documents -1
+meos/src/temporal/spanset.c	spanset_mem_size	validates with -1
+meos/src/temporal/spanset.c	spanset_lower_inc	validates with NULL
+meos/src/temporal/spanset.c	spanset_upper_inc	validates with NULL
+meos/src/temporal/spanset.c	datespanset_num_dates	documents -1
+meos/src/temporal/spanset.c	datespanset_num_dates	validates with -1
+meos/src/temporal/spanset.c	tstzspanset_num_timestamps	documents -1
+meos/src/temporal/spanset.c	tstzspanset_num_timestamps	validates with -1
+meos/src/temporal/spanset.c	spanset_num_spans	documents -1
+meos/src/temporal/spanset.c	spanset_num_spans	validates with -1
+meos/src/temporal/spanset_meos.c	intspanset_width	documents -1
+meos/src/temporal/spanset_meos.c	intspanset_width	validates with -1
+meos/src/temporal/spanset_meos.c	bigintspanset_width	documents -1
+meos/src/temporal/spanset_meos.c	bigintspanset_width	validates with -1
+meos/src/temporal/spanset_ops.c	overright_spanset_value	validates with NULL
+meos/src/temporal/spanset_ops.c	contains_spanset_timestamptz	validates with NULL
+meos/src/temporal/tbox.c	tbox_make	documents `NULL`
+meos/src/temporal/tbox.c	tbox_hash	documents INT_MAX
+meos/src/temporal/tbox.c	tbox_hash	validates with INT_MAX
+meos/src/temporal/temporal.c	temporal_value_n	validates with NULL
+meos/src/temporal/temporal.c	temporal_num_sequences	documents -1
+meos/src/temporal/temporal.c	temporal_num_sequences	validates with -1
+meos/src/temporal/temporal.c	temporal_num_instants	documents -1
+meos/src/temporal/temporal.c	temporal_num_instants	validates with -1
+meos/src/temporal/temporal.c	temporal_num_timestamps	documents -1
+meos/src/temporal/temporal.c	temporal_num_timestamps	validates with -1
+meos/src/temporal/temporal.c	temporal_timestamptz_n	validates with NULL
+meos/src/temporal/temporal.c	temporal_hash	documents INT_MAX
+meos/src/temporal/temporal.c	temporal_hash	validates with INT_MAX
+meos/src/temporal/temporal_analytics.c	temporal_hausdorff_distance	documents `DBL_MAX`
+meos/src/temporal/temporal_boxops_meos.c	contains_temporal_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	contained_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	contained_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	contained_temporal_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	overlaps_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	overlaps_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	overlaps_temporal_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	same_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	same_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	same_temporal_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	adjacent_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	adjacent_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	adjacent_temporal_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	contains_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_boxops_meos.c	contains_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_posops_meos.c	overafter_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_posops_meos.c	before_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_posops_meos.c	overbefore_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_posops_meos.c	after_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_posops_meos.c	overafter_temporal_tstzspan	validates with NULL
+meos/src/temporal/temporal_posops_meos.c	before_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_posops_meos.c	overbefore_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_posops_meos.c	after_tstzspan_temporal	validates with NULL
+meos/src/temporal/temporal_tile.c	bigint_get_bin	documents INT_MAX
+meos/src/temporal/tinstant.c	tinstant_hash	documents INT_MAX
+meos/src/temporal/tinstant.c	tinstant_hash	validates with INT_MAX
+meos/src/temporal/type_util.c	datum_hash	documents INT_MAX

--- a/tools/scripts/meos_only_files_baseline.txt
+++ b/tools/scripts/meos_only_files_baseline.txt
@@ -1,71 +1,71 @@
 # Findings of tools/scripts/check_meos_only_files.py that are
 # grandfathered in. The list only shrinks: a new violation
 # fails the check. Regenerate with --rebaseline after a split.
-meos/src/geo/postgis_funcs.c:66: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/geo/tgeo_spatialfuncs.c:790: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/geo/tspatial.c:353: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/geo/tspatial_transform_meos.c:213: MEOS conditional inside a MEOS-only file
-meos/src/geo/tspatial_transform_meos.c:236: MEOS conditional inside a MEOS-only file
-meos/src/geo/tspatial_transform_meos.c:30: MEOS conditional inside a MEOS-only file
-meos/src/geo/tspatial_transform_meos.c:36: MEOS conditional inside a MEOS-only file
-meos/src/geo/tspatial_transform_meos.c:653: MEOS conditional inside a MEOS-only file
-meos/src/geo/tspatial_transform_meos.c:676: MEOS conditional inside a MEOS-only file
-meos/src/geo/tspatial_transform_meos.c:97: MEOS conditional inside a MEOS-only file
-meos/src/h3/h3index.c:106: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:120: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:558: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:643: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:753: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:771: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:789: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:808: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:826: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:845: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:864: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:888: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index.c:92: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:111: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:153: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:201: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:242: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:278: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:315: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:365: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:394: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/h3/h3index_sets.c:427: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/json/jsonbset.c:355: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/npoint/npoint.c:48: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/pointcloud/schema_hook.c:18: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/doublen.c:131: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/doublen.c:202: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/doublen.c:63: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/error.c:153: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/error.c:226: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/error.c:42: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/error.c:68: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos.c:137: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos.c:186: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos.c:215: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos.c:82: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos_catalog.c:1083: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos_catalog.c:1285: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos_catalog.c:1331: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos_catalog.c:1402: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos_catalog.c:811: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos_catalog.c:869: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/meos_catalog.c:904: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/set.c:804: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/skiplist.c:186: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/skiplist.c:413: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/skiplist.c:49: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/skiplist.c:575: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/skiplist.c:60: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/skiplist.c:762: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/spanset.c:1068: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/temporal.c:1643: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/temporal.c:284: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/temporal.c:343: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/temporal_aggfuncs.c:62: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/temporal_boxops.c:695: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/tsequence.c:1253: file-scope MEOS conditional: move the definition to the module's _meos.c
-meos/src/temporal/tsequenceset.c:1400: file-scope MEOS conditional: move the definition to the module's _meos.c
+meos/src/geo/postgis_funcs.c	meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR, \	file-scope conditional
+meos/src/geo/tgeo_spatialfuncs.c	ensure_same_dimensionality_geo(const GSERIALIZED *gs1, const GSERIALIZ	file-scope conditional
+meos/src/geo/tspatial.c	inline char **	file-scope conditional
+meos/src/geo/tspatial_transform_meos.c	#define MAX_LEN_HEADER 1024	conditional in a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c	#include "lwgeom_pg.h"	conditional in a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c	#include <libpq/pqformat.h>	conditional in a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c	GetProjStringsSPI(int32_t srid)	conditional in a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c	SPI_pstrdup(const char *str)	conditional in a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c	lwproj_lookup(int32_t srid_from, int32_t srid_to, LWPROJ **pj)	conditional in a MEOS-only file
+meos/src/geo/tspatial_transform_meos.c	spheroid_init_from_srid(int32_t srid, SPHEROID *s)	conditional in a MEOS-only file
+meos/src/h3/h3index.c	h3_is_valid_cell(H3Index cell)	file-scope conditional
+meos/src/h3/h3index.c	h3_is_valid_directed_edge(H3Index edge)	file-scope conditional
+meos/src/h3/h3index.c	h3_is_valid_vertex(H3Index vertex)	file-scope conditional
+meos/src/h3/h3index.c	h3index_cmp(H3Index a, H3Index b)	file-scope conditional
+meos/src/h3/h3index.c	h3index_eq(H3Index a, H3Index b)	file-scope conditional
+meos/src/h3/h3index.c	h3index_ge(H3Index a, H3Index b)	file-scope conditional
+meos/src/h3/h3index.c	h3index_gt(H3Index a, H3Index b)	file-scope conditional
+meos/src/h3/h3index.c	h3index_hash(H3Index cell)	file-scope conditional
+meos/src/h3/h3index.c	h3index_in(const char *str)	file-scope conditional
+meos/src/h3/h3index.c	h3index_le(H3Index a, H3Index b)	file-scope conditional
+meos/src/h3/h3index.c	h3index_lt(H3Index a, H3Index b)	file-scope conditional
+meos/src/h3/h3index.c	h3index_ne(H3Index a, H3Index b)	file-scope conditional
+meos/src/h3/h3index.c	h3index_out(H3Index cell)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_cell_to_children(H3Index origin, int childRes)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_cell_to_vertexes(H3Index cell)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_compact_cells(const Set *cells)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_get_icosahedron_faces(H3Index cell)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_grid_disk(H3Index origin, int k)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_grid_path_cells(H3Index start, H3Index end)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_grid_ring(H3Index origin, int k)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_origin_to_directed_edges(H3Index origin)	file-scope conditional
+meos/src/h3/h3index_sets.c	h3_uncompact_cells(const Set *cells, int res)	file-scope conditional
+meos/src/json/jsonbset.c	jsonb_union_transfn(Set *state, const Jsonb *jb)	file-scope conditional
+meos/src/npoint/npoint.c	#include <libpq/pqformat.h>	file-scope conditional
+meos/src/pointcloud/schema_hook.c	#include <utils/memutils.h>  /* TopMemoryContext */	file-scope conditional
+meos/src/temporal/doublen.c	double2_make(double a, double b)	file-scope conditional
+meos/src/temporal/doublen.c	double3_make(double a, double b, double c)	file-scope conditional
+meos/src/temporal/doublen.c	double4_make(double a, double b, double c, double d)	file-scope conditional
+meos/src/temporal/error.c	#include "utils/elog.h"	file-scope conditional
+meos/src/temporal/error.c	default_error_handler(int errlevel, int errcode, const char *errmsg)	file-scope conditional
+meos/src/temporal/error.c	meos_errno_set(int err)	file-scope conditional
+meos/src/temporal/error.c	pg_error(int errlevel, const char *errmsg)	file-scope conditional
+meos/src/temporal/meos.c	#define USE_POSTGRES_DATES 0	file-scope conditional
+meos/src/temporal/meos.c	geos_finalize(void)	file-scope conditional
+meos/src/temporal/meos.c	gsl_finalize(void)	file-scope conditional
+meos/src/temporal/meos.c	proj_finalize(void)	file-scope conditional
+meos/src/temporal/meos_catalog.c	ensure_numset_type(MeosType type)	file-scope conditional
+meos/src/temporal/meos_catalog.c	ensure_spatialset_type(MeosType type)	file-scope conditional
+meos/src/temporal/meos_catalog.c	ensure_tgeo_type(MeosType type)	file-scope conditional
+meos/src/temporal/meos_catalog.c	ensure_tgeodetic_type(MeosType type)	file-scope conditional
+meos/src/temporal/meos_catalog.c	ensure_timespanset_type(MeosType type)	file-scope conditional
+meos/src/temporal/meos_catalog.c	ensure_tspatial_type(MeosType type)	file-scope conditional
+meos/src/temporal/meos_catalog.c	geoset_type(MeosType type)	file-scope conditional
+meos/src/temporal/set.c	set_compact(const Set *s)	file-scope conditional
+meos/src/temporal/skiplist.c	#define MaxAllocSize   ((Size) 0x3fffffff) /* 1 gigabyte - 1 */	file-scope conditional
+meos/src/temporal/skiplist.c	datum_func2 func, bool crossings, SkipListType sktype)	file-scope conditional
+meos/src/temporal/skiplist.c	extern FunctionCallInfo fetch_fcinfo();	file-scope conditional
+meos/src/temporal/skiplist.c	line 413	file-scope conditional
+meos/src/temporal/skiplist.c	skiplist_elempos(const SkipList *list, void *key, void *value, int cur	file-scope conditional
+meos/src/temporal/skiplist.c	skiplist_keys_values(SkipList *list, void **values)	file-scope conditional
+meos/src/temporal/spanset.c	spanset_compact(const SpanSet *ss)	file-scope conditional
+meos/src/temporal/temporal.c	ensure_temporal_isof_basetype(const Temporal *temp, MeosType basetype)	file-scope conditional
+meos/src/temporal/temporal.c	ensure_valid_tnumber_numspan(const Temporal *temp, const Span *s)	file-scope conditional
+meos/src/temporal/temporal.c	temporal_restart(Temporal *temp, int count)	file-scope conditional
+meos/src/temporal/temporal_aggfuncs.c	extern FunctionCallInfo fetch_fcinfo();	file-scope conditional
+meos/src/temporal/temporal_boxops.c	tsequence_compute_bbox(TSequence *seq)	file-scope conditional
+meos/src/temporal/tsequence.c	tsequence_restart(TSequence *seq, int count)	file-scope conditional
+meos/src/temporal/tsequenceset.c	tsequenceset_restart(TSequenceSet *ss, int count)	file-scope conditional


### PR DESCRIPTION
The two checks grandfather their findings in a baseline keyed by file and line. A line number moves with any edit above it, so a change that inserts a documentation line — or an unrelated change that master merges into the branch the checks run on — shifts every finding below it and the check reads them all as new. The baseline records which findings exist, and a finding does not become another one because the file grew above it.

Each finding is now keyed by the file, the function it is in, and what is wrong with it. The conditionals are keyed by the declarator their block guards rather than by the line after the `#if`, which holds the return type alone and is shared by several blocks in a file: keying on it collapsed 68 findings onto 42 keys, and a collision lets one fixed finding mask another.

Verified: inserting fifty lines into four of the scanned files leaves both checks green, which the previous form did not.