### PR TITLE
Carry a caller's row identifier through the in-memory indexes as an int64

### DIFF
--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -105,7 +105,7 @@ verify_search(const char *name, const RTree *rtree, RTreeSearchOp op,
   bool *indexed = calloc(NUM_BBOX, sizeof(bool));
   for (int i = 0; i < index_count; i++)
   {
-    int id = *(int *) meos_array_get(ids, i);
+    int64 id = *(int64 *) meos_array_get(ids, i);
     indexed[id] = true;
   }
 
@@ -391,7 +391,7 @@ int main(void)
   printf("RTree index test (%d boxes per type)\n", NUM_BBOX);
 
   /* Create a single MeosArray and reuse it across all searches */
-  MeosArray *ids = meos_array_create(sizeof(int));
+  MeosArray *ids = meos_array_create(sizeof(int64));
   test_floatspan(ids);
   test_tstzspan(ids);
   test_tbox(ids);

--- a/meos/examples/rtree_mest_example.c
+++ b/meos/examples/rtree_mest_example.c
@@ -231,7 +231,7 @@ int main(void)
   }
 
   /* Result array reused across searches */
-  MeosArray *ids = meos_array_create(sizeof(int));
+  MeosArray *ids = meos_array_create(sizeof(int64));
 
   /* Aggregated totals over all queries */
   long total_truth = 0;
@@ -273,7 +273,7 @@ int main(void)
     int single_fp = 0;
     for (int k = 0; k < single_count; k++)
     {
-      int id = *(int *) meos_array_get(ids, k);
+      int64 id = *(int64 *) meos_array_get(ids, k);
       assert(! seen[id]);
       seen[id] = true;
       if (! truth[id])
@@ -292,7 +292,7 @@ int main(void)
     assert(deg_count == single_count);
     for (int k = 0; k < deg_count; k++)
     {
-      int id = *(int *) meos_array_get(ids, k);
+      int64 id = *(int64 *) meos_array_get(ids, k);
       assert(seen[id]);
     }
 
@@ -308,7 +308,7 @@ int main(void)
       int mest_fp = 0;
       for (int k = 0; k < cand; k++)
       {
-        int id = *(int *) meos_array_get(ids, k);
+        int64 id = *(int64 *) meos_array_get(ids, k);
         /* Invariant (ii): dedup, each id appears at most once */
         assert(! seen[id]);
         seen[id] = true;

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -368,9 +368,9 @@ extern RTree *rtree_create_stbox();
 extern RTree *rtree_create_tpcbox();
 #endif
 extern void rtree_free(RTree *rtree);
-extern void rtree_insert(RTree *rtree, void *box, int id);
-extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id);
-extern void rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int id, int maxboxes);
+extern void rtree_insert(RTree *rtree, void *box, int64 id);
+extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int64 id);
+extern void rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int64 id, int maxboxes);
 extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, MeosArray *result);
 extern int rtree_join(const RTree *rtree1, const RTree *rtree2, RTreeSearchOp op, MeosArray *result);
 extern int rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
@@ -382,7 +382,7 @@ extern int rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op, con
 typedef struct RTreeNNCursor RTreeNNCursor;
 
 extern RTreeNNCursor *rtree_nn_cursor_open(const RTree *rtree, const void *query);
-extern bool rtree_nn_cursor_next(RTreeNNCursor *cursor, int *id_out, double *dist_out);
+extern bool rtree_nn_cursor_next(RTreeNNCursor *cursor, int64 *id_out, double *dist_out);
 extern void rtree_nn_cursor_close(RTreeNNCursor *cursor);
 
 /**
@@ -413,9 +413,9 @@ extern SPTree *sptree_create_stbox(SPTreeKind kind);
 extern SPTree *sptree_create_tpcbox(SPTreeKind kind);
 #endif
 extern void sptree_free(SPTree *sptree);
-extern void sptree_insert(SPTree *sptree, void *box, int id);
-extern void sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int id);
-extern void sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int id, int maxboxes);
+extern void sptree_insert(SPTree *sptree, void *box, int64 id);
+extern void sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int64 id);
+extern void sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int64 id, int maxboxes);
 extern int sptree_search(const SPTree *sptree, RTreeSearchOp op, const void *query, MeosArray *result);
 extern int sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
 extern int sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
@@ -426,7 +426,7 @@ extern int sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op, 
 typedef struct SPNNCursor SPNNCursor;
 
 extern SPNNCursor *sptree_nn_cursor_open(const SPTree *sptree, const void *query);
-extern bool sptree_nn_cursor_next(SPNNCursor *cursor, int *id_out, double *dist_out);
+extern bool sptree_nn_cursor_next(SPNNCursor *cursor, int64 *id_out, double *dist_out);
 extern void sptree_nn_cursor_close(SPNNCursor *cursor);
 
 /*****************************************************************************

--- a/meos/include/temporal/temporal_rtree.h
+++ b/meos/include/temporal/temporal_rtree.h
@@ -67,7 +67,7 @@ typedef struct RTreeNode
   union 
   {
     struct RTreeNode *nodes[MAXITEMS];
-    int ids[MAXITEMS];
+    int64 ids[MAXITEMS];
   };
   /* The bounding boxes can be of type Span, TBox, or STBox */
   char boxes[];

