### PR TITLE
Declare each function once in the headers that repeat a declaration

### DIFF
--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -121,7 +121,6 @@ extern bool ensure_has_Z_geo(const GSERIALIZED *gs);
 extern bool ensure_has_not_Z_geo(const GSERIALIZED *gs);
 extern bool ensure_has_M_geo(const GSERIALIZED *gs);
 extern bool ensure_has_not_M_geo(const GSERIALIZED *gs);
-extern bool ensure_not_geodetic_geo(const GSERIALIZED *gs);
 extern bool ensure_point_type(const GSERIALIZED *gs);
 extern bool ensure_mline_type(const GSERIALIZED *gs);
 extern bool circle_type(const GSERIALIZED *gs);

--- a/meos/include/geo/tgeo_spatialrels.h
+++ b/meos/include/geo/tgeo_spatialrels.h
@@ -60,7 +60,6 @@ extern Datum datum_geom_dwithin2d(Datum geom1, Datum geom2, Datum dist);
 extern Datum datum_geom_dwithin3d(Datum geom1, Datum geom2, Datum dist);
 extern Datum datum_geog_dwithin(Datum geog1, Datum geog2, Datum dist);
 extern Datum datum_geom_relate_pattern(Datum geog1, Datum geog2, Datum p);
-extern Datum datum_geom_touches(Datum geom1, Datum geom2);
 
 extern datum_func2 geo_disjoint_fn(int16 flags1, int16 flags2);
 extern datum_func2 geo_disjoint_fn_geo(int16 flags1, uint8_t flags2);

--- a/meos/include/geo/tgeo_tempspatialrels.h
+++ b/meos/include/geo/tgeo_tempspatialrels.h
@@ -67,9 +67,6 @@ extern int tdwithin_add_solutions(int solutions, TimestampTz lower,
   TimestampTz t1, TimestampTz t2, TInstant **instants, TSequence **result);
 extern Temporal *tdwithin_tspatial_spatial(const Temporal *temp, Datum base,
   Datum dist, datum_func3 func, tpfunc_temp tpfn);
-extern Temporal *tdwithin_tspatial_tspatial(const Temporal *sync1,
-  const Temporal *sync2, Datum dist,
-  datum_func3 func, tpfunc_temp tpfn);
 
 /*****************************************************************************/
 

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -686,7 +686,6 @@ extern TimestampTz tstzspanset_upper(const SpanSet *ss);
  *****************************************************************************/
 
 extern Set *bigintset_shift_scale(const Set *s, int64 shift, int64 width, bool hasshift, bool haswidth);
-extern Span *bigintspan_expand(const Span *s, int64 value);
 extern Span *bigintspan_shift_scale(const Span *s, int64 shift, int64 width, bool hasshift, bool haswidth);
 extern SpanSet *bigintspanset_shift_scale(const SpanSet *ss, int64 shift, int64 width, bool hasshift, bool haswidth);
 extern Set *dateset_shift_scale(const Set *s, int shift, int width, bool hasshift, bool haswidth);
@@ -699,7 +698,6 @@ extern Set *floatset_radians(const Set *s);
 extern Set *floatset_shift_scale(const Set *s, double shift, double width, bool hasshift, bool haswidth);
 extern Span *floatspan_ceil(const Span *s);
 extern Span *floatspan_degrees(const Span *s, bool normalize);
-extern Span *floatspan_expand(const Span *s, double value);
 extern Span *floatspan_floor(const Span *s);
 extern Span *floatspan_radians(const Span *s);
 extern Span *floatspan_round(const Span *s, int maxdd);
@@ -711,7 +709,6 @@ extern SpanSet *floatspanset_radians(const SpanSet *ss);
 extern SpanSet *floatspanset_round(const SpanSet *ss, int maxdd);
 extern SpanSet *floatspanset_shift_scale(const SpanSet *ss, double shift, double width, bool hasshift, bool haswidth);
 extern Set *intset_shift_scale(const Set *s, int shift, int width, bool hasshift, bool haswidth);
-extern Span *intspan_expand(const Span *s, int32 value);
 extern Span *intspan_shift_scale(const Span *s, int shift, int width, bool hasshift, bool haswidth);
 extern SpanSet *intspanset_shift_scale(const SpanSet *ss, int shift, int width, bool hasshift, bool haswidth);
 extern Span *tstzspan_expand(const Span *s, const Interval *interv);
