### PR TITLE
Convert a curve polygon that is not a circle by the circle enclosing it

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -132,6 +132,8 @@ extern bool relate_point_on_boundary(double x, double y, Edge **edges,
   int nedges);
 extern int relate_point_in_area(double x, double y, Edge **edges, int nedges);
 
+extern bool circle_type(const GSERIALIZED *gs);
+extern bool ensure_circle_type(const GSERIALIZED *gs);
 extern LWGEOM *lwcircle_make(double x, double y, double radius,
   int32_t srid);
 extern GSERIALIZED *geocircle_make(double x, double y, double radius,

--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -123,8 +123,6 @@ extern bool ensure_has_M_geo(const GSERIALIZED *gs);
 extern bool ensure_has_not_M_geo(const GSERIALIZED *gs);
 extern bool ensure_point_type(const GSERIALIZED *gs);
 extern bool ensure_mline_type(const GSERIALIZED *gs);
-extern bool circle_type(const GSERIALIZED *gs);
-extern bool ensure_circle_type(const GSERIALIZED *gs);
 extern bool ensure_not_empty(const GSERIALIZED *gs);
 extern bool ensure_valid_stbox_geo(const STBox *box, const GSERIALIZED *gs);
 extern bool ensure_valid_tspatial_geo(const Temporal *temp,

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -561,10 +561,12 @@ geom_to_cbuffer(const GSERIALIZED *gs)
   if (type == POINTTYPE)
     return cbuffer_make(gs, 0.0);
 
-  /* CURVEPOLYTYPE */
+  /* A curve polygon that is a circle carries its centre and its radius
+   * exactly; one that bounds any other shape is read like any other geometry,
+   * by the circle that encloses it */
   GSERIALIZED *gscenter;
   double radius;
-  if (type == CURVEPOLYTYPE)
+  if (circle_type(gs))
   {
     int32_t srid = gserialized_get_srid(gs);
     LWCURVEPOLY *poly = (LWCURVEPOLY *) lwgeom_from_gserialized(gs);
@@ -572,18 +574,19 @@ geom_to_cbuffer(const GSERIALIZED *gs)
     POINT4D p1, p2;
     getPoint4d_p(ring->points, 0, &p1);
     getPoint4d_p(ring->points, 1, &p2);
-    /* Compute the radius. We cannot call the PostGIS function
+    /* The two points are the ends of a diameter, so the centre is halfway
+     * between them and the radius is half of what separates them. We cannot
+     * call the PostGIS function
      * interpolate_point4d(&p1, &p2, &p, ratio);
      * since it uses a double and not a long double for the interpolation */
     double x = p1.x + (double) ((long double) (p2.x - p1.x) * 0.5);
     double y = p1.y + (double) ((long double) (p2.y - p1.y) * 0.5);
-    radius = fabs(p2.x - p1.x) / 2;
+    radius = hypot(p2.x - p1.x, p2.y - p1.y) / 2;
     LWGEOM *center = (LWGEOM *) lwpoint_make2d(srid, x, y);
     gscenter = geom_serialize(center);
     lwgeom_free((LWGEOM *) poly); lwgeom_free(center); 
   }
   else
-  /* geotype != POINTTYPE && geotype != CURVEPOLYTYPE */
   {
     gscenter = geom_min_bounding_radius(gs, &radius);
   }

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -47,49 +47,6 @@
 #include "cbuffer/cbuffer.h"
 
 /*****************************************************************************
- * Utility functions
- *****************************************************************************/
-
-/**
- * @brief Return true if the geometry/geography is a circle
- */
-bool
-circle_type(const GSERIALIZED *gs)
-{
-  if (gserialized_get_type(gs) != CURVEPOLYTYPE)
-    return false;
-  LWGEOM *geo = lwgeom_from_gserialized(gs);
-  if (lwgeom_count_rings(geo) != 1)
-  {
-    pfree(geo); 
-    return false;
-  }
-  LWCURVEPOLY *circle = (LWCURVEPOLY *) geo;
-  LWCIRCSTRING *ring = (LWCIRCSTRING *) circle->rings[0];
-  if (ring->points->npoints != 3 || ! ptarray_is_closed(ring->points))
-  {
-    pfree(geo); 
-    return false;
-  }
-  return true;
-}
-
-/**
- * @brief Ensure that the geometry/geography is a circle
- */
-bool
-ensure_circle_type(const GSERIALIZED *gs)
-{
-  if (! circle_type(gs))
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "Only circle polygons accepted");
-    return false;
-  }
-  return true;
-}
-
-/*****************************************************************************
  * Traversed area 
  *****************************************************************************/
 

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -849,6 +849,50 @@ geocircle_make(double x, double y, double radius, int32_t srid)
   return result;
 }
 
