### PR TITLE
Place the oriented envelope and the convex hull of a geometry natively

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -910,6 +910,12 @@
 			<title>Funciones sobre Geometrías</title>
 			<itemizedlist>
 				<listitem>
+					<para><link linkend="geo_orientedenvelope"><varname>OrientedEnvelope</varname></link>: Devuelve el rectángulo de área mínima que encierra una geometría</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="geo_convexhull"><varname>ConvexHull</varname></link>: Devuelve la geometría convexa más pequeña que encierra una geometría</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="geo_buffer"><varname>Buffer</varname></link>: Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>
 				</listitem>
 			</itemizedlist>

--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -41,9 +41,35 @@
 	<sect1 xml:id="geo_funcs">
 		<title>Funciones sobre Geometrías</title>
 
-		<para>Las funciones de esta sección responden una pregunta sobre una geometría y no sobre un tipo temporal. Una geometría delimitada por arcos circulares los conserva: la respuesta se construye a partir de los arcos mismos y no de una aproximación poligonal de ellos.</para>
+		<para>Las funciones de esta sección responden una pregunta sobre una geometría y no sobre un tipo temporal. Cada una indica cómo lee una geometría delimitada por arcos circulares, ya que una respuesta construida a partir de los arcos mismos y una construida a partir de una aproximación poligonal de ellos no son la misma respuesta.</para>
 
 		<itemizedlist>
+			<listitem xml:id="geo_orientedenvelope">
+				<indexterm significance="normal"><primary><varname>OrientedEnvelope</varname></primary></indexterm>
+				<para>Devuelve el rectángulo de área mínima que encierra una geometría</para>
+				<para><varname>OrientedEnvelope(geometry) → geometry</varname></para>
+				<para>El rectángulo se orienta en el ángulo que lo hace más pequeño, que en general no es el ángulo de los ejes. Se devuelve como una línea cuando la geometría está contenida en una y como un punto cuando la geometría es uno. Una geometría que lleva un arco circular la responde GEOS, que lee el arco como la cadena de segmentos que lo aproxima.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
+-- POLYGON((0 0,3 4,-1 7,-4 3,0 0))
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
+-- LINESTRING(0 0,10 0)
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="geo_convexhull">
+				<indexterm significance="normal"><primary><varname>ConvexHull</varname></primary></indexterm>
+				<para>Devuelve la geometría convexa más pequeña que encierra una geometría</para>
+				<para><varname>ConvexHull(geometry) → geometry</varname></para>
+				<para>El resultado es un polígono en el que cada esquina es un punto de la geometría, una línea cuando la geometría está contenida en una y un punto cuando la geometría es uno. Una geometría que lleva un arco circular la responde GEOS, que lee el arco como la cadena de segmentos que lo aproxima.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
+-- POLYGON((0 0,0 10,10 10,10 0,0 0))
+SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
+-- POLYGON((0 0,0 10,10 10,10 0,0 0))
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="geo_buffer">
 				<indexterm significance="normal"><primary><varname>Buffer</varname></primary></indexterm>
 				<para>Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -910,6 +910,12 @@
 			<title>Functions on Geometries</title>
 			<itemizedlist>
 				<listitem>
+					<para><link linkend="geo_orientedenvelope"><varname>OrientedEnvelope</varname></link>: Return the rectangle of minimum area enclosing a geometry</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="geo_convexhull"><varname>ConvexHull</varname></link>: Return the smallest convex geometry enclosing a geometry</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="geo_buffer"><varname>Buffer</varname></link>: Return the geometry holding every point within a distance of a geometry</para>
 				</listitem>
 			</itemizedlist>

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -41,9 +41,35 @@
 	<sect1 xml:id="geo_funcs">
 		<title>Functions on Geometries</title>
 
-		<para>The functions in this section answer a question about a geometry rather than about a temporal type. A geometry bounded by circular arcs keeps them: the answer is built from the arcs themselves rather than from a polygonal approximation of them.</para>
+		<para>The functions in this section answer a question about a geometry rather than about a temporal type. Each states how it reads a geometry bounded by circular arcs, since an answer built from the arcs themselves and an answer built from a polygonal approximation of them are not the same answer.</para>
 
 		<itemizedlist>
+			<listitem xml:id="geo_orientedenvelope">
+				<indexterm significance="normal"><primary><varname>OrientedEnvelope</varname></primary></indexterm>
+				<para>Return the rectangle of minimum area enclosing a geometry</para>
+				<para><varname>OrientedEnvelope(geometry) → geometry</varname></para>
+				<para>The rectangle is at the angle that makes it smallest, which is not in general the angle of the axes. It is answered as a line when the geometry is contained in one and as a point when the geometry is one. A geometry carrying a circular arc is answered by GEOS, which reads the arc as the chain of segments approximating it.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
+-- POLYGON((0 0,3 4,-1 7,-4 3,0 0))
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
+-- LINESTRING(0 0,10 0)
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="geo_convexhull">
+				<indexterm significance="normal"><primary><varname>ConvexHull</varname></primary></indexterm>
+				<para>Return the smallest convex geometry enclosing a geometry</para>
+				<para><varname>ConvexHull(geometry) → geometry</varname></para>
+				<para>The result is a polygon whose every corner is a point of the geometry, a line when the geometry is contained in one, and a point when the geometry is one. A geometry carrying a circular arc is answered by GEOS, which reads the arc as the chain of segments approximating it.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
+-- POLYGON((0 0,0 10,10 10,10 0,0 0))
+SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
+-- POLYGON((0 0,0 10,10 10,10 0,0 0))
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="geo_buffer">
 				<indexterm significance="normal"><primary><varname>Buffer</varname></primary></indexterm>
 				<para>Return the geometry holding every point within a distance of a geometry</para>

--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -119,6 +119,7 @@ angle_normalize(double a)
 
 extern void arc_set_bbox(Edge *e);
 extern bool arc_contains_angle(const Edge *e, double phi);