@@ -724,7 +721,6 @@ extern Set *textset_upper(const Set *s);
 extern TimestampTz timestamptz_tprecision(TimestampTz t, const Interval *duration, TimestampTz torigin);
 extern Set *tstzset_shift_scale(const Set *s, const Interval *shift, const Interval *duration);
 extern Set *tstzset_tprecision(const Set *s, const Interval *duration, TimestampTz torigin);
-extern Span *tstzspan_expand(const Span *s, const Interval *interv);
 extern Span *tstzspan_shift_scale(const Span *s, const Interval *shift, const Interval *duration);
 extern Span *tstzspan_tprecision(const Span *s, const Interval *duration, TimestampTz torigin);
 extern SpanSet *tstzspanset_shift_scale(const SpanSet *ss, const Interval *shift, const Interval *duration);
@@ -1262,11 +1258,7 @@ extern TBox *tbox_round(const TBox *box, int maxdd);
 extern TBox *tfloatbox_shift_scale(const TBox *box, double shift, double width, bool hasshift, bool haswidth);
 extern TBox *tintbox_shift_scale(const TBox *box, int shift, int width, bool hasshift, bool haswidth);
 extern TBox *tbox_shift_scale_time(const TBox *box, const Interval *shift, const Interval *duration);
-extern TBox *tfloatbox_expand(const TBox *box, double d);
-extern TBox *tfloatbox_shift_scale(const TBox *box, double shift, double width, bool hasshift, bool haswidth);
-extern TBox *tintbox_expand(const TBox *box, int i);
 extern TBox *tbigintbox_expand(const TBox *box, int64 i);
-extern TBox *tintbox_shift_scale(const TBox *box, int shift, int width, bool hasshift, bool haswidth);
 extern TBox *tbigintbox_shift_scale(const TBox *box, int64 shift, int64 width, bool hasshift, bool haswidth);
 
 /*****************************************************************************

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -626,7 +626,6 @@ extern Temporal *tgeompoint_from_mfjson(const char *str);
 extern Temporal *tgeompoint_in(const char *str);
 extern char *tspatial_as_ewkt(const Temporal *temp, int maxdd);
 extern char *tspatial_as_text(const Temporal *temp, int maxdd);
-extern char *tspatial_out(const Temporal *temp, int maxdd);
 
 /* Constructor functions */
 

--- a/meos/include/temporal/temporal_aggfuncs.h
+++ b/meos/include/temporal/temporal_aggfuncs.h
@@ -95,8 +95,6 @@ extern SkipList *tdiscseq_tagg_transfn(SkipList *state, const TSequence *seq,
 
 extern SkipList *temporal_tagg_transfn(SkipList *state, const Temporal *temp,
   datum_func2, bool crossings);
-extern SkipList *temporal_tagg_combinefn(SkipList *state1, SkipList *state2,
-  datum_func2 func, bool crossings);
 extern SkipList *temporal_tagg_transform_transfn(SkipList *state, const Temporal *temp,
   datum_func2 func, bool crossings, TInstant *(*transform)(const TInstant *));
   

--- a/mobilitydb/pg_include/pg_temporal/type_util.h
+++ b/mobilitydb/pg_include/pg_temporal/type_util.h
@@ -77,8 +77,6 @@ extern Datum call_function4(PGFunction func, Datum arg1, Datum arg2,
 extern Datum CallerFInfoFunctionCall4(PGFunction func, FmgrInfo *flinfo,
   Oid collid, Datum arg1, Datum arg2, Datum arg3, Datum arg4);
 
-extern Datum CallerFInfoFunctionCall4(PGFunction func, FmgrInfo *flinfo,
-    Oid collid, Datum arg1, Datum arg2, Datum arg3, Datum arg4);
 
 /* Range functions */
 


### PR DESCRIPTION
Fourteen declarations appear twice in the same header, across seven headers in both trees: eight in `meos.h` (`bigintspan_expand`, `floatspan_expand`, `intspan_expand`, `tstzspan_expand`, `tfloatbox_expand`, `tfloatbox_shift_scale`, `tintbox_expand`, `tintbox_shift_scale`) and one each in `meos_geo.h`, `temporal_aggfuncs.h`, `tgeo_tempspatialrels.h`, `tgeo_spatialfuncs.h`, `tgeo_spatialrels.h` and `type_util.h`.

Each pair is unconditional — no `#if` separates the two copies — and identical up to the indentation of a continuation line, so the repetition carries no meaning. It is a second copy that a reader has to compare against the first to be sure the two agree, and that a change to the signature has to find.

This keeps the first of each pair.
