### PR TITLE
Hold the pose unit-norm invariant on both 3D constructors

### DIFF
--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -912,32 +912,13 @@ pose_make_point3d(const GSERIALIZED *gs, double W, double X, double Y,
       ! ensure_has_Z_geo(gs) || ! ensure_has_not_M_geo(gs))
     return NULL;
 
-  /* Ensure a unique representation for the quaternion */
-  if (W < 0.0)
-  {
-    W = -W;
-    X = -X;
-    Y = -Y;
-    Z = -Z;
-  }
-
+  /* The point supplies the position, the frame and the geodetic flag; the
+   * quaternion is renormalized and canonicalized by the constructor that
+   * owns those invariants. */
   const POINT4D *p = (const POINT4D *) GS_POINT_PTR(gs);
-  const double * coordarr = (const double *) p;
-  size_t memsize = DOUBLE_PAD(sizeof(Pose)) + 7 * sizeof(double);
-  Pose *result = palloc0(memsize);
-  SET_VARSIZE(result, memsize);
-  MEOS_FLAGS_SET_X(result->flags, true);
-  MEOS_FLAGS_SET_Z(result->flags, true);
-  MEOS_FLAGS_SET_GEODETIC(result->flags, FLAGS_GET_GEODETIC(gs->gflags));
-  pose_set_srid_int(result, gserialized_get_srid(gs));
-  result->data[0] = coordarr[0];
-  result->data[1] = coordarr[1];
-  result->data[2] = coordarr[2];
-  result->data[3] = W;
-  result->data[4] = X;
-  result->data[5] = Y;
-  result->data[6] = Z;
-  return result;
+  const double *coordarr = (const double *) p;
+  return pose_make_3d(coordarr[0], coordarr[1], coordarr[2], W, X, Y, Z,
+    FLAGS_GET_GEODETIC(gs->gflags), gserialized_get_srid(gs));
 }
 
 /**

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -221,6 +221,18 @@ SELECT asText(poseNormalize(pose 'Pose(Point(1 1 1), 0.5, 0.5, 0.5, 0.5)'));
  Pose(POINT Z (1 1 1),0.5,0.5,0.5,0.5)
 (1 row)
 
+SELECT asText(pose(1, 1, 1, 1.0005, 0, 0, 0), 12);
+            astext             
+-------------------------------
+ Pose(POINT Z (1 1 1),1,0,0,0)
+(1 row)
+
+SELECT asText(pose(ST_PointZ(1,1,1), 1.0005, 0, 0, 0), 12);
+            astext             
+-------------------------------
+ Pose(POINT Z (1 1 1),1,0,0,0)
+(1 row)
+
 SELECT ST_AsText(round(pose 'Pose(Point(1 1),0.2)'::geometry, 6));
  st_astext  
 ------------

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -124,6 +124,12 @@ SELECT asText(poseNormalize(pose 'Pose(Point(1 1), 0.5)'));
 SELECT asText(poseNormalize(pose 'Pose(Point(1 1 1), 1, 0, 0, 0)'));
 SELECT asText(poseNormalize(pose 'Pose(Point(1 1 1), 0.5, 0.5, 0.5, 0.5)'));
 
+-- Both 3D constructors hold the unit-norm invariant: a quaternion within
+-- the accepted drift is renormalized before it is stored, whether the
+-- position arrives as coordinates or as a point geometry.
+SELECT asText(pose(1, 1, 1, 1.0005, 0, 0, 0), 12);
+SELECT asText(pose(ST_PointZ(1,1,1), 1.0005, 0, 0, 0), 12);
+
 -------------------------------------------------------------------------------
 -- Cast functions 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The manual states that the pose constructor accepts a quaternion whose norm is within `1e-3` of unit and renormalizes it to exactly unit norm before storing, so that comparison, hashing, SLERP and the Tait-Bryan decomposition rely on `|q| = 1`. `pose_make_3d` does that. `pose_make_point3d` validates the norm and then stores the components as they arrive, so the invariant holds or not depending on whether the caller passes coordinates or a point geometry.

`pose_make_point3d` reads the position, the frame and the geodetic flag off the geometry and hands the rest to `pose_make_3d`, which owns the norm and the `q <-> -q` canonicalization. The invariant has one implementation rather than one and a half.

The manual needs no change: it already describes this behaviour for the constructor as a whole.

A test covers both paths with a quaternion inside the accepted drift:

```
SELECT asText(pose(1, 1, 1, 1.0005, 0, 0, 0), 12);
--  Pose(POINT Z (1 1 1),1,0,0,0)
SELECT asText(pose(ST_PointZ(1,1,1), 1.0005, 0, 0, 0), 12);
--  Pose(POINT Z (1 1 1),1,0,0,0)
```