### PR TITLE
Document the route operators and the Z-axis position operators

### DIFF
--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -793,6 +793,30 @@ SELECT ST_AsText(twCentroid(tnpoint '{[NPoint(1, 0.3)@2001-01-01,
 	<sect1 xml:id="tnpoint_bbox_ops">
 		<title>Operaciones de cuadro delimitador</title>
 		<itemizedlist>
+			<listitem xml:id="tnpoint_routeops">
+				<indexterm significance="normal"><primary><varname>?@</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>@?</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>@@</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>@=</varname></primary></indexterm>
+				<para>Operadores de rutas, que comparan los identificadores de ruta que visita un punto de red temporal: contenido en, contiene, se superpone e igual</para>
+				<para><varname>{bigint,bigintset,npoint,tnpoint} {?@, @?, @@, @=} {bigint,bigintset,npoint,tnpoint} → boolean</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT bigint '1' ?@ tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]';
+-- true
+SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]' @? bigint '1';
+-- true
+SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01, NPoint(3, 0.5)@2001-01-02}' @@
+  bigintset '{3, 7}';
+-- true
+SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01, NPoint(3, 0.5)@2001-01-02}' @=
+  bigintset '{1, 3}';
+-- true
+SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01, NPoint(3, 0.5)@2001-01-02}' @=
+  bigintset '{1}';
+-- false
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="tnpoint_topo">
 				<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -694,10 +694,12 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01
 				<indexterm significance="normal"><primary><varname>&gt;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&amp;&lt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&amp;&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;&lt;/</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>/&gt;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
 				<para>Operadores de posición espacial y temporal</para>
-				<para>El conjunto completo <varname>&lt;&lt;</varname>, <varname>&gt;&gt;</varname>, <varname>&amp;&lt;</varname>, <varname>&amp;&gt;</varname>, <varname>&lt;&lt;|</varname>, <varname>&amp;&lt;|</varname>, <varname>|&gt;&gt;</varname>, <varname>|&amp;&gt;</varname>, <varname>&lt;&lt;#</varname>, <varname>&amp;&lt;#</varname>, <varname>#&gt;&gt;</varname>, <varname>#&amp;&gt;</varname> acepta <varname>trgeometry</varname> en cualquiera de los lados.</para>
+				<para>El conjunto completo <varname>&lt;&lt;</varname>, <varname>&gt;&gt;</varname>, <varname>&amp;&lt;</varname>, <varname>&amp;&gt;</varname>, <varname>&lt;&lt;|</varname>, <varname>&amp;&lt;|</varname>, <varname>|&gt;&gt;</varname>, <varname>|&amp;&gt;</varname>, <varname>&lt;&lt;/</varname>, <varname>&amp;&lt;/</varname>, <varname>/&gt;&gt;</varname>, <varname>/&amp;&gt;</varname>, <varname>&lt;&lt;#</varname>, <varname>&amp;&lt;#</varname>, <varname>#&gt;&gt;</varname>, <varname>#&amp;&gt;</varname> acepta <varname>trgeometry</varname> en cualquiera de los lados. Los operadores <varname>&lt;&lt;/</varname>, <varname>&amp;&lt;/</varname>, <varname>/&gt;&gt;</varname> y <varname>/&amp;&gt;</varname> comparan el eje Z y requieren que ambos argumentos tengan dimensión Z.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
   Pose(Point(3 0),0)@2001-01-02]' &lt;&lt; stbox 'STBOX X((5,5),(6,6))';
@@ -705,6 +707,14 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
   Pose(Point(3 0),0)@2001-01-02]' &lt;&lt;# tstzspan '[2001-01-03, 2001-01-04]';
 -- true
