### PR TITLE
Answer the questions about points and segments in the geometry layer

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -132,6 +132,16 @@ extern bool relate_point_on_boundary(double x, double y, Edge **edges,
   int nedges);
 extern int relate_point_in_area(double x, double y, Edge **edges, int nedges);
 
+extern long double closest_point2d_on_segment_ratio(const POINT2D *p,
+  const POINT2D *A, const POINT2D *B, POINT2D *closest);
+extern long double closest_point3dz_on_segment_ratio(const POINT3DZ *p,
+  const POINT3DZ *A, const POINT3DZ *B, POINT3DZ *closest);
+extern LWGEOM **lwpointarr_remove_duplicates(LWGEOM **points, int count,
+  int *newcount);
+extern LWGEOM *lwpointarr_make_trajectory(LWGEOM **points, int count,
+  interpType interp);
+extern bool ensure_valid_geo_geo(const GSERIALIZED *gs1,
+  const GSERIALIZED *gs2);
 extern bool circle_type(const GSERIALIZED *gs);
 extern bool ensure_circle_type(const GSERIALIZED *gs);
 extern LWGEOM *lwcircle_make(double x, double y, double radius,

--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -133,8 +133,6 @@ extern bool ensure_valid_tspatial_tspatial(const Temporal *temp1,
 extern bool ensure_valid_spatial_stbox_stbox(const STBox *box1,
   const STBox *box2);
 extern bool ensure_valid_tgeo_stbox(const Temporal *temp, const STBox *box);
-extern bool ensure_valid_geo_geo(const GSERIALIZED *gs1,
-  const GSERIALIZED *gs2);
 extern bool ensure_valid_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern bool ensure_valid_tgeo_tgeo(const Temporal *temp1,
   const Temporal *temp2);
@@ -155,14 +153,6 @@ extern int eacomp_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
 
 /* Functions derived from PostGIS to increase floating-point precision */
 
-extern long double closest_point2d_on_segment_ratio(const POINT2D *p,
-  const POINT2D *A, const POINT2D *B, POINT2D *closest);
-extern long double closest_point3dz_on_segment_ratio(const POINT3DZ *p,
-  const POINT3DZ *A, const POINT3DZ *B, POINT3DZ *closest);
-extern long double closest_point_on_segment_sphere(const POINT4D *p,
-  const POINT4D *A, const POINT4D *B, POINT4D *closest, double *dist);
-extern void interpolate_point4d_spheroid(const POINT4D *p1, const POINT4D *p2,
-  POINT4D *p, const SPHEROID *s, double f);
 
 /* Functions specializing the PostGIS functions ST_LineInterpolatePoint and
  * ST_LineLocatePoint */
@@ -188,13 +178,7 @@ extern bool geopoint_collinear(Datum value1, Datum value2, Datum value3,
 
 /* Trajectory functions */
 
-extern LWGEOM **lwpointarr_remove_duplicates(LWGEOM **points, int count,
-  int *newcount);
-extern LWGEOM *lwpointarr_make_trajectory(LWGEOM **points, int count,
-  interpType interp);
 extern LWLINE *lwline_make(Datum value1, Datum value2);
-extern LWGEOM *lwcoll_from_points_lines(LWGEOM **points, LWGEOM **lines,
-  int npoints, int nlines);
 
 /* Stop function */
 

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -41,6 +41,7 @@
 #include <math.h>
 /* PostgreSQL */
 #include "postgres.h"
+#include <pgtypes.h>
 /* PostGIS */
 #include "liblwgeom.h"
 #include "liblwgeom_internal.h"
@@ -804,6 +805,217 @@ pointarr_find_splits(const POINT2D **points, int npoints, int *count)
   }
   *count = numsplits;
   return bitarr;
+}
+
+/*****************************************************************************
+ * Segments and arrays of points
+ *****************************************************************************/
+
+/**
+ * @brief Return -1, 0, or 1 depending on whether the first @p LWPOINT
+ * is less than, equal to, or greater than the second one
+ * @pre The points are not empty and are of the same dimensionality
+ */
+static int
+lwpoint_cmp(const LWPOINT *p, const LWPOINT *q)
+{
+  assert(FLAGS_GET_ZM(p->flags) == FLAGS_GET_ZM(q->flags));
+  POINT4D p4d, q4d;
+  /* We are sure the points are not empty */
+  lwpoint_getPoint4d_p(p, &p4d);
+  lwpoint_getPoint4d_p(q, &q4d);
+  int cmp = pg_float8_cmp(p4d.x, q4d.x);
+  if (cmp != 0)
+    return cmp;
+  cmp = pg_float8_cmp(p4d.y, q4d.y);
+  if (cmp != 0)
+    return cmp;
+  if (FLAGS_GET_Z(p->flags))
+  {
+    cmp = pg_float8_cmp(p4d.z, q4d.z);
+    if (cmp != 0)
+      return cmp;
+  }
+  if (FLAGS_GET_M(p->flags))
+  {
+    cmp = pg_float8_cmp(p4d.m, q4d.m);
+    if (cmp != 0)
+      return cmp;
+  }
+  return 0;
+}
+
+/**
+ * @brief Comparator function for lwpoints
+ */
+static int
+lwpoint_sort_cmp(const LWPOINT **l, const LWPOINT **r)
+{
+  return lwpoint_cmp(*l, *r);
+}
+/**
+ * @brief Sort function for lwpoints
+ */
+static void
+lwpointarr_sort(LWPOINT **points, int count)
+{
+  qsort(points, (size_t) count, sizeof(LWPOINT *),
+    (qsort_comparator) &lwpoint_sort_cmp);
+  return;
+}
+
+/**
+ * @brief Return a long double between 0 and 1 representing the location of the
+ * closest point on the 2D segment to the given point, as a fraction of total
+ * segment length
+ * @note Function derived from the PostGIS function @p closest_point_on_segment
+ */
+long double
+closest_point2d_on_segment_ratio(const POINT2D *p, const POINT2D *A,
+  const POINT2D *B, POINT2D *closest)
+{
+  if (FP_EQUALS(A->x, B->x) && FP_EQUALS(A->y, B->y))
+  {
+    if (closest)
+      *closest = *A;
+    return 0.0;
+  }
+
+  /*
+   * We use comp.graphics.algorithms Frequently Asked Questions method
+   *
+   * (1)          AC dot AB
+   *         r = ----------
+   *              ||AB||^2
+   *  r has the following meaning:
+   *  r=0 P = A
+   *  r=1 P = B
+   *  r<0 P is on the backward extension of AB
+   *  r>1 P is on the forward extension of AB
+   *  0<r<1 P is interior to AB
+   *
+   */
+  long double r = ( (p->x-A->x) * (B->x-A->x) + (p->y-A->y) * (B->y-A->y) ) /
+    ( (B->x-A->x) * (B->x-A->x) + (B->y-A->y) * (B->y-A->y) );
+
+  if (r < 0)
+  {
+    if (closest)
+      *closest = *A;
+    return 0.0;
+  }
+  if (r > 1)
+  {
+    if (closest)
+      *closest = *B;
+    return 1.0;
+  }
+
+  if (closest)
+  {
+    closest->x = (double) (A->x + ( (B->x - A->x) * r ));
+    closest->y = (double) (A->y + ( (B->y - A->y) * r ));
+  }
+  return r;
+}
+
+/**
+ * @brief Return a long double between 0 and 1 representing the location of the
+ * closest point on the 3D segment to the given point, as a fraction of total
+ * segment length
+ * @note Function derived from the PostGIS function @p closest_point_on_segment
+ */
+long double
+closest_point3dz_on_segment_ratio(const POINT3DZ *p, const POINT3DZ *A,
+  const POINT3DZ *B, POINT3DZ *closest)
+{
+  if (FP_EQUALS(A->x, B->x) && FP_EQUALS(A->y, B->y) && FP_EQUALS(A->z, B->z))
+  {
+    *closest = *A;
+    return 0.0;
+  }
+
+  /* Function #closest_point2d_on_segment_ratio explains how r is computed */
+  long double r = ( (p->x-A->x) * (B->x-A->x) + (p->y-A->y) * (B->y-A->y) +
+      (p->z-A->z) * (B->z-A->z) ) /
+    ( (B->x-A->x) * (B->x-A->x) + (B->y-A->y) * (B->y-A->y) +
+      (B->z-A->z) * (B->z-A->z) );
+
+  if (r < 0)
+  {
+    *closest = *A;
+    return 0.0;
+  }
+  if (r > 1)
+  {
+    *closest = *B;
+    return 1.0;
+  }
+
+  closest->x = (double) (A->x + ( (B->x - A->x) * r ));
+  closest->y = (double) (A->y + ( (B->y - A->y) * r ));
+  closest->z = (double) (A->z + ( (B->z - A->z) * r ));
+  return r;
+}
+
+/**
+ * @brief Remove duplicates from an array of LWGEOM points
+ */
+LWGEOM **
+lwpointarr_remove_duplicates(LWGEOM **points, int count, int *newcount)
+{
+  assert(count > 0);
+  LWGEOM **newpoints = palloc(sizeof(LWGEOM *) * count);
+  memcpy(newpoints, points, sizeof(LWGEOM *) * count);
+  lwpointarr_sort((LWPOINT **) newpoints, count);
+  int count1 = 0;
+  for (int i = 1; i < count; i++)
+    if (! lwpoint_same((LWPOINT *) newpoints[count1], (LWPOINT *) newpoints[i]))
+      newpoints[++ count1] = newpoints[i];
+  *newcount = count1 + 1;
+  return newpoints;
+}
+
+/**
+ * @brief Return a trajectory from a set of points
+ * @details The result is either a linestring or a multipoint depending on
+ * whether the interpolation is step/discrete or linear.
+ * @param[in] points Array of points
+ * @param[in] count Number of elements in the input array
+ * @param[in] interp Interpolation
+ * @note The function does not remove duplicate points, that is, repeated
+ * points in a multipoint or consecutive equal points in a line string
+ */
+LWGEOM *
+lwpointarr_make_trajectory(LWGEOM **points, int count, interpType interp)
+{
+  assert(points); assert(count > 0);
+  if (count == 1)
+    return lwpoint_as_lwgeom(lwpoint_clone(lwgeom_as_lwpoint(points[0])));
+
+  LWGEOM *result = (interp == LINEAR) ?
+    (LWGEOM *) lwline_from_lwgeom_array(points[0]->srid, (uint32_t) count,
+      points) :
+    (LWGEOM *) lwcollection_construct(MULTIPOINTTYPE, points[0]->srid,
+      NULL, (uint32_t) count, points);
+  FLAGS_SET_Z(result->flags, FLAGS_GET_Z(points[0]->flags));
+  FLAGS_SET_GEODETIC(result->flags, FLAGS_GET_GEODETIC(points[0]->flags));
+  return result;
+}
+
+/**
+ * @brief Ensure the validity of two temporal points
+ */
+bool
+ensure_valid_geo_geo(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(gs1, false); VALIDATE_NOT_NULL(gs2, false);
+  if (! ensure_same_srid(gserialized_get_srid(gs1),
+        gserialized_get_srid(gs2)) ||
+      ! ensure_same_geodetic_geo(gs1, gs2))
+    return false;
+  return true;
 }
 
 /*****************************************************************************

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -33,6 +33,7 @@
  * PostGIS functions in order to bypass the function manager in @p fmgr.c
  */
 
+#include "geo/geo_funcs.h"
 #include "geo/postgis_funcs.h"
 
 /* C */

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -32,6 +32,7 @@
  * @brief Temporal distance functions for temporal geos
  */
 
+#include "geo/geo_funcs.h"
 #include "geo/tgeo_distance.h"
 
 /* C */

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -51,6 +51,7 @@
 #include "temporal/temporal_restrict.h"
 #include "temporal/tsequence.h"
 #include "temporal/type_util.h"
+#include "geo/geo_funcs.h"
 #include "geo/clip_clipper2.h"
 #include "geo/postgis_funcs.h"
 #include "geo/tgeo.h"

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -74,20 +74,6 @@
  * Validity functions
  *****************************************************************************/
 
-/**
- * @brief Ensure the validity of two temporal points
- */
-bool
-ensure_valid_geo_geo(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs1, false); VALIDATE_NOT_NULL(gs2, false);
-  if (! ensure_same_srid(gserialized_get_srid(gs1),
-        gserialized_get_srid(gs2)) ||
-      ! ensure_same_geodetic_geo(gs1, gs2))
-    return false;
-  return true;
-}
 
 /**
  * @brief Ensure the validity of two temporal points
@@ -227,99 +213,7 @@ tpoint_get_z(const Temporal *temp)
  * Functions derived from PostGIS to increase floating-point precision
  *****************************************************************************/
 
