### PR TITLE
Name the edge entry points after the edges rather than the clip engine

### DIFF
--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -234,8 +234,8 @@ extern TSequenceSet *tgeoseqset_restrict_stbox(const TSequenceSet *ss, const STB
 
 /* Native temporal-point geometry-clip engine */
 
-extern void *geo_clip_ctx_make(const GSERIALIZED *gs);
-extern void geo_clip_ctx_free(void *ctx);
+extern void *geo_edge_ctx_make(const GSERIALIZED *gs);
+extern void geo_edge_ctx_free(void *ctx);
 extern bool geo_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geo_intersects2d_ctx(const GSERIALIZED *gs, const void *ctx);
 extern bool geo_covers2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
@@ -245,7 +245,7 @@ extern Temporal *tpoint_linear_dwithin_geom(const Temporal *temp, const GSERIALI
 extern Temporal *tpoint_linear_dwithin_geom_ctx(const Temporal *temp, const void *ctx, double dist);
 extern Temporal *tpoint_linear_distance_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpoint_linear_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc);
-extern bool geom_clip_supported(const LWGEOM *geom);
+extern bool geom_meos_supported(const LWGEOM *geom);
 
 /*****************************************************************************/
 

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -411,14 +411,20 @@ geom_extract_edges(const LWGEOM *geom)
 }
 
 /**
- * @brief Return true if a geometry is composed solely of the types the clip
- * engine can extract into edges
- * @details Mirrors the type dispatch of #geom_extract_edges_iter. Geometries
- * containing any other type (curved polygons, TIN, polyhedral surfaces, ...)
- * are not supported and must be handled by the caller
+ * @brief Return true if a geometry is composed solely of the types the native
+ * implementations can extract into edges
+ * @details Mirrors the type dispatch of #geom_extract_edges_iter, which every
+ * native implementation of a PostGIS function reads its geometry through, so
+ * the predicate answers for all of them: the clip engine, the DE-9IM matrix,
+ * the convex hull, the oriented envelope and the buffer alike. A geometry
+ * holding any other type, a TIN or a polyhedral surface, is uncovered and
+ * belongs to the caller, which either answers it another way or reports that
+ * it is not supported
+ * @note Uncovered never means unrelated: a @p false is the absence of an
+ * answer, not a negative one
  */
 bool
-geom_clip_supported(const LWGEOM *geom)
+geom_meos_supported(const LWGEOM *geom)
 {
   if (! geom)
     return false;
@@ -443,7 +449,7 @@ geom_clip_supported(const LWGEOM *geom)
        * polygons, each validated by the recursive call */
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       for (uint32_t i = 0; i < col->ngeoms; i++)
-        if (! geom_clip_supported(col->geoms[i]))
+        if (! geom_meos_supported(col->geoms[i]))
           return false;
       return true;
     }
@@ -457,7 +463,7 @@ geom_clip_supported(const LWGEOM *geom)
         uint8_t rt = cp->rings[r]->type;
         if (rt != LINETYPE && rt != CIRCSTRINGTYPE && rt != COMPOUNDTYPE)
           return false;
