### PR TITLE
Read the h3 parser rejection from its state code, not from its message

### DIFF
--- a/mobilitydb/test/h3/expected/250_h3index.test.out
+++ b/mobilitydb/test/h3/expected/250_h3index.test.out
@@ -23,6 +23,10 @@ SELECT (622236750694711295::bigint::h3index)::bigint = 622236750694711295;
 (1 row)
 
 /* Errors */
+-- The message, the position and the hint of the rejection are the h3
+-- extension's, which the suite takes from the environment rather than pinning,
+-- and their wording differs between its releases. The state code is the part
+-- an extension keeps, so the rejection is read from that alone
 SELECT h3index '0';
  h3index 
 ---------
@@ -30,10 +34,7 @@ SELECT h3index '0';
 (1 row)
 
 SELECT h3index 'not-a-hex-cell';
-ERROR:  error code: 1
-LINE 1: SELECT h3index 'not-a-hex-cell';
-                       ^
-HINT:  https://h3geo.org/docs/library/errors#table-of-error-codes
+ERROR:  38000
 SELECT h3index '12345';
  h3index 
 ---------

--- a/mobilitydb/test/h3/queries/250_h3index.test.sql
+++ b/mobilitydb/test/h3/queries/250_h3index.test.sql
@@ -28,9 +28,15 @@ SELECT h3index '622236750694711295';
 SELECT (622236750694711295::bigint::h3index)::bigint = 622236750694711295;
 
 /* Errors */
+-- The message, the position and the hint of the rejection are the h3
+-- extension's, which the suite takes from the environment rather than pinning,
+-- and their wording differs between its releases. The state code is the part
+-- an extension keeps, so the rejection is read from that alone
+\set VERBOSITY sqlstate
 SELECT h3index '0';
 SELECT h3index 'not-a-hex-cell';
 SELECT h3index '12345';   -- not a valid H3 cell
+\set VERBOSITY default
 
 -------------------------------------------------------------------------------
 -- Values the h3 extension's parser admits are rejected where they enter a


### PR DESCRIPTION
The h3index literal is parsed by the input function of the h3 extension, and
the suite takes that extension from the environment rather than pinning a
version of it: the workflow installs the distribution package, while the tree
carries a source subtree of h3-pg that the maintainer tooling imports from and
the build never installs. The expected output nevertheless records the
message, the position and the hint the extension prints when it rejects a
spelling, and those change between its releases -- one release answers
`error code: 1` and another answers `H3 error 1: The operation failed but a
more specific error is not available` -- so the suite fails on the version it
does not happen to record, on a wording MobilityDB neither owns nor can fix.

Read the rejection under the sqlstate verbosity, which prints the state code
alone. The state code is the part an extension keeps stable, being what a
caller matches on, and it carries what the test asserts: that this spelling is
rejected where the two beside it are admitted. The sibling cases that report
MobilityDB's own message, the h3indexset elements and the th3index values that
enter through the MEOS parser, keep recording it, since that message is ours
to hold.