### PR TITLE
Write a temporal pose as a whole OGC GeoPose Stream

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1594,6 +1594,9 @@
 					<listitem>
 						<para><link linkend="tpose_geopose_funcs"><varname>asGeoPose</varname>, <varname>tposeFromGeoPose</varname></link>: Convierte una pose temporal hacia o desde una envoltura JSON TemporalGeoPose. Cada carga útil por instante es un documento GeoPose de clase Basic estrictamente válido según OGC más un miembro <varname>validTime</varname>; la envoltura registra la clase de conformidad, la interpolación y (para secuencias y conjuntos de secuencias) la inclusión de los límites del período. Un consumidor GeoPose ajeno a MEOS puede iterar sobre <varname>instants[]</varname> (o cada <varname>sequences[].instants[]</varname>) y consumir cada elemento como un documento GeoPose estático.</para>
 					</listitem>
+					<listitem>
+						<para><link linkend="tpose_geopose_stream"><varname>asGeoPoseStream</varname></link>: Escribe una pose temporal como un Stream de OGC GeoPose</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 		</sect2>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -1477,6 +1477,23 @@ SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01,
 --     "validTime":"2026-01-02"}]}
 </programlisting>
 				</listitem>
+
+				<listitem xml:id="tpose_geopose_stream">
+					<indexterm significance="normal"><primary><varname>asGeoPoseStream</varname></primary></indexterm>
+					<para>Escribe una pose temporal como un Stream de OGC GeoPose</para>
+					<para><varname>asGeoPoseStream(tpose,maxdecimaldigits int4=-1) → text</varname></para>
+					<para>Un stream lleva los marcos de una Serie Irregular sin declarar cuántas poses hay ni cuándo terminan, ya que pueden llegar más. El estándar lo escribe como un <varname>header</varname>, que contiene el modelo de transición y el marco exterior, y un arreglo <varname>streamElements</varname> con un elemento por pose. El marco exterior es el plano tangente local Este-Norte-Arriba en la posición de la primera pose, de modo que la cabecera y cada elemento hablan de un mismo punto de tangencia.</para>
+					<para>La biblioteca C también escribe los dos documentos por partes, mediante <varname>tpose_as_geopose_stream_header</varname> y <varname>tpose_as_geopose_stream_element</varname>, para un productor que emite poses a medida que llegan. Una consulta devuelve un valor que ya posee entero, que es lo que esta función escribe.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPoseStream(tpose 'Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01', 6);
+/* {"header":{"transitionModel":{"authority":"/geopose/1.0","id":"none",
+   "parameters":"interpolation=None"},"outerFrame":{"authority":"/geopose/1.0",
+   "id":"LTP-ENU","parameters":"longitude=0&amp;latitude=0&amp;height=0&amp;crs=EPSG:4979"}},
+   "streamElements":[{"streamElement":{"frame":{"authority":"/geopose/1.0",
+   "id":"RotateTranslate","parameters":"translation=[0, 0, 0]&amp;rotation=[1, 0, 0, 0]"},
+   "validTime":1767254400000}}]} */
+</programlisting>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1605,6 +1605,9 @@
 					<listitem>
 						<para><link linkend="tpose_geopose_funcs"><varname>asGeoPose</varname>, <varname>tposeFromGeoPose</varname></link>: Convert a temporal pose to or from its OGC GeoPose v1.0 encoding</para>
 					</listitem>
+					<listitem>
+						<para><link linkend="tpose_geopose_stream"><varname>asGeoPoseStream</varname></link>: Write a temporal pose as an OGC GeoPose Stream</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 		</sect2>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1555,6 +1555,23 @@ SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01,
 --     "validTime":"2026-01-02"}]}
 </programlisting>
 				</listitem>