--- a/meos/include/temporal/temporal_sptree.h
+++ b/meos/include/temporal/temporal_sptree.h
@@ -57,7 +57,7 @@
  */
 typedef struct SPNode
 {
-  int id;                     /**< Identifier of the box stored at this node */
+  int64 id;                   /**< Identifier of the box stored at this node */
   struct SPNode **children;   /**< Array of @p nchild child pointers */
   char centroid[];            /**< The bounding box of this node */
 } SPNode;

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -805,7 +805,7 @@ tcbuffer_disc_within_dist(double cx, double cy, double r, double dist,
   for (int j = 0; j < nc; j++)
   {
     const DistEdge *ed =
-      &g->segs[*(int *) meos_array_get(dist_pip_results, j)];
+      &g->segs[*(int64 *) meos_array_get(dist_pip_results, j)];
     if (box2d_distance_sqr(ed->xmin, ed->ymin, ed->xmax, ed->ymax, sxmin,
         symin, sxmax, symax) > dist2)
       continue;
@@ -1054,7 +1054,7 @@ tcbuffer_geo_ctx_make(const GSERIALIZED *gs)
     0, dist_geom_build_rtree(segs, n) };
   /* Scratch buffer for the R-tree candidate ids, created with the R-tree and
    * freed with it in #tcbuffer_geo_ctx_free (see dist_pip_results). */
-  dist_pip_results = meos_array_create(sizeof(int));
+  dist_pip_results = meos_array_create(sizeof(int64));
   return ctx;
 }
 
@@ -1324,7 +1324,7 @@ tcbufferseg_within_ctx(const Cbuffer *cb1, const Cbuffer *cb2, double dist,
   for (int j = 0; j < ncand; j++)
   {
     const DistEdge *ed =
-      &ctx->g.segs[*(int *) meos_array_get(dist_pip_results, j)];
+      &ctx->g.segs[*(int64 *) meos_array_get(dist_pip_results, j)];
     if (box2d_distance_sqr(ed->xmin, ed->ymin, ed->xmax, ed->ymax, cxmin,
         cymin, cxmax, cymax) > reach2)
       continue;
@@ -1419,7 +1419,7 @@ tcbuffer_disc_signed_boundary(double cx, double cy, double r,
   for (int j = 0; j < nc; j++)
   {
     const DistEdge *ed =
-      &g->segs[*(int *) meos_array_get(dist_pip_results, j)];
+      &g->segs[*(int64 *) meos_array_get(dist_pip_results, j)];
     if (box2d_distance_sqr(ed->xmin, ed->ymin, ed->xmax, ed->ymax, cx, cy,
         cx, cy) > reach2)
       continue;
@@ -1529,7 +1529,7 @@ tcbufferseg_sg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   for (int j = 0; j < ncand; j++)
   {
     const DistEdge *ed =
-      &ctx->g.segs[*(int *) meos_array_get(dist_pip_results, j)];
+      &ctx->g.segs[*(int64 *) meos_array_get(dist_pip_results, j)];
     if (box2d_distance_sqr(ed->xmin, ed->ymin, ed->xmax, ed->ymax, cxmin,
         cymin, cxmax, cymax) > rmax2)
       continue;

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1012,7 +1012,7 @@ dist_geom_point_inside(double x, double y, const DistGeom *g)
     int nc = rtree_search(g->rtree, RTREE_OVERLAPS, &query, dist_pip_results);
     for (int j = 0; j < nc; j++)
       dist_poly_seg_raycross(
-        &g->segs[*(int *) meos_array_get(dist_pip_results, j)], x, y,
+        &g->segs[*(int64 *) meos_array_get(dist_pip_results, j)], x, y,
         &inside);
     return inside;
   }

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -2239,14 +2239,16 @@ setset_box_pairs(const STBox *bb1, int count1, const STBox *bb2, int count2,
   for (int j = 0; j < count2; j++)
     rtree_insert(rtree2, (void *) &bb2[j], j);
 
-  MeosArray *found = meos_array_create(sizeof(int));
+  MeosArray *found = meos_array_create(sizeof(int64));
   int n = rtree_join(rtree1, rtree2, RTREE_OVERLAPS, found);
   int *result = NULL;
   if (n > 0)
   {
     result = palloc((size_t) n * 2 * sizeof(int));
+    /* The ids are the segment positions inserted above, so they are bounded by
+     * count1/count2 and the narrowing back to int is exact */
     for (int k = 0; k < 2 * n; k++)
-      result[k] = *(int *) meos_array_get(found, k);
+      result[k] = (int) *(int64 *) meos_array_get(found, k);
     qsort(result, (size_t) n, 2 * sizeof(int), pair_cmp);
   }
   meos_array_destroy(found);

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -413,7 +413,7 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
   for (int i = 0; i < n; i++)
   {
     const Edge *restrict e = rtree ?
-      edges[*(int *) meos_array_get(rtree_results, i)] : edges[i];
+      edges[*(int64 *) meos_array_get(rtree_results, i)] : edges[i];
 
     /* Only polygon boundary edges bound a region. Point, line, and standalone
      * (1D) arc edges are ignored by the even-odd containment test */
@@ -982,7 +982,7 @@ tpointinst_clip_edges(const TInstant *inst, Edge **edges, int nedges,
 
     /* Convert the result of an R-tree look up into an edge pointer array */
     for (int j = 0; j < cand_nedges; j++)
-      cand_edges[j] = edges[*(int *) meos_array_get(rtree_results, j)];
+      cand_edges[j] = edges[*(int64 *) meos_array_get(rtree_results, j)];
     sel_edges = cand_edges;
     sel_nedges = cand_nedges;
   }
@@ -1060,7 +1060,7 @@ tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
 
       /* Convert the result of an R-tree look up into an edge pointer array */
       for (int j = 0; j < cand_nedges; j++)
-        cand_edges[j] = edges[*(int *) meos_array_get(rtree_results, j)];
+        cand_edges[j] = edges[*(int64 *) meos_array_get(rtree_results, j)];
       sel_edges = cand_edges;
       sel_nedges = cand_nedges;
     }
@@ -1212,7 +1212,7 @@ geo_clip_ctx_make(const GSERIALIZED *gs)
     }
     ctx->cand_edges = palloc(sizeof(Edge *) * ctx->nedges);
     /* Array for collecting the ids resulting from an R-tree search */
-    rtree_results = meos_array_create(sizeof(int));
+    rtree_results = meos_array_create(sizeof(int64));
   }
   return ctx;
 }
@@ -1355,7 +1355,7 @@ geo_intersects2d_ctx(const GSERIALIZED *gs, const void *ctxv)
       int nc = rtree_search(ctx->rtree, RTREE_OVERLAPS, &query, rtree_results);
       for (int j = 0; j < nc; j++)
         ctx->cand_edges[j] =
-          ctx->edge_ptrs[*(int *) meos_array_get(rtree_results, j)];
+          ctx->edge_ptrs[*(int64 *) meos_array_get(rtree_results, j)];
       for (int j = 0; j < nc && ! result; j++)
         if (edge_intersect(e, ctx->cand_edges[j]))
           result = true;
@@ -1920,7 +1920,7 @@ point_geom_within(double px, double py, Edge **edges, int nedges,
     int nc = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
     for (int i = 0; i < nc; i++)
       if (point_edge_dist2(px, py,
-            edges[*(int *) meos_array_get(rtree_results, i)]) <=
+            edges[*(int64 *) meos_array_get(rtree_results, i)]) <=
           d2 + FP_TOLERANCE)
         return true;
   }
@@ -2198,7 +2198,7 @@ tpointseq_dwithin_edges(const TSequence *seq, Edge **edges, int nedges,
       int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query,
         rtree_results);
       for (int j = 0; j < cand_nedges; j++)
-        cand_edges[j] = edges[*(int *) meos_array_get(rtree_results, j)];
+        cand_edges[j] = edges[*(int64 *) meos_array_get(rtree_results, j)];
       sel_edges = cand_edges;
       sel_nedges = cand_nedges;
     }

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -561,7 +561,7 @@ node_swap(const RTree *rtree, RTreeNode *node, int i, int j)
   memcpy(RTREE_NODE_BBOX_N(node, j), buf, rtree->bboxsize);
   if (node->node_type == RTREE_LEAF)
   {
-    int tmp = node->ids[i];
+    int64 tmp = node->ids[i];
     node->ids[i] = node->ids[j];
     node->ids[j] = tmp;
   }
