### PR TITLE
Answer the questions about points and serialization in the geometry layer

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -162,6 +162,15 @@ extern LWGEOM *lwpointarr_make_trajectory(LWGEOM **points, int count,
   interpType interp);
 extern bool ensure_valid_geo_geo(const GSERIALIZED *gs1,
   const GSERIALIZED *gs2);
+extern int geopoint_cmp(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
+extern bool geopoint_eq(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
+extern bool geopoint_same(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
+extern bool same_spatial_dimensionality(int16 flags1, int16 flags2);
+extern bool mline_type(const GSERIALIZED *gs);
+extern GSERIALIZED *geopoint_make(double x, double y, double z, bool hasz,
+  bool geodetic, int32_t srid);
+extern GSERIALIZED **geo_extract_elements(const GSERIALIZED *gs, int *count);
+extern GSERIALIZED *geo_serialize(const LWGEOM *geom);
 extern bool circle_type(const GSERIALIZED *gs);
 extern bool ensure_circle_type(const GSERIALIZED *gs);
 extern LWGEOM *lwcircle_make(double x, double y, double radius,

--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -60,9 +60,6 @@
 /* Utility functions */
 
 extern void datum_point4d(Datum value, POINT4D *p);
-extern int geopoint_cmp(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
-extern bool geopoint_eq(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
-extern bool geopoint_same(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool datum_point_eq(Datum point1, Datum point2);
 extern bool datum_point_same(Datum point1, Datum point2);
 extern Datum datum2_point_eq(Datum point1, Datum point2);
@@ -71,8 +68,6 @@ extern Datum datum2_point_same(Datum point1, Datum point2);
 extern Datum datum2_point_nsame(Datum point1, Datum point2);
 extern Datum datum2_geom_centroid(Datum geo);
 extern Datum datum2_geog_centroid(Datum geo);
-extern GSERIALIZED **geo_extract_elements(const GSERIALIZED *gs, int *count);
-extern GSERIALIZED *geo_serialize(const LWGEOM *geom);
 
 /* Generic functions */
 
@@ -92,7 +87,6 @@ extern bool ensure_spatial_validity(const Temporal *temp1,
 extern int spheroid_init_from_srid(int32_t srid, SPHEROID *s);
 extern bool ensure_same_geodetic_tspatial_geo(const Temporal *temp,
   const GSERIALIZED *gs);
-extern bool same_spatial_dimensionality(int16 flags1, int16 flags2);
 extern bool same_dimensionality_tspatial_geo(const Temporal *temp,
   const GSERIALIZED *gs);
 extern bool ensure_same_dimensionality_tspatial_geo(const Temporal *temp,
@@ -116,7 +110,6 @@ extern bool ensure_valid_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
 extern bool ensure_valid_tpoint_tpoint(const Temporal *temp1,
   const Temporal *temp2);
 
-extern bool mline_type(const GSERIALIZED *gs);
 
 /* Functions for extracting coordinates */
 
@@ -133,8 +126,6 @@ extern int eacomp_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
 /* Functions specializing the PostGIS functions ST_LineInterpolatePoint and
  * ST_LineLocatePoint */
 
-extern GSERIALIZED *geopoint_make(double x, double y, double z, bool hasz,
-  bool geodetic, int32_t srid);
 extern Datum pointsegm_interpolate(Datum start, Datum end,
   long double ratio);
 extern long double pointsegm_locate(Datum start, Datum end, Datum point,

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -41,6 +41,7 @@
 #include <math.h>
 /* PostgreSQL */
 #include "postgres.h"
+#include <utils/float.h>
 #include <pgtypes.h>
 /* PostGIS */
 #include "liblwgeom.h"
@@ -48,10 +49,9 @@
 /* MEOS */
 #include "meos.h"
 #include "meos_internal_geo.h"
-#include "temporal/temporal.h"
 #include "geo/geo_funcs.h"
+#include "geo/postgis_funcs.h"
 #include "geo/meos_transform.h"
-#include "geo/tgeo_spatialfuncs.h"
 
 /*****************************************************************************
  * Extract edges from a geometry that can be of type point, line, polygon or
@@ -806,6 +806,192 @@ pointarr_find_splits(const POINT2D **points, int npoints, int *count)
   }
   *count = numsplits;
   return bitarr;
+}
+
+/*****************************************************************************
+ * Points, and the geometry a value serializes to
+ *****************************************************************************/
+
+/**
+ * @brief Return -1, 0, or 1 depending on whether the first point is less than,
+ * equal to, or greater than the second one
+ */
+int
+geopoint_cmp(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
+{
+  if (FLAGS_GET_Z(gs1->gflags))
+  {
+    const POINT3DZ *point1 = GSERIALIZED_POINT3DZ_P(gs1);
+    const POINT3DZ *point2 = GSERIALIZED_POINT3DZ_P(gs2);
+    if (float8_lt(point1->x, point2->x))
+      return -1;
+    if (float8_gt(point1->x, point2->x))
+      return 1;
+    if (float8_lt(point1->y, point2->y))
+      return -1;
+    if (float8_gt(point1->y, point2->y))
+      return 1;
+    if (float8_lt(point1->z, point2->z))
+      return -1;
+    if (float8_gt(point1->z, point2->z))
+      return 1;
+    return 0;
+  }
+  else
+  {
+    const POINT2D *point1 = GSERIALIZED_POINT2D_P(gs1);
+    const POINT2D *point2 = GSERIALIZED_POINT2D_P(gs2);
+    if (float8_lt(point1->x, point2->x))
+      return -1;
+    if (float8_gt(point1->x, point2->x))
+      return 1;
+    if (float8_lt(point1->y, point2->y))
+      return -1;
+    if (float8_gt(point1->y, point2->y))
+      return 1;
+    return 0;
+  }
+}
+/**
+ * @brief Return true if the points are equal
+ * @note This function is called in the iterations over sequences where we
+ * are sure that their SRID and GEODETIC are equal. The function accepts
+ * mixed 2D/3D arguments
+ */
+bool
+geopoint_eq(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
+{
+  // TODO: Currently, activating these lines break tests
+  // assert(gserialized_get_srid(gs1) == gserialized_get_srid(gs2));
+  // assert(FLAGS_GET_GEODETIC(gs1->gflags) == FLAGS_GET_GEODETIC(gs2->gflags));
+  if (FLAGS_GET_Z(gs1->gflags) && FLAGS_GET_Z(gs2->gflags) )
+  {
+    const POINT3DZ *point1 = GSERIALIZED_POINT3DZ_P(gs1);
+    const POINT3DZ *point2 = GSERIALIZED_POINT3DZ_P(gs2);
+    return float8_eq(point1->x, point2->x) &&
+      float8_eq(point1->y, point2->y) && float8_eq(point1->z, point2->z);
+  }
+  else
+  {
+    const POINT2D *point1 = GSERIALIZED_POINT2D_P(gs1);
+    const POINT2D *point2 = GSERIALIZED_POINT2D_P(gs2);
+    return float8_eq(point1->x, point2->x) && float8_eq(point1->y, point2->y);
+  }
+}
+/**
+ * @brief Return true if the points are equal taking into account floating
+ * point imprecision
+ * @note This function is called in the iterations over sequences where we
+ * are sure that their SRID, Z, and GEODETIC are equal
+ */
+bool
+geopoint_same(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
+{
+  assert(gserialized_get_srid(gs1) == gserialized_get_srid(gs2));
+  assert(FLAGS_GET_Z(gs1->gflags) == FLAGS_GET_Z(gs2->gflags));
+  assert(FLAGS_GET_GEODETIC(gs1->gflags) == FLAGS_GET_GEODETIC(gs2->gflags));
+  if (FLAGS_GET_Z(gs1->gflags))
+  {
+    const POINT3DZ *point1 = GSERIALIZED_POINT3DZ_P(gs1);
+    const POINT3DZ *point2 = GSERIALIZED_POINT3DZ_P(gs2);
+    return MEOS_FP_EQ(point1->x, point2->x) &&
+      MEOS_FP_EQ(point1->y, point2->y) && MEOS_FP_EQ(point1->z, point2->z);
+  }
+  else
+  {
+    const POINT2D *point1 = GSERIALIZED_POINT2D_P(gs1);
+    const POINT2D *point2 = GSERIALIZED_POINT2D_P(gs2);
+    return MEOS_FP_EQ(point1->x, point2->x) &&
+      MEOS_FP_EQ(point1->y, point2->y);
+  }
+}
+/**
+ * @brief Return true if the two temporal points have the same spatial
+ * dimensionality as given by their flags
+ */
+bool
+same_spatial_dimensionality(int16 flags1, int16 flags2)
+{
+  if (MEOS_FLAGS_GET_X(flags1) == MEOS_FLAGS_GET_X(flags2) &&
+      MEOS_FLAGS_GET_Z(flags1) == MEOS_FLAGS_GET_Z(flags2))
+    return true;
+  return false;
+}
+/**
+ * @brief Ensure that the geometry/geography is a (multi)line
+ */
+bool
+mline_type(const GSERIALIZED *gs)
+{
+  uint32_t geotype = gserialized_get_type(gs);
+  if (geotype == LINETYPE || geotype == MULTILINETYPE)
+    return true;
+  return false;
+}
+/**
+ * @brief Return a point created from the arguments
+ */
+GSERIALIZED *
+geopoint_make(double x, double y, double z, bool hasz, bool geodetic,
+  int32_t srid)
+{
+  /* The coordinate list, the point array, and the point are in the stack,
+   * since only the serialized result outlives the function */
+  double coords[3] = {x, y, z};
+  lwflags_t flags = 0;
+  FLAGS_SET_Z(flags, hasz);
+  FLAGS_SET_GEODETIC(flags, geodetic);
+  POINTARRAY pa;
+  pa.npoints = pa.maxpoints = 1;
+  pa.flags = flags;
+  pa.serialized_pointlist = (uint8_t *) coords;
+  LWPOINT point;
+  point.bbox = NULL;
+  point.point = &pa;
+  point.srid = srid;
+  point.flags = flags;
+  point.type = POINTTYPE;
+  return geo_serialize((LWGEOM *) &point);
+}
+/**
+ * @brief Extract the first-level elements of a gemetry collection
+ */
+GSERIALIZED **
+geo_extract_elements(const GSERIALIZED *gs, int *count)
+{
+  assert(gs); assert(count);
+  /* Extract the elements of the arguments, if they are collections */
+  LWCOLLECTION *coll;
+  GSERIALIZED **result = NULL;
+  if (geo_is_unitary(gs))
+  {
+    *count = 1;
+    result = palloc(sizeof(LWGEOM *));
+    result[0] = geo_copy(gs);
+  }
+  else
+  {
+    LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+    coll = lwgeom_as_lwcollection(lwgeom);
+    *count = coll->ngeoms;
+    result = palloc(sizeof(LWGEOM *) * coll->ngeoms);
+    for (uint32_t i = 0; i < coll->ngeoms; i++)
+      result[i] = geo_serialize(coll->geoms[i]);
+    lwgeom_free(lwgeom);
+  }
+  return result;
+}
+/**
+ * @brief Serialize a geometry/geography
+ * @pre It is supposed that the flags such as Z and geodetic have been
+ * set up before by the calling function
+ */
+GSERIALIZED *
+geo_serialize(const LWGEOM *geom)
+{
+  GSERIALIZED *result = FLAGS_GET_GEODETIC(geom->flags) ?
+    geog_serialize((LWGEOM *) geom) : geom_serialize((LWGEOM *) geom);
+  return result;
 }
 
 /*****************************************************************************

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2572,34 +2572,6 @@ geom_buffer(const GSERIALIZED *gs, double size, const char *params)
 
 /*****************************************************************************/
 
-/**
- * @brief Extract the first-level elements of a gemetry collection
- */
-GSERIALIZED **
-geo_extract_elements(const GSERIALIZED *gs, int *count)
-{
-  assert(gs); assert(count);
-  /* Extract the elements of the arguments, if they are collections */
-  LWCOLLECTION *coll;
-  GSERIALIZED **result = NULL;
-  if (geo_is_unitary(gs))
-  {
-    *count = 1;
-    result = palloc(sizeof(LWGEOM *));
-    result[0] = geo_copy(gs);
-  }
-  else
-  {
-    LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    coll = lwgeom_as_lwcollection(lwgeom);
-    *count = coll->ngeoms;
-    result = palloc(sizeof(LWGEOM *) * coll->ngeoms);
-    for (uint32_t i = 0; i < coll->ngeoms; i++)
-      result[i] = geo_serialize(coll->geoms[i]);
-    lwgeom_free(lwgeom);
-  }
-  return result;
-}
 
 /**
  * @ingroup meos_geo_base_spatial
@@ -2767,18 +2739,6 @@ geog_serialize(LWGEOM *lwgeom)
   return result;
 }
 
-/**
- * @brief Serialize a geometry/geography
- * @pre It is supposed that the flags such as Z and geodetic have been
- * set up before by the calling function
- */
-GSERIALIZED *
-geo_serialize(const LWGEOM *geom)
-{
-  GSERIALIZED *result = FLAGS_GET_GEODETIC(geom->flags) ?
-    geog_serialize((LWGEOM *) geom) : geom_serialize((LWGEOM *) geom);
-  return result;
-}
 
 /*****************************************************************************
  * Functions adapted from lwgeom_transform.c

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -107,101 +107,10 @@ datum_point4d(Datum value, POINT4D *p)
   return;
 }
 
-/**
- * @brief Return a point created from the arguments
- */
-GSERIALIZED *
-geopoint_make(double x, double y, double z, bool hasz, bool geodetic,
-  int32_t srid)
-{
-  /* The coordinate list, the point array, and the point are in the stack,
-   * since only the serialized result outlives the function */
-  double coords[3] = {x, y, z};
-  lwflags_t flags = 0;
-  FLAGS_SET_Z(flags, hasz);
-  FLAGS_SET_GEODETIC(flags, geodetic);
-  POINTARRAY pa;
-  pa.npoints = pa.maxpoints = 1;
-  pa.flags = flags;
-  pa.serialized_pointlist = (uint8_t *) coords;
-  LWPOINT point;
-  point.bbox = NULL;
-  point.point = &pa;
-  point.srid = srid;
-  point.flags = flags;
-  point.type = POINTTYPE;
-  return geo_serialize((LWGEOM *) &point);
-}
 
 /*****************************************************************************/
 
-/**
- * @brief Return -1, 0, or 1 depending on whether the first point is less than,
- * equal to, or greater than the second one
- */
-int
-geopoint_cmp(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
-{
-  if (FLAGS_GET_Z(gs1->gflags))
-  {
-    const POINT3DZ *point1 = GSERIALIZED_POINT3DZ_P(gs1);
-    const POINT3DZ *point2 = GSERIALIZED_POINT3DZ_P(gs2);
-    if (float8_lt(point1->x, point2->x))
-      return -1;
-    if (float8_gt(point1->x, point2->x))
-      return 1;
-    if (float8_lt(point1->y, point2->y))
-      return -1;
-    if (float8_gt(point1->y, point2->y))
-      return 1;
-    if (float8_lt(point1->z, point2->z))
-      return -1;
-    if (float8_gt(point1->z, point2->z))
-      return 1;
-    return 0;
-  }
-  else
-  {
-    const POINT2D *point1 = GSERIALIZED_POINT2D_P(gs1);
-    const POINT2D *point2 = GSERIALIZED_POINT2D_P(gs2);
-    if (float8_lt(point1->x, point2->x))
-      return -1;
-    if (float8_gt(point1->x, point2->x))
-      return 1;
-    if (float8_lt(point1->y, point2->y))
-      return -1;
-    if (float8_gt(point1->y, point2->y))
-      return 1;
-    return 0;
-  }
-}
 
-/**
- * @brief Return true if the points are equal
- * @note This function is called in the iterations over sequences where we
- * are sure that their SRID and GEODETIC are equal. The function accepts
- * mixed 2D/3D arguments
- */
-bool
-geopoint_eq(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
-{
-  // TODO: Currently, activating these lines break tests
-  // assert(gserialized_get_srid(gs1) == gserialized_get_srid(gs2));
-  // assert(FLAGS_GET_GEODETIC(gs1->gflags) == FLAGS_GET_GEODETIC(gs2->gflags));
-  if (FLAGS_GET_Z(gs1->gflags) && FLAGS_GET_Z(gs2->gflags) )
-  {
-    const POINT3DZ *point1 = GSERIALIZED_POINT3DZ_P(gs1);
-    const POINT3DZ *point2 = GSERIALIZED_POINT3DZ_P(gs2);
-    return float8_eq(point1->x, point2->x) &&
-      float8_eq(point1->y, point2->y) && float8_eq(point1->z, point2->z);
-  }
-  else
-  {
-    const POINT2D *point1 = GSERIALIZED_POINT2D_P(gs1);
-    const POINT2D *point2 = GSERIALIZED_POINT2D_P(gs2);
-    return float8_eq(point1->x, point2->x) && float8_eq(point1->y, point2->y);
-  }
-}
 
 /**
  * @brief Return true if the points are equal
@@ -218,33 +127,6 @@ datum_point_eq(Datum point1, Datum point2)
   return geopoint_eq(gs1, gs2);
 }
 
-/**
- * @brief Return true if the points are equal taking into account floating
- * point imprecision
- * @note This function is called in the iterations over sequences where we
- * are sure that their SRID, Z, and GEODETIC are equal
- */
-bool
-geopoint_same(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
-{
-  assert(gserialized_get_srid(gs1) == gserialized_get_srid(gs2));
-  assert(FLAGS_GET_Z(gs1->gflags) == FLAGS_GET_Z(gs2->gflags));
-  assert(FLAGS_GET_GEODETIC(gs1->gflags) == FLAGS_GET_GEODETIC(gs2->gflags));
-  if (FLAGS_GET_Z(gs1->gflags))
-  {
-    const POINT3DZ *point1 = GSERIALIZED_POINT3DZ_P(gs1);
-    const POINT3DZ *point2 = GSERIALIZED_POINT3DZ_P(gs2);
-    return MEOS_FP_EQ(point1->x, point2->x) &&
-      MEOS_FP_EQ(point1->y, point2->y) && MEOS_FP_EQ(point1->z, point2->z);
-  }
-  else
-  {
-    const POINT2D *point1 = GSERIALIZED_POINT2D_P(gs1);
-    const POINT2D *point2 = GSERIALIZED_POINT2D_P(gs2);
-    return MEOS_FP_EQ(point1->x, point2->x) &&
-      MEOS_FP_EQ(point1->y, point2->y);
-  }
-}
 
 /**
  * @brief Return true if the points are equal taking into account floating 
@@ -640,18 +522,6 @@ ensure_same_geodetic_tspatial_geo(const Temporal *temp, const GSERIALIZED *gs)
 
 
 
-/**
- * @brief Return true if the two temporal points have the same spatial
- * dimensionality as given by their flags
- */
-bool
-same_spatial_dimensionality(int16 flags1, int16 flags2)
-{
-  if (MEOS_FLAGS_GET_X(flags1) == MEOS_FLAGS_GET_X(flags2) &&
-      MEOS_FLAGS_GET_Z(flags1) == MEOS_FLAGS_GET_Z(flags2))
-    return true;
-  return false;
-}
 
 
 /**
@@ -723,17 +593,6 @@ ensure_same_geodetic_stbox_geo(const STBox *box, const GSERIALIZED *gs)
 
 
 
-/**
- * @brief Ensure that the geometry/geography is a (multi)line
- */
-bool
-mline_type(const GSERIALIZED *gs)
-{
-  uint32_t geotype = gserialized_get_type(gs);
-  if (geotype == LINETYPE || geotype == MULTILINETYPE)
-    return true;
-  return false;
-}
 
 
 


### PR DESCRIPTION
Eight of the functions the temporal geometry header states name no temporal type. A point is made from two or three coordinates, two points are compared, are equal, or are equal to the precision the reference system is written at; a geometry is serialized from the value liblwgeom works on, is taken apart into the elements a collection holds, or is asked whether it is a multiline; and two flags words agree on how many dimensions they carry. They read a geometry, a coordinate or a flags word, so `geo_funcs.c` holds them and `geo/geo_funcs.h` states them. Nine families reach the point constructor and the serialization, from sixteen and twenty-five files.

The two the header keeps are the ones that return a `datum_func2`: choosing which distance a pair of values is measured with is how the lifting machinery is told what to apply, not a question about a geometry.

The layering rests one way. Exactly three of these names — the serialization, the multiline check and the dimensionality agreement — are what the geometry layer reaches the temporal geometry header for, while that header includes the geometry layer. With them moved, `geo_funcs.c` names no temporal header at all.

The check that a spheroid is read from a reference system stays where it is: PostGIS defines it in `libpgcommon`, which the extension links and a standalone MEOS does not, so the copy in `tspatial_transform_meos.c` is the one that build needs and a copy in an always-compiled file collides with the one PostGIS brings.

The move is verbatim: the diff is the eight bodies, one section banner, and the include swap.