### PR TITLE
Test the box of a geometry before decomposing it in the clip engine

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1781,6 +1781,22 @@ tpoint_linear_inter_geom(const Temporal *temp, const GSERIALIZED *gs,
   bool clip)
 {
   assert(temp); assert(gs); assert(! gserialized_is_empty(gs));
+  /* Bounding box test, made before building the context so that a rejected
+   * pair does not pay for the decomposition of the geometry */
+  STBox box1, box2;
+  tspatial_set_stbox(temp, &box1);
+  geo_set_stbox(gs, &box2);
+  if (! overlaps_stbox_stbox(&box1, &box2))
+  {
+    if (clip)
+      return NULL;
+    SpanSet *ss = temporal_time(temp);
+    Temporal *result = (Temporal *) tsequenceset_from_base_tstzspanset(
+      BoolGetDatum(false), T_TBOOL, ss, STEP);
+    pfree(ss);
+    return result;
+  }
+
   void *ctx = geo_clip_ctx_make(gs);
   if (! ctx)
     return NULL;
@@ -2368,6 +2384,22 @@ tpoint_linear_dwithin_geom(const Temporal *temp, const GSERIALIZED *gs,
   double dist)
 {
   assert(temp); assert(gs); assert(! gserialized_is_empty(gs));
+  /* Bounding box test, made before building the context so that a rejected
+   * pair does not pay for the decomposition of the geometry. The geometry box
+   * is the one the within region reaches, so it is expanded by the distance */
+  STBox box1, box2, box2e;
+  tspatial_set_stbox(temp, &box1);
+  geo_set_stbox(gs, &box2);
+  stbox_expand_space_set(&box2, (dist > 0.0) ? dist : 0.0, &box2e);
+  if (! overlaps_stbox_stbox(&box1, &box2e))
+  {
+    SpanSet *ss = temporal_time(temp);
+    Temporal *result = (Temporal *) tsequenceset_from_base_tstzspanset(
+      BoolGetDatum(false), T_TBOOL, ss, STEP);
+    pfree(ss);
+    return result;
+  }
+
   void *ctx = geo_clip_ctx_make(gs);
   if (! ctx)
     return NULL;


### PR DESCRIPTION
The clip engine resolves a temporal point against a geometry through a
context carrying the geometry's box, its edge decomposition and the R-tree
indexing those edges, and the operations named without the ctx suffix build
one, use it and free it. Their bounding-box test reads the box out of that
context, so the pair the box rejects has already paid for the decomposition
and the index of a geometry it never touches. On a spatial join, where most
pairs stand apart, that is the whole cost: the temporal relationships of a
temporal point against a geometry spend the run building an index per
rejected pair, and a temporal circular buffer answers the same query faster
than the temporal point it carries.

Read the box off the geometry and test it before the context is built. It is
the geometry's own box either way, and it costs a header read against a
decomposition, so a rejected pair returns the constant false its own kernel
returns and an accepted one builds the context exactly as before. The
distance sibling expands the geometry box by the distance, which is the
region its within test reaches. The intersects leaf of the same engine
already tests the box ahead of the decomposition and says so in its comment;
the two temporal entry points now do the same.

On a 100 by 100 join of vessel trajectories against natural-area polygons,
best of three warm runs each: tIntersects 7.60 s to 3.79 s, tContains
11.84 s to 4.68 s, tDwithin 8.02 s to 4.23 s. The temporal point returns to
below the cost of the temporal circular buffer on the same query, which is
unchanged at 4.33 s and stands as the control, being the one relationship of
the four that does not reach this engine. A second reading of the base after
the branch measures 8.5 s against its first 7.6 s, so the machine drifts
upwards by about a tenth over the run and the ratios, not the absolute
times, are what carries.

All 10000 pairs of each of the four relationships return the identical
value, as a filter that only rejects pairs the kernel decides false cannot
change one.