### PR TITLE
Take the discriminant of the segment critical point in the form that cannot cancel

### DIFF
--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1864,10 +1864,11 @@ cbuffersegm_edge_crit_in_t(double e, double q, double v, double dr2, double r_su
   double diff = v - dr2sq;
   double aa = v * diff;
   double bb = -2.0 * q * diff;
-  double cc = q * q - dr2sq * e;
-  double disc = bb * bb - 4.0 * aa * cc;
+  /* Same reduction as the sibling in s: 4 diff dr2^2 (v e - q^2), which the
+   * Cauchy-Schwarz slack of E and V keeps non-negative */
+  double disc = 4.0 * diff * dr2sq * (v * e - q * q);
   if (disc < 0.0)
-    return;
+    disc = 0.0;
   double sq = sqrt(disc);
   for (int sign = -1; sign <= 1; sign += 2)
   {
@@ -1907,10 +1908,16 @@ cbuffersegm_edge_crit_in_s(double e, double p, double u, double dr1,
   double diff = u - dr1sq;
   double aa = u * diff;
   double bb = 2.0 * p * diff;
-  double cc = p * p - dr1sq * e;
-  double disc = bb * bb - 4.0 * aa * cc;
+  /* The discriminant reduces to 4 diff dr1^2 (u e - p^2), which is never
+   * negative: diff is positive above, and u e - p^2 is the Cauchy-Schwarz
+   * slack of E and U.  Taking it in that form rather than as bb^2 - 4 aa cc
+   * keeps the two products from cancelling: with a radius that holds over the
+   * segment, dr1 is zero and the subtraction of two equal quantities rounds
+   * to a small negative, which reads as no critical point and leaves the
+   * minimum of the segment at whichever endpoint is nearer */
+  double disc = 4.0 * diff * dr1sq * (u * e - p * p);
   if (disc < 0.0)
-    return;
+    disc = 0.0;
   double sq = sqrt(disc);
   for (int sign = -1; sign <= 1; sign += 2)
   {


### PR DESCRIPTION
The minimum distance of two temporal circular buffers solves, along each edge
of a segment pair, a quadratic whose discriminant the code forms as
bb^2 - 4 aa cc. That difference reduces to 4 diff dr^2 (u e - p^2), and every
factor of it is non-negative: diff is positive under the guard above it, and
u e - p^2 is the Cauchy-Schwarz slack of the two vectors. The subtraction is
therefore of two quantities that agree, and when the radius holds over the
segment the agreement is exact: dr is zero, the two products are 4 p^2 u^2
computed in different orders, and their difference rounds to a small negative.
A negative discriminant reads as no critical point, so the interior minimum of
the segment is discarded and the segment reports whichever endpoint is nearer.

A radius that holds over a segment is not a corner case for a value whose
radius is capped: an AIS noise footprint sits at its cap for long stretches,
and the pair whose closest approach falls inside such a stretch answers a
distance it never attains. Over a 100 by 100 join of vessel trajectories
against natural-area discs, 8 of the 10000 pairs report a nearest approach
larger than a distance the pair reaches, by as much as 0.013254: one pair
answers 11104.032571 where the disks close to 11104.019317 at the instant the
nearest approach instant itself returns.

Take the discriminant in the reduced form, and clamp to zero the negative that
rounding can still produce. Both edge helpers carry the same construction and
both take it. The eight pairs answer the minimum they attain, and the three
identities that define the surface hold on all 10000: the length of the
shortest line, the value of the nearest approach distance, and the minimum of
the temporal distance agree, as does the minDistance that shares the kernel.