### PR TITLE
Give every remaining sentinel the maximum of its own return type

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -1505,13 +1505,14 @@ cbuffer_ge(const Cbuffer *cb1, const Cbuffer *cb2)
  * @ingroup meos_cbuffer_base_accessor
  * @brief Return the 32-bit hash value of a circular buffer
  * @param[in] cb Circular buffer
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Cbuffer_hash()
  */
 uint32
 cbuffer_hash(const Cbuffer *cb)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(cb, INT_MAX);
+  VALIDATE_NOT_NULL(cb, UINT32_MAX);
 
   /* Compute hashes of the coordinates and the radius */
   uint32 x_hash = float8_hash(cb->x);

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -2619,7 +2619,7 @@ stbox_gt(const STBox *box1, const STBox *box2)
  * @ingroup meos_geo_box_accessor
  * @brief Return the 32-bit hash value of a spatiotemporal box
  * @param[in] box Spatiotemporal box
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT32_MAX
  * @sqlfn hash()
  * @csqlfn #Stbox_hash()
  */
@@ -2627,7 +2627,7 @@ uint32
 stbox_hash(const STBox *box)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box, INT_MAX);
+  VALIDATE_NOT_NULL(box, UINT32_MAX);
 
   /* Determine the dimensions of the spatiotemporal box */
   bool hasx = MEOS_FLAGS_GET_X(box->flags);

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -1394,12 +1394,13 @@ nsegment_ge(const Nsegment *ns1, const Nsegment *ns2)
  * @ingroup meos_npoint_base_accessor
  * @brief Return the 32-bit hash value of a network point
  * @param[in] np Network point
+ * @return On error return @p UINT32_MAX
  */
 uint32
 npoint_hash(const Npoint *np)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(np, INT_MAX);
+  VALIDATE_NOT_NULL(np, UINT32_MAX);
 
   /* Compute hashes of value and position */
   uint32 rid_hash = int64_hash(np->rid);

--- a/meos/src/npoint/tnpoint.c
+++ b/meos/src/npoint/tnpoint.c
@@ -826,7 +826,7 @@ tnpointinst_route(const TInstant *inst)
 /**
  * @ingroup meos_npoint_accessor
  * @brief Return the single route of a temporal network point
- * @return On error return @p INT_MAX
+ * @return On error return @p INT64_MAX
  * @csqlfn #Tnpoint_route()
  */
 int64

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -289,13 +289,14 @@ uint32_t pcpatch_npoints(const Pcpatch *pa)
 /**
  * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 32-bit hash of a pcpatch
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Pcpatch_hash()
  */
 uint32
 pcpatch_hash(const Pcpatch *pa)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(pa, INT_MAX);
+  VALIDATE_NOT_NULL(pa, UINT32_MAX);
   return hash_any((const unsigned char *) pa,
     (int) pcpatch_meaningful_size(pa));
 }

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -319,13 +319,14 @@ pcpoint_get_pcid(const Pcpoint *pt)
  * @note Hashes only the meaningful-prefix bytes — pgpointcloud's
  *   struct-tail padding is skipped because it holds uninitialized heap
  *   bytes that differ between otherwise-identical values.
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Pcpoint_hash()
  */
 uint32
 pcpoint_hash(const Pcpoint *pt)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(pt, INT_MAX);
+  VALIDATE_NOT_NULL(pt, UINT32_MAX);
   return hash_any((const unsigned char *) pt,
     (int) pcpoint_meaningful_size(pt));
 }

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -2043,13 +2043,14 @@ void hashlittle2(const void *key, size_t length, uint32_t *pc, uint32_t *pb);
  * @ingroup meos_pose_base_accessor
  * @brief Return the 32-bit hash value of a pose
  * @param[in] pose Pose
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Pose_hash()
  */
 uint32
 pose_hash(const Pose *pose)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(pose, INT_MAX);
+  VALIDATE_NOT_NULL(pose, UINT32_MAX);
 
   /* Use same code as gserialized2_hash */
   int32_t hval;

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -42,6 +42,7 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 #include <limits.h>
 #include <math.h>
 #include <string.h>
@@ -647,13 +648,14 @@ raquet_copy(const Raquet *rq)
 /**
  * @ingroup meos_raster_base_accessor
  * @brief Return the QUADBIN cell of a Raquet tile
+ * @return On error return @p UINT64_MAX
  * @csqlfn #Raquet_quadbin()
  */
 uint64
 raquet_quadbin(const Raquet *rq)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rq, 0);
