### PR TITLE
Name the pose orientation accessor after the quaternion it returns

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1548,7 +1548,7 @@
 					</listitem>
 
 					<listitem>
-						<para><link linkend="pose_orientation"><varname>orientation</varname></link>: Devuelve la orientación</para>
+						<para><link linkend="pose_quaternion"><varname>quaternion</varname></link>: Devuelve el cuaternión de orientación de una pose 3D</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -251,13 +251,14 @@ SELECT rotation(pose 'Pose(Point(1 1), 0.3)');
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="pose_orientation">
-					<indexterm significance="normal"><primary><varname>orientation</varname></primary></indexterm>
-					<para>Devuelve la orientación</para>
-					<para><varname>orientation(pose3D) → (X,W,Z,T)</varname></para>
+				<listitem xml:id="pose_quaternion">
+					<indexterm significance="normal"><primary><varname>quaternion</varname></primary></indexterm>
+					<para>Devuelve el cuaternión de orientación de una pose 3D</para>
+					<para><varname>quaternion(pose3D) → quaternion</varname></para>
+					<para>Las componentes se devuelven en el orden <varname>W</varname>, <varname>X</varname>, <varname>Y</varname>, <varname>Z</varname>, la convención de Hamilton en la que la pose las almacena. Esta es una de las dos codificaciones de orientación que prescribe el estándar OGC GeoPose v1.0; la otra, yaw / pitch / roll, la proporcionan <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> y <varname>roll</varname>. Una pose 2D no tiene cuaternión y la función emite un error para ella; su orientación es el ángulo único que devuelve <link linkend="pose_rotation"><varname>rotation</varname></link>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT orientation(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
--- (0, 0, 0, 1)
+SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
+-- (0,0,0,1)
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1530,7 +1530,7 @@
 					</listitem>
 
 					<listitem>
-						<para><link linkend="pose_orientation"><varname>orientation</varname></link>: Return the orientation</para>
+						<para><link linkend="pose_quaternion"><varname>quaternion</varname></link>: Return the orientation quaternion of a 3D pose</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -258,13 +258,14 @@ SELECT rotation(pose 'Pose(Point(1 1), 0.3)');
 </programlisting>
 				</listitem>
 
-				<listitem xml:id="pose_orientation">
-					<indexterm significance="normal"><primary><varname>orientation</varname></primary></indexterm>
-					<para>Return the orientation</para>
-					<para><varname>orientation(pose3D) → (X,W,Z,T)</varname></para>
+				<listitem xml:id="pose_quaternion">
+					<indexterm significance="normal"><primary><varname>quaternion</varname></primary></indexterm>
+					<para>Return the orientation quaternion of a 3D pose</para>
+					<para><varname>quaternion(pose3D) → quaternion</varname></para>
+					<para>The components are returned in the order <varname>W</varname>, <varname>X</varname>, <varname>Y</varname>, <varname>Z</varname>, the Hamilton convention in which the pose stores them. This is one of the two orientation encodings the OGC GeoPose v1.0 standard prescribes; the other, yaw / pitch / roll, is given by <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> and <varname>roll</varname>. A 2D pose has no quaternion and the function emits an error for it; its orientation is the single angle returned by <link linkend="pose_rotation"><varname>rotation</varname></link>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT orientation(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
--- (0, 0, 0, 1)
+SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
+-- (0,0,0,1)
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -136,7 +136,7 @@ extern STBox *pose_to_stbox(const Pose *pose);
 
 extern uint32 pose_hash(const Pose *pose);
 extern uint64 pose_hash_extended(const Pose *pose, uint64 seed);
-extern double *pose_orientation(const Pose *pose, int *count);
+extern double *pose_quaternion(const Pose *pose, int *count);
 extern double pose_rotation(const Pose *pose);
 extern double pose_yaw(const Pose *pose);
 extern double pose_pitch(const Pose *pose);
@@ -249,7 +249,7 @@ extern Temporal *tpose_to_tpoint(const Temporal *temp);
 
 extern Pose *tpose_end_value(const Temporal *temp);
 extern Set *tpose_points(const Temporal *temp);
-// extern Temporal *tpose_orientation(const Temporal *temp);
+// extern Temporal *tpose_quaternion(const Temporal *temp);
 extern Temporal *tpose_rotation(const Temporal *temp);
 extern Temporal *tpose_yaw(const Temporal *temp);
 extern Temporal *tpose_pitch(const Temporal *temp);

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1037,14 +1037,19 @@ datum_pose_roll(Datum pose)
 
 /**
  * @ingroup meos_pose_base_accessor
- * @brief Return the orientation of a 3D pose
+ * @brief Return the orientation quaternion of a 3D pose
+ * @details The four components are returned in the order @p W, @p X, @p Y,
+ * @p Z, the Hamilton convention in which the pose stores them. The
+ * yaw / pitch / roll encoding of the same orientation, the other
+ * representation the OGC GeoPose standard prescribes, is returned by
+ * #pose_yaw(), #pose_pitch() and #pose_roll().
  * @param[in] pose Pose
  * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
- * @csqlfn #Pose_orientation()
+ * @csqlfn #Pose_quaternion()
  */
 double *
-pose_orientation(const Pose *pose, int *count)
+pose_quaternion(const Pose *pose, int *count)
 {
   /* The out parameter is defined even when a later check fails */
   VALIDATE_NOT_NULL(count, NULL);

--- a/mobilitydb/sql/pose/100_pose.in.sql
+++ b/mobilitydb/sql/pose/100_pose.in.sql
@@ -238,9 +238,9 @@ CREATE TYPE quaternion AS (
   Z float
 );
 
-CREATE FUNCTION orientation(pose)
+CREATE FUNCTION quaternion(pose)
   RETURNS quaternion
-  AS 'MODULE_PATHNAME', 'Pose_orientation'
+  AS 'MODULE_PATHNAME', 'Pose_quaternion'
   LANGUAGE C IMMUTABLE STRICT;
 
 /*****************************************************************************

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -287,9 +287,12 @@ CREATE FUNCTION angularSpeed(tpose)
   AS 'MODULE_PATHNAME', 'Tpose_angular_speed'
   LANGUAGE C IMMUTABLE STRICT;
 
--- CREATE FUNCTION orientation(tpose)
+-- A quaternion is a composite type, not a temporal base type, so the
+-- orientation of a temporal pose has no temporal lift. The temporal
+-- orientation channel is given by yaw / pitch / roll above.
+-- CREATE FUNCTION quaternion(tpose)
   -- RETURNS quaternion[]
-  -- AS 'MODULE_PATHNAME', 'Tpose_orientation'
+  -- AS 'MODULE_PATHNAME', 'Tpose_quaternion'
   -- LANGUAGE C IMMUTABLE STRICT;
 
 /******************************************************************************/

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -554,15 +554,15 @@ Pose_rotation(PG_FUNCTION_ARGS)
   PG_RETURN_FLOAT8(result);
 }
 
-PGDLLEXPORT Datum Pose_orientation(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Pose_orientation);
+PGDLLEXPORT Datum Pose_quaternion(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pose_quaternion);
 /**
  * @ingroup mobilitydb_pose_base_accessor
- * @brief Return the orientation of a 3D pose
- * @sqlfn orientation()
+ * @brief Return the orientation quaternion of a 3D pose
+ * @sqlfn quaternion()
  */
 Datum
-Pose_orientation(PG_FUNCTION_ARGS)
+Pose_quaternion(PG_FUNCTION_ARGS)
 {
   /* Define the return type properties */
   TupleDesc tupdesc;
@@ -580,7 +580,7 @@ Pose_orientation(PG_FUNCTION_ARGS)
   Pose *pose = PG_GETARG_POSE_P(0);
   /* Get the array of doubles representing the orientation */
   int count;
-  double *quaternion = pose_orientation(pose, &count);
+  double *quaternion = pose_quaternion(pose, &count);
   /* Create values for the tuple */
   values[0] = Float8GetDatum(quaternion[0]);
   values[1] = Float8GetDatum(quaternion[1]);

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -128,6 +128,26 @@ SELECT roll(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
     0
 (1 row)
 
+SELECT quaternion(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
+ quaternion 
+------------
+ (1,0,0,0)
+(1 row)
+
+SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
+ quaternion 
+------------
+ (0,0,0,1)
+(1 row)
+
+SELECT quaternion(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)');
+    quaternion     
+-------------------
+ (0.5,0.5,0.5,0.5)
+(1 row)
+
+SELECT quaternion(pose 'Pose(Point(1 1),0.5)');
+ERROR:  The pose must have Z dimension
 SELECT asText(round(pose 'Pose(Point(1.123456789 1.123456789), 0.123456789)', 6));
                  astext                  
 -----------------------------------------

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -76,6 +76,18 @@ SELECT yaw(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
 SELECT pitch(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
 SELECT roll(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
 
+-- The orientation quaternion of a 3D pose, in the stored (W, X, Y, Z)
+-- Hamilton order. A 2D pose has no quaternion.
+SELECT quaternion(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
+SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
+-- A 120-degree turn about (1 1 1). Its components are exactly
+-- representable, so the unit-norm renormalization leaves them alone and
+-- the output carries no libm-dependent trailing digits.
+SELECT quaternion(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)');
+\set VERBOSITY terse
+SELECT quaternion(pose 'Pose(Point(1 1),0.5)');
+\set VERBOSITY default
+
 -------------------------------------------------------------------------------
 -- Modification functions
 -------------------------------------------------------------------------------

--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -707,8 +707,8 @@ TPOSE_CONFIG = dict(
         # point geometry.
         "pose_make_3d":      {3: "1.0", 4: "0.0", 5: "0.0", 6: "0.0"},
         "pose_make_point3d": {0: "geom_pointz1", 1: "1.0", 2: "0.0", 3: "0.0", 4: "0.0"},
-        # pose_orientation reads a 3D pose's quaternion.
-        "pose_orientation":  {0: "pose3d1"},
+        # pose_quaternion reads a 3D pose's quaternion.
+        "pose_quaternion":   {0: "pose3d1"},
         # tpose_make(tpoint, tradius): a temporal geometry point and a temporal
         # float radius.
         "tpose_make":        {0: "tpoint1", 1: "tfloat1"},


### PR DESCRIPTION
OGC GeoPose keeps `orientation` as the abstract slot and names two encodings that fill it, a unit quaternion and a yaw / pitch / roll triple. This names the accessor that answers the first of those after what it returns, `quaternion`, the composite type it is already declared to produce, rather than after the slot it fills only one encoding of. It sits beside `yaw` / `pitch` / `roll`, which answer the other encoding under their own names.

The name also pairs the accessor legibly with `rotation`, which answers the single angle a 2D pose stores: the two are dimension-split rather than one being a subset of the other.

`orientation` stays where it names the abstract slot: the chapter prose, and `pose_orientation_apply_frame_change`, which corrects the orientation whatever its encoding.

- MEOS `pose_orientation` → `pose_quaternion`, wrapper `Pose_orientation` → `Pose_quaternion`, SQL `orientation(pose)` → `quaternion(pose)`.
- The manual entry states the components come back as `(X,W,Z,T)`; they are `(W,X,Y,Z)`, the Hamilton order the pose stores. The EN and ES chapters and reference indexes move together.
- The accessor carries no regression coverage. This adds it for both dimensions, including the error a 2D pose raises.
- The commented-out temporal twin is renamed with it and states why it stays commented: a quaternion is a composite type, not a temporal base type, so the orientation of a `tpose` has no temporal lift — that channel is `yaw` / `pitch` / `roll`.