+extern LWGEOM *meos_oriented_envelope(const LWGEOM *geom);
 extern bool point_on_arc(double px, double py, const Edge *e);
 extern bool point_on_segment(double px, double py, double x1, double y1,
   double x2, double y2);

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -405,10 +405,13 @@ extern GSERIALIZED *geom_buffer(const GSERIALIZED *gs, double size, const char *
 extern GSERIALIZED *geom_buffer_meos(const GSERIALIZED *gs, double size, const char *params);
 extern GSERIALIZED *geom_centroid(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_convex_hull(const GSERIALIZED *gs);
+extern GSERIALIZED *geom_convex_hull_meos(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern GSERIALIZED *geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern GSERIALIZED *geom_intersection2d_coll(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern GSERIALIZED *geom_min_bounding_radius(const GSERIALIZED *geom, double *radius);
+extern GSERIALIZED *geom_oriented_envelope(const GSERIALIZED *gs);
+extern GSERIALIZED *geom_oriented_envelope_meos(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_shortestline2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern GSERIALIZED *geom_shortestline3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern GSERIALIZED *geom_unary_union(const GSERIALIZED *gs, double prec);

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -809,6 +809,632 @@ pointarr_find_splits(const POINT2D **points, int npoints, int *count)
 }
 
 /*****************************************************************************
+ * Oriented envelope (a.k.a minimum rotated rectangle) and convex hull of a
+ * geometry whose every edge is a segment.
+ *
+ * Both are placed on the vertices of the geometry, which for such a geometry
+ * are the whole of it: a convex hull has a vertex of the input at every corner,
+ * and a rectangle of minimum area has a side flush with an edge of that hull,
+ * so trying the direction of each hull edge finds it exactly.
+ *
+ * A geometry carrying a circular arc is declined rather than answered, since
+ * the arc reaches past the points that define it and a region placed on those
+ * points does not enclose it.
+ *****************************************************************************/
+
+/**
+ * @brief Compare two 2D points lexicographically
+ */
+static int
+point2d_cmp(const void *a, const void *b)
+{
+  const POINT2D *pa = (const POINT2D *) a;
+  const POINT2D *pb = (const POINT2D *) b;
+  if (pa->x < pb->x)
+    return -1;
+  if (pa->x > pb->x)
+    return 1;
+  if (pa->y < pb->y)
+    return -1;
+  if (pa->y > pb->y)
+    return 1;
+  return 0;
+}
+
+/**
+ * @brief Cross product of AB and AC
+ */
+static inline double
+cross_product(const POINT2D *a, const POINT2D *b, const POINT2D *c)
+{
+  return (b->x - a->x) * (c->y - a->y) - (b->y - a->y) * (c->x - a->x);
+}
+
+/**
+ * @brief Add a point to an array
+ */
+static inline void
+add_point(POINT2D *points, uint32_t *npoints, double x, double y)
+{
+  points[*npoints].x = x;
+  points[*npoints].y = y;
+  (*npoints)++;
+}
+
+/**
+ * @brief Add the geometrically relevant points of an edge
+ * @details For a line, only the two endpoints are needed. For an arc, the two
+ * endpoints and every cardinal point of the supporting circle lying on the arc
+ * are added. The latter are essential: an arc may attain its X/Y extrema in
+ * its interior.
+ */
+static void
+add_edge_points(const Edge *e, POINT2D *points, uint32_t *npoints)
+{
+  assert(e); assert(points); assert(npoints);
+  add_point(points, npoints, e->x1, e->y1);
+  if (fabs(e->x2 - e->x1) > FP_TOLERANCE || fabs(e->y2 - e->y1) > FP_TOLERANCE)
+    add_point(points, npoints, e->x2, e->y2);
+}
+
+/**
+ * @brief Compute the convex hull of a set of 2D points
+ * @details The returned hull is not closed.
+ * The implementation uses Andrew's monotone-chain algorithm.
+ */
+static uint32_t
+convex_hull_points(const POINT2D *points, uint32_t npoints, POINT2D **hull)
+{
+  assert(points); assert(hull);
+  *hull = NULL;
+  if (npoints == 0)
+    return 0;
+
+  /* Sort a copy of the points */
+  POINT2D *sorted = palloc(sizeof(POINT2D) * npoints);
+  memcpy(sorted, points, sizeof(POINT2D) * npoints);
+  qsort(sorted, npoints, sizeof(POINT2D), point2d_cmp);
+
+  /* Remove duplicate points */
+  uint32_t n = 0;
+  for (uint32_t i = 0; i < npoints; i++)
+  {
+    if (n == 0 || sorted[i].x != sorted[n - 1].x ||
+        sorted[i].y != sorted[n - 1].y)
+    {
+      sorted[n++] = sorted[i];
+    }
+  }
+
+  /* Point or line */
+  if (n <= 2)
+  {
+    *hull = sorted;
+    return n;
+  }
+
+  /* Maximum size is 2*n */
+  POINT2D *h = palloc(sizeof(POINT2D) * (2 * n));
+  uint32_t nhull = 0;
+
+  /* Lower hull */
+  for (uint32_t i = 0; i < n; i++)
+  {
+    while (nhull >= 2 &&
+      cross_product(&h[nhull - 2], &h[nhull - 1], &sorted[i]) <= 0.0)
+    {
+      nhull--;
+    }
+    h[nhull++] = sorted[i];
+  }
+
+  /* Upper hull */
+  uint32_t lower = nhull;
+  for (int i = (int) n - 2; i >= 0; i--)
+  {
+    while (nhull > lower &&
+        cross_product(&h[nhull - 2], &h[nhull - 1], &sorted[i]) <= 0.0)
+      nhull--;
+    h[nhull++] = sorted[i];
+  }
+
+  /* Last point duplicates the first */
+  nhull--;
+  pfree(sorted);
+
+  *hull = palloc(sizeof(POINT2D) * nhull);
+  memcpy(*hull, h, sizeof(POINT2D) * nhull);
+  pfree(h);
+  return nhull;
+}
+
+/**
+ * @brief Compute the rectangle defined by a given orientation
+ * @details The rectangle axes are:
+ *   u = (ux,uy)
+ *   v = (-uy,ux)
+ * The function computes the bounding rectangle of the supplied
+ * convex-hull points in that coordinate system.
+ */
+static double
+mrr_rectangle_for_direction(const POINT2D *points, uint32_t npoints,
+  double ux, double uy, POINT2D rect[5])
+{
+  double vx = -uy;
+  double vy = ux;
+  double min_u = DBL_MAX;
+  double max_u = -DBL_MAX;
+  double min_v = DBL_MAX;
+  double max_v = -DBL_MAX;
+  for (uint32_t i = 0; i < npoints; i++)
+  {
+    double u = points[i].x * ux + points[i].y * uy;
+    double v = points[i].x * vx + points[i].y * vy;
+    if (u < min_u)
+      min_u = u;
+    if (u > max_u)
+      max_u = u;
+    if (v < min_v)
+      min_v = v;
+    if (v > max_v)
+      max_v = v;
+  }
+
+  double width = max_u - min_u;
+  double height = max_v - min_v;
+  /* Convert the corners back to XY */
+  rect[0].x = min_u * ux + min_v * vx;
+  rect[0].y = min_u * uy + min_v * vy;
+  rect[1].x = max_u * ux + min_v * vx;
+  rect[1].y = max_u * uy + min_v * vy;
+  rect[2].x = max_u * ux + max_v * vx;
+  rect[2].y = max_u * uy + max_v * vy;
+  rect[3].x = min_u * ux + max_v * vx;
+  rect[3].y = min_u * uy + max_v * vy;
+  rect[4] = rect[0];
+  return width * height;
+}
+
+/**
+ * @brief Add candidate rectangle directions generated by an edge
+ * @details For a straight edge, the rectangle orientation only needs the edge
+ * direction. For a circular arc, its tangent direction varies continuously.
+ * The cardinal directions of the supporting circle delimit the intervals over
+ * which the support point changes continuously. We therefore add:
+ *   - the arc endpoint tangent directions
+ *   - the four cardinal tangent directions when they occur on the arc
+ * This keeps the calculation entirely analytic and avoids polygonizing the arc
+ */
+static void
+mrr_add_edge_directions(const Edge *e, double *angles, uint32_t *nangles)
+{
+  if (e->etype != EDGE_LINEARC && e->etype != EDGE_POLYARC)
+  {
+    /* Straight edge */
+    double angle = atan2(e->y2 - e->y1, e->x2 - e->x1);
+    angles[(*nangles)++] = angle;
+    return;
+  }
+
+  /* Circular arc: For CCW traversal the tangent direction at angle theta is:
+   *   (-sin(theta), cos(theta))
+   * We only need orientations, so adding pi is equivalent. */
+  double theta[6];
+  int ntheta = 0;
+  theta[ntheta++] = e->theta0;
+  theta[ntheta++] = e->theta1;
+
+  /* Cardinal points split the circle into analytically simple
+   * support-function intervals */
+  const double cardinal[4] = { 0.0, M_PI_2, M_PI, -M_PI_2 };
+  for (int i = 0; i < 4; i++)
+  {
+    if (arc_contains_angle(e, cardinal[i]))
+      theta[ntheta++] = cardinal[i];
+  }
+  for (int i = 0; i < ntheta; i++)
+  {
+    double angle = theta[i] + (e->ccw ? M_PI_2 : -M_PI_2);
+    /* Rectangle orientation has period pi */
+    angle = fmod(angle, M_PI);
+    if (angle < 0)
+      angle += M_PI;
+    angles[(*nangles)++] = angle;
+  }
+}
+
+/**
+ * @brief Construct a POINT/LINESTRING/POLYGON from a set of points
+ */
+static LWGEOM *
+make_geometry_points(int32_t srid, const POINT2D *points, uint32_t nhull)
+{
+  /* Point */
+  if (nhull == 1)
+    return lwpoint_as_lwgeom(lwpoint_make2d(srid, points[0].x, points[0].y));
+
+  /* Line */
+  if (nhull == 2)
+  {
+    POINTARRAY *pa = ptarray_construct_empty(0, 0, 2);
+    POINT4D p;
+    p.z = 0.0;
+    p.m = 0.0;
+    p.x = points[0].x;
+    p.y = points[0].y;
+    ptarray_append_point(pa, &p, LW_TRUE);
+    p.x = points[1].x;
+    p.y = points[1].y;
+    ptarray_append_point(pa, &p, LW_TRUE);
+    return lwline_as_lwgeom(lwline_construct(srid, NULL, pa));
+  }
+
+  /* Polygon */
+  POINTARRAY *pa = ptarray_construct_empty(0, 0, 5);
+  POINT4D p;
+  p.z = 0.0;
+  p.m = 0.0;
+  for (int i = 0; i < 5; i++)
+  {
+    p.x = points[i].x;
+    p.y = points[i].y;
+    ptarray_append_point(pa, &p, LW_TRUE);
+  }
+  LWPOLY *poly = lwpoly_construct_empty(srid, 0, 0);
+  lwpoly_add_ring(poly, pa);
+  return lwpoly_as_lwgeom(poly);
+}
+
+/**
+ * @brief Order the two vertices of a degenerate hull as they appear in the
+ * geometry
+ * @details PostGIS function @p ST_ConvexHull() reports a two-vertex hull in
+ * the order the vertices occur in its argument, which the sort performed by
+ * #convex_hull_points() loses.
+ */
+static void
+hull_order_as_input(const POINT2D *points, uint32_t npoints, POINT2D *hull)
+{
+  for (uint32_t i = 0; i < npoints; i++)
+  {
+    if (points[i].x == hull[0].x && points[i].y == hull[0].y)
+      return;
+    if (points[i].x == hull[1].x && points[i].y == hull[1].y)
+    {
+      POINT2D tmp = hull[0];
+      hull[0] = hull[1];
+      hull[1] = tmp;
+      return;
+    }
+  }
+}
+
+/**
+ * @brief Construct a POINT/LINESTRING/POLYGON from the vertices of a convex
+ * hull
+ * @details The hull computed by #convex_hull_points() is not closed, so the
+ * polygon ring repeats the first vertex. One and two vertices give a POINT and
+ * a LINESTRING, as PostGIS function @p ST_ConvexHull() does.
+ */
+static LWGEOM *
+make_geometry_hull(int32_t srid, const POINT2D *hull, uint32_t nhull)
+{
+  /* Point and line */
+  if (nhull <= 2)
+    return make_geometry_points(srid, hull, nhull);
+
+  /* Polygon.
+   * #convex_hull_points() delivers the vertices counterclockwise starting at
+   * an arbitrary vertex. PostGIS function @p ST_ConvexHull() reports the ring
+   * clockwise starting at its lowest vertex, so the ring is emitted in that
+   * order to keep both functions textually interchangeable. */
+  uint32_t start = 0;
+  for (uint32_t i = 1; i < nhull; i++)
+  {
+    if (hull[i].y < hull[start].y ||
+        (hull[i].y == hull[start].y && hull[i].x < hull[start].x))
+      start = i;
+  }
+  POINTARRAY *pa = ptarray_construct_empty(0, 0, nhull + 1);
+  POINT4D p;
+  p.z = 0.0;
+  p.m = 0.0;
+  for (uint32_t i = 0; i <= nhull; i++)
+  {
+    /* Walking the counterclockwise vertices backwards gives the clockwise
+     * ring, and the last vertex closes it on the first one */
+    const POINT2D *v = &hull[(start + nhull - i % nhull) % nhull];
+    p.x = v->x;
+    p.y = v->y;
+    ptarray_append_point(pa, &p, LW_TRUE);
+  }
+  LWPOLY *poly = lwpoly_construct_empty(srid, 0, 0);
+  lwpoly_add_ring(poly, pa);
+  return lwpoly_as_lwgeom(poly);
+}
+
+/**
+ * @brief Return the oriented envelop (a.k.a. minimum-area rotated rectangle)
+ * of a geometry
+ * @details Works directly on the exact circular arcs represented by the Edge
+ * structure.
+ */
+LWGEOM *
+meos_oriented_envelope(const LWGEOM *geom)
+{
+  assert(geom);
+  /* The placement below reads the vertices, which are the whole of a
+   * geometry only while every edge of it is a segment */
+  assert(! lwgeom_has_arc(geom));
+
+  /* Empty input */
+  if (lwgeom_is_empty(geom))
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(geom->srid, 0, 0));
+
+  /* Extract the geometry */
+  MeosArray *edge_array = geom_extract_edges(geom);
+  uint32_t nedges = edge_array->count;
+  if (nedges == 0)
+  {
+    meos_array_destroy(edge_array);
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(geom->srid, 0, 0));
+  }
+
+  /* Every edge contributes its two end points */
+  uint32_t maxpoints = 2 * nedges;
+  POINT2D *points = palloc(sizeof(POINT2D) * maxpoints);
+  uint32_t npoints = 0;
+
+  /* Extract the exact extremal points */
+  for (uint32_t i = 0; i < nedges; i++)
+  {
+    const Edge *e = (Edge *) meos_array_get(edge_array, i);
+    add_edge_points(e, points, &npoints);
+  }
+
+  /* We no longer need the edge array for the convex hull */
+  meos_array_destroy(edge_array);
+
+  /* Convex hull */
+  POINT2D *hull = NULL;
+  uint32_t nhull = convex_hull_points(points, npoints, &hull);
+  pfree(points);
+  if (nhull == 0)
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(geom->srid, 0, 0));
+
+  /* Degenerate cases */
+  if (nhull == 1)
+  {
+    POINT2D rect[5];
+    for (int i = 0; i < 5; i++)
+      rect[i] = hull[0];
+    LWGEOM *result = make_geometry_points(geom->srid, rect, nhull);
+    pfree(hull);
+    return result;
+  }
+
+  if (nhull == 2)
+  {
+    POINT2D rect[5];
+    rect[0] = hull[0];
+    rect[1] = hull[1];
+    rect[2] = hull[1];
+    rect[3] = hull[0];
+    rect[4] = hull[0];
+    LWGEOM *result = make_geometry_points(geom->srid, rect, nhull);
+    pfree(hull);
+    return result;
+  }
+
+  /*
+   * Generate candidate orientations.
+   * - For a polygonal convex hull these are simply the hull-edge
+   *   orientations.
+   * - For an arc, its tangent direction changes continuously. We therefore
+   *   inspect the analytically significant tangent directions of the arc.
+   * Because the rectangle orientation is periodic modulo pi, all angles are
+   * normalized to [0,pi).
+   */
+
+  /*
+   * Maximum number of candidate directions. Every hull edge contributes one
+   * direction. The actual Edge array may have more entries than the hull, but
+   * using a generous bound keeps this implementation simple.
+   */
+  uint32_t maxangles = 8 * nedges + 8 * nhull;
+  double *angles = palloc(sizeof(double) * maxangles);
+  uint32_t nangles = 0;
+
+  /*
+   * Re-extract the edges. This is inexpensive compared with the convex-hull
+   * computation and keeps the code independent from any Edge pointer retained
+   * after the first array was freed.
+   */
+  edge_array = geom_extract_edges(geom);
+  nedges = edge_array->count;
+  for (uint32_t i = 0; i < nedges; i++)
+  {
+    const Edge *e = (Edge *) meos_array_get(edge_array, i);
+    /* Only directions which can define a support side need to be considered */
+    mrr_add_edge_directions(e, angles, &nangles);
+  }
+  meos_array_destroy(edge_array);
+
+  /* Also add all convex-hull edge directions.
+   * This is important because the hull itself is the object whose
+   * bounding rectangle is being computed. */
+  for (uint32_t i = 0; i < nhull; i++)
+  {
+    const POINT2D *a = &hull[i];
+    const POINT2D *b = &hull[(i + 1) % nhull];
+    double dx = b->x - a->x;
+    double dy = b->y - a->y;
+    if (hypot(dx, dy) <= FP_TOLERANCE)
+      continue;
+    double angle = atan2(dy, dx);
+    angle = fmod(angle, M_PI);
+    if (angle < 0)
+      angle += M_PI;
+    angles[nangles++] = angle;
+  }
+
+  /* No candidate direction: the hull has no support side to align with */
+  if (nangles == 0)
+  {
+    pfree(angles); pfree(hull);
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(geom->srid, 0, 0));
+  }
+
+  /* Find the minimum-area rectangle. The rectangle of the first direction
+   * seeds the result: a comparison against it is false for every direction
+   * when a coordinate is not a number, and the rectangle must be defined in
+   * that case too. */
+  double best_area = DBL_MAX;
+  POINT2D best_rect[5] = {0};
+  for (uint32_t i = 0; i < nangles; i++)
+  {
+    double angle = angles[i];
+    double ux = cos(angle);
+    double uy = sin(angle);
+    POINT2D rect[5];
+    double area = mrr_rectangle_for_direction(hull, nhull, ux, uy, rect);
+    if (i == 0 || area < best_area)
+    {
+      best_area = area;
+      for (int j = 0; j < 5; j++)
+        best_rect[j] = rect[j];
+    }
+  }
+
+  /* Clean up and return */
+  pfree(angles); pfree(hull);
+  return make_geometry_points(geom->srid, best_rect, 4);
+}
+
+/**
+ * @ingroup meos_geo_base_spatial
+ * @brief Return the oriented envelope (a.k.a. minimum-area rotated rectangle)
+ * of a geometry
+ * @param[in] gs Geometry
+ * @note PostGIS function: @p ST_OrientedEnvelope(PG_FUNCTION_ARGS).
+ * @csqlfn #Geom_oriented_envelope()
+ */
+GSERIALIZED *
+geom_oriented_envelope_meos(const GSERIALIZED *gs)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(gs, NULL);
+  if (! ensure_not_geodetic_geo(gs))
+    return NULL;
+
+  /* A geometry carrying a circular arc has no native placement yet, and the
+   * arc reaches past the points that define it, so it is answered by GEOS */
+  LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+  if (lwgeom_has_arc(lwgeom))
+  {
+    lwgeom_free(lwgeom);
+    return geom_oriented_envelope(gs);
+  }
+  LWGEOM *res = meos_oriented_envelope(lwgeom);
+  GSERIALIZED *result = geo_serialize(res);
+  lwgeom_free(lwgeom); lwgeom_free(res);
+  return result;
+}
+
+/******************************************************************************/
+
+/**
+ * @brief Return the convex hull of a geometry
+ * @details Works directly on the exact circular arcs represented by the Edge
+ * structure.
+ */
+LWGEOM *
+convex_hull(const LWGEOM *geom)
+{
+  assert(geom);
+  /* The placement below reads the vertices, which are the whole of a
+   * geometry only while every edge of it is a segment */
+  assert(! lwgeom_has_arc(geom));
+
+  /* Empty input */
+  if (lwgeom_is_empty(geom))
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(geom->srid, 0, 0));
+
+  /* Extract the geometry */
+  MeosArray *edge_array = geom_extract_edges(geom);
+  uint32_t nedges = edge_array->count;
+  if (nedges == 0)
+  {
+    meos_array_destroy(edge_array);
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(geom->srid, 0, 0));
+  }
+
+  /* Every edge contributes its two end points */
+  uint32_t maxpoints = 2 * nedges;
+  POINT2D *points = palloc(sizeof(POINT2D) * maxpoints);
+  uint32_t npoints = 0;
+
+  /* Extract the exact extremal points */
+  for (uint32_t i = 0; i < nedges; i++)
+  {
+    const Edge *e = (Edge *) meos_array_get(edge_array, i);
+    add_edge_points(e, points, &npoints);
+  }
+
+  /* We no longer need the edge array for the convex hull */
+  meos_array_destroy(edge_array);
+
+  /* Convex hull */
+  POINT2D *hull = NULL;
+  uint32_t nhull = convex_hull_points(points, npoints, &hull);
+  if (nhull == 0)
+  {
+    pfree(points);
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(geom->srid, 0, 0));
+  }
+  if (nhull == 2)
+    hull_order_as_input(points, npoints, hull);
+  pfree(points);
+
+  LWGEOM *result = make_geometry_hull(geom->srid, hull, nhull);
+  pfree(hull);
+  return result;
+}
+
+/**
+ * @ingroup meos_geo_base_spatial
+ * @brief Return the convex hull of a geometry
+ * @param[in] gs Geometry
+ * @note PostGIS function: @p ST_ConvexHull(PG_FUNCTION_ARGS). With respect to
+ * the original function we do not use the @p prec argument.
+ */
+GSERIALIZED *
+geom_convex_hull_meos(const GSERIALIZED *gs)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(gs, NULL);
+  if (! ensure_not_geodetic_geo(gs))
+    return NULL;
+
+  /* Empty.ConvexHull() == Empty */
+  if (gserialized_is_empty(gs))
+    return geo_copy(gs);
+
+  /* A geometry carrying a circular arc has no native hull yet, and the arc
+   * reaches past the points that define it, so it is answered by GEOS */
+  LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+  if (lwgeom_has_arc(lwgeom))
+  {
+    lwgeom_free(lwgeom);
+    return geom_convex_hull(gs);
+  }
+  LWGEOM *res = convex_hull(lwgeom);
+  GSERIALIZED *result = geo_serialize(res);
+  lwgeom_free(lwgeom); lwgeom_free(res);
+  return result;
+}
+
+/*****************************************************************************
  * Points, and the geometry a value serializes to
  *****************************************************************************/
 

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2288,6 +2288,59 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
 
 /**
  * @ingroup meos_geo_base_spatial
+ * @brief Return the rectangle of minimum area enclosing a geometry
+ * @param[in] gs Geometry
+ * @note PostGIS function: @p ST_OrientedEnvelope(PG_FUNCTION_ARGS)
+ */
+GSERIALIZED *
+geom_oriented_envelope(const GSERIALIZED *gs)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(gs, NULL);
+  if (! ensure_not_geodetic_geo(gs))
+    return NULL;
+
+  /* The rectangle enclosing nothing is nothing */
+  if (gserialized_is_empty(gs))
+    return geo_copy(gs);
+
+  int32_t srid = gserialized_get_srid(gs);
+  GEOSContextHandle_t ctx = geos_get_context();
+
+  GEOSGeometry *geos1 = POSTGIS2GEOS(gs);
+  if (! geos1)
+  {
+    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
+      "First argument geometry could not be converted to GEOS");
+    return NULL;
+  }
+
+  GEOSGeometry *geos2 = GEOSMinimumRotatedRectangle_r(ctx, geos1);
+  GEOSGeom_destroy_r(ctx, geos1);
+  if (! geos2)
+  {
+    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
+      "GEOS minimumRotatedRectangle() threw an error !");
+    return NULL;
+  }
+
+  GEOSSetSRID_r(ctx, geos2, srid);
+  LWGEOM *lwout = GEOS2LWGEOM(geos2, (uint8_t) gserialized_has_z(gs));
+  GEOSGeom_destroy_r(ctx, geos2);
+  if (! lwout)
+  {
+    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
+      "minimumRotatedRectangle() failed to convert GEOS geometry to LWGEOM");
+    return NULL;
+  }
+
+  GSERIALIZED *result = geo_serialize(lwout);
+  lwgeom_free(lwout);
+  return result;
+}
+
+/**
+ * @ingroup meos_geo_base_spatial
  * @brief Return the convex hull of the geometry
  * @param[in] gs Geometry
  * @note PostGIS function: @p ST_ConvexHull(PG_FUNCTION_ARGS). With respect to

--- a/meos/test/geo_op_diff.c
+++ b/meos/test/geo_op_diff.c
@@ -143,6 +143,36 @@ area_tolerance(void)
 }
 
 /**
+ * @brief Return the oriented envelope GEOS answers for a geometry
+ */
+static GSERIALIZED *
+geos_oriented_envelope(const GSERIALIZED *gs)
+{
+  GEOSGeometry *input = geos_stroked(gs);
+  if (! input)
+    return NULL;
+  GEOSGeometry *mrr = GEOSMinimumRotatedRectangle(input);
+  GEOSGeom_destroy(input);
+  if (! mrr)
+    return NULL;
+  size_t size;
+  unsigned char *hex = GEOSGeomToHEX_buf(mrr, &size);
+  GEOSGeom_destroy(mrr);
+  if (! hex)
+    return NULL;
+  GSERIALIZED *result = geom_in((const char *) hex, -1);
+  GEOSFree(hex);
+  /* The round trip through GEOS drops the reference system */
+  if (result)
+  {
+    GSERIALIZED *located = geo_set_srid(result, geo_srid(gs));
+    free(result);
+    result = located;
+  }
+  return result;
+}
+
+/**
  * @brief Return true if the symmetric difference of two geometries covers a
  * negligible fraction of the expected area
  */
