### PR TITLE
Let the compiler check the array-building helpers against their declarations

### DIFF
--- a/mobilitydb/pg_include/pg_temporal/type_util.h
+++ b/mobilitydb/pg_include/pg_temporal/type_util.h
@@ -92,11 +92,12 @@ extern Datum *datumarr_extract(ArrayType *array, int *count);
 extern TimestampTz *timestamparr_extract(ArrayType *array, int *count);
 #if CBUFFER
 extern Cbuffer **cbufferarr_extract(ArrayType *array, int *count);
-extern ArrayType *cbufferarr_to_array(const Cbuffer **cbarr, int count);
+extern ArrayType *cbufferarr_to_array(Cbuffer **cbarr, int count,
+  bool free_all);
 #endif
 #if POSE || RGEO
 extern Pose **posearr_extract(ArrayType *array, int *count);
-extern ArrayType *posearr_to_array(const Pose **posearr, int count);
+extern ArrayType *posearr_to_array(Pose **posearr, int count, bool free_all);
 #endif
 #if RASTER
 extern Raquet **raquetarr_extract(ArrayType *array, int *count);
@@ -110,7 +111,7 @@ extern ArrayType *boolarr_to_array(bool *values, int count);
 extern ArrayType *int64arr_to_array(int64 *longints, int count);
 extern ArrayType *datearr_to_array(DateADT *dates, int count);
 extern ArrayType *tstzarr_to_array(TimestampTz *times, int count);
-extern ArrayType *spanarr_to_array(const Span *spans, int count);
+extern ArrayType *spanarr_to_array(Span *spans, int count);
 extern ArrayType *strarr_to_textarray(char **strarr, int count);
 extern ArrayType *temparr_to_array(Temporal **temporal, int count, bool free_all);
 extern ArrayType *tboxarr_to_array(TBox *boxarr, int count);

--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -503,7 +503,7 @@ Cbufferarr_round(PG_FUNCTION_ARGS)
 
   Cbuffer **cbarr = cbufferarr_extract(array, &count);
   Cbuffer **resarr = cbufferarr_round((const Cbuffer **) cbarr, count, maxdd);
-  ArrayType *result = cbufferarr_to_array((const Cbuffer **) resarr, count);
+  ArrayType *result = cbufferarr_to_array(resarr, count, true);
   pfree(cbarr);
   PG_FREE_IF_COPY(array, 0);
   PG_RETURN_ARRAYTYPE_P(result);

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -746,7 +746,7 @@ Posearr_round(PG_FUNCTION_ARGS)
 
   Pose **posearr = posearr_extract(array, &count);
   Pose **resarr = posearr_round((const Pose **) posearr, count, maxdd);
-  ArrayType *result = posearr_to_array((const Pose **) resarr, count);
+  ArrayType *result = posearr_to_array(resarr, count, true);
   pfree(posearr);
   PG_FREE_IF_COPY(array, 0);
   PG_RETURN_ARRAYTYPE_P(result);

--- a/mobilitydb/src/temporal/type_util.c
+++ b/mobilitydb/src/temporal/type_util.c
@@ -62,6 +62,7 @@
 #endif
 /* MobilityDB */
 #include "pg_temporal/meos_catalog.h"
+#include "pg_temporal/type_util.h"
 #include "pg_temporal/doublen.h"
 
 extern Datum range_out(PG_FUNCTION_ARGS);


### PR DESCRIPTION
`mobilitydb/src/temporal/type_util.c` includes the MEOS-side
`temporal/type_util.h` and not the MobilityDB-side `pg_temporal/type_util.h`
that declares the functions it defines, so nothing holds the two sides
together. Three of them differ: `cbufferarr_to_array` and `posearr_to_array`
take a `free_all` flag their declarations omit, and `spanarr_to_array` takes a
non-const array its declaration marks const.

A call made through a declaration one parameter short leaves the callee reading
that parameter from wherever the register happens to point, and `free_all`
decides whether the elements are freed while the constructed array still refers
to them. `Posearr_round` and `Cbufferarr_round` are the two callers, and both
want the elements freed. Neither is reachable from SQL: no `CREATE FUNCTION`
names either one.

This adds the header the definitions belong to, and writes the declarations the
definitions ask for. The include is the part that lasts: a fourth drift fails
the build rather than waiting for a caller to meet it, and it is what surfaces
the const mismatch, which no call site reports.
