### PR TITLE
Hold a static GeoPose document to the strict schema of its class

### DIFF
--- a/mobilitydb/test/pose/schemas/GeoPose.Basic.Strict_Quaternion.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Basic.Strict_Quaternion.Schema.json
@@ -1,0 +1,61 @@
+{
+  "description": "Basic-Quaternion-Strict: Basic GeoPose using quaternion to specify orientation - no additional properties",
+  "definitions": {
+    "Position": {
+      "type": "object",
+      "properties": {
+        "lat": {
+          "type": "number"
+        },
+        "lon": {
+          "type": "number"
+        },
+        "h": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "lat",
+        "lon",
+        "h"
+      ]
+    },
+    "Quaternion": {
+      "type": "object",
+      "properties": {
+        "x": {
+          "type": "number"
+        },
+        "y": {
+          "type": "number"
+        },
+        "z": {
+          "type": "number"
+        },
+        "w": {
+          "type": "number"
+        }
+      },
+      "required": [
+        "x",
+        "y",
+        "z",
+        "w"
+      ]
+    }
+  },
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "position": {
+      "$ref": "#/definitions/Position"
+    },
+    "quaternion": {
+      "$ref": "#/definitions/Quaternion"
+    }
+  },
+  "required": [
+    "position",
+    "quaternion"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/README.md
+++ b/mobilitydb/test/pose/schemas/README.md
@@ -15,6 +15,7 @@ MobilityDB implements, retrieved on 2026-08-14 from
 | `GeoPose.Composite.Sequence.StreamHeader.Schema.json` | Stream, the document opening one |
 | `GeoPose.Composite.Sequence.StreamElement.Schema.json` | Stream, the document repeated in one |
 | `GeoPose.Composite.Sequence.Stream.Schema.json` | Stream, the whole of one as a single document |
+| `GeoPose.Basic.Strict_Quaternion.Schema.json` | Basic-Quaternion, the form admitting no other member |
 
 The schemas are those of OGC GeoPose 1.0 (OGC 21-056r11) and belong to the
 Open Geospatial Consortium, which licenses them for redistribution under the
@@ -31,12 +32,32 @@ are held here unmodified, byte for byte as retrieved, with these digests:
     ee3b1944912b…  GeoPose.Composite.Sequence.StreamHeader.Schema.json
     01791c205790…  GeoPose.Composite.Sequence.StreamElement.Schema.json
     fd24663a1241…  GeoPose.Composite.Sequence.Stream.Schema.json
+    06d999a2b309…  GeoPose.Basic.Strict_Quaternion.Schema.json
 
 `tools/scripts/check_geopose_conformance.py` validates against them the GeoPose
 documents that `expected/103_pose_geopose.test.out` holds. Keeping a copy here
 rather than fetching at run time makes the check depend on nothing outside the
 repository, so it gives the same verdict in a network-less build as in CI.
 
-The two remaining conformance classes, Chain and Graph, have schemas at the
-same place, and belong here as soon as MobilityDB emits a document of one of
-them.
+A Basic-Quaternion document carrying only what a static pose has to say
+satisfies the strict schema as well, which admits `position` and `quaternion`
+and nothing else; a temporal instant additionally carries `validTime` and
+satisfies the permissive schema alone. The check therefore holds every
+Basic-Quaternion document that names no time to the strict schema, so a member
+added to the static encoding is reported rather than quietly narrowing what
+MobilityDB can claim. The conformance test suite exercises the permissive form,
+which is the one a claim is made against.
+
+Four schemas published at the same place are deliberately absent.
+`GeoPose.Composite.Chain.Schema.json` and `GeoPose.Composite.Graph.Schema.json`
+describe the two conformance classes MobilityDB does not implement, and belong
+here as soon as it emits a document of one of them.
+`GeoPose.Basic.Euler.Schema.json` describes a flat `longitude`/`latitude`/
+`height`/`rotations` form that is not one of the eight conformance classes and
+that no MobilityDB encoding produces. `GeoPose.Composite.Sequence.Stream.Header.Schema.json`
+requires a single `transitionModel` typed as a string, where the `StreamHeader`
+schema beside it, and the composite `Stream` schema that embeds one, require an
+object of `authority`, `id` and `parameters` together with an `outerFrame`: a
+header satisfying either fails the other, so the two cannot both describe a
+conformant document. MobilityDB writes the form the suite and the composite
+schema agree on, and the contradiction is a question for the working group.

--- a/tools/scripts/check_geopose_conformance.py
+++ b/tools/scripts/check_geopose_conformance.py
@@ -82,6 +82,14 @@ CLASSES = [
         'GeoPose.Basic.YPR.Schema.json'),
 ]
 