@@ -299,6 +329,95 @@ boundary_hausdorff_in_tolerance(const GEOSGeometry *actual,
 }
 
 /**
+ * @brief Return true if every coordinate of a geometry is a finite number
+ * @details At coordinates near the range of a double the rotation GEOS applies
+ * to place a rectangle overflows, and it answers a geometry carrying NaN. Such
+ * an answer asserts nothing, so a record it comes from is reported rather than
+ * counted against the native implementation.
+ */
+static bool
+geo_is_finite(const GSERIALIZED *gs)
+{
+  GEOSGeometry *g = geos_stroked(gs);
+  if (! g)
+    return false;
+  double xmin, xmax, ymin, ymax, area;
+  /* The extent is read as well as the area, since the extent of a ring
+   * carrying a NaN vertex is still the extent of the vertices that are not */
+  bool result = GEOSGeom_getXMin(g, &xmin) && GEOSGeom_getXMax(g, &xmax) &&
+    GEOSGeom_getYMin(g, &ymin) && GEOSGeom_getYMax(g, &ymax) &&
+    GEOSArea(g, &area) &&
+    isfinite(xmin) && isfinite(xmax) && isfinite(ymin) && isfinite(ymax) &&
+    isfinite(area);
+  GEOSGeom_destroy(g);
+  return result;
+}
+
+/**
+ * @brief Return true if a rectangle answers the oriented envelope of a geometry
+ * @details The operation asks for a rectangle of minimum area enclosing the
+ * geometry, and that rectangle is not unique: whenever the convex hull has two
+ * supporting directions of equal width the minimum is attained twice, and the
+ * two answers cover different regions. Asserting the region GEOS happens to
+ * return would test which of the tied rectangles an implementation reaches,
+ * which no definition fixes. The two properties the definition does fix are
+ * asserted instead: the answer encloses the geometry, and its area does not
+ * exceed the area of the rectangle GEOS returns.
+ */
+static bool
+envelope_matches(const GSERIALIZED *actual, const GSERIALIZED *expected,
+  const GSERIALIZED *input, char *reason, size_t size)
+{
+  bool e1 = geo_is_empty(actual), e2 = geo_is_empty(expected);
+  if (e1 && e2)
+    return true;
+  if (e1 || e2)
+  {
+    snprintf(reason, size, "one result is empty and the other is not");
+    return false;
+  }
+  /* The two agree outright, which a degenerate rectangle answers as a line or
+   * a point and which no area comparison is defined on */
+  if (geo_equals(actual, expected) == 1)
+    return true;
+  GEOSGeometry *g1 = geos_stroked(actual);
+  GEOSGeometry *g2 = geos_stroked(expected);
+  GEOSGeometry *in = geos_stroked(input);
+  if (! g1 || ! g2 || ! in)
+  {
+    snprintf(reason, size, "a result does not convert to a polygon");
+    if (g1) GEOSGeom_destroy(g1);
+    if (g2) GEOSGeom_destroy(g2);
+    if (in) GEOSGeom_destroy(in);
+    return false;
+  }
+  double a1, a2;
+  bool result = false;
+  if (! GEOSArea(g1, &a1) || ! GEOSArea(g2, &a2))
+    snprintf(reason, size, "the area of a result is not available");
+  else
+  {
+    /* The enclosure is asked for at the scale the coordinates are written at,
+     * since the rectangle is placed by arithmetic on those coordinates */
+    double scale = sqrt(a2 > 0.0 ? a2 : 1.0);
+    GEOSGeometry *grown = GEOSBuffer(g1, scale * EXACT_AREA_DIFFERENCE, 8);
+    if (! grown)
+      snprintf(reason, size, "the answer does not admit a tolerance");
+    else if (GEOSCovers(grown, in) != 1)
+      snprintf(reason, size, "the answer does not enclose the geometry");
+    else if (a1 > a2 * (1.0 + EXACT_AREA_DIFFERENCE))
+      snprintf(reason, size, "the answer covers %g of the area GEOS answers, "
+        "so it is not of minimum area", a2 > 0.0 ? a1 / a2 : a1);
+    else
+      result = true;
+    if (grown)
+      GEOSGeom_destroy(grown);
+  }
+  GEOSGeom_destroy(g1); GEOSGeom_destroy(g2); GEOSGeom_destroy(in);
+  return result;
+}
+
+/**
  * @brief Return true if a buffer matches the one the GEOS suite asserts
  */
 static bool