+
+				<listitem xml:id="tpose_geopose_stream">
+					<indexterm significance="normal"><primary><varname>asGeoPoseStream</varname></primary></indexterm>
+					<para>Write a temporal pose as an OGC GeoPose Stream</para>
+					<para><varname>asGeoPoseStream(tpose,maxdecimaldigits int4=-1) → text</varname></para>
+					<para>A stream carries the frames of an Irregular Series while stating neither how many poses there are nor when they end, since more may arrive. The standard writes it as a <varname>header</varname>, holding the transition model and the outer frame, and a <varname>streamElements</varname> array holding one element per pose. The outer frame is the local tangent plane East-North-Up frame at the position of the first pose, so the header and every element speak of one tangent point.</para>
+					<para>The C library also writes the two documents a piece at a time, through <varname>tpose_as_geopose_stream_header</varname> and <varname>tpose_as_geopose_stream_element</varname>, for a producer emitting poses as they arrive. A query returns a value it already holds whole, which is what this writes.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPoseStream(tpose 'Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01', 6);
+/* {"header":{"transitionModel":{"authority":"/geopose/1.0","id":"none",
+   "parameters":"interpolation=None"},"outerFrame":{"authority":"/geopose/1.0",
+   "id":"LTP-ENU","parameters":"longitude=0&amp;latitude=0&amp;height=0&amp;crs=EPSG:4979"}},
+   "streamElements":[{"streamElement":{"frame":{"authority":"/geopose/1.0",
+   "id":"RotateTranslate","parameters":"translation=[0, 0, 0]&amp;rotation=[1, 0, 0, 0]"},
+   "validTime":1767254400000}}]} */
+</programlisting>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -116,6 +116,7 @@ extern Temporal *tpose_from_geopose(const char *json);
 extern char *tpose_as_geopose(const Temporal *temp, int conformance, int precision);
 extern char *tpose_as_geopose_stream_header(const Temporal *temp, int precision);
 extern char *tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst, int precision);
+extern char *tpose_as_geopose_stream(const Temporal *temp, int precision);
 extern GSERIALIZED *pose_apply_geo(const Pose *pose, const GSERIALIZED *body);
 extern Temporal *tpose_apply_geo(const Temporal *temp, const GSERIALIZED *body);
 

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -1607,6 +1607,39 @@ tpose_as_geopose(const Temporal *temp, int conformance, int precision)
  * @param[in] precision Significant digits in JSON numbers; -1 = lossless
  * @return On error return @p NULL
  */
