### PR TITLE
Report a circular buffer as containing the one it covers

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -1063,11 +1063,21 @@ distance_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
 int
 cbuffer_contains(const Cbuffer *cb1, const Cbuffer *cb2)
 {
-  /* The disk (pt2, r2) is contained in the disk (pt1, r1) exactly when its
-   * farthest point from pt1, at distance dist(pt1, pt2) + r2, is strictly
-   * inside (pt1, r1) */
+  /* Containment asks that (pt2, r2) be covered by (pt1, r1) and that their
+   * interiors meet. A disk of a strictly positive radius that is covered has
+   * its interior inside the interior of the covering disk, since a point of an
+   * open set lying on the boundary would carry a neighborhood across it, so
+   * the covering settles the containment. A disk of a zero radius is the point
+   * at its centre, whose interior is the point itself: it is contained in a
+   * disk of a strictly positive radius when it lies strictly inside, and in a
+   * disk of a zero radius when the two coincide */
   double dist = hypot(cb2->x - cb1->x, cb2->y - cb1->y);
-  return (dist + cb2->radius < cb1->radius) ? 1 : 0;
+  if (dist + cb2->radius > cb1->radius)
+    return 0;
+  if (cb2->radius > 0)
+    return 1;
+  return (cb1->radius > 0) ? (dist < cb1->radius ? 1 : 0) :
+    (dist == 0 ? 1 : 0);
 }
 
 /**

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -934,3 +934,57 @@ SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=38
 ERROR:  Operation on mixed SRID
 SELECT eDwithin(tcbuffer 'SRID=3812;Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 ERROR:  Operation on mixed SRID
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),2)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),1)@2000-01-01');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),2)@2000-01-01', tcbuffer 'Cbuffer(Point(1.5 0),1)@2000-01-01');
+ econtains 
+-----------
+ f
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),2)@2000-01-01', tcbuffer 'Cbuffer(Point(1.5 0),1)@2000-01-01');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),0)@2000-01-01');
+ econtains 
+-----------
+ f
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),0)@2000-01-01');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(0.5 0),0)@2000-01-01');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
+ econtains 
+-----------
+ t
+(1 row)
+

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -43,13 +43,13 @@ SELECT COUNT(*) FROM tbl_tcbuffer, tbl_cbuffer WHERE aContains(temp, cb);
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE eContains(t1.temp, t2.temp);
  count 
 -------
-     0
+   100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aContains(t1.temp, t2.temp);
  count 
 -------
-     0
+   100
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aCovers(g, temp);

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -324,3 +324,25 @@ SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=38
 SELECT eDwithin(tcbuffer 'SRID=3812;Cbuffer(Point(1 1),0.5)@2000-01-01', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 
 -------------------------------------------------------------------------------
+-- Containment of a disc asks that it be covered and that the interiors meet,
+-- so a disc of a strictly positive radius that is covered is contained, and a
+-- disc of a zero radius is the point at its centre
+-------------------------------------------------------------------------------
+
+-- A disc contains itself, and covers itself
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01');
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01');
+-- A disc that meets the boundary of the containing one from inside is contained
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),2)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),1)@2000-01-01');
+-- A disc reaching outside is neither contained nor covered
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),2)@2000-01-01', tcbuffer 'Cbuffer(Point(1.5 0),1)@2000-01-01');
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),2)@2000-01-01', tcbuffer 'Cbuffer(Point(1.5 0),1)@2000-01-01');
+-- A point on the boundary is covered but not contained, and one strictly
+-- inside is both
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),0)@2000-01-01');
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(1 0),0)@2000-01-01');
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(Point(0.5 0),0)@2000-01-01');
+-- A point contains the point it coincides with
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Containment of a circular buffer asks that the second disc be covered by the first and that their interiors meet, while the kernel asks that the farthest point of the second lie strictly inside the first.

A disc of a strictly positive radius that is covered has its interior inside the interior of the covering disc, since a point of an open set lying on the boundary would carry a neighborhood across it. The covering therefore settles the containment, and the two answers separate only when the second disc is a point: a point on the boundary is covered and not contained, and a point strictly inside is both.

A disc consequently does not contain itself, and a disc meeting the boundary of the containing one from inside is reported as outside it. Over the temporal circular buffer table the self join reports no value containing itself, which becomes the hundred rows of the table; the pairs of distinct values answer alike, so the whole movement is the diagonal.

A disc of a zero radius is the point at its centre, and contains the point it coincides with.

The covering kernel asks the question it answers, and keeps its formula. The added cases carry the identity, a disc meeting the boundary from inside, a disc reaching outside, a point on the boundary against the same point strictly inside, and two coinciding points.