@@ -335,13 +454,15 @@ buffer_matches(const GSERIALIZED *actual, const GSERIALIZED *expected,
 int
 main(int argc, char **argv)
 {
-  if (argc != 2 || strcmp(argv[1], "buffer"))
+  if (argc != 2 || (strcmp(argv[1], "convexhull") && strcmp(argv[1], "buffer")
+      && strcmp(argv[1], "orientedenvelope")))
   {
     fprintf(stderr,
-      "usage: %s buffer < corpus\n",
-      argv[0]);
+      "usage: %s {convexhull|buffer|orientedenvelope} < corpus\n", argv[0]);
     return 2;
   }
+  bool is_buffer = ! strcmp(argv[1], "buffer");
+  bool is_envelope = ! strcmp(argv[1], "orientedenvelope");
   meos_initialize();
   /* A geometry the native implementation declines raises an error, and the
    * corpus is walked to its end rather than stopped on the first one */
@@ -351,7 +472,7 @@ main(int argc, char **argv)
   char *line = NULL;
   size_t cap = 0;
   ssize_t len;
-  int nchecked = 0, nfailed = 0, nunsupported = 0;
+  int nchecked = 0, nfailed = 0, nunsupported = 0, nnoreference = 0;
   while ((len = getline(&line, &cap, stdin)) > 0)
   {
     if (line[0] == '#' || line[0] == '\n')
@@ -368,19 +489,29 @@ main(int argc, char **argv)
       if (expected_wkt)
         *expected_wkt++ = '\0';
     }
-    if (! arg || ! expected_wkt)
+    if (! is_envelope && (! arg || ! expected_wkt))
       continue;
 
     GSERIALIZED *gs = geom_in(line, -1);
-    GSERIALIZED *expected = geom_in(expected_wkt, -1);
+    /* The GEOS suite asserts no oriented envelope, so GEOS answers it here */
+    GSERIALIZED *expected = is_envelope ? geos_oriented_envelope(gs) :
+      geom_in(expected_wkt, -1);
     if (! gs || ! expected)
     {
       fprintf(stderr, "PARSE %.90s\n", line);
       free(gs); free(expected);
       continue;
     }
-    double distance = atof(arg);
-    GSERIALIZED *actual = geom_buffer_meos(gs, distance, "");
+    if (is_envelope && ! geo_is_finite(expected))
+    {
+      nnoreference++;
+      printf("NOREFERENCE %.90s\n", line);
+      free(gs); free(expected);
+      continue;
+    }
+    double distance = is_buffer ? atof(arg) : 0.0;
+    GSERIALIZED *actual = is_buffer ? geom_buffer_meos(gs, distance, "") :
+      (is_envelope ? geom_oriented_envelope_meos(gs) : geom_convex_hull_meos(gs));
     if (! actual)
     {
       nunsupported++;
@@ -390,14 +521,20 @@ main(int argc, char **argv)
     }
     nchecked++;
     char reason[256] = "the result differs from the assertion";
-    bool ok = buffer_matches(actual, expected, distance, reason,
-      sizeof(reason));
+    bool ok = is_buffer ?
+      buffer_matches(actual, expected, distance, reason, sizeof(reason)) :
+      (is_envelope ?
+        envelope_matches(actual, expected, gs, reason, sizeof(reason)) :
+        geo_equals(actual, expected) == 1);
     if (! ok)
     {
       nfailed++;
       char *wa = geo_as_ewkt(actual, 8), *we = geo_as_ewkt(expected, 8);
       printf("FAIL   in       %.100s\n", line);
-      printf("       distance %g: %s\n", distance, reason);
+      if (is_buffer)
+        printf("       distance %g: %s\n", distance, reason);
+      else if (is_envelope)
+        printf("       %s\n", reason);
       printf("       expected %.100s\n", we);
       printf("       actual   %.100s\n", wa);
       free(wa); free(we);
@@ -405,6 +542,9 @@ main(int argc, char **argv)
     free(actual); free(gs); free(expected);
   }
   free(line);
+  if (nnoreference)
+    printf("%d records carry no reference, GEOS overflowing on their coordinates\n",
+      nnoreference);
   printf("%d of %d checked records pass, %d unsupported\n",
     nchecked - nfailed, nchecked, nunsupported);
   finishGEOS();

--- a/mobilitydb/sql/geo/049_geo_funcs.in.sql
+++ b/mobilitydb/sql/geo/049_geo_funcs.in.sql
@@ -34,6 +34,19 @@
  */
 
 /*****************************************************************************
+ * Oriented envelope (a.k.a minimum rotated rectangle) and convex hull
+ *****************************************************************************/
+
+CREATE FUNCTION OrientedEnvelope(geometry)
+  RETURNS geometry
+  AS 'MODULE_PATHNAME', 'Geom_oriented_envelope'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ConvexHull(geometry)
+  RETURNS geometry
+  AS 'MODULE_PATHNAME', 'Geom_convex_hull'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************
  * Buffer
  *****************************************************************************/
 

--- a/mobilitydb/src/geo/geo_funcs.c
+++ b/mobilitydb/src/geo/geo_funcs.c
@@ -49,6 +49,46 @@
 #include "pg_geo/postgis.h"
 
 /*****************************************************************************
+ * Oriented envelope (a.k.a minimum rotated rectangle) and convex hull
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Geom_oriented_envelope(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Geom_oriented_envelope);
+/**
+ * @ingroup mobilitydb_geo_base_spatial
+ * @brief Return the oriented envelope of a geometry
+ * @sqlfn OrientedEnvelope()
+ */
+Datum
+Geom_oriented_envelope(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+  GSERIALIZED *result = geom_oriented_envelope_meos(gs);
+  PG_FREE_IF_COPY(gs, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_GSERIALIZED_P(result);
+}
+
+PGDLLEXPORT Datum Geom_convex_hull(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Geom_convex_hull);
+/**
+ * @ingroup mobilitydb_geo_base_spatial
+ * @brief Return the convex hull of a geometry
+ * @sqlfn ConvexHull()
+ */
+Datum
+Geom_convex_hull(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+  GSERIALIZED *result = geom_convex_hull_meos(gs);
+  PG_FREE_IF_COPY(gs, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_GSERIALIZED_P(result);
+}
+
+/*****************************************************************************
  * Buffer
  *****************************************************************************/
 

--- a/mobilitydb/test/geo/expected/049_geo_funcs.test.out
+++ b/mobilitydb/test/geo/expected/049_geo_funcs.test.out
@@ -1,3 +1,67 @@
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Point(1 2)'), 6));
+ st_astext  
+------------
+ POINT(1 2)
+(1 row)
+
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
+      st_astext       
+----------------------
+ LINESTRING(0 0,10 0)
+(1 row)
+
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,10 0,10 5,0 5,0 0))'), 6));
+            st_astext             
+----------------------------------
+ POLYGON((0 0,10 0,10 5,0 5,0 0))
+(1 row)
+
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
+            st_astext             
+----------------------------------
+ POLYGON((0 0,3 4,-1 7,-4 3,0 0))
+(1 row)
+
+SELECT ST_Equals(
+  OrientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'),
+  ST_OrientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
+ st_equals 
+-----------
+ t
+(1 row)
+
+SELECT ST_AsText(round(ConvexHull(geometry 'Point(1 2)'), 6));
+ st_astext  
+------------
+ POINT(1 2)
+(1 row)
+
+SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,1 1,2 2)'), 6));
+      st_astext      
+---------------------
+ LINESTRING(0 0,2 2)
+(1 row)
+
+SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
+             st_astext              
+------------------------------------
+ POLYGON((0 0,0 10,10 10,10 0,0 0))
+(1 row)
+
+SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
+             st_astext              
+------------------------------------
+ POLYGON((0 0,0 10,10 10,10 0,0 0))
+(1 row)
+
+SELECT ST_Equals(
+  ConvexHull(geometry 'Circularstring(0 0,2 2,4 0)'),
+  ST_ConvexHull(geometry 'Circularstring(0 0,2 2,4 0)'));
+ st_equals 
+-----------
+ t
+(1 row)
+
 SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', 1), 6));
                   st_astext                  
 ---------------------------------------------

--- a/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
+++ b/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
@@ -25,6 +25,41 @@
 -- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
 
 -------------------------------------------------------------------------------
+-- Oriented envelope and convex hull
+-- Both are placed on the vertices of a geometry whose every edge is a segment,
+-- which for such a geometry are the whole of it
+-------------------------------------------------------------------------------
+
+-- The envelope of a point is that point, of two points the segment they span
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Point(1 2)'), 6));
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
+
+-- A rectangle is its own envelope, whatever angle it is written at
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,10 0,10 5,0 5,0 0))'), 6));
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
+
+-- An arc reaches past the points that define it, so a geometry carrying one
+-- has no native placement yet and is answered by GEOS, as PostGIS answers it
+SELECT ST_Equals(
+  OrientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'),
+  ST_OrientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
+
+-- The hull of a point is that point, and of collinear points their segment
+SELECT ST_AsText(round(ConvexHull(geometry 'Point(1 2)'), 6));
+SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,1 1,2 2)'), 6));
+
+-- A point inside the hull of the others does not reach its boundary
+SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
+
+-- The hull of a concave polygon closes over the notch
+SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
+
+-- And the hull of an arc is answered by GEOS for the same reason
+SELECT ST_Equals(
+  ConvexHull(geometry 'Circularstring(0 0,2 2,4 0)'),
+  ST_ConvexHull(geometry 'Circularstring(0 0,2 2,4 0)'));
+
+-------------------------------------------------------------------------------
 -- Buffer
 -- A buffer is bounded by the offsets of the geometry and by the joins and caps
 -- between them, and a circular arc is kept as an arc rather than sampled


