### PR TITLE
Pin the radius cases the box filters of a circular buffer must survive

### DIFF
--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -927,6 +927,48 @@ SELECT aDwithin(tcbuffer '[Cbuffer(Point(8 0),0.5)@2000-01-01, Cbuffer(Point(8 8
  f
 (1 row)
 
+SELECT aDwithin(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(0 0),100)@2000-01-02]', geometry 'Point(0 0)', 1);
+ adwithin 
+----------
+ t
+(1 row)
+
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(0 0),100)@2000-01-02]', geometry 'Point(0 0)', 1);
+ edwithin 
+----------
+ t
+(1 row)
+
+SELECT aDwithin(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(20 0),100)@2000-01-02]', geometry 'Point(0 0)', 1);
+ adwithin 
+----------
+ t
+(1 row)
+
+SELECT aDwithin(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(500 0),100)@2000-01-02]', geometry 'Point(0 0)', 1);
+ adwithin 
+----------
+ f
+(1 row)
+
+SELECT aTouches(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(0 0),100)@2000-01-02]', geometry 'Point(0 0)');
+ atouches 
+----------
+ f
+(1 row)
+
+SELECT eCovers(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(0 0),100)@2000-01-02]');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT aCovers(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(0 0),1)@2000-01-02]');
+ acovers 
+---------
+ t
+(1 row)
+
 /* Errors */
 SELECT eDwithin(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 ERROR:  Operation on mixed SRID

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -318,6 +318,26 @@ SELECT eDwithin(geometry 'CircularString(5 0, 4 3, 0 5)', tcbuffer '[Cbuffer(Poi
 SELECT aDwithin(geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', tcbuffer '[Cbuffer(Point(0 0),0.5)@2000-01-01, Cbuffer(Point(3 0),0.5)@2000-01-03]', 1);
 SELECT aDwithin(tcbuffer '[Cbuffer(Point(8 0),0.5)@2000-01-01, Cbuffer(Point(8 8),0.5)@2000-01-03]', geometry 'CurvePolygon(CircularString(5 0, 0 5, -5 0, 0 -5, 5 0))', 1);
 
+-- A disk far wider than the geometry it sits on. The distance is the one to
+-- the NEAREST point of the disk, so the disk is always within it while its
+-- radius-aware box exceeds the geometry box grown by the distance a
+-- hundredfold; a prefilter demanding that box be CONTAINED in the grown one,
+-- which is what the temporal point families may soundly demand, answers false
+-- here and the answer is true
+SELECT aDwithin(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(0 0),100)@2000-01-02]', geometry 'Point(0 0)', 1);
+SELECT eDwithin(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(0 0),100)@2000-01-02]', geometry 'Point(0 0)', 1);
+-- The same with the wide disk in motion, so the test reads a moving unit
+SELECT aDwithin(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(20 0),100)@2000-01-02]', geometry 'Point(0 0)', 1);
+-- A disk that leaves the neighbourhood is not always within it
+SELECT aDwithin(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(500 0),100)@2000-01-02]', geometry 'Point(0 0)', 1);
+-- Contact needs the boundary: a geometry strictly inside the disk interior is
+-- met, not touched
+SELECT aTouches(tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(0 0),100)@2000-01-02]', geometry 'Point(0 0)');
+-- A disk wider than the geometry fits in no part of it, so it is covered at no
+-- instant; a narrow one sitting inside is covered throughout
+SELECT eCovers(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(0 0),100)@2000-01-01, Cbuffer(Point(0 0),100)@2000-01-02]');
+SELECT aCovers(geometry 'Polygon((-5 -5,-5 5,5 5,5 -5,-5 -5))', tcbuffer '[Cbuffer(Point(0 0),1)@2000-01-01, Cbuffer(Point(0 0),1)@2000-01-02]');
+
 /* Errors */
 SELECT eDwithin(geometry 'SRID=3812;Point(1 1)', tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', 2);
 SELECT eDwithin(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01', geometry 'SRID=3812;Point(1 1)', 2);


### PR DESCRIPTION
Tests only.

The ever and always relationships of a temporal circular buffer against a geometry are filtered by bounding boxes before any kernel runs, and the soundness of those filters turns on a distinction the existing fixtures never exercise: the distance is the one to the NEAREST point of the disk, so a disk far wider than the geometry it sits on is always within a small distance of it while its radius-aware box exceeds the geometry box grown by that distance a hundredfold.

A filter demanding that the value's box be CONTAINED in the grown geometry box is sound for a temporal point, whose value at an instant is the single point the distance constrains, and unsound for a disk. Every fixture in the file agrees with such a filter, so it leaves no trace, while it answers false on exactly the pairs that are always within.

The cases that separate the two readings arrive here: a wide disk resting on a point, the same disk in motion, and one that carries the point out of the neighbourhood. Contact is pinned beside them, a geometry inside the disk interior being met rather than touched, and containment is pinned in both directions, a disk wider than the geometry fitting inside no part of it while a narrow one sits within throughout.