### PR TITLE
Restrict a temporal pose and a temporal rigid geometry by elevation

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1728,6 +1728,10 @@
 					<listitem>
 						<para><link linkend="tpose_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringe a (el complemento de) una geometría</para>
 					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_atElevation"><varname>atElevation</varname>, <varname>minusElevation</varname></link>: Restringe a (el complemento de) un span de elevación</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 
@@ -2533,6 +2537,10 @@
 
 				<listitem>
 					<para><link linkend="trgeometry_atStbox"><varname>atStbox</varname>, <varname>minusStbox</varname></link>: Restringe una trgeometry a (el complemento de) un cuadro espaciotemporal</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="trgeometry_atElevation"><varname>atElevation</varname>, <varname>minusElevation</varname></link>: Restringe una trgeometry a (el complemento de) un span de elevación</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -911,6 +911,27 @@ SELECT minusGeometry(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
    Pose(Point(2 2),0.7)@2001-01-03]} */
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="tpose_atElevation">
+				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
+				<para>Restringir al (complemento de) un span de elevación</para>
+				<para><varname>atElevation(tpose,floatspan) → tpose</varname></para>
+				<para><varname>minusElevation(tpose,floatspan) → tpose</varname></para>
+				<para>La elevación de una pose es la elevación de su posición, por lo que la restricción conserva los tiempos en los que esa posición se encuentra dentro del span. La pose temporal debe tener dimensión Z.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(atElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
+  Pose(Point(0 0 4),1,0,0,0)@2001-01-05]', floatspan '[1, 2]'));
+/* {[Pose(POINT Z (0 0 1),1,0,0,0)@2001-01-02,
+   Pose(POINT Z (0 0 2),1,0,0,0)@2001-01-03]} */
+SELECT asText(minusElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
+  Pose(Point(0 0 4),1,0,0,0)@2001-01-05]', floatspan '[1, 2]'));
+/* {[Pose(POINT Z (0 0 0),1,0,0,0)@2001-01-01,
+   Pose(POINT Z (0 0 1),1,0,0,0)@2001-01-02),
+   (Pose(POINT Z (0 0 2),1,0,0,0)@2001-01-03,
+   Pose(POINT Z (0 0 4),1,0,0,0)@2001-01-05]} */
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -493,6 +493,30 @@ SELECT temporalTime(atStbox(
 </programlisting>
 				<para>Si la STBox solo tiene un componente temporal, la llamada se reduce a <varname>atTime</varname> estándar; si solo tiene un componente espacial, se conserva el dominio temporal.</para>
 			</listitem>
+
+			<listitem xml:id="trgeometry_atElevation">
+				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
+				<para>Restringir una trgeometry al (complemento de) un span de elevación</para>
+				<para><varname>atElevation(trgeometry, floatspan) → trgeometry</varname></para>
+				<para><varname>minusElevation(trgeometry, floatspan) → trgeometry</varname></para>
+				<para>La elevación es la de la posición de la pose, no la del cuerpo: un cuerpo se extiende por encima y por debajo de su posición, y el span se evalúa únicamente sobre la posición. La geometría de referencia se conserva en el resultado. La geometría rígida temporal debe tener dimensión Z.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(atElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+  [Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+/* POLYGON Z ((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+   {[Pose(POINT Z (0 0 1),1,0,0,0)@2001-01-02,
+   Pose(POINT Z (0 0 2),1,0,0,0)@2001-01-03]} */
+
+SELECT getTime(minusElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+  [Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+-- {[2001-01-01, 2001-01-02), (2001-01-03, 2001-01-05]}
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1710,6 +1710,10 @@
 					<listitem>
 						<para><link linkend="tpose_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restrict to (the complement of) a geometry</para>
 					</listitem>
+
+					<listitem>
+						<para><link linkend="tpose_atElevation"><varname>atElevation</varname>, <varname>minusElevation</varname></link>: Restrict to (the complement of) an elevation span</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 
@@ -2507,6 +2511,10 @@
 
 				<listitem>
 					<para><link linkend="trgeometry_atStbox"><varname>atStbox</varname>, <varname>minusStbox</varname></link>: Restrict a trgeometry to (the complement of) a spatiotemporal box</para>
+				</listitem>
+
+				<listitem>
+					<para><link linkend="trgeometry_atElevation"><varname>atElevation</varname>, <varname>minusElevation</varname></link>: Restrict a trgeometry to (the complement of) an elevation span</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -920,6 +920,27 @@ SELECT minusGeometry(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
    Pose(Point(2 2),0.7)@2001-01-03]} */
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="tpose_atElevation">
+				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
+				<para>Restrict to (the complement of) an elevation span</para>
+				<para><varname>atElevation(tpose,floatspan) → tpose</varname></para>
+				<para><varname>minusElevation(tpose,floatspan) → tpose</varname></para>
+				<para>The elevation of a pose is the elevation of its position, so the restriction keeps the times at which that position lies within the span. The temporal pose must have Z dimension.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(atElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
+  Pose(Point(0 0 4),1,0,0,0)@2001-01-05]', floatspan '[1, 2]'));
+/* {[Pose(POINT Z (0 0 1),1,0,0,0)@2001-01-02,
+   Pose(POINT Z (0 0 2),1,0,0,0)@2001-01-03]} */
+SELECT asText(minusElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
+  Pose(Point(0 0 4),1,0,0,0)@2001-01-05]', floatspan '[1, 2]'));
+/* {[Pose(POINT Z (0 0 0),1,0,0,0)@2001-01-01,
+   Pose(POINT Z (0 0 1),1,0,0,0)@2001-01-02),
+   (Pose(POINT Z (0 0 2),1,0,0,0)@2001-01-03,
+   Pose(POINT Z (0 0 4),1,0,0,0)@2001-01-05]} */
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -493,6 +493,30 @@ SELECT temporalTime(atStbox(
 </programlisting>
 				<para>If the STBox has only a temporal component the call collapses to the standard <varname>atTime</varname>; if it has only a spatial component the temporal domain is preserved.</para>
 			</listitem>
+
+			<listitem xml:id="trgeometry_atElevation">
+				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
+				<para>Restrict a trgeometry to (the complement of) an elevation span</para>
+				<para><varname>atElevation(trgeometry, floatspan) → trgeometry</varname></para>
+				<para><varname>minusElevation(trgeometry, floatspan) → trgeometry</varname></para>
+				<para>The elevation is that of the position of the pose, not that of the body: a body extends above and below its position, and the span is tested against the position alone. The reference geometry is carried over to the result. The temporal rigid geometry must have Z dimension.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(atElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+  [Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+/* POLYGON Z ((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+   {[Pose(POINT Z (0 0 1),1,0,0,0)@2001-01-02,
+   Pose(POINT Z (0 0 2),1,0,0,0)@2001-01-03]} */
+
+SELECT getTime(minusElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
+  [Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+-- {[2001-01-01, 2001-01-02), (2001-01-03, 2001-01-05]}
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -266,9 +266,11 @@ extern Pose **tpose_values(const Temporal *temp, int *count);
  * Restriction functions
  *****************************************************************************/
 
+extern Temporal *tpose_at_elevation(const Temporal *temp, const Span *s);
 extern Temporal *tpose_at_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpose_at_stbox(const Temporal *temp, const STBox *box, bool border_inc);
 extern Temporal *tpose_at_pose(const Temporal *temp, const Pose *pose);
+extern Temporal *tpose_minus_elevation(const Temporal *temp, const Span *s);
 extern Temporal *tpose_minus_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpose_minus_pose(const Temporal *temp, const Pose *pose);
 extern Temporal *tpose_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc);

--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -184,10 +184,10 @@ extern Temporal *trgeometry_at_tstzspan(const Temporal *temp, const Span *s);
 extern Temporal *trgeometry_minus_tstzspan(const Temporal *temp, const Span *s);
 extern Temporal *trgeometry_at_tstzspanset(const Temporal *temp, const SpanSet *ss);
 extern Temporal *trgeometry_minus_tstzspanset(const Temporal *temp, const SpanSet *ss);
+extern Temporal *trgeometry_at_elevation(const Temporal *temp, const Span *s);
+extern Temporal *trgeometry_minus_elevation(const Temporal *temp, const Span *s);
 // extern Temporal *trgeometry_at_geo(const Temporal *temp, const GSERIALIZED *gs);
-// extern Temporal *trgeometry_at_elevation(const Temporal *temp, const Span *s);
 // extern Temporal *trgeometry_minus_geo(const Temporal *temp, const GSERIALIZED *gs);
-// extern Temporal *trgeometry_minus_elevation(const Temporal *temp, const Span *s);
 
 /*****************************************************************************
  * Distance functions

--- a/meos/include/rgeo/trgeo_spatialfuncs.h
+++ b/meos/include/rgeo/trgeo_spatialfuncs.h
@@ -44,6 +44,8 @@ extern Temporal *trgeo_restrict_geom(const Temporal *temp,
   const GSERIALIZED *gs, bool atfunc);
 extern Temporal *trgeo_restrict_stbox(const Temporal *temp, const STBox *box,
   bool border_inc, bool atfunc);
+extern Temporal *trgeo_restrict_elevation(const Temporal *temp, const Span *s,
+  bool atfunc);
 
 /*****************************************************************************/
 

--- a/meos/src/pose/tpose_spatialfuncs.c
+++ b/meos/src/pose/tpose_spatialfuncs.c
@@ -191,3 +191,65 @@ tpose_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
 }
 
 /*****************************************************************************/
+
+/**
+ * @ingroup meos_internal_pose_restrict
+ * @brief Return a temporal pose restricted to (the complement of) an elevation
+ * span
+ * @details The elevation of a pose is the elevation of its position, so the
+ * restriction is taken on the temporal point of the positions and the result
+ * is the temporal pose restricted to the times it keeps
+ * @param[in] temp Temporal pose
+ * @param[in] s Elevation span
+ * @param[in] atfunc True if the restriction is `at`, false for `minus`
+ */
+Temporal *
+tpose_restrict_elevation(const Temporal *temp, const Span *s, bool atfunc)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TPOSE(temp, NULL); VALIDATE_NOT_NULL(s, NULL);
+  if (! ensure_has_Z(temp->temptype, temp->flags))
+    return NULL;
+
+  Temporal *tpoint = tpose_to_tpoint(temp);
+  Temporal *res = tgeo_restrict_elevation(tpoint, s, atfunc);
+  Temporal *result = NULL;
+  if (res)
+  {
+    /* We do not call the function tgeompoint_tpose to avoid roundoff errors */
+    SpanSet *ss = temporal_time(res);
+    result = temporal_restrict_tstzspanset(temp, ss, REST_AT);
+    pfree(res); pfree(ss);
+  }
+  pfree(tpoint);
+  return result;
+}
+
+/**
+ * @ingroup meos_pose_restrict
+ * @brief Return a temporal pose restricted to an elevation span
+ * @param[in] temp Temporal pose
+ * @param[in] s Elevation span
+ * @csqlfn #Tpose_at_elevation()
+ */
+Temporal *
+tpose_at_elevation(const Temporal *temp, const Span *s)
+{
+  return tpose_restrict_elevation(temp, s, REST_AT);
+}
+
+/**
+ * @ingroup meos_pose_restrict
+ * @brief Return a temporal pose restricted to the complement of an elevation
+ * span
+ * @param[in] temp Temporal pose
+ * @param[in] s Elevation span
+ * @csqlfn #Tpose_minus_elevation()
+ */
+Temporal *
+tpose_minus_elevation(const Temporal *temp, const Span *s)
+{
+  return tpose_restrict_elevation(temp, s, REST_MINUS);
+}
+
+/*****************************************************************************/

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -653,6 +653,74 @@ trgeometry_minus_stbox(const Temporal *temp, const STBox *box, bool border_inc)
   return trgeo_restrict_stbox(temp, box, border_inc, REST_MINUS);
 }
 
+/*****************************************************************************
+ * Restriction by elevation
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_internal_rgeo_restrict
+ * @brief Return a temporal rigid geometry restricted to (the complement of) an
+ * elevation span
+ * @details The elevation of a rigid geometry is the elevation of the position
+ * of its pose, so the restriction is taken on the temporal point of the
+ * positions and the result is the temporal rigid geometry restricted to the
+ * times it keeps. The body geometry is not taken into account: a body extends
+ * above and below its position, and the elevation span is tested against the
+ * position alone
+ * @param[in] temp Temporal rigid geometry
+ * @param[in] s Elevation span
+ * @param[in] atfunc True if the restriction is `at`, false for `minus`
+ */
+Temporal *
+trgeo_restrict_elevation(const Temporal *temp, const Span *s, bool atfunc)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_NOT_NULL(s, NULL);
+  if (! ensure_has_Z(temp->temptype, temp->flags))
+    return NULL;
+
+  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
+  Temporal *res = tgeo_restrict_elevation(tpoint, s, atfunc);
+  pfree(tpoint);
+  if (! res)
+    return NULL;
+  /* We restrict the temporal rigid geometry to the times the restricted point
+   * keeps rather than converting the point back, so that the poses and the
+   * reference geometry are preserved exactly */
+  SpanSet *ss = temporal_time(res);
+  pfree(res);
+  Temporal *result = trgeo_restrict_overlap(temp, ss, REST_AT);
+  pfree(ss);
+  return result;
+}
+
+/**
+ * @ingroup meos_rgeo_restrict
+ * @brief Return a temporal rigid geometry restricted to an elevation span
+ * @param[in] temp Temporal rigid geometry
+ * @param[in] s Elevation span
+ * @csqlfn #Trgeometry_at_elevation()
+ */
+Temporal *
+trgeometry_at_elevation(const Temporal *temp, const Span *s)
+{
+  return trgeo_restrict_elevation(temp, s, REST_AT);
+}
+
+/**
+ * @ingroup meos_rgeo_restrict
+ * @brief Return a temporal rigid geometry restricted to the complement of an
+ * elevation span
+ * @param[in] temp Temporal rigid geometry
+ * @param[in] s Elevation span
+ * @csqlfn #Trgeometry_minus_elevation()
+ */
+Temporal *
+trgeometry_minus_elevation(const Temporal *temp, const Span *s)
+{
+  return trgeo_restrict_elevation(temp, s, REST_MINUS);
+}
+
 /**
  * @brief Apply a pose to a body-frame geometry and return the centroid of the
  * world-frame result as a Datum

--- a/mobilitydb/sql/pose/105_tpose_spatialfuncs.in.sql
+++ b/mobilitydb/sql/pose/105_tpose_spatialfuncs.in.sql
@@ -81,6 +81,16 @@ CREATE FUNCTION minusStbox(tpose, stbox, bool DEFAULT TRUE)
   AS 'MODULE_PATHNAME', 'Tpose_minus_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION atElevation(tpose, floatspan)
+  RETURNS tpose
+  AS 'MODULE_PATHNAME', 'Tpose_at_elevation'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION minusElevation(tpose, floatspan)
+  RETURNS tpose
+  AS 'MODULE_PATHNAME', 'Tpose_minus_elevation'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************
  * traversedArea, centroid, convexHull
  *****************************************************************************/

--- a/mobilitydb/sql/rgeo/156_trgeo_spatialfuncs.in.sql
+++ b/mobilitydb/sql/rgeo/156_trgeo_spatialfuncs.in.sql
@@ -127,4 +127,14 @@ CREATE FUNCTION minusStbox(trgeometry, stbox, bool DEFAULT TRUE)
   AS 'MODULE_PATHNAME', 'Trgeometry_minus_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION atElevation(trgeometry, floatspan)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Trgeometry_at_elevation'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION minusElevation(trgeometry, floatspan)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Trgeometry_minus_elevation'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************/

--- a/mobilitydb/src/pose/tpose_spatialfuncs.c
+++ b/mobilitydb/src/pose/tpose_spatialfuncs.c
@@ -38,6 +38,7 @@
 #include <meos.h>
 #include <meos_internal.h>
 #include <meos_pose.h>
+#include "temporal/span.h"
 #include "geo/stbox.h"
 #include "pose/pose.h"
 #include "pose/tpose_spatialfuncs.h"
@@ -157,6 +158,51 @@ inline Datum
 Tpose_minus_stbox(PG_FUNCTION_ARGS)
 {
   return Tpose_restrict_stbox(fcinfo, REST_MINUS);
+}
+
+/*****************************************************************************/
+
+/**
+ * @brief Return a temporal pose restricted to (the complement of) an elevation
+ * span
+ */
+static Datum
+Tpose_restrict_elevation(FunctionCallInfo fcinfo, bool atfunc)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Span *s = PG_GETARG_SPAN_P(1);
+  Temporal *result = tpose_restrict_elevation(temp, s, atfunc);
+  PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Tpose_at_elevation(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tpose_at_elevation);
+/**
+ * @ingroup mobilitydb_pose_restrict
+ * @brief Return a temporal pose restricted to an elevation span
+ * @sqlfn atElevation()
+ */
+inline Datum
+Tpose_at_elevation(PG_FUNCTION_ARGS)
+{
+  return Tpose_restrict_elevation(fcinfo, REST_AT);
+}
+
+PGDLLEXPORT Datum Tpose_minus_elevation(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tpose_minus_elevation);
+/**
+ * @ingroup mobilitydb_pose_restrict
+ * @brief Return a temporal pose restricted to the complement of an elevation
+ * span
+ * @sqlfn minusElevation()
+ */
+inline Datum
+Tpose_minus_elevation(PG_FUNCTION_ARGS)
+{
+  return Tpose_restrict_elevation(fcinfo, REST_MINUS);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
+++ b/mobilitydb/src/rgeo/trgeo_spatialfuncs.c
@@ -41,6 +41,7 @@
 #include <meos.h>
 #include <meos_internal.h>
 #include <meos_rgeo.h>
+#include "temporal/span.h"
 #include "geo/stbox.h"
 #include "rgeo/trgeo.h"
 #include "rgeo/trgeo_spatialfuncs.h"
@@ -167,6 +168,50 @@ Trgeometry_minus_stbox(PG_FUNCTION_ARGS)
   return Trgeometry_restrict_stbox(fcinfo, REST_MINUS);
 }
 
+/*****************************************************************************/
+
+/**
+ * @brief Return a temporal rigid geometry restricted to (the complement of) an
+ * elevation span
+ */
+static Datum
+Trgeometry_restrict_elevation(FunctionCallInfo fcinfo, bool atfunc)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Span *s = PG_GETARG_SPAN_P(1);
+  Temporal *result = trgeo_restrict_elevation(temp, s, atfunc);
+  PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Trgeometry_at_elevation(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Trgeometry_at_elevation);
+/**
+ * @ingroup mobilitydb_rgeo_restrict
+ * @brief Return a temporal rigid geometry restricted to an elevation span
+ * @sqlfn atElevation()
+ */
+inline Datum
+Trgeometry_at_elevation(PG_FUNCTION_ARGS)
+{
+  return Trgeometry_restrict_elevation(fcinfo, REST_AT);
+}
+
+PGDLLEXPORT Datum Trgeometry_minus_elevation(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Trgeometry_minus_elevation);
+/**
+ * @ingroup mobilitydb_rgeo_restrict
+ * @brief Return a temporal rigid geometry restricted to the complement of an
+ * elevation span
+ * @sqlfn minusElevation()
+ */
+inline Datum
+Trgeometry_minus_elevation(PG_FUNCTION_ARGS)
+{
+  return Trgeometry_restrict_elevation(fcinfo, REST_MINUS);
+}
 
 /*****************************************************************************
  * Centroid and convex hull functions

--- a/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
+++ b/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
@@ -239,3 +239,29 @@ SELECT COUNT(*) FROM tbl_tpose2d WHERE minusStbox(temp,
     41
 (1 row)
 
+SELECT asText(atElevation(
+  tpose '[Pose(Point(0 0 0),1,0,0,0)@2000-01-01, Pose(Point(0 0 4),1,0,0,0)@2000-01-05]',
+  floatspan '[1, 2]'));
+                                                           astext                                                           
+----------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT Z (0 0 1),1,0,0,0)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT Z (0 0 2),1,0,0,0)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusElevation(
+  tpose '[Pose(Point(0 0 0),1,0,0,0)@2000-01-01, Pose(Point(0 0 4),1,0,0,0)@2000-01-05]',
+  floatspan '[1, 2]'));
+                                                                                                                        astext                                                                                                                        
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[Pose(POINT Z (0 0 0),1,0,0,0)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT Z (0 0 1),1,0,0,0)@Sun Jan 02 00:00:00 2000 PST), (Pose(POINT Z (0 0 2),1,0,0,0)@Mon Jan 03 00:00:00 2000 PST, Pose(POINT Z (0 0 4),1,0,0,0)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT atElevation(
+  tpose '[Pose(Point(0 0 0),1,0,0,0)@2000-01-01, Pose(Point(0 0 4),1,0,0,0)@2000-01-05]',
+  floatspan '[10, 20]');
+ atelevation 
+-------------
+ 
+(1 row)
+
+SELECT atElevation(tpose 'Pose(Point(1 1),0.5)@2000-01-01', floatspan '[1, 2]');
+ERROR:  The tpose must have Z dimension

--- a/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
+++ b/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
@@ -160,3 +160,22 @@ SELECT COUNT(*) FROM tbl_tpose2d WHERE minusStbox(temp,
   stbox 'SRID=3812;STBOX XT(((-200,-200),(200,200)),[2001-06-01, 2001-12-31])') IS NOT NULL;
 
 -------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+-- atElevation / minusElevation
+
+SELECT asText(atElevation(
+  tpose '[Pose(Point(0 0 0),1,0,0,0)@2000-01-01, Pose(Point(0 0 4),1,0,0,0)@2000-01-05]',
+  floatspan '[1, 2]'));
+SELECT asText(minusElevation(
+  tpose '[Pose(Point(0 0 0),1,0,0,0)@2000-01-01, Pose(Point(0 0 4),1,0,0,0)@2000-01-05]',
+  floatspan '[1, 2]'));
+
+-- The elevation span may miss the pose entirely
+SELECT atElevation(
+  tpose '[Pose(Point(0 0 0),1,0,0,0)@2000-01-01, Pose(Point(0 0 4),1,0,0,0)@2000-01-05]',
+  floatspan '[10, 20]');
+
+-- A 2D pose has no elevation
+SELECT atElevation(tpose 'Pose(Point(1 1),0.5)@2000-01-01', floatspan '[1, 2]');
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/expected/153_trgeo_spatialfuncs.test.out
+++ b/mobilitydb/test/rgeo/expected/153_trgeo_spatialfuncs.test.out
@@ -81,3 +81,31 @@ SELECT getTime(atStbox(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 0.0)@2001-01-05]',
   stbox 'STBOX T([2001-01-02, 2001-01-04])'));
 ERROR:  The stbox must have X dimension
+SELECT getTime(atElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));[Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+                            gettime                             
+----------------------------------------------------------------
+ {[Tue Jan 02 00:00:00 2001 PST, Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT getTime(minusElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));[Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+                                                           gettime                                                            
+------------------------------------------------------------------------------------------------------------------------------
+ {[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST), (Wed Jan 03 00:00:00 2001 PST, Fri Jan 05 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(atElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));[Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+                                                                                 astext                                                                                 
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON Z ((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));{[Pose(POINT Z (0 0 1),1,0,0,0)@Tue Jan 02 00:00:00 2001 PST, Pose(POINT Z (0 0 2),1,0,0,0)@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT atElevation(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 0.0)@2001-01-05]',
+  floatspan '[1, 2]');
+ERROR:  The trgeometry must have Z dimension

--- a/mobilitydb/test/rgeo/queries/153_trgeo_spatialfuncs.test.sql
+++ b/mobilitydb/test/rgeo/queries/153_trgeo_spatialfuncs.test.sql
@@ -95,3 +95,24 @@ SELECT getTime(atStbox(
   stbox 'STBOX T([2001-01-02, 2001-01-04])'));
 
 -------------------------------------------------------------------------------
+-- atElevation restricts to the times the position is within the elevation span
+SELECT getTime(atElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));[Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+
+-- minusElevation returns the complement
+SELECT getTime(minusElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));[Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+
+-- The reference geometry survives the restriction
+SELECT asText(atElevation(
+  trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));[Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]',
+  floatspan '[1, 2]'));
+
+-- A planar rigid geometry has no elevation
+SELECT atElevation(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 0.0)@2001-01-05]',
+  floatspan '[1, 2]');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
A pose carries a position, so it has an elevation whenever that position has a Z coordinate, and a rigid geometry carries a pose. Both types therefore admit the elevation restriction that temporal points already have, and both keep their own type under it: restricting by elevation selects instants, it does not convert the value to a point.

```
SELECT asText(atElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
  Pose(Point(0 0 4),1,0,0,0)@2001-01-05]', floatspan '[1, 2]'));
/* {[Pose(POINT Z (0 0 1),1,0,0,0)@2001-01-02,
   Pose(POINT Z (0 0 2),1,0,0,0)@2001-01-03]} */
```

The restriction reads the elevation off the temporal point of the positions and keeps the times that point retains, which is the shape the geometry and box restrictions of these two families already take. For a rigid geometry the times are applied through the pose component and the reference geometry is re-attached, so the body survives the restriction:

```
POLYGON Z ((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));{[Pose(POINT Z (0 0 1),1,0,0,0)@2001-01-02, …]}
```

The elevation is that of the position alone: a body extends above and below its position, and the span is not tested against the body extent. A value without Z dimension reports that.

This fills the internal declaration for the pose form, which `tpose_spatialfuncs.h` declares without a definition, and uncomments the two public rigid geometry declarations in `meos_rgeo.h`, which the tracker entry for trgeometry elevation asks for. Both manuals document the two functions with the results above, and both reference indexes list them.
