### PR TITLE
Publish the enabled families in the installed meos.pc

### DIFF
--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -516,6 +516,29 @@ if(MEOS)
     string(REPLACE ";" " " MEOS_PC_LIBS_PRIVATE "${_meos_pc_libs}")
   endif()
 
+  # The public headers gate declarations on the family macros -- meos.h alone
+  # carries #if MEOS, #if POINTCLOUD and #if JSON blocks -- so a consumer that
+  # compiles without them sees a different API than the library exports: a
+  # declaration it cannot link, or a function it cannot see. Nothing else in the
+  # installed tree records which families the library was built with, leaving
+  # every consumer to hand-maintain its own list of -D flags and guess.
+  #
+  # These are the RESOLVED per-family values, not the ALL alias: ALL selects the
+  # families at configure time and is never passed to a compiler, so a consumer
+  # given -DALL=1 still evaluates #if POINTCLOUD as false and silently loses the
+  # family. Each family is emitted with its value, 1 and 0 alike, mirroring the
+  # add_definitions() pairs in the top-level CMakeLists, so that the installed
+  # library describes its own feature set.
+  set(_meos_pc_cflags -DMEOS=1)
+  foreach(_family CBUFFER H3 JSON NPOINT POINTCLOUD POSE QUADBIN RASTER RGEO)
+    if(${_family})
+      list(APPEND _meos_pc_cflags -D${_family}=1)
+    else()
+      list(APPEND _meos_pc_cflags -D${_family}=0)
+    endif()
+  endforeach()
+  string(REPLACE ";" " " MEOS_PC_CFLAGS "${_meos_pc_cflags}")
+
   configure_file(
     ${CMAKE_SOURCE_DIR}/tools/meos.pc.in
     ${CMAKE_BINARY_DIR}/meos.pc

--- a/tools/meos.pc.in
+++ b/tools/meos.pc.in
@@ -7,6 +7,6 @@ Name: MEOS
 Description: Mobility Engine, Open Source - C API
 Requires:
 Version: @VERSION@
-Cflags: -I${includedir}
+Cflags: -I${includedir} @MEOS_PC_CFLAGS@
 Libs: -L${libdir} -lmeos
 Libs.private: @MEOS_PC_LIBS_PRIVATE@


### PR DESCRIPTION
The installed `meos.pc` carries the family macros the library is compiled with, so `pkg-config --cflags meos` describes the feature set a consumer links against.

The public headers gate declarations on those macros — `meos.h` alone holds `#if MEOS`, `#if POINTCLOUD` and `#if JSON` blocks — so a consumer compiling without them sees a different API than the library exports: a declaration it cannot link, or a function it cannot see. Nothing else in the installed tree records which families are enabled, which leaves every binding hand-maintaining its own list of `-D` flags and guessing. GoMEOS spells all ten out in its cgo preamble, beside a comment stating that they mirror the `if(ALL)` loop in `CMakeLists.txt`.

The values are the resolved per-family ones rather than the `ALL` alias. `ALL` selects the families at configure time and never reaches a compiler, so a consumer handed `-DALL=1` still evaluates `#if POINTCLOUD` as false and silently loses the family.

Both branches of the option set:

```
-DALL=ON   Cflags: -I${includedir} -DMEOS=1 -DCBUFFER=1 -DH3=1 -DJSON=1 -DNPOINT=1 -DPOINTCLOUD=1 -DPOSE=1 -DQUADBIN=1 -DRASTER=1 -DRGEO=1
default    Cflags: -I${includedir} -DMEOS=1 -DCBUFFER=0 -DH3=0 -DJSON=1 -DNPOINT=1 -DPOINTCLOUD=0 -DPOSE=0 -DQUADBIN=0 -DRASTER=0 -DRGEO=0
```

The first line matches the list GoMEOS hardcodes; the second matches the option defaults, `JSON` and `NPOINT` on and the rest off.