### PR TITLE
Select the JSONB set aggregate by file as the other set families do

### DIFF
--- a/meos/src/json/CMakeLists.txt
+++ b/meos/src/json/CMakeLists.txt
@@ -8,4 +8,10 @@ set(JSON_SOURCES
   tjsonb_compops.c
 )
 
+if(MEOS)
+  list(APPEND JSON_SOURCES
+  jsonbset_meos.c
+)
+endif()
+
 add_library(json OBJECT ${JSON_SOURCES})

--- a/meos/src/json/jsonbset.c
+++ b/meos/src/json/jsonbset.c
@@ -348,26 +348,4 @@ minus_set_jsonb(const Set *s, const Jsonb *jb)
   return minus_set_value(s, PointerGetDatum(jb));
 }
 
-/*****************************************************************************
- * Aggregate functions for set types
- *****************************************************************************/
-
-#if MEOS
-/**
- * @ingroup meos_json_set_json
- * @brief Transition function for set union aggregate of JSONB values
- * @param[in,out] state Current aggregate state
- * @param[in] jb Value
- */
-Set *
-jsonb_union_transfn(Set *state, const Jsonb *jb)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(jb, NULL);
-  if (state && ! ensure_set_isof_type(state, T_JSONBSET))
-    return NULL;
-  return value_union_transfn(state, PointerGetDatum(jb), T_JSONB);
-}
-#endif /* MEOS */
-
 /*****************************************************************************/

--- a/meos/src/json/jsonbset_meos.c
+++ b/meos/src/json/jsonbset_meos.c
@@ -1,0 +1,63 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Functions for sets of JSONB type that the MEOS library defines
+ */
+
+/* PostgreSQL */
+#include <postgres.h>
+#include <utils/jsonb.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_internal.h>
+#include "temporal/set.h"
+
+/*****************************************************************************
+ * Aggregate functions for set types
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_json_set_json
+ * @brief Transition function for set union aggregate of JSONB values
+ * @param[in,out] state Current aggregate state
+ * @param[in] jb Value
+ */
+Set *
+jsonb_union_transfn(Set *state, const Jsonb *jb)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(jb, NULL);
+  if (state && ! ensure_set_isof_type(state, T_JSONBSET))
+    return NULL;
+  return value_union_transfn(state, PointerGetDatum(jb), T_JSONB);
+}
+
+/*****************************************************************************/

--- a/tools/scripts/meos_only_files_baseline.txt
+++ b/tools/scripts/meos_only_files_baseline.txt
@@ -33,7 +33,6 @@ meos/src/h3/h3index_sets.c	h3_grid_path_cells(H3Index start, H3Index end)	file-s
 meos/src/h3/h3index_sets.c	h3_grid_ring(H3Index origin, int k)	file-scope conditional
 meos/src/h3/h3index_sets.c	h3_origin_to_directed_edges(H3Index origin)	file-scope conditional
 meos/src/h3/h3index_sets.c	h3_uncompact_cells(const Set *cells, int res)	file-scope conditional
-meos/src/json/jsonbset.c	jsonb_union_transfn(Set *state, const Jsonb *jb)	file-scope conditional
 meos/src/npoint/npoint.c	#include <libpq/pqformat.h>	file-scope conditional
 meos/src/pointcloud/schema_hook.c	#include <utils/memutils.h>  /* TopMemoryContext */	file-scope conditional
 meos/src/temporal/doublen.c	double2_make(double a, double b)	file-scope conditional


### PR DESCRIPTION
Moves the JSONB set union transition function into meos/src/json/jsonbset_meos.c and appends that file to JSON_SOURCES under if(MEOS), so the JSON family selects its MEOS-only surface by file like every other family with a set type: cbufferset_meos.c, geoset_meos.c, npointset_meos.c, pcset_meos.c and poseset_meos.c. An #if MEOS conditional inside jsonbset.c carries the function instead, which check_meos_only_files.py reports as a file-scope conditional to move to the module's _meos.c. Both mechanisms select the same target, the MEOS library and not the PostgreSQL extension, so this moves the selection from the preprocessor to CMake and leaves what each build contains alone.

The conditional carries a baselined finding, so removing it also retires that entry: --rebaseline shrinks tools/scripts/meos_only_files_baseline.txt from 68 findings to 67, which is what the checker prints for a finding the code stops producing.
