### PR TITLE
Refute the always relationships of a circular buffer from its centre

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -222,6 +222,73 @@ tcbufferinst_xybox(const TInstant *inst, double *xmin, double *ymin,
 }
 
 /**
+ * @brief Return true when a temporal circular buffer holds a unit every point
+ * of which is farther than @p dist from the box @p bxmin, @p bymin, @p bxmax,
+ * @p bymax, which refutes an always relationship requiring the buffer to stay
+ * within @p dist of what the box bounds
+ *
+ * A disk is within @p dist of a set exactly when its centre is within dist plus
+ * its radius of it, the disk reaching exactly its radius beyond the centre. A
+ * unit whose centre box stands farther than dist plus the larger of its two
+ * radii from the box therefore holds no instant within the distance, and one
+ * such unit refutes the always semantics. Reading the centre against a
+ * radius-widened threshold, rather than reading a radius-widened box against
+ * the distance, keeps the radius from being removed on both axes at once,
+ * exactly as the nearest-approach prune does.
+ *
+ * The centre box and the radius maximum both over-approximate the unit, so a
+ * value that is always within the distance is never refuted. Taking units
+ * rather than instants keeps the test independent of which bounds the sequence
+ * carries, the interior of a unit always belonging to the definition time.
+ */
+static bool
+tcbuffer_escapes_box(const Temporal *temp, double bxmin, double bymin,
+  double bxmax, double bymax, double dist)
+{
+  assert(temp); assert(temptype_subtype(temp->subtype));
+  if (temp->subtype == TINSTANT)
+  {
+    const Cbuffer *cb = DatumGetCbufferP(tinstant_value_p((TInstant *) temp));
+    const POINT2D *p = cbuffer_point2d_p(cb);
+    double thr = dist + cb->radius;
+    return box2d_distance_sqr(p->x, p->y, p->x, p->y, bxmin, bymin, bxmax,
+      bymax) > thr * thr;
+  }
+  int nseqs = (temp->subtype == TSEQUENCE) ? 1 :
+    ((TSequenceSet *) temp)->count;
+  for (int s = 0; s < nseqs; s++)
+  {
+    const TSequence *seq = (temp->subtype == TSEQUENCE) ?
+      (const TSequence *) temp :
+      TSEQUENCESET_SEQ_N((const TSequenceSet *) temp, s);
+    const Cbuffer *cb1 = DatumGetCbufferP(
+      tinstant_value_p(TSEQUENCE_INST_N(seq, 0)));
+    const POINT2D *p1 = cbuffer_point2d_p(cb1);
+    if (seq->count == 1)
+    {
+      double thr = dist + cb1->radius;
+      if (box2d_distance_sqr(p1->x, p1->y, p1->x, p1->y, bxmin, bymin, bxmax,
+          bymax) > thr * thr)
+        return true;
+      continue;
+    }
+    for (int i = 1; i < seq->count; i++)
+    {
+      const Cbuffer *cb2 = DatumGetCbufferP(
+        tinstant_value_p(TSEQUENCE_INST_N(seq, i)));
+      const POINT2D *p2 = cbuffer_point2d_p(cb2);
+      double thr = dist + fmax(cb1->radius, cb2->radius);
+      if (box2d_distance_sqr(fmin(p1->x, p2->x), fmin(p1->y, p2->y),
+          fmax(p1->x, p2->x), fmax(p1->y, p2->y), bxmin, bymin, bxmax,
+          bymax) > thr * thr)
+        return true;
+      cb1 = cb2; p1 = p2;
+    }
+  }
+  return false;
+}
+
+/**
  * @brief Decide a per-segment spatial relationship from bounding boxes alone
  * @details When the swept-capsule box of a segment is disjoint from the
  * geometry box, the two geometries are disjoint, so every supported
@@ -1556,12 +1623,22 @@ ea_touches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   if (! overlaps_stbox_stbox(&box1, &box2))
     return 0;
 
-  /* Touch requires the temporal value and the geometry to be at distance
-   * zero; a strictly positive exact nearest-approach distance means they
-   * are disjoint, so they cannot touch under either quantifier. This is
+  /* Touch requires the temporal value and the geometry to be at distance zero,
+   * so a strictly positive exact nearest-approach distance proves them disjoint
+   * and unable to touch. That is the ever question -- whether contact happens
+   * anywhere -- and a running minimum over the whole value is what answers it.
+   * The always question is refuted by a single unit that fails to reach the
+   * geometry, which the centre-against-radius test settles from the geometry
+   * box alone, ahead of the edge decomposition the running scan builds. This is
    * applied only on the geometry path: the cbuffer path turns into a
    * many-vertex disk for which the analytic distance is not a win. */
