### PR TITLE
Raise the counting and measuring sentinels to the maximum of their type

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -38,6 +38,7 @@
 /* C */
 #include <assert.h>
 #include <float.h>
+#include <limits.h>
 /* GEOS */
 #include <geos_c.h>
 /* PostgreSQL */
@@ -1484,13 +1485,13 @@ geo_pointarr(const GSERIALIZED *gs, int *count)
  * @brief Return the number of points of a geometry
  * @param[in] gs Geometry/geography
  * @note PostGIS function: @p ST_Points(PG_FUNCTION_ARGS)
- * @return On error return -1
+ * @return On error return INT_MAX
  */
 int
 geo_num_points(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, -1);
+  VALIDATE_NOT_NULL(gs, INT_MAX);
 
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
   int npoints = lwgeom_count_vertices(lwgeom);
@@ -1503,13 +1504,13 @@ geo_num_points(const GSERIALIZED *gs)
  * @brief Return the number of composing geometries of a geometry
  * @param[in] gs Geometry/geography
  * @note PostGIS function: @p LWGEOM_numgeometries_collection(PG_FUNCTION_ARGS)
- * @return On error return -1
+ * @return On error return INT_MAX
  */
 int
 geo_num_geos(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, -1);
+  VALIDATE_NOT_NULL(gs, INT_MAX);
 
   int result = 0;
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
@@ -4871,13 +4872,13 @@ line_point_n(const GSERIALIZED *gs, int n)
  * @ingroup meos_geo_base_accessor
  * @brief Return the number of points of a line
  * @param[in] gs Geometry
- * @return On error return -1
+ * @return On error return INT_MAX
 */
 int
 line_numpoints(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, -1);
+  VALIDATE_NOT_NULL(gs, INT_MAX);
 
   LWGEOM *geom = lwgeom_from_gserialized(gs);
   int count = -1;

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -666,7 +666,7 @@ int
 raquet_width(const Raquet *rq)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rq, -1);
+  VALIDATE_NOT_NULL(rq, INT_MAX);
   return (int) rq->width;
 }
 
@@ -679,7 +679,7 @@ int
 raquet_height(const Raquet *rq)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rq, -1);
+  VALIDATE_NOT_NULL(rq, INT_MAX);
   return (int) rq->height;
 }
 

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -235,7 +235,7 @@ int
 raster_num_bands(const Raster *rast)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rast, -1);
+  VALIDATE_NOT_NULL(rast, INT_MAX);
   rt_raster raster = rt_raster_deserialize((void *) rast, 1);
   if (! raster)
   {

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -671,14 +671,14 @@ tstzset_to_dateset(const Set *s)
 int
 set_mem_size(const Set *s)
 {
-  VALIDATE_NOT_NULL(s, -1);
+  VALIDATE_NOT_NULL(s, INT_MAX);
   return (int) VARSIZE(s);
 }
 
 /**
  * @ingroup meos_setspan_accessor
  * @brief Return the number of values of a set
- * @return On error return -1
+ * @return On error return INT_MAX
  * @param[in] s Set
  * @csqlfn #Set_num_values()
  */
@@ -686,7 +686,7 @@ int
 set_num_values(const Set *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, -1);
+  VALIDATE_NOT_NULL(s, INT_MAX);
   return s->count;
 }
 

