### PR TITLE
Take the larger and the smaller of two coordinates from one macro

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -73,8 +73,8 @@ emit_ring_edges(const POINTARRAY *pa, MeosArray *edges, EdgeType etype)
     Edge e;
     e.x1 = a.x; e.y1 = a.y;
     e.x2 = b.x; e.y2 = b.y;
-    e.xmin = FP_MIN(e.x1, e.x2); e.xmax = FP_MAX(e.x1, e.x2);
-    e.ymin = FP_MIN(e.y1, e.y2); e.ymax = FP_MAX(e.y1, e.y2);
+    e.xmin = Min(e.x1, e.x2); e.xmax = Max(e.x1, e.x2);
+    e.ymin = Min(e.y1, e.y2); e.ymax = Max(e.y1, e.y2);
     e.dx = e.x2 - e.x1; e.dy = e.y2 - e.y1;
     e.length = e.dx * e.dx + e.dy * e.dy;
     e.etype = etype;
@@ -203,8 +203,8 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
       Edge e;
       e.x1 = px[i]; e.y1 = py[i];
       e.x2 = px[i + 1]; e.y2 = py[i + 1];
-      e.xmin = FP_MIN(e.x1, e.x2); e.xmax = FP_MAX(e.x1, e.x2);
-      e.ymin = FP_MIN(e.y1, e.y2); e.ymax = FP_MAX(e.y1, e.y2);
+      e.xmin = Min(e.x1, e.x2); e.xmax = Max(e.x1, e.x2);
+      e.ymin = Min(e.y1, e.y2); e.ymax = Max(e.y1, e.y2);
       e.dx = e.x2 - e.x1; e.dy = e.y2 - e.y1;
       e.length = e.dx * e.dx + e.dy * e.dy;
       e.etype = line_etype;
