### PR TITLE
Document the same surface in both manuals

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -1182,22 +1182,20 @@ FROM Temp;
 
 			<listitem xml:id="tcbuffer_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
-				<para>TODO Centroide temporal</para>
-				<para><varname>tCentroid(tcbuffer) → tgeompoint</varname></para>
+				<para>Agregar los centros de un conjunto de búferes circulares temporales en su centroide temporal, convirtiendo a <varname>tgeompoint</varname></para>
+				<para><varname>tCentroid(tcbuffer::tgeompoint) → tgeompoint</varname></para>
+				<para>La agregación pertenece al tipo <varname>tgeompoint</varname>: la trayectoria del centro de un búfer circular es un punto temporal, de modo que la conversión alcanza la agregación en lugar de que el tipo búfer lleve su propia copia.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
-  Cbuffer(Point(1 1), 0.3)@2001-01-03)' UNION
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
-  Cbuffer(Point(1 1), 0.4)@2001-01-03)' UNION
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
-  Cbuffer(Point(1 1), 0.5)@2001-01-03)' )
-SELECT astext(tCentroid(Temp))
-FROM Temp;
-/* {[POINT(72.451531682218 76.5231414472853)@2001-01-01,
-   POINT(55.7001249027598 72.9552602410653)@2001-01-03)} */
+  SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
+    Cbuffer(Point(1 1), 0.3)@2001-01-03)' UNION
+  SELECT tcbuffer '[Cbuffer(Point(3 3), 0.2)@2001-01-01,
+    Cbuffer(Point(3 3), 0.4)@2001-01-03)' )
+SELECT asText(tCentroid(temp::tgeompoint)) FROM Temp;
+-- {[POINT(2 2)@2001-01-01, POINT(2 2)@2001-01-03)}
 </programlisting>
 			</listitem>
+
 		</itemizedlist>
 	</sect1>
 

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -241,6 +241,17 @@ SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raquet_pixels">
+				<indexterm significance="normal"><primary><varname>pixels</varname></primary></indexterm>
+				<para>Devolver los bytes de píxeles de un mosaico Raquet</para>
+				<para><varname>pixels(raquet) → bytea</varname></para>
+				<para>Los bytes están en orden de fila mayor y empaquetados, <varname>width</varname> × <varname>height</varname> píxeles del tamaño de <varname>pixtype</varname> cada uno, en little-endian cuando un píxel ocupa más de un byte, que es la disposición que aceptan los constructores. Por lo tanto, un mosaico se reconstruye a través de sus propios accesores.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
+-- \x01020304
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raquetFromBinary">
 				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
 				<para>Devolver una tesela Raquet a partir de su representación Well-Known Binary (WKB)</para>

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -297,6 +297,31 @@ SELECT dynTimeWarpPath(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03
 		</itemizedlist>
 	</sect1>
 
+	<sect1 xml:id="ttype_kalmanFilter">
+		<title>Filtro de Kalman extendido</title>
+		<itemizedlist>
+			<listitem xml:id="ttype_extendedKalmanFilter">
+				<indexterm significance="normal"><primary><varname>extendedKalmanFilter</varname></primary></indexterm>
+				<para>Devolver un flotante temporal o un punto temporal suavizado, obtenido al filtrar una trayectoria ruidosa con un <ulink url="https://es.wikipedia.org/wiki/Filtro_de_Kalman">filtro de Kalman extendido</ulink> &Z_support;
+</para>
+				<para><varname>extendedKalmanFilter(tfloat, gate float, q float, variance float, to_drop boolean DEFAULT TRUE) → tfloat</varname></para>
+				<para><varname>extendedKalmanFilter(tgeompoint, gate float, q float, variance float, to_drop boolean DEFAULT TRUE) → tgeompoint</varname></para>
+				<para>El filtro modela el movimiento subyacente de un objeto móvil y lo separa del ruido de medición y de los valores atípicos ocasionales. El parámetro <varname>gate</varname> controla el rigor de la detección de atípicos, <varname>q</varname> es la escala del ruido de proceso, <varname>variance</varname> es la varianza del ruido de medición y <varname>to_drop</varname> elige si los atípicos se eliminan (<literal>true</literal>) o se reemplazan por la trayectoria predicha (<literal>false</literal>).</para>
+				<para>Estas funciones están pensadas para trayectorias con al menos tres instantes y se aplican normalmente a valores temporales con interpolación lineal.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asEWKT(extendedKalmanFilter(tgeompoint
+  '[Point(1 1)@2001-01-01, Point(50 50)@2001-01-02, Point(2 2)@2001-01-03]',
+  1e-5, 5e-10, 5e-10, true));
+-- [POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-03]
+SELECT asEWKT(extendedKalmanFilter(tgeompoint
+  '[Point(1 1)@2001-01-01, Point(50 50)@2001-01-02, Point(2 2)@2001-01-03]',
+  1e-5, 5e-10, 5e-10, false));
+-- [POINT(1 1)@2001-01-01, POINT(1 1)@2001-01-02, POINT(2 2)@2001-01-03]
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
 	<sect1 xml:id="ttype_splitting">
 		<title>Operaciones de división</title>
 

--- a/doc/temporal_alpha.xml
+++ b/doc/temporal_alpha.xml
@@ -72,6 +72,18 @@ SELECT tfloat '(1@2001-01-01, 3@2001-01-03, 2@2001-01-05]'::tbox;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="talpha_valueSpan">
+				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
+				<para>Return the span of values, ignoring any gaps</para>
+				<para><varname>valueSpan(tnumber) → numspan</varname></para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT valueSpan(tint '{1@2001-01-01, 5@2001-01-02, 3@2001-01-03}');
+-- [1, 6)
+SELECT valueSpan(tfloat '[1.5@2001-01-01, 4.5@2001-01-03]');
+-- [1.5, 4.5]
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="tbool_tint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tint(tbool)</varname></primary></indexterm>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -1184,6 +1184,22 @@ FROM Temp;
    1@2001-01-06)} */
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="tcbuffer_tCentroid">
+				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
+				<para>Aggregate the centres of a set of temporal circular buffers into their temporal centroid, by casting to <varname>tgeompoint</varname></para>
+				<para><varname>tCentroid(tcbuffer::tgeompoint) → tgeompoint</varname></para>
+				<para>The aggregate belongs to the <varname>tgeompoint</varname> type: a circular buffer's centre trajectory is a temporal point, so the cast reaches the aggregate rather than the buffer type carrying its own copy of it.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
+    Cbuffer(Point(1 1), 0.3)@2001-01-03)' UNION
+  SELECT tcbuffer '[Cbuffer(Point(3 3), 0.2)@2001-01-01,
+    Cbuffer(Point(3 3), 0.4)@2001-01-03)' )
+SELECT asText(tCentroid(temp::tgeompoint)) FROM Temp;
+-- {[POINT(2 2)@2001-01-01, POINT(2 2)@2001-01-03)}
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1343,6 +1343,24 @@ SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
 -- [0@2000-01-01, 0.5@2000-01-02]
 </programlisting>
 				</listitem>