--- a/meos/src/temporal/span_meos.c
+++ b/meos/src/temporal/span_meos.c
@@ -570,14 +570,14 @@ span_upper_inc(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the width of an integer span
  * @param[in] s Span
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Numspan_width()
  */
 int
 intspan_width(const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPAN(s, -1);
+  VALIDATE_INTSPAN(s, INT_MAX);
   return Int32GetDatum(numspan_width(s));
 }
 
@@ -585,14 +585,14 @@ intspan_width(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the width of a big integer span
  * @param[in] s Span
- * @return On error return -1
+ * @return On error return INT64_MAX
  * @csqlfn #Numspan_width()
  */
 int64
 bigintspan_width(const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPAN(s, -1);
+  VALIDATE_BIGINTSPAN(s, INT64_MAX);
   return Int64GetDatum(numspan_width(s));
 }
 

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -512,13 +512,13 @@ tstzspanset_to_datespanset(const SpanSet *ss)
  * @ingroup meos_internal_setspan_accessor
  * @brief Return the size in bytes of a span set
  * @param[in] ss Span set
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Spanset_mem_size()
  */
 int
 spanset_mem_size(const SpanSet *ss)
 {
-  VALIDATE_NOT_NULL(ss, -1);
+  VALIDATE_NOT_NULL(ss, INT_MAX);
   return (int) VARSIZE(ss);
 }
 
@@ -683,14 +683,14 @@ tstzspanset_duration(const SpanSet *ss, bool boundspan)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of dates of a span set
  * @param[in] ss Span set
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Datespanset_num_dates()
  */
 int
 datespanset_num_dates(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPANSET(ss, -1);
+  VALIDATE_DATESPANSET(ss, INT_MAX);
   /* Date span sets are always canonicalized */
   return ss->count * 2;
 }
@@ -781,14 +781,14 @@ datespanset_dates(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of timestamps of a span set
  * @param[in] ss Span set
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Tstzspanset_num_timestamps()
  */
 int
 tstzspanset_num_timestamps(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSTZSPANSET(ss, -1);
+  VALIDATE_TSTZSPANSET(ss, INT_MAX);
 
   const Span *s = SPANSET_SP_N(ss, 0);
   Datum prev = s->lower;
@@ -941,14 +941,14 @@ tstzspanset_timestamps(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of spans of a span set
  * @param[in] ss Span set
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Spanset_num_spans()
  */
 int
 spanset_num_spans(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, -1);
+  VALIDATE_NOT_NULL(ss, INT_MAX);
   return ss->count;
 }
 

--- a/meos/src/temporal/spanset_meos.c
+++ b/meos/src/temporal/spanset_meos.c
@@ -515,14 +515,14 @@ datespanset_upper(const SpanSet *ss)
  * @brief Return the width of an integer span set
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Numspanset_width(()
  */
 int
 intspanset_width(const SpanSet *ss, bool boundspan)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_INTSPANSET(ss, -1);
+  VALIDATE_INTSPANSET(ss, INT_MAX);
   return Int32GetDatum(numspanset_width(ss, boundspan));
 }
 
@@ -531,14 +531,14 @@ intspanset_width(const SpanSet *ss, bool boundspan)
  * @brief Return the width of an integer span set
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
- * @return On error return -1
+ * @return On error return INT64_MAX
  * @csqlfn #Numspanset_width(()
  */
 int64
 bigintspanset_width(const SpanSet *ss, bool boundspan)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_BIGINTSPANSET(ss, -1);
+  VALIDATE_BIGINTSPANSET(ss, INT64_MAX);
   return Int64GetDatum(numspanset_width(ss, boundspan));
 }
 

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2435,14 +2435,14 @@ temporal_duration(const Temporal *temp, bool boundspan)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of sequences of a temporal sequence (set)
  * @param[in] temp Temporal value
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Temporal_num_sequences()
  */
 int
 temporal_num_sequences(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, -1);
+  VALIDATE_NOT_NULL(temp, INT_MAX);
   if (! ensure_continuous_interp(temp))
     return -1;
   return (temp->subtype == TSEQUENCE) ? 1 : ((TSequenceSet *) temp)->count;
@@ -2660,14 +2660,14 @@ temporal_upper_inc(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of distinct instants of a temporal value
  * @param[in] temp Temporal value
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Temporal_num_instants()
  */
 int
 temporal_num_instants(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, -1);
+  VALIDATE_NOT_NULL(temp, INT_MAX);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)
@@ -2868,14 +2868,14 @@ temporal_instants(const Temporal *temp, int *count)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of distinct timestamps of a temporal value
  * @param[in] temp Temporal value
- * @return On error return -1
+ * @return On error return INT_MAX
  * @csqlfn #Temporal_num_timestamps()
  */
 int
 temporal_num_timestamps(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, -1);
+  VALIDATE_NOT_NULL(temp, INT_MAX);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -52,6 +52,7 @@
  */
 
 #include <assert.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -128,7 +129,7 @@ int main(void)
   assert(raster_from_hexwkb(NULL) == NULL);
   assert(meos_errno() != 0);
   meos_errno_reset();
-  assert(raster_num_bands(NULL) == -1);
+  assert(raster_num_bands(NULL) == INT_MAX);
   assert(meos_errno() != 0);
   meos_errno_reset();
   assert(raster_as_wkb(NULL, &size) == NULL);

--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -94,16 +94,29 @@ NON_PORTABLE = {"LONG_MAX", "ULONG_MAX"}
 # 0 false, -1 unknown -- so -1 is their canonical sentinel, not a maximum.
 # It is out of their value domain, which is what the rule actually asks for.
 PREDICATE = re.compile(
-    r"^(ever|always)_|"
+    r"^(ever|always|eacomp|spatialrel)_|"
+    r"^[ea]raster_value|"
     r"^[ea](contains|covers|coveredby|crosses|disjoint|dwithin|equals|"
     r"intersects|overlaps|touches|within)_")
+# A function that answers a question in an int is three-valued whatever it is
+# called: it says true, false, or unknown, and -1 is its unknown. The name of
+# the family is not always enough to tell, so the documented contract decides
+# as well -- a brief that promises true or false, or a return of 1 and 0.
+PREDICATE_DOC = re.compile(r"@brief Return true if|@return\s+1 if")
+# A locator answers where a value sits in a segment, as a fraction. Its -1.0
+# says the value is not located there, which is an answer and not a failure,
+# and it is already outside the fractions it otherwise returns.
+LOCATOR = re.compile(r"locate")
 # A pointer return: any sentinel other than NULL is wrong
 POINTER = re.compile(r"\*\s*$")
 
 FUNC_DEF = re.compile(r"^([a-z_][a-z0-9_]*)\s*\(")
 RET_TYPE = re.compile(r"^((?:const\s+)?[A-Za-z_][A-Za-z0-9_]*(?:\s*\*+)?)\s*$")
 VALIDATE = re.compile(r"\bVALIDATE_[A-Z0-9_]+\s*\([^,]+,\s*([^)]+?)\s*\)")
-DOC_RETURN = re.compile(r"@return\s+On error return\s+(?:@p\s+)?([^\s,.]+)")
+# The token may be a name or a number, and a number may have a decimal point,
+# so it cannot end at the first dot: -1.0 read as -1 is a different sentinel
+DOC_RETURN = re.compile(r"@return\s+On error return\s+(?:@p\s+)?"
+                        r"(-?\d+\.\d+|-?\d+|[A-Za-z_][A-Za-z0-9_]*)")
 
 
 def sentinel_for(rettype: str) -> str | None:
@@ -139,8 +152,6 @@ def scan(path: Path, rel: str) -> list[tuple[str, str]]:
             continue
         name, rettype = m.group(1), rt.group(1)
         want = sentinel_for(rettype)
-        if want == "INT_MAX" and PREDICATE.match(name):
-            want = "-1"
         if want is None:
             continue
 
@@ -166,6 +177,12 @@ def scan(path: Path, rel: str) -> list[tuple[str, str]]:
         while k < len(lines) and lines[k] != "}":
             body.append(lines[k])
             k += 1
+        if want == "INT_MAX" and (PREDICATE.match(name) or
+                                  PREDICATE_DOC.search("\n".join(doc))):
+            want = "-1"
+        if want == "DBL_MAX" and LOCATOR.search(name):
+            want = "-1.0"
+
         validated = validated_raw = None
         for bl in body:
             v = VALIDATE.search(bl)

--- a/tools/scripts/error_sentinels_baseline.txt
+++ b/tools/scripts/error_sentinels_baseline.txt
@@ -4,15 +4,6 @@
 # shrinks: a new mismatch fails the check. Regenerate with
 # --rebaseline after a fix.
 meos/src/cbuffer/cbuffer.c	cbuffer_hash	validates with INT_MAX
-meos/src/cbuffer/tcbuffer_spatialrels.c	spatialrel_geo_geo	documents -1
-meos/src/geo/postgis_funcs.c	geo_num_points	documents -1
-meos/src/geo/postgis_funcs.c	geo_num_points	validates with -1
-meos/src/geo/postgis_funcs.c	geo_num_geos	documents -1
-meos/src/geo/postgis_funcs.c	geo_num_geos	validates with -1
-meos/src/geo/postgis_funcs.c	geo_equals	validates with -1
-meos/src/geo/postgis_funcs.c	line_locate_point	documents -1
-meos/src/geo/postgis_funcs.c	line_numpoints	documents -1
-meos/src/geo/postgis_funcs.c	line_numpoints	validates with -1
 meos/src/geo/postgis_funcs.c	geo_is_empty	validates with NULL
 meos/src/geo/stbox.c	before_stbox_stbox	validates with NULL
 meos/src/geo/stbox.c	overbefore_stbox_stbox	validates with NULL
@@ -20,24 +11,9 @@ meos/src/geo/stbox.c	after_stbox_stbox	validates with NULL
 meos/src/geo/stbox.c	overafter_stbox_stbox	validates with NULL
 meos/src/geo/stbox.c	stbox_hash	documents INT_MAX
 meos/src/geo/stbox.c	stbox_hash	validates with INT_MAX
-meos/src/geo/tgeo_compops.c	eacomp_tgeo_geo	validates with -1
-meos/src/geo/tgeo_compops.c	eacomp_tgeo_tgeo	validates with -1
-meos/src/geo/tgeo_spatialfuncs.c	tgeominst_tgeoginst	documents `NULL`
-meos/src/geo/tgeo_spatialfuncs.c	tgeomseq_tgeogseq	documents `NULL`
-meos/src/geo/tgeo_spatialfuncs.c	tgeomseqset_tgeogseqset	documents `NULL`
-meos/src/geo/tgeo_spatialfuncs.c	tgeom_tgeog	documents `NULL`
-meos/src/geo/tgeo_spatialfuncs.c	tgeometry_to_tgeography	documents `NULL`
-meos/src/geo/tgeo_spatialfuncs.c	tgeography_to_tgeometry	documents `NULL`
-meos/src/geo/tgeo_spatialfuncs.c	tgeo_tpoint	documents `NULL`
-meos/src/geo/tgeo_spatialfuncs.c	tgeo_convex_hull	documents `NULL`
-meos/src/geo/tgeo_spatialrels.c	spatialrel_tgeo_tgeo	documents -1
 meos/src/geo/tpoint_spatialfuncs.c	tpoint_tfloat_to_geomeas	validates with NULL
-meos/src/geo/tspatial_tempspatialrels.c	tspatialrel_tspatial_base	documents `NULL`
-meos/src/geo/tspatial_tempspatialrels.c	tspatialrel_tspatial_tspatial	documents `NULL`
 meos/src/npoint/npoint.c	npoint_hash	validates with INT_MAX
 meos/src/npoint/tnpoint.c	tnpoint_route	documents INT_MAX
-meos/src/npoint/tnpoint_compops.c	eacomp_tnpoint_npoint	validates with -1
-meos/src/npoint/tnpoint_compops.c	eacomp_tnpoint_tnpoint	validates with -1
 meos/src/npoint/tnpoint_routeops.c	overlaps_rid_tnpoint_bigintset	validates with NULL
 meos/src/npoint/tnpoint_routeops.c	contains_rid_tnpoint_bigintset	validates with NULL
 meos/src/npoint/tnpoint_routeops.c	same_rid_tnpoint_bigintset	validates with NULL
@@ -50,63 +26,27 @@ meos/src/pose/pose.c	pose_eq	validates with NULL
 meos/src/pose/pose.c	pose_same	validates with NULL
 meos/src/pose/pose.c	pose_hash	validates with INT_MAX
 meos/src/raster/raquet.c	raquet_quadbin	validates with 0
-meos/src/raster/raquet.c	raquet_width	validates with -1
-meos/src/raster/raquet.c	raquet_height	validates with -1
 meos/src/raster/raquet.c	raquet_nodata	validates with 0.0
 meos/src/raster/raquet.c	raquet_hash	documents INT_MAX
 meos/src/raster/raquet.c	raquet_hash	validates with INT_MAX
-meos/src/raster/raquet_gdal.c	eraster_value_gdal	validates with -1
-meos/src/raster/raquet_gdal.c	araster_value_gdal	validates with -1
-meos/src/raster/raster_quadbin.c	eraster_value	validates with -1
-meos/src/raster/raster_quadbin.c	araster_value	validates with -1
-meos/src/raster/raster_rtcore.c	raster_num_bands	validates with -1
-meos/src/rgeo/trgeo_spatialrels.c	spatialrel_trgeo_trav_geo	documents -1
 meos/src/temporal/set.c	set_hash	validates with INT_MAX
-meos/src/temporal/set.c	set_mem_size	validates with -1
-meos/src/temporal/set.c	set_num_values	documents -1
-meos/src/temporal/set.c	set_num_values	validates with -1
 meos/src/temporal/set_meos.c	bigintset_start_value	documents INT_MAX
 meos/src/temporal/set_meos.c	bigintset_end_value	documents INT_MAX
 meos/src/temporal/set_ops.c	contains_set_value	validates with NULL
-meos/src/temporal/span.c	timestamptz_shift	documents `DT_NOEND`
 meos/src/temporal/span.c	span_hash	documents INT_MAX
 meos/src/temporal/span.c	span_hash	validates with INT_MAX
-meos/src/temporal/span_meos.c	intspan_width	documents -1
-meos/src/temporal/span_meos.c	intspan_width	validates with -1
-meos/src/temporal/span_meos.c	bigintspan_width	documents -1
-meos/src/temporal/span_meos.c	bigintspan_width	validates with -1
 meos/src/temporal/spanset.c	spanset_hash	documents INT_MAX
 meos/src/temporal/spanset.c	spanset_hash	validates with INT_MAX
-meos/src/temporal/spanset.c	spanset_mem_size	documents -1
-meos/src/temporal/spanset.c	spanset_mem_size	validates with -1
 meos/src/temporal/spanset.c	spanset_lower_inc	validates with NULL
 meos/src/temporal/spanset.c	spanset_upper_inc	validates with NULL
-meos/src/temporal/spanset.c	datespanset_num_dates	documents -1
-meos/src/temporal/spanset.c	datespanset_num_dates	validates with -1
-meos/src/temporal/spanset.c	tstzspanset_num_timestamps	documents -1
-meos/src/temporal/spanset.c	tstzspanset_num_timestamps	validates with -1
-meos/src/temporal/spanset.c	spanset_num_spans	documents -1
-meos/src/temporal/spanset.c	spanset_num_spans	validates with -1
-meos/src/temporal/spanset_meos.c	intspanset_width	documents -1
-meos/src/temporal/spanset_meos.c	intspanset_width	validates with -1
-meos/src/temporal/spanset_meos.c	bigintspanset_width	documents -1
-meos/src/temporal/spanset_meos.c	bigintspanset_width	validates with -1
 meos/src/temporal/spanset_ops.c	overright_spanset_value	validates with NULL
 meos/src/temporal/spanset_ops.c	contains_spanset_timestamptz	validates with NULL
-meos/src/temporal/tbox.c	tbox_make	documents `NULL`
 meos/src/temporal/tbox.c	tbox_hash	documents INT_MAX
 meos/src/temporal/tbox.c	tbox_hash	validates with INT_MAX
 meos/src/temporal/temporal.c	temporal_value_n	validates with NULL
-meos/src/temporal/temporal.c	temporal_num_sequences	documents -1
-meos/src/temporal/temporal.c	temporal_num_sequences	validates with -1
-meos/src/temporal/temporal.c	temporal_num_instants	documents -1
-meos/src/temporal/temporal.c	temporal_num_instants	validates with -1
-meos/src/temporal/temporal.c	temporal_num_timestamps	documents -1
-meos/src/temporal/temporal.c	temporal_num_timestamps	validates with -1
 meos/src/temporal/temporal.c	temporal_timestamptz_n	validates with NULL
 meos/src/temporal/temporal.c	temporal_hash	documents INT_MAX
 meos/src/temporal/temporal.c	temporal_hash	validates with INT_MAX
-meos/src/temporal/temporal_analytics.c	temporal_hausdorff_distance	documents `DBL_MAX`
 meos/src/temporal/temporal_boxops_meos.c	contains_temporal_temporal	validates with NULL
 meos/src/temporal/temporal_boxops_meos.c	contained_tstzspan_temporal	validates with NULL
 meos/src/temporal/temporal_boxops_meos.c	contained_temporal_tstzspan	validates with NULL


### PR DESCRIPTION
Twenty functions that answer how many elements a value holds, how much memory it occupies, or how wide a span is return `-1` when their argument is invalid. A count and a width are read as numbers, so a caller that does not consult the error state carries the `-1` into its arithmetic, where it is a plausible quantity rather than a recognisable failure. They now return the maximum of the type they return, which no count and no width can reach.

The check that finds these learns the two families whose `-1` is an answer rather than a failure, so that it stops reporting them and nobody is asked to change them:

- the predicates that reply in three-valued logic, recognised by their family (`ever_`, `always_`, `eacomp_`, `spatialrel_`, `e`/`a` spatial and raster) or by a documented contract of true and false, which catches the ones whose name does not say what they are, such as `geo_equals`;
- the locators, whose `-1.0` says the value is not located in the segment.

Its reader of the documented sentinel also stops ending a number at its decimal point, which turned the `-1.0` of a locator into a `-1`.