-/**
- * @brief Return a long double between 0 and 1 representing the location of the
- * closest point on the 2D segment to the given point, as a fraction of total
- * segment length
- * @note Function derived from the PostGIS function @p closest_point_on_segment
- */
-long double
-closest_point2d_on_segment_ratio(const POINT2D *p, const POINT2D *A,
-  const POINT2D *B, POINT2D *closest)
-{
-  if (FP_EQUALS(A->x, B->x) && FP_EQUALS(A->y, B->y))
-  {
-    if (closest)
-      *closest = *A;
-    return 0.0;
-  }
 
-  /*
-   * We use comp.graphics.algorithms Frequently Asked Questions method
-   *
-   * (1)          AC dot AB
-   *         r = ----------
-   *              ||AB||^2
-   *  r has the following meaning:
-   *  r=0 P = A
-   *  r=1 P = B
-   *  r<0 P is on the backward extension of AB
-   *  r>1 P is on the forward extension of AB
-   *  0<r<1 P is interior to AB
-   *
-   */
-  long double r = ( (p->x-A->x) * (B->x-A->x) + (p->y-A->y) * (B->y-A->y) ) /
-    ( (B->x-A->x) * (B->x-A->x) + (B->y-A->y) * (B->y-A->y) );
-
-  if (r < 0)
-  {
-    if (closest)
-      *closest = *A;
-    return 0.0;
-  }
-  if (r > 1)
-  {
-    if (closest)
-      *closest = *B;
-    return 1.0;
-  }
-
-  if (closest)
-  {
-    closest->x = (double) (A->x + ( (B->x - A->x) * r ));
-    closest->y = (double) (A->y + ( (B->y - A->y) * r ));
-  }
-  return r;
-}
-
-/**
- * @brief Return a long double between 0 and 1 representing the location of the
- * closest point on the 3D segment to the given point, as a fraction of total
- * segment length
- * @note Function derived from the PostGIS function @p closest_point_on_segment
- */
-long double
-closest_point3dz_on_segment_ratio(const POINT3DZ *p, const POINT3DZ *A,
-  const POINT3DZ *B, POINT3DZ *closest)
-{
-  if (FP_EQUALS(A->x, B->x) && FP_EQUALS(A->y, B->y) && FP_EQUALS(A->z, B->z))
-  {
-    *closest = *A;
-    return 0.0;
-  }
-
-  /* Function #closest_point2d_on_segment_ratio explains how r is computed */
-  long double r = ( (p->x-A->x) * (B->x-A->x) + (p->y-A->y) * (B->y-A->y) +
-      (p->z-A->z) * (B->z-A->z) ) /
-    ( (B->x-A->x) * (B->x-A->x) + (B->y-A->y) * (B->y-A->y) +
-      (B->z-A->z) * (B->z-A->z) );
-
-  if (r < 0)
-  {
-    *closest = *A;
-    return 0.0;
-  }
-  if (r > 1)
-  {
-    *closest = *B;
-    return 1.0;
-  }
-
-  closest->x = (double) (A->x + ( (B->x - A->x) * r ));
-  closest->y = (double) (A->y + ( (B->y - A->y) * r ));
-  closest->z = (double) (A->z + ( (B->z - A->z) * r ));
-  return r;
-}
 
 /**
  * @brief Return a float between 0 and 1 representing the location of the
@@ -330,7 +224,7 @@ closest_point3dz_on_segment_ratio(const POINT3DZ *p, const POINT3DZ *A,
  * @param[out] closest Closest point in the segment
  * @param[out] dist Distance between the closest point and the reference point
  */