+
+				<listitem xml:id="tpose_yaw_pitch_roll">
+					<indexterm significance="normal"><primary><varname>yaw</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
+					<para>Lift the Euler angle accessors over a temporal pose, returning a temporal float in radians</para>
+					<para><varname>yaw(tpose) → tfloat</varname></para>
+					<para><varname>pitch(tpose) → tfloat</varname></para>
+					<para><varname>roll(tpose) → tfloat</varname></para>
+					<para>The result carries step interpolation, since an angle read from a rotation does not vary linearly between two poses.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(yaw(tpose '[Pose(Point(0 0),0.5)@2001-01-01,
+  Pose(Point(1 1),1.5)@2001-01-02]'), 6);
+-- Interp=Step;[0.5@2001-01-01, 1.5@2001-01-02]
+SELECT round(pitch(tpose 'Pose(Point(0 0 0),1,0,0,0)@2001-01-01'), 6);
+-- 0@2001-01-01
+</programlisting>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -313,21 +313,14 @@ SELECT dynTimeWarpPath(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03
 				<para>The filter models the underlying motion of a moving object and separates it from measurement noise and occasional outliers. The <varname>gate</varname> parameter controls how strict the outlier detection is, <varname>q</varname> is the process-noise scale, <varname>variance</varname> is the measurement-noise variance, and <varname>to_drop</varname> chooses whether outliers are removed (<literal>true</literal>) or replaced by the predicted trajectory (<literal>false</literal>).</para>
 				<para>These functions are intended for trajectories with at least three instants and are typically applied to temporal values with linear interpolation.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asEWKT(
-  extendedKalmanFilter(
-    tgeompoint '[Point(1 1)@2001-01-01,
-                 Point(50 50)@2001-01-02,
-                 Point(2 2)@2001-01-03]',
-    1e-5, 5e-10, 5e-10, true));
--- Drop mode: the outlier at 2001-01-02 is removed
-
-SELECT asEWKT(
-  extendedKalmanFilter(
-    tgeompoint '[Point(1 1)@2001-01-01,
-                 Point(50 50)@2001-01-02,
-                 Point(2 2)@2001-01-03]',
-    1e-5, 5e-10, 5e-10, false));
--- Fill mode: the outlier is replaced by a point predicted from the surrounding motion
+SELECT asEWKT(extendedKalmanFilter(tgeompoint
+  '[Point(1 1)@2001-01-01, Point(50 50)@2001-01-02, Point(2 2)@2001-01-03]',
+  1e-5, 5e-10, 5e-10, true));
+-- [POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-03]
+SELECT asEWKT(extendedKalmanFilter(tgeompoint
+  '[Point(1 1)@2001-01-01, Point(50 50)@2001-01-02, Point(2 2)@2001-01-03]',
+  1e-5, 5e-10, 5e-10, false));
+-- [POINT(1 1)@2001-01-01, POINT(1 1)@2001-01-02, POINT(2 2)@2001-01-03]
 </programlisting>
 			</listitem>
 		</itemizedlist>


### PR DESCRIPTION
The Spanish chapters carry the Raquet pixel accessor and the extended Kalman filter section; the English chapters carry the value span of a temporal number and the Euler angle accessors lifted over a temporal pose. Both manuals hold 715 function entries.

The temporal centroid of circular buffers reads through the cast to `tgeompoint`, where the aggregate lives, in place of an entry for a `tCentroid(tcbuffer)` that no server provides — `tCentroid` is defined for `tgeompoint` and `tnpoint`, and the cast is the documented path for every derived spatial type.

The extended Kalman filter results come from a run rather than from a description of what the filter does.

Both manuals build: 236 English and 236 Spanish pages, no errors.