+static json_object *
+geopose_stream_header_obj(const Temporal *temp, const GeoPoseAnchor *anchor,
+  int precision)
+{
+  json_object *res = json_object_new_object();
+  json_object_object_add(res, "transitionModel",
+    geopose_transition_model(MEOS_FLAGS_GET_INTERP(temp->flags)));
+  json_object_object_add(res, "outerFrame",
+    geopose_outer_frame(anchor, precision));
+  return res;
+}
+
+/**
+ * @brief Build the `StreamElement` of one instant against an anchored outer
+ * frame. Returns @p NULL on error.
+ */
+static json_object *
+geopose_stream_element_obj(const GeoPoseAnchor *anchor, const TInstant *inst,
+  int precision)
+{
+  json_object *frame = geopose_inner_frame(anchor,
+    DatumGetPoseP(tinstant_value_p(inst)), precision);
+  if (frame == NULL)
+    return NULL;
+  json_object *fat = json_object_new_object();
+  json_object_object_add(fat, "frame", frame);
+  json_object_object_add(fat, "validTime",
+    json_object_new_int64(geopose_instant_out(inst->t)));
+  json_object *res = json_object_new_object();
+  json_object_object_add(res, "streamElement", fat);
+  return res;
+}
+
 char *
 tpose_as_geopose_stream_header(const Temporal *temp, int precision)
 {
@@ -1619,11 +1652,7 @@ tpose_as_geopose_stream_header(const Temporal *temp, int precision)
   if (! geopose_anchor_from_instant(first, &anchor))
     return NULL;
 
-  json_object *root = json_object_new_object();
-  json_object_object_add(root, "transitionModel",
-    geopose_transition_model(MEOS_FLAGS_GET_INTERP(temp->flags)));
-  json_object_object_add(root, "outerFrame",
-    geopose_outer_frame(&anchor, precision));
+  json_object *root = geopose_stream_header_obj(temp, &anchor, precision);
   char *res = pstrdup(json_object_to_json_string_ext(root,
     GEOPOSE_JSON_FLAGS));
   json_object_put(root);
@@ -1658,20 +1687,72 @@ tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst,
   if (! geopose_anchor_from_instant(first, &anchor))
     return NULL;
 
-  json_object *frame = geopose_inner_frame(&anchor,
-    DatumGetPoseP(tinstant_value_p(inst)), precision);
-  if (frame == NULL)
+  json_object *root = geopose_stream_element_obj(&anchor, inst, precision);
+  if (root == NULL)
     return NULL;
-  json_object *fat = json_object_new_object();
-  json_object_object_add(fat, "frame", frame);
-  json_object_object_add(fat, "validTime",
-    json_object_new_int64(geopose_instant_out(inst->t)));
-
-  json_object *root = json_object_new_object();
-  json_object_object_add(root, "streamElement", fat);
   char *res = pstrdup(json_object_to_json_string_ext(root,
     GEOPOSE_JSON_FLAGS));
   json_object_put(root);
+  return res;
+}
+
+/**
+ * @ingroup meos_pose_base_geopose
+ * @brief Return the OGC GeoPose Stream of a temporal pose
+ * @details A stream written as one document: the `StreamHeader` that opens
+ * it, and every `StreamElement` it carries, as
+ * `GeoPose.Composite.Sequence.Stream.Schema.json` requires. The two
+ * incremental entry points write the same documents a piece at a time, for a
+ * producer emitting poses as they arrive; this writes the stream a reader
+ * already holds whole, which is what a query returns and what a conformance
+ * submission carries.
+ *
+ * The outer frame is anchored at the first pose of @p temp, so the header and
+ * every element speak of one tangent point, exactly as the incremental pair
+ * does.
+ * @param[in] temp Temporal pose
+ * @param[in] precision Significant digits in JSON numbers; -1 = lossless
+ * @return On error return @p NULL
+ * @csqlfn #Tpose_as_geopose_stream()
+ */
+char *
+tpose_as_geopose_stream(const Temporal *temp, int precision)
+{
+  VALIDATE_TPOSE(temp, NULL);
+
+  int count;
+  const TInstant **instants = temporal_insts_p(temp, &count);
+  if (instants == NULL)
+    return NULL;
+  GeoPoseAnchor anchor;
+  if (! geopose_anchor_from_instant(instants[0], &anchor))
+  {
+    pfree(instants);
+    return NULL;
+  }
+
+  json_object *arr = json_object_new_array();
+  for (int i = 0; i < count; i++)
+  {
+    json_object *elem = geopose_stream_element_obj(&anchor, instants[i],
+      precision);
+    if (elem == NULL)
+    {
+      json_object_put(arr);
+      pfree(instants);
+      return NULL;
+    }
+    json_object_array_add(arr, elem);
+  }
+
+  json_object *root = json_object_new_object();
+  json_object_object_add(root, "header",
+    geopose_stream_header_obj(temp, &anchor, precision));
+  json_object_object_add(root, "streamElements", arr);
+  char *res = pstrdup(json_object_to_json_string_ext(root,
+    GEOPOSE_JSON_FLAGS));
+  json_object_put(root);
+  pfree(instants);
   return res;
 }
 

--- a/meos/test/geopose_test.c
+++ b/meos/test/geopose_test.c
@@ -404,6 +404,26 @@ int main(void)
   printf("Stream first element: %s\n", se1);
   assert(strstr(se1, "translation=[0, 0, 0]") != NULL);
   free(se1); free(first);