-        if (rt == COMPOUNDTYPE && ! geom_clip_supported(cp->rings[r]))
+        if (rt == COMPOUNDTYPE && ! geom_meos_supported(cp->rings[r]))
           return false;
       }
       return true;

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1773,7 +1773,7 @@ tdistance_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
       MEOS_FLAGS_LINEAR_INTERP(temp->flags) && ! MEOS_FLAGS_GET_Z(temp->flags))
   {
     LWGEOM *geom = lwgeom_from_gserialized(gs);
-    bool native = geom->type != POINTTYPE && geom_clip_supported(geom);
+    bool native = geom->type != POINTTYPE && geom_meos_supported(geom);
     lwgeom_free(geom);
     if (native)
       return tpoint_linear_distance_geom(temp, gs);

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -2122,7 +2122,7 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
       MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR)
   {
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    bool supported = geom_clip_supported(lwgeom);
+    bool supported = geom_meos_supported(lwgeom);
     lwgeom_free(lwgeom);
     if (supported)
       return tpoint_linear_restrict_geom(temp, gs, atfunc);

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1042,7 +1042,7 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   result = 0;
   /* The planar 2D relationship indexes the edges of the geometry to resolve
    * one composing value against it. Since the geometry is the same for every
-   * value, its edges are extracted and indexed once, in a clip context the
+   * value, its edges are extracted and indexed once, in a edge context the
    * loop reuses, instead of once per value as calling the relationship
    * directly would do. The condition selecting the context is the one
    * #geo_disjoint_fn_geo uses to select the planar 2D relationship */
@@ -1056,8 +1056,8 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
      * reaches the decomposition only for a value whose box meets the
      * geometry, and answers from the boxes alone for the values that do not */
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    if (geom_clip_supported(lwgeom))
-      ctx = geo_clip_ctx_make(gs);
+    if (geom_meos_supported(lwgeom))
+      ctx = geo_edge_ctx_make(gs);
     lwgeom_free(lwgeom);
   }
   datum_func2 func = geo_disjoint_fn_geo(temp->flags, gs->gflags);
@@ -1072,7 +1072,7 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
       break;
     }
   }
-  geo_clip_ctx_free(ctx);
+  geo_edge_ctx_free(ctx);
   pfree(datumarr);
   return result;
 }
@@ -1267,7 +1267,7 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
       ! FLAGS_GET_Z(gs->gflags))
   {
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    bool supported = geom_clip_supported(lwgeom);
+    bool supported = geom_meos_supported(lwgeom);
     lwgeom_free(lwgeom);
     if (supported)
     {
@@ -1817,7 +1817,7 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
       gserialized_get_type(gs) != POINTTYPE)
   {
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    bool supported = geom_clip_supported(lwgeom);
+    bool supported = geom_meos_supported(lwgeom);
     lwgeom_free(lwgeom);
     if (supported)
     {

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1126,7 +1126,7 @@ next_segment:
 }
 
 /*****************************************************************************
- * Geometry clip context
+ * Geometry edge context
  *
  * Everything the engine derives from a geometry -- its bounding box, its edge
  * decomposition, and the R-tree indexing those edges -- depends on that
@@ -1151,10 +1151,10 @@ typedef struct
                             of them to amortize its construction */
   Edge **cand_edges;   /**< Buffer receiving the edges selected by the index,
                             NULL when there is no index */
-} GeoClipCtx;
+} GeoEdgeCtx;
 
 /**
- * @brief Return the clip context of a geometry, or NULL if the geometry is
+ * @brief Return the edge context of a geometry, or NULL if the geometry is
  * empty
  * @details The context owns the edges of the geometry and, when they are
  * numerous enough to amortize its construction, an R-tree indexing them
@@ -1164,13 +1164,13 @@ typedef struct
  * index (the same lifetime the operations gave it when each built its own)
  */
 void *
-geo_clip_ctx_make(const GSERIALIZED *gs)
+geo_edge_ctx_make(const GSERIALIZED *gs)
 {
   assert(gs);
   if (gserialized_is_empty(gs))
     return NULL;
 
-  GeoClipCtx *ctx = palloc0(sizeof(GeoClipCtx));
+  GeoEdgeCtx *ctx = palloc0(sizeof(GeoEdgeCtx));
   geo_set_stbox(gs, &ctx->box);
   ctx->srid = gserialized_get_srid(gs);
   /* Extract the edges */
@@ -1206,14 +1206,14 @@ geo_clip_ctx_make(const GSERIALIZED *gs)
 }
 
 /**
- * @brief Free a clip context built by #geo_clip_ctx_make
+ * @brief Free an edge context built by #geo_edge_ctx_make
  */
 void
