### PR TITLE
[docs-only] Give the manual the quaternion the frame transform returns

### DIFF
--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -317,7 +317,7 @@ SELECT asEWKT(round(
 -- del cuerpo en la base ECEF es la rotación canónica Este-Norte-Arriba a ECEF
 SELECT asEWKT(round(
   transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
--- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)
+-- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,0.5,0.5,0.5)
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH test(pose, pipeline) AS (

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -324,7 +324,7 @@ SELECT asEWKT(round(
 -- ECEF basis is the canonical East-North-Up to ECEF rotation
 SELECT asEWKT(round(
   transform(pose 'SRID=4326;Pose(Point(0 0 0), 1, 0, 0, 0)', 4978), 6));
--- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,-0.5,-0.5,-0.5)
+-- SRID=4978;Pose(POINT Z (6378137 0 0),0.5,0.5,0.5,0.5)
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH test(pose, pipeline) AS (


### PR DESCRIPTION
**Docs-only PR** — the English and Spanish manuals only, no code or behaviour
change.

The one-way transform of an identity pose at the equator-meridian into WGS-84
geocentric coordinates returns `(0.5,0.5,0.5,0.5)`, which is what the pose and
temporal-pose tests assert. Both manuals show its inverse.

At that point the East, North and Up axes lie along geocentric +Y, +Z and +X,
so a body at rest in the local frame carries that basis change and no other.
