### PR TITLE
Name each edge type after the piece of geometry it is

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -59,9 +59,9 @@
 typedef enum
 {
   EDGE_POINT = 0,
-  EDGE_LINE,
-  EDGE_POLY,
-  EDGE_ARC,
+  EDGE_LINESEG,
+  EDGE_LINEARC,
+  EDGE_POLYSEG,
   EDGE_POLYARC
 } EdgeType;
 
@@ -73,9 +73,9 @@ typedef struct
   double x1, y1, x2, y2;         /**< Coordinates of the start/end 2D points */
   double xmin, ymin, xmax, ymax; /**< Precomputed bounding box of the edge */
   double dx, dy, length;         /**< Precomputed dx, dy, and length */
-  double cx, cy, radius;         /**< Arc center and radius (EDGE_ARC only) */
-  double theta0, theta1;         /**< Arc start/end angles (EDGE_ARC only) */
-  bool ccw;                      /**< Arc traversed counterclockwise (EDGE_ARC) */
+  double cx, cy, radius;         /**< Arc center and radius (an arc only) */
+  double theta0, theta1;         /**< Arc start/end angles (an arc only) */
+  bool ccw;                      /**< Arc traversed counterclockwise */
   EdgeType etype;                /**< Edge type */
 } Edge;
 

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -122,7 +122,7 @@ extract_mpoint(const LWMPOINT *mp, MeosArray *edges)
 static void
 extract_line(const LWLINE *line, MeosArray *edges)
 {
-  emit_ring_edges(line->points, edges, EDGE_LINE);
+  emit_ring_edges(line->points, edges, EDGE_LINESEG);
   return;
 }
 
@@ -146,7 +146,7 @@ static void
 extract_poly(const LWPOLY *poly, MeosArray *edges)
 {
   for (int r = 0; r < (int) poly->nrings; r++)
-    emit_ring_edges(poly->rings[r], edges, EDGE_POLY);
+    emit_ring_edges(poly->rings[r], edges, EDGE_POLYSEG);
   return;
 }
 
@@ -171,7 +171,7 @@ extract_mpoly(const LWMPOLY *mp, MeosArray *edges)
 static void
 extract_triangle(const LWTRIANGLE *tri, MeosArray *edges)
 {
-  emit_ring_edges(tri->points, edges, EDGE_POLY);
+  emit_ring_edges(tri->points, edges, EDGE_POLYSEG);
   return;
 }
 
@@ -237,8 +237,8 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
  * from a circular string, emitting them with the given line/arc edge types
  * @details Straight components (collinear point triples) are emitted with
  * @p line_etype and genuine arcs with @p arc_etype. A standalone circular
