### PR TITLE
Return false rather than NULL when a boolean function rejects its argument

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -544,7 +544,7 @@ bool
 geo_is_empty(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, NULL);
+  VALIDATE_NOT_NULL(gs, false);
   return gserialized_is_empty(gs);
 }
 

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -2191,7 +2191,7 @@ bool
 before_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, NULL); VALIDATE_NOT_NULL(box2, NULL);
+  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
   if (! ensure_has_T(T_STBOX, box1->flags) ||
       ! ensure_has_T(T_STBOX, box2->flags))
     return false;
@@ -2209,7 +2209,7 @@ bool
 overbefore_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, NULL); VALIDATE_NOT_NULL(box2, NULL);
+  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
   if (! ensure_has_T(T_STBOX, box1->flags) ||
       ! ensure_has_T(T_STBOX, box2->flags))
     return false;
@@ -2226,7 +2226,7 @@ bool
 after_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, NULL); VALIDATE_NOT_NULL(box2, NULL);
+  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
   if (! ensure_has_T(T_STBOX, box1->flags) ||
       ! ensure_has_T(T_STBOX, box2->flags))
     return false;
@@ -2244,7 +2244,7 @@ bool
 overafter_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, NULL); VALIDATE_NOT_NULL(box2, NULL);
+  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
   if (! ensure_has_T(T_STBOX, box1->flags) ||
       ! ensure_has_T(T_STBOX, box2->flags))
     return false;

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -1423,9 +1423,9 @@ tpoint_tfloat_to_geomeas(const Temporal *tpoint, const Temporal *meas,
   bool segmentize, GSERIALIZED **result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TPOINT(tpoint, NULL);
+  VALIDATE_TPOINT(tpoint, false);
   if (meas)
-    VALIDATE_TFLOAT(meas, NULL);
+    VALIDATE_TFLOAT(meas, false);
 
   Temporal *sync1, *sync2;
   if (meas)

--- a/meos/src/npoint/tnpoint_routeops.c
+++ b/meos/src/npoint/tnpoint_routeops.c
@@ -62,7 +62,7 @@ contains_rid_tnpoint_bigint(const Temporal *temp, int64 rid,
   bool invert UNUSED)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNPOINT(temp, NULL);
+  VALIDATE_TNPOINT(temp, false);
   Set *routes = tnpoint_routes(temp);
   bool result = contains_set_value(routes, Int64GetDatum(rid));
   pfree(routes);
@@ -89,7 +89,7 @@ same_rid_tnpoint_bigint(const Temporal *temp, int64 rid,
   bool invert UNUSED)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNPOINT(temp, NULL);
+  VALIDATE_TNPOINT(temp, false);
   Set *routes = tnpoint_routes(temp);
   bool result = (routes->count == 1) &&
     (DatumGetInt64(SET_VAL_N(routes, 0)) == rid);
@@ -108,7 +108,7 @@ overlaps_rid_tnpoint_bigintset(const Temporal *temp, const Set *s,
   bool invert UNUSED)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNPOINT(temp, NULL); VALIDATE_BIGINTSET(s, NULL);
+  VALIDATE_TNPOINT(temp, false); VALIDATE_BIGINTSET(s, false);
   Set *routes = tnpoint_routes(temp);
   bool result = overlaps_set_set(routes, s);
   pfree(routes);
@@ -124,7 +124,7 @@ contains_rid_tnpoint_bigintset(const Temporal *temp, const Set *s,
   bool invert)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNPOINT(temp, NULL); VALIDATE_BIGINTSET(s, NULL);
+  VALIDATE_TNPOINT(temp, false); VALIDATE_BIGINTSET(s, false);
   Set *routes = tnpoint_routes(temp);
   bool result = invert ? contains_set_set(s, routes) :
     contains_set_set(routes, s);
@@ -152,7 +152,7 @@ same_rid_tnpoint_bigintset(const Temporal *temp, const Set *s,
   bool invert UNUSED)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TNPOINT(temp, NULL); VALIDATE_BIGINTSET(s, NULL);
+  VALIDATE_TNPOINT(temp, false); VALIDATE_BIGINTSET(s, false);
   Set *routes = tnpoint_routes(temp);
   bool result = set_eq(routes, s);
   pfree(routes);

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -203,7 +203,7 @@ bool
 npoint_same(const Npoint *np1, const Npoint *np2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(np1, NULL); VALIDATE_NOT_NULL(np2, NULL);
+  VALIDATE_NOT_NULL(np1, false); VALIDATE_NOT_NULL(np2, false);
 
   /* Equal route identifier and same position */
   if (np1->rid == np2->rid && fabs(np1->pos - np2->pos) > MEOS_EPSILON)

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1865,7 +1865,7 @@ bool
 pose_eq(const Pose *pose1, const Pose *pose2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(pose1, NULL); VALIDATE_NOT_NULL(pose2, NULL);
+  VALIDATE_NOT_NULL(pose1, false); VALIDATE_NOT_NULL(pose2, false);
 
   if (MEOS_FLAGS_GET_Z(pose1->flags) != MEOS_FLAGS_GET_Z(pose2->flags) ||
       pose_srid(pose1) != pose_srid(pose2))
@@ -1907,7 +1907,7 @@ bool
 pose_same(const Pose *pose1, const Pose *pose2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(pose1, NULL); VALIDATE_NOT_NULL(pose2, NULL);
+  VALIDATE_NOT_NULL(pose1, false); VALIDATE_NOT_NULL(pose2, false);
 
   if (MEOS_FLAGS_GET_Z(pose1->flags) != MEOS_FLAGS_GET_Z(pose2->flags) ||
       pose_srid(pose1) != pose_srid(pose2))

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -186,7 +186,7 @@ bool
 contains_set_value(const Set *s, Datum value)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, NULL);
+  VALIDATE_NOT_NULL(s, false);
   /* Bound test */
   if (! contains_bound_set_value(s, value))
     return false;

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -574,7 +574,7 @@ bool
 spanset_lower_inc(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, NULL);
+  VALIDATE_NOT_NULL(ss, false);
   return ss->elems[0].lower_inc;
 }
 
@@ -588,7 +588,7 @@ bool
 spanset_upper_inc(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, NULL);
+  VALIDATE_NOT_NULL(ss, false);
   return ss->elems[ss->count - 1].upper_inc;
 }
 

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -80,7 +80,7 @@ bool
 contains_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSTZSPANSET(ss, NULL);
+  VALIDATE_TSTZSPANSET(ss, false);
   return contains_spanset_value(ss, TimestampTzGetDatum(t));
 }
 
