### PR TITLE
Report the liblwgeom messages and answer the buffer instant from its kernel

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -796,15 +796,14 @@ nai_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
     return NULL;
 
-  GSERIALIZED *geom = cbuffer_to_geom(cb);
-  Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
-  TInstant *resultgeom = nai_tgeo_geo(tpoint, geom);
-  /* We do not call the function tgeompointinst_tcbufferinst to avoid
-   * roundoff errors. The closest point may be at an exclusive bound. */
-  Datum value;
-  temporal_value_at_timestamptz(temp, resultgeom->t, false, &value);
-  TInstant *result = tinstant_make_free(value, temp->temptype, resultgeom->t);
-  pfree(tpoint); pfree(resultgeom); pfree(geom);
+  /* A static disc is a constant temporal circular buffer, so the nearest
+   * approach instant is the one the two-temporal kernel already computes.
+   * Converting the disc to a geometry instead would measure to the circle's
+   * defining vertices, and dropping the temporal radius would minimise a
+   * different quantity than the nearest approach distance reports. */
+  Temporal *ctemp = tcbuffer_from_base_temp(cb, temp);
+  TInstant *result = nai_tcbuffer_tcbuffer(temp, ctemp);
+  pfree(ctemp);
   return result;
 }
 

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -620,6 +620,55 @@ meos_get_intervalstyle(void)
 
 /*****************************************************************************/
 
+/*****************************************************************************
+ * liblwgeom message handlers
+ *****************************************************************************/
+
+/* Bound for a formatted liblwgeom message, matching liblwgeom's own
+ * LW_MSG_MAXLEN, which is file-scope in lwutil.c and so not shared. */
+#define MEOS_LW_MSG_MAXLEN 256
+
+/**
+ * @brief Report a liblwgeom error through the MEOS error channel
+ * @details liblwgeom reports through a handler the embedder installs, and a
+ * PostgreSQL backend installs one in @c mobilitydb_init that raises. A
+ * standalone MEOS program installs none, so liblwgeom keeps its own default,
+ * which writes the message to @c stderr and ends the process — the message
+ * reaches the caller with no error code, and a host that meant to catch it
+ * never gets the chance.
+ * @note This handler does NOT return. liblwgeom's callers continue as though
+ * the value were valid — @c bytes_from_hexbytes reads on after reporting an
+ * odd-length string — so returning would hand them uninitialised memory. The
+ * host's own handler decides what happens first: one that raises (an exception,
+ * a longjmp) never comes back here, which is the case this exists to serve. One
+ * that returns leaves no way to honour liblwgeom's contract except to end the
+ * process, exactly as its own default does.
+ */
+static void
+meos_lwerror_handler(const char *fmt, va_list ap)
+{
+  char msg[MEOS_LW_MSG_MAXLEN + 1];
+  vsnprintf(msg, sizeof(msg), fmt, ap);
+  msg[MEOS_LW_MSG_MAXLEN] = '\0';
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "%s", msg);
+  exit(EXIT_FAILURE);
+}
+
+/**
+ * @brief Report a liblwgeom notice through the MEOS error channel
+ * @details A notice is advisory, so this handler returns as liblwgeom expects.
+ */
+static void
+meos_lwnotice_handler(const char *fmt, va_list ap)
+{
+  char msg[MEOS_LW_MSG_MAXLEN + 1];
+  vsnprintf(msg, sizeof(msg), fmt, ap);
+  msg[MEOS_LW_MSG_MAXLEN] = '\0';
+  meos_error(WARNING, MEOS_ERR_INVALID_ARG_VALUE, "%s", msg);
+}
+
+/*****************************************************************************/
+
 extern void init_database_collation(void);
 
 /**
@@ -632,6 +681,11 @@ meos_initialize(void)
   /* Install the default (libc) allocator before anything else can allocate */
   meos_initialize_allocator(NULL, NULL, NULL);
   meos_initialize_error_handler(NULL);
