### PR TITLE
Read both arguments in the trgeometry nearest approach distance, and name its wrappers

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2334,7 +2334,7 @@ nai_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_rgeo_dist
  * @brief Return the nearest approach distance between a temporal rigid
  * geometry and a geometry
- * @sqlop @p |=|
+ * @csqlfn #NAD_trgeometry_geo() #NAD_geo_trgeometry()
  */
 double
 nad_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2353,7 +2353,7 @@ nad_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @ingroup meos_rgeo_dist
  * @brief Return the nearest approach distance between a temporal rigid
  * geometry and a spatiotemporal box
- * @sqlop @p |=|
+ * @csqlfn #NAD_trgeometry_stbox() #NAD_stbox_trgeometry()
  */
 double
 nad_trgeometry_stbox(const Temporal *temp, const STBox *box)
@@ -2389,7 +2389,6 @@ nad_trgeometry_stbox(const Temporal *temp, const STBox *box)
  * @ingroup meos_rgeo_dist
  * @brief Return the nearest approach distance between a spatiotemporal box and
  * a temporal rigid geometry
- * @sqlop @p |=|
  */
 double
 nad_stbox_trgeometry(const STBox *box, const Temporal *temp)
@@ -2399,9 +2398,9 @@ nad_stbox_trgeometry(const STBox *box, const Temporal *temp)
 
 /**
  * @ingroup meos_rgeo_dist
- * @brief Return the nearest approach distance between two temporal rigid
- * geometries
- * @sqlop @p |=|
+ * @brief Return the nearest approach distance between a temporal rigid
+ * geometry and a temporal point
+ * @csqlfn #NAD_trgeometry_tpoint() #NAD_tpoint_trgeometry()
  */
 double
 nad_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
@@ -2423,13 +2422,13 @@ nad_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_rgeo_dist
  * @brief Return the nearest approach distance between two temporal rigid
  * geometries
- * @sqlop @p |=|
+ * @csqlfn #NAD_trgeometry_trgeometry()
  */
 double
 nad_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_trgeo(temp2, temp2))
+  if (! ensure_valid_trgeo_trgeo(temp1, temp2))
     return DBL_MAX;
 
   Temporal *dist = tdistance_trgeometry_trgeometry(temp1, temp2);


### PR DESCRIPTION
Two things about the temporal-rigid-geometry nearest approach distance.

**The validator reads one argument twice.** `nad_trgeometry_trgeometry` calls `ensure_valid_trgeo_trgeo(temp2, temp2)`, so its first argument passes no check of its own.

The returned value is the same either way: `tdistance_trgeometry_trgeometry` runs that validator with both arguments a frame later, nothing dereferences `temp1` in between, and the function answers infinity on an invalid pair by either route — no input separates the two and no test distinguishes them. What the correct arguments restore is a public function checking its own precondition rather than leaning on its callee. This is the only `ensure_*` call in the repository that repeats an argument:

```
ensure_[a-z0-9_]+\(\s*(\w+)\s*,\s*\1\s*[,)]     # exactly one hit, meos/src + mobilitydb/src
```

**The family names no wrapper.** The division of labour everywhere else is: the PostgreSQL wrapper carries `@sqlfn nearestApproachDistance()` and `@sqlop @p |=|`, and the MEOS function carries `@csqlfn #Wrapper()`. All 49 `nad_*` blocks follow it except the five rigid-geometry ones, which hold the inverse — `@sqlop` on the MEOS function and no `@csqlfn` at all. An `@sqlop`-only block names nothing (the catalog parser skips it precisely because it carries no SQL name), so the whole surface stays invisible.

Naming the wrappers brings the family to the shape the other six use. Measured with the catalog's own parser (`parser/sqlfn.py::_meos_to_mdb`) over the tree with and without the change:

| | claimed NAD wrappers | lost |
|---|---|---|
| without | 40 | — |
| with | 47 | 0 |

Seven wrappers, one SQL overload each: `NAD_trgeometry_geo`, `NAD_geo_trgeometry`, `NAD_trgeometry_stbox`, `NAD_stbox_trgeometry`, `NAD_trgeometry_tpoint`, `NAD_tpoint_trgeometry`, `NAD_trgeometry_trgeometry`. Afterwards the only nearest approach wrapper unnamed anywhere is the pointcloud one.

`nad_stbox_trgeometry` keeps no `@csqlfn` because no wrapper calls it. The commuted SQL surface is not missing: `nearestApproachDistance(stbox, trgeometry)` exists and binds `NAD_stbox_trgeometry`, which calls `nad_trgeometry_stbox` and is named there. That MEOS entry point simply has no wrapper of its own to name.

`nad_trgeometry_tpoint` describes its operands as two rigid geometries; it takes a rigid geometry and a temporal point.