@@ -835,7 +835,7 @@ node_search(const RTree *rtree, const RTreeNode *node, RTreeSearchOp op,
     {
       if (leaf_consistent(rtree, RTREE_NODE_BBOX_N(node, i), query, op))
       {
-        int id = node->ids[i];
+        int64 id = node->ids[i];
         meos_array_add(result, &id);
       }
     }
@@ -885,8 +885,8 @@ node_join(const RTree *rtree1, const RTreeNode *node1, const void *box1,
       {
         if (leaf_consistent(rtree1, key, RTREE_NODE_BBOX_N(node2, j), op))
         {
-          int id1 = node1->ids[i];
-          int id2 = node2->ids[j];
+          int64 id1 = node1->ids[i];
+          int64 id2 = node2->ids[j];
           meos_array_add(result, &id1);
           meos_array_add(result, &id2);
         }
@@ -1076,7 +1076,7 @@ rtree_create_tpcbox()
  * @param[in] id The id of the box being inserted
  */
 void
-rtree_insert(RTree *rtree, void *box, int id)
+rtree_insert(RTree *rtree, void *box, int64 id)
 {
   while (1)
   {
@@ -1122,7 +1122,7 @@ rtree_insert(RTree *rtree, void *box, int id)
  * @p RTREE_CONTAINED_BY finds boxes contained by the query
  * @param[in] query The bounding box that serves as query
  * @param[out] result MeosArray of int to collect matching IDs (created by the
- * caller with `meos_array_create(sizeof(int))`)
+ * caller with `meos_array_create(sizeof(int64))`)
  * @return Number of matching IDs
  */
 int
@@ -1152,7 +1152,7 @@ rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
  * of @p rtree2, @p RTREE_CONTAINED_BY pairs entries of @p rtree1 contained by
  * an entry of @p rtree2
  * @param[out] result MeosArray of int to collect the ids (created by the caller
- * with `meos_array_create(sizeof(int))`)
+ * with `meos_array_create(sizeof(int64))`)
  * @return Number of qualifying pairs, half the number of collected ids
  */
 int
@@ -1180,7 +1180,7 @@ rtree_join(const RTree *rtree1, const RTree *rtree2, RTreeSearchOp op,
  * @param[in] id The id of the temporal value being inserted
  */
 void
-rtree_insert_temporal(RTree *rtree, const Temporal *temp, int id)
+rtree_insert_temporal(RTree *rtree, const Temporal *temp, int64 id)
 {
   if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
     return;
@@ -1259,7 +1259,7 @@ rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
  * @see rtree_insert_temporal
  */
 void
-rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int id,
+rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int64 id,
   int maxboxes)
 {
   if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
@@ -1296,6 +1296,18 @@ rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int id,
  * @return Number of distinct matching ids
  * @see rtree_search_temporal
  */
+/**
+ * @brief Order two indexed ids, in the form @p qsort takes
+ * @note `int64_cmp` in type_util.c compares two `int64` values rather than two
+ * pointers to them, so it is not a `qsort` comparator
+ */
+static int
+rtree_id_cmp(const void *a, const void *b)
+{
+  int64 l = *(const int64 *) a, r = *(const int64 *) b;
+  return (l < r) ? -1 : ((l > r) ? 1 : 0);
+}
+
 int
 rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op,
   const Temporal *temp, int maxboxes, MeosArray *result)
@@ -1309,42 +1321,38 @@ rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op,
   if (! boxes)
     return 0;
 
-  /* Accumulate the raw (possibly duplicated) candidate ids of every query
-   * box, tracking the maximum id seen to size the dedup bitset */
-  MeosArray *raw = meos_array_create(sizeof(int));
-  MeosArray *hits = meos_array_create(sizeof(int));
-  int maxid = -1;
+  /* Accumulate the raw (possibly duplicated) candidate ids of every query box */
+  MeosArray *raw = meos_array_create(sizeof(int64));
+  MeosArray *hits = meos_array_create(sizeof(int64));
   for (int i = 0; i < count; i++)
   {
     int nhits = rtree_search(rtree, op,
       (char *) boxes + (size_t) i * rtree->bboxsize, hits);
     for (int j = 0; j < nhits; j++)
     {
-      int id = *(int *) meos_array_get(hits, j);
-      if (id > maxid)
-        maxid = id;
+      int64 id = *(int64 *) meos_array_get(hits, j);
       meos_array_add(raw, &id);
     }
   }
   pfree(boxes);
   meos_array_destroy(hits);
 
-  /* Collapse duplicates with a seen-set sized to the maximum id, mirroring
-   * the bool indexed[] idiom of the rtree example */
+  /* Collapse duplicates by sorting. The memory this costs is proportional to
+   * the NUMBER of candidate ids, never to their magnitude: an id is the
+   * caller's own row identifier, so a set sized to the largest id allocates in
+   * proportion to a value the caller chooses and reaches gigabytes on an
+   * ordinary sparse id space. */
   int nraw = meos_array_count(raw);
-  if (maxid >= 0 && nraw > 0)
+  if (nraw > 0)
   {
-    bool *seen = palloc0((size_t) (maxid + 1) * sizeof(bool));
+    int64 *ids = palloc((size_t) nraw * sizeof(int64));
     for (int i = 0; i < nraw; i++)
-    {
-      int id = *(int *) meos_array_get(raw, i);
-      if (! seen[id])
-      {
-        seen[id] = true;
-        meos_array_add(result, &id);
-      }
-    }
-    pfree(seen);
+      ids[i] = *(int64 *) meos_array_get(raw, i);
+    qsort(ids, (size_t) nraw, sizeof(int64), rtree_id_cmp);
+    for (int i = 0; i < nraw; i++)
+      if (i == 0 || ids[i] != ids[i - 1])
+        meos_array_add(result, &ids[i]);
+    pfree(ids);
   }
   meos_array_destroy(raw);
   return meos_array_count(result);
@@ -1417,7 +1425,7 @@ typedef struct RTreeNNEntry
 {
   double dist;             /**< Distance from the query to the entry's box */
   bool is_leaf_entry;      /**< True for an emittable id, false for a node */
-  int id;                  /**< Leaf id (when @p is_leaf_entry) */
+  int64 id;                /**< Leaf id (when @p is_leaf_entry) */
   const RTreeNode *node;   /**< Tree node to expand (when not @p is_leaf_entry) */
 } RTreeNNEntry;
 
@@ -1551,7 +1559,7 @@ rtree_nn_cursor_open(const RTree *rtree, const void *query)
  * @return @p true if a neighbour was produced, @p false once exhausted
  */
 bool
-rtree_nn_cursor_next(RTreeNNCursor *cursor, int *id_out, double *dist_out)
+rtree_nn_cursor_next(RTreeNNCursor *cursor, int64 *id_out, double *dist_out)
 {
   assert(cursor);
   while (cursor->count > 0)

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -475,7 +475,7 @@ sptree_create_tpcbox(SPTreeKind kind)
  * @brief Return a new node holding a bounding box
  */
 static SPNode *
-spnode_make(const SPTree *sptree, const void *box, int id)
+spnode_make(const SPTree *sptree, const void *box, int64 id)
 {
   SPNode *node = palloc0(sizeof(SPNode) + sptree->boxsize);
   node->id = id;
@@ -495,7 +495,7 @@ spnode_make(const SPTree *sptree, const void *box, int id)
  * @param[in] id The id associated with the box
  */
 void
-sptree_insert(SPTree *sptree, void *box, int id)
+sptree_insert(SPTree *sptree, void *box, int64 id)
 {
   /* Project the incoming box into the internal box type (TPCBox: STBox) */
   bboxunion proj;
@@ -550,7 +550,7 @@ spnode_search(const SPTree *sptree, const SPNode *node, const void *nodebox,
 {
   if (sptree->leaf_consistent(node->centroid, query, op))
   {
-    int id = node->id;
+    int64 id = node->id;
     meos_array_add(result, &id);
   }
   for (int quadrant = 0; quadrant < sptree->nchild; quadrant++)
@@ -626,7 +626,7 @@ sptree_search(const SPTree *sptree, RTreeSearchOp op, const void *query,
  * @param[in] id The id of the temporal value being inserted
  */
 void
-sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int id)
+sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int64 id)
 {
   if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
     return;
@@ -684,7 +684,7 @@ sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op,
  * @see sptree_insert_temporal
  */
 void
-sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int id,
+sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int64 id,
   int maxboxes)
 {
   if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
@@ -718,6 +718,16 @@ sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int id,
  * @return Number of distinct matching ids
  * @see sptree_search_temporal
  */
+/**
+ * @brief Order two indexed ids, in the form @p qsort takes
+ */
+static int
+sptree_id_cmp(const void *a, const void *b)
+{
+  int64 l = *(const int64 *) a, r = *(const int64 *) b;
+  return (l < r) ? -1 : ((l > r) ? 1 : 0);
+}
+
 int
 sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op,
   const Temporal *temp, int maxboxes, MeosArray *result)
@@ -731,41 +741,35 @@ sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op,
   if (! boxes)
     return 0;
 
-  /* Accumulate the raw (possibly duplicated) candidate ids of every query
-   * box, tracking the maximum id seen to size the dedup bitset */
-  MeosArray *raw = meos_array_create(sizeof(int));
-  MeosArray *hits = meos_array_create(sizeof(int));
-  int maxid = -1;
+  /* Accumulate the raw (possibly duplicated) candidate ids of every query box */
+  MeosArray *raw = meos_array_create(sizeof(int64));
+  MeosArray *hits = meos_array_create(sizeof(int64));
   for (int i = 0; i < count; i++)
   {
     int nhits = sptree_search(sptree, op,
       (char *) boxes + (size_t) i * sptree->boxsize, hits);
     for (int j = 0; j < nhits; j++)
     {
-      int id = *(int *) meos_array_get(hits, j);
-      if (id > maxid)
-        maxid = id;
+      int64 id = *(int64 *) meos_array_get(hits, j);
       meos_array_add(raw, &id);
     }
   }
   pfree(boxes);
   meos_array_destroy(hits);
 
-  /* Collapse duplicates with a seen-set sized to the maximum id */
+  /* Collapse duplicates by sorting, so the memory is proportional to the
+   * NUMBER of candidate ids rather than to their magnitude */
   int nraw = meos_array_count(raw);
-  if (maxid >= 0 && nraw > 0)
+  if (nraw > 0)
   {
-    bool *seen = palloc0((size_t) (maxid + 1) * sizeof(bool));
+    int64 *ids = palloc((size_t) nraw * sizeof(int64));
     for (int i = 0; i < nraw; i++)
-    {
-      int id = *(int *) meos_array_get(raw, i);
-      if (! seen[id])
-      {
-        seen[id] = true;
-        meos_array_add(result, &id);
-      }
-    }
-    pfree(seen);
+      ids[i] = *(int64 *) meos_array_get(raw, i);
+    qsort(ids, (size_t) nraw, sizeof(int64), sptree_id_cmp);
+    for (int i = 0; i < nraw; i++)
+      if (i == 0 || ids[i] != ids[i - 1])
+        meos_array_add(result, &ids[i]);
+    pfree(ids);
   }
   meos_array_destroy(raw);
   return meos_array_count(result);
@@ -879,7 +883,7 @@ typedef struct SPNNEntry
 {
   double dist;                 /**< Distance from the query to the entry */
   bool is_emit;                /**< True for an emittable id, false for a node */
-  int id;                      /**< Stored id (when @p is_emit) */
+  int64 id;                    /**< Stored id (when @p is_emit) */
   const SPNode *node;          /**< Tree node to expand (when not @p is_emit) */
   int level;                   /**< Depth of @p node (drives the k-d dimension) */
   char region[SPTREE_NODEBOX_MAXSIZE];  /**< Region covered by @p node */
@@ -1012,7 +1016,7 @@ sptree_nn_cursor_open(const SPTree *sptree, const void *query)
  * @return @p true if a neighbour was produced, @p false once exhausted
  */
 bool
-sptree_nn_cursor_next(SPNNCursor *cursor, int *id_out, double *dist_out)
+sptree_nn_cursor_next(SPNNCursor *cursor, int64 *id_out, double *dist_out)
 {
   assert(cursor);
   const SPTree *sptree = cursor->sptree;

--- a/meos/test/rtree_join_test.c
+++ b/meos/test/rtree_join_test.c
@@ -181,13 +181,13 @@ test_stbox_join(RTreeSearchOp op, const char *opname, int count1, int count2,
       }
 
   /* Answer of the join */
-  MeosArray *result = meos_array_create(sizeof(int));
+  MeosArray *result = meos_array_create(sizeof(int64));
   int npairs = rtree_join(rtree1, rtree2, op, result);
   int *found = malloc((size_t) (npairs ? npairs : 1) * 2 * sizeof(int));
   for (int k = 0; k < npairs; k++)
   {
-    found[2 * k] = *(int *) meos_array_get(result, 2 * k);
-    found[2 * k + 1] = *(int *) meos_array_get(result, 2 * k + 1);
+    found[2 * k] = *(int64 *) meos_array_get(result, 2 * k);
+    found[2 * k + 1] = *(int64 *) meos_array_get(result, 2 * k + 1);
   }
 
   char name[128];
@@ -253,7 +253,7 @@ test_stbox_join(RTreeSearchOp op, const char *opname, int count1, int count2,
 static void
 test_degenerate(void)
 {
-  MeosArray *result = meos_array_create(sizeof(int));
+  MeosArray *result = meos_array_create(sizeof(int64));
 
   /* An index with no box joins to nothing */
   RTree *empty1 = rtree_create_stbox();
@@ -285,8 +285,8 @@ test_degenerate(void)
   int n = rtree_join(filled, near, RTREE_OVERLAPS, result);
   check("a single overlapping pair is reported once", n == 1);
   check("the reported ids are the inserted ones", n == 1 &&
-    *(int *) meos_array_get(result, 0) == 0 &&
-    *(int *) meos_array_get(result, 1) == 7);
+    *(int64 *) meos_array_get(result, 0) == 0 &&
+    *(int64 *) meos_array_get(result, 1) == 7);
 
   /* Boxes overlapping in space but not in time are not reported, since an
    * STBox pair must overlap in every dimension the two boxes share */

--- a/meos/test/rtree_knn_test.c
+++ b/meos/test/rtree_knn_test.c
@@ -134,9 +134,10 @@ test_stbox_knn(void)
   /* Full drain of the cursor */
   int *seen = calloc(NUM_BOXES, sizeof(int));
   double *cur_dist = malloc(NUM_BOXES * sizeof(double));
-  int *cur_id = malloc(NUM_BOXES * sizeof(int));
+  int64 *cur_id = malloc(NUM_BOXES * sizeof(int64));
   RTreeNNCursor *cursor = rtree_nn_cursor_open(rtree, query);
-  int n = 0, id;
+  int n = 0;
+  int64 id;
   double dist;
   while (rtree_nn_cursor_next(cursor, &id, &dist))
   {
@@ -187,7 +188,7 @@ test_stbox_knn(void)
   RTreeNNCursor *kcursor = rtree_nn_cursor_open(rtree, query);
   for (int i = 0; i < K && early_ok; i++)
   {
-    int kid;
+    int64 kid;
     double kdist;
     if (! rtree_nn_cursor_next(kcursor, &kid, &kdist) ||
         kid != cur_id[i] || fabs(kdist - cur_dist[i]) > EPS)
@@ -237,9 +238,10 @@ test_tbox_knn(void)
 
   int *seen = calloc(NUM_BOXES, sizeof(int));
   double *cur_dist = malloc(NUM_BOXES * sizeof(double));
-  int *cur_id = malloc(NUM_BOXES * sizeof(int));
+  int64 *cur_id = malloc(NUM_BOXES * sizeof(int64));
   RTreeNNCursor *cursor = rtree_nn_cursor_open(rtree, query);
-  int n = 0, id;
+  int n = 0;
+  int64 id;
   double dist;
   while (rtree_nn_cursor_next(cursor, &id, &dist))
   {

--- a/meos/test/rtree_mest_test.c
+++ b/meos/test/rtree_mest_test.c
@@ -140,9 +140,9 @@ int main(void)
    * meaningful for the dedup search) */
   Temporal *query = make_wiggly_trip(123456, buf, sizeof(buf));
 
-  MeosArray *single_ids = meos_array_create(sizeof(int));
-  MeosArray *mest_ids = meos_array_create(sizeof(int));
-  MeosArray *deg_ids = meos_array_create(sizeof(int));
+  MeosArray *single_ids = meos_array_create(sizeof(int64));
+  MeosArray *mest_ids = meos_array_create(sizeof(int64));
+  MeosArray *deg_ids = meos_array_create(sizeof(int64));
 
   int single_count = rtree_search_temporal(rtree_single, RTREE_OVERLAPS,
     query, single_ids);
@@ -158,16 +158,16 @@ int main(void)
   int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
   int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
   for (int i = 0; i < single_count; i++)
-    in_single[*(int *) meos_array_get(single_ids, i)] = true;
+    in_single[*(int64 *) meos_array_get(single_ids, i)] = true;
   for (int i = 0; i < mest_count; i++)
   {
-    int id = *(int *) meos_array_get(mest_ids, i);
+    int64 id = *(int64 *) meos_array_get(mest_ids, i);
     in_mest[id] = true;
     mest_seen[id]++;
   }
   for (int i = 0; i < deg_count; i++)
   {
-    int id = *(int *) meos_array_get(deg_ids, i);
+    int64 id = *(int64 *) meos_array_get(deg_ids, i);
     in_deg[id] = true;
     deg_seen[id]++;
   }

--- a/meos/test/rtree_span_test.c
+++ b/meos/test/rtree_span_test.c
@@ -88,12 +88,12 @@ test_intspan_rtree(void)
   int qlo = random_int(-10000, 10000);
   Span *query = intspan_make(qlo, qlo + 500, true, false);
 
-  MeosArray *result = meos_array_create(sizeof(int));
+  MeosArray *result = meos_array_create(sizeof(int64));
   int count = rtree_search(rtree, RTREE_OVERLAPS, query, result);
 
   bool *in_index = calloc(NUM_SPANS, sizeof(bool));
   for (int i = 0; i < count; i++)
-    in_index[*(int *) meos_array_get(result, i)] = true;
+    in_index[*(int64 *) meos_array_get(result, i)] = true;
 
   printf("Integer span RTree (%d random spans):\n", NUM_SPANS);
 
@@ -134,12 +134,12 @@ test_floatspan_rtree(void)
   double qlo = random_int(-10000, 10000) / 10.0;
   Span *query = floatspan_make(qlo, qlo + 50.0, true, false);
 
-  MeosArray *result = meos_array_create(sizeof(int));
+  MeosArray *result = meos_array_create(sizeof(int64));
   int count = rtree_search(rtree, RTREE_OVERLAPS, query, result);
 
   bool *in_index = calloc(NUM_SPANS, sizeof(bool));
   for (int i = 0; i < count; i++)
-    in_index[*(int *) meos_array_get(result, i)] = true;
+    in_index[*(int64 *) meos_array_get(result, i)] = true;
 
   printf("Float span RTree (%d random spans):\n", NUM_SPANS);
 

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -101,11 +101,11 @@ static void
 compare(const char *label, const SPTree *sptree, RTreeSearchOp op,
   const void *query, const bool *truth)
 {
-  MeosArray *result = meos_array_create(sizeof(int));
+  MeosArray *result = meos_array_create(sizeof(int64));
   int count = sptree_search(sptree, op, query, result);
   bool *in_index = calloc(NUM_BOXES, sizeof(bool));
   for (int i = 0; i < count; i++)
-    in_index[*(int *) meos_array_get(result, i)] = true;
+    in_index[*(int64 *) meos_array_get(result, i)] = true;
 
   int missed = 0, extra = 0;
   for (int i = 0; i < NUM_BOXES; i++)
@@ -410,9 +410,9 @@ test_mest(void)
   }
   Temporal *query = make_wiggly_tfloat(123456, buf, sizeof(buf));
 
-  MeosArray *single_ids = meos_array_create(sizeof(int));
-  MeosArray *mest_ids = meos_array_create(sizeof(int));
-  MeosArray *deg_ids = meos_array_create(sizeof(int));
+  MeosArray *single_ids = meos_array_create(sizeof(int64));
+  MeosArray *mest_ids = meos_array_create(sizeof(int64));
+  MeosArray *deg_ids = meos_array_create(sizeof(int64));
   int single_count = sptree_search_temporal(single, RTREE_OVERLAPS, query,
     single_ids);
   int mest_count = sptree_search_temporal_dedup(mest, RTREE_OVERLAPS, query,
@@ -426,16 +426,16 @@ test_mest(void)
   int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
   int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
   for (int i = 0; i < single_count; i++)
-    in_single[*(int *) meos_array_get(single_ids, i)] = true;
+    in_single[*(int64 *) meos_array_get(single_ids, i)] = true;
   for (int i = 0; i < mest_count; i++)
   {
-    int id = *(int *) meos_array_get(mest_ids, i);
+    int64 id = *(int64 *) meos_array_get(mest_ids, i);
     in_mest[id] = true;
     mest_seen[id]++;
   }
   for (int i = 0; i < deg_count; i++)
   {
-    int id = *(int *) meos_array_get(deg_ids, i);
+    int64 id = *(int64 *) meos_array_get(deg_ids, i);
     in_deg[id] = true;
     deg_seen[id]++;
   }
@@ -545,9 +545,9 @@ test_stbox_mest(void)
   }
   Temporal *query = make_wiggly_trip(123456, buf, sizeof(buf));
 
-  MeosArray *single_ids = meos_array_create(sizeof(int));
-  MeosArray *mest_ids = meos_array_create(sizeof(int));
-  MeosArray *deg_ids = meos_array_create(sizeof(int));
+  MeosArray *single_ids = meos_array_create(sizeof(int64));
+  MeosArray *mest_ids = meos_array_create(sizeof(int64));
+  MeosArray *deg_ids = meos_array_create(sizeof(int64));
   int single_count = sptree_search_temporal(single, RTREE_OVERLAPS, query,
     single_ids);
   int mest_count = sptree_search_temporal_dedup(mest, RTREE_OVERLAPS, query,
@@ -561,16 +561,16 @@ test_stbox_mest(void)
   int *mest_seen = calloc(NUM_TRIPS, sizeof(int));
   int *deg_seen = calloc(NUM_TRIPS, sizeof(int));
   for (int i = 0; i < single_count; i++)
-    in_single[*(int *) meos_array_get(single_ids, i)] = true;
+    in_single[*(int64 *) meos_array_get(single_ids, i)] = true;
   for (int i = 0; i < mest_count; i++)
   {
-    int id = *(int *) meos_array_get(mest_ids, i);
+    int64 id = *(int64 *) meos_array_get(mest_ids, i);
     in_mest[id] = true;
     mest_seen[id]++;
   }
   for (int i = 0; i < deg_count; i++)
   {
-    int id = *(int *) meos_array_get(deg_ids, i);
+    int64 id = *(int64 *) meos_array_get(deg_ids, i);
     in_deg[id] = true;
     deg_seen[id]++;
   }
@@ -659,9 +659,10 @@ span_gap(double qlo, double qhi, double lo, double hi)
 /* Drain the cursor fully, recording the id and distance sequence and how many
  * times each id is produced */
 static int
-drain(SPNNCursor *cursor, int *cur_id, double *cur_dist, int *seen)
+drain(SPNNCursor *cursor, int64 *cur_id, double *cur_dist, int *seen)
 {
-  int n = 0, id;
+  int n = 0;
+  int64 id;
   double dist;
   while (sptree_nn_cursor_next(cursor, &id, &dist))
   {
@@ -681,7 +682,7 @@ drain(SPNNCursor *cursor, int *cur_id, double *cur_dist, int *seen)
  * the first K results match the full-drain prefix */
 static void
 check_structural(const char *label, SPTree *sptree, const void *query,
-  const int *cur_id, const double *cur_dist, const int *seen, int n)
+  const int64 *cur_id, const double *cur_dist, const int *seen, int n)
 {
   char name[128];
   bool complete = (n == NUM_BOXES);
@@ -702,7 +703,7 @@ check_structural(const char *label, SPTree *sptree, const void *query,
   SPNNCursor *kc = sptree_nn_cursor_open(sptree, query);
   for (int i = 0; i < K && early; i++)
   {
-    int kid;
+    int64 kid;
     double kdist;
     if (! sptree_nn_cursor_next(kc, &kid, &kdist) || kid != cur_id[i] ||
         fabs(kdist - cur_dist[i]) > EPS)
@@ -715,7 +716,7 @@ check_structural(const char *label, SPTree *sptree, const void *query,
 
 /* Additionally check the reported distances against a brute-force oracle */
 static void
-check_metric(const char *label, const int *cur_id, const double *cur_dist,
+check_metric(const char *label, const int64 *cur_id, const double *cur_dist,
   int n, const double *brute)
 {
   char name[128];
@@ -765,7 +766,7 @@ test_nn_floatspan(void)
 
   int *seen = calloc(NUM_BOXES, sizeof(int));
   double *cd = malloc(NUM_BOXES * sizeof(double));
-  int *ci = malloc(NUM_BOXES * sizeof(int));
+  int64 *ci = malloc(NUM_BOXES * sizeof(int64));
   SPNNCursor *cursor = sptree_nn_cursor_open(sptree, query);
   int n = drain(cursor, ci, cd, seen);
   sptree_nn_cursor_close(cursor);
@@ -817,7 +818,7 @@ test_nn_tbox(void)
 
   int *seen = calloc(NUM_BOXES, sizeof(int));
   double *cd = malloc(NUM_BOXES * sizeof(double));
-  int *ci = malloc(NUM_BOXES * sizeof(int));
+  int64 *ci = malloc(NUM_BOXES * sizeof(int64));
   SPNNCursor *cursor = sptree_nn_cursor_open(sptree, query);
   int n = drain(cursor, ci, cd, seen);
   sptree_nn_cursor_close(cursor);
@@ -845,7 +846,7 @@ test_nn_stbox(void)
 
   int *seen = calloc(NUM_BOXES, sizeof(int));
   double *cd = malloc(NUM_BOXES * sizeof(double));
-  int *ci = malloc(NUM_BOXES * sizeof(int));
+  int64 *ci = malloc(NUM_BOXES * sizeof(int64));
   SPNNCursor *cursor = sptree_nn_cursor_open(sptree, query);
   int n = drain(cursor, ci, cd, seen);
   sptree_nn_cursor_close(cursor);
@@ -875,11 +876,11 @@ static void
 selective(const char *label, const SPTree *sptree, const void *query,
   const bool *truth, int ntruth)
 {
-  MeosArray *result = meos_array_create(sizeof(int));
+  MeosArray *result = meos_array_create(sizeof(int64));
   int count = sptree_search(sptree, RTREE_OVERLAPS, query, result);
   bool *in_index = calloc(SEL_BOXES, sizeof(bool));
   for (int i = 0; i < count; i++)
-    in_index[*(int *) meos_array_get(result, i)] = true;
+    in_index[*(int64 *) meos_array_get(result, i)] = true;
   int missed = 0;
   for (int i = 0; i < SEL_BOXES; i++)
     if (truth[i] && ! in_index[i])


### PR DESCRIPTION
The in-memory RTree and SPTree take the identifier a caller stores as an `int`, while a caller identifies a row with an `int64`. DuckDB's `row_t` is `int64`, so MobilityDuck narrows every identifier it inserts and the index answers with a truncated one. The ceiling is invisible until a table exceeds 2^31 rows.

This widens the identifier to `int64` along the whole path:

- the six insert entry points — `rtree_insert`, `rtree_insert_temporal`, `rtree_insert_temporal_split` and the `sptree_` equivalents;
- `rtree_nn_cursor_next` and `sptree_nn_cursor_next`, whose `id_out` carries the same identifier back;
- `RTreeNode.ids[]` and the `id` of an SPTree node;
- every `MeosArray` that a search, a join or a dedup fills, together with the cast that reads it back.

`meos_array_add` ends in `memcpy(dest, value, array->elem_size)`, so the element size belongs to the caller and an array created at one width and read at another is silent rather than a compile error. The element size and the cast therefore move together at each site: `tgeo_spatialrels.c`, `tgeo_distance.c`, `tpoint_geom_clip.c`, `tcbuffer_distance.c`, the four index tests and the two index examples. Where a consumer keeps its own `int` array — the segment pairs `rtree_join` returns in `tgeo_spatialrels.c` — the identifiers are the segment positions inserted a few lines above, so they are bounded by the segment count and the narrowing back to `int` is exact and explicit.

The split search also collapses its duplicates by sorting. A `bool` set indexed with the identifier allocates in proportion to a value the caller chooses: roughly 2 GB for an identifier near `INT_MAX`, and no bound at all once an identifier is 64 bits. Sorting the candidates and emitting the distinct ones costs memory proportional to the number of candidates.

## For binding consumers

A binding that creates the result array itself is on the other side of this change and keeps its own ceiling until it widens. In MobilityDuck (`main`) that is `src/index/rtree_module.cpp:546,554` and `src/index/sptree_module.cpp:561,569`, which create with `meos_array_create(sizeof(int))` and read through `*(int *) meos_array_get(...)`, plus the six insert-side casts to `int`.

On a little-endian target such a binding keeps the behaviour it has: `meos_array_add` copies the caller's four bytes, which hold the low half of the identifier, and the reader takes the same four bytes back, so identifiers below 2^31 round-trip exactly and larger ones truncate. On a big-endian target those four bytes hold the high half and no identifier round-trips. Either way the binding gains nothing from this change until both the element size and the cast widen, and the discrepancy is invisible to a suite whose tables are small enough to keep every identifier under 2^31.