-long double
+static long double
 closest_point_on_segment_sphere(const POINT4D *p, const POINT4D *A,
   const POINT4D *B, POINT4D *closest, double *dist)
 {
@@ -378,7 +272,7 @@ closest_point_on_segment_sphere(const POINT4D *p, const POINT4D *A,
  * @param[in] f Fraction
  * @param[out] p Result
  */
-void
+static void
 interpolate_point4d_spheroid(const POINT4D *p1, const POINT4D *p2,
   POINT4D *p, const SPHEROID *s, double f)
 {
@@ -615,104 +509,10 @@ geopoint_collinear(Datum value1, Datum value2, Datum value3,
  * Trajectory functions
  *****************************************************************************/
 
-/**
- * @brief Return -1, 0, or 1 depending on whether the first @p LWPOINT
- * is less than, equal to, or greater than the second one
- * @pre The points are not empty and are of the same dimensionality
- */
-static int
-lwpoint_cmp(const LWPOINT *p, const LWPOINT *q)
-{
-  assert(FLAGS_GET_ZM(p->flags) == FLAGS_GET_ZM(q->flags));
-  POINT4D p4d, q4d;
-  /* We are sure the points are not empty */
-  lwpoint_getPoint4d_p(p, &p4d);
-  lwpoint_getPoint4d_p(q, &q4d);
-  int cmp = pg_float8_cmp(p4d.x, q4d.x);
-  if (cmp != 0)
-    return cmp;
-  cmp = pg_float8_cmp(p4d.y, q4d.y);
-  if (cmp != 0)
-    return cmp;
-  if (FLAGS_GET_Z(p->flags))
-  {
-    cmp = pg_float8_cmp(p4d.z, q4d.z);
-    if (cmp != 0)
-      return cmp;
-  }
-  if (FLAGS_GET_M(p->flags))
-  {
-    cmp = pg_float8_cmp(p4d.m, q4d.m);
-    if (cmp != 0)
-      return cmp;
-  }
-  return 0;
-}
 
-/**
- * @brief Comparator function for lwpoints
- */
-static int
-lwpoint_sort_cmp(const LWPOINT **l, const LWPOINT **r)
-{
-  return lwpoint_cmp(*l, *r);
-}
 
-/**
- * @brief Sort function for lwpoints
- */
-void
-lwpointarr_sort(LWPOINT **points, int count)
-{
-  qsort(points, (size_t) count, sizeof(LWPOINT *),
-    (qsort_comparator) &lwpoint_sort_cmp);
-  return;
-}
 
-/**
- * @brief Remove duplicates from an array of LWGEOM points
- */
-LWGEOM **
-lwpointarr_remove_duplicates(LWGEOM **points, int count, int *newcount)
-{
-  assert(count > 0);
-  LWGEOM **newpoints = palloc(sizeof(LWGEOM *) * count);
-  memcpy(newpoints, points, sizeof(LWGEOM *) * count);
-  lwpointarr_sort((LWPOINT **) newpoints, count);
-  int count1 = 0;
-  for (int i = 1; i < count; i++)
-    if (! lwpoint_same((LWPOINT *) newpoints[count1], (LWPOINT *) newpoints[i]))
-      newpoints[++ count1] = newpoints[i];
-  *newcount = count1 + 1;
-  return newpoints;
-}
 
-/**
- * @brief Return a trajectory from a set of points
- * @details The result is either a linestring or a multipoint depending on
- * whether the interpolation is step/discrete or linear.
- * @param[in] points Array of points
- * @param[in] count Number of elements in the input array
- * @param[in] interp Interpolation
- * @note The function does not remove duplicate points, that is, repeated
- * points in a multipoint or consecutive equal points in a line string
- */
-LWGEOM *
-lwpointarr_make_trajectory(LWGEOM **points, int count, interpType interp)
-{
-  assert(points); assert(count > 0);
-  if (count == 1)
-    return lwpoint_as_lwgeom(lwpoint_clone(lwgeom_as_lwpoint(points[0])));
-
-  LWGEOM *result = (interp == LINEAR) ?
-    (LWGEOM *) lwline_from_lwgeom_array(points[0]->srid, (uint32_t) count,
-      points) :
-    (LWGEOM *) lwcollection_construct(MULTIPOINTTYPE, points[0]->srid,
-      NULL, (uint32_t) count, points);
-  FLAGS_SET_Z(result->flags, FLAGS_GET_Z(points[0]->flags));
-  FLAGS_SET_GEODETIC(result->flags, FLAGS_GET_GEODETIC(points[0]->flags));
-  return result;
-}
 
 /**
  * @brief Return the line connecting two geometry points
@@ -743,7 +543,7 @@ lwline_make(Datum value1, Datum value2)
  * @brief Return a geometry from an array of points and lines
  * @pre There is at least one geometry in both arrays
  */
-LWGEOM *
+static LWGEOM *
 lwcoll_from_points_lines(LWGEOM **points, LWGEOM **lines, int npoints,
   int nlines)
 {

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -65,6 +65,7 @@
 #include "temporal/type_inout.h"
 #include "temporal/type_parser.h"
 #include "temporal/type_util.h"
+#include "geo/geo_funcs.h"
 #include "geo/postgis_funcs.h"
 #include "geo/tgeo.h"
 #include "geo/tgeo_spatialfuncs.h"


### PR DESCRIPTION
The temporal point file holds functions that name no temporal type: the ratio
at which a point is closest to a segment in two and in three dimensions, the
comparison and the sorting of an array of points, the removal of its
duplicates, the trajectory built from one, and the check that two geometries go
together. They answer a question about a geometry, so they belong where every
implementation reaches them rather than where one of them happens to live.
geo_funcs.c holds them, and geo/geo_funcs.h announces the five that the
distance, the restriction, the network point and the PostGIS surface call.

The comparison, its comparator and the sort travel with the array cleaner that
is their only caller, and stay that file's own. The sort carries no declaration
in any header and reaches its caller only by standing above it, which is what
stops working the moment the caller moves.

Three more are announced in the header while nothing outside their own file
asks for them: the closest point on a segment of the sphere, the interpolation
of a point along a spheroid, and the collection built from points and lines.
They keep to the file that uses them.

The temporal point file keeps what names a temporal type or takes a Datum,
which is the lifting surface: the two segment intersections, the interpolation
and the location along a segment, the collinearity of three points, the line
built from two values, and the validity checks that read a temporal point.

