### PR TITLE
Name the wrappers of the nearest approach instant

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -750,7 +750,7 @@ nai_tcbuffer_geo_analytic(const Temporal *temp, const GSERIALIZED *gs,
  * and a geometry
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
- * @csqlfn #NAI_tcbuffer_geo()
+ * @csqlfn #NAI_tcbuffer_geo() #NAI_geo_tcbuffer()
  */
 TInstant *
 nai_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -787,7 +787,7 @@ nai_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * temporal circular buffer
  * @param[in] temp Temporal circular buffer
  * @param[in] cb Circular buffer
- * @csqlfn #NAI_tcbuffer_cbuffer()
+ * @csqlfn #NAI_tcbuffer_cbuffer() #NAI_cbuffer_tcbuffer()
  */
 TInstant *
 nai_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2537,7 +2537,7 @@ nai_tpoint_geo_analytic(const Temporal *temp, const GSERIALIZED *gs,
  * a geometry/geography
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry/geography
- * @csqlfn #NAI_tgeo_geo()
+ * @csqlfn #NAI_tgeo_geo() #NAI_geo_tgeo()
  */
 TInstant *
 nai_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)

--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -137,7 +137,7 @@ tdistance_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * and a geometry
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
- * @csqlfn #NAI_tnpoint_geo()
+ * @csqlfn #NAI_tnpoint_geo() #NAI_geo_tnpoint()
  */
 TInstant *
 nai_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -163,7 +163,7 @@ nai_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
  * temporal network point
  * @param[in] temp Temporal point
  * @param[in] np Network point
- * @csqlfn #NAI_tnpoint_npoint()
+ * @csqlfn #NAI_tnpoint_npoint() #NAI_npoint_tnpoint()
  */
 TInstant *
 nai_tnpoint_npoint(const Temporal *temp, const Npoint *np)

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -119,7 +119,7 @@ tdistance_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * geometry
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @csqlfn #NAI_tpose_geo()
+ * @csqlfn #NAI_tpose_geo() #NAI_geo_tpose()
  */
 TInstant *
 nai_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -144,7 +144,7 @@ nai_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return the nearest approach instant of a pose and a temporal pose
  * @param[in] temp Temporal pose
  * @param[in] pose Pose
- * @csqlfn #NAI_tpose_pose()
+ * @csqlfn #NAI_tpose_pose() #NAI_pose_tpose()
  */
 TInstant *
 nai_tpose_pose(const Temporal *temp, const Pose *pose)

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2240,6 +2240,7 @@ tdistance_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
  * @brief Return the nearest approach instant between a temporal rigid geometry
  * and a geometry
  * @sqlfn nearestApproachInstant()
+ * @csqlfn #NAI_trgeometry_geo() #NAI_geo_trgeometry()
  */
 TInstant *
 nai_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2274,6 +2275,7 @@ nai_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return the nearest approach instant between a temporal rigid
  * geometry and a temporal point
  * @sqlfn nearestApproachInstant()
+ * @csqlfn #NAI_trgeometry_tpoint() #NAI_tpoint_trgeometry()
  */
 TInstant *
 nai_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
@@ -2302,6 +2304,7 @@ nai_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
  * @brief Return the nearest approach instant between two temporal rigid
  * geometries
  * @sqlfn nearestApproachInstant()
+ * @csqlfn #NAI_trgeometry_trgeometry()
  */
 TInstant *
 nai_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)


### PR DESCRIPTION
Twelve PostgreSQL wrappers of the nearest approach instant are named by nothing, so the SQL overloads they bind reach no catalog. Naming them completes the family. Measured with the catalog's own parser (`parser/sqlfn.py::_meos_to_mdb`) over the tree with and without the change:

| | claimed NAI wrappers | lost |
|---|---|---|
| without | 11 | — |
| with | 23 | 0 |

23 wrappers in C, 23 named, 13 SQL overloads gained — `NAI_geo_tgeo` alone carries 4.

**Seven are the commuted argument order** over a function that already names its other wrapper, so each gains one reference: the cbuffer, geo, npoint and pose families.

**Five are the temporal rigid geometries**, which need the kind of tag changed rather than a reference added. Their three functions carry `@sqlfn nearestApproachInstant()` alone — the direct form, for a surface whose PostgreSQL registration is deferred to a host extension and which therefore has no wrapper to chain through. These do have wrappers, so the two-hop `@csqlfn` chain is what carries their signatures; the direct tag supplies a name and nothing else. `shortestline_trgeometry_geo` in the same file already shows the settled shape, carrying both tags, and the parser reads the chain whenever it is present.

**Two of the twelve gain no overload**, and that is worth stating rather than hiding. `nearestApproachInstant(cbuffer, tcbuffer)` and `(pose, tpose)` exist, but a SQL-language cast composition binds them rather than the C wrapper, which stays unreachable. Naming the wrapper records what calls the function; which of the two binds the signature is a separate change.

The change is comment-only: every changed line is a doxygen `@` line.