+# A Basic-Quaternion document that carries only what a static pose has to say
+# satisfies the standard's stricter schema for the class as well, which admits
+# `position` and `quaternion` and nothing else. A temporal instant additionally
+# carries `validTime` and satisfies the permissive schema alone, so the strict
+# one is demanded of exactly those documents that hold no time.
+STRICT = ('Basic-Quaternion', 'validTime',
+    'GeoPose.Basic.Strict_Quaternion.Schema.json')
+
 # The classes the SQL surface writes, and which the expected output therefore
 # has to contain for this check to mean anything. A whole stream is among them:
 # a value a query already holds is written in one piece. The two INCREMENTAL
@@ -154,6 +162,14 @@ def validate(value, schema, root, path, errors):
                 validate(value[name], sub, root, '%s.%s' % (path, name),
                     errors)
 
+        # `additionalProperties: false` is what makes a schema strict: the
+        # document may carry the members the schema names and no others.
+        if schema.get('additionalProperties') is False:
+            for name in value:
+                if name not in schema.get('properties', {}):
+                    errors.append('%s: carries `%s`, which the schema does '
+                        'not allow' % (path or '(document)', name))
+
     items = schema.get('items')
     if items is not None and isinstance(value, list):
         for i, elem in enumerate(value):
@@ -207,8 +223,18 @@ def main():
         with open(path, encoding='utf-8') as f:
             schemas[name] = json.load(f)
 
+    strict_class, strict_unless, strict_file = STRICT
+    strict_path = os.path.join(SCHEMA_DIR, strict_file)
+    if not os.path.isfile(strict_path):
+        print('check_geopose_conformance: no schema at %s' %
+            os.path.relpath(strict_path, ROOT))
+        return 1
+    with open(strict_path, encoding='utf-8') as f:
+        strict_schema = json.load(f)
+
     total = 0
     failed = 0
+    strict = 0
     seen = {}
     for doc in documents(EXPECTED):
         name, _ = classify(doc)
@@ -218,6 +244,9 @@ def main():
         seen[name] = seen.get(name, 0) + 1
         errors = []
         validate(doc, schemas[name], schemas[name], '', errors)
+        if name == strict_class and strict_unless not in doc:
+            validate(doc, strict_schema, strict_schema, '', errors)
+            strict += 1
         if listing:
             print('  %-18s %s' % (name, 'ok' if not errors else 'INVALID'))
         if errors:
@@ -245,8 +274,10 @@ def main():
         return 1
 
     print('check_geopose_conformance: %d documents conform to the OGC '
-        'GeoPose 1.0 schemas (%s).' % (total,
-        ', '.join('%s %d' % (n, c) for n, c in sorted(seen.items()))))
+        'GeoPose 1.0 schemas (%s); %d of them satisfy the strict %s schema '
+        'as well.' % (total,
+        ', '.join('%s %d' % (n, c) for n, c in sorted(seen.items())),
+        strict, strict_class))
     return 0
 
 


### PR DESCRIPTION
This branch sits on top of the whole-stream PR, which is the one to read first.

The standard publishes two schemas for Basic-Quaternion. The permissive one, which the OGC conformance test suite exercises and which a claim is made against, admits members beyond `position` and `quaternion`; `GeoPose.Basic.Strict_Quaternion.Schema.json` admits none. A static pose emits exactly that pair and satisfies both. A temporal instant carries `validTime` as well and satisfies the permissive schema alone.

The check holds every Basic-Quaternion document naming no time to the strict schema, so a member added to the static encoding is reported rather than quietly narrowing what MobilityDB can claim. Twelve of the thirty-two documents the regression tests emit satisfy it.

Supporting that needs one keyword the validator lacks, `additionalProperties`. Widening a hand-rolled validator is only safe against the real one, so the two are cross-checked over mutants of the documents and schemas involved: 141 mutants, no disagreement with `jsonschema`. The strict schema rejects what it must:

```
static document              -> conforms
static + an extra member     -> REJECTED: carries `extraneous`, which the schema does not allow
static + validTime           -> REJECTED: carries `validTime`, which the schema does not allow
```

Four schemas published beside these stay out, and the README says why. `Composite.Chain` and `Composite.Graph` describe the two conformance classes MobilityDB does not implement, and belong there as soon as it emits a document of one. `Basic.Euler` describes a flat `longitude`/`latitude`/`height`/`rotations` form outside the eight conformance classes that no MobilityDB encoding produces. `Composite.Sequence.Stream.Header` requires a single `transitionModel` typed as a string, where the `StreamHeader` schema beside it and the composite `Stream` schema that embeds one require an object of `authority`, `id` and `parameters` together with an `outerFrame`: a header satisfying either fails the other, so vendoring it would mean validating against a schema the conformant output fails.