### PR TITLE
Restrict a circular buffer to a box by its disk, not by its centre

### DIFF
--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -1492,26 +1492,52 @@ tcbuffer_restrict_stbox(const Temporal *temp, const STBox *box,
   if (! ensure_valid_tcbuffer_stbox(temp, box))
     return NULL;
 
-  /* Bounding box test */
+  bool hasx = MEOS_FLAGS_GET_X(box->flags);
+  bool hast = MEOS_FLAGS_GET_T(box->flags);
+  assert(hasx || hast);
+
+  /* A box carrying only the time dimension restricts on the period alone */
+  if (! hasx)
+    return temporal_restrict_tstzspan(temp, &box->period, atfunc);
+
+  /* Bounding box test. The box of the value is radius-aware, so it encloses
+   * the swept disks and a miss proves that no disk ever reaches the box */
   STBox box1;
   tspatial_set_stbox(temp, &box1);
   if (! overlaps_stbox_stbox(&box1, box))
     return atfunc ? NULL : temporal_copy(temp);
 
-  /* Restrict the centre trajectory to the box with the same semantics as
-   * before (for both at and minus), then slice the original buffer to the
-   * sub-periods that survive instead of rebuilding it from its point and
-   * radius projections with tcbuffer_make: restricting the temporal circular
-   * buffer to those periods keeps the radius without reconstructing the value,
-   * and interpolates the same point and radius at any box-boundary crossing. */
-  Temporal *tpoint = tcbuffer_to_tgeompoint(temp);
-  Temporal *tpoint_rest = tgeo_restrict_stbox(tpoint, box, NULL, atfunc);
-  pfree(tpoint);
-  if (! tpoint_rest)
-    return NULL;
-  SpanSet *ss = temporal_time(tpoint_rest);
-  pfree(tpoint_rest);
-  Temporal *result = temporal_restrict_tstzspanset(temp, ss, REST_AT);
+  /* Restrict by the circular disk footprint, not the centre trajectory: the
+   * buffer meets the box exactly when the moving disk intersects it, which is
+   * the same reading the geometry restriction takes, and the space of a box is
+   * a geometry like any other. A disk overlapping the box while its centre
+   * stays outside belongs to the result, and the centre reading drops it. That
+   * is the true time of the (arc-exact) temporal intersects relationship, so
+   * the box restriction reduces to restricting the buffer to that time (`at`)
+   * or to its complement (`minus`), intersected with the period the box
+   * carries. Slicing the buffer by time keeps the radius without rebuilding the
+   * value from its point and radius projections, and interpolates the same
+   * point and radius at any crossing. */
+  GSERIALIZED *geo = stbox_to_geo(box);
+  if (! geo)
+    return atfunc ? NULL : temporal_copy(temp);
+  Temporal *tinter = tinterrel_tcbuffer_geo(temp, geo, TINTERSECTS);
+  pfree(geo);
+  if (! tinter)
+    return atfunc ? NULL : temporal_copy(temp);
+  SpanSet *ss = tbool_when_true(tinter);
+  pfree(tinter);
+  if (! ss)
+    return atfunc ? NULL : temporal_copy(temp);
+  if (hast)
+  {
+    SpanSet *ss1 = intersection_spanset_span(ss, &box->period);
+    pfree(ss);
+    if (! ss1)
+      return atfunc ? NULL : temporal_copy(temp);
+    ss = ss1;
+  }
+  Temporal *result = temporal_restrict_tstzspanset(temp, ss, atfunc);
   pfree(ss);
   return result;
 }

