### PR TITLE
Read the box of a geometry the clip engine can give one for

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1782,10 +1782,13 @@ tpoint_linear_inter_geom(const Temporal *temp, const GSERIALIZED *gs,
 {
   assert(temp); assert(gs); assert(! gserialized_is_empty(gs));
   /* Bounding box test, made before building the context so that a rejected
-   * pair does not pay for the decomposition of the geometry */
+   * pair does not pay for the decomposition of the geometry. An empty
+   * geometry has no box to read, and the context declines to build on one,
+   * so the test yields to it rather than reading a box that was never set */
   STBox box1, box2;
   tspatial_set_stbox(temp, &box1);
-  geo_set_stbox(gs, &box2);
+  if (! geo_set_stbox(gs, &box2))
+    return NULL;
   if (! overlaps_stbox_stbox(&box1, &box2))
   {
     if (clip)
@@ -2386,10 +2389,14 @@ tpoint_linear_dwithin_geom(const Temporal *temp, const GSERIALIZED *gs,
   assert(temp); assert(gs); assert(! gserialized_is_empty(gs));
   /* Bounding box test, made before building the context so that a rejected
    * pair does not pay for the decomposition of the geometry. The geometry box
-   * is the one the within region reaches, so it is expanded by the distance */
+   * is the one the within region reaches, so it is expanded by the distance.
+   * An empty geometry has no box to read, and the context declines to build
+   * on one, so the test yields to it rather than reading a box that was
+   * never set */
   STBox box1, box2, box2e;
   tspatial_set_stbox(temp, &box1);
-  geo_set_stbox(gs, &box2);
+  if (! geo_set_stbox(gs, &box2))
+    return NULL;
   stbox_expand_space_set(&box2, (dist > 0.0) ? dist : 0.0, &box2e);
   if (! overlaps_stbox_stbox(&box1, &box2e))
   {


### PR DESCRIPTION
The bounding-box test the two temporal entry points of the clip engine make
ahead of the context reads the geometry's box with geo_set_stbox, which
declines an empty geometry and leaves the box it was handed untouched. The
test then compares an STBox that was never set, and the pair is admitted or
rejected on whatever the stack held.

Take the answer the function returns. An empty geometry is the one case it
declines, the context declines to build on it for the same reason, and the
entry point already answers NULL when the context is not built, so yielding
there gives the caller what it gave before the box test moved in front.

The wrappers state a non-empty geometry as a precondition and every caller
of the four relationships tests geom_clip_supported before reaching them,
so this closes the gap between what the code asserts and what it survives
rather than a live defect.