-  if (nad_tcbuffer_geo(temp, gs) > 1e-6)
+  if (ever)
+  {
+    if (nad_tcbuffer_geo(temp, gs) > 1e-6)
+      return 0;
+  }
+  else if (tcbuffer_escapes_box(temp, box2.xmin, box2.ymin, box2.xmax,
+      box2.ymax, 0.0))
     return 0;
   /* Native path: eTouches/aTouches derive from the exact boundary-contact
    * instants, consistent with ever/always(tTouches). A geometry that has no
@@ -1774,6 +1851,18 @@ ea_dwithin_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   stbox_expand_space_set(&box_geo, dist, &box_geo_exp);
   bool pass = overlaps_stbox_stbox(&box_temp, &box_geo_exp);
   if (! pass)
+    return 0;
+
+  /* The always semantics are refuted by a single unit that stays farther than
+   * the distance from the geometry, which the centre-against-radius test reads
+   * from the geometry box alone. The overlap test above cannot serve here: a
+   * value always within the distance may still reach far outside the expanded
+   * box, the distance being the one to the NEAREST point of the disk while the
+   * rest of the disk is unconstrained. This reject spares the expanded copy and
+   * the coverage kernel below for a pair that leaves the neighbourhood at any
+   * point, the common case in a spatial join. */
+  if (! ever && tcbuffer_escapes_box(temp, box_geo.xmin, box_geo.ymin,
+      box_geo.xmax, box_geo.ymax, dist))
     return 0;
 
   /* The ever semantics reduce exactly to the native nearest-approach

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -2427,6 +2427,69 @@ eacontains_tcbuffer_ctx_native(const Temporal *temp, const void *ctx,
   return result;
 }
 
+/**
+ * @brief Return true when some unit of a temporal circular buffer could have
+ * its disk inside the box @p bxmin, @p bymin, @p bxmax, @p bymax
+ *
+ * A disk inside a geometry is inside the box of that geometry, so its centre
+ * lies in that box shrunk by the radius on every side, and a shrunk box that
+ * comes out empty admits no disk at all. Over a unit the centres lie in their
+ * own box and the radius is at least the smaller of the two endpoint radii, so
+ * testing that centre box against the box shrunk by that smaller radius accepts
+ * every disk the unit really holds. A value for which no unit passes is inside
+ * the geometry at no instant, which refutes ever contains and ever covers.
+ *
+ * The relaxation is one-sided, so a passing unit proves nothing and the running
+ * scan decides it. Reading the radius off the centre this way, instead of
+ * comparing the radius-widened box of the value, is what makes the test bite
+ * when the disks are large next to the geometry.
+ */
+static bool
+tcbuffer_disk_may_fit_box(const Temporal *temp, double bxmin, double bymin,
+  double bxmax, double bymax)
+{
+  assert(temp); assert(temptype_subtype(temp->subtype));
+  if (temp->subtype == TINSTANT)
+  {
+    const Cbuffer *cb = DatumGetCbufferP(tinstant_value_p((TInstant *) temp));
+    const POINT2D *p = cbuffer_point2d_p(cb);
+    double r = cb->radius;
+    return p->x >= bxmin + r && p->x <= bxmax - r &&
+      p->y >= bymin + r && p->y <= bymax - r;
+  }
+  int nseqs = (temp->subtype == TSEQUENCE) ? 1 :
+    ((TSequenceSet *) temp)->count;
+  for (int s = 0; s < nseqs; s++)
+  {
+    const TSequence *seq = (temp->subtype == TSEQUENCE) ?
+      (const TSequence *) temp :
+      TSEQUENCESET_SEQ_N((const TSequenceSet *) temp, s);
+    const Cbuffer *cb1 = DatumGetCbufferP(
+      tinstant_value_p(TSEQUENCE_INST_N(seq, 0)));
+    const POINT2D *p1 = cbuffer_point2d_p(cb1);
+    if (seq->count == 1)
+    {
+      double r = cb1->radius;
+      if (p1->x >= bxmin + r && p1->x <= bxmax - r &&
+          p1->y >= bymin + r && p1->y <= bymax - r)
+        return true;
+      continue;
+    }
+    for (int i = 1; i < seq->count; i++)
+    {
+      const Cbuffer *cb2 = DatumGetCbufferP(
+        tinstant_value_p(TSEQUENCE_INST_N(seq, i)));
+      const POINT2D *p2 = cbuffer_point2d_p(cb2);
+      double r = fmin(cb1->radius, cb2->radius);
+      if (fmax(p1->x, p2->x) >= bxmin + r && fmin(p1->x, p2->x) <= bxmax - r &&
+          fmax(p1->y, p2->y) >= bymin + r && fmin(p1->y, p2->y) <= bymax - r)
+        return true;
+      cb1 = cb2; p1 = p2;
+    }
+  }
+  return false;
+}
+
 int
 eacontains_tcbuffer_geo_native(const Temporal *temp, const GSERIALIZED *gs,
   bool ever, bool strict)
