### PR TITLE
Carry the reference frame of a pose into its temporal value

### DIFF
--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -664,7 +664,7 @@ SELECT asText(tpose(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02)',
 
 	<sect1 xml:id="tpose_conversions">
 		<title>Conversión de tipos</title>
-		<para>Un valor de pose temporal se puede convertir hacia y desde un punto geométrico temporal. Esto se puede hacer utilizando un <varname>CAST</varname> explícito o utilizando la notación <varname>::</varname>. Se devuelve un valor nulo si alguno de los valores de punto geométrico que lo componen no se puede convertir en un valor <varname>pose</varname>.</para>
+		<para>Un valor de pose temporal se puede convertir hacia y desde un punto temporal, que es un punto geométrico temporal para una pose planar y un punto geográfico temporal para una pose geodésica. Esto se puede hacer utilizando un <varname>CAST</varname> explícito o utilizando la notación <varname>::</varname>. Convertir una pose temporal al tipo de punto temporal del otro marco de referencia genera un error. Se devuelve un valor nulo si alguno de los valores de punto geométrico que lo componen no se puede convertir en un valor <varname>pose</varname>.</para>
 		<itemizedlist>
 			<listitem xml:id="tpose_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -671,7 +671,7 @@ SELECT asText(tpose(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02)',
 
 	<sect1 xml:id="tpose_conversions">
 		<title>Conversions</title>
-		<para>A temporal pose value can be converted to and from a temporal point, which is a temporal geometry point for a planar pose and a temporal geography point for a geodetic pose. This can be done using an explicit <varname>CAST</varname> or using the <varname>::</varname> notation. A null value is returned if any of the composing geometry point values cannot be converted into a <varname>pose</varname> value.</para>
+		<para>A temporal pose value can be converted to and from a temporal point, which is a temporal geometry point for a planar pose and a temporal geography point for a geodetic pose. This can be done using an explicit <varname>CAST</varname> or using the <varname>::</varname> notation. Converting a temporal pose to the temporal point type of the other reference frame raises an error. A null value is returned if any of the composing geometry point values cannot be converted into a <varname>pose</varname> value.</para>
 		<itemizedlist>
 			<listitem xml:id="tpose_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -453,6 +453,7 @@ pose_flags(Pose *pose)
   int16 result = 0; /* Set all flags to false */
   MEOS_FLAGS_SET_X(result, true);
   MEOS_FLAGS_SET_Z(result, MEOS_FLAGS_GET_Z(pose->flags));
+  MEOS_FLAGS_SET_GEODETIC(result, MEOS_FLAGS_GET_GEODETIC(pose->flags));
   return result;
 }
 #endif /* POSE || RGEO */

--- a/mobilitydb/src/pose/tpose.c
+++ b/mobilitydb/src/pose/tpose.c
@@ -40,9 +40,11 @@
 #include <meos.h>
 #include <meos_pose.h>
 #include "temporal/set.h"
+#include "geo/tgeo_spatialfuncs.h"
 #include "geo/tspatial_parser.h"
 #include "pose/pose.h"
 /* MobilityDB */
+#include "pg_temporal/meos_catalog.h"
 #include "pg_geo/tspatial.h"
 #include "pg_geo/postgis.h"
 
@@ -137,6 +139,20 @@ Datum
 Tpose_to_tpoint(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  /* A pose carries its own reference frame, so the pose decides the type of the
+   * point: a planar pose yields a temporal geometry point and a geodetic one a
+   * temporal geography point. Both conversions share this function, so the frame
+   * of the argument must agree with the type the caller asked for — converting
+   * to the other one returns a value whose declared type contradicts its
+   * coordinates, which every operator dispatching on that type then misreads */
+  MeosType restype = oid_meostype(get_fn_expr_rettype(fcinfo->flinfo));
+  bool valid = (restype == T_TGEOGPOINT) ?
+    ensure_geodetic(temp->flags) : ensure_not_geodetic(temp->flags);
+  if (! valid)
+  {
+    PG_FREE_IF_COPY(temp, 0);
+    PG_RETURN_NULL();
+  }
   Temporal *result = tpose_to_tpoint(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_POINTER(result);

--- a/mobilitydb/test/pose/expected/102_tpose.test.out
+++ b/mobilitydb/test/pose/expected/102_tpose.test.out
@@ -2473,6 +2473,10 @@ SELECT pg_typeof(tgeogpoint(tpose '[GeodPose(Point(1 1),0.1)@2000-01-01]'));
  tgeogpoint
 (1 row)
 
+SELECT asText(tgeogpoint(tpose '[Pose(Point(1 1),0.1)@2000-01-01]'));
+ERROR:  Only geodetic coordinates supported
+SELECT asText(tgeompoint(tpose '[GeodPose(Point(1 1),0.1)@2000-01-01]'));
+ERROR:  Only planar coordinates supported
 WITH ais(mmsi, temp) AS (
   SELECT mmsi, tposeSeq(array_agg(tpose(pose(geom, heading), t) ORDER BY t))
   FROM tbl_ais_instant GROUP BY mmsi )

--- a/mobilitydb/test/pose/queries/102_tpose.test.sql
+++ b/mobilitydb/test/pose/queries/102_tpose.test.sql
@@ -637,6 +637,9 @@ SELECT asText(tgeompoint(tpose '[Pose(Point(1 1),0.1)@2000-01-01, Pose(Point(2 2
 SELECT asText(tgeogpoint(tpose '[GeodPose(Point(1 1),0.1)@2000-01-01, GeodPose(Point(2 2),0.2)@2000-01-02]'));
 SELECT pg_typeof(tgeompoint(tpose '[Pose(Point(1 1),0.1)@2000-01-01]'));
 SELECT pg_typeof(tgeogpoint(tpose '[GeodPose(Point(1 1),0.1)@2000-01-01]'));
+-- The frame of the pose must agree with the type asked for
+SELECT asText(tgeogpoint(tpose '[Pose(Point(1 1),0.1)@2000-01-01]'));
+SELECT asText(tgeompoint(tpose '[GeodPose(Point(1 1),0.1)@2000-01-01]'));
 
 -------------------------------------------------------------------------------/
 


### PR DESCRIPTION
The MEOS flags of a temporal value are built per base type in `tgeo_spatialfuncs.c`, and the pose case sets the X and Z flags but drops the geodetic one, while the geometry and cell index cases beside it copy it. A temporal pose built from `GeodPose` values therefore reports planar coordinates.

`tpose_to_tpoint` reads that flag to choose its result type, so it always produces a temporal geometry point. The `tgeogpoint(tpose)` cast returns that value under the `tgeogpoint` label — a value whose declared type contradicts its coordinates — and the `tgeompoint(tpose)` cast accepts a geodetic pose just as readily.

This sets the flag from the pose, and lets each conversion require the frame it is named for: a pose converts to the temporal point type of its own frame, and asking for the other one reports the mismatch through the existing `ensure_geodetic`/`ensure_not_geodetic` gates instead of returning a mislabelled value.

The manual already describes this behaviour — "a temporal geometry point for a planar pose and a temporal geography point for a geodetic pose". It also states that the other frame is an error, and the Spanish paragraph, which describes only a single geometric conversion, matches the English one.

Every existing test and manual example pairs the frame with its type and is unchanged; two cases cover the rejected pairings.
