### PR TITLE
Declare the interval functions once, in the public header

### DIFF
--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -59,6 +59,7 @@
 #include <utils/jsonb.h>
 #include <utils/numeric.h>
 #include <pgtypes.h>
+#include <pg_interval.h>
 
 /*****************************************************************************
  * Parameter tests

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -55,6 +55,7 @@
 #include <utils/jsonb.h>
 #include <utils/numeric.h>
 #include <pgtypes.h>
+#include <pg_interval.h>
 
 /*****************************************************************************
  * Parameter tests

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -60,6 +60,7 @@
 #include <utils/jsonb.h>
 #include <utils/numeric.h>
 #include <pgtypes.h>
+#include <pg_interval.h>
 
 /*****************************************************************************
  * General functions

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -65,10 +65,6 @@
 #include "pg_temporal/type_util.h"
 #include "pg_geo/tspatial.h"
 
-/* To avoid including fmgrprotos.h */
-extern PGDLLEXPORT Datum timestamp_mi(PG_FUNCTION_ARGS);
-extern PGDLLEXPORT Datum interval_cmp(PG_FUNCTION_ARGS);
-
 /*
  * This is required in a SINGLE file for builds against PostgreSQL
  */

--- a/pgtypes/pg_interval.h
+++ b/pgtypes/pg_interval.h
@@ -48,7 +48,13 @@ typedef struct NumericData *Numeric;
 
 extern Interval *add_interval_interval(const Interval *interv1, const Interval *interv2);
 extern Interval *div_interval_float8(const Interval *interv, float8 factor);
+/* interval_cmp, interval_in and interval_out carry the names of the
+ * SQL-callable functions of the backend, so they are built only for the
+ * standalone library; the extension build reaches them through the
+ * pg_-prefixed twins declared in pgtypes.h */
+#if MEOS
 extern int32 interval_cmp(const Interval *interv1, const Interval *interv2);
+#endif /* MEOS */
 extern Interval *interval_copy(const Interval *interv);
 extern bool interval_eq(const Interval *interv1, const Interval *interv2);
 extern Numeric interval_extract(const Interval *interv, const text *units);
@@ -56,7 +62,9 @@ extern bool interval_ge(const Interval *interv1, const Interval *interv2);
 extern bool interval_gt(const Interval *interv1, const Interval *interv2);
 extern uint32 interval_hash(const Interval *interv);
 extern uint64 interval_hash_extended(const Interval *interv, uint64 seed);
+#if MEOS
 extern Interval *interval_in(const char *str, int32 typmod);
+#endif /* MEOS */
 extern bool interval_is_finite(const Interval *interv);
 extern Interval *interval_justify_days(const Interval *interv);
 extern Interval *interval_justify_hours(const Interval *interv);
@@ -67,7 +75,9 @@ extern bool interval_lt(const Interval *interv1, const Interval *interv2);
 extern Interval *interval_make(int32 years, int32 months, int32 weeks, int32 days, int32 hours, int32 mins, float8 secs);
 extern bool interval_ne(const Interval *interv1, const Interval *interv2);
 extern Interval *interval_negate(const Interval *interv);
+#if MEOS
 extern char *interval_out(const Interval *interv);
+#endif /* MEOS */
 extern float8 interval_part(const Interval *interv, const text *units);
 extern Interval *interval_scale(const Interval *interv, int32 typmod);
 extern Interval *interval_smaller(const Interval *interv1, const Interval *interv2);

--- a/pgtypes/pgtypes.h
+++ b/pgtypes/pgtypes.h
@@ -691,15 +691,18 @@ extern Timestamp timestamptz_to_timestamp(TimestampTz tstz);
 
 /* Functions for intervals */
 
-extern Interval *add_interval_interval(const Interval *interv1, const Interval *interv2);
-extern Interval *div_interval_float8(const Interval *interv, float8 factor);
-extern Numeric interval_extract(const Interval *interv, const text *units);
-extern bool interval_is_finite(const Interval *interv);
-extern Interval *interval_make(int32 years, int32 months, int32 weeks, int32 days, int32 hours, int32 mins, float8 secs);
-extern Interval *interval_negate(const Interval *interv);
-extern Interval *minus_interval_interval(const Interval *interv1, const Interval *interv2);
-extern Interval *mul_float8_interval(float8 factor, const Interval *interv);
-extern Interval *mul_interval_float8(const Interval *interv, float8 factor);
+/* The interval functions that carry no pg_ prefix are declared once, in the
+ * public pg_interval.h. A second declaration here leaves the catalog
+ * attributing a function to whichever copy it reads first, which is how
+ * interval_make came to be attributed to this header while interval_in,
+ * interval_out and interval_cmp are attributed to pg_interval.h, putting
+ * interval_make out of reach of a binding that projects the public header.
+ * This header does not include pg_interval.h: the extension build compiles
+ * against the backend, whose SQL-callable interval_cmp, interval_in and
+ * interval_out carry the same names with a Datum signature, so the unprefixed
+ * declarations must stay out of every translation unit that sees them. The
+ * pg_-prefixed twins below are what the extension build uses. */
+
 extern int32 pg_interval_cmp(const Interval *interv1, const Interval *interv2);
 extern bool pg_interval_eq(const Interval *interv1, const Interval *interv2);
 extern bool pg_interval_ge(const Interval *interv1, const Interval *interv2);


### PR DESCRIPTION
The nine interval functions that carry no `pg_` prefix have one declaration site, in the public `pg_interval.h`, which `pgtypes.h` includes rather than repeating: `add_interval_interval`, `div_interval_float8`, `interval_extract`, `interval_is_finite`, `interval_make`, `interval_negate`, `minus_interval_interval`, `mul_float8_interval` and `mul_interval_float8`.

A repeated declaration leaves the catalog attributing a function to whichever copy it reads first. So `interval_make` is attributed to `pgtypes.h` while `interval_in`, `interval_out` and `interval_cmp` are attributed to `pg_interval.h`, even though all four are `@ingroup meos_base_interval` and all four are exported by libmeos.

The two headers are not interchangeable to a consumer. `pgtypes.h` includes `<postgres.h>`, so a binding compiling against the installed MEOS umbrella cannot include it — `<meos.h>` supplies its PostgreSQL-compat definitions under `#ifndef POSTGRES_H`, and including both leaves that block skipped. `pg_interval.h` has no includes at all. A binding projecting the public header therefore reaches `interval_in` and not `interval_make`, which is what MEOS.js hits.

Every consumer of `pgtypes.h` sees the same surface, through the include, and the catalog attributes all nine to `pg_interval.h`.