### PR TITLE
Name the commuted wrapper of the pointcloud nearest approach distance

### DIFF
--- a/meos/src/pointcloud/tpc_boxops.c
+++ b/meos/src/pointcloud/tpc_boxops.c
@@ -354,7 +354,7 @@ nad_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
  * @param[in] temp Temporal pointcloud value
  * @param[in] box Bounding box
  * @return On error or if the time frames do not intersect return infinity
- * @csqlfn #NAD_tpointcloud_tpcbox()
+ * @csqlfn #NAD_tpointcloud_tpcbox() #NAD_tpcbox_tpointcloud()
  */
 double
 nad_tpointcloud_tpcbox(const Temporal *temp, const TPCBox *box)


### PR DESCRIPTION
`nad_tpointcloud_tpcbox` names one of the two PostgreSQL wrappers that call it. The other is the commuted argument order — `NAD_tpcbox_tpointcloud` — and being named by nothing, the overloads it binds reach no catalog.

That one wrapper carries two of them:

```sql
CREATE FUNCTION nearestApproachDistance(tpcbox, tpcpoint) ... 'NAD_tpcbox_tpointcloud'
CREATE FUNCTION nearestApproachDistance(tpcbox, tpcpatch) ... 'NAD_tpcbox_tpointcloud'
```

Measured with the catalog's own parser (`parser/sqlfn.py::_meos_to_mdb`) over the tree with and without the change:

| | claimed NAD wrappers | lost |
|---|---|---|
| without | 40 | — |
| with | 41 | 0 |

With this and the rigid-geometry naming, every wrapper of the nearest approach distance is named: 48 wrappers, 48 claimed, no exceptions.