### PR TITLE
Run the tpose and tnpoint smoke suites under the strict leak check

### DIFF
--- a/meos/test/run_smoketests.sh
+++ b/meos/test/run_smoketests.sh
@@ -70,15 +70,15 @@ for suite in "${SUITES[@]}"; do
     -L"$MEOS_BUILD_DIR" -lmeos -lm
   echo "[run]   $suite"
   # Leak-check mode is coupled to what the current base library already fixes:
-  #  - trgeometry/tpose/tnpoint: build on the temporal pose, whose bbox accessor
-  #    leaks are not yet fixed in this base, so they run summary until the pose
-  #    leak-fix PRs land; they still surface crashes, invalid memory and new
-  #    leaks. Flip them to full once those fixes are in the base.
-  #  - everything else (tgeometry, tcbuffer, ...) is leak-clean and runs the
-  #    strict full check; meos_smoketest.supp filters the PROJ/SQLite3 SRS
-  #    possibly-lost noise so it only reports genuine MEOS/liblwgeom leaks.
+  #  - trgeometry: builds on the temporal pose and still carries unfixed leaks in
+  #    the moving-rigid-geometry surface, so it runs summary until those land; it
+  #    still surfaces crashes, invalid memory and new leaks.
+  #  - everything else (tpose, tnpoint, tgeometry, tcbuffer, ...) is leak-clean
+  #    and runs the strict full check; meos_smoketest.supp filters the
+  #    PROJ/SQLite3 SRS possibly-lost noise so it only reports genuine
+  #    MEOS/liblwgeom leaks.
   case "$suite" in
-    trgeometry_test|tpose_smoketest|tnpoint_smoketest)
+    trgeometry_test)
       vg_leak="--leak-check=summary" ;;
     *)
       vg_leak="--leak-check=full" ;;


### PR DESCRIPTION
The tpose and tnpoint smoke suites run under the strict --leak-check=full valgrind check, together with tgeometry, tcbuffer and the other suites; only trgeometry_test, whose moving-rigid-geometry surface still carries leaks, stays on --leak-check=summary. The suppression file filters the PROJ and SQLite3 SRS possibly-lost noise so the check reports only genuine MEOS and liblwgeom leaks.