+
+  /* The same stream written whole: one document holding the header and every
+   * element, which is what a reader already holding the value writes and what
+   * a conformance submission carries. */
+  char *sw = tpose_as_geopose_stream(stream, 6);
+  assert(sw != NULL);
+  printf("Stream whole: %s\n", sw);
+  ensure_member("Stream", sw, "\"header\"");
+  ensure_member("Stream", sw, "\"streamElements\"");
+  ensure_member("Stream", sw, "\"transitionModel\"");
+  ensure_member("Stream", sw, "\"outerFrame\"");
+  /* It carries one element per instant, and anchors where the header does */
+  int nelem = 0;
+  for (const char *q = sw; (q = strstr(q, "\"streamElement\"")) != NULL; q++)
+    nelem++;
+  printf("Stream elements: %d of %d instants\n", nelem, ninsts);
+  assert(nelem == ninsts);
+  assert(strstr(sw, "translation=[0, 0, 0]") != NULL);
+  free(sw);
+
   free(sh); free(stream);
 
   /*--------------------------------------------------------------------------
@@ -503,6 +523,13 @@ int main(void)
   printf("stream element(planar value): %s, errno %d\n",
     bad_se ? "non-NULL" : "NULL", meos_errno());
   assert(bad_se == NULL);
+
+  meos_errno_reset();
+  char *bad_sw = tpose_as_geopose_stream(planar_s, 6);
+  printf("stream whole(planar value): %s, errno %d\n",
+    bad_sw ? "non-NULL" : "NULL", meos_errno());
+  assert(bad_sw == NULL);
+  assert(meos_errno() != 0);
   assert(meos_errno() != 0);
   free(planar_i); free(planar_s);
 

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -119,6 +119,13 @@ CREATE FUNCTION asGeoPose(tpose, conformance int4 DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Tpose_as_geopose'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- A stream written as one document: the header that opens it and every
+-- element it carries.
+CREATE FUNCTION asGeoPoseStream(tpose, maxdecimaldigits int4 DEFAULT -1)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tpose_as_geopose_stream'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION applyPose(geometry, tpose)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tpose_apply_geo'

--- a/mobilitydb/src/pose/tpose.c
+++ b/mobilitydb/src/pose/tpose.c
@@ -309,6 +309,26 @@ Tpose_as_geopose(PG_FUNCTION_ARGS)
   PG_RETURN_TEXT_P(result_text);
 }
 
+PGDLLEXPORT Datum Tpose_as_geopose_stream(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tpose_as_geopose_stream);
+/**
+ * @ingroup mobilitydb_pose_inout
+ * @brief Return the OGC GeoPose Stream of a temporal pose
+ * @sqlfn asGeoPoseStream()
+ */
+Datum
+Tpose_as_geopose_stream(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  int precision = PG_GETARG_INT32(1);
+  char *result = tpose_as_geopose_stream(temp, precision);
+  PG_FREE_IF_COPY(temp, 0);
+  if (result == NULL) PG_RETURN_NULL();
+  text *result_text = cstring_to_text(result);
+  pfree(result);
+  PG_RETURN_TEXT_P(result_text);
+}
+
 /*****************************************************************************
  * Body-to-world rigid transform (workstream #4)
  *****************************************************************************/

--- a/mobilitydb/test/pose/expected/103_pose_geopose.test.out
+++ b/mobilitydb/test/pose/expected/103_pose_geopose.test.out
@@ -632,3 +632,27 @@ ERROR:  GeoPose 'frameSpecification' parameter 'crs' must name a WGS-84 geograph
 SELECT poseFromGeoPose('{"frameSpecification":{"authority":"/geopose/1.0",
   "id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=0"}}');
 ERROR:  GeoPose Advanced JSON missing required 'quaternion' object
+SELECT asGeoPoseStream(tpose '[Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(0 0 0), 0.707107, 0, 0, 0.707107)@2026-01-02]', 6);
+                                                                                                                                                                                                                                                                                                   asgeoposestream                                                                                                                                                                                                                                                                                                   
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"header":{"transitionModel":{"authority":"/geopose/1.0","id":"interpolate","parameters":"interpolation=Linear"},"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"}},"streamElements":[{"streamElement":{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},"validTime":1767254400000}},{"streamElement":{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[0.707107, 0, 0, 0.707107]"},"validTime":1767340800000}}]}
+(1 row)
+
+SELECT asGeoPoseStream(tpose 'Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01', 6);
+                                                                                                                                                                                                     asgeoposestream                                                                                                                                                                                                     
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"header":{"transitionModel":{"authority":"/geopose/1.0","id":"none","parameters":"interpolation=None"},"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"}},"streamElements":[{"streamElement":{"frame":{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},"validTime":1767254400000}}]}
+(1 row)
+
+SELECT asGeoPoseStream(tpose 'SRID=4326;[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(8.001 47 1500), 1, 0, 0, 0)@2026-01-02]', 6)
+  LIKE '{"header":%"streamElements":[{"streamElement":%},{"streamElement":%}]}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT asGeoPoseStream(tpose '[Pose(Point(8 47), 0)@2026-01-01,
+  Pose(Point(9 47), 0)@2026-01-02]', 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one

