### PR TITLE
Answer whether a geometry is simple from the segments it is made of

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -916,6 +916,9 @@
 					<para><link linkend="geo_convexhull"><varname>ConvexHull</varname></link>: Devuelve la geometría convexa más pequeña que encierra una geometría</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="geo_issimple"><varname>isSimple</varname></link>: Devuelve verdadero si una geometría no tiene ningún punto en el que se cruce o se toque a sí misma</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="geo_buffer"><varname>Buffer</varname></link>: Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>
 				</listitem>
 			</itemizedlist>

--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -70,6 +70,21 @@ SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="geo_issimple">
+				<indexterm significance="normal"><primary><varname>isSimple</varname></primary></indexterm>
+				<para>Devuelve verdadero si una geometría no tiene ningún punto en el que se cruce o se toque a sí misma</para>
+				<para><varname>isSimple(geometry) → boolean</varname></para>
+				<para>Un punto siempre es simple, un multipunto es simple cuando no repite ningún punto, una línea es simple cuando se encuentra consigo misma solo donde dos de sus segmentos se siguen y, cuando se cierra, en el punto donde se cierra, y una geometría de área es simple cuando cada uno de sus anillos lo es. Además, dos líneas de una multilínea pueden encontrarse en un punto que termina ambas. Una geometría que lleva un arco circular la responde GEOS, ya que tal geometría se encuentra consigo misma a lo largo de un arco y no en un punto.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isSimple(geometry 'Linestring(0 0,10 10,10 0,0 10)');
+-- false
+SELECT isSimple(geometry 'Linestring(0 0,10 0,10 10,0 0)');
+-- true
+SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(10 0,10 10))');
+-- true
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="geo_buffer">
 				<indexterm significance="normal"><primary><varname>Buffer</varname></primary></indexterm>
 				<para>Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -916,6 +916,9 @@
 					<para><link linkend="geo_convexhull"><varname>ConvexHull</varname></link>: Return the smallest convex geometry enclosing a geometry</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="geo_issimple"><varname>isSimple</varname></link>: Return true if a geometry has no point at which it crosses or touches itself</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="geo_buffer"><varname>Buffer</varname></link>: Return the geometry holding every point within a distance of a geometry</para>
 				</listitem>
 			</itemizedlist>

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -70,6 +70,21 @@ SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="geo_issimple">
+				<indexterm significance="normal"><primary><varname>isSimple</varname></primary></indexterm>
+				<para>Return true if a geometry has no point at which it crosses or touches itself</para>
+				<para><varname>isSimple(geometry) → boolean</varname></para>
+				<para>A point is always simple, a multipoint is simple when it repeats no point, a line is simple when it meets itself only where two of its segments follow one another and, when it closes, at the point where it closes, and an areal geometry is simple when each of its rings is. Two lines of a multiline may additionally meet at a point that ends both. A geometry carrying a circular arc is answered by GEOS, since such a geometry meets itself along an arc rather than at a point.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isSimple(geometry 'Linestring(0 0,10 10,10 0,0 10)');
+-- false
+SELECT isSimple(geometry 'Linestring(0 0,10 0,10 10,0 0)');
+-- true
+SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(10 0,10 10))');
+-- true
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="geo_buffer">
 				<indexterm significance="normal"><primary><varname>Buffer</varname></primary></indexterm>
 				<para>Return the geometry holding every point within a distance of a geometry</para>

--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -120,6 +120,7 @@ angle_normalize(double a)
 extern void arc_set_bbox(Edge *e);
 extern bool arc_contains_angle(const Edge *e, double phi);
 extern LWGEOM *meos_oriented_envelope(const LWGEOM *geom);
+extern bool meos_is_simple(const LWGEOM *geom, bool *result);
 extern bool point_on_arc(double px, double py, const Edge *e);
 extern bool point_on_segment(double px, double py, double x1, double y1,
   double x2, double y2);