+SELECT trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+  [Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(3 0 0),1,0,0,0)@2001-01-02]'
+  &lt;&lt;/ stbox 'STBOX Z((5,5,5),(6,6,6))';
+-- true
+SELECT trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+  [Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(3 0 0),1,0,0,0)@2001-01-02]'
+  /&amp;&gt; stbox 'STBOX Z((5,5,5),(6,6,6))';
+-- false
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -809,6 +809,30 @@ SELECT ST_AsText(twCentroid(tnpoint '{[NPoint(1, 0.3)@2001-01-01,
 	<sect1 xml:id="tnpoint_bbox_ops">
 		<title>Bounding Box Operations</title>
 		<itemizedlist>
+			<listitem xml:id="tnpoint_routeops">
+				<indexterm significance="normal"><primary><varname>?@</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>@?</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>@@</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>@=</varname></primary></indexterm>
+				<para>Route operators, which compare the route identifiers a temporal network point visits: contained in, contains, overlaps, and equal</para>
+				<para><varname>{bigint,bigintset,npoint,tnpoint} {?@, @?, @@, @=} {bigint,bigintset,npoint,tnpoint} → boolean</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT bigint '1' ?@ tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]';
+-- true
+SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]' @? bigint '1';
+-- true
+SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01, NPoint(3, 0.5)@2001-01-02}' @@
+  bigintset '{3, 7}';
+-- true
+SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01, NPoint(3, 0.5)@2001-01-02}' @=
+  bigintset '{1, 3}';
+-- true
+SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01, NPoint(3, 0.5)@2001-01-02}' @=
+  bigintset '{1}';
+-- false
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="tnpoint_topo">
 				<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -694,10 +694,12 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01
 				<indexterm significance="normal"><primary><varname>&gt;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&amp;&lt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&amp;&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;&lt;/</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>/&gt;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
 				<para>Spatial and temporal position operators</para>
-				<para>The full set <varname>&lt;&lt;</varname>, <varname>&gt;&gt;</varname>, <varname>&amp;&lt;</varname>, <varname>&amp;&gt;</varname>, <varname>&lt;&lt;|</varname>, <varname>&amp;&lt;|</varname>, <varname>|&gt;&gt;</varname>, <varname>|&amp;&gt;</varname>, <varname>&lt;&lt;#</varname>, <varname>&amp;&lt;#</varname>, <varname>#&gt;&gt;</varname>, <varname>#&amp;&gt;</varname> all accept <varname>trgeometry</varname> on either side.</para>
+				<para>The full set <varname>&lt;&lt;</varname>, <varname>&gt;&gt;</varname>, <varname>&amp;&lt;</varname>, <varname>&amp;&gt;</varname>, <varname>&lt;&lt;|</varname>, <varname>&amp;&lt;|</varname>, <varname>|&gt;&gt;</varname>, <varname>|&amp;&gt;</varname>, <varname>&lt;&lt;/</varname>, <varname>&amp;&lt;/</varname>, <varname>/&gt;&gt;</varname>, <varname>/&amp;&gt;</varname>, <varname>&lt;&lt;#</varname>, <varname>&amp;&lt;#</varname>, <varname>#&gt;&gt;</varname>, <varname>#&amp;&gt;</varname> all accept <varname>trgeometry</varname> on either side. The operators <varname>&lt;&lt;/</varname>, <varname>&amp;&lt;/</varname>, <varname>/&gt;&gt;</varname> and <varname>/&amp;&gt;</varname> compare the Z axis and require both arguments to have a Z dimension.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
   Pose(Point(3 0),0)@2001-01-02]' &lt;&lt; stbox 'STBOX X((5,5),(6,6))';
@@ -705,6 +707,14 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
   Pose(Point(3 0),0)@2001-01-02]' &lt;&lt;# tstzspan '[2001-01-03, 2001-01-04]';
 -- true
+SELECT trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+  [Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(3 0 0),1,0,0,0)@2001-01-02]'
+  &lt;&lt;/ stbox 'STBOX Z((5,5,5),(6,6,6))';
+-- true
+SELECT trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+  [Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(3 0 0),1,0,0,0)@2001-01-02]'
+  /&amp;&gt; stbox 'STBOX Z((5,5,5),(6,6,6))';
+-- false
 </programlisting>
 			</listitem>
 		</itemizedlist>


### PR DESCRIPTION
The network point chapter carries the route operators `?@`, `@?`, `@@` and `@=`, which compare the route identifiers a temporal network point visits, with an example harvested against the `ways` fixture.

The rigid geometry chapter names the four Z-axis position operators `<</`, `&</`, `/>>` and `/&>`. They accept `trgeometry` on either side like the twelve the chapter already lists, and require both arguments to have a Z dimension.

An operator that no chapter names cannot be found by a reader who does not already know it exists.

Both manuals build: 236 English and 235 Spanish pages, no errors.