@@ -583,18 +583,18 @@ static bool
 lw_seg_interact(const POINT2D *p1, const POINT2D *p2, const POINT2D *q1,
   const POINT2D *q2)
 {
-  double minq = FP_MIN(q1->x, q2->x);
-  double maxq = FP_MAX(q1->x, q2->x);
-  double minp = FP_MIN(p1->x, p2->x);
-  double maxp = FP_MAX(p1->x, p2->x);
+  double minq = Min(q1->x, q2->x);
+  double maxq = Max(q1->x, q2->x);
+  double minp = Min(p1->x, p2->x);
+  double maxp = Max(p1->x, p2->x);
 
   if (FP_GT(minp, maxq) || FP_LT(maxp, minq))
     return false;
 
-  minq = FP_MIN(q1->y, q2->y);
-  maxq = FP_MAX(q1->y, q2->y);
-  minp = FP_MIN(p1->y, p2->y);
-  maxp = FP_MAX(p1->y, p2->y);
+  minq = Min(q1->y, q2->y);
+  maxq = Max(q1->y, q2->y);
+  minp = Min(p1->y, p2->y);
+  maxp = Max(p1->y, p2->y);
 
   if (FP_GT(minp,maxq) || FP_LT(maxp,minq))
     return false;

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -194,8 +194,8 @@ arc_contains_angle(const Edge *e, double phi)
 void
 arc_set_bbox(Edge *e)
 {
-  double xmin = FP_MIN(e->x1, e->x2), xmax = FP_MAX(e->x1, e->x2);
-  double ymin = FP_MIN(e->y1, e->y2), ymax = FP_MAX(e->y1, e->y2);
+  double xmin = Min(e->x1, e->x2), xmax = Max(e->x1, e->x2);
+  double ymin = Min(e->y1, e->y2), ymax = Max(e->y1, e->y2);
   const double ang[4] = {0.0, M_PI_2, M_PI, -M_PI_2};
   const double ex[4] = {e->cx + e->radius, e->cx, e->cx - e->radius, e->cx};
   const double ey[4] = {e->cy, e->cy + e->radius, e->cy, e->cy - e->radius};
@@ -579,10 +579,10 @@ intervals_from_lines(const POINT2D *a, const POINT2D *b, Edge **edges,
   const double bx = b->x, by = b->y;
 
   /* Segment bounding box */
-  const double seg_xmin = FP_MIN(ax, bx);
-  const double seg_xmax = FP_MAX(ax, bx);
-  const double seg_ymin = FP_MIN(ay, by);
-  const double seg_ymax = FP_MAX(ay, by);
+  const double seg_xmin = Min(ax, bx);
+  const double seg_xmax = Max(ax, bx);
+  const double seg_ymin = Min(ay, by);
+  const double seg_ymax = Max(ay, by);
   /* Segment vector */
   const double rx = bx - ax;  
   const double ry = by - ay;  
@@ -664,10 +664,10 @@ intervals_from_arcs(const POINT2D *a, const POINT2D *b, Edge **edges,
   const double ax = a->x, ay = a->y;
   const double bx = b->x, by = b->y;
   /* Segment bounding box */
-  const double seg_xmin = FP_MIN(ax, bx);
-  const double seg_xmax = FP_MAX(ax, bx);
-  const double seg_ymin = FP_MIN(ay, by);
-  const double seg_ymax = FP_MAX(ay, by);
+  const double seg_xmin = Min(ax, bx);
+  const double seg_xmax = Max(ax, bx);
+  const double seg_ymin = Min(ay, by);
+  const double seg_ymax = Max(ay, by);
   /* Segment vector */
   const double rx = bx - ax;
   const double ry = by - ay;
@@ -763,10 +763,10 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
   const double bx = b->x, by = b->y;
 
   /* Segment bounding box */
-  const double seg_xmin = FP_MIN(ax, bx);
-  const double seg_xmax = FP_MAX(ax, bx);
-  const double seg_ymin = FP_MIN(ay, by);
-  const double seg_ymax = FP_MAX(ay, by);
+  const double seg_xmin = Min(ax, bx);
+  const double seg_xmax = Max(ax, bx);
+  const double seg_ymin = Min(ay, by);
+  const double seg_ymax = Max(ay, by);
   /* Segment vector */
   const double rx = bx - ax;
   const double ry = by - ay;
@@ -1040,8 +1040,8 @@ tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
     {
       /* Build the segment bounding box */
       STBox query;
-      stbox_set(true, false, false, srid, FP_MIN(a->x, b->x),
-        FP_MAX(a->x, b->x), FP_MIN(a->y, b->y), FP_MAX(a->y, b->y),
+      stbox_set(true, false, false, srid, Min(a->x, b->x),
+        Max(a->x, b->x), Min(a->y, b->y), Max(a->y, b->y),
         0, 0, NULL, &query);
       /* Query the R-tree */
       int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
@@ -1859,7 +1859,7 @@ point_arc_dist2(double px, double py, const Edge *e)
   const double d1x = px - e->x2, d1y = py - e->y2;
   const double d0 = d0x * d0x + d0y * d0y;
   const double d1 = d1x * d1x + d1y * d1y;
-  return FP_MIN(d0, d1);
+  return Min(d0, d1);
 }
 
 /**
@@ -2053,8 +2053,8 @@ intervals_within_edges(const POINT2D *a, const POINT2D *b, Edge **sel_edges,
   events->count = 0;
   const double ax = a->x, ay = a->y;
   const double rx = b->x - ax, ry = b->y - ay;
-  const double seg_xmin = FP_MIN(a->x, b->x), seg_xmax = FP_MAX(a->x, b->x);
-  const double seg_ymin = FP_MIN(a->y, b->y), seg_ymax = FP_MAX(a->y, b->y);
+  const double seg_xmin = Min(a->x, b->x), seg_xmax = Max(a->x, b->x);
+  const double seg_ymin = Min(a->y, b->y), seg_ymax = Max(a->y, b->y);
 
   /* Gather boundary crossing candidates from the (filtered) edges */
   for (int i = 0; i < sel_nedges; i++)
@@ -2180,9 +2180,9 @@ tpointseq_dwithin_edges(const TSequence *seq, Edge **edges, int nedges,
     if (use_index)
     {
       STBox query;
-      stbox_set(true, false, false, srid, FP_MIN(a->x, b->x) - dist,
-        FP_MAX(a->x, b->x) + dist, FP_MIN(a->y, b->y) - dist,
-        FP_MAX(a->y, b->y) + dist, 0, 0, NULL, &query);
+      stbox_set(true, false, false, srid, Min(a->x, b->x) - dist,
+        Max(a->x, b->x) + dist, Min(a->y, b->y) - dist,
+        Max(a->y, b->y) + dist, 0, 0, NULL, &query);
       int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query,
         rtree_results);
       for (int j = 0; j < cand_nedges; j++)
@@ -2451,7 +2451,7 @@ point_geom_dist(double px, double py, Edge **edges, int nedges)
    * and at two tiny vertical nudges that move the ray off any aligned junction;
    * the nudge is far below any real feature size so a strictly interior or
    * strictly exterior point is unaffected */
-  const double eps = 1e-9 * FP_MAX(1.0, fabs(py));
+  const double eps = 1e-9 * Max(1.0, fabs(py));
   int inside = point_in_polygon(px, py, edges, nedges) +
     point_in_polygon(px, py + eps, edges, nedges) +
     point_in_polygon(px, py - eps, edges, nedges);


### PR DESCRIPTION
Depends on #2049, whose commit the diff also carries.

MEOS reads two spellings of the same operation. `FP_MAX` and `FP_MIN` come from `liblwgeom_internal.h`, a header internal to PostGIS, and `Max` and `Min` from the PostgreSQL headers MEOS already reads. Both expand to the same conditional expression.

The census says which one MEOS speaks: `Max` and `Min` in **30 files**, `FP_MAX` and `FP_MIN` in **2** — `geo_funcs.c` and `tpoint_geom_clip.c`, and neither of those two uses `Max` or `Min` at all. The two files take the pair the other thirty take.

What it buys is one fewer name the geometry files ask a PostGIS-internal header for. With the edge kernels holding their own tolerance, `liblwgeom_internal.h` is reached for the geometry types alone.

Both definitions stay where their projects put them. Each belongs to a vendored library, so removing either is a change to a vendored tree that a release of that library then conflicts with.

### The conditional form is what carries over

`FP_MAX(A, B)` is `(((A) > (B)) ? (A) : (B))` and `Max(x, y)` is `((x) > (y) ? (x) : (y))`, the same expression.

The C99 `fmax` and `fmin` are a different substitution and not this one: they suppress a NaN second operand where a conditional propagates it, so `fmax(5, NaN)` is `5` where `Max(5, NaN)` is `NaN`. The four `fmax` and `fmin` calls already in `tpoint_geom_clip.c` are left alone.

### That the files are unaffected

The objects built from the geometry layer and from the clipping engine hold the same instructions and the same size as the objects built from the base, byte for byte: 55736 and 58800 bytes either way, and a disassembly diff reporting no instruction difference in either.
