### PR TITLE
Read the containment of a geometry by a circular buffer from its distances

### DIFF
--- a/meos/include/cbuffer/tcbuffer_spatialfuncs.h
+++ b/meos/include/cbuffer/tcbuffer_spatialfuncs.h
@@ -45,6 +45,8 @@
 /* Degenerate value functions */
 
 extern bool tcbuffer_is_tpoint(const Temporal *temp);
+extern int cbuffer_covers_geo(const Cbuffer *cb, const GSERIALIZED *gs);
+extern int cbuffer_contains_geo(const Cbuffer *cb, const GSERIALIZED *gs);
 
 /*****************************************************************************/
 

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -441,6 +441,7 @@ extern STBox *geo_split_n_stboxes(const GSERIALIZED *gs, int box_count, int *cou
 
 extern double geog_distance(const GSERIALIZED *g1, const GSERIALIZED *g2);
 extern double geom_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
+extern double geom_max_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern double geom_distance3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 
 /* Comparison functions */

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -32,6 +32,8 @@
  * @brief Spatial functions for temporal circular buffers
  */
 
+/* C */
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <utils/float.h>
@@ -711,6 +713,53 @@ tcbuffer_is_tpoint(const Temporal *temp)
   for (int i = 0; i < count && result; i++)
     result = (DatumGetCbufferP(tinstant_value_p(instants[i]))->radius == 0.0);
   pfree(instants);
+  return result;
+}
+
+/*****************************************************************************/
+
+/**
+ * @brief Return 1 if a circular buffer covers a geometry, 0 if not, and -1
+ * when the relationship cannot be read from the distances
+ * @details The disc covers the geometry when every point of the geometry lies
+ * in the closed disc, that is, when the point of the geometry farthest from
+ * the centre is at most the radius away. The maximum distance is not defined
+ * for a geometry carrying a circular arc, which the caller answers by its own
+ * path
+ * @param[in] cb Circular buffer
+ * @param[in] gs Geometry
+ */
+int
+cbuffer_covers_geo(const Cbuffer *cb, const GSERIALIZED *gs)
+{
+  GSERIALIZED *centre = cbuffer_point(cb);
+  double maxdist = geom_max_distance2d(centre, gs);
+  pfree(centre);
+  if (maxdist == DBL_MAX)
+    return -1;
+  return (maxdist <= cb->radius) ? 1 : 0;
+}
+
+/**
+ * @brief Return 1 if a circular buffer contains a geometry, 0 if not, and -1
+ * when the relationship cannot be read from the distances
+ * @details Containment asks that the geometry be covered and that the two
+ * interiors meet. A covered geometry that reaches the interior of the disc at
+ * any of its points meets it, since the interior is open, so the containment
+ * fails only for a geometry that lies entirely on the boundary circle, which
+ * is where its nearest point is at the radius
+ * @param[in] cb Circular buffer
+ * @param[in] gs Geometry
+ */
+int
+cbuffer_contains_geo(const Cbuffer *cb, const GSERIALIZED *gs)
+{
+  GSERIALIZED *centre = cbuffer_point(cb);
+  double maxdist = geom_max_distance2d(centre, gs);
+  int result = (maxdist == DBL_MAX) ? -1 :
+    ((maxdist <= cb->radius && geom_distance2d(centre, gs) < cb->radius) ?
+      1 : 0);
+  pfree(centre);
   return result;
 }
 

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -283,6 +283,21 @@ ea_spatialrel_tcbufferinst_geo(const TInstant *inst, const GSERIALIZED *gs,
       iymax, gbox.xmin, gbox.ymin, gbox.xmax, gbox.ymax, &decided))
     return decided;
   const Cbuffer *cb = DatumGetCbufferP(tinstant_value_p(inst));