### PR DESCRIPTION
The rectangle of minimum area enclosing a geometry and the smallest convex geometry enclosing it are both placed on the vertices of the geometry, which for a geometry whose every edge is a segment are the whole of it: a convex hull has a vertex of the input at every corner, and a rectangle of minimum area has a side flush with an edge of that hull, so trying the direction of each hull edge finds it exactly. `geo_funcs.c` places both that way and answers them without calling GEOS, and `geom_oriented_envelope_meos` and `geom_convex_hull_meos` are the entries that reach them. The SQL functions `OrientedEnvelope` and `ConvexHull` answer a geometry the way `Buffer` does.

A geometry carrying a circular arc is answered by GEOS, following the rule that GEOS stays as a fallback for a type that is not native yet. The arc reaches past the points that define it, so a region placed on those points does not enclose it: placing the envelope of a circle of radius 2 on the four cardinal points of its supporting circle leaves 36% of the circle outside its own envelope, and placing the hull of a semicircular arc on its three defining points leaves the whole arc outside its own hull. GEOS reads such an arc as the chain of segments approximating it, which is what MobilityDB answers for one. `geom_oriented_envelope` is the GEOS entry the fallback reaches, beside the convex hull entry that already exists.

The rectangle is asserted by what the operation fixes rather than by the region GEOS returns. A minimum is attained twice whenever the convex hull has two supporting directions of equal width, and the two rectangles cover different regions, so `geo_op_diff` asks instead that the answer encloses the geometry and that its area does not exceed the area GEOS answers. Six records of the GEOS suites are such a tie. A record whose coordinates overflow the rotation GEOS applies carries no assertion at all, and is reported rather than counted.

Over the convex hull suite the hull agrees on 14 of 14 records and the envelope on 13 of 13, the fourteenth being the one GEOS answers with NaN; over the buffer suite the envelope agrees on 34 of 34. Every answer of the two suites encloses its geometry, and none is of larger area than an independently computed minimum. The regression answers are harvested, and each is checked against that independent minimum as well.

The base of this branch is the geometry-layer serialization PR, whose commit is the first of the two here.