--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -407,6 +407,7 @@ extern GSERIALIZED *geom_centroid(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_convex_hull(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_convex_hull_meos(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
+extern bool geom_is_simple(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern GSERIALIZED *geom_intersection2d_coll(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern GSERIALIZED *geom_min_bounding_radius(const GSERIALIZED *geom, double *radius);

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -1435,6 +1435,317 @@ geom_convex_hull_meos(const GSERIALIZED *gs)
 }
 
 /*****************************************************************************
+ * Simple geometries
+ * Implementation of the PostGIS function ST_IsSimple improving its
+ * performance and answering it without GEOS
+ * A geometry is simple when it has no anomalous point, which is a point at
+ * which it crosses or touches itself. A point is always simple, a multipoint
+ * is simple when it repeats no point, a line is simple when it meets itself
+ * only where two of its segments follow one another and, when it closes, at
+ * the point where it closes, and an areal geometry is simple when each of its
+ * rings is. The components of a multipart geometry are answered one by one,
+ * except that the lines of a multiline may meet only at a point that ends
+ * both of them.
+ *****************************************************************************/
+
+/**
+ * @brief Collect the points of a point array, dropping a point that repeats
+ * the one before it
+ * @details A repeated point contributes a segment of no length, which the
+ * standard does not read as the geometry meeting itself
+ * @param[in] pa Point array
+ * @param[out] points Array receiving the points, of at least @p pa->npoints
+ * elements
+ * @return Number of points collected
+ */
+static int
+pointarr_collect(const POINTARRAY *pa, const POINT2D **points)
+{
+  assert(pa); assert(points);
+  int npoints = 0;
+  for (uint32_t i = 0; i < pa->npoints; i++)
+  {
+    const POINT2D *point = getPoint2d_cp(pa, i);
+    if (npoints == 0 ||
+        point->x != points[npoints - 1]->x ||
+        point->y != points[npoints - 1]->y)
+      points[npoints++] = point;
+  }
+  return npoints;
+}
+
+/**
+ * @brief Return true if a sequence of points closes on itself
+ */
+static bool
+pointarr_is_closed(const POINT2D **points, int npoints)
+{
+  assert(points);
+  return npoints > 1 && points[0]->x == points[npoints - 1]->x &&
+    points[0]->y == points[npoints - 1]->y;
+}
+
+/**
+ * @brief Return true if the polyline joining a sequence of points meets itself
+ * nowhere it is not allowed to
+ * @details Two segments that follow one another meet at the point they share,
+ * and the first and the last segment of a closed polyline meet at the point
+ * that closes it. Meeting anywhere else, meeting at more than a point, or an
+ * end of one segment falling inside another, is the geometry crossing or
+ * touching itself.
+ * @param[in] points Array of points, holding no point that repeats the one
+ * before it
+ * @param[in] npoints Number of elements in the array of points
+ */
+static bool
+pointarr_is_simple(const POINT2D **points, int npoints)
+{
+  assert(points);
+  /* A single point and a single segment cannot meet themselves */
+  if (npoints < 3)
+    return true;
+  const bool closed = pointarr_is_closed(points, npoints);
+  const int nsegs = npoints - 1;
+  for (int i = 0; i < nsegs; i++)
+  {
+    for (int j = i + 1; j < nsegs; j++)
+    {
+      POINT2D p = { 0 }; /* make compiler quiet */
+      int intertype = seg2d_intersection(points[i], points[i + 1],
+        points[j], points[j + 1], &p);
+      if (intertype == MEOS_SEG_NO_INTERSECTION)
+        continue;
+      /* Two segments that follow one another meet at the point they share */
+      if (intertype == MEOS_SEG_TOUCH_END && j == i + 1 &&
+          p.x == points[j]->x && p.y == points[j]->y)
+        continue;
+      /* The two ends of a closed polyline meet at the point that closes it */
+      if (intertype == MEOS_SEG_TOUCH_END && closed && i == 0 &&
+          j == nsegs - 1 && p.x == points[0]->x && p.y == points[0]->y)
+        continue;
+      return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief Return true if two polylines meet only at a point that ends both of
+ * them
+ * @details A closed polyline has no end, so a closed one meeting another
+ * polyline anywhere is the pair touching itself.
+ * @param[in] points1,points2 Arrays of points
+ * @param[in] npoints1,npoints2 Number of elements in the arrays of points
+ */
+static bool
+pointarrs_meet_at_ends(const POINT2D **points1, int npoints1,
+  const POINT2D **points2, int npoints2)
+{
+  assert(points1); assert(points2);
+  if (npoints1 < 2 || npoints2 < 2)
+    return true;
+  const bool closed1 = pointarr_is_closed(points1, npoints1);
+  const bool closed2 = pointarr_is_closed(points2, npoints2);
+  for (int i = 0; i < npoints1 - 1; i++)
+  {
+    for (int j = 0; j < npoints2 - 1; j++)
+    {
+      POINT2D p = { 0 }; /* make compiler quiet */
+      int intertype = seg2d_intersection(points1[i], points1[i + 1],
+        points2[j], points2[j + 1], &p);
+      if (intertype == MEOS_SEG_NO_INTERSECTION)
+        continue;
+      /* Meeting along a stretch, or at a point inside either segment, is not
+       * the two ends meeting */
+      if (intertype != MEOS_SEG_TOUCH_END || closed1 || closed2)
+        return false;
+      /* The point ends both polylines, not only the two segments carrying it */
+      if (! ((p.x == points1[0]->x && p.y == points1[0]->y) ||
+             (p.x == points1[npoints1 - 1]->x &&
+              p.y == points1[npoints1 - 1]->y)))
+        return false;
+      if (! ((p.x == points2[0]->x && p.y == points2[0]->y) ||
+             (p.x == points2[npoints2 - 1]->x &&
+              p.y == points2[npoints2 - 1]->y)))
+        return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief Return true if a point array is simple as a polyline of its own
+ */
+static bool
+ptarray_is_simple(const POINTARRAY *pa)
+{
+  assert(pa);
+  if (pa->npoints == 0)
+    return true;
+  const POINT2D **points = palloc(sizeof(POINT2D *) * pa->npoints);
+  int npoints = pointarr_collect(pa, points);
+  bool result = pointarr_is_simple(points, npoints);
+  pfree(points);
+  return result;
+}
+
+/**
+ * @brief Return true if the points of a multipoint are all distinct
+ */
+static bool
+lwmpoint_is_simple(const LWMPOINT *mpoint)
+{
+  assert(mpoint);
+  for (uint32_t i = 0; i < mpoint->ngeoms; i++)
+  {
+    const LWPOINT *point1 = mpoint->geoms[i];
+    if (! point1 || lwpoint_is_empty(point1))
+      continue;
+    POINT2D p1;
+    lwpoint_getPoint2d_p(point1, &p1);
+    for (uint32_t j = i + 1; j < mpoint->ngeoms; j++)
+    {
+      const LWPOINT *point2 = mpoint->geoms[j];
+      if (! point2 || lwpoint_is_empty(point2))
+        continue;
+      POINT2D p2;
+      lwpoint_getPoint2d_p(point2, &p2);
+      if (p1.x == p2.x && p1.y == p2.y)
+        return false;
+    }
+  }
+  return true;
+}
+
+/**
+ * @brief Return true if the lines of a multiline are each simple and meet one
+ * another only where they end
+ */
+static bool
+lwmline_is_simple(const LWMLINE *mline)
+{
+  assert(mline);
+  const POINT2D ***points = palloc0(sizeof(POINT2D **) * mline->ngeoms);
+  int *npoints = palloc0(sizeof(int) * mline->ngeoms);
+  bool result = true;
+  for (uint32_t i = 0; i < mline->ngeoms && result; i++)
+  {
+    const LWLINE *line = mline->geoms[i];
+    if (! line || ! line->points || line->points->npoints == 0)
+      continue;
+    points[i] = palloc(sizeof(POINT2D *) * line->points->npoints);
+    npoints[i] = pointarr_collect(line->points, points[i]);
+    result = pointarr_is_simple(points[i], npoints[i]);
+  }
+  for (uint32_t i = 0; i < mline->ngeoms && result; i++)
+  {
+    if (! points[i])
+      continue;
+    for (uint32_t j = i + 1; j < mline->ngeoms && result; j++)
+    {
+      if (! points[j])
+        continue;
+      result = pointarrs_meet_at_ends(points[i], npoints[i], points[j],
+        npoints[j]);
+    }
+  }
+  for (uint32_t i = 0; i < mline->ngeoms; i++)
+    if (points[i])
+      pfree(points[i]);
+  pfree(points); pfree(npoints);
+  return result;
+}
+
+/**
+ * @brief Return true if every ring of an areal geometry is simple
+ */
+static bool
+lwpoly_is_simple(const LWPOLY *poly)
+{
+  assert(poly);
+  for (uint32_t i = 0; i < poly->nrings; i++)
+    if (poly->rings[i] && ! ptarray_is_simple(poly->rings[i]))
+      return false;
+  return true;
+}
+
+/**
+ * @brief Return true if a geometry has no anomalous point
+ * @details The result is reported in the last argument, the function itself
+ * reporting whether the geometry is covered. A geometry holding a circular
+ * arc is not covered.
+ * @param[in] geom Geometry
+ * @param[out] result True if the geometry is simple
+ * @return True if the geometry is covered
+ */
+bool
+meos_is_simple(const LWGEOM *geom, bool *result)
+{
+  assert(geom); assert(result);
+  if (lwgeom_is_empty(geom))
+  {
+    *result = true;
+    return true;
+  }
+  switch (geom->type)
+  {
+    case POINTTYPE:
+      *result = true;
+      return true;
+    case MULTIPOINTTYPE:
+      *result = lwmpoint_is_simple((const LWMPOINT *) geom);
+      return true;
+    case LINETYPE:
+      *result = ptarray_is_simple(((const LWLINE *) geom)->points);
+      return true;
+    case MULTILINETYPE:
+      *result = lwmline_is_simple((const LWMLINE *) geom);
+      return true;
+    case TRIANGLETYPE:
+      *result = ptarray_is_simple(((const LWTRIANGLE *) geom)->points);
+      return true;
+    case POLYGONTYPE:
+      *result = lwpoly_is_simple((const LWPOLY *) geom);
+      return true;
+    case MULTIPOLYGONTYPE:
+    {
+      const LWMPOLY *mpoly = (const LWMPOLY *) geom;
+      for (uint32_t i = 0; i < mpoly->ngeoms; i++)
+        if (mpoly->geoms[i] && ! lwpoly_is_simple(mpoly->geoms[i]))
+        {
+          *result = false;
+          return true;
+        }
+      *result = true;
+      return true;
+    }
+    case COLLECTIONTYPE:
+    {
+      const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
+      for (uint32_t i = 0; i < coll->ngeoms; i++)
+      {
+        bool component;
+        if (! coll->geoms[i])
+          continue;
+        if (! meos_is_simple(coll->geoms[i], &component))
+          return false;
+        if (! component)
+        {
+          *result = false;
+          return true;
+        }
+      }
+      *result = true;
+      return true;
+    }
+    default:
+      /* A geometry holding a circular arc meets itself along an arc, which
+       * the segment intersection this rests on does not answer */
+      return false;
+  }
+}
+
+/*****************************************************************************
  * Points, and the geometry a value serializes to
  *****************************************************************************/
 

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2288,6 +2288,49 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
 
 /**
  * @ingroup meos_geo_base_spatial
+ * @brief Return true if a geometry has no anomalous point, which is a point
+ * at which it crosses or touches itself
+ * @details A point is always simple, a multipoint is simple when it repeats
+ * no point, a line is simple when it meets itself only where two of its
+ * segments follow one another and, when it closes, at the point where it
+ * closes, and an areal geometry is simple when each of its rings is. The
+ * lines of a multiline may additionally meet at a point that ends both.
+ * @param[in] gs Geometry
+ * @note PostGIS function: @p ST_IsSimple(PG_FUNCTION_ARGS). With respect to
+ * the original function we do not use the @p flags argument.
+ * @csqlfn #Geom_is_simple()
+ */
+bool
+geom_is_simple(const GSERIALIZED *gs)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(gs, false);
+  if (! ensure_not_geodetic_geo(gs))
+    return false;
+
+  LWGEOM *geom = lwgeom_from_gserialized(gs);
+  bool result;
+  if (meos_is_simple(geom, &result))
+  {
+    lwgeom_free(geom);
+    return result;
+  }
+
+  /* A geometry carrying a circular arc meets itself along an arc, which the
+   * segment intersection the answer above rests on does not read */
+  int simple = lwgeom_is_simple(geom);
+  lwgeom_free(geom);
+  if (simple < 0)
+  {
+    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
+      "Whether the geometry is simple could not be determined");
+    return false;
+  }
+  return simple != 0;
+}
+
+/**
+ * @ingroup meos_geo_base_spatial
  * @brief Return the rectangle of minimum area enclosing a geometry
  * @param[in] gs Geometry
  * @note PostGIS function: @p ST_OrientedEnvelope(PG_FUNCTION_ARGS)

--- a/meos/test/geo_op_diff.c
+++ b/meos/test/geo_op_diff.c
@@ -54,6 +54,7 @@
  * geo_op_diff convexhull        < convexhull_corpus_geos.txt
  * geo_op_diff buffer            < buffer_corpus_geos.txt
  * geo_op_diff orientedenvelope  < any corpus, whose first field is read
+ * geo_op_diff issimple          < issimple_corpus_geos.txt
  * @endcode
  */
 
@@ -455,14 +456,16 @@ int
 main(int argc, char **argv)
 {
   if (argc != 2 || (strcmp(argv[1], "convexhull") && strcmp(argv[1], "buffer")
-      && strcmp(argv[1], "orientedenvelope")))
+      && strcmp(argv[1], "orientedenvelope") && strcmp(argv[1], "issimple")))
   {
     fprintf(stderr,
-      "usage: %s {convexhull|buffer|orientedenvelope} < corpus\n", argv[0]);
+      "usage: %s {convexhull|buffer|orientedenvelope|issimple} < corpus\n",
+      argv[0]);
     return 2;
   }
   bool is_buffer = ! strcmp(argv[1], "buffer");
   bool is_envelope = ! strcmp(argv[1], "orientedenvelope");
+  bool is_simple = ! strcmp(argv[1], "issimple");
   meos_initialize();
   /* A geometry the native implementation declines raises an error, and the
    * corpus is walked to its end rather than stopped on the first one */
@@ -491,6 +494,41 @@ main(int argc, char **argv)
     }
     if (! is_envelope && (! arg || ! expected_wkt))
       continue;
+
+    /* The assertion of this operation is a truth value, not a geometry */
+    if (is_simple)
+    {
+      meos_errno_reset();
+      GSERIALIZED *gs1 = geom_in(line, -1);
+      if (! gs1)
+      {
+        fprintf(stderr, "PARSE %.90s\n", line);
+        meos_errno_reset();
+        continue;
+      }
+      bool want = ! strcmp(expected_wkt, "true");
+      meos_errno_reset();
+      bool got = geom_is_simple(gs1);
+      if (meos_errno())
+      {
+        meos_errno_reset();
+        nunsupported++;
+        printf("UNSUPPORTED %.90s\n", line);
+      }
+      else
+      {
+        nchecked++;
+        if (got != want)
+        {
+          nfailed++;
+          printf("FAIL   in       %.100s\n", line);
+          printf("       expected %s, actual %s\n", want ? "true" : "false",
+            got ? "true" : "false");
+        }
+      }
+      free(gs1);
+      continue;
+    }
 
     GSERIALIZED *gs = geom_in(line, -1);
     /* The GEOS suite asserts no oriented envelope, so GEOS answers it here */

--- a/mobilitydb/sql/geo/049_geo_funcs.in.sql
+++ b/mobilitydb/sql/geo/049_geo_funcs.in.sql
@@ -47,6 +47,15 @@ CREATE FUNCTION ConvexHull(geometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
+ * Simple geometries
+ *****************************************************************************/
+
+CREATE FUNCTION isSimple(geometry)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Geom_is_simple'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************
  * Buffer
  *****************************************************************************/
 

--- a/mobilitydb/src/geo/geo_funcs.c
+++ b/mobilitydb/src/geo/geo_funcs.c
@@ -89,6 +89,27 @@ Geom_convex_hull(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
+ * Simple geometries
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Geom_is_simple(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Geom_is_simple);
+/**
+ * @ingroup mobilitydb_geo_base_accessor
+ * @brief Return true if a geometry has no anomalous point, which is a point
+ * at which it crosses or touches itself
+ * @sqlfn isSimple()
+ */
+Datum
+Geom_is_simple(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+  bool result = geom_is_simple(gs);
+  PG_FREE_IF_COPY(gs, 0);
+  PG_RETURN_BOOL(result);
+}
+
+/*****************************************************************************
  * Buffer
  *****************************************************************************/
 

--- a/mobilitydb/test/geo/expected/049_geo_funcs.test.out
+++ b/mobilitydb/test/geo/expected/049_geo_funcs.test.out
@@ -62,6 +62,92 @@ SELECT ST_Equals(
  t
 (1 row)
 
+SELECT isSimple(geometry 'Point(1 2)');
+ issimple 
+----------
+ t
+(1 row)
+
+SELECT isSimple(geometry 'Multipoint(0 0,1 1)');
+ issimple 
+----------
+ t
+(1 row)
+
+SELECT isSimple(geometry 'Multipoint(0 0,1 1,0 0)');
+ issimple 
+----------
+ f
+(1 row)
+
+SELECT isSimple(geometry 'Linestring(0 0,10 10,10 0,0 10)');
+ issimple 
+----------
+ f
+(1 row)
+
+SELECT isSimple(geometry 'Linestring(0 0,10 0,10 10,0 0)');
+ issimple 
+----------
+ t
+(1 row)
+
+SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(10 0,10 10))');
+ issimple 
+----------
+ t
+(1 row)
+
+SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(5 -5,5 5))');
+ issimple 
+----------
+ f
+(1 row)
+
+SELECT isSimple(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))');
+ issimple 
+----------
+ t
+(1 row)
+
+SELECT isSimple(geometry 'Polygon((0 0,10 10,10 0,0 10,0 0))');
+ issimple 
+----------
+ f
+(1 row)
+
+SELECT isSimple(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0),(2 2,4 2,4 4,2 4,2 2))');
+ issimple 
+----------
+ t
+(1 row)
+
+SELECT isSimple(geometry 'Geometrycollection(Point(0 0),Linestring(1 1,2 2))');
+ issimple 
+----------
+ t
+(1 row)
+
+SELECT isSimple(geometry 'Geometrycollection(Point(0 0),Linestring(0 0,10 10,10 0,0 10))');
+ issimple 
+----------
+ f
+(1 row)
+
+SELECT isSimple(geometry 'Circularstring(0 0,2 2,4 0)') =
+  ST_IsSimple(geometry 'Circularstring(0 0,2 2,4 0)');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT isSimple(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))') =
+  ST_IsSimple(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))');
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', 1), 6));
                   st_astext                  
 ---------------------------------------------

--- a/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
+++ b/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
@@ -60,6 +60,41 @@ SELECT ST_Equals(
   ST_ConvexHull(geometry 'Circularstring(0 0,2 2,4 0)'));
 
 -------------------------------------------------------------------------------
+-- Simple geometries
+-- A geometry is simple when it has no point at which it crosses or touches
+-- itself, which is read from the segments the geometry is made of
+-------------------------------------------------------------------------------
+
+-- A point is always simple, a multipoint is simple when it repeats no point
+SELECT isSimple(geometry 'Point(1 2)');
+SELECT isSimple(geometry 'Multipoint(0 0,1 1)');
+SELECT isSimple(geometry 'Multipoint(0 0,1 1,0 0)');
+
+-- A line that crosses itself is not simple, one that only closes is
+SELECT isSimple(geometry 'Linestring(0 0,10 10,10 0,0 10)');
+SELECT isSimple(geometry 'Linestring(0 0,10 0,10 10,0 0)');
+
+-- Two lines of a multiline may meet at a point that ends both, not elsewhere
+SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(10 0,10 10))');
+SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(5 -5,5 5))');
+
+-- An areal geometry is simple when each of its rings is
+SELECT isSimple(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))');
+SELECT isSimple(geometry 'Polygon((0 0,10 10,10 0,0 10,0 0))');
+SELECT isSimple(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0),(2 2,4 2,4 4,2 4,2 2))');
+
+-- A collection is simple when each of its components is
+SELECT isSimple(geometry 'Geometrycollection(Point(0 0),Linestring(1 1,2 2))');
+SELECT isSimple(geometry 'Geometrycollection(Point(0 0),Linestring(0 0,10 10,10 0,0 10))');
+
+-- An arc meets itself along an arc rather than at a point, and a geometry
+-- carrying one is answered by GEOS, as PostGIS answers it
+SELECT isSimple(geometry 'Circularstring(0 0,2 2,4 0)') =
+  ST_IsSimple(geometry 'Circularstring(0 0,2 2,4 0)');
+SELECT isSimple(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))') =
+  ST_IsSimple(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))');
+
+-------------------------------------------------------------------------------
 -- Buffer
 -- A buffer is bounded by the offsets of the geometry and by the joins and caps
 -- between them, and a circular arc is kept as an arc rather than sampled