+  /* The containment of a geometry by the disc is read from the distances of
+   * the geometry to the centre, which are exact for a circular arc, where a
+   * relationship of the rendered disc is read from a polygonal approximation
+   * of it */
+  if (! invert && numparam == 2)
+  {
+    int res = -1;
+    if (func == (varfunc) &datum_geom_contains)
+      res = cbuffer_contains_geo(cb, gs);
+    else if (func == (varfunc) &datum_geom_covers)
+      res = cbuffer_covers_geo(cb, gs);
+    if (res >= 0)
+      return res;
+  }
+
   GSERIALIZED *trav = cbuffer_to_geom(cb);
   int result = spatialrel_geo_geo(trav, gs, param, func, numparam, invert);
   pfree(trav);

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -79,8 +79,23 @@ static Datum
 tcbufferinst_geo_rel(const TInstant *inst, const GSERIALIZED *gs, bool invert,
   datum_func2 func)
 {
-  GSERIALIZED *disc =
-    cbuffer_to_geom(DatumGetCbufferP(tinstant_value_p(inst)));
+  const Cbuffer *cb = DatumGetCbufferP(tinstant_value_p(inst));
+  /* The containment of a geometry by the disc is read from the distances of
+   * the geometry to the centre, which are exact for a circular arc, where a
+   * relationship of the rendered disc is read from a polygonal approximation
+   * of it */
+  if (! invert)
+  {
+    int res = -1;
+    if (func == &datum_geom_contains)
+      res = cbuffer_contains_geo(cb, gs);
+    else if (func == &datum_geom_covers)
+      res = cbuffer_covers_geo(cb, gs);
+    if (res >= 0)
+      return BoolGetDatum(res > 0);
+  }
+
+  GSERIALIZED *disc = cbuffer_to_geom(cb);
   int result = spatialrel_geo_geo(disc, gs, (Datum) NULL, (varfunc) func, 2,
     invert);
   pfree(disc);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1045,6 +1045,35 @@ geom_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
 /**
  * @ingroup meos_geo_base_dist
+ * @brief Return the maximum distance between two geometries
+ * @details The maximum distance is the distance between the two points, one
+ * on each geometry, that are farthest from each other
+ * @param[in] gs1,gs2 Geometries
+ * @note PostGIS function: @p ST_MaxDistance(PG_FUNCTION_ARGS)
+ * @note A geometry carrying a circular arc is not supported, since the
+ * underlying computation implements the maximum only for straight edges
+ * @return On error, on empty geometries, or on a geometry carrying a circular
+ * arc return DBL_MAX
+ */
+double
+geom_max_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_geo_geo(gs1, gs2) || ! ensure_not_geodetic_geo(gs1) ||
+      gserialized_is_empty(gs1) || gserialized_is_empty(gs2))
+    return DBL_MAX;
+
+  LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
+  LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
+  double maxdist = (lwgeom_has_arc(geom1) || lwgeom_has_arc(geom2)) ?
+    DBL_MAX : lwgeom_maxdistance2d(geom1, geom2);
+  lwgeom_free(geom1);
+  lwgeom_free(geom2);
+  return maxdist;
+}
+
+/**
+ * @ingroup meos_geo_base_dist
  * @brief Return the 3D distance between two geometries
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p ST_3DDistance(PG_FUNCTION_ARGS)

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -988,3 +988,63 @@ SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(
  t
 (1 row)
 
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(1 0)');
+ eintersects 
+-------------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(1 0)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(1 0)');
+ econtains 
+-----------
+ f
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(0 1)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(0.5 0)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(0.5 0)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(1.5 0)');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Linestring(0 0,1 0)');
+ ecovers 
+---------
+ t
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Linestring(0 0,1 0)');
+ econtains 
+-----------
+ t
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),5)@2000-01-01', geometry 'CircularString(1 0, 0 1, -1 0)');
+ ecovers 
+---------
+ t
+(1 row)
+

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -346,3 +346,25 @@ SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', tcbuffer 'Cbuffer(
 SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01', tcbuffer 'Cbuffer(Point(0 0),0)@2000-01-01');
 
 -------------------------------------------------------------------------------
+-- The containment of a geometry by the disc is read from the distances of the
+-- geometry to the centre, so a geometry meeting the circle is covered
+-------------------------------------------------------------------------------
+
+-- A point on the circle is covered, and intersects, and is not contained
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(1 0)');
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(1 0)');
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(1 0)');
+-- The same holds where the circle meets an axis other than the one the
+-- rendered disc carries a vertex on
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(0 1)');
+-- A point strictly inside is covered and contained, one outside neither
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(0.5 0)');
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(0.5 0)');
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Point(1.5 0)');
+-- A segment whose far end meets the circle is covered and not contained
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Linestring(0 0,1 0)');
+SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2000-01-01', geometry 'Linestring(0 0,1 0)');
+-- A geometry carrying a circular arc keeps the path that renders the disc
+SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),5)@2000-01-01', geometry 'CircularString(1 0, 0 1, -1 0)');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
A circular buffer covers a geometry when every point of the geometry lies in the closed disc, and contains it when it covers it and the two interiors meet. Both relationships answer through a rendering of the disc as a geometry, and that rendering carries a circular arc, which the underlying library replaces with a chain of straight segments before the relationship runs. The approximation of a circle is inscribed, so a geometry meeting the circle reads as reaching outside it.

A disc of radius one at the origin therefore intersects `Point(1 0)` and does not cover it, which no pair of relationships can both satisfy.

The two relationships read the distances of the geometry to the centre instead: the disc covers the geometry when the farthest point of the geometry is at most the radius away, and contains it when it covers it and the nearest point is strictly nearer, since a covered geometry meets the open interior unless it lies entirely on the circle. Both engines of the family reach the same two functions, so the ever, always and temporal answers agree.

The maximum distance is a new geometry function, which generalizes the one the external library exposes as `ST_MaxDistance`. That computation is defined for straight edges alone, so a geometry carrying a circular arc keeps the rendering path, and the added cases pin one together with a point on the circle, a point on another of its axes, a point strictly inside, a point outside, and a segment whose far end meets the circle.

The committed expectations of the four relationship files are unchanged, which holds because none of them carries a geometry meeting the circle.