--- a/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
+++ b/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
@@ -552,3 +552,28 @@ SELECT poseFromGeoPose('{"frameSpecification":{"authority":"/geopose/1.0",
   "id":"LTP-ENU","parameters":"longitude=8&latitude=47&height=0"}}');
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- OGC GeoPose Stream, written whole
+-------------------------------------------------------------------------------
+
+-- A stream holds the header that opens it and every element it carries. The
+-- tangent point is the equator-meridian, where the frame conversion is exact,
+-- so the document carries no round-off for a libm to disagree about.
+SELECT asGeoPoseStream(tpose '[Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(0 0 0), 0.707107, 0, 0, 0.707107)@2026-01-02]', 6);
+
+-- An instant value is a stream of one element, which sits at the tangent
+-- point the header anchors.
+SELECT asGeoPoseStream(tpose 'Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01', 6);
+
+-- One element per instant, wherever the poses are.
+SELECT asGeoPoseStream(tpose 'SRID=4326;[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+  Geodpose(Point(8.001 47 1500), 1, 0, 0, 0)@2026-01-02]', 6)
+  LIKE '{"header":%"streamElements":[{"streamElement":%},{"streamElement":%}]}';
+
+\set VERBOSITY terse
+-- A planar value has no topocentric frame to anchor.
+SELECT asGeoPoseStream(tpose '[Pose(Point(8 47), 0)@2026-01-01,
+  Pose(Point(9 47), 0)@2026-01-02]', 6);
+\set VERBOSITY default