### PR DESCRIPTION
A geometry is simple when it has no point at which it crosses or touches itself. A point is always simple, a multipoint is simple when it repeats no point, a line is simple when it meets itself only where two of its segments follow one another and, when it closes, at the point where it closes, and an areal geometry is simple when each of its rings is; two lines of a multiline may additionally meet at a point that ends both. Each of those reads the segments the geometry is made of, so `geo_funcs.c` answers them without calling GEOS and `meos_is_simple` is the entry that reaches them. The SQL function `isSimple` answers a geometry the way `Buffer`, `OrientedEnvelope` and `ConvexHull` do.

`meos_is_simple` says whether it answered rather than only what it answered, so `geom_is_simple` asks it first and reaches GEOS for a geometry it does not cover. The geometries it does not cover are the ones carrying a circular arc, which meet themselves along an arc rather than at a point.

Over the isSimple suite of GEOS the answer agrees on 41 of 41 records. That suite carries no geometry of several areal components and none carrying an arc, so those classes are asserted directly against GEOS as well: an overlapping and a disjoint multipolygon, a polygon with a hole, a bow-tie ring, a collection holding a crossing line, a triangle, a circular string, a curve polygon and a compound curve all agree, the fourteen made of segments answered natively and the three carrying an arc answered by GEOS.