@@ -696,7 +696,7 @@ overright_span_spanset(const Span *s, const SpanSet *ss)
 bool
 overright_spanset_value(const SpanSet *ss, Datum value)
 {
-  VALIDATE_NOT_NULL(ss, NULL);
+  VALIDATE_NOT_NULL(ss, false);
   return overright_span_value(SPANSET_SP_N(ss, 0), value);
 }
 

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2283,7 +2283,7 @@ bool
 temporal_value_n(const Temporal *temp, int n, Datum *result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(result, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_NOT_NULL(result, false);
   if (! ensure_positive(n))
     return false;
 
@@ -2953,7 +2953,7 @@ bool
 temporal_timestamptz_n(const Temporal *temp, int n, TimestampTz *result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_NOT_NULL(result, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_NOT_NULL(result, false);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/src/temporal/temporal_boxops_meos.c
+++ b/meos/src/temporal/temporal_boxops_meos.c
@@ -70,7 +70,7 @@ bool
 contains_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &contains_span_span, INVERT);
 }
 
@@ -86,7 +86,7 @@ bool
 contains_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &contains_span_span, INVERT_NO);
 }
 
@@ -101,7 +101,7 @@ bool
 contains_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp1, NULL); VALIDATE_NOT_NULL(temp2, NULL);
+  VALIDATE_NOT_NULL(temp1, false); VALIDATE_NOT_NULL(temp2, false);
   return boxop_temporal_temporal(temp1, temp2, &contains_span_span);
 }
 
@@ -119,7 +119,7 @@ bool
 contained_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &contained_span_span, INVERT);
 }
 
@@ -135,7 +135,7 @@ bool
 contained_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &contained_span_span, INVERT_NO);
 }
 
@@ -150,7 +150,7 @@ bool
 contained_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp1, NULL); VALIDATE_NOT_NULL(temp2, NULL);
+  VALIDATE_NOT_NULL(temp1, false); VALIDATE_NOT_NULL(temp2, false);
   return boxop_temporal_temporal(temp1, temp2, &contained_span_span);
 }
 
@@ -168,7 +168,7 @@ bool
 overlaps_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &overlaps_span_span, INVERT);
 }
 
@@ -184,7 +184,7 @@ bool
 overlaps_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &overlaps_span_span, INVERT_NO);
 }
 