--- a/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.Stream.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Composite.Sequence.Stream.Schema.json
@@ -1,0 +1,106 @@
+{
+  "description": "Stream: GeoPose stream is an open-ended irregular timeseries suitable for streaming from a sensor or information service.",
+  "definitions": {
+    "FrameAndTime": {
+      "type": "object",
+      "properties": {
+        "frame": {
+          "$ref": "#/definitions/FrameSpecification"
+        },
+        "validTime": {
+          "type": "integer"
+        }
+      },
+      "required": [
+        "frame"
+      ]
+    },
+    "FrameSpecification": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    },
+    "StreamElement": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "streamElement": {
+          "$ref": "#/definitions/FrameAndTime"
+        }
+      },
+      "required": [
+        "streamElement"
+      ]
+    },
+    "StreamHeader": {
+      "type": "object",
+      "properties": {
+        "transitionModel": {
+          "$ref": "#/definitions/TransitionModel"
+        },
+        "outerFrame": {
+          "$ref": "#/definitions/FrameSpecification"
+        }
+      },
+      "required": [
+        "transitionModel",
+        "outerFrame"
+      ]
+    },
+    "TransitionModel": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "header": {
+      "$ref": "#/definitions/StreamHeader"
+    },
+    "streamElements": {
+      "type": [
+        "array",
+        "null"
+      ],
+      "items": {
+        "$ref": "#/definitions/StreamElement"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "header",
+    "streamElements"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/README.md
+++ b/mobilitydb/test/pose/schemas/README.md
@@ -14,6 +14,7 @@ MobilityDB implements, retrieved on 2026-08-14 from
 | `GeoPose.Composite.Sequence.Series.Irregular.Schema.json` | Irregular Time Series |
 | `GeoPose.Composite.Sequence.StreamHeader.Schema.json` | Stream, the document opening one |
 | `GeoPose.Composite.Sequence.StreamElement.Schema.json` | Stream, the document repeated in one |
+| `GeoPose.Composite.Sequence.Stream.Schema.json` | Stream, the whole of one as a single document |
 
 The schemas are those of OGC GeoPose 1.0 (OGC 21-056r11) and belong to the
 Open Geospatial Consortium, which licenses them for redistribution under the
@@ -29,6 +30,7 @@ are held here unmodified, byte for byte as retrieved, with these digests:
     69f49530f65f…  GeoPose.Composite.Sequence.Series.Irregular.Schema.json
     ee3b1944912b…  GeoPose.Composite.Sequence.StreamHeader.Schema.json
     01791c205790…  GeoPose.Composite.Sequence.StreamElement.Schema.json
+    fd24663a1241…  GeoPose.Composite.Sequence.Stream.Schema.json
 
 `tools/scripts/check_geopose_conformance.py` validates against them the GeoPose
 documents that `expected/103_pose_geopose.test.out` holds. Keeping a copy here

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -267,7 +267,7 @@ representation_families:
     - FromText
     - FromEWKT
     - FromMFJSON
-  - lit: "CREATE FUNCTION tposeFromGeoPose(text)\n  RETURNS tpose\n  AS 'MODULE_PATHNAME', 'Tpose_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- conformance:      0 = Basic-Quaternion (default), 1 = Basic-YPR, 2 = Advanced\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(tpose, conformance int4 DEFAULT 0,\n    maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tpose_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION applyPose(geometry, tpose)\n  RETURNS tgeompoint\n  AS 'MODULE_PATHNAME', 'Tpose_apply_geo'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
+  - lit: "CREATE FUNCTION tposeFromGeoPose(text)\n  RETURNS tpose\n  AS 'MODULE_PATHNAME', 'Tpose_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- conformance:      0 = Basic-Quaternion (default), 1 = Basic-YPR, 2 = Advanced\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(tpose, conformance int4 DEFAULT 0,\n    maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tpose_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- A stream written as one document: the header that opens it and every\n-- element it carries.\nCREATE FUNCTION asGeoPoseStream(tpose, maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tpose_as_geopose_stream'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION applyPose(geometry, tpose)\n  RETURNS tgeompoint\n  AS 'MODULE_PATHNAME', 'Tpose_apply_geo'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
   - ops:
     - FromBinary
     - FromEWKB

--- a/tools/scripts/check_geopose_conformance.py
+++ b/tools/scripts/check_geopose_conformance.py
@@ -55,6 +55,10 @@ EXPECTED = os.path.join(ROOT, 'mobilitydb', 'test', 'pose', 'expected',
 # this order so that a Series is never mistaken for the Basic document of its
 # inner frames.
 CLASSES = [
+    # A whole stream holds a header and its elements, so its own member names
+    # it before either of theirs is looked for.
+    ('streamElements', 'Stream',
+        'GeoPose.Composite.Sequence.Stream.Schema.json'),
     ('innerFrameSeries', 'Regular Series',
         'GeoPose.Composite.Sequence.Series.Regular.Schema.json'),
     ('innerFrameAndTimeSeries', 'Irregular Series',
@@ -79,12 +83,14 @@ CLASSES = [
 ]
 
 # The classes the SQL surface writes, and which the expected output therefore
-# has to contain for this check to mean anything. The two stream documents are
-# written through the C API alone -- a stream is emitted a piece at a time by a
-# producer, which a query is not -- so they are validated wherever they appear
-# rather than demanded here; `meos/test/geopose_test.c` is what exercises them.
+# has to contain for this check to mean anything. A whole stream is among them:
+# a value a query already holds is written in one piece. The two INCREMENTAL
+# stream documents are written through the C API alone -- those are emitted a
+# piece at a time by a producer, which a query is not -- so they are validated
+# wherever they appear rather than demanded here; `meos/test/geopose_test.c` is
+# what exercises them.
 REQUIRED = ('Regular Series', 'Irregular Series', 'Basic-Quaternion',
-    'Basic-YPR', 'Advanced')
+    'Basic-YPR', 'Advanced', 'Stream')
 
 TYPES = {
     'object': dict,


### PR DESCRIPTION
The standard gives the Stream three documents. Beside the `StreamHeader` that opens one and the `StreamElement` repeated within it, `GeoPose.Composite.Sequence.Stream.Schema.json` defines the stream itself as `{header, streamElements}`, and the OGC conformance test suite asks a candidate implementation for exactly that document, under its `streamrecord` key. The two incremental entry points cover a producer emitting poses as they arrive; a value a reader already holds whole — what a query returns, and what a conformance submission carries — has no entry point.

`asGeoPoseStream(tpose, maxdecimaldigits)` and `tpose_as_geopose_stream` write it. A stream has one form, so there is no `conformance` argument.

The header and the element builders are functions returning the JSON object rather than the serialized document, so all three entry points compose the same two builders. The whole stream anchors its outer frame where the incremental pair anchors it, at the first pose, and header and elements speak of one tangent point by construction.

```
SELECT asGeoPoseStream(tpose 'Geodpose(Point(0 0 0), 1, 0, 0, 0)@2026-01-01', 6);
-- {"header":{"transitionModel":{"authority":"/geopose/1.0","id":"none",
--  "parameters":"interpolation=None"},"outerFrame":{"authority":"/geopose/1.0",
--  "id":"LTP-ENU","parameters":"longitude=0&latitude=0&height=0&crs=EPSG:4979"}},
--  "streamElements":[{"streamElement":{"frame":{"authority":"/geopose/1.0",
--  "id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},
--  "validTime":1767254400000}}]}
```

The schema joins the vendored set, held unmodified with its digest recorded beside the others. The conformance check demands a Stream among the documents the regression tests emit rather than validating one only where it happens to appear: 32 documents conform, two of them streams.

The printed documents are anchored at the equator-meridian, where the frame conversion is exact, so they carry no round-off for a libm to disagree about; a pose away from that tangent point is asserted structurally instead. The SQL block is generator-owned, so the manifest and the emitted file move together and `generate.py --validate` reports no difference.