+/**
+ * @brief Return true if a geometry is a circle
+ * @details A circle is a curve polygon of a single ring, that ring a closed
+ * circular string of three points: the two ends, which are the same point,
+ * and the point opposite them. A ring of any other kind belongs to a curve
+ * polygon that bounds some other shape, and the members it carries are not
+ * the ones a circular string carries, so its kind is read before it is
+ * addressed as one.
+ */
+bool
+circle_type(const GSERIALIZED *gs)
+{
+  if (gserialized_get_type(gs) != CURVEPOLYTYPE)
+    return false;
+  LWGEOM *geo = lwgeom_from_gserialized(gs);
+  bool result = false;
+  if (lwgeom_count_rings(geo) == 1)
+  {
+    LWGEOM *ring = ((LWCURVEPOLY *) geo)->rings[0];
+    if (ring->type == CIRCSTRINGTYPE)
+    {
+      const POINTARRAY *points = ((LWCIRCSTRING *) ring)->points;
+      result = points->npoints == 3 && ptarray_is_closed(points);
+    }
+  }
+  lwgeom_free(geo);
+  return result;
+}
+
+/**
+ * @brief Ensure that the geometry/geography is a circle
+ */
+bool
+ensure_circle_type(const GSERIALIZED *gs)
+{
+  if (! circle_type(gs))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Only circle polygons accepted");
+    return false;
+  }
+  return true;
+}
+
 /*****************************************************************************
  * Point classification
  *****************************************************************************/

--- a/mobilitydb/test/cbuffer/expected/200_cbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/200_cbuffer.test.out
@@ -186,6 +186,24 @@ SELECT ST_AsText(round(cbuffer(geometry 'CurvePolygon(CircularString(2 5, 8 5, 2
  CURVEPOLYGON(CIRCULARSTRING(2 5,8 5,2 5))
 (1 row)
 
+SELECT asText(round(cbuffer(geometry 'CurvePolygon(CircularString(0 -1, 0 1, 0 -1))'), 6));
+        astext         
+-----------------------
+ Cbuffer(POINT(0 0),1)
+(1 row)
+
+SELECT asText(round(cbuffer(geometry 'CurvePolygon(CircularString(0 0, 2 2, 4 0, 2 -2, 0 0))'), 6));
+        astext         
+-----------------------
+ Cbuffer(POINT(2 0),2)
+(1 row)
+
+SELECT asText(round(cbuffer(geometry 'CurvePolygon(CompoundCurve(CircularString(0 0, 2 2, 4 0),(4 0, 0 0)))'), 6));
+        astext         
+-----------------------
+ Cbuffer(POINT(2 0),2)
+(1 row)
+
 SELECT asText(round(cbuffer(geometry 'Linestring(0 0, 10 0)'), 6));
         astext         
 -----------------------

--- a/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
@@ -106,6 +106,13 @@ SELECT asText(round((cbuffer 'Cbuffer(Point(1 1),0.2)'::geometry)::cbuffer, 6));
 SELECT asText(round(cbuffer(geometry 'CurvePolygon(CircularString(2 5, 8 5, 2 5))'), 6));
 SELECT ST_AsText(round(cbuffer(geometry 'CurvePolygon(CircularString(2 5, 8 5, 2 5))')::geometry, 6));
 
+-- A circle stands the same way whichever pair of opposite points its ring
+-- names, and a curve polygon that is not a circle converts by the circle that
+-- encloses it
+SELECT asText(round(cbuffer(geometry 'CurvePolygon(CircularString(0 -1, 0 1, 0 -1))'), 6));
+SELECT asText(round(cbuffer(geometry 'CurvePolygon(CircularString(0 0, 2 2, 4 0, 2 -2, 0 0))'), 6));
+SELECT asText(round(cbuffer(geometry 'CurvePolygon(CompoundCurve(CircularString(0 0, 2 2, 4 0),(4 0, 0 0)))'), 6));
+
 -- SELECT geometry 'SRID=5676;Point(610.455019399524 528.508247341961)'::cbuffer;
 
 -- Minimum Enclosing Circle (via geometry::cbuffer cast for non-point geometries)


### PR DESCRIPTION
A circular buffer converted from a geometry reads a curve polygon as a circle
and takes its centre and radius from the first two points of the ring. Two
things follow from reading it that way rather than asking first whether it is
one.

A curve polygon bounds any shape an arc can trace, so its ring is a circular
string only when the shape is a circle; a compound curve ring carries the
pieces it is made of where a circular string carries points, and reading the
one as the other reads memory that holds something else. Converting
CurvePolygon(CompoundCurve(CircularString(0 0, 2 2, 4 0),(4 0, 0 0))) ends the
session.

The first two points of the ring are the ends of a diameter only when the ring
names three of them. A circle written with five, as
CurvePolygon(CircularString(0 0, 2 2, 4 0, 2 -2, 0 0)), takes its centre from
two points that are a quarter turn apart, and answers a circle of radius 1 at
(1 1) for one of radius 2 at (2 0).

circle_type answers whether a geometry is a circle, and the conversion asks it
before taking the exact route; everything else converts by the circle that
encloses it, as a polygon or a collection already does. The predicate reads
the kind of the ring before addressing it as a circular string, and releases
the geometry it opens on every path rather than only where it answers false.

Reading the radius from the distance between the two points, rather than from
how far apart they stand along the x axis alone, is what a circle written
about a vertical diameter needs: CurvePolygon(CircularString(0 -1, 0 1, 0 -1))
answers radius 1 where the axis-wise reading answers 0.

The predicate and the validator beside it move to the geometry layer, where
the circle constructors they belong with already are: a question about a
geometry is answered in one place, and the circular buffer type asks it.