- * string uses the 1D types (#EDGE_LINE / #EDGE_ARC); a circular string that
- * bounds a curve polygon ring uses the region types (#EDGE_POLY /
+ * string uses the 1D types (#EDGE_LINESEG / #EDGE_LINEARC); a circular string that
+ * bounds a curve polygon ring uses the region types (#EDGE_POLYSEG /
  * #EDGE_POLYARC)
  */
 static void
@@ -265,7 +265,7 @@ emit_circstring_edges(const LWCIRCSTRING *circ, MeosArray *edges,
 static void
 extract_circstring(const LWCIRCSTRING *circ, MeosArray *edges)
 {
-  emit_circstring_edges(circ, edges, EDGE_LINE, EDGE_ARC);
+  emit_circstring_edges(circ, edges, EDGE_LINESEG, EDGE_LINEARC);
   return;
 }
 
@@ -274,7 +274,7 @@ extract_circstring(const LWCIRCSTRING *circ, MeosArray *edges)
  * edges obtained from a ring of a curve polygon
  * @details A ring is a line string, a circular string, or a compound curve
  * chaining both. Every edge is emitted with polygon (region) semantics
- * (#EDGE_POLY / #EDGE_POLYARC) so that the even-odd containment test in
+ * (#EDGE_POLYSEG / #EDGE_POLYARC) so that the even-odd containment test in
  * #point_in_polygon treats it as a boundary rather than a 1D feature
  */
 static void
@@ -283,11 +283,11 @@ extract_curvepoly_ring(const LWGEOM *ring, MeosArray *edges)
   switch (ring->type)
   {
     case LINETYPE:
-      emit_ring_edges(((const LWLINE *) ring)->points, edges, EDGE_POLY);
+      emit_ring_edges(((const LWLINE *) ring)->points, edges, EDGE_POLYSEG);
       break;
 
     case CIRCSTRINGTYPE:
-      emit_circstring_edges((const LWCIRCSTRING *) ring, edges, EDGE_POLY,
+      emit_circstring_edges((const LWCIRCSTRING *) ring, edges, EDGE_POLYSEG,
         EDGE_POLYARC);
       break;
 

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -465,7 +465,7 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
       continue;
     }
 
-    if (e->etype != EDGE_POLY)
+    if (e->etype != EDGE_POLYSEG)
       continue;
 
     const double dx  = e->dx;
@@ -607,7 +607,7 @@ intervals_from_lines(const POINT2D *a, const POINT2D *b, Edge **edges,
   {
     const Edge *e = edges[i];
     /* Iterate only for the line edges */
-    if (e->etype != EDGE_LINE)
+    if (e->etype != EDGE_LINESEG)
       continue;
 
     /* Bounding box filter */
@@ -643,7 +643,7 @@ intervals_from_lines(const POINT2D *a, const POINT2D *b, Edge **edges,
     {
       const Edge *e = edges[i];
       /* Iterate only for the lines edges */
-      if (e->etype != EDGE_LINE)
+      if (e->etype != EDGE_LINESEG)
         continue;
 
       /* Fast bbox check first */
@@ -689,7 +689,7 @@ intervals_from_arcs(const POINT2D *a, const POINT2D *b, Edge **edges,
   for (int i = 0; i < nedges; i++)
   {
     const Edge *e = edges[i];
-    if (e->etype != EDGE_ARC)
+    if (e->etype != EDGE_LINEARC)
       continue;
 
     /* Bounding box filter */
@@ -723,7 +723,7 @@ float8_qsort_cmp(const void *a1, const void *a2)
 /**
  * @brief Return true if a point lies on the boundary of a polygonal component
  * @details Only the polygon boundary edges are considered, straight
- * (#EDGE_POLY) and circular (#EDGE_POLYARC). The candidate array filtered by
+ * (#EDGE_POLYSEG) and circular (#EDGE_POLYARC). The candidate array filtered by
  * the box of a segment suffices for a point lying on that segment: a boundary
  * edge through such a point has a box meeting the segment box, so it is in the
  * candidates
@@ -734,7 +734,7 @@ point_on_poly_boundary(double px, double py, Edge **edges, int nedges)
   for (int i = 0; i < nedges; i++)
   {
     const Edge *e = edges[i];
-    if (e->etype == EDGE_POLY)
+    if (e->etype == EDGE_POLYSEG)
     {
       if (point_on_segment(px, py, e->x1, e->y1, e->x2, e->y2))
         return true;
@@ -784,13 +784,13 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
   const double ry = by - ay;
 
   /* Check whether any polygon boundary edges exist using the full edge array.
-   * A curve polygon contributes straight (EDGE_POLY) and arc (EDGE_POLYARC)
+   * A curve polygon contributes straight (EDGE_POLYSEG) and arc (EDGE_POLYARC)
    * boundary edges */
   bool has_polys = false;
   for (int i = 0; i < all_nedges; i++)
   {
     EdgeType et = all_edges[i]->etype;
-    if (et == EDGE_POLY || et == EDGE_POLYARC)
+    if (et == EDGE_POLYSEG || et == EDGE_POLYARC)
     {
       has_polys = true;
       break;
@@ -805,7 +805,7 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
   {
     const Edge *e = edges[i];
     /* Iterate only for the polygon boundary edges (straight or arc) */
-    if (e->etype != EDGE_POLY && e->etype != EDGE_POLYARC)
+    if (e->etype != EDGE_POLYSEG && e->etype != EDGE_POLYARC)
       continue;
 
     /* Bounding box filter */
@@ -813,7 +813,7 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
         e->ymax < seg_ymin || e->ymin > seg_ymax)
       continue;
 
-    if (e->etype == EDGE_POLY)
+    if (e->etype == EDGE_POLYSEG)
     {
       /* Compute the crossing with the straight boundary segment */
       IntersectResult r = linesegm_intersect(ax, ay, rx, ry,
@@ -929,12 +929,12 @@ point_inter_points_lines(const POINT2D *a, Edge **edges, int nedges)
       if (fabs(e->x1 - ax) < FP_TOLERANCE && fabs(e->y1 - ay) < FP_TOLERANCE)
         return true;
     }
-    else if (e->etype == EDGE_LINE)
+    else if (e->etype == EDGE_LINESEG)
     {
       if (point_on_segment(ax, ay, e->x1, e->y1, e->x2, e->y2))
         return true;
     }
-    else if (e->etype == EDGE_ARC)
+    else if (e->etype == EDGE_LINEARC)
     {
       if (point_on_arc(ax, ay, e))
         return true;
@@ -1256,8 +1256,8 @@ edge_intersect(const Edge *e1, const Edge *e2)
       e1->ymax < e2->ymin - FP_TOLERANCE || e2->ymax < e1->ymin - FP_TOLERANCE)
     return false;
 
-  bool arc1 = (e1->etype == EDGE_ARC || e1->etype == EDGE_POLYARC);
-  bool arc2 = (e2->etype == EDGE_ARC || e2->etype == EDGE_POLYARC);
+  bool arc1 = (e1->etype == EDGE_LINEARC || e1->etype == EDGE_POLYARC);
+  bool arc2 = (e2->etype == EDGE_LINEARC || e2->etype == EDGE_POLYARC);
 
   /* A point edge meets another edge only by lying on it */
   if (e1->etype == EDGE_POINT && e2->etype == EDGE_POINT)
@@ -1295,7 +1295,7 @@ static bool
 edges_have_area(Edge **edges, int nedges)
 {
   for (int i = 0; i < nedges; i++)
-    if (edges[i]->etype == EDGE_POLY || edges[i]->etype == EDGE_POLYARC)
+    if (edges[i]->etype == EDGE_POLYSEG || edges[i]->etype == EDGE_POLYARC)
       return true;
   return false;
 }
@@ -1445,12 +1445,12 @@ edges_contain_point(double px, double py, Edge **edges, int nedges,
       if (fabs(px - e->x1) < FP_TOLERANCE && fabs(py - e->y1) < FP_TOLERANCE)
         return true;
     }
-    else if (e->etype == EDGE_ARC || e->etype == EDGE_POLYARC)
+    else if (e->etype == EDGE_LINEARC || e->etype == EDGE_POLYARC)
     {
       if (point_on_arc(px, py, e))
         return true;
     }
-    else /* EDGE_LINE, EDGE_POLY */
+    else /* EDGE_LINESEG, EDGE_POLYSEG */
     {
       if (point_on_segment(px, py, e->x1, e->y1, e->x2, e->y2))
         return true;
@@ -1480,7 +1480,7 @@ segment_within_closure(const Edge *e, Edge **aedges, int na, bool has_area)
   for (int i = 0; i < na; i++)
   {
     const Edge *ea = aedges[i];
-    if (ea->etype == EDGE_ARC || ea->etype == EDGE_POLYARC)
+    if (ea->etype == EDGE_LINEARC || ea->etype == EDGE_POLYARC)
     {
       double out[2];
       int m = arcsegm_intersect(e->x1, e->y1, e->dx, e->dy, ea, out);
@@ -1642,7 +1642,7 @@ geo_covers2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
     const Edge *e = bedges[i];
     if (e->etype == EDGE_POINT)
       continue;
-    if (e->etype == EDGE_ARC || e->etype == EDGE_POLYARC)
+    if (e->etype == EDGE_LINEARC || e->etype == EDGE_POLYARC)
     {
       if (! arc_within_closure(e, aedges, na, has_area))
         result = false;
@@ -1868,10 +1868,10 @@ point_edge_dist2(double px, double py, const Edge *e)
       const double dx = px - e->x1, dy = py - e->y1;
       return dx * dx + dy * dy;
     }
-    case EDGE_LINE:
-    case EDGE_POLY:
+    case EDGE_LINESEG:
+    case EDGE_POLYSEG:
       return point_seg_dist2(px, py, e->x1, e->y1, e->x2, e->y2);
-    default: /* EDGE_ARC / EDGE_POLYARC */
+    default: /* EDGE_LINEARC / EDGE_POLYARC */
       return point_arc_dist2(px, py, e);
   }
 }
@@ -1975,8 +1975,8 @@ within_roots_from_edge(double ax, double ay, double rx, double ry,
         wx * wx + wy * wy - d2, ev);
       return;
     }
-    case EDGE_LINE:
-    case EDGE_POLY:
+    case EDGE_LINESEG:
+    case EDGE_POLYSEG:
     {
       /* Endpoint caps: discs of radius dist around each segment endpoint */
       const double w0x = ax - e->x1, w0y = ay - e->y1;
@@ -2002,7 +2002,7 @@ within_roots_from_edge(double ax, double ay, double rx, double ry,
       }
       return;
     }
-    default: /* EDGE_ARC / EDGE_POLYARC */
+    default: /* EDGE_LINEARC / EDGE_POLYARC */
     {
       const double wx = ax - e->cx, wy = ay - e->cy;
       const double B = 2.0 * (wx * rx + wy * ry);
@@ -2460,8 +2460,8 @@ distance_cands_from_edge(double ax, double ay, double rx, double ry,
       add_within_root(-(wx * rx + wy * ry) / A, ev);
       return;
     }
-    case EDGE_LINE:
-    case EDGE_POLY:
+    case EDGE_LINESEG:
+    case EDGE_POLYSEG:
     {
       const double w0x = ax - e->x1, w0y = ay - e->y1;
       const double w1x = ax - e->x2, w1y = ay - e->y2;
@@ -2487,7 +2487,7 @@ distance_cands_from_edge(double ax, double ay, double rx, double ry,
       }
       return;
     }
-    default: /* EDGE_ARC / EDGE_POLYARC */
+    default: /* EDGE_LINEARC / EDGE_POLYARC */
     {
       const double wx = ax - e->cx, wy = ay - e->cy;
       /* Radial extremum: the time at which || P(t) - center || is stationary


### PR DESCRIPTION
An edge is either a straight segment or a circular arc, and it comes either
from a line or from the boundary of a polygon. The names carry half of that:
EDGE_LINE and EDGE_POLY name the geometry an edge comes from without saying
it is a segment, EDGE_ARC names an arc without saying which geometry it comes
from, and EDGE_POLYARC alone says both.

The four are EDGE_LINESEG, EDGE_LINEARC, EDGE_POLYSEG and EDGE_POLYARC, the
enumeration listing the two of a line before the two of a polygon. The type
lives in memory and reaches no serialized form, so the values it takes carry
nothing, and no comparison orders one edge type against another.
