### PR TITLE
Give the network point stbox constructor a correct entry in both manuals

### DIFF
--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -212,6 +212,21 @@ SELECT geometry 'SRID=5676;LINESTRING(406.7 702.6,383.6 845.1)'::nsegment;
 -- NULL
 </programlisting>
 				</listitem>
+
+				<listitem xml:id="npoint_stbox">
+					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
+					<para>Construir una caja espaciotemporal a partir de un punto de red y, opcionalmente, una marca de tiempo o un período</para>
+					<para><varname>stbox(npoint) → stbox</varname></para>
+					<para><varname>stbox(npoint,{timestamptz,tstzspan}) → stbox</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT stbox(npoint 'NPoint(1,0.3)');
+-- SRID=5676;STBOX X((62.786633,80.143556),(62.786633,80.143556))
+SELECT stbox(npoint 'NPoint(1,0.3)', timestamptz '2001-01-01');
+-- SRID=5676;STBOX XT(((62.786633,80.143556),(62.786633,80.143556)),[2001-01-01, 2001-01-01])
+SELECT stbox(npoint 'NPoint(1,0.3)', tstzspan '[2001-01-01,2001-01-02]');
+-- SRID=5676;STBOX XT(((62.786633,80.143556),(62.786633,80.143556)),[2001-01-01, 2001-01-02])
+</programlisting>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -220,11 +220,11 @@ SELECT geometry 'SRID=5676;LINESTRING(406.7 702.6,383.6 845.1)'::nsegment;
 					<para><varname>stbox(npoint,{timestamptz,tstzspan}) → stbox</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(npoint 'NPoint(1,0.3)');
--- STBOX X((48.711754,20.92568),(48.711758,20.925682))
+-- SRID=5676;STBOX X((62.786633,80.143556),(62.786633,80.143556))
 SELECT stbox(npoint 'NPoint(1,0.3)', timestamptz '2001-01-01');
--- STBOX XT(((62.786633,80.143555),(62.786636,80.143562)),[2001-01-01,2001-01-01])
+-- SRID=5676;STBOX XT(((62.786633,80.143556),(62.786633,80.143556)),[2001-01-01, 2001-01-01])
 SELECT stbox(npoint 'NPoint(1,0.3)', tstzspan '[2001-01-01,2001-01-02]');
--- STBOX XT(((62.786633,80.143555),(62.786636,80.143562)),[2001-01-01,2001-01-02])
+-- SRID=5676;STBOX XT(((62.786633,80.143556),(62.786633,80.143556)),[2001-01-01, 2001-01-02])
 </programlisting>
 				</listitem>
 			</itemizedlist>


### PR DESCRIPTION
The Spanish chapter carries the `stbox` constructor entry the English one has, so both manuals document the same surface.

The results come from a run against the `ways` fixture, rounded to six decimals: they carry the SRID the network inherits from that table, and a network point yields a box of zero extent. The results the entry carried show two different coordinate pairs for one input and no SRID, which no run reproduces.

Both manuals build: 236 English and 235 Spanish pages, no errors.