### PR TITLE
Answer the moving nearest approach of a circular buffer from its disks

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -771,14 +771,23 @@ nai_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
     return tinstant_make_free(value, temp->temptype, t);
   }
 
-  /* A geometry that has no edge decomposition: fall back to the centreline */
-  Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
-  TInstant *resultgeom = nai_tgeo_geo(tpoint, gs);
+  /* A geometry that has no edge decomposition: take the instant from the exact
+   * temporal distance, which honours the radius through the traversed area, as
+   * the nearest approach distance does on the same geometries. Reading the
+   * centreline instead minimises the distance of the centre, a quantity that
+   * parts from the one the nearest approach reports as soon as the radius
+   * varies, so the instant it returns is one whose distance is not the nearest
+   * approach. */
+  Temporal *dist = tdistance_tcbuffer_geo(temp, gs);
+  if (! dist)
+    return NULL;
+  const TInstant *min = temporal_min_inst_p((const Temporal *) dist);
+  TimestampTz tmin = min->t;
+  pfree(dist);
   Datum value;
-  temporal_value_at_timestamptz(temp, resultgeom->t, false, &value);
-  TInstant *result = tinstant_make_free(value, temp->temptype, resultgeom->t);
-  pfree(tpoint); pfree(resultgeom);
-  return result;
+  if (! temporal_value_at_timestamptz(temp, tmin, false, &value))
+    return NULL;
+  return tinstant_make_free(value, temp->temptype, tmin);
 }
 
 /**
@@ -2417,11 +2426,64 @@ shortestline_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
   if (! ensure_valid_tcbuffer_tcbuffer(temp1, temp2))
     return NULL;
 
-  Temporal *tpoint1 = tcbuffer_to_tgeompoint(temp1);
-  Temporal *tpoint2 = tcbuffer_to_tgeompoint(temp2);
-  GSERIALIZED *result = shortestline_tgeo_tgeo(tpoint1, tpoint2);
-  pfree(tpoint1); pfree(tpoint2);
-  return result;
+  /* The nearest approach of two moving disks is attained at the instant where
+   * the temporal distance is least, that distance honouring both radii and the
+   * turning points. Read the two disks there and the line follows in closed
+   * form: it runs along the line of centres, leaving the boundary of one disk
+   * and reaching the boundary of the other, so its length is the nearest
+   * approach distance. Reading the centres instead answers a different
+   * question, one whose line is longer than the distance it is supposed to
+   * realise by exactly the two radii. */
+  Temporal *dist = tdistance_tcbuffer_tcbuffer(temp1, temp2);
+  if (! dist)
+    return NULL;
+  const TInstant *min = temporal_min_inst_p((const Temporal *) dist);
+  TimestampTz t = min->t;
+  pfree(dist);
+
+  /* The closest point may be at an exclusive bound */
+  Datum value1, value2;
+  if (! temporal_value_at_timestamptz(temp1, t, false, &value1) ||
+      ! temporal_value_at_timestamptz(temp2, t, false, &value2))
+    return NULL;
+  const Cbuffer *cb1 = DatumGetCbufferP(value1);
+  const Cbuffer *cb2 = DatumGetCbufferP(value2);
+  const POINT2D *c1 = cbuffer_point2d_p(cb1);
+  const POINT2D *c2 = cbuffer_point2d_p(cb2);
+  double vx = c2->x - c1->x, vy = c2->y - c1->y;
+  double vl = sqrt(vx * vx + vy * vy);
+  double px, py, qx, qy;
+  if (vl <= MEOS_EPSILON || vl <= cb1->radius + cb2->radius)
+  {
+    /* Concentric or overlapping disks meet, and the line degenerates to the
+     * point where the boundary of the first reaches the second, clamped to the
+     * centre when there is no direction to take */
+    double f = (vl <= MEOS_EPSILON) ? 0.0 : cb1->radius / vl;
+    if (f > 1.0) f = 1.0;
+    px = qx = c1->x + vx * f;
+    py = qy = c1->y + vy * f;
+  }
+  else
+  {
+    px = c1->x + vx * (cb1->radius / vl);
+    py = c1->y + vy * (cb1->radius / vl);
+    qx = c2->x - vx * (cb2->radius / vl);
+    qy = c2->y - vy * (cb2->radius / vl);
+  }
+  int32_t srid = tspatial_srid(temp1);
+  pfree(DatumGetPointer(value1)); pfree(DatumGetPointer(value2));
+
+  POINTARRAY *pa = ptarray_construct(0, 0, 2);
+  POINT4D p4;
+  p4.z = 0.0; p4.m = 0.0;
+  p4.x = px; p4.y = py;
+  ptarray_set_point4d(pa, 0, &p4);
+  p4.x = qx; p4.y = qy;
+  ptarray_set_point4d(pa, 1, &p4);
+  LWLINE *ln = lwline_construct(srid, NULL, pa);
+  GSERIALIZED *line = geo_serialize(lwline_as_lwgeom(ln));
+  lwline_free(ln);
+  return line;
 }
 
 /*****************************************************************************/

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -805,6 +805,30 @@ SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01'
  0.000000
 (1 row)
 
+SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-05]', tcbuffer '[Cbuffer(Point(0 6), 2)@2000-01-01, Cbuffer(Point(10 6), 2)@2000-01-05]'))::numeric, 6);
+  round   
+----------
+ 3.000000
+(1 row)
+
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-05]', tcbuffer '[Cbuffer(Point(0 6), 2)@2000-01-01, Cbuffer(Point(10 6), 2)@2000-01-05]')::numeric, 6);
+  round   
+----------
+ 3.000000
+(1 row)
+
+SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 3)@2000-01-01, Cbuffer(Point(10 0), 3)@2000-01-05]', tcbuffer '[Cbuffer(Point(0 4), 2)@2000-01-01, Cbuffer(Point(10 4), 2)@2000-01-05]'))::numeric, 6);
+  round   
+----------
+ 0.000000
+(1 row)
+
+SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(1 0), 1)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 6), 2)@2000-01-05, Cbuffer(Point(1 6), 2)@2000-01-06]'));
+ st_astext 
+-----------
+ 
+(1 row)
+
 SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(4 4), 0.3)@2000-01-01', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))'))::numeric, 6);
   round   
 ----------

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -333,6 +333,18 @@ SELECT round(ST_Length(shortestLine(tcbuffer 'Interp=Step;[Cbuffer(Point(0 0), 1
 -- the arc-exact nearest-approach distance (2.544004, 0, 0.356854 respectively)
 SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(3 8), 1)@2000-01-01', geometry 'CircularString(5 0, 0 5, -5 0)'))::numeric, 6);
 SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))'))::numeric, 6);
+
+-- The moving shortest line runs between the two disk boundaries, so its length
+-- is the nearest approach distance of the same pair rather than the distance of
+-- the two centres, which exceeds it by the two radii. The two disks hold a
+-- constant separation, so the length is the same wherever the witness is taken
+-- and the test does not depend on how equal minima are broken
+SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-05]', tcbuffer '[Cbuffer(Point(0 6), 2)@2000-01-01, Cbuffer(Point(10 6), 2)@2000-01-05]'))::numeric, 6);
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-05]', tcbuffer '[Cbuffer(Point(0 6), 2)@2000-01-01, Cbuffer(Point(10 6), 2)@2000-01-05]')::numeric, 6);
+-- Disks that meet: the line degenerates where the boundary of one reaches the other
+SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 3)@2000-01-01, Cbuffer(Point(10 0), 3)@2000-01-05]', tcbuffer '[Cbuffer(Point(0 4), 2)@2000-01-01, Cbuffer(Point(10 4), 2)@2000-01-05]'))::numeric, 6);
+-- Operands whose time frames do not meet have no nearest approach
+SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(1 0), 1)@2000-01-02]', tcbuffer '[Cbuffer(Point(0 6), 2)@2000-01-05, Cbuffer(Point(1 6), 2)@2000-01-06]'));
 SELECT round(ST_Length(shortestLine(tcbuffer 'Cbuffer(Point(4 4), 0.3)@2000-01-01', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))'))::numeric, 6);
 SELECT round(ST_Length(shortestLine(tcbuffer '{[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(4 0), 1)@2000-01-02], [Cbuffer(Point(20 20), 2)@2000-01-03, Cbuffer(Point(25 20), 1)@2000-01-04]}', geometry 'Polygon((-5 -5,-5 15,15 15,15 -5,-5 -5),(0 0,4 0,4 4,0 4,0 0))'))::numeric, 6);
 SELECT round(ST_Length(shortestLine(tcbuffer '{Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(8 3), 2)@2000-01-02}', geometry 'Multipolygon(((200 200,200 210,210 210,210 200,200 200)),((9 -1,9 1,12 1,12 -1,9 -1)))'))::numeric, 6);


### PR DESCRIPTION
The shortest line between two temporal circular buffers converts both operands to temporal points and delegates. That discards the radii, so the line runs centre to centre and its length exceeds the nearest approach distance of the same pair by exactly the two radii: for a disk of radius 1 passing a disk of radius 2 six units away, the line measures 6 while nearestApproachDistance reports 3.

Answer it from the disks. The nearest approach is attained where the temporal distance is least, that distance honouring both radii and the turning points, and reading the two disks there gives the line in closed form: it runs along the line of centres, leaving the boundary of one disk and reaching the boundary of the other, so its length is the nearest approach distance. Overlapping or concentric disks meet, and the line degenerates to the point where the boundary of the first reaches the second. The same pair measures 3 on a LINESTRING(0 1,0 4).

The nearest approach instant carries a companion fallback for a geometry that has no edge decomposition, and it minimises the distance of the centre. That quantity parts from the one the nearest approach reports as soon as the radius varies, so the instant it returns is one whose distance is not the nearest approach, while the nearest approach distance itself falls back to the exact traversed area on those same geometries. The instant comes from the exact temporal distance, which agrees with it.

Dropping the conversions drops their cost: on a 100 by 100 self-join of vessel trajectories the moving shortest line runs 14.7 s to 6.4 s, against 4.9 s for the temporal point on the same query.