### PR TITLE
Answer the circular buffer and pose nearest approach distance from their kernels

### DIFF
--- a/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
@@ -202,8 +202,8 @@ CREATE FUNCTION nearestApproachDistance(tcbuffer, stbox)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tcbuffer, cbuffer)
   RETURNS float
-  AS 'SELECT @extschema@.nearestApproachDistance($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAD_tcbuffer_cbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tcbuffer, tcbuffer)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_tcbuffer_tcbuffer'

--- a/mobilitydb/sql/pose/110_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/110_tpose_distance.in.sql
@@ -201,8 +201,8 @@ CREATE FUNCTION nearestApproachDistance(tpose, stbox)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tpose, pose)
   RETURNS float
-  AS 'SELECT @extschema@.nearestApproachDistance($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAD_tpose_pose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tpose, tpose)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_tpose_tpose'

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -645,6 +645,38 @@ SELECT round(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(141.421
      0
 (1 row)
 
+SELECT round(nearestApproachDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.7)')::numeric, 6);
+  round   
+----------
+ 0.214214
+(1 row)
+
+SELECT round(nearestApproachDistance(cbuffer 'Cbuffer(Point(1 1), 0.7)', tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01')::numeric, 6);
+  round   
+----------
+ 0.214214
+(1 row)
+
+SELECT nearestApproachDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.7)')
+     = nearestApproachDistance(cbuffer 'Cbuffer(Point(1 1), 0.7)', tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT nearestApproachDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.7)')
+     = minDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.7)');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)')::numeric, 6);
+  round   
+----------
+ 7.800000
+(1 row)
+
 SELECT geometrytype(shortestLine(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01', geometry 'Polygon((5 5,5 8,8 8,8 5,5 5))'));
  geometrytype 
 --------------

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -271,6 +271,20 @@ SELECT round(nearestApproachDistance(tcbuffer '{Cbuffer(Point(0 0), 1)@2000-01-0
 -- taken, giving 0 rather than the edge-endpoint distance.
 SELECT round(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(141.4213562373095 173.20508075688772), 1)@2000-01-02]' |=| geometry 'Linestring(173.20508075688772 0, 0 141.4213562373095)', 6);
 
+-- A circular buffer as the other argument, in both orders. The distance between
+-- two buffers is the distance between their centres less both radii, so centres
+-- sqrt(2) apart with radii 0.5 and 0.7 give sqrt(2) - 0.5 - 0.7 = 0.214214
+-- exactly, the two orders of a commutative operation agree, and minDistance --
+-- which names the same kernel -- agrees with both.
+SELECT round(nearestApproachDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.7)')::numeric, 6);
+SELECT round(nearestApproachDistance(cbuffer 'Cbuffer(Point(1 1), 0.7)', tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01')::numeric, 6);
+SELECT nearestApproachDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.7)')
+     = nearestApproachDistance(cbuffer 'Cbuffer(Point(1 1), 0.7)', tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01');
+SELECT nearestApproachDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.7)')
+     = minDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', cbuffer 'Cbuffer(Point(1 1), 0.7)');
+-- A buffer beside the path: the distance is the centre distance less both radii
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)')::numeric, 6);
+
 -------------------------------------------------------------------------------
 
 -- Analytic shortestLine: its length equals the nearest-approach distance;


### PR DESCRIPTION
The two argument orders of one commutative operation bind different implementations:

| signature | binds |
|---|---|
| `nearestApproachDistance(cbuffer, tcbuffer)` | C wrapper `NAD_cbuffer_tcbuffer` |
| `nearestApproachDistance(tcbuffer, cbuffer)` | `'SELECT nearestApproachDistance($1, geometry($2))'` |

Pose carries the same asymmetry. For the circular buffer the composition also answers wrongly: `geometry(cbuffer)` builds a curve through `lwcircle_make`, and measuring against a curve linearises it, so the answer describes an approximation of the circle rather than the circle.

`nad_tcbuffer_cbuffer` computes the exact plane-sweep minimum instead. Two buffers whose centres lie √2 apart with radii 0.5 and 0.7 are √2 − 0.5 − 0.7 = 0.214214 apart:

| | value |
|---|---|
| kernel | **0.214214** (exact) |
| composition | 0.418034 |

`210_tcbuffer_distance.in.sql` states that `minDistance` and `nearestApproachDistance` agree for these arguments, and binds the first to the kernel and the second to the composition.

For pose the two agree numerically, because `geometry(pose)` is `Pose_to_point` and a point carries no curve to approximate. Binding the wrapper there settles which implementation answers rather than changing an answer.

**Scope: four signatures** — the nearest approach distance in both argument orders, for both families. The nearest approach instant and the shortest line keep their composition: their kernels are that same composition moved into C, `cbuffer_to_geom` included, so binding them carries the approximation rather than removes it.

**Coverage.** No test exercises a circular buffer as the second argument, which is how the asymmetry reaches a release. `210_tcbuffer_distance.test.sql` gains the exact value, both argument orders agreeing, agreement with `minDistance` which names the same kernel, and an off-path probe whose distance is the centre distance less both radii. The expected output is harvested from the harness rather than written by hand.