### PR TITLE
Mark the operator token in every @sqlop tag

### DIFF
--- a/mobilitydb/src/cbuffer/tcbuffer_distance.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_distance.c
@@ -446,7 +446,7 @@ PG_FUNCTION_INFO_V1(NAD_geo_tcbuffer);
  * @brief Return the nearest approach distance between a geometry and a
  * temporal circular buffer
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_geo_tcbuffer(PG_FUNCTION_ARGS)
@@ -468,7 +468,7 @@ PG_FUNCTION_INFO_V1(NAD_tcbuffer_geo);
  * @brief Return the nearest approach distance between a temporal circular
  * buffer and a geometry
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tcbuffer_geo(PG_FUNCTION_ARGS)
@@ -492,7 +492,7 @@ PG_FUNCTION_INFO_V1(NAD_cbuffer_tcbuffer);
  * @brief Return the nearest approach distance between a circular buffer and a
  * temporal circular buffer
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_cbuffer_tcbuffer(PG_FUNCTION_ARGS)
@@ -514,7 +514,7 @@ PG_FUNCTION_INFO_V1(NAD_tcbuffer_cbuffer);
  * @brief Return the nearest approach distance between a temporal circular
  * buffer and a circular buffer
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tcbuffer_cbuffer(PG_FUNCTION_ARGS)
@@ -538,7 +538,7 @@ PG_FUNCTION_INFO_V1(NAD_tcbuffer_tcbuffer);
  * @brief Return the nearest approach distance between two temporal circular
  * points
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tcbuffer_tcbuffer(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/geo/tspatial_posops.c
+++ b/mobilitydb/src/geo/tspatial_posops.c
@@ -464,7 +464,7 @@ PG_FUNCTION_INFO_V1(Overback_tspatial_stbox);
  * @brief Return true if a spatiotemporal value does not extend to the front
  * of a spatiotemporal box
  * @sqlfn overback()
- * @sqlop @ /&>
+ * @sqlop @p /&>
  */
 inline Datum
 Overback_tspatial_stbox(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/json/jsonbset_jsonfuncs.c
+++ b/mobilitydb/src/json/jsonbset_jsonfuncs.c
@@ -450,7 +450,7 @@ Jsonbset_delete_path(PG_FUNCTION_ARGS)
 /**
  * @brief Extract an array element from a JSONB set value
  * @sqlfn jsonbsetArrayElement(), jsonbsetArrayElementOpr()
-  * @sqlop ->
+  * @sqlop @p ->
 */
 Datum
 Jsonbset_array_element_common(FunctionCallInfo fcinfo, bool astext)

--- a/mobilitydb/src/json/tjsonb_jsonfuncs.c
+++ b/mobilitydb/src/json/tjsonb_jsonfuncs.c
@@ -532,7 +532,7 @@ Tjsonb_delete_path(PG_FUNCTION_ARGS)
 /**
  * @brief Extract an array element from a temporal JSON value
  * @sqlfn tjsonArrayElement(), tjsonArrayElementOpr()
- * @sqlop ->
+ * @sqlop @p ->
  */
 Datum
 Tjson_array_element_common(FunctionCallInfo fcinfo)
@@ -585,7 +585,7 @@ Tjson_array_element_opr(PG_FUNCTION_ARGS)
 /**
  * @brief Extract an array element from a temporal JSONB value
  * @sqlfn tjsonbArrayElement(), tjsonbArrayElementOpr()
-  * @sqlop ->
+  * @sqlop @p ->
 */
 Datum
 Tjsonb_array_element_common(FunctionCallInfo fcinfo, bool astext)

--- a/mobilitydb/src/npoint/tnpoint_distance.c
+++ b/mobilitydb/src/npoint/tnpoint_distance.c
@@ -266,7 +266,7 @@ PG_FUNCTION_INFO_V1(NAD_geo_tnpoint);
  * @brief Return the nearest approach distance between a geometry and a
  * temporal network point
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_geo_tnpoint(PG_FUNCTION_ARGS)
@@ -288,7 +288,7 @@ PG_FUNCTION_INFO_V1(NAD_tnpoint_geo);
  * @brief Return the nearest approach distance between a temporal network point
  * and a geometry
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tnpoint_geo(PG_FUNCTION_ARGS)
@@ -310,7 +310,7 @@ PG_FUNCTION_INFO_V1(NAD_stbox_tnpoint);
  * @brief Return the nearest approach distance between a spatiotemporal box and
  * a temporal network point
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_stbox_tnpoint(PG_FUNCTION_ARGS)
@@ -331,7 +331,7 @@ PG_FUNCTION_INFO_V1(NAD_tnpoint_stbox);
  * @brief Return the nearest approach distance between a temporal network point
  * and a spatiotemporal box
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tnpoint_stbox(PG_FUNCTION_ARGS)
@@ -352,7 +352,7 @@ PG_FUNCTION_INFO_V1(NAD_npoint_tnpoint);
  * @brief Return the nearest approach distance between a network point and a
  * temporal network point
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_npoint_tnpoint(PG_FUNCTION_ARGS)
@@ -373,7 +373,7 @@ PG_FUNCTION_INFO_V1(NAD_tnpoint_npoint);
  * @brief Return the nearest approach distance between a temporal network point
  * and a network point
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tnpoint_npoint(PG_FUNCTION_ARGS)
@@ -394,7 +394,7 @@ PG_FUNCTION_INFO_V1(NAD_tnpoint_tnpoint);
  * @brief Return the nearest approach distance between two temporal network
  * points
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tnpoint_tnpoint(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -368,7 +368,7 @@ PG_FUNCTION_INFO_V1(NAD_geo_tpose);
  * @brief Return the nearest approach distance between a geometry and a
  * temporal pose
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_geo_tpose(PG_FUNCTION_ARGS)
@@ -390,7 +390,7 @@ PG_FUNCTION_INFO_V1(NAD_tpose_geo);
  * @brief Return the nearest approach distance between a temporal pose and a
  * geometry
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tpose_geo(PG_FUNCTION_ARGS)
@@ -458,7 +458,7 @@ PG_FUNCTION_INFO_V1(NAD_pose_tpose);
  * @brief Return the nearest approach distance between a pose and a temporal
  * pose
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_pose_tpose(PG_FUNCTION_ARGS)
@@ -479,7 +479,7 @@ PG_FUNCTION_INFO_V1(NAD_tpose_pose);
  * @brief Return the nearest approach distance between a temporal pose and a
  * pose
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tpose_pose(PG_FUNCTION_ARGS)
@@ -501,7 +501,7 @@ PG_FUNCTION_INFO_V1(NAD_tpose_tpose);
  * @ingroup mobilitydb_pose_dist
  * @brief Return the nearest approach distance between two temporal poses
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tpose_tpose(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/tnumber_distance.c
+++ b/mobilitydb/src/temporal/tnumber_distance.c
@@ -119,7 +119,7 @@ PG_FUNCTION_INFO_V1(NAD_number_tnumber);
  * @brief Return the nearest approach distance between a number and a temporal
  * number
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_number_tnumber(PG_FUNCTION_ARGS)
@@ -141,7 +141,7 @@ PG_FUNCTION_INFO_V1(NAD_tnumber_number);
  * @brief Return the nearest approach distance between a temporal number and a
  * number
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tnumber_number(PG_FUNCTION_ARGS)
@@ -162,7 +162,7 @@ PG_FUNCTION_INFO_V1(NAD_tbox_tbox);
  * @ingroup mobilitydb_temporal_dist
  * @brief Return the nearest approach distance between two temporal boxes
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tbox_tbox(PG_FUNCTION_ARGS)
@@ -183,7 +183,7 @@ PG_FUNCTION_INFO_V1(NAD_tbox_tnumber);
  * @brief Return the nearest approach distance between a temporal box and a
  * temporal number
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tbox_tnumber(PG_FUNCTION_ARGS)
@@ -205,7 +205,7 @@ PG_FUNCTION_INFO_V1(NAD_tnumber_tbox);
  * @brief Return the nearest approach distance between a temporal number and a
  * temporal box
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tnumber_tbox(PG_FUNCTION_ARGS)
@@ -226,7 +226,7 @@ PG_FUNCTION_INFO_V1(NAD_tnumber_tnumber);
  * @ingroup mobilitydb_temporal_dist
  * @brief Return the nearest approach distance between two temporal numbers
  * @sqlfn nearestApproachDistance()
- * @sqlop |=|
+ * @sqlop @p |=|
  */
 Datum
 NAD_tnumber_tnumber(PG_FUNCTION_ARGS)


### PR DESCRIPTION
Every `@sqlop` tag marks its operator with Doxygen's `@p`, which renders the token that follows it literally. The catalog extractor reads the operator from that token, so a tag without `@p` leaves its operator out of the catalog and out of every binding generated from the catalog.

Twenty-seven tags carry the marker: twenty-three name `|=|`, the nearest-approach operator, across tnumber, tcbuffer, tnpoint and tpose; three name the JSON `->`; and `Overback_tspatial_stbox` names `/&>` the way the sibling wrapper for the same operator does.

The boundary is visible within a single file. `NAD_tcbuffer_stbox` and `NAD_geo_tcbuffer` sit in `tcbuffer_distance.c` and describe the same operator, and MobilityDuck registers `|=|` for the first and carries no overload for the second. On the numeric side, where every wrapper's tag is unmarked, a k-nearest query over a temporal number has no operator to express it.

Comments only. The PostgreSQL operators themselves are declared in the SQL files and are unaffected, so this changes what downstream catalogs and bindings see rather than what PostgreSQL exposes.
