### PR TITLE
Cover the temporal spatial relationships of the pose and cell index families

### DIFF
--- a/mobilitydb/test/h3/expected/264_th3index_tempspatialrels.test.out
+++ b/mobilitydb/test/h3/expected/264_th3index_tempspatialrels.test.out
@@ -1,0 +1,56 @@
+SELECT tIntersects(NULL::geometry, th3index '831c00fffffffff@2001-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(getValue(th3CellToBoundary(th3index '831c00fffffffff@2001-01-01')::tgeometry), NULL::th3index);
+ tintersects 
+-------------
+ 
+(1 row)
+
+WITH t AS (
+  SELECT th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}' AS seq1,
+         th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}' AS seq2,
+         getValue(th3CellToBoundary(th3index '831c00fffffffff@2001-01-01')::tgeometry) AS cell_geom
+)
+SELECT
+  asText(tContains(cell_geom, seq1)) = asText(tContains(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS tc_geo_c,
+  asText(tContains(seq1, cell_geom)) = asText(tContains(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS tc_c_geo,
+  asText(tContains(seq1, seq2)) = asText(tContains(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS tc_c_c,
+  asText(tCovers(cell_geom, seq1)) = asText(tCovers(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS tcv_geo_c,
+  asText(tCovers(seq1, cell_geom)) = asText(tCovers(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS tcv_c_geo,
+  asText(tCovers(seq1, seq2)) = asText(tCovers(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS tcv_c_c,
+  asText(tDisjoint(cell_geom, seq1)) = asText(tDisjoint(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS tdj_geo_c,
+  asText(tDisjoint(seq1, cell_geom)) = asText(tDisjoint(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS tdj_c_geo,
+  asText(tDisjoint(seq1, seq2)) = asText(tDisjoint(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS tdj_c_c,
+  asText(tIntersects(cell_geom, seq1)) = asText(tIntersects(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS ti_geo_c,
+  asText(tIntersects(seq1, cell_geom)) = asText(tIntersects(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS ti_c_geo,
+  asText(tIntersects(seq1, seq2)) = asText(tIntersects(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS ti_c_c,
+  asText(tTouches(cell_geom, seq1)) = asText(tTouches(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS ttc_geo_c,
+  asText(tTouches(seq1, cell_geom)) = asText(tTouches(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS ttc_c_geo,
+  asText(tTouches(seq1, seq2)) = asText(tTouches(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS ttc_c_c,
+  asText(tDwithin(cell_geom, seq1, 0.1)) = asText(tDwithin(cell_geom, th3CellToBoundary(seq1)::tgeometry, 0.1)) AS tdw_geo_c,
+  asText(tDwithin(seq1, cell_geom, 0.1)) = asText(tDwithin(th3CellToBoundary(seq1)::tgeometry, cell_geom, 0.1)) AS tdw_c_geo,
+  asText(tDwithin(seq1, seq2, 0.1)) = asText(tDwithin(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry, 0.1)) AS tdw_c_c
+FROM t;
+ tc_geo_c | tc_c_geo | tc_c_c | tcv_geo_c | tcv_c_geo | tcv_c_c | tdj_geo_c | tdj_c_geo | tdj_c_c | ti_geo_c | ti_c_geo | ti_c_c | ttc_geo_c | ttc_c_geo | ttc_c_c | tdw_geo_c | tdw_c_geo | tdw_c_c 
+----------+----------+--------+-----------+-----------+---------+-----------+-----------+---------+----------+----------+--------+-----------+-----------+---------+-----------+-----------+---------
+ t        | t        | t      | t         | t         | t       | t         | t         | t       | t        | t        | t      | t         | t         | t       | t         | t         | t
+(1 row)
+
+SELECT tIntersects(th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}',
+  th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}');
+                           tintersects                            
+------------------------------------------------------------------
+ {t@Mon Jan 01 00:00:00 2001 PST, t@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+SELECT tDisjoint(th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}',
+  th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}');
+                            tdisjoint                             
+------------------------------------------------------------------
+ {t@Mon Jan 01 00:00:00 2001 PST, t@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+

--- a/mobilitydb/test/h3/queries/264_th3index_tempspatialrels.test.sql
+++ b/mobilitydb/test/h3/queries/264_th3index_tempspatialrels.test.sql
@@ -1,0 +1,86 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-- Regression tests for the th3index temporal spatial-rel surface
+-- (264_th3index_tempspatialrels.in.sql).
+--
+-- Each function returns a tbool whose value at instant t is the static
+-- spatial relation applied to the boundary of the cell the value holds at t:
+-- take the boundary with th3CellToBoundary, cast it to tgeometry, and delegate to
+-- the temporal spatial-rel kernel of tgeometry
+-- (072_tgeo_tempspatialrels.in.sql). Each block checks that the direct th3index
+-- overload agrees with the equivalent manual chain.
+--
+-- The geometry operand is the boundary of one of the cells, so that the
+-- relations answer over the same ground the cells cover.
+--
+-------------------------------------------------------------------------------
+
+-- Test for NULL inputs since the functions are not STRICT
+SELECT tIntersects(NULL::geometry, th3index '831c00fffffffff@2001-01-01');
+SELECT tIntersects(getValue(th3CellToBoundary(th3index '831c00fffffffff@2001-01-01')::tgeometry), NULL::th3index);
+
+-------------------------------------------------------------------------------
+-- tContains, tCovers, tDisjoint, tIntersects, tTouches, tDwithin
+-------------------------------------------------------------------------------
+
+WITH t AS (
+  SELECT th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}' AS seq1,
+         th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}' AS seq2,
+         getValue(th3CellToBoundary(th3index '831c00fffffffff@2001-01-01')::tgeometry) AS cell_geom
+)
+SELECT
+  asText(tContains(cell_geom, seq1)) = asText(tContains(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS tc_geo_c,
+  asText(tContains(seq1, cell_geom)) = asText(tContains(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS tc_c_geo,
+  asText(tContains(seq1, seq2)) = asText(tContains(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS tc_c_c,
+  asText(tCovers(cell_geom, seq1)) = asText(tCovers(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS tcv_geo_c,
+  asText(tCovers(seq1, cell_geom)) = asText(tCovers(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS tcv_c_geo,
+  asText(tCovers(seq1, seq2)) = asText(tCovers(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS tcv_c_c,
+  asText(tDisjoint(cell_geom, seq1)) = asText(tDisjoint(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS tdj_geo_c,
+  asText(tDisjoint(seq1, cell_geom)) = asText(tDisjoint(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS tdj_c_geo,
+  asText(tDisjoint(seq1, seq2)) = asText(tDisjoint(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS tdj_c_c,
+  asText(tIntersects(cell_geom, seq1)) = asText(tIntersects(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS ti_geo_c,
+  asText(tIntersects(seq1, cell_geom)) = asText(tIntersects(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS ti_c_geo,
+  asText(tIntersects(seq1, seq2)) = asText(tIntersects(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS ti_c_c,
+  asText(tTouches(cell_geom, seq1)) = asText(tTouches(cell_geom, th3CellToBoundary(seq1)::tgeometry)) AS ttc_geo_c,
+  asText(tTouches(seq1, cell_geom)) = asText(tTouches(th3CellToBoundary(seq1)::tgeometry, cell_geom)) AS ttc_c_geo,
+  asText(tTouches(seq1, seq2)) = asText(tTouches(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry)) AS ttc_c_c,
+  asText(tDwithin(cell_geom, seq1, 0.1)) = asText(tDwithin(cell_geom, th3CellToBoundary(seq1)::tgeometry, 0.1)) AS tdw_geo_c,
+  asText(tDwithin(seq1, cell_geom, 0.1)) = asText(tDwithin(th3CellToBoundary(seq1)::tgeometry, cell_geom, 0.1)) AS tdw_c_geo,
+  asText(tDwithin(seq1, seq2, 0.1)) = asText(tDwithin(th3CellToBoundary(seq1)::tgeometry, th3CellToBoundary(seq2)::tgeometry, 0.1)) AS tdw_c_c
+FROM t;
+
+-------------------------------------------------------------------------------
+-- Direct values
+-------------------------------------------------------------------------------
+
+SELECT tIntersects(th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}',
+  th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}');
+SELECT tDisjoint(th3index '{831c00fffffffff@2001-01-01, 831c02fffffffff@2001-01-02}',
+  th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}');
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/expected/114_tpose_tempspatialrels.test.out
+++ b/mobilitydb/test/pose/expected/114_tpose_tempspatialrels.test.out
@@ -1,0 +1,65 @@
+SELECT tContains(NULL::geometry, tpose 'Pose(Point(1 1), 0.2)@2000-01-01');
+ tcontains 
+-----------
+ 
+(1 row)
+
+SELECT tContains(geometry 'Polygon((0 0,0 5,5 5,5 0,0 0))', NULL::tpose);
+ tcontains 
+-----------
+ 
+(1 row)
+
+WITH t AS (
+  SELECT tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]' AS seq1,
+         tpose 'Interp=Step;[Pose(Point(2 2), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]' AS seq2,
+         geometry 'Polygon((0 0,0 5,5 5,5 0,0 0))' AS region,
+         geometry 'Point(50 50)' AS far_point
+)
+SELECT
+  asText(tContains(region, seq1)) = asText(tContains(region, seq1::tgeompoint::tgeometry)) AS tc_geo_po,
+  asText(tContains(seq1, region)) = asText(tContains(seq1::tgeompoint::tgeometry, region)) AS tc_po_geo,
+  asText(tContains(seq1, seq2)) = asText(tContains(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tc_po_po,
+  asText(tCovers(region, seq1)) = asText(tCovers(region, seq1::tgeompoint::tgeometry)) AS tcv_geo_po,
+  asText(tCovers(seq1, region)) = asText(tCovers(seq1::tgeompoint::tgeometry, region)) AS tcv_po_geo,
+  asText(tCovers(seq1, seq2)) = asText(tCovers(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tcv_po_po,
+  asText(tDisjoint(far_point, seq1)) = asText(tDisjoint(far_point, seq1::tgeompoint::tgeometry)) AS tdj_geo_po,
+  asText(tDisjoint(seq1, far_point)) = asText(tDisjoint(seq1::tgeompoint::tgeometry, far_point)) AS tdj_po_geo,
+  asText(tDisjoint(seq1, seq2)) = asText(tDisjoint(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tdj_po_po,
+  asText(tIntersects(region, seq1)) = asText(tIntersects(region, seq1::tgeompoint::tgeometry)) AS ti_geo_po,
+  asText(tIntersects(seq1, region)) = asText(tIntersects(seq1::tgeompoint::tgeometry, region)) AS ti_po_geo,
+  asText(tIntersects(seq1, seq2)) = asText(tIntersects(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ti_po_po,
+  asText(tTouches(region, seq1)) = asText(tTouches(region, seq1::tgeompoint::tgeometry)) AS ttc_geo_po,
+  asText(tTouches(seq1, region)) = asText(tTouches(seq1::tgeompoint::tgeometry, region)) AS ttc_po_geo,
+  asText(tTouches(seq1, seq2)) = asText(tTouches(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ttc_po_po,
+  asText(tDwithin(region, seq1, 1.0)) = asText(tDwithin(region, seq1::tgeompoint::tgeometry, 1.0)) AS tdw_geo_po,
+  asText(tDwithin(seq1, region, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, region, 1.0)) AS tdw_po_geo,
+  asText(tDwithin(seq1, seq2, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry, 1.0)) AS tdw_po_po
+FROM t;
+ tc_geo_po | tc_po_geo | tc_po_po | tcv_geo_po | tcv_po_geo | tcv_po_po | tdj_geo_po | tdj_po_geo | tdj_po_po | ti_geo_po | ti_po_geo | ti_po_po | ttc_geo_po | ttc_po_geo | ttc_po_po | tdw_geo_po | tdw_po_geo | tdw_po_po 
+-----------+-----------+----------+------------+------------+-----------+------------+------------+-----------+-----------+-----------+----------+------------+------------+-----------+------------+------------+-----------
+ t         | t         | t        | t          | t          | t         | t          | t          | t         | t         | t         | t        | t          | t          | t         | t          | t          | t
+(1 row)
+
+SELECT tContains(geometry 'Polygon((0 0,0 5,5 5,5 0,0 0))',
+  tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]');
+                            tcontains                             
+------------------------------------------------------------------
+ [t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT tDisjoint(geometry 'Point(50 50)',
+  tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]');
+                            tdisjoint                             
+------------------------------------------------------------------
+ [t@Sat Jan 01 00:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT tDwithin(
+  tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]',
+  tpose 'Interp=Step;[Pose(Point(2 2), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]', 1.0);
+                             tdwithin                             
+------------------------------------------------------------------
+ [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+

--- a/mobilitydb/test/pose/queries/114_tpose_tempspatialrels.test.sql
+++ b/mobilitydb/test/pose/queries/114_tpose_tempspatialrels.test.sql
@@ -1,0 +1,90 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-- Regression tests for the tpose temporal spatial-rel surface
+-- (114_tpose_tempspatialrels.in.sql).
+--
+-- Each function returns a tbool whose value at instant t is the static
+-- spatial relation applied to the position the pose holds at t: cast the
+-- tpose to tgeompoint, then to tgeometry, and delegate to the temporal
+-- spatial-rel kernel of tgeometry (072_tgeo_tempspatialrels.in.sql). Each
+-- block checks that the direct tpose overload agrees with the equivalent
+-- manual cast chain (::tgeompoint::tgeometry).
+--
+-- The delegate target tgeometry only supports step interpolation, so the
+-- sequences below carry step interpolation.
+--
+-------------------------------------------------------------------------------
+
+-- Test for NULL inputs since the functions are not STRICT
+SELECT tContains(NULL::geometry, tpose 'Pose(Point(1 1), 0.2)@2000-01-01');
+SELECT tContains(geometry 'Polygon((0 0,0 5,5 5,5 0,0 0))', NULL::tpose);
+
+-------------------------------------------------------------------------------
+-- tContains, tCovers, tDisjoint, tIntersects, tTouches, tDwithin
+-------------------------------------------------------------------------------
+
+WITH t AS (
+  SELECT tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]' AS seq1,
+         tpose 'Interp=Step;[Pose(Point(2 2), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]' AS seq2,
+         geometry 'Polygon((0 0,0 5,5 5,5 0,0 0))' AS region,
+         geometry 'Point(50 50)' AS far_point
+)
+SELECT
+  asText(tContains(region, seq1)) = asText(tContains(region, seq1::tgeompoint::tgeometry)) AS tc_geo_po,
+  asText(tContains(seq1, region)) = asText(tContains(seq1::tgeompoint::tgeometry, region)) AS tc_po_geo,
+  asText(tContains(seq1, seq2)) = asText(tContains(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tc_po_po,
+  asText(tCovers(region, seq1)) = asText(tCovers(region, seq1::tgeompoint::tgeometry)) AS tcv_geo_po,
+  asText(tCovers(seq1, region)) = asText(tCovers(seq1::tgeompoint::tgeometry, region)) AS tcv_po_geo,
+  asText(tCovers(seq1, seq2)) = asText(tCovers(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tcv_po_po,
+  asText(tDisjoint(far_point, seq1)) = asText(tDisjoint(far_point, seq1::tgeompoint::tgeometry)) AS tdj_geo_po,
+  asText(tDisjoint(seq1, far_point)) = asText(tDisjoint(seq1::tgeompoint::tgeometry, far_point)) AS tdj_po_geo,
+  asText(tDisjoint(seq1, seq2)) = asText(tDisjoint(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tdj_po_po,
+  asText(tIntersects(region, seq1)) = asText(tIntersects(region, seq1::tgeompoint::tgeometry)) AS ti_geo_po,
+  asText(tIntersects(seq1, region)) = asText(tIntersects(seq1::tgeompoint::tgeometry, region)) AS ti_po_geo,
+  asText(tIntersects(seq1, seq2)) = asText(tIntersects(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ti_po_po,
+  asText(tTouches(region, seq1)) = asText(tTouches(region, seq1::tgeompoint::tgeometry)) AS ttc_geo_po,
+  asText(tTouches(seq1, region)) = asText(tTouches(seq1::tgeompoint::tgeometry, region)) AS ttc_po_geo,
+  asText(tTouches(seq1, seq2)) = asText(tTouches(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ttc_po_po,
+  asText(tDwithin(region, seq1, 1.0)) = asText(tDwithin(region, seq1::tgeompoint::tgeometry, 1.0)) AS tdw_geo_po,
+  asText(tDwithin(seq1, region, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, region, 1.0)) AS tdw_po_geo,
+  asText(tDwithin(seq1, seq2, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry, 1.0)) AS tdw_po_po
+FROM t;
+
+-------------------------------------------------------------------------------
+-- Direct values
+-------------------------------------------------------------------------------
+
+SELECT tContains(geometry 'Polygon((0 0,0 5,5 5,5 0,0 0))',
+  tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]');
+SELECT tDisjoint(geometry 'Point(50 50)',
+  tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]');
+SELECT tDwithin(
+  tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]',
+  tpose 'Interp=Step;[Pose(Point(2 2), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]', 1.0);
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/quadbin/expected/364_tquadbin_tempspatialrels.test.out
+++ b/mobilitydb/test/quadbin/expected/364_tquadbin_tempspatialrels.test.out
@@ -1,0 +1,56 @@
+SELECT tIntersects(NULL::geometry, tquadbin '480fffffffffffff@2001-01-01');
+ tintersects 
+-------------
+ 
+(1 row)
+
+SELECT tIntersects(getValue(tquadbinCellToBoundary(tquadbin '480fffffffffffff@2001-01-01')::tgeometry), NULL::tquadbin);
+ tintersects 
+-------------
+ 
+(1 row)
+
+WITH t AS (
+  SELECT tquadbin '{480fffffffffffff@2001-01-01, 481fffffffffffff@2001-01-02}' AS seq1,
+         tquadbin '{481fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-02}' AS seq2,
+         getValue(tquadbinCellToBoundary(tquadbin '480fffffffffffff@2001-01-01')::tgeometry) AS cell_geom
+)
+SELECT
+  asText(tContains(cell_geom, seq1)) = asText(tContains(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS tc_geo_c,
+  asText(tContains(seq1, cell_geom)) = asText(tContains(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS tc_c_geo,
+  asText(tContains(seq1, seq2)) = asText(tContains(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS tc_c_c,
+  asText(tCovers(cell_geom, seq1)) = asText(tCovers(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS tcv_geo_c,
+  asText(tCovers(seq1, cell_geom)) = asText(tCovers(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS tcv_c_geo,
+  asText(tCovers(seq1, seq2)) = asText(tCovers(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS tcv_c_c,
+  asText(tDisjoint(cell_geom, seq1)) = asText(tDisjoint(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS tdj_geo_c,
+  asText(tDisjoint(seq1, cell_geom)) = asText(tDisjoint(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS tdj_c_geo,
+  asText(tDisjoint(seq1, seq2)) = asText(tDisjoint(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS tdj_c_c,
+  asText(tIntersects(cell_geom, seq1)) = asText(tIntersects(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS ti_geo_c,
+  asText(tIntersects(seq1, cell_geom)) = asText(tIntersects(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS ti_c_geo,
+  asText(tIntersects(seq1, seq2)) = asText(tIntersects(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS ti_c_c,
+  asText(tTouches(cell_geom, seq1)) = asText(tTouches(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS ttc_geo_c,
+  asText(tTouches(seq1, cell_geom)) = asText(tTouches(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS ttc_c_geo,
+  asText(tTouches(seq1, seq2)) = asText(tTouches(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS ttc_c_c,
+  asText(tDwithin(cell_geom, seq1, 0.1)) = asText(tDwithin(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry, 0.1)) AS tdw_geo_c,
+  asText(tDwithin(seq1, cell_geom, 0.1)) = asText(tDwithin(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom, 0.1)) AS tdw_c_geo,
+  asText(tDwithin(seq1, seq2, 0.1)) = asText(tDwithin(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry, 0.1)) AS tdw_c_c
+FROM t;
+ tc_geo_c | tc_c_geo | tc_c_c | tcv_geo_c | tcv_c_geo | tcv_c_c | tdj_geo_c | tdj_c_geo | tdj_c_c | ti_geo_c | ti_c_geo | ti_c_c | ttc_geo_c | ttc_c_geo | ttc_c_c | tdw_geo_c | tdw_c_geo | tdw_c_c 
+----------+----------+--------+-----------+-----------+---------+-----------+-----------+---------+----------+----------+--------+-----------+-----------+---------+-----------+-----------+---------
+ t        | t        | t      | t         | t         | t       | t         | t         | t       | t        | t        | t      | t         | t         | t       | t         | t         | t
+(1 row)
+
+SELECT tIntersects(tquadbin '{480fffffffffffff@2001-01-01, 481fffffffffffff@2001-01-02}',
+  tquadbin '{480fffffffffffff@2001-01-01, 481fffffffffffff@2001-01-02}');
+                           tintersects                            
+------------------------------------------------------------------
+ {t@Mon Jan 01 00:00:00 2001 PST, t@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+SELECT tDisjoint(tquadbin '{480fffffffffffff@2001-01-01, 481fffffffffffff@2001-01-02}',
+  tquadbin '{481fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-02}');
+                            tdisjoint                             
+------------------------------------------------------------------
+ {t@Mon Jan 01 00:00:00 2001 PST, t@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+

--- a/mobilitydb/test/quadbin/queries/364_tquadbin_tempspatialrels.test.sql
+++ b/mobilitydb/test/quadbin/queries/364_tquadbin_tempspatialrels.test.sql
@@ -1,0 +1,86 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-- Regression tests for the tquadbin temporal spatial-rel surface
+-- (364_tquadbin_tempspatialrels.in.sql).
+--
+-- Each function returns a tbool whose value at instant t is the static
+-- spatial relation applied to the boundary of the cell the value holds at t:
+-- take the boundary with tquadbinCellToBoundary, cast it to tgeometry, and delegate to
+-- the temporal spatial-rel kernel of tgeometry
+-- (072_tgeo_tempspatialrels.in.sql). Each block checks that the direct tquadbin
+-- overload agrees with the equivalent manual chain.
+--
+-- The geometry operand is the boundary of one of the cells, so that the
+-- relations answer over the same ground the cells cover.
+--
+-------------------------------------------------------------------------------
+
+-- Test for NULL inputs since the functions are not STRICT
+SELECT tIntersects(NULL::geometry, tquadbin '480fffffffffffff@2001-01-01');
+SELECT tIntersects(getValue(tquadbinCellToBoundary(tquadbin '480fffffffffffff@2001-01-01')::tgeometry), NULL::tquadbin);
+
+-------------------------------------------------------------------------------
+-- tContains, tCovers, tDisjoint, tIntersects, tTouches, tDwithin
+-------------------------------------------------------------------------------
+
+WITH t AS (
+  SELECT tquadbin '{480fffffffffffff@2001-01-01, 481fffffffffffff@2001-01-02}' AS seq1,
+         tquadbin '{481fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-02}' AS seq2,
+         getValue(tquadbinCellToBoundary(tquadbin '480fffffffffffff@2001-01-01')::tgeometry) AS cell_geom
+)
+SELECT
+  asText(tContains(cell_geom, seq1)) = asText(tContains(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS tc_geo_c,
+  asText(tContains(seq1, cell_geom)) = asText(tContains(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS tc_c_geo,
+  asText(tContains(seq1, seq2)) = asText(tContains(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS tc_c_c,
+  asText(tCovers(cell_geom, seq1)) = asText(tCovers(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS tcv_geo_c,
+  asText(tCovers(seq1, cell_geom)) = asText(tCovers(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS tcv_c_geo,
+  asText(tCovers(seq1, seq2)) = asText(tCovers(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS tcv_c_c,
+  asText(tDisjoint(cell_geom, seq1)) = asText(tDisjoint(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS tdj_geo_c,
+  asText(tDisjoint(seq1, cell_geom)) = asText(tDisjoint(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS tdj_c_geo,
+  asText(tDisjoint(seq1, seq2)) = asText(tDisjoint(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS tdj_c_c,
+  asText(tIntersects(cell_geom, seq1)) = asText(tIntersects(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS ti_geo_c,
+  asText(tIntersects(seq1, cell_geom)) = asText(tIntersects(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS ti_c_geo,
+  asText(tIntersects(seq1, seq2)) = asText(tIntersects(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS ti_c_c,
+  asText(tTouches(cell_geom, seq1)) = asText(tTouches(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry)) AS ttc_geo_c,
+  asText(tTouches(seq1, cell_geom)) = asText(tTouches(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom)) AS ttc_c_geo,
+  asText(tTouches(seq1, seq2)) = asText(tTouches(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry)) AS ttc_c_c,
+  asText(tDwithin(cell_geom, seq1, 0.1)) = asText(tDwithin(cell_geom, tquadbinCellToBoundary(seq1)::tgeometry, 0.1)) AS tdw_geo_c,
+  asText(tDwithin(seq1, cell_geom, 0.1)) = asText(tDwithin(tquadbinCellToBoundary(seq1)::tgeometry, cell_geom, 0.1)) AS tdw_c_geo,
+  asText(tDwithin(seq1, seq2, 0.1)) = asText(tDwithin(tquadbinCellToBoundary(seq1)::tgeometry, tquadbinCellToBoundary(seq2)::tgeometry, 0.1)) AS tdw_c_c
+FROM t;
+
+-------------------------------------------------------------------------------
+-- Direct values
+-------------------------------------------------------------------------------
+
+SELECT tIntersects(tquadbin '{480fffffffffffff@2001-01-01, 481fffffffffffff@2001-01-02}',
+  tquadbin '{480fffffffffffff@2001-01-01, 481fffffffffffff@2001-01-02}');
+SELECT tDisjoint(tquadbin '{480fffffffffffff@2001-01-01, 481fffffffffffff@2001-01-02}',
+  tquadbin '{481fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-02}');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
The eighteen functions of the temporal spatial-rel surface of tpose, and the eighteen of th3index and of tquadbin, carry no regression test. Each returns a tbool whose value at an instant is the static spatial relation applied to what the value denotes there, reached by a conversion: a tpose casts to tgeompoint and then to tgeometry, and a cell index takes the boundary of its cell and casts that to tgeometry, both delegating to the temporal spatial-rel kernel of tgeometry.

Each file checks the direct overload against the equivalent manual chain, over the three directions of the six relations, and closes with direct values. The geometry operand of a cell index file is the boundary of one of the cells, so that the relations answer over the same ground the cells cover.

The delegate target tgeometry only supports step interpolation, so the tpose sequences carry step interpolation.

The three families share one conversion shape and one file shape, so they arrive together.