### PR TITLE
Name the commuted wrappers of the nearest approach distance

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1782,7 +1782,7 @@ nad_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
  * and a geometry
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
- * @csqlfn #NAD_tcbuffer_geo()
+ * @csqlfn #NAD_tcbuffer_geo() #NAD_geo_tcbuffer()
  */
 double
 nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -1800,7 +1800,7 @@ nad_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * and a spatiotemporal box
  * @param[in] temp Temporal circular buffer
  * @param[in] box Spatiotemporal box
- * @csqlfn #NAD_tcbuffer_stbox()
+ * @csqlfn #NAD_tcbuffer_stbox() #NAD_stbox_tcbuffer()
  */
 double
 nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
@@ -1822,7 +1822,7 @@ nad_tcbuffer_stbox(const Temporal *temp, const STBox *box)
  * and a circular buffer
  * @param[in] temp Temporal circular buffer
  * @param[in] cb Circular buffer
- * @csqlfn #NAD_tcbuffer_cbuffer()
+ * @csqlfn #NAD_tcbuffer_cbuffer() #NAD_cbuffer_tcbuffer()
  */
 double
 nad_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2645,7 +2645,7 @@ nai_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * and a geometry/geography
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry/geography
- * @csqlfn #NAD_tgeo_geo()
+ * @csqlfn #NAD_tgeo_geo() #NAD_geo_tgeo()
  * @return On error return infinity
  */
 double
@@ -2685,7 +2685,7 @@ nad_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * and a geometry/geography
  * @param[in] box Spatiotemporal box/geography
  * @param[in] gs Geometry
- * @csqlfn #NAD_stbox_geo()
+ * @csqlfn #NAD_stbox_geo() #NAD_geo_stbox()
  * @return On error return infinity
  */
 double
@@ -2710,7 +2710,7 @@ nad_stbox_geo(const STBox *box, const GSERIALIZED *gs)
  * boxes
  * @param[in] box1,box2 Spatiotemporal boxes
  * @return On error or if the time frames do not intersect return infinity
- * @csqlfn #NAD_stbox_stbox ()
+ * @csqlfn #NAD_stbox_stbox()
  */
 double
 nad_stbox_stbox(const STBox *box1, const STBox *box2)
@@ -2738,7 +2738,7 @@ nad_stbox_stbox(const STBox *box1, const STBox *box2)
  * @param[in] temp Temporal geo
  * @param[in] box Spatiotemporal box
  * @return On error or if the time frames do not intersect return infinity
- * @csqlfn #NAD_tgeo_stbox()
+ * @csqlfn #NAD_tgeo_stbox() #NAD_stbox_tgeo()
  */
 double
 nad_tgeo_stbox(const Temporal *temp, const STBox *box)

--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -220,7 +220,7 @@ nai_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * and a geometry
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
- * @csqlfn #NAD_tnpoint_geo()
+ * @csqlfn #NAD_tnpoint_geo() #NAD_geo_tnpoint()
  */
 double
 nad_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -241,7 +241,7 @@ nad_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
  * and a spatiotemporal box
  * @param[in] temp Temporal point
  * @param[in] box Spatiotemporal box
- * @csqlfn #NAD_tnpoint_stbox()
+ * @csqlfn #NAD_tnpoint_stbox() #NAD_stbox_tnpoint()
  */
 double
 nad_tnpoint_stbox(const Temporal *temp, const STBox *box)
@@ -264,7 +264,7 @@ nad_tnpoint_stbox(const Temporal *temp, const STBox *box)
  * and a network point
  * @param[in] temp Temporal point
  * @param[in] np Network point
- * @csqlfn #NAD_tnpoint_npoint()
+ * @csqlfn #NAD_tnpoint_npoint() #NAD_npoint_tnpoint()
  */
 double
 nad_tnpoint_npoint(const Temporal *temp, const Npoint *np)

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -201,7 +201,7 @@ nai_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * and a geometry
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @csqlfn #NAD_tpose_geo()
+ * @csqlfn #NAD_tpose_geo() #NAD_geo_tpose()
  */
 double
 nad_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -217,12 +217,12 @@ nad_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
 }
 
 /**
- * @ingroup meos_cbuffer_dist
+ * @ingroup meos_pose_dist
  * @brief Return the nearest approach distance of a temporal pose and a
  * spatiotemporal box
  * @param[in] temp Temporal pose
  * @param[in] box Spatiotemporal box
- * @csqlfn #NAD_tpose_geo()
+ * @csqlfn #NAD_tpose_stbox() #NAD_stbox_tpose()
  */
 double
 nad_tpose_stbox(const Temporal *temp, const STBox *box)
@@ -244,7 +244,7 @@ nad_tpose_stbox(const Temporal *temp, const STBox *box)
  * and a pose
  * @param[in] temp Temporal pose
  * @param[in] pose Pose
- * @csqlfn #NAD_tpose_pose()
+ * @csqlfn #NAD_tpose_pose() #NAD_pose_tpose()
  */
 double
 nad_tpose_pose(const Temporal *temp, const Pose *pose)

