### PR TITLE
Analyze the temporal QUADBIN cells for the box they store

### DIFF
--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -87,7 +87,7 @@ CREATE TYPE tquadbin (
   typmod_out = temporal_typmod_out,
   storage = extended,
   alignment = double,
-  analyze = temporal_analyze
+  analyze = tspatial_analyze
 );
 
 -- GENERATED-IO-END quadbin

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -852,15 +852,17 @@ for a spatial family, `tnumber_supportfn` for a number one, and none for an alph
 one — there is no `temporal_supportfn` to name, and the alpha reference `ttext`
 declares none.
 
-Two divergences remain open:
+The `analyze` clause a type declares follows the same class, in its
+`io_families:` entry: every family whose bounding box is an `STBox` — the ten
+`tspatial_type` members and the two pointcloud ones — names `tspatial_analyze`,
+and the alpha families name `temporal_analyze`. `temporal_bbox_size()`
+(`meos/src/temporal/temporal_boxops.c`) is the authority on which box a family
+stores, returning `sizeof(STBox)` for every `tspatial_type`; a family that stores
+an `STBox` and analyses it as a `tstzspan` collects no X statistics at all, and
+its spatial factor then rests on the default however its operators are declared.
 
-- **`tquadbin` declares `analyze = temporal_analyze`**
-  (`quadbin/353_tquadbin.in.sql`) while carrying an `STBox` bounding box — its
-  SP-GiST opclass declares `<<`, `&&` and `~=` against `stbox`
-  (`quadbin/373_tquadbin_spgist.in.sql:56-73`) — and while its operators declare
-  `tspatial_sel`. Its `Tcell<T>` sibling `th3index` declares `tspatial_analyze`
-  (`h3/253_th3index.in.sql`), so no X statistics are collected for `tquadbin` and
-  its spatial factor rests on the default.
+One divergence remains open:
+
 - **`pcpoint` and `pcpatch` are not admitted by `tspatial_sel_type`.** They are
   `pointcloud_basetype`, not `spatial_basetype`, and `spatial_set_stbox()` — whose
   assertion defines the base types the estimator can convert — does not cover

--- a/tools/codegen/inherited/manifest.d/io_families.yaml
+++ b/tools/codegen/inherited/manifest.d/io_families.yaml
@@ -369,7 +369,7 @@ io_families:
   - lit: '
 
       '
-  - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = temporal_typmod_in,\n  typmod_out = temporal_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = temporal_analyze\n);"
+  - stmt: "CREATE TYPE {t} (\n  internallength = variable,\n  input = {t}_in,\n  output = temporal_out,\n  send = temporal_send,\n  receive = {t}_recv,\n  typmod_in = temporal_typmod_in,\n  typmod_out = temporal_typmod_out,\n  storage = extended,\n  alignment = double,\n  analyze = tspatial_analyze\n);"
   - lit: '
 
       '


### PR DESCRIPTION
The bounding box of a temporal QUADBIN cell is an stbox, the box temporal_bbox_size returns for every member of the spatial class, so the type declares tspatial_analyze and its columns carry the spatial statistics that the estimators of its operators read. Every other family storing an stbox declares the same — the nine spatial siblings including its own cell-index twin th3index, and the two pointcloud types — while the alpha families, whose box is a tstzspan, declare temporal_analyze. Section 10 of the inherited-surface map records the analyze clause as following the bounding-box class of the type.