+  /* Route liblwgeom's messages into the MEOS error channel, symmetric with the
+   * PG backend's mobilitydb_init. The allocators stay liblwgeom's own: a
+   * backend passes palloc, a standalone program keeps malloc. */
+  lwgeom_set_handlers(NULL, NULL, NULL, meos_lwerror_handler,
+    meos_lwnotice_handler);
   meos_initialize_timezone(NULL);
   /* Initialize collation */
   meos_initialize_collation();

--- a/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
@@ -159,8 +159,8 @@ CREATE FUNCTION nearestApproachInstant(stbox, tcbuffer)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(cbuffer, tcbuffer)
   RETURNS tcbuffer
-  AS 'SELECT @extschema@.nearestApproachInstant(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAI_cbuffer_tcbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(tcbuffer, geometry)
   RETURNS tcbuffer
   AS 'MODULE_PATHNAME', 'NAI_tcbuffer_geo'
@@ -171,8 +171,8 @@ CREATE FUNCTION nearestApproachInstant(tcbuffer, stbox)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(tcbuffer, cbuffer)
   RETURNS tcbuffer
-  AS 'SELECT @extschema@.nearestApproachInstant($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAI_tcbuffer_cbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(tcbuffer, tcbuffer)
   RETURNS tcbuffer
   AS 'MODULE_PATHNAME', 'NAI_tcbuffer_tcbuffer'

--- a/mobilitydb/sql/pose/110_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/110_tpose_distance.in.sql
@@ -158,8 +158,8 @@ CREATE FUNCTION nearestApproachInstant(stbox, tpose)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(pose, tpose)
   RETURNS tpose
-  AS 'SELECT @extschema@.nearestApproachInstant(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAI_pose_tpose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(tpose, geometry)
   RETURNS tpose
   AS 'MODULE_PATHNAME', 'NAI_tpose_geo'
@@ -170,8 +170,8 @@ CREATE FUNCTION nearestApproachInstant(tpose, stbox)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(tpose, pose)
   RETURNS tpose
-  AS 'SELECT @extschema@.nearestApproachInstant($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAI_tpose_pose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(tpose, tpose)
   RETURNS tpose
   AS 'MODULE_PATHNAME', 'NAI_tpose_tpose'

--- a/mobilitydb/src/cbuffer/tcbuffer_distance.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_distance.c
@@ -321,6 +321,8 @@ NAI_cbuffer_tcbuffer(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   TInstant *result = nai_tcbuffer_cbuffer(temp, cb);
   PG_FREE_IF_COPY(temp, 1);
+  if (! result)
+    PG_RETURN_NULL();
   PG_RETURN_TINSTANT_P(result);
 }
 
@@ -339,6 +341,8 @@ NAI_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
   Cbuffer *cb = PG_GETARG_CBUFFER_P(1);
   TInstant *result = nai_tcbuffer_cbuffer(temp, cb);
   PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
   PG_RETURN_TINSTANT_P(result);
 }
 

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -312,6 +312,8 @@ NAI_pose_tpose(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   TInstant *result = nai_tpose_pose(temp, pose);
   PG_FREE_IF_COPY(temp, 1);
+  if (! result)
+    PG_RETURN_NULL();
   PG_RETURN_TINSTANT_P(result);
 }
 
@@ -330,6 +332,8 @@ NAI_tpose_pose(PG_FUNCTION_ARGS)
   Pose *pose = PG_GETARG_POSE_P(1);
   TInstant *result = nai_tpose_pose(temp, pose);
   PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
   PG_RETURN_TINSTANT_P(result);
 }
 

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -489,6 +489,68 @@ SELECT abs(a - b) < 1e-3 FROM d;
  t
 (1 row)
 