--- a/meos/src/temporal/tnumber_distance.c
+++ b/meos/src/temporal/tnumber_distance.c
@@ -229,7 +229,7 @@ nad_tbox_tbox(const TBox *box1, const TBox *box2)
  * @param[in] box Temporal box
  * @return On error or if the time frames do not overlap return the
  * sentinel of the base type given by #distance_sentinel()
- * @csqlfn #NAD_tnumber_tbox()
+ * @csqlfn #NAD_tnumber_tbox() #NAD_tbox_tnumber()
  */
 Datum
 nad_tnumber_tbox(const Temporal *temp, const TBox *box)

--- a/meos/src/temporal/tnumber_distance_meos.c
+++ b/meos/src/temporal/tnumber_distance_meos.c
@@ -96,7 +96,7 @@ tdistance_tfloat_float(const Temporal *temp, double d)
  * @param[in] temp Temporal value
  * @param[in] i Value
  * @return On error return INT_MAX
- * @csqlfn #NAD_tnumber_number()
+ * @csqlfn #NAD_tnumber_number() #NAD_number_tnumber()
  */
 int
 nad_tint_int(const Temporal *temp, int i)
@@ -113,7 +113,7 @@ nad_tint_int(const Temporal *temp, int i)
  * @param[in] temp Temporal value
  * @param[in] i Value
  * @return On error return @p INT64_MAX
- * @csqlfn #NAD_tnumber_number()
+ * @csqlfn #NAD_tnumber_number() #NAD_number_tnumber()
  */
 int64
 nad_tbigint_bigint(const Temporal *temp, int64 i)
@@ -130,7 +130,7 @@ nad_tbigint_bigint(const Temporal *temp, int64 i)
  * @param[in] temp Temporal value
  * @param[in] d Value
  * @return On error return DBL_MAX
- * @csqlfn #NAD_tnumber_number()
+ * @csqlfn #NAD_tnumber_number() #NAD_number_tnumber()
  */
 double
 nad_tfloat_float(const Temporal *temp, double d)


### PR DESCRIPTION
A MEOS function names the PostgreSQL wrappers that call it in its `@csqlfn` tag, and the catalog gives that function the SQL surface of every wrapper it names. The commuted argument order of a nearest approach distance is a second wrapper over the same MEOS function — `nearestApproachDistance(stbox, tgeompoint)` is `NAD_stbox_tgeo` over `nad_tgeo_stbox` — and fifteen of those wrappers are named by nothing, so their overloads have nowhere to land.

Naming them adds 29 SQL overloads across 14 functions. Measured with the catalog's own parser (`parser/sqlfn.py::_meos_to_mdb`) over the tree with and without the change:

| | claimed NAD wrappers | lost |
|---|---|---|
| without | 25 | — |
| with | 40 | 0 |

| wrapper | overloads | wrapper | overloads |
|---|---|---|---|
| `NAD_geo_tgeo` | 8 | `NAD_geo_tnpoint` | 1 |
| `NAD_stbox_tgeo` | 4 | `NAD_geo_tpose` | 1 |
| `NAD_number_tnumber` | 3 | `NAD_npoint_tnpoint` | 1 |
| `NAD_tbox_tnumber` | 3 | `NAD_pose_tpose` | 1 |
| `NAD_cbuffer_tcbuffer` | 2 | `NAD_stbox_tnpoint` | 1 |
| `NAD_geo_stbox` | 2 | `NAD_stbox_tcbuffer` | 0 |
| `NAD_geo_tcbuffer` | 2 | `NAD_tpose_stbox` | 0 |
| | | `NAD_stbox_tpose` | 0 |

Three carry no overload because no `CREATE FUNCTION` names them at all: `NAD_stbox_tcbuffer`, `NAD_tpose_stbox` and `NAD_stbox_tpose` compile into the extension and stay unreachable from SQL, as does the already-named `NAD_tcbuffer_stbox`. Naming them states what calls the function; whether that surface belongs in SQL is a separate question.

Two tags are wrong rather than missing:

- `nad_tpose_stbox` names `#NAD_tpose_geo()`, which is `nad_tpose_geo`'s wrapper. Its own two wrappers go unnamed, and a wrapper belonging to another function carries two claimants.
- The same block puts a pose function in `@ingroup meos_cbuffer_dist`, alone among the twelve in that file.

The spacing of `#NAD_stbox_stbox ()` matches its siblings; the parser reads either form, so that one is formatting only.

`nad_tnumber_number` stays unnamed: it carries `@ingroup meos_internal_temporal_dist`, and the public surface sits on `nad_tint_int`, `nad_tbigint_bigint` and `nad_tfloat_float`, which take the three overloads one each.

`NAD_number_tnumber` is the single wrapper this change makes shared, and its claimants are those same three functions, which already share `NAD_tnumber_number`, so type-scope resolution meets no new name to derive.

The change is comment-only: all 18 changed lines are doxygen `@` lines.

The trgeometry nearest approach distances stay unnamed, as does the pointcloud pair. Those are their own families and their own change.