@@ -198,7 +198,7 @@ bool
 overlaps_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp1, NULL); VALIDATE_NOT_NULL(temp2, NULL);
+  VALIDATE_NOT_NULL(temp1, false); VALIDATE_NOT_NULL(temp2, false);
   return boxop_temporal_temporal(temp1, temp2, &overlaps_span_span);
 }
 
@@ -216,7 +216,7 @@ bool
 same_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &span_eq, INVERT);
 }
 
@@ -232,7 +232,7 @@ bool
 same_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &span_eq, INVERT_NO);
 }
 
@@ -246,7 +246,7 @@ bool
 same_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp1, NULL); VALIDATE_NOT_NULL(temp2, NULL);
+  VALIDATE_NOT_NULL(temp1, false); VALIDATE_NOT_NULL(temp2, false);
   return boxop_temporal_temporal(temp1, temp2, &span_eq);
 }
 
@@ -264,7 +264,7 @@ bool
 adjacent_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &adjacent_span_span, INVERT);
 }
 
@@ -280,7 +280,7 @@ bool
 adjacent_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &adjacent_span_span, INVERT_NO);
 }
 
@@ -294,7 +294,7 @@ bool
 adjacent_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp1, NULL); VALIDATE_NOT_NULL(temp2, NULL);
+  VALIDATE_NOT_NULL(temp1, false); VALIDATE_NOT_NULL(temp2, false);
   return boxop_temporal_temporal(temp1, temp2, &adjacent_span_span);
 }
 

--- a/meos/src/temporal/temporal_posops_meos.c
+++ b/meos/src/temporal/temporal_posops_meos.c
@@ -60,7 +60,7 @@ bool
 before_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &left_span_span, INVERT);
 }
 
@@ -75,7 +75,7 @@ bool
 overbefore_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &overleft_span_span, INVERT);
 }
 
@@ -90,7 +90,7 @@ bool
 after_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &right_span_span, INVERT);
 }
 
@@ -105,7 +105,7 @@ bool
 overafter_tstzspan_temporal(const Span *s, const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &overright_span_span, INVERT);
 }
 
@@ -123,7 +123,7 @@ bool
 before_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &left_span_span, INVERT_NO);
 }
 
@@ -138,7 +138,7 @@ bool
 overbefore_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &overleft_span_span, INVERT_NO);
 }
 
@@ -153,7 +153,7 @@ bool
 after_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &right_span_span, INVERT_NO);
 }
 
@@ -168,7 +168,7 @@ bool
 overafter_temporal_tstzspan(const Temporal *temp, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSPAN(s, NULL);
+  VALIDATE_NOT_NULL(temp, false); VALIDATE_TSTZSPAN(s, false);
   return boxop_temporal_tstzspan(temp, s, &overright_span_span, INVERT_NO);
 }
 

--- a/tools/scripts/error_sentinels_baseline.txt
+++ b/tools/scripts/error_sentinels_baseline.txt
@@ -4,26 +4,12 @@
 # shrinks: a new mismatch fails the check. Regenerate with
 # --rebaseline after a fix.
 meos/src/cbuffer/cbuffer.c	cbuffer_hash	validates with INT_MAX
-meos/src/geo/postgis_funcs.c	geo_is_empty	validates with NULL
-meos/src/geo/stbox.c	before_stbox_stbox	validates with NULL
-meos/src/geo/stbox.c	overbefore_stbox_stbox	validates with NULL
-meos/src/geo/stbox.c	after_stbox_stbox	validates with NULL
-meos/src/geo/stbox.c	overafter_stbox_stbox	validates with NULL
 meos/src/geo/stbox.c	stbox_hash	documents INT_MAX
 meos/src/geo/stbox.c	stbox_hash	validates with INT_MAX
-meos/src/geo/tpoint_spatialfuncs.c	tpoint_tfloat_to_geomeas	validates with NULL
 meos/src/npoint/npoint.c	npoint_hash	validates with INT_MAX
 meos/src/npoint/tnpoint.c	tnpoint_route	documents INT_MAX
