### PR TITLE
Answer the frame change in the direction the function names

### DIFF
--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1609,10 +1609,12 @@ pose_quaternion_mul(double aw, double ax, double ay, double az,
 /**
  * @brief Build the unit quaternion representing the rotation from the
  * East-North-Up basis at geographic point (@p lat_rad, @p lon_rad) to the
- * WGS-84 ECEF basis. Standard ENU → ECEF rotation matrix:
- *   [ -sin λ              cos λ              0     ]
- *   [ -sin φ · cos λ     -sin φ · sin λ      cos φ ]
- *   [  cos φ · cos λ      cos φ · sin λ      sin φ ]
+ * WGS-84 ECEF basis. The columns of the matrix are the East, North and Up
+ * axes written in the ECEF basis, which is what carries an ENU vector into
+ * ECEF:
+ *   [ -sin λ     -sin φ · cos λ      cos φ · cos λ ]
+ *   [  cos λ     -sin φ · sin λ      cos φ · sin λ ]
+ *   [    0            cos φ               sin φ    ]
  * Converted to a quaternion via Shepperd's algorithm with the
  * largest-trace branch for numerical stability.
  */
@@ -1623,9 +1625,9 @@ pose_enu_to_ecef_quaternion(double lat_rad, double lon_rad,
   double sl = sin(lon_rad), cl = cos(lon_rad);
   double sp = sin(lat_rad), cp = cos(lat_rad);
   /* Row-major 3x3 matrix R[i][j] (R takes ENU column vectors to ECEF) */
-  double R00 = -sl,        R01 =  cl,        R02 =  0.0;
-  double R10 = -sp * cl,   R11 = -sp * sl,   R12 =  cp;
-  double R20 =  cp * cl,   R21 =  cp * sl,   R22 =  sp;
+  double R00 = -sl,   R01 = -sp * cl,   R02 = cp * cl;
+  double R10 =  cl,   R11 = -sp * sl,   R12 = cp * sl;
+  double R20 =  0.0,  R21 =  cp,        R22 = sp;
   double trace = R00 + R11 + R22;
   if (trace > 0.0)
   {

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -836,10 +836,9 @@ typedef struct
 
 /**
  * @brief Initialize the outer-frame anchor at a geographic tangent point.
- * @details @p pose_enu_to_ecef_quaternion returns the quaternion of the
- * matrix whose rows are the East, North and Up unit vectors expressed in
- * ECEF, that is the rotation that takes ECEF components to ENU components
- * at the tangent point. That is exactly what is needed here.
+ * @details What the anchor holds is the rotation that takes ECEF components
+ * to ENU components at the tangent point, which is the conjugate of the one
+ * @p pose_enu_to_ecef_quaternion builds, both being unit.
  */
 static void
 geopose_anchor_set(GeoPoseAnchor *anchor, double lat_rad, double lon_rad,
@@ -852,6 +851,9 @@ geopose_anchor_set(GeoPoseAnchor *anchor, double lat_rad, double lon_rad,
     &anchor->Z);
   pose_enu_to_ecef_quaternion(lat_rad, lon_rad, &anchor->qw, &anchor->qx,
     &anchor->qy, &anchor->qz);
+  anchor->qx = -anchor->qx;
+  anchor->qy = -anchor->qy;
+  anchor->qz = -anchor->qz;
 }
 
 /**
@@ -903,10 +905,10 @@ geopose_anchor_rotation(const GeoPoseAnchor *anchor, double lat_rad,
 {
   double lw, lx, ly, lz;
   pose_enu_to_ecef_quaternion(lat_rad, lon_rad, &lw, &lx, &ly, &lz);
-  /* q(R_anchorENU<-ECEF) * q(R_ECEF<-localENU), the latter being the
-   * conjugate of the local ENU quaternion since both are unit. */
+  /* q(R_anchorENU<-ECEF) * q(R_ECEF<-localENU), which are what the anchor
+   * holds and what the call above returns. */
   pose_quaternion_mul(anchor->qw, anchor->qx, anchor->qy, anchor->qz,
-    lw, -lx, -ly, -lz, W, X, Y, Z);
+    lw, lx, ly, lz, W, X, Y, Z);
 }
 
 /*****************************************************************************

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -390,9 +390,17 @@ SELECT asEWKT(round(transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0
 (1 row)
 
 SELECT asEWKT(round(transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
-                          asewkt                          
-----------------------------------------------------------
- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)
+                        asewkt                         
+-------------------------------------------------------
+ SRID=4978;Pose(POINT Z (6378137 0 0),0.5,0.5,0.5,0.5)
+(1 row)
+
+SELECT round(degrees(yaw(transform(pose 'SRID=4326;Pose(Point(0 45 0), 1, 0, 0, 0)', 4978)))::numeric, 6) AS yaw,
+  round(degrees(pitch(transform(pose 'SRID=4326;Pose(Point(0 45 0), 1, 0, 0, 0)', 4978)))::numeric, 6) AS pitch,
+  round(degrees(roll(transform(pose 'SRID=4326;Pose(Point(0 45 0), 1, 0, 0, 0)', 4978)))::numeric, 6) AS roll;
+    yaw    |  pitch   |   roll    
+-----------+----------+-----------
+ 90.000000 | 0.000000 | 45.000000
 (1 row)
 
 SELECT asEWKT(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4326));

--- a/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
+++ b/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
@@ -41,9 +41,9 @@ SELECT asEWKT(round(transform(transform(tpose
 
 SELECT asEWKT(round(transform(tpose
   'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01', 4978), 6));
-                                        asewkt                                         
----------------------------------------------------------------------------------------
- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)@Sat Jan 01 00:00:00 2000 PST
+                                       asewkt                                       
+------------------------------------------------------------------------------------
+ SRID=4978;Pose(POINT Z (6378137 0 0),0.5,0.5,0.5,0.5)@Sat Jan 01 00:00:00 2000 PST
 (1 row)
 
 SELECT asEWKT(transform(tpose

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -187,8 +187,20 @@ SELECT pose 'Pose(Point(1 1),0.5)' >= pose 'Pose(Point(2 2),0.5)';
 -- between WGS-84 geographic (4326) and WGS-84 ECEF (4978) is the local
 -- East-North-Up basis change at the point. Round-trip lands at the input.
 SELECT asEWKT(round(transform(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4978), 4326), 6));
--- At lat=lon=0 the ENU->ECEF rotation maps body identity to (0.5,-0.5,-0.5,-0.5).
+-- A round trip cannot see the direction of the orientation correction, since an
+-- inverse rotation composed with itself restores the input either way. These
+-- one-way transforms can: at the equator-meridian the East, North and Up axes
+-- point along geocentric +Y, +Z and +X, so a body at rest in the local frame
+-- carries that basis change and no other.
 SELECT asEWKT(round(transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
+-- Away from the equator the rotation and its inverse share a yaw and a pitch
+-- and differ in the sign of the roll, which is 90 degrees less the latitude.
+-- The angles are read rather than the quaternion because they bound their own
+-- precision, which round(pose) cannot do for a quaternion: it renormalizes the
+-- rounded components back to unit length.
+SELECT round(degrees(yaw(transform(pose 'SRID=4326;Pose(Point(0 45 0), 1, 0, 0, 0)', 4978)))::numeric, 6) AS yaw,
+  round(degrees(pitch(transform(pose 'SRID=4326;Pose(Point(0 45 0), 1, 0, 0, 0)', 4978)))::numeric, 6) AS pitch,
+  round(degrees(roll(transform(pose 'SRID=4326;Pose(Point(0 45 0), 1, 0, 0, 0)', 4978)))::numeric, 6) AS roll;
 -- Same-SRID transform is a no-op.
 SELECT asEWKT(transform(pose 'SRID=4326;Pose(Point(8 47 0), 1, 0, 0, 0)', 4326));
 

--- a/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
+++ b/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
@@ -45,7 +45,9 @@ SELECT asEWKT(round(transform(transform(tpose
   'SRID=4326;[Pose(Point(8 47 0), 1, 0, 0, 0)@2000-01-01,
     Pose(Point(9 48 0), 1, 0, 0, 0)@2000-01-02]', 4978), 4326), 6));
 -- At the equator-meridian the body identity quaternion expressed in the ECEF
--- basis is the canonical East-North-Up to ECEF rotation
+-- basis is the canonical East-North-Up to ECEF rotation, which carries East to
+-- geocentric +Y, North to +Z and Up to +X. The round trips above cannot see
+-- that direction; this one-way transform can
 SELECT asEWKT(round(transform(tpose
   'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)@2000-01-01', 4978), 6));
 -- A same-SRID transformation is a no-op


### PR DESCRIPTION
`pose_enu_to_ecef_quaternion` builds its rotation from a matrix whose columns
are the East, North and Up unit vectors written in the geocentric basis, which
is what carries a vector from the local tangent frame into WGS-84 ECEF. Its
comment records those columns, so the direction of the rotation can be read off
the matrix.

Two callers use it, in opposite directions. The orientation correction of a
frame transform between geographic and geocentric coordinates wants the
rotation the name states, and takes it as it comes. The GeoPose outer-frame
anchor wants the inverse — the rotation carrying geocentric components into the
tangent frame of its anchor point — and conjugates, the two being unit.

The pose transform between SRID 4326 and 4978 therefore applies the local
East-North-Up basis change at the point in the sense the transform runs. At the
equator-meridian, where the three axes point along geocentric +Y, +Z and +X, a
body at rest in the local frame carries that basis change and no other.

A round trip through the other frame and back restores the input whichever way
the rotation turns, so it constrains only the correction's magnitude. The
direction lives in the one-way transforms, and the pose and temporal-pose tests
each assert one at the equator-meridian. A second one-way transform covers
latitude 45, where the rotation and its inverse share a yaw and a pitch and
differ in the sign of the roll. It reads the angles rather than the quaternion,
because `round(pose, n)` renormalizes the rounded components back to unit
length and so cannot bound a quaternion's precision, while the angles bound
their own.