-geo_clip_ctx_free(void *ctxv)
+geo_edge_ctx_free(void *ctxv)
 {
   if (! ctxv)
     return;
-  GeoClipCtx *ctx = (GeoClipCtx *) ctxv;
+  GeoEdgeCtx *ctx = (GeoEdgeCtx *) ctxv;
   if (ctx->rtree)
   {
     rtree_free(ctx->rtree);
@@ -1306,7 +1306,7 @@ bool
 geo_intersects2d_ctx(const GSERIALIZED *gs, const void *ctxv)
 {
   assert(gs); assert(ctxv);
-  const GeoClipCtx *ctx = (const GeoClipCtx *) ctxv;
+  const GeoEdgeCtx *ctx = (const GeoEdgeCtx *) ctxv;
   /* An empty geometry intersects nothing, matching PostGIS ST_Intersects.
    * Callers such as the touches predicates pass the (possibly empty) boundary
    * of a geometry or trajectory, so the leaf must tolerate empty input. */
@@ -1377,7 +1377,7 @@ geo_intersects2d_ctx(const GSERIALIZED *gs, const void *ctxv)
 
 /**
  * @brief Return true if two 2D geometries intersect, computed natively
- * @details Builds the clip context of the second geometry, which is the one
+ * @details Builds the edge context of the second geometry, which is the one
  * whose edges are indexed, and resolves the relationship with
  * #geo_intersects2d_ctx
  * @pre The arguments have the same SRID
@@ -1399,11 +1399,11 @@ geo_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (! overlaps_stbox_stbox(&box1, &box2))
     return false;
 
-  void *ctx = geo_clip_ctx_make(gs2);
+  void *ctx = geo_edge_ctx_make(gs2);
   if (! ctx)
     return false;
   bool result = geo_intersects2d_ctx(gs1, ctx);
-  geo_clip_ctx_free(ctx);
+  geo_edge_ctx_free(ctx);
   return result;
 }
 
@@ -1648,7 +1648,7 @@ geo_covers2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
 /**
  * @brief Return the temporal intersection/intersects of a temporal geometric
- * point with linear interpolation and the geometry of a clip context
+ * point with linear interpolation and the geometry of a edge context
  * @details The temporal geometric point may be in 2D or 3D and the Z dimension
  * is also computed. Clipping several temporal points against one geometry
  * extracts and indexes its edges once, since the context outlives the call
@@ -1664,7 +1664,7 @@ tpoint_linear_inter_geom_ctx(const Temporal *temp, const void *ctxv, bool clip)
   assert(MEOS_FLAGS_LINEAR_INTERP(temp->flags));
   assert(temp->subtype != TINSTANT);
   assert(! MEOS_FLAGS_GET_GEODETIC(temp->flags));
-  const GeoClipCtx *ctx = (const GeoClipCtx *) ctxv;
+  const GeoEdgeCtx *ctx = (const GeoEdgeCtx *) ctxv;
 
   /* Bounding box test */
   STBox box1;
@@ -1759,7 +1759,7 @@ cleanup_return:
  * @ingroup meos_internal_geo
  * @brief Return the temporal intersection/intersects of a temporal geometric
  * point with linear interpolation and a 2D geometry
- * @details Builds the clip context of the geometry and resolves the
+ * @details Builds the edge context of the geometry and resolves the
  * relationship with #tpoint_linear_inter_geom_ctx
  * @pre The arguments have the same SRID, the geometry is 2D and is not empty.
  * This is verified in #tgeo_restrict_geom
@@ -1788,11 +1788,11 @@ tpoint_linear_inter_geom(const Temporal *temp, const GSERIALIZED *gs,
     return result;
   }
 
-  void *ctx = geo_clip_ctx_make(gs);
+  void *ctx = geo_edge_ctx_make(gs);
   if (! ctx)
     return NULL;
   Temporal *result = tpoint_linear_inter_geom_ctx(temp, ctx, clip);
-  geo_clip_ctx_free(ctx);
+  geo_edge_ctx_free(ctx);
   return result;
 }
 
@@ -2280,7 +2280,7 @@ tpoint_linear_dwithin_geom_ctx(const Temporal *temp, const void *ctxv,
   assert(MEOS_FLAGS_LINEAR_INTERP(temp->flags));
   assert(temp->subtype != TINSTANT);
   assert(! MEOS_FLAGS_GET_GEODETIC(temp->flags));
-  const GeoClipCtx *ctx = (const GeoClipCtx *) ctxv;
+  const GeoEdgeCtx *ctx = (const GeoEdgeCtx *) ctxv;
 
   /* A zero distance is exactly the temporal intersects relationship */
   if (dist <= 0.0)
@@ -2364,7 +2364,7 @@ tpoint_linear_dwithin_geom_ctx(const Temporal *temp, const void *ctxv,
  * @ingroup meos_internal_geo
  * @brief Return a temporal Boolean that states whether a temporal geometric
  * point with linear interpolation is within a distance of a 2D geometry
- * @details Builds the clip context of the geometry and resolves the
+ * @details Builds the edge context of the geometry and resolves the
  * relationship with #tpoint_linear_dwithin_geom_ctx
  * @pre The arguments have the same SRID, are 2D and planar, and the geometry
  * is not empty and is supported by the clip engine. This is verified by the
@@ -2395,11 +2395,11 @@ tpoint_linear_dwithin_geom(const Temporal *temp, const GSERIALIZED *gs,
     return result;
   }
 
-  void *ctx = geo_clip_ctx_make(gs);
+  void *ctx = geo_edge_ctx_make(gs);
   if (! ctx)
     return NULL;
   Temporal *result = tpoint_linear_dwithin_geom_ctx(temp, ctx, dist);
-  geo_clip_ctx_free(ctx);
+  geo_edge_ctx_free(ctx);
   return result;
 }
 

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -537,7 +537,7 @@ tinterrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool tinter)
       MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR)
   {
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    bool supported = geom_clip_supported(lwgeom);
+    bool supported = geom_meos_supported(lwgeom);
     lwgeom_free(lwgeom);
     if (supported)
     {
@@ -1574,7 +1574,7 @@ tdwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
         ! MEOS_FLAGS_GET_Z(temp->flags) && ! FLAGS_GET_Z(gs->gflags))
     {
       LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-      bool supported = geom_clip_supported(lwgeom);
+      bool supported = geom_meos_supported(lwgeom);
       lwgeom_free(lwgeom);
       if (supported)
         return tpoint_linear_dwithin_geom(temp, gs, dist);


### PR DESCRIPTION
The edge decomposition of a geometry left the clipping engine for its own file in #2018, within reach of every implementation that answers a question about a geometry without calling GEOS. Two names it reaches stayed behind, and this gives them the name of what they work on.

### The support predicate

`geom_clip_supported` becomes `geom_meos_supported`. It answers whether `geom_extract_edges` can decompose a geometry, and it is defined in `geo_funcs.c`, the edge decomposition's own file. Every native implementation reads its geometry through that decomposition, so the predicate answers for all of them: the clip engine, the DE-9IM matrix, the convex hull, the oriented envelope and the buffer alike. The name attributed a shared predicate to one of its callers.

Its comment is corrected along with it. The text says a geometry containing a curved polygon is unsupported, which is not what the code does: `CURVEPOLYTYPE` has its own branch accepting line, circular and compound rings. Read against the type constants, exactly two of the fifteen reach the default branch, `POLYHEDRALSURFACETYPE` and `TINTYPE`. The comment names those two, and records that declining a geometry withholds an answer rather than giving a negative one.

### The reusable decomposition

`GeoClipCtx` and `geo_clip_ctx_make` / `geo_clip_ctx_free` become `GeoEdgeCtx` and `geo_edge_ctx_make` / `geo_edge_ctx_free`. The structure's own comment describes it as "keeping the reusable decomposition of a geometry": it holds the edges, the pointer array the kernels expect, and the R-tree indexing them. `edge` is the token the edge type, the extraction function, the index builder, `edge_ptrs` and `cand_edges` already carry, so the context takes the same one. The prose describing it follows.

### Scope

A rename and a comment correction. No signature, no behaviour, no call graph changes: 11 references for the predicate and 24 for the context, every one inside `meos/`. Neither name carries an `@ingroup` tag, so neither is projected to a binding.