--- a/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/202_tcbuffer.test.out
@@ -1640,6 +1640,30 @@ SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Po
  {[Cbuffer(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(atStbox(tcbuffer 'Cbuffer(Point(3 1), 1.5)@2000-01-01', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(3 1),1.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(3 1), 1.5)@2000-01-01, Cbuffer(Point(3 1), 1.5)@2000-01-02]', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
+                                                     astext                                                     
+----------------------------------------------------------------------------------------------------------------
+ {[Cbuffer(POINT(3 1),1.5)@Sat Jan 01 00:00:00 2000 PST, Cbuffer(POINT(3 1),1.5)@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atGeometry(tcbuffer 'Cbuffer(Point(3 1), 1.5)@2000-01-01', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))'));
+                        astext                        
+------------------------------------------------------
+ Cbuffer(POINT(3 1),1.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(atStbox(tcbuffer 'Cbuffer(Point(9 9), 0.5)@2000-01-01', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
+ astext 
+--------
+ 
+(1 row)
+
 SELECT asText(minusStbox(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 'STBOX XT(((10,10),(20,20)),[2000-01-01,2000-01-02])'));
                         astext                        
 ------------------------------------------------------
@@ -1674,6 +1698,18 @@ SELECT asText(minusStbox(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer
                                                      astext                                                     
 ----------------------------------------------------------------------------------------------------------------
  {(Cbuffer(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Cbuffer(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusStbox(tcbuffer 'Cbuffer(Point(3 1), 1.5)@2000-01-01', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(minusStbox(tcbuffer '[Cbuffer(Point(3 1), 1.5)@2000-01-01, Cbuffer(Point(3 1), 1.5)@2000-01-02]', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
+ astext 
+--------
+ 
 (1 row)
 
 SELECT asText(atTime(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));

--- a/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/202_tcbuffer.test.sql
@@ -441,6 +441,13 @@ SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Po
 SELECT asText(atStbox(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}', 'STBOX XT(((0,0),(3,3)),[2000-01-01,2000-01-05])'));
 SELECT asText(atStbox(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])', false));
 SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])', false));
+-- The disk reaches the box while its centre stays outside it
+SELECT asText(atStbox(tcbuffer 'Cbuffer(Point(3 1), 1.5)@2000-01-01', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
+SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(3 1), 1.5)@2000-01-01, Cbuffer(Point(3 1), 1.5)@2000-01-02]', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
+-- The same disk against the geometry of that box, which must agree
+SELECT asText(atGeometry(tcbuffer 'Cbuffer(Point(3 1), 1.5)@2000-01-01', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))'));
+-- A disk that reaches neither the box nor its geometry
+SELECT asText(atStbox(tcbuffer 'Cbuffer(Point(9 9), 0.5)@2000-01-01', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
 
 SELECT asText(minusStbox(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 'STBOX XT(((10,10),(20,20)),[2000-01-01,2000-01-02])'));
 SELECT asText(minusStbox(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
@@ -448,6 +455,9 @@ SELECT asText(minusStbox(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer
 SELECT asText(minusStbox(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03], [Cbuffer(Point(2 2), 0.6)@2000-01-04, Cbuffer(Point(2 2), 0.6)@2000-01-05]}', 'STBOX XT(((0,0),(3,3)),[2000-01-01,2000-01-05])'));
 SELECT asText(minusStbox(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])', false));
 SELECT asText(minusStbox(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2000-01-01, Cbuffer(Point(1 1), 0.4)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03]', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])', false));
+-- The disk reaches the box while its centre stays outside it
+SELECT asText(minusStbox(tcbuffer 'Cbuffer(Point(3 1), 1.5)@2000-01-01', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
+SELECT asText(minusStbox(tcbuffer '[Cbuffer(Point(3 1), 1.5)@2000-01-01, Cbuffer(Point(3 1), 1.5)@2000-01-02]', 'STBOX XT(((0,0),(2,2)),[2000-01-01,2000-01-02])'));
 
 SELECT asText(atTime(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
 SELECT asText(atTime(tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));


### PR DESCRIPTION
The restriction of a temporal circular buffer to a spatiotemporal box converts the value to a temporal point and clips the centre trajectory, so a disk overlapping the box while its centre stays outside is dropped. The geometry restriction beside it reads the circular disk footprint, and the space of a box is a geometry like any other, so the two contradict each other: a disk of radius 20 centred at (60,0) reaches x=40 and meets the box X((0,-50),(50,50)), which atGeometry and eIntersects both report and atStbox denies.

The disk footprint is what the box restriction reads too. The buffer meets the box exactly when the moving disk intersects it, which is the true time of the arc-exact temporal intersects relationship, so the restriction reduces to restricting the buffer to that time for `at` or to its complement for `minus`, intersected with the period the box carries. A box carrying only time restricts on the period alone, and the radius-aware box test in front proves that no disk reaches a box it misses.

The identity this restores is exact: over a 100 by 100 join of vessel trajectories against natural-area envelopes, atStbox(temp, box) and atGeometry(temp, stbox_to_geo(box)) disagree on 124 of the 10000 pairs and agree on all of them once the footprint is read, the count of non-empty results rising from 40 to 128. Reaching the relationship rather than the conversion is also cheaper: atStbox runs 0.65 s to 0.39 s and minusStbox 0.96 s to 0.61 s.

The test file gains the cases that separate the two readings, a disk reaching the box from outside it and the same disk against the geometry of that box, which the existing fixtures never exercised since each of them keeps the centre inside.