### PR TITLE
Restore the documentation build

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -22,7 +22,11 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          sparse-checkout: doc
+          # The job builds the manual from doc/ and runs the local apt-resilient action, which is
+          # read from the checkout: both paths belong in the sparse set.
+          sparse-checkout: |
+            doc
+            .github
 
       # Install dblatex
       - uses: ./.github/actions/apt-resilient

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -1279,7 +1279,7 @@ SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 1,
 -- {"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}
 SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 6);
 /* {"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":
-    "longitude=8&latitude=47&height=1500&crs=EPSG:4979"},
+    "longitude=8&amp;latitude=47&amp;height=1500&amp;crs=EPSG:4979"},
    "quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}} */
 SELECT asEWKT(poseFromGeoPose(
   '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'), 6);

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1288,7 +1288,7 @@ SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 1,
 -- {"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}
 SELECT asGeoPose(pose 'Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)', 2, 6);
 /* {"frameSpecification":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":
-    "longitude=8&latitude=47&height=1500&crs=EPSG:4979"},
+    "longitude=8&amp;latitude=47&amp;height=1500&amp;crs=EPSG:4979"},
    "quaternion":{"x":0,"y":0,"z":0.707107,"w":0.707107}} */
 SELECT asEWKT(poseFromGeoPose(
   '{"position":{"lat":47,"lon":8,"h":1500},"angles":{"yaw":90,"pitch":0,"roll":0}}'), 6);


### PR DESCRIPTION
The documentation job checks out both `doc` and `.github`, so the local `apt-resilient` action it runs is present in the checkout.

The GeoPose example in the English and Spanish pose chapters escapes the ampersands of its URL query string, so both manuals are well-formed XML and `xsltproc` renders 236 English and 235 Spanish pages.