-meos/src/npoint/tnpoint_routeops.c	overlaps_rid_tnpoint_bigintset	validates with NULL
-meos/src/npoint/tnpoint_routeops.c	contains_rid_tnpoint_bigintset	validates with NULL
-meos/src/npoint/tnpoint_routeops.c	same_rid_tnpoint_bigintset	validates with NULL
-meos/src/npoint/tnpoint_routeops.c	contains_rid_tnpoint_bigint	validates with NULL
-meos/src/npoint/tnpoint_routeops.c	same_rid_tnpoint_bigint	validates with NULL
-meos/src/npoint/tnpoint_spatialfuncs.c	npoint_same	validates with NULL
 meos/src/pointcloud/pcpatch.c	pcpatch_hash	validates with INT_MAX
 meos/src/pointcloud/pcpoint.c	pcpoint_hash	validates with INT_MAX
-meos/src/pose/pose.c	pose_eq	validates with NULL
-meos/src/pose/pose.c	pose_same	validates with NULL
 meos/src/pose/pose.c	pose_hash	validates with INT_MAX
 meos/src/raster/raquet.c	raquet_quadbin	validates with 0
 meos/src/raster/raquet.c	raquet_nodata	validates with 0.0
@@ -32,44 +18,14 @@ meos/src/raster/raquet.c	raquet_hash	validates with INT_MAX
 meos/src/temporal/set.c	set_hash	validates with INT_MAX
 meos/src/temporal/set_meos.c	bigintset_start_value	documents INT_MAX
 meos/src/temporal/set_meos.c	bigintset_end_value	documents INT_MAX
-meos/src/temporal/set_ops.c	contains_set_value	validates with NULL
 meos/src/temporal/span.c	span_hash	documents INT_MAX
 meos/src/temporal/span.c	span_hash	validates with INT_MAX
 meos/src/temporal/spanset.c	spanset_hash	documents INT_MAX
 meos/src/temporal/spanset.c	spanset_hash	validates with INT_MAX
-meos/src/temporal/spanset.c	spanset_lower_inc	validates with NULL
-meos/src/temporal/spanset.c	spanset_upper_inc	validates with NULL
-meos/src/temporal/spanset_ops.c	overright_spanset_value	validates with NULL
-meos/src/temporal/spanset_ops.c	contains_spanset_timestamptz	validates with NULL
 meos/src/temporal/tbox.c	tbox_hash	documents INT_MAX
 meos/src/temporal/tbox.c	tbox_hash	validates with INT_MAX
-meos/src/temporal/temporal.c	temporal_value_n	validates with NULL
-meos/src/temporal/temporal.c	temporal_timestamptz_n	validates with NULL
 meos/src/temporal/temporal.c	temporal_hash	documents INT_MAX
 meos/src/temporal/temporal.c	temporal_hash	validates with INT_MAX
-meos/src/temporal/temporal_boxops_meos.c	contains_temporal_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	contained_tstzspan_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	contained_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	contained_temporal_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	overlaps_tstzspan_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	overlaps_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	overlaps_temporal_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	same_tstzspan_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	same_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	same_temporal_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	adjacent_tstzspan_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	adjacent_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	adjacent_temporal_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	contains_tstzspan_temporal	validates with NULL
-meos/src/temporal/temporal_boxops_meos.c	contains_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_posops_meos.c	overafter_tstzspan_temporal	validates with NULL
-meos/src/temporal/temporal_posops_meos.c	before_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_posops_meos.c	overbefore_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_posops_meos.c	after_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_posops_meos.c	overafter_temporal_tstzspan	validates with NULL
-meos/src/temporal/temporal_posops_meos.c	before_tstzspan_temporal	validates with NULL
-meos/src/temporal/temporal_posops_meos.c	overbefore_tstzspan_temporal	validates with NULL
-meos/src/temporal/temporal_posops_meos.c	after_tstzspan_temporal	validates with NULL
 meos/src/temporal/temporal_tile.c	bigint_get_bin	documents INT_MAX
 meos/src/temporal/tinstant.c	tinstant_hash	documents INT_MAX
 meos/src/temporal/tinstant.c	tinstant_hash	validates with INT_MAX


### PR DESCRIPTION
Forty-four functions returning a boolean use `false` to answer a rejected argument, the sentinel the boolean type asks for.

The guard of each of them reads `NULL`, the sentinel of a pointer. That value is right by accident, since `NULL` converts to `false`, so the change is inert at run time; what it corrects is what the source says about the type. A binding derives its null check from the return type, and a boolean guarded by a pointer sentinel offers it the wrong one. `temporal_value_n` carries both spellings in a single body, validating with `NULL` and returning `false` two lines below for a different failure.

The baseline of the sentinel check shrinks by the forty-four findings this fixes, from 71 to 27.