+SELECT asText(nearestApproachInstant(geometry 'Point(2 3)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(2 0),0.5)@Mon Jan 03 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(stbox 'STBOX X((5,2),(7,4))', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(4 0),0.5)@Wed Jan 05 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(cbuffer 'Cbuffer(Point(4 9), 0.7)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(4 0),0.5)@Wed Jan 05 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', geometry 'Point(2 3)'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(2 0),0.5)@Mon Jan 03 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX X((5,2),(7,4))'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(4 0),0.5)@Wed Jan 05 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(4 0),0.5)@Wed Jan 05 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(nearestApproachInstant(
+  tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]',
+  tcbuffer '[Cbuffer(Point(0 9), 0.5)@2000-01-01, Cbuffer(Point(4 1), 0.5)@2000-01-05]'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(4 0),0.5)@Wed Jan 05 00:00:00 2000 PST
+(1 row)
+
+WITH d(a, b) AS (
+  SELECT nearestApproachDistance(nearestApproachInstant(t, p), p),
+         nearestApproachDistance(t, p)
+  FROM (SELECT tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]' AS t,
+               cbuffer 'Cbuffer(Point(4 9), 0.7)' AS p) v)
+SELECT a = b FROM d;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)')
+     = nearestApproachInstant(cbuffer 'Cbuffer(Point(4 9), 0.7)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]');
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT round(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01' |=| geometry 'Polygon((5 5,5 8,8 8,8 5,5 5))', 6);
   round   
 ----------

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -224,6 +224,36 @@ WITH d(a, b) AS (
 SELECT abs(a - b) < 1e-3 FROM d;
 
 -------------------------------------------------------------------------------
+-- nearestApproachInstant
+-------------------------------------------------------------------------------
+
+-- Every overload, against a buffer sweeping from (0 0) to (4 0). Each probe is
+-- placed so that a single instant attains the minimum.
+SELECT asText(nearestApproachInstant(geometry 'Point(2 3)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
+SELECT asText(nearestApproachInstant(stbox 'STBOX X((5,2),(7,4))', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
+SELECT asText(nearestApproachInstant(cbuffer 'Cbuffer(Point(4 9), 0.7)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
+SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', geometry 'Point(2 3)'));
+SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX X((5,2),(7,4))'));
+SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)'));
+SELECT asText(nearestApproachInstant(
+  tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]',
+  tcbuffer '[Cbuffer(Point(0 9), 0.5)@2000-01-01, Cbuffer(Point(4 1), 0.5)@2000-01-05]'));
+
+-- The instant answers the same minimisation the distance reports, so measuring
+-- the distance at the instant it names gives the distance itself. Taken on the
+-- centreline against the circle's defining vertices, the buffer probe would
+-- instead name x = 3.3, the probe radius subtracted along x.
+WITH d(a, b) AS (
+  SELECT nearestApproachDistance(nearestApproachInstant(t, p), p),
+         nearestApproachDistance(t, p)
+  FROM (SELECT tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]' AS t,
+               cbuffer 'Cbuffer(Point(4 9), 0.7)' AS p) v)
+SELECT a = b FROM d;
+-- The two argument orders name the same instant
+SELECT nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)')
+     = nearestApproachInstant(cbuffer 'Cbuffer(Point(4 9), 0.7)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]');
+
+-------------------------------------------------------------------------------
 
 
 -- Analytic nearest approach distance (|=| and nearestApproachDistance):

--- a/postgis/liblwgeom/lwutil.c
+++ b/postgis/liblwgeom/lwutil.c
@@ -163,8 +163,14 @@ lwgeom_set_handlers(lwallocator allocator, lwreallocator reallocator,
 	if ( reallocator ) lwrealloc_var = reallocator;
 	if ( freeor ) lwfree_var = freeor;
 
-	if ( errorreporter ) lwerror_var = errorreporter;
-	if ( noticereporter ) lwnotice_var = noticereporter;
+	/* MEOS: the reporters are process-wide policy that every host thread
+	 * installs through meos_initialize, so publish them atomically, the same
+	 * release/acquire pair MEOS uses for its own error handler. The allocators
+	 * keep plain assignment: a host chooses those before it starts threads. */
+	if ( errorreporter )
+		__atomic_store_n(&lwerror_var, errorreporter, __ATOMIC_RELEASE);
+	if ( noticereporter )
+		__atomic_store_n(&lwnotice_var, noticereporter, __ATOMIC_RELEASE);
 }
 
 void
@@ -181,7 +187,8 @@ lwnotice(const char *fmt, ...)
 	va_start(ap, fmt);
 
 	/* Call the supplied function */
-	(*lwnotice_var)(fmt, ap);
+	/* MEOS: paired with the release store in lwgeom_set_handlers */
+	(*__atomic_load_n(&lwnotice_var, __ATOMIC_ACQUIRE))(fmt, ap);
 
 	va_end(ap);
 }
@@ -194,7 +201,8 @@ lwerror(const char *fmt, ...)
 	va_start(ap, fmt);
 
 	/* Call the supplied function */
-	(*lwerror_var)(fmt, ap);
+	/* MEOS: paired with the release store in lwgeom_set_handlers */
+	(*__atomic_load_n(&lwerror_var, __ATOMIC_ACQUIRE))(fmt, ap);
 
 	va_end(ap);
 }


### PR DESCRIPTION
Two errors in the MEOS layer that a host sees and a PostgreSQL backend does not.

**liblwgeom reports through a handler its embedder installs.** A backend installs one in `mobilitydb_init`, so a malformed geometry raises there with an error class. `meos_initialize` is the separate entry point a standalone program calls, and without a handler of its own liblwgeom keeps its default: write the message to stderr and end the process. Every binding that links libmeos rather than running inside a backend therefore ends its host process on any liblwgeom error. In MobilityDuck, `'garbage'::raquet` reaches `bytes_from_hexbytes`, which reports an odd-length hex string; the message arrives with no error class while the process exits, so a `statement error` block cannot catch it and the run stops without a summary. `'garbage'::tgeompoint` and `'garbage'::stbox` raise inside MEOS instead and arrive as ordinary errors — the parser they reach, not the cast registration, is what separates them.

`meos_initialize` installs handlers that report through `meos_error`, symmetric with `mobilitydb_init`. The allocators stay liblwgeom's own, so a backend keeps palloc and a standalone program keeps malloc. The error handler does not return: liblwgeom's callers treat the value as valid and read on — `bytes_from_hexbytes` continues past its own report — so a return hands them uninitialised memory. A host whose own handler raises never comes back, which is the case this serves; one whose handler returns leaves no way to honour that contract except to end the process, exactly as liblwgeom's own default does. The notice handler returns, as a notice is advisory.

**`nai_tcbuffer_cbuffer` answers with an instant that contradicts the distance the same pair reports.** Converting the static buffer with `cbuffer_to_geom` and the temporal one to its centreline sends the measurement to a defining vertex of the circle and drops the temporal radius. For a buffer sweeping x = 0 to 4 against a probe at (4, 9) of radius 0.7 the answer is x = 3.3, the probe radius subtracted along x, whose distance is 7.827 while `nearestApproachDistance` on the same pair reports 7.800. The kernel wraps the static buffer as a constant temporal one and delegates to `nai_tcbuffer_tcbuffer`, which minimises the same quantity the distance reports, mirroring what `nad_tcbuffer_cbuffer` does.

That kernel is unreachable from SQL, which is why the contradiction outlives the fix the geometry argument received. `nearestApproachInstant(tcbuffer, cbuffer)` reads `nearestApproachInstant($1, geometry($2))`, and its three siblings likewise, so `NAI_tcbuffer_cbuffer`, `NAI_cbuffer_tcbuffer`, `NAI_pose_tpose` and `NAI_tpose_pose` are declared and never called while the composition measures to the cast geometry instead. The four signatures name their wrapper, as the nearest approach distance ones already do. The pose pair keeps its values — `geometry(pose)` is `Pose_to_point`, the same conversion `nai_tpose_pose` performs — and binding it retires the composition and the orphan together. Each of the four wrappers carries the `PG_RETURN_NULL` its two-temporal sibling has, being reachable.

`shortestline_tcbuffer_cbuffer` keeps its conversion: the two-temporal kernel it would delegate to is itself centreline-based, so moving to it relocates the approximation rather than removing it.

The circular buffer distance tests gain a nearest approach instant section: every overload on probes placed to have a single minimising instant, the distance measured at the instant the operation names, and the two argument orders compared. The expected output is harvested from the harness, not predicted. `113_tpose_distance` is unchanged, which is the check on the pose rebind.