@@ -2443,6 +2506,17 @@ eacontains_tcbuffer_geo_native(const Temporal *temp, const GSERIALIZED *gs,
   tspatial_set_stbox(temp, &box1);
   geo_set_stbox(gs, &box2);
   if (! overlaps_stbox_stbox(&box1, &box2))
+    return 0;
+
+  /* A disk inside the geometry fits inside the geometry box, which the box
+   * overlap above does not test: the box of the value is widened by the radius,
+   * so it overlaps wherever the disks merely reach the geometry. A value no
+   * unit of which admits a disk inside that box is inside the geometry at no
+   * instant, and neither ever nor always contains or covers it. This spares the
+   * edge decomposition below for a pair whose disks are large next to the
+   * geometry, the common case for a wide buffer over small polygons. */
+  if (! tcbuffer_disk_may_fit_box(temp, box2.xmin, box2.ymin, box2.xmax,
+      box2.ymax))
     return 0;
 
   void *ctx = tcbuffer_geo_ctx_make(gs);


### PR DESCRIPTION
The ever and always spatial relationships of a temporal circular buffer against a geometry share one bounding box prefilter, and it compares the value's box, which is widened by the radius, against the geometry's. That box answers the ever question well and the always question hardly at all: it overlaps wherever the disks merely reach the geometry, so a pair that plainly leaves the neighbourhood reaches the coverage kernel and the edge decomposition it builds.

The always quantifier is refuted by one unit, and a disk is within a distance of a set exactly when its centre is within that distance plus its radius. A centre test reads it: a unit whose centre box stands farther than the distance plus the larger of its two radii from the geometry box holds no instant within the distance and refutes always dwithin. Taking units rather than instants keeps the test independent of which bounds the sequence carries, and both the centre box and the radius maximum over-approximate the unit, so a value that is always within the distance is never refuted.

Reading the widened box against the distance instead is unsound here, which is why the temporal point sibling's containment prefilter does not carry over: the distance is the one to the NEAREST point of the disk, so a large disk parked on a small geometry is always within it while reaching far outside the expanded box.

Always touches is the same test at distance zero, and it takes the place of the exact nearest approach on that branch. A running minimum over the whole value answers whether contact happens anywhere, which is the ever question; the always question falls to a single unit that fails to reach the geometry, so the centre test settles it from the geometry box alone, ahead of the decomposition the running scan builds. Ever touches keeps the exact reject, which earns its cost there.

Contains and covers carry the companion test on the same footing. A disk inside the geometry fits inside the geometry box, so its centre lies in that box shrunk by the radius; a value no unit of which admits such a disk is inside the geometry at no instant, and neither ever nor always contains or covers it. The relaxation is one-sided, so a passing unit is decided by the running scan.

On a 100 by 100 join of vessel trajectories against natural-area polygons, where the disk radius averages 5 km against polygons of comparable size: aDwithin 0.78 s to 0.015 s, aTouches 5.76 s to 0.17 s, eCovers 3.44 s to 0.99 s, aCovers 2.30 s to 0.40 s, aContains 2.34 s to 0.42 s. All 10000 pairs return identical answers for every ever and always relationship, which one-sided rejects cannot change.