### PR TITLE
Name each manual entry the same way in both languages

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -313,7 +313,7 @@
 				</listitem>
 
 				<listitem>
-					<para><link linkend="floatspanset_degrees"><varname>degrees</varname>, <varname>radians</varname></link>: Convertir a grados o radianes</para>
+					<para><link linkend="floatsetspan_degrees"><varname>degrees</varname>, <varname>radians</varname></link>: Convertir a grados o radianes</para>
 				</listitem>
 
 				<listitem>

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -859,7 +859,7 @@ SELECT round(floatspanset '{[1.123456789, 2.123456789],[3.123456789,4.123456789]
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="floatspanset_degrees">
+			<listitem xml:id="floatsetspan_degrees">
 				<indexterm significance="normal"><primary><varname>degrees</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>radians</varname></primary></indexterm>
 				<para>Convertir a grados o radianes</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -852,11 +852,11 @@
 			<title>Restrictions</title>
 			<itemizedlist>
 			<listitem>
-					<para><link linkend="type_atValues"><varname>atValue</varname>, <varname>minusValue</varname>, <varname>atValues</varname>, <varname>minusValues</varname></link>: Restrict to (the complement of) a value or a set of values</para>
+					<para><link linkend="ttype_atValues"><varname>atValue</varname>, <varname>minusValue</varname>, <varname>atValues</varname>, <varname>minusValues</varname></link>: Restrict to (the complement of) a value or a set of values</para>
 				</listitem>
 
 				<listitem>
-					<para><link linkend="type_atTime"><varname>atTime</varname>, <varname>minusTime</varname></link>: Restrict to (the complement of) a time value</para>
+					<para><link linkend="ttype_atTime"><varname>atTime</varname>, <varname>minusTime</varname></link>: Restrict to (the complement of) a time value</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_types_p2.xml
+++ b/doc/temporal_types_p2.xml
@@ -312,7 +312,7 @@ SELECT merge(inst) FROM temp;
 		<para>There are three complementary sets of restriction functions. The first set functions restricts the temporal value with respect to a value or a time extent. Examples are <varname>atValues</varname> or <varname>atTime</varname>. The second set functions restricts the temporal value with respect to the <emphasis>complement</emphasis> of a value or a time extent. Examples are <varname>minusValues</varname> or <varname>minusTime</varname>.  Finally, the third set functions restricts the temporal value before or after a timestamptz. Examples are <varname>beforeTimestamp</varname> or <varname>afterTimestamp</varname>.</para>
 
 		<itemizedlist>
-			<listitem xml:id="type_atValues">
+			<listitem xml:id="ttype_atValues">
 				<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
@@ -376,7 +376,7 @@ SELECT asText(minusValue(tgeometry '[Point(0 0)@2001-01-01, Linestring(0 0,2 2)@
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="type_atTime">
+			<listitem xml:id="ttype_atTime">
 				<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusTime</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a time value</para>


### PR DESCRIPTION
The restriction entries follow the `ttype_` prefix the rest of their chapter uses, and the degrees entry carries the identifier naming the types it documents.

Both manuals share every entry identifier, so a cross-reference resolves to the same entry whichever language a reader opens. Each rename moves its `linkend` in `reference.xml` with it: no link dangles in either language.

Both manuals build: 236 English and 236 Spanish pages, no errors.