### PR TITLE
Answer the shortest line to a circular buffer from the two disks

### DIFF
--- a/doc/contributing/distance_design_notes.md
+++ b/doc/contributing/distance_design_notes.md
@@ -384,6 +384,16 @@ to the boundary of the other, at the instant where the temporal distance is
 least; overlapping or concentric discs meet, and it degenerates to the point
 where the boundary of the first reaches the second.
 
+The centre is not the only substitution that breaks the identity. Rendering the
+operands — stroking the static disc into a polygon and materialising the moving
+one as its traversed area, then handing both to a geometry-to-geometry shortest
+line — measures between two polygonal approximations of the pair. Its endpoints
+sit on approximating chords rather than on the two boundaries, and its length
+answers neither the exact question nor the scalar the family reports. The
+rendering also costs more than the closed form it replaces, so the exactness
+carries no price: a static disc is a constant temporal circular buffer, and
+delegating to the two-temporal kernel gives the line directly.
+
 The same reasoning governs a fallback. When a geometry has no edge decomposition
 the nearest approach distance falls back to the exact traversed area, so the
 nearest approach *instant* must fall back to something that agrees with it —
@@ -394,7 +404,16 @@ argmin moves away from it as soon as the radius varies.
 of the shortest line equals the nearest approach distance, and the distance at
 the nearest approach instant equals it too.** Both hold by construction when the
 witness is read from the same signed gap as the scalar (§2), and both fail
-loudly when a centre has been substituted for a value.
+loudly when a centre or a rendering stands in for a value.
+
+Run the check as a census, not as a spot test. Counting the pairs of a real
+join on which the two disagree separates a witness that is wrong everywhere
+from one that is wrong on a configuration the fixtures miss, and it names the
+operand the defect belongs to: over a 100 by 100 join of vessel trajectories,
+the identity holds on every pair for the geometry operand and for the moving
+one, and fails on 9951 of 10000 for the static circular buffer. A fixture file
+whose cases all agree with an approximation leaves the approximation no trace,
+which is why the pairs that separate the two readings are the ones to pin.
 
 ### Where a zero radius stops being a temporal point
 

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -2295,10 +2295,14 @@ shortestline_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
   if (! ensure_valid_tcbuffer_cbuffer(temp, cb))
     return NULL;
 
-  GSERIALIZED *geom = cbuffer_to_geom(cb);
-  GSERIALIZED *trav = tcbuffer_traversed_area(temp, false);
-  GSERIALIZED *result = geom_shortestline2d(trav, geom);
-  pfree(geom); pfree(trav);
+  /* A static disc is a constant temporal circular buffer, so the line is the
+   * one the two-temporal kernel computes in closed form from the two disks.
+   * Rendering the disc and the traversed area as polygons instead measures
+   * between two polygonal approximations, and the line it returns is not the
+   * one realising the nearest approach distance of the same pair. */
+  Temporal *ctemp = tcbuffer_from_base_temp(cb, temp);
+  GSERIALIZED *result = shortestline_tcbuffer_tcbuffer(temp, ctemp);
+  pfree(ctemp);
   return result;
 }
 

--- a/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
@@ -257,8 +257,8 @@ CREATE FUNCTION shortestLine(stbox, tcbuffer)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION shortestLine(cbuffer, tcbuffer)
   RETURNS geometry
-  AS 'SELECT @extschema@.shortestLine(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Shortestline_cbuffer_tcbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tcbuffer, geometry)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_tcbuffer_geo'
@@ -269,8 +269,8 @@ CREATE FUNCTION shortestLine(tcbuffer, stbox)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tcbuffer, cbuffer)
   RETURNS geometry
-  AS 'SELECT @extschema@.shortestLine($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Shortestline_tcbuffer_cbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tcbuffer, tcbuffer)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_tcbuffer_tcbuffer'

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -739,6 +739,48 @@ SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01
  7.800000
 (1 row)
 
+SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]', cbuffer 'Cbuffer(Point(5 6), 2)'));
+      st_astext      
+---------------------
+ LINESTRING(5 1,5 4)
+(1 row)
+
+SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]', cbuffer 'Cbuffer(Point(5 6), 2)'))::numeric, 6);
+  round   
+----------
+ 3.000000
+(1 row)
+
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]', cbuffer 'Cbuffer(Point(5 6), 2)')::numeric, 6);
+  round   
+----------
+ 3.000000
+(1 row)
+
+SELECT ST_AsText(shortestLine(cbuffer 'Cbuffer(Point(5 6), 2)', tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]'));
+      st_astext      
+---------------------
+ LINESTRING(5 1,5 4)
+(1 row)
+
+SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 3)@2000-01-01, Cbuffer(Point(10 0), 3)@2000-01-02]', cbuffer 'Cbuffer(Point(5 4), 2)'));
+          st_astext          
+-----------------------------
+ LINESTRING(3.8 2.4,3.8 2.4)
+(1 row)
+
+SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 5)@2000-01-05]', cbuffer 'Cbuffer(Point(5 6), 0)'))::numeric, 6);
+  round   
+----------
+ 2.499091
+(1 row)
+
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 5)@2000-01-05]', cbuffer 'Cbuffer(Point(5 6), 0)')::numeric, 6);
+  round   
+----------
+ 2.499091
+(1 row)
+
 SELECT geometrytype(shortestLine(tcbuffer 'Cbuffer(Point(0 0), 1)@2000-01-01', geometry 'Polygon((5 5,5 8,8 8,8 5,5 5))'));
  geometrytype 
 --------------

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -315,6 +315,24 @@ SELECT nearestApproachDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', c
 -- A buffer beside the path: the distance is the centre distance less both radii
 SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)')::numeric, 6);
 
+-- The shortest line against a static circular buffer runs between the two disk
+-- boundaries, so its length is the nearest approach distance of the same pair.
+-- Reading the disc and the traversed area as polygons measures between two
+-- polygonal approximations and answers neither. A disk of radius 1 passing a
+-- disk of radius 2 six units away has a nearest approach of 3 at the midpoint,
+-- where the line leaves (5 1) and reaches (5 4)
+SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]', cbuffer 'Cbuffer(Point(5 6), 2)'));
+SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]', cbuffer 'Cbuffer(Point(5 6), 2)'))::numeric, 6);
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]', cbuffer 'Cbuffer(Point(5 6), 2)')::numeric, 6);
+-- The two argument orders name the same line
+SELECT ST_AsText(shortestLine(cbuffer 'Cbuffer(Point(5 6), 2)', tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]'));
+-- Disks that meet: the line degenerates where the boundary of one reaches the other
+SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 3)@2000-01-01, Cbuffer(Point(10 0), 3)@2000-01-02]', cbuffer 'Cbuffer(Point(5 4), 2)'));
+-- A radius that varies over the segment carries the witness off the midpoint,
+-- as it does for the nearest approach distance the line must realise
+SELECT round(ST_Length(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 5)@2000-01-05]', cbuffer 'Cbuffer(Point(5 6), 0)'))::numeric, 6);
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 5)@2000-01-05]', cbuffer 'Cbuffer(Point(5 6), 0)')::numeric, 6);
+
 -------------------------------------------------------------------------------
 
 -- Analytic shortestLine: its length equals the nearest-approach distance;


### PR DESCRIPTION
The shortest line between a temporal circular buffer and a static circular
buffer is composed in SQL as `shortestLine($1, geometry($2))`, which strokes
the disc into a ring and hands it to the geometry overload; that overload
materialises the moving operand as its traversed area, so the line is measured
between two polygonal approximations. Its endpoints sit on approximating
chords rather than on the two boundaries, and its length is not the nearest
approach distance the scalar reports for the same pair: a disc of radius 1
passing a disc of radius 2 six units away returns LINESTRING(3 1,3 6),
measuring 5 against a nearest approach distance of 3.

A static disc is a constant temporal circular buffer, which is how the nearest
approach distance and the nearest approach instant of the same operands
already read it, so the line is the one the two-temporal kernel gives in
closed form: along the line of centres, from the boundary of one disk to the
boundary of the other, at the instant where the temporal distance is least.
The same pair measures 3 on LINESTRING(5 1,5 4).

Answer it there and bind the two signatures to the wrappers that reach it.
Both wrappers exist and neither is reachable, the compositions standing in
front of them, so the kernel alone leaves the SQL surface answering as before.
Disks that overlap meet, and the line degenerates to the point where the
boundary of the first reaches the second, taken at the earliest instant of
contact as the running minimum reports it.

Over a 100 by 100 join of vessel trajectories against natural-area discs the
length of the line and the nearest approach distance disagree on 9951 of the
10000 pairs, by as much as 47044.5, and agree on all of them once the line is
read from the disks. The geometry operand and the two-temporal pair hold the
identity throughout, which is what locates the defect on this one operand.

The test file gains the cases the identity turns on, a passing disc measured
against its own nearest approach distance in both argument orders, disks that
meet, and a radius that varies over the segment.

The distance design notes gain the rendering trap beside the centre one they
already carry, and the rule that the identity is read as a census over a join
rather than as a spot test, since a fixture file that agrees with an
approximation leaves it no trace.