+  VALIDATE_NOT_NULL(rq, UINT64_MAX);
   return rq->quadbin;
 }
 
@@ -686,13 +688,14 @@ raquet_height(const Raquet *rq)
 /**
  * @ingroup meos_raster_base_accessor
  * @brief Return the nodata sentinel value of a Raquet tile
+ * @return On error return @p DBL_MAX
  * @csqlfn #Raquet_nodata()
  */
 double
 raquet_nodata(const Raquet *rq)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rq, 0.0);
+  VALIDATE_NOT_NULL(rq, DBL_MAX);
   return rq->nodata;
 }
 
@@ -901,13 +904,13 @@ raquet_gt(const Raquet *rq1, const Raquet *rq2)
  * @brief Return the 32-bit hash of a Raquet tile
  * @param[in] rq Raquet tile
  * @csqlfn #Raquet_hash()
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT32_MAX
  */
 uint32
 raquet_hash(const Raquet *rq)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rq, INT_MAX);
+  VALIDATE_NOT_NULL(rq, UINT32_MAX);
   return hash_any(((const unsigned char *) rq) + VARHDRSZ,
     (int) raquet_meaningful_size(rq));
 }

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -1244,13 +1244,14 @@ set_ge(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_accessor
  * @brief Return the 32-bit hash of a set
  * @param[in] s Set
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Set_hash()
  */
 uint32
 set_hash(const Set *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, INT_MAX);
+  VALIDATE_NOT_NULL(s, UINT32_MAX);
   uint32 result = 1;
   for (int i = 0; i < s->count; i++)
   {

--- a/meos/src/temporal/set_meos.c
+++ b/meos/src/temporal/set_meos.c
@@ -462,7 +462,7 @@ intset_start_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the start value of a big integer set
  * @param[in] s Set
- * @return On error return @p INT_MAX
+ * @return On error return @p INT64_MAX
  * @csqlfn #Set_start_value()
  */
 int64
@@ -554,7 +554,7 @@ intset_end_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the end value of a big integer set
  * @param[in] s Set
- * @return On error return @p INT_MAX
+ * @return On error return @p INT64_MAX
  * @csqlfn #Set_end_value()
  */
 int64

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1740,14 +1740,14 @@ span_gt(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_accessor
  * @brief Return the 32-bit hash of a span
  * @param[in] s Span
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Span_hash()
  */
 uint32
 span_hash(const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, INT_MAX);
+  VALIDATE_NOT_NULL(s, UINT32_MAX);
 
   /* Create flags from the lower_inc and upper_inc values */
   char flags = '\0';

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -1539,14 +1539,14 @@ spanset_gt(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_accessor
  * @brief Return the 32-bit hash value of a span set
  * @param[in] ss Span set
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Spanset_hash()
  */
 uint32
 spanset_hash(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, INT_MAX);
+  VALIDATE_NOT_NULL(ss, UINT32_MAX);
   uint32 result = 1;
   for (int i = 0; i < ss->count; i++)
   {

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -2015,14 +2015,14 @@ tbox_gt(const TBox *box1, const TBox *box2)
  * @ingroup meos_box_accessor
  * @brief Return the 32-bit hash of a temporal box
  * @param[in] box Temporal box
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Tbox_hash()
  */
 uint32
 tbox_hash(const TBox *box)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box, INT_MAX);
+  VALIDATE_NOT_NULL(box, UINT32_MAX);
 
   /* Determine the dimensions of the temporal box */
   bool hasx = MEOS_FLAGS_GET_X(box->flags);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -3724,14 +3724,14 @@ temporal_gt(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_temporal_accessor
  * @brief Return the 32-bit hash value of a temporal value
  * @param[in] temp Temporal value
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Temporal_hash()
  */
 uint32
 temporal_hash(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, INT_MAX);
+  VALIDATE_NOT_NULL(temp, UINT32_MAX);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -121,7 +121,7 @@ int_get_bin(int value, int size, int origin)
  * @param[in] value Input value
  * @param[in] size Size of the bins
  * @param[in] origin Origin of the bins
- * @return On error return @p INT_MAX
+ * @return On error return @p INT64_MAX
  */
 int64
 bigint_get_bin(int64 value, int64 size, int64 origin)

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -654,14 +654,14 @@ tinstant_cmp(const TInstant *inst1, const TInstant *inst2)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return the 32-bit hash of a temporal instant
  * @param[in] inst Temporal instant
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT32_MAX
  * @csqlfn #Temporal_hash()
  */
 uint32
 tinstant_hash(const TInstant *inst)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(inst, INT_MAX);
+  VALIDATE_NOT_NULL(inst, UINT32_MAX);
 
   MeosType basetype = temptype_basetype(inst->temptype);
   /* Apply the hash function to the base type */

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -519,7 +519,7 @@ datum_div(Datum l, Datum r, MeosType type)
  * @brief Return the 32-bit hash of a value
  * @param[in] d Value
  * @param[in] type Type of the value
- * @return On error return @p INT_MAX
+ * @return On error return @p UINT32_MAX
  */
 uint32
 datum_hash(Datum d, MeosType type)

--- a/tools/scripts/error_sentinels_baseline.txt
+++ b/tools/scripts/error_sentinels_baseline.txt
@@ -3,30 +3,4 @@
 # an edit above a finding does not read as a new one. The list only
 # shrinks: a new mismatch fails the check. Regenerate with
 # --rebaseline after a fix.
-meos/src/cbuffer/cbuffer.c	cbuffer_hash	validates with INT_MAX
-meos/src/geo/stbox.c	stbox_hash	documents INT_MAX
-meos/src/geo/stbox.c	stbox_hash	validates with INT_MAX
-meos/src/npoint/npoint.c	npoint_hash	validates with INT_MAX
-meos/src/npoint/tnpoint.c	tnpoint_route	documents INT_MAX
-meos/src/pointcloud/pcpatch.c	pcpatch_hash	validates with INT_MAX
-meos/src/pointcloud/pcpoint.c	pcpoint_hash	validates with INT_MAX
-meos/src/pose/pose.c	pose_hash	validates with INT_MAX
-meos/src/raster/raquet.c	raquet_quadbin	validates with 0
-meos/src/raster/raquet.c	raquet_nodata	validates with 0.0
-meos/src/raster/raquet.c	raquet_hash	documents INT_MAX
-meos/src/raster/raquet.c	raquet_hash	validates with INT_MAX
-meos/src/temporal/set.c	set_hash	validates with INT_MAX
-meos/src/temporal/set_meos.c	bigintset_start_value	documents INT_MAX
-meos/src/temporal/set_meos.c	bigintset_end_value	documents INT_MAX
-meos/src/temporal/span.c	span_hash	documents INT_MAX
-meos/src/temporal/span.c	span_hash	validates with INT_MAX
-meos/src/temporal/spanset.c	spanset_hash	documents INT_MAX
-meos/src/temporal/spanset.c	spanset_hash	validates with INT_MAX
-meos/src/temporal/tbox.c	tbox_hash	documents INT_MAX
-meos/src/temporal/tbox.c	tbox_hash	validates with INT_MAX
-meos/src/temporal/temporal.c	temporal_hash	documents INT_MAX
-meos/src/temporal/temporal.c	temporal_hash	validates with INT_MAX
-meos/src/temporal/temporal_tile.c	bigint_get_bin	documents INT_MAX
-meos/src/temporal/tinstant.c	tinstant_hash	documents INT_MAX
-meos/src/temporal/tinstant.c	tinstant_hash	validates with INT_MAX
-meos/src/temporal/type_util.c	datum_hash	documents INT_MAX
+


### PR DESCRIPTION
The branch carries the boolean-sentinel commit beneath it; the second commit is the one to review.

Twenty accessors answer a rejected argument with a value of the wrong type. Fourteen hashes return `uint32` and fall back to `INT_MAX`, a hash that a set can genuinely produce and not the maximum of the type. `raquet_quadbin` falls back to `0`, which is a valid cell, and `raquet_nodata` to `0.0`, which is a valid nodata value. Four functions returning `int64` document `INT_MAX` while their guard already yields `INT64_MAX`, so the contract a binding reads disagrees with the value it receives.

Each guard yields the maximum of the type it returns, and each `@return` line states that value, added where absent. The baseline of the sentinel check empties, leaving the check to hold the whole library to the rule rather than grandfathering a remainder.

Neither raquet accessor is reachable on its error path from SQL: both wrappers are strict, and neither inspects the value it receives.