### PR TITLE
Check the frame of the value in the set operations of a spatial set

### DIFF
--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -87,6 +87,8 @@ extern bool ensure_spatial_validity(const Temporal *temp1,
 extern int spheroid_init_from_srid(int32_t srid, SPHEROID *s);
 extern bool ensure_same_geodetic_tspatial_geo(const Temporal *temp,
   const GSERIALIZED *gs);
+extern bool ensure_same_geodetic_set_geo(const Set *s,
+  const GSERIALIZED *gs);
 extern bool same_dimensionality_tspatial_geo(const Temporal *temp,
   const GSERIALIZED *gs);
 extern bool ensure_same_dimensionality_tspatial_geo(const Temporal *temp,

--- a/meos/src/geo/geoset_meos.c
+++ b/meos/src/geo/geoset_meos.c
@@ -239,11 +239,13 @@ geoset_values(const Set *s, int *count)
  * @param[in] gs Value
  */
 bool
-ensure_valid_set_geo(const Set *s, const GSERIALIZED *gs)
+ensure_valid_geoset_geo(const Set *s, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_GEOSET(s, false); VALIDATE_NOT_NULL(gs, false);
-  if (! ensure_not_empty(gs))
+  if (! ensure_not_empty(gs) ||
+      ! ensure_same_srid(spatialset_srid(s), geo_srid(gs)) ||
+      ! ensure_same_geodetic_set_geo(s, gs))
     return false;
   return true;
 }
@@ -259,7 +261,7 @@ bool
 contains_set_geo(const Set *s, GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_geo(s, gs))
+  if (! ensure_valid_geoset_geo(s, gs))
     return false;
   return contains_set_value(s, PointerGetDatum(gs));
 }
@@ -275,7 +277,7 @@ bool
 contained_geo_set(const GSERIALIZED *gs, const Set *s)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_geo(s, gs))
+  if (! ensure_valid_geoset_geo(s, gs))
     return false;
   return contained_value_set(PointerGetDatum(gs), s);
 }
@@ -291,7 +293,7 @@ Set *
 union_set_geo(const Set *s, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_geo(s, gs))
+  if (! ensure_valid_geoset_geo(s, gs))
     return NULL;
   return union_set_value(s, PointerGetDatum(gs));
 }
@@ -320,7 +322,7 @@ Set *
 intersection_set_geo(const Set *s, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_geo(s, gs))
+  if (! ensure_valid_geoset_geo(s, gs))
     return NULL;
   return intersection_set_value(s, PointerGetDatum(gs));
 }
@@ -349,7 +351,7 @@ Set *
 minus_geo_set(const GSERIALIZED *gs, const Set *s)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_geo(s, gs))
+  if (! ensure_valid_geoset_geo(s, gs))
     return NULL;
   return minus_value_set(PointerGetDatum(gs), s);
 }
@@ -365,7 +367,7 @@ Set *
 minus_set_geo(const Set *s, const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_geo(s, gs))
+  if (! ensure_valid_geoset_geo(s, gs))
     return NULL;
   return minus_set_value(s, PointerGetDatum(gs));
 }

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -540,6 +540,24 @@ ensure_same_geodetic_tspatial_geo(const Temporal *temp, const GSERIALIZED *gs)
   return true;
 }
 
+/**
+ * @brief Ensure that a spatial set and a geometry/geography are both planar
+ * or both geodetic
+ * @param[in] s Spatial set
+ * @param[in] gs Geometry/geography
+ */
+bool
+ensure_same_geodetic_set_geo(const Set *s, const GSERIALIZED *gs)
+{
+  if (MEOS_FLAGS_GET_GEODETIC(s->flags) != FLAGS_GET_GEODETIC(gs->gflags))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Operation on mixed planar and geodetic coordinates");
+    return false;
+  }
+  return true;
+}
+
 
 
 

--- a/meos/src/pose/poseset_meos.c
+++ b/meos/src/pose/poseset_meos.c
@@ -215,20 +215,6 @@ poseset_values(const Set *s, int *count)
  *****************************************************************************/
 
 /**
- * @brief Return true if a set and a pose are valid for set
- * operations
- * @param[in] s Set
- * @param[in] pose Value
- */
-bool
-ensure_valid_set_pose(const Set *s, const Pose *pose)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_POSESET(s, false); VALIDATE_NOT_NULL(pose, false);
-  return true;
-}
-
-/**
  * @ingroup meos_pose_set_setops
  * @brief Return true if a set contains a pose
  * @param[in] s Set
@@ -239,7 +225,7 @@ bool
 contains_set_pose(const Set *s, Pose *pose)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_pose(s, pose))
+  if (! ensure_valid_poseset_pose(s, pose))
     return false;
   return contains_set_value(s, PointerGetDatum(pose));
 }
@@ -255,7 +241,7 @@ bool
 contained_pose_set(const Pose *pose, const Set *s)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_pose(s, pose))
+  if (! ensure_valid_poseset_pose(s, pose))
     return false;
   return contained_value_set(PointerGetDatum(pose), s);
 }
@@ -271,7 +257,7 @@ Set *
 union_set_pose(const Set *s, const Pose *pose)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_pose(s, pose))
+  if (! ensure_valid_poseset_pose(s, pose))
     return NULL;
   return union_set_value(s, PointerGetDatum(pose));
 }
@@ -300,7 +286,7 @@ Set *
 intersection_set_pose(const Set *s, const Pose *pose)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_pose(s, pose))
+  if (! ensure_valid_poseset_pose(s, pose))
     return NULL;
   return intersection_set_value(s, PointerGetDatum(pose));
 }
@@ -329,7 +315,7 @@ Set *
 minus_pose_set(const Pose *pose, const Set *s)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_pose(s, pose))
+  if (! ensure_valid_poseset_pose(s, pose))
     return NULL;
   return minus_value_set(PointerGetDatum(pose), s);
 }
@@ -345,7 +331,7 @@ Set *
 minus_set_pose(const Set *s, const Pose *pose)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_set_pose(s, pose))
+  if (! ensure_valid_poseset_pose(s, pose))
     return NULL;
   return minus_set_value(s, PointerGetDatum(pose));
 }

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -49,6 +49,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <meos.h>
+#include <meos_geo.h>
+#include <meos_pose.h>
 
 /* Main program */
 int main(void)
@@ -147,6 +149,40 @@ int main(void)
   printf("temporal_frechet_path(count NULL): NULL, errno %d\n", meos_errno());
   assert(meos_errno() == MEOS_ERR_INVALID_ARG);
 
+  /* A set operation between a spatial set and a value of another frame is
+   * rejected rather than answered, as every other operation mixing two
+   * spatial reference systems is. The set operations of a spatial set take
+   * the value through the same validity check as the rest of the library */
+  Set *gset = geomset_in("{\"SRID=4326;Point(1 1)\"}");
+  GSERIALIZED *other = geom_in("SRID=3812;Point(1 1)", -1);
+  assert(gset != NULL); assert(other != NULL);
+  meos_errno_reset();
+  assert(contains_set_geo(gset, other) == false);
+  printf("contains_set_geo(mixed SRID): false, errno %d\n", meos_errno());
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+
+  /* The same holds when the two agree on the SRID but not on whether their
+   * coordinates are planar or geodetic */
+  GSERIALIZED *geodetic = geog_in("SRID=4326;Point(1 1)", -1);
+  assert(geodetic != NULL);
+  meos_errno_reset();
+  assert(contains_set_geo(gset, geodetic) == false);
+  printf("contains_set_geo(mixed planar/geodetic): false, errno %d\n",
+    meos_errno());
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+
+  Set *pset = poseset_in("{\"SRID=4326;Pose(Point(1 1),0.5)\"}");
+  Pose *pose_other = pose_in("SRID=3812;Pose(Point(1 1),0.5)");
+  assert(pset != NULL); assert(pose_other != NULL);
+  meos_errno_reset();
+  assert(contains_set_pose(pset, pose_other) == false);
+  printf("contains_set_pose(mixed SRID): false, errno %d\n", meos_errno());
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+
+  meos_errno_reset();
+
+  free(gset); free(other); free(geodetic);
+  free(pset); free(pose_other);
   free(num);
   free(inst); free(seq);
   free(good); free(good_out);


### PR DESCRIPTION
The set operations of a geometry set and of a pose set answer a value expressed in another spatial reference system instead of rejecting it, where every other operation combining two spatial values rejects it. `contains_set_geo(geomset 'SRID=4326;{...}', geometry 'SRID=3812;Point(1 1)')` answers about two frames that have no common meaning.

A pose set takes its value through `ensure_valid_poseset_pose`, the family validator that requires an SRID and a dimension in common. `poseset_meos.c` holds a second validator of its own that requires neither, and this removes it.

A geometry set takes its value through `ensure_valid_geoset_geo`, which requires a common SRID and, since `VALIDATE_GEOSET` admits a `geogset` as well as a `geomset`, agreement on planar or geodetic coordinates. `ensure_same_geodetic_set_geo` states the second of those beside the two functions that answer it for a temporal value and for a box, so the message lives in one place.

A network point set needs no such check: `npoint_srid` ignores its argument and returns the SRID of the `ways` table, which every network point in a database shares, so comparing the two sides compares one value with itself.

`meos/test/error_test.c` covers the three rejections. The set operations of a spatial set belong to the MEOS API alone — the SQL operators reach the generic wrappers directly — so the error status is what observes them.