### PR TITLE
Handle the edge-edge closest feature of the rigid geometry distance

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -1733,14 +1733,12 @@ dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs)
           &cfp.cf_1, &cfp.cf_2, &dir1, &dir2, &ratio);
       else /* edge <-> edge */
       {
-        // state = edge_edge_tpoly_poly(poly1, pose1, pose2, poly2,
-        //   &cfp.cf_1, &cfp.cf_2, &dir1, &dir2, &ratio);
-        /* See doc-comment on meos_error in meos/include/meos.h: handler is
-         * not guaranteed to abort. Bail before reading uninitialised `state`
-         * in the `if (state == MEOS_CONTINUE)` check below. Matches the
-         * surrounding `return NULL` idiom on impossible-state paths. */
-        meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "Can't happen");
-        return NULL;
+        /* Two edges are the closest feature pair, e.g. the parallel facing
+         * edges of two convex polygons. No further feature transition is
+         * tracked from this state, so the walk ends for the segment. The
+         * distance at the segment ends and every interior turning point are
+         * taken from the v-clip oracle, so the result stays exact. */
+        state = MEOS_DISJOINT;
       }
 
       // printf("Features after %d, %d\n", cfp.cf_1, cfp.cf_2);
@@ -1936,10 +1934,14 @@ dist2d_trgeoseq_trgeoseq(const TSequence *seq1, const TSequence *seq2,
       else if (cfp.cf_2 % 2 == 0)
         state = edge_vertex_tpoly_poly(poly1, p1s, p1e, p2s, p2e, poly2,
           &cfp.cf_1, &cfp.cf_2, &dir1, &dir2, &ratio);
-      else /* edge <-> edge, unreachable: v-clip resolves ties to vertex-edge */
+      else /* edge <-> edge */
       {
-        meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "Can't happen");
-        return NULL;
+        /* Two edges are the closest feature pair, e.g. the parallel facing
+         * edges of two convex polygons. No further feature transition is
+         * tracked from this state, so the walk ends for the segment. The
+         * distance at the segment ends and every interior turning point are
+         * taken from the v-clip oracle, so the result stays exact. */
+        state = MEOS_DISJOINT;
       }
 
       if (state == MEOS_CONTINUE)

--- a/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
@@ -70,6 +70,22 @@ SELECT round(minValue(tDistance(
  0.000000
 (1 row)
 
+SELECT round(nearestApproachDistance(
+  trgeometry 'Polygon((2 2,2 1,4 0,4 4,2 2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-02]',
+  geometry 'Polygon((5 0,2 1,1 1,5 0))')::numeric, 6);
+  round   
+----------
+ 0.000000
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((2 2,2 1,4 0,4 4,2 2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-02]',
+  geometry 'Polygon((5 0,2 1,1 1,5 0))'))::numeric, 6);
+  round   
+----------
+ 0.000000
+(1 row)
+
 SELECT round(minValue(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]' <->
   geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))')::numeric, 6);

--- a/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
@@ -75,6 +75,16 @@ SELECT round(minValue(tDistance(
   trgeometry 'Polygon((0 0,3 0,3 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.141592653589793)@2001-01-02]',
   geometry 'Polygon((1.5 1.5,2.5 1.5,2.5 2.5,1.5 2.5,1.5 1.5))'))::numeric, 6);
 
+-- Two convex polygons whose closest features are a facing pair of edges: the
+-- distance handles the edge-edge closest-feature state and reports their
+-- separation
+SELECT round(nearestApproachDistance(
+  trgeometry 'Polygon((2 2,2 1,4 0,4 4,2 2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-02]',
+  geometry 'Polygon((5 0,2 1,1 1,5 0))')::numeric, 6);
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((2 2,2 1,4 0,4 4,2 2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),0)@2001-01-02]',
+  geometry 'Polygon((5 0,2 1,1 1,5 0))'))::numeric, 6);
+
 -- The distance operator agrees with the function
 SELECT round(minValue(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]' <->


### PR DESCRIPTION
When two convex polygons have a facing pair of parallel edges as their closest feature, the closest-feature walk of the rigid geometry distance ends its transition tracking for the segment on that state. The distance at the segment ends and every interior turning point are taken from the v-clip oracle, so the nearest approach distance, nearest approach instant, shortest line and temporal distance between a rigid geometry and a geometry, and between two rigid geometries, are exact whenever their closest features are a pair of edges.