### PR TITLE
Answer a pose orientation in either encoding the GeoPose standard prescribes

### DIFF
--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -181,6 +181,8 @@ SELECT asEWKT(poseFromHexEWKB(
 					<para>Constructor para poses</para>
 					<para><varname>pose(geompoint2D,float) → pose</varname></para>
 					<para><varname>pose(geompoint3D,float,float,float,float) → pose</varname></para>
+					<para><varname>pose(geompoint3D,yaw float,pitch float,roll float) → pose</varname></para>
+					<para>La forma de tres ángulos toma la orientación en la otra codificación que prescribe el estándar OGC GeoPose v1.0, una terna yaw / pitch / roll en radianes bajo la convención Tait-Bryan intrínseca ZYX, y almacena el cuaternión que denota. Es la inversa de <link linkend="pose_ypr"><varname>ypr</varname></link>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(pose(ST_Point(1,1), radians(45)), 6);
 -- Pose(POINT(1 1),0.785398)
@@ -188,6 +190,8 @@ SELECT asEWKT(pose(ST_Point(1,1,3812), radians(45)), 6);
 -- SRID=3812;Pose(POINT(1 1),0.785398)
 SELECT asText(pose(ST_PointZ(1,1,1), 1, 0, 0, 0));
 -- Pose(POINT Z (1 1 1),1,0,0,0)
+SELECT asText(pose(ST_PointZ(1,1,1), radians(90), 0, 0), 6);
+-- Pose(POINT Z (1 1 1),0.707107,0,0,0.707107)
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -1348,6 +1352,21 @@ SELECT roll(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.707106781186547
 -- 0
 SELECT yaw(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)');
 -- 1.5707963267948966
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="pose_ypr">
+					<indexterm significance="normal"><primary><varname>ypr</varname></primary></indexterm>
+					<para>Devuelve la orientación de una pose como una terna yaw / pitch / roll, en radianes</para>
+					<para><varname>ypr(pose) → ypr</varname></para>
+					<para>Esta es la codificación Basic-YPR de la orientación en OGC GeoPose, la contraparte de <link linkend="pose_quaternion"><varname>quaternion</varname></link>, y devuelve los tres ángulos que <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> y <varname>roll</varname> responden de uno en uno. A diferencia de <varname>quaternion</varname>, que lee una codificación que solo almacena una pose 3D, está definida para ambas dimensiones: una pose 2D gira por su ángulo almacenado y no cabecea ni alabea. Los ángulos están en radianes, mientras que la codificación JSON de GeoPose los escribe en grados.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ypr(pose 'Pose(Point(1 1), 0.5)');
+-- (0.5,0,0)
+SELECT ypr(pose 'Pose(Point Z(1 1 1), 1, 0, 0, 0)');
+-- (0,0,0)
+SELECT ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)');
+-- (1.5707963267948966,0,1.5707963267948966)
 </programlisting>
 				</listitem>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2649,6 +2649,9 @@
 					<listitem>
 						<para><link linkend="pose_yaw_pitch_roll"><varname>yaw</varname>, <varname>pitch</varname>, <varname>roll</varname></link>: Return the yaw, pitch, or roll angle of a (temporal) pose, in radians, under the ZYX intrinsic Tait-Bryan convention required by the OGC GeoPose Basic-YPR conformance class</para>
 					</listitem>
+					<listitem>
+						<para><link linkend="pose_ypr"><varname>ypr</varname></link>: Return the orientation of a pose as a yaw / pitch / roll triple, in radians</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -188,6 +188,8 @@ SELECT asEWKT(poseFromHexEWKB(
 					<para>Constructor for poses</para>
 					<para><varname>pose(geompoint2D,float) → pose</varname></para>
 					<para><varname>pose(geompoint3D,float,float,float,float) → pose</varname></para>
+					<para><varname>pose(geompoint3D,yaw float,pitch float,roll float) → pose</varname></para>
+					<para>The three-angle form takes the orientation in the other encoding the OGC GeoPose v1.0 standard prescribes, a yaw / pitch / roll triple in radians under the ZYX intrinsic Tait-Bryan convention, and stores the quaternion it denotes. It is the inverse of <link linkend="pose_ypr"><varname>ypr</varname></link>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(pose(ST_Point(1,1), radians(45)), 6);
 -- Pose(POINT(1 1),0.785398)
@@ -195,6 +197,8 @@ SELECT asEWKT(pose(ST_Point(1,1,3812), radians(45)), 6);
 -- SRID=3812;Pose(POINT(1 1),0.785398)
 SELECT asText(pose(ST_PointZ(1,1,1), 1, 0, 0, 0));
 -- Pose(POINT Z (1 1 1),1,0,0,0)
+SELECT asText(pose(ST_PointZ(1,1,1), radians(90), 0, 0), 6);
+-- Pose(POINT Z (1 1 1),0.707107,0,0,0.707107)
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -1363,6 +1367,21 @@ SELECT yaw(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475
 SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
   Pose(Point(1 1), 0.5)@2000-01-02]'));
 -- [0@2000-01-01, 0.5@2000-01-02]
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="pose_ypr">
+					<indexterm significance="normal"><primary><varname>ypr</varname></primary></indexterm>
+					<para>Return the orientation of a pose as a yaw / pitch / roll triple, in radians</para>
+					<para><varname>ypr(pose) → ypr</varname></para>
+					<para>This is the OGC GeoPose Basic-YPR encoding of the orientation, the counterpart of <link linkend="pose_quaternion"><varname>quaternion</varname></link>, and it returns the three angles <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> and <varname>roll</varname> answer one at a time. Unlike <varname>quaternion</varname>, which reads an encoding only a 3D pose stores, it is defined for both dimensions: a 2D pose yaws by its stored angle and neither pitches nor rolls. The angles are in radians, where the GeoPose JSON encoding writes them in degrees.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ypr(pose 'Pose(Point(1 1), 0.5)');
+-- (0.5,0,0)
+SELECT ypr(pose 'Pose(Point Z(1 1 1), 1, 0, 0, 0)');
+-- (0,0,0)
+SELECT ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)');
+-- (1.5707963267948966,0,1.5707963267948966)
 </programlisting>
 				</listitem>
 

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -126,6 +126,7 @@ extern Pose *pose_make_2d(double x, double y, double theta, bool geodetic, int32
 extern Pose *pose_make_3d(double x, double y, double z, double W, double X, double Y, double Z, bool geodetic, int32_t srid);
 extern Pose *pose_make_point2d(const GSERIALIZED *gs, double theta);
 extern Pose *pose_make_point3d(const GSERIALIZED *gs, double W, double X, double Y, double Z);
+extern Pose *pose_make_point3d_ypr(const GSERIALIZED *gs, double yaw, double pitch, double roll);
 
 /* Conversion functions */
 
@@ -137,6 +138,7 @@ extern STBox *pose_to_stbox(const Pose *pose);
 extern uint32 pose_hash(const Pose *pose);
 extern uint64 pose_hash_extended(const Pose *pose, uint64 seed);
 extern double *pose_quaternion(const Pose *pose, int *count);
+extern double *pose_ypr(const Pose *pose, int *count);
 extern double pose_rotation(const Pose *pose);
 extern double pose_yaw(const Pose *pose);
 extern double pose_pitch(const Pose *pose);

--- a/meos/include/pose/pose.h
+++ b/meos/include/pose/pose.h
@@ -109,6 +109,10 @@ extern Datum datum_pose_round(Datum pose, Datum size);
 extern void pose_quaternion_mul(double aw, double ax, double ay, double az,
   double bw, double bx, double by, double bz,
   double *ow, double *ox, double *oy, double *oz);
+extern void pose_ypr_to_quaternion(double yaw_rad, double pitch_rad,
+  double roll_rad, double *W, double *X, double *Y, double *Z);
+extern void pose_quaternion_to_ypr(double W, double X, double Y, double Z,
+  double *yaw_rad, double *pitch_rad, double *roll_rad);
 extern void pose_enu_to_ecef_quaternion(double lat_rad, double lon_rad,
   double *W, double *X, double *Y, double *Z);
 extern Pose *pose_transf_pj(const Pose *pose, int32_t srid_to,

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -401,6 +401,63 @@ ensure_unit_norm(double W, double X, double Y, double Z)
 }
 
 /*****************************************************************************
+ * Orientation encodings
+ *
+ * The OGC GeoPose v1.0 standard prescribes two encodings of the same
+ * orientation, a unit quaternion and a yaw / pitch / roll triple, and the
+ * conversion between them has a single home here. Everything that needs
+ * either direction — the accessors, the constructors, and the GeoPose JSON
+ * reader and writer — goes through these two functions.
+ *****************************************************************************/
+
+/**
+ * @brief Convert (yaw, pitch, roll) in radians, ZYX intrinsic Tait-Bryan
+ * convention, to a unit quaternion (W, X, Y, Z) in Hamilton convention
+ * @details ZYX order is the one the OGC GeoPose standard prescribes: yaw
+ * about Z, then pitch about the new Y, then roll about the new X. The
+ * output is unit-norm by construction, modulo float rounding.
+ * @param[in] yaw_rad,pitch_rad,roll_rad Angles in radians
+ * @param[out] W,X,Y,Z Quaternion components
+ */
+void
+pose_ypr_to_quaternion(double yaw_rad, double pitch_rad, double roll_rad,
+  double *W, double *X, double *Y, double *Z)
+{
+  assert(W); assert(X); assert(Y); assert(Z);
+  double cy = cos(yaw_rad   * 0.5), sy = sin(yaw_rad   * 0.5);
+  double cp = cos(pitch_rad * 0.5), sp = sin(pitch_rad * 0.5);
+  double cr = cos(roll_rad  * 0.5), sr = sin(roll_rad  * 0.5);
+  *W = cr * cp * cy + sr * sp * sy;
+  *X = sr * cp * cy - cr * sp * sy;
+  *Y = cr * sp * cy + sr * cp * sy;
+  *Z = cr * cp * sy - sr * sp * cy;
+  return;
+}
+
+/**
+ * @brief Convert a unit quaternion (W, X, Y, Z) in Hamilton convention to
+ * (yaw, pitch, roll) in radians, ZYX intrinsic Tait-Bryan convention
+ * @details The pitch term is clamped to @p [-1, 1] before @p asin to absorb
+ * the small numeric drift @p |q| - 1 that long quaternion compositions can
+ * introduce.
+ * @param[in] W,X,Y,Z Quaternion components
+ * @param[out] yaw_rad,pitch_rad,roll_rad Angles in radians
+ */
+void
+pose_quaternion_to_ypr(double W, double X, double Y, double Z,
+  double *yaw_rad, double *pitch_rad, double *roll_rad)
+{
+  assert(yaw_rad); assert(pitch_rad); assert(roll_rad);
+  double sinp = 2.0 * (W * Y - Z * X);
+  if (sinp >  1.0) sinp =  1.0;
+  if (sinp < -1.0) sinp = -1.0;
+  *pitch_rad = asin(sinp);
+  *roll_rad  = atan2(2.0 * (W * X + Y * Z), 1.0 - 2.0 * (X * X + Y * Y));
+  *yaw_rad   = atan2(2.0 * (W * Z + X * Y), 1.0 - 2.0 * (Y * Y + Z * Z));
+  return;
+}
+
+/*****************************************************************************
  * Input/output functions
  *****************************************************************************/
 
@@ -885,6 +942,41 @@ pose_make_point3d(const GSERIALIZED *gs, double W, double X, double Y,
 
 /**
  * @ingroup meos_pose_base_constructor
+ * @brief Construct a 3D pose value from a 3D point and a yaw / pitch / roll
+ * triple
+ * @details The angles are in radians and are read in the ZYX intrinsic
+ * Tait-Bryan convention the OGC GeoPose Basic-YPR conformance class
+ * prescribes, the same convention #pose_ypr() decomposes into. This is the
+ * inverse of that accessor: a pose built here and decomposed there returns
+ * the angles it was given, modulo the wrap the decomposition applies and
+ * the gimbal-lock degeneracy at @p pitch = ±π/2, where yaw and roll are no
+ * longer separable.
+ * @param[in] gs 3D Point
+ * @param[in] yaw,pitch,roll Angles in radians
+ */
+Pose *
+pose_make_point3d_ypr(const GSERIALIZED *gs, double yaw, double pitch,
+  double roll)
+{
+  /* Ensure the validity of parameters */
+  VALIDATE_NOT_NULL(gs, NULL);
+  if (! ensure_not_empty(gs) || ! ensure_has_Z_geo(gs) ||
+      ! ensure_has_not_M_geo(gs))
+    return NULL;
+  if (! isfinite(yaw) || ! isfinite(pitch) || ! isfinite(roll))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The yaw, pitch and roll angles must be finite");
+    return NULL;
+  }
+
+  double W, X, Y, Z;
+  pose_ypr_to_quaternion(yaw, pitch, roll, &W, &X, &Y, &Z);
+  return pose_make_point3d(gs, W, X, Y, Z);
+}
+
+/**
+ * @ingroup meos_pose_base_constructor
  * @brief Copy a pose value
  * @param[in] pose Pose
  */
@@ -1069,6 +1161,44 @@ pose_quaternion(const Pose *pose, int *count)
 }
 
 /**
+ * @ingroup meos_pose_base_accessor
+ * @brief Return the orientation of a pose as a yaw / pitch / roll triple,
+ * in radians
+ * @details The three angles are returned in the order @p yaw, @p pitch,
+ * @p roll, the ZYX intrinsic Tait-Bryan decomposition the OGC GeoPose
+ * Basic-YPR conformance class prescribes. Unlike #pose_quaternion(), which
+ * reads an encoding only a 3D pose stores, this is defined for both
+ * dimensions: a 2D pose yaws by its stored angle and neither pitches nor
+ * rolls. The angles are in radians, where the GeoPose JSON encoding
+ * writes them in degrees.
+ * @param[in] pose Pose
+ * @param[out] count Number of elements in the output array
+ * @return On error return @p NULL
+ * @csqlfn #Pose_ypr()
+ */
+double *
+pose_ypr(const Pose *pose, int *count)
+{
+  /* The out parameter is defined even when a later check fails */
+  VALIDATE_NOT_NULL(count, NULL);
+  *count = 0;
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pose, NULL);
+
+  double *result = palloc(sizeof(double) * 3);
+  if (! MEOS_FLAGS_GET_Z(pose->flags))
+  {
+    result[0] = pose->data[2];
+    result[1] = result[2] = 0.0;
+  }
+  else
+    pose_quaternion_to_ypr(pose->data[3], pose->data[4], pose->data[5],
+      pose->data[6], &result[0], &result[1], &result[2]);
+  *count = 3;
+  return result;
+}
+
+/**
  * @ingroup meos_pose_base_geopose
  * @brief Return the yaw angle of a pose, in radians
  * @details For a 2D pose this is the stored rotation @p theta, which is by
@@ -1087,9 +1217,10 @@ pose_yaw(const Pose *pose)
 
   if (! MEOS_FLAGS_GET_Z(pose->flags))
     return pose->data[2];
-  double W = pose->data[3], X = pose->data[4];
-  double Y = pose->data[5], Z = pose->data[6];
-  return atan2(2.0 * (W * Z + X * Y), 1.0 - 2.0 * (Y * Y + Z * Z));
+  double yaw, pitch, roll;
+  pose_quaternion_to_ypr(pose->data[3], pose->data[4], pose->data[5],
+    pose->data[6], &yaw, &pitch, &roll);
+  return yaw;
 }
 
 /**
@@ -1111,12 +1242,10 @@ pose_pitch(const Pose *pose)
 
   if (! MEOS_FLAGS_GET_Z(pose->flags))
     return 0.0;
-  double W = pose->data[3], X = pose->data[4];
-  double Y = pose->data[5], Z = pose->data[6];
-  double sinp = 2.0 * (W * Y - Z * X);
-  if (sinp >  1.0) sinp =  1.0;
-  if (sinp < -1.0) sinp = -1.0;
-  return asin(sinp);
+  double yaw, pitch, roll;
+  pose_quaternion_to_ypr(pose->data[3], pose->data[4], pose->data[5],
+    pose->data[6], &yaw, &pitch, &roll);
+  return pitch;
 }
 
 /**
@@ -1136,9 +1265,10 @@ pose_roll(const Pose *pose)
 
   if (! MEOS_FLAGS_GET_Z(pose->flags))
     return 0.0;
-  double W = pose->data[3], X = pose->data[4];
-  double Y = pose->data[5], Z = pose->data[6];
-  return atan2(2.0 * (W * X + Y * Z), 1.0 - 2.0 * (X * X + Y * Y));
+  double yaw, pitch, roll;
+  pose_quaternion_to_ypr(pose->data[3], pose->data[4], pose->data[5],
+    pose->data[6], &yaw, &pitch, &roll);
+  return roll;
 }
 
 /**

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -193,47 +193,6 @@ geopose_get_number(json_object *obj, const char *name, double *out)
   return true;
 }
 
-/**
- * @brief Convert (yaw, pitch, roll) — radians, ZYX intrinsic Tait-Bryan
- * convention — to a unit quaternion (W, X, Y, Z) in Hamilton convention.
- * @details ZYX order matches the OGC GeoPose spec (yaw about Z, then
- * pitch about new Y, then roll about new X). The output is unit-norm by
- * construction (modulo float rounding).
- */
-static void
-geopose_ypr_to_quaternion(double yaw_rad, double pitch_rad, double roll_rad,
-  double *W, double *X, double *Y, double *Z)
-{
-  double cy = cos(yaw_rad   * 0.5), sy = sin(yaw_rad   * 0.5);
-  double cp = cos(pitch_rad * 0.5), sp = sin(pitch_rad * 0.5);
-  double cr = cos(roll_rad  * 0.5), sr = sin(roll_rad  * 0.5);
-  *W = cr * cp * cy + sr * sp * sy;
-  *X = sr * cp * cy - cr * sp * sy;
-  *Y = cr * sp * cy + sr * cp * sy;
-  *Z = cr * cp * sy - sr * sp * cy;
-}
-
-/**
- * @brief Convert a unit quaternion (W, X, Y, Z, Hamilton convention) to
- * (yaw, pitch, roll) in radians, ZYX intrinsic Tait-Bryan convention.
- * @details The pitch term is clamped to [-1, 1] before `asin` to absorb
- * the small numeric drift `|q| - 1 = O(1e-15)` that long quaternion
- * compositions can introduce.
- */
-static void
-geopose_quaternion_to_ypr(double W, double X, double Y, double Z,
-  double *yaw_rad, double *pitch_rad, double *roll_rad)
-{
-  double sinp = 2.0 * (W * Y - Z * X);
-  if (sinp > 1.0)  sinp = 1.0;
-  if (sinp < -1.0) sinp = -1.0;
-  *pitch_rad = asin(sinp);
-  *roll_rad  = atan2(2.0 * (W * X + Y * Z),
-                     1.0 - 2.0 * (X * X + Y * Y));
-  *yaw_rad   = atan2(2.0 * (W * Z + X * Y),
-                     1.0 - 2.0 * (Y * Y + Z * Z));
-}
-
 /* Serialization flags: compact, and with '/' left unescaped so that the
  * emitted authority strings read as the standard writes them. */
 #define GEOPOSE_JSON_FLAGS \
@@ -375,7 +334,7 @@ geopose_pose_components(const Pose *pose, double *lon, double *lat, double *h,
   }
   else
     /* 2D pose: pure yaw rotation about the local vertical. */
-    geopose_ypr_to_quaternion(pose->data[2], 0.0, 0.0, W, X, Y, Z);
+    pose_ypr_to_quaternion(pose->data[2], 0.0, 0.0, W, X, Y, Z);
   return true;
 }
 
@@ -600,7 +559,7 @@ pose_from_geopose_object(json_object *root)
     else
     {
       double W, X, Y, Z;
-      geopose_ypr_to_quaternion(GEOPOSE_DEG2RAD(yaw_deg),
+      pose_ypr_to_quaternion(GEOPOSE_DEG2RAD(yaw_deg),
         GEOPOSE_DEG2RAD(pitch_deg), GEOPOSE_DEG2RAD(roll_deg),
         &W, &X, &Y, &Z);
       result = pose_make_3d(lon, lat, h, W, X, Y, Z, true,
@@ -726,7 +685,7 @@ pose_to_geopose_object(const Pose *pose, int conformance, int precision)
   else /* GEOPOSE_BASIC_YPR */
   {
     double yaw_rad, pitch_rad, roll_rad;
-    geopose_quaternion_to_ypr(W, X, Y, Z, &yaw_rad, &pitch_rad, &roll_rad);
+    pose_quaternion_to_ypr(W, X, Y, Z, &yaw_rad, &pitch_rad, &roll_rad);
     json_object *ja = json_object_new_object();
     json_object_object_add(ja, "yaw",
       geopose_new_double(GEOPOSE_RAD2DEG(yaw_rad), precision));

--- a/mobilitydb/sql/pose/100_pose.in.sql
+++ b/mobilitydb/sql/pose/100_pose.in.sql
@@ -191,6 +191,14 @@ CREATE FUNCTION pose(geometry, double precision, double precision,
   AS 'MODULE_PATHNAME', 'Pose_constructor_point'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- The OGC GeoPose Basic-YPR encoding of the same orientation: yaw, pitch
+-- and roll in radians, ZYX intrinsic Tait-Bryan.
+CREATE FUNCTION pose(geometry, yaw double precision, pitch double precision,
+    roll double precision)
+  RETURNS pose
+  AS 'MODULE_PATHNAME', 'Pose_constructor_point_ypr'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /*****************************************************************************
  * Conversions
  *****************************************************************************/
@@ -241,6 +249,17 @@ CREATE TYPE quaternion AS (
 CREATE FUNCTION quaternion(pose)
   RETURNS quaternion
   AS 'MODULE_PATHNAME', 'Pose_quaternion'
+  LANGUAGE C IMMUTABLE STRICT;
+
+CREATE TYPE ypr AS (
+  yaw float,
+  pitch float,
+  roll float
+);
+
+CREATE FUNCTION ypr(pose)
+  RETURNS ypr
+  AS 'MODULE_PATHNAME', 'Pose_ypr'
   LANGUAGE C IMMUTABLE STRICT;
 
 /*****************************************************************************

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -446,6 +446,24 @@ Pose_constructor_point(PG_FUNCTION_ARGS)
   PG_RETURN_POINTER(result);
 }
 
+PGDLLEXPORT Datum Pose_constructor_point_ypr(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pose_constructor_point_ypr);
+/**
+ * @ingroup mobilitydb_pose_base_constructor
+ * @brief Construct a 3D pose value from a 3D point and a yaw / pitch / roll
+ * triple
+ * @sqlfn pose()
+ */
+Datum
+Pose_constructor_point_ypr(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+  double yaw = PG_GETARG_FLOAT8(1);
+  double pitch = PG_GETARG_FLOAT8(2);
+  double roll = PG_GETARG_FLOAT8(3);
+  PG_RETURN_POINTER(pose_make_point3d_ypr(gs, yaw, pitch, roll));
+}
+
 /*****************************************************************************
  * Conversion functions
  *****************************************************************************/
@@ -586,6 +604,43 @@ Pose_quaternion(PG_FUNCTION_ARGS)
   values[1] = Float8GetDatum(quaternion[1]);
   values[2] = Float8GetDatum(quaternion[2]);
   values[3] = Float8GetDatum(quaternion[3]);
+  /* Create a new tuple */
+  tuple = heap_form_tuple(tupdesc, values, nulls);
+  /* Return the tuple */
+  PG_RETURN_DATUM(HeapTupleGetDatum(tuple));
+}
+
+PGDLLEXPORT Datum Pose_ypr(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pose_ypr);
+/**
+ * @ingroup mobilitydb_pose_base_accessor
+ * @brief Return the orientation of a pose as a yaw / pitch / roll triple,
+ * in radians
+ * @sqlfn ypr()
+ */
+Datum
+Pose_ypr(PG_FUNCTION_ARGS)
+{
+  /* Define the return type properties */
+  TupleDesc tupdesc;
+  HeapTuple tuple;
+  Datum values[3];
+  bool nulls[3] = { false, false, false }; // Assume no nulls
+  /* Define the structure of the returned tuple */
+  tupdesc = CreateTemplateTupleDesc(3);
+  TupleDescInitEntry(tupdesc, (AttrNumber) 1, "yaw", FLOAT8OID, -1, 0);
+  TupleDescInitEntry(tupdesc, (AttrNumber) 2, "pitch", FLOAT8OID, -1, 0);
+  TupleDescInitEntry(tupdesc, (AttrNumber) 3, "roll", FLOAT8OID, -1, 0);
+  BlessTupleDesc(tupdesc);
+  /* Get input pose */
+  Pose *pose = PG_GETARG_POSE_P(0);
+  /* Get the array of doubles representing the angles */
+  int count;
+  double *angles = pose_ypr(pose, &count);
+  /* Create values for the tuple */
+  values[0] = Float8GetDatum(angles[0]);
+  values[1] = Float8GetDatum(angles[1]);
+  values[2] = Float8GetDatum(angles[2]);
   /* Create a new tuple */
   tuple = heap_form_tuple(tupdesc, values, nulls);
   /* Return the tuple */

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -74,6 +74,35 @@ SELECT pose('Point(1 1)',-1.5);
  POSE (0101000000000000000000F03F000000000000F03F, -1.5)
 (1 row)
 
+SELECT asText(pose(ST_PointZ(1,1,1), 0, 0, 0));
+            astext             
+-------------------------------
+ Pose(POINT Z (1 1 1),1,0,0,0)
+(1 row)
+
+SELECT asText(pose(ST_PointZ(1,1,1), radians(90), 0, 0), 6);
+                   astext                    
+---------------------------------------------
+ Pose(POINT Z (1 1 1),0.707107,0,0,0.707107)
+(1 row)
+
+SELECT asText(pose(ST_PointZ(1,1,1), radians(30), radians(45), radians(60)), 6);
+                         astext                          
+---------------------------------------------------------
+ Pose(POINT Z (1 1 1),0.822363,0.360423,0.43968,0.02226)
+(1 row)
+
+SELECT round(degrees(yaw(pose(ST_PointZ(0,0,0), radians(30), radians(45),
+  radians(60))))::numeric, 6);
+   round   
+-----------
+ 30.000000
+(1 row)
+
+SELECT asText(pose(ST_Point(1,1), 0, 0, 0));
+ERROR:  The geometry must have Z dimension
+SELECT asText(pose(ST_PointZ(1,1,1), 'NaN', 0, 0));
+ERROR:  The yaw, pitch and roll angles must be finite
 SELECT ST_AsText(point(pose 'Pose(Point(1 1),0.5)'));
  st_astext  
 ------------
@@ -148,6 +177,26 @@ SELECT quaternion(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)');
 
 SELECT quaternion(pose 'Pose(Point(1 1),0.5)');
 ERROR:  The pose must have Z dimension
+SELECT ypr(pose 'Pose(Point(1 1),0.5)');
+    ypr    
+-----------
+ (0.5,0,0)
+(1 row)
+
+SELECT ypr(pose 'Pose(Point Z(1 1 1), 1, 0, 0, 0)');
+   ypr   
+---------
+ (0,0,0)
+(1 row)
+
+SELECT round(degrees((ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)')).yaw)::numeric, 6),
+  round(degrees((ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)')).pitch)::numeric, 6),
+  round(degrees((ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)')).roll)::numeric, 6);
+   round   |  round   |   round   
+-----------+----------+-----------
+ 90.000000 | 0.000000 | 90.000000
+(1 row)
+
 SELECT asText(round(pose 'Pose(Point(1.123456789 1.123456789), 0.123456789)', 6));
                  astext                  
 -----------------------------------------

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -57,6 +57,20 @@ SELECT pose(geography 'Point(1 1)',1.5);
 \set VERBOSITY default
 SELECT pose('Point(1 1)',-1.5);
 
+-- The Basic-YPR constructor: the orientation given as yaw, pitch and roll
+-- in radians rather than as a quaternion.
+SELECT asText(pose(ST_PointZ(1,1,1), 0, 0, 0));
+SELECT asText(pose(ST_PointZ(1,1,1), radians(90), 0, 0), 6);
+SELECT asText(pose(ST_PointZ(1,1,1), radians(30), radians(45), radians(60)), 6);
+-- It round-trips against the ypr accessor.
+SELECT round(degrees(yaw(pose(ST_PointZ(0,0,0), radians(30), radians(45),
+  radians(60))))::numeric, 6);
+\set VERBOSITY terse
+-- A 2D point has no 3D orientation to carry.
+SELECT asText(pose(ST_Point(1,1), 0, 0, 0));
+SELECT asText(pose(ST_PointZ(1,1,1), 'NaN', 0, 0));
+\set VERBOSITY default
+
 -------------------------------------------------------------------------------
 -- Accessing values
 -------------------------------------------------------------------------------
@@ -87,6 +101,16 @@ SELECT quaternion(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)');
 \set VERBOSITY terse
 SELECT quaternion(pose 'Pose(Point(1 1),0.5)');
 \set VERBOSITY default
+
+-- The same orientation in the other GeoPose encoding. Defined for both
+-- dimensions: a 2D pose yaws by its stored angle and neither pitches nor
+-- rolls.
+SELECT ypr(pose 'Pose(Point(1 1),0.5)');
+SELECT ypr(pose 'Pose(Point Z(1 1 1), 1, 0, 0, 0)');
+-- Bounded in degrees: an unbounded pi/2 would drift across libm.
+SELECT round(degrees((ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)')).yaw)::numeric, 6),
+  round(degrees((ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)')).pitch)::numeric, 6),
+  round(degrees((ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)')).roll)::numeric, 6);
 
 -------------------------------------------------------------------------------
 -- Modification functions

--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -707,6 +707,9 @@ TPOSE_CONFIG = dict(
         # point geometry.
         "pose_make_3d":      {3: "1.0", 4: "0.0", 5: "0.0", 6: "0.0"},
         "pose_make_point3d": {0: "geom_pointz1", 1: "1.0", 2: "0.0", 3: "0.0", 4: "0.0"},
+        # The YPR constructor needs the same 3D point; its angles are plain
+        # radians, so the default "double -> 1.0" mapping is already valid.
+        "pose_make_point3d_ypr": {0: "geom_pointz1"},
         # pose_quaternion reads a 3D pose's quaternion.
         "pose_quaternion":   {0: "pose3d1"},
         # tpose_make(tpoint, tradius): a temporal geometry point and a temporal


### PR DESCRIPTION
OGC GeoPose v1.0 prescribes two encodings of an orientation, a unit quaternion and a yaw / pitch / roll triple, and the surface answers them asymmetrically: the quaternion comes back whole, as one composite value, while the angles come back one at a time; and the conversion between the two runs only inside the JSON reader and writer, so a caller holding yaw, pitch and roll reaches a pose only by composing a GeoPose document and parsing it back.

This gives the YPR encoding the same standing as the quaternion.

- `ypr(pose) → ypr` returns the triple as one composite value, the counterpart of `quaternion(pose)`. Unlike the quaternion, which is an encoding only a 3D pose stores, it is defined for both dimensions: a 2D pose yaws by its stored angle and neither pitches nor rolls.
- `pose(geompoint3D, yaw, pitch, roll)` builds a pose from the angles, the inverse of that accessor and the direction the surface lacks. Three floats after a geometry, so it stands apart from the one-float 2D form and the four-float quaternion form.

The conversion between the two encodings gets a single home in `pose.c`. It exists in two copies: one inside the GeoPose JSON code, another spread over the `yaw`, `pitch` and `roll` accessors, which each carry their own copy of one component of the same decomposition. Both call the one kernel, so the accessors and the JSON writer cannot drift apart.

The angles are in radians, the unit the pose stores its 2D rotation in, where the GeoPose JSON encoding writes them in degrees. The manual states this on both sides.

The EN and ES chapters move together. `doc/es/reference.xml` carries no GeoPose section at all — the whole EN "Euler-Angle Accessors" group is absent from the Spanish index — so the ES index row for `ypr` has no group to join. Backfilling that group belongs to a separate doc PR.