### PR TITLE
Convert a temporal rigid geometry only to a temporal geometry point

### DIFF
--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -277,10 +277,10 @@ trgeometry_to_tpose(const Temporal *temp)
 
 /**
  * @ingroup meos_rgeo_conversion
- * @brief Return a temporal point obtained from the points of the temporal
- * pose of a temporal rigid geometry
+ * @brief Return a temporal geometry point obtained from the points of the
+ * temporal pose of a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
- * @csqlfn #Trgeometry_to_tpoint()
+ * @csqlfn #Trgeometry_to_tgeompoint()
  */
 Temporal *
 trgeometry_to_tgeompoint(const Temporal *temp)

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -213,11 +213,7 @@ CREATE FUNCTION tpose(trgeometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tgeompoint(trgeometry)
   RETURNS tgeompoint
-  AS 'MODULE_PATHNAME', 'Trgeometry_to_tpoint'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tgeogpoint(trgeometry)
-  RETURNS tgeogpoint
-  AS 'MODULE_PATHNAME', 'Trgeometry_to_tpoint'
+  AS 'MODULE_PATHNAME', 'Trgeometry_to_tgeompoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION tgeometry(trgeometry)
   RETURNS tgeometry
@@ -226,7 +222,6 @@ CREATE FUNCTION tgeometry(trgeometry)
 
 CREATE CAST (trgeometry AS tpose) WITH FUNCTION tpose(trgeometry);
 CREATE CAST (trgeometry AS tgeompoint) WITH FUNCTION tgeompoint(trgeometry);
-CREATE CAST (trgeometry AS tgeogpoint) WITH FUNCTION tgeogpoint(trgeometry);
 CREATE CAST (trgeometry AS tgeometry) WITH FUNCTION tgeometry(trgeometry);
 
 CREATE FUNCTION stbox(trgeometry)

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -417,15 +417,15 @@ Trgeometry_to_tpose(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
-PGDLLEXPORT Datum Trgeometry_to_tpoint(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Trgeometry_to_tpoint);
+PGDLLEXPORT Datum Trgeometry_to_tgeompoint(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Trgeometry_to_tgeompoint);
 /**
  * @ingroup mobilitydb_rgeo_conversion
- * @brief Convert a temporal rigid geometry into a temporal point
- * @sqlfn tgeompoint(), tgeogpoint()
+ * @brief Convert a temporal rigid geometry into a temporal geometry point
+ * @sqlfn tgeompoint()
  */
 Datum
-Trgeometry_to_tpoint(PG_FUNCTION_ARGS)
+Trgeometry_to_tgeompoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   Temporal *result = trgeometry_to_tgeompoint(temp);

--- a/tools/codegen/inherited/manifest.d/conversion_families.yaml
+++ b/tools/codegen/inherited/manifest.d/conversion_families.yaml
@@ -96,10 +96,9 @@ conversion_families:
   - lit: "/******************************************************************************\n * Conversion functions\n ******************************************************************************/\n\n"
   - fns:
     - {sig: "tpose(trgeometry)", ret: tpose, sym: Trgeometry_to_tpose}
-    - {sig: "tgeompoint(trgeometry)", ret: tgeompoint, sym: Trgeometry_to_tpoint}
-    - {sig: "tgeogpoint(trgeometry)", ret: tgeogpoint, sym: Trgeometry_to_tpoint}
+    - {sig: "tgeompoint(trgeometry)", ret: tgeompoint, sym: Trgeometry_to_tgeompoint}
     - {sig: "tgeometry(trgeometry)", ret: tgeometry, sym: Trgeometry_to_tgeometry}
-  - lit: "\nCREATE CAST (trgeometry AS tpose) WITH FUNCTION tpose(trgeometry);\nCREATE CAST (trgeometry AS tgeompoint) WITH FUNCTION tgeompoint(trgeometry);\nCREATE CAST (trgeometry AS tgeogpoint) WITH FUNCTION tgeogpoint(trgeometry);\nCREATE CAST (trgeometry AS tgeometry) WITH FUNCTION tgeometry(trgeometry);\n\n"
+  - lit: "\nCREATE CAST (trgeometry AS tpose) WITH FUNCTION tpose(trgeometry);\nCREATE CAST (trgeometry AS tgeompoint) WITH FUNCTION tgeompoint(trgeometry);\nCREATE CAST (trgeometry AS tgeometry) WITH FUNCTION tgeometry(trgeometry);\n\n"
   - fns:
     - {sig: "stbox(trgeometry)", ret: stbox, sym: Tspatial_to_stbox}
   - lit: "\nCREATE CAST (trgeometry AS stbox) WITH FUNCTION stbox(trgeometry);\n\nCREATE FUNCTION expandSpace(trgeometry, float)\n  RETURNS stbox\n  AS 'SELECT @extschema@.expandSpace($1::stbox, $2)'\n  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;\n\n"


### PR DESCRIPTION
A rigid geometry is planar: `trgeoinst_make` sets the geodetic flag to false and the sequence and sequence set constructors only propagate it, so the type has a single leaf and no geographic form.

The cast to `tgeogpoint` nevertheless exists and shares its backing function with the `tgeompoint` one, so it returns a temporal geometry point carrying the `tgeogpoint` label — a value whose declared type and contents disagree, which the operators dispatching on that type then read as geodetic. Nothing references it: no test, no manual entry, no other declaration.

This removes that cast and names the wrapper for the type it returns, matching the MEOS function `trgeometry_to_tgeompoint` it calls and the sibling `Tcbuffer_to_tgeompoint` of the other planar family. The manifest entry mirrors the declaration, so the conversion region still self-regenerates.
