### PR TITLE
Declare the set type the value-and-set set operations return

### DIFF
--- a/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
+++ b/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
@@ -438,7 +438,7 @@ CREATE OPERATOR + (
 /*****************************************************************************/
 
 CREATE FUNCTION setMinus(cbuffer, cbufferset)
-  RETURNS cbuffer
+  RETURNS cbufferset
   AS 'MODULE_PATHNAME', 'Minus_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setMinus(cbufferset, cbuffer)
@@ -466,11 +466,11 @@ CREATE OPERATOR - (
 /*****************************************************************************/
 
 CREATE FUNCTION setIntersection(cbuffer, cbufferset)
-  RETURNS cbuffer
+  RETURNS cbufferset
   AS 'MODULE_PATHNAME', 'Intersection_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(cbufferset, cbuffer)
-  RETURNS cbuffer
+  RETURNS cbufferset
   AS 'MODULE_PATHNAME', 'Intersection_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(cbufferset, cbufferset)

--- a/mobilitydb/sql/geo/050_geoset.in.sql
+++ b/mobilitydb/sql/geo/050_geoset.in.sql
@@ -798,7 +798,7 @@ CREATE OPERATOR + (
 /*****************************************************************************/
 
 CREATE FUNCTION setMinus(geometry, geomset)
-  RETURNS geometry
+  RETURNS geomset
   AS 'MODULE_PATHNAME', 'Minus_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setMinus(geomset, geometry)
@@ -811,7 +811,7 @@ CREATE FUNCTION setMinus(geomset, geomset)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION setMinus(geography, geogset)
-  RETURNS geography
+  RETURNS geogset
   AS 'MODULE_PATHNAME', 'Minus_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setMinus(geogset, geography)
@@ -852,11 +852,11 @@ CREATE OPERATOR - (
 /*****************************************************************************/
 
 CREATE FUNCTION setIntersection(geometry, geomset)
-  RETURNS geometry
+  RETURNS geomset
   AS 'MODULE_PATHNAME', 'Intersection_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(geomset, geometry)
-  RETURNS geometry
+  RETURNS geomset
   AS 'MODULE_PATHNAME', 'Intersection_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(geomset, geomset)
@@ -865,11 +865,11 @@ CREATE FUNCTION setIntersection(geomset, geomset)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION setIntersection(geography, geogset)
-  RETURNS geography
+  RETURNS geogset
   AS 'MODULE_PATHNAME', 'Intersection_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(geogset, geography)
-  RETURNS geography
+  RETURNS geogset
   AS 'MODULE_PATHNAME', 'Intersection_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(geogset, geogset)

--- a/mobilitydb/sql/json/450_jsonbset.in.sql
+++ b/mobilitydb/sql/json/450_jsonbset.in.sql
@@ -397,7 +397,7 @@ CREATE OPERATOR + (
 /*****************************************************************************/
 
 CREATE FUNCTION setMinus(jsonb, jsonbset)
-  RETURNS jsonb
+  RETURNS jsonbset
   AS 'MODULE_PATHNAME', 'Minus_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setMinus(jsonbset, jsonb)
@@ -425,11 +425,11 @@ CREATE OPERATOR - (
 /*****************************************************************************/
 
 CREATE FUNCTION setIntersection(jsonb, jsonbset)
-  RETURNS jsonb
+  RETURNS jsonbset
   AS 'MODULE_PATHNAME', 'Intersection_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(jsonbset, jsonb)
-  RETURNS jsonb
+  RETURNS jsonbset
   AS 'MODULE_PATHNAME', 'Intersection_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(jsonbset, jsonbset)

--- a/mobilitydb/sql/npoint/301_npointset.in.sql
+++ b/mobilitydb/sql/npoint/301_npointset.in.sql
@@ -427,7 +427,7 @@ CREATE OPERATOR + (
 /*****************************************************************************/
 
 CREATE FUNCTION setMinus(npoint, npointset)
-  RETURNS npoint
+  RETURNS npointset
   AS 'MODULE_PATHNAME', 'Minus_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setMinus(npointset, npoint)
@@ -455,11 +455,11 @@ CREATE OPERATOR - (
 /*****************************************************************************/
 
 CREATE FUNCTION setIntersection(npoint, npointset)
-  RETURNS npoint
+  RETURNS npointset
   AS 'MODULE_PATHNAME', 'Intersection_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(npointset, npoint)
-  RETURNS npoint
+  RETURNS npointset
   AS 'MODULE_PATHNAME', 'Intersection_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(npointset, npointset)

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -621,7 +621,7 @@ CREATE OPERATOR + (
 );
 
 CREATE FUNCTION setMinus(pcpoint, pcpointset)
-  RETURNS pcpoint
+  RETURNS pcpointset
   AS 'MODULE_PATHNAME', 'Minus_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setMinus(pcpointset, pcpoint)
@@ -647,11 +647,11 @@ CREATE OPERATOR - (
 );
 
 CREATE FUNCTION setIntersection(pcpoint, pcpointset)
-  RETURNS pcpoint
+  RETURNS pcpointset
   AS 'MODULE_PATHNAME', 'Intersection_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(pcpointset, pcpoint)
-  RETURNS pcpoint
+  RETURNS pcpointset
   AS 'MODULE_PATHNAME', 'Intersection_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(pcpointset, pcpointset)
@@ -996,7 +996,7 @@ CREATE OPERATOR + (
 );
 
 CREATE FUNCTION setMinus(pcpatch, pcpatchset)
-  RETURNS pcpatch
+  RETURNS pcpatchset
   AS 'MODULE_PATHNAME', 'Minus_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setMinus(pcpatchset, pcpatch)
@@ -1022,11 +1022,11 @@ CREATE OPERATOR - (
 );
 
 CREATE FUNCTION setIntersection(pcpatch, pcpatchset)
-  RETURNS pcpatch
+  RETURNS pcpatchset
   AS 'MODULE_PATHNAME', 'Intersection_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(pcpatchset, pcpatch)
-  RETURNS pcpatch
+  RETURNS pcpatchset
   AS 'MODULE_PATHNAME', 'Intersection_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(pcpatchset, pcpatchset)

--- a/mobilitydb/sql/pose/101_poseset.in.sql
+++ b/mobilitydb/sql/pose/101_poseset.in.sql
@@ -449,7 +449,7 @@ CREATE OPERATOR + (
 /*****************************************************************************/
 
 CREATE FUNCTION setMinus(pose, poseset)
-  RETURNS pose
+  RETURNS poseset
   AS 'MODULE_PATHNAME', 'Minus_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setMinus(poseset, pose)
@@ -477,11 +477,11 @@ CREATE OPERATOR - (
 /*****************************************************************************/
 
 CREATE FUNCTION setIntersection(pose, poseset)
-  RETURNS pose
+  RETURNS poseset
   AS 'MODULE_PATHNAME', 'Intersection_value_set'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(poseset, pose)
-  RETURNS pose
+  RETURNS poseset
   AS 'MODULE_PATHNAME', 'Intersection_set_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION setIntersection(poseset, poseset)

--- a/mobilitydb/test/cbuffer/expected/201_cbufferset_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/201_cbufferset_tbl.test.out
@@ -181,3 +181,21 @@ SELECT numValues(setUnion(cb)) FROM tbl_cbuffer;
        100
 (1 row)
 
+SELECT asText(setMinus(cbuffer 'Cbuffer(Point(1 1),0.5)', cbufferset '{"Cbuffer(Point(2 2),0.5)"}'));
+           astext            
+-----------------------------
+ {"Cbuffer(POINT(1 1),0.5)"}
+(1 row)
+
+SELECT asText(setIntersection(cbuffer 'Cbuffer(Point(1 1),0.5)', cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),0.5)"}'));
+           astext            
+-----------------------------
+ {"Cbuffer(POINT(1 1),0.5)"}
+(1 row)
+
+SELECT asText(setIntersection(cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),0.5)"}', cbuffer 'Cbuffer(Point(1 1),0.5)'));
+           astext            
+-----------------------------
+ {"Cbuffer(POINT(1 1),0.5)"}
+(1 row)
+

--- a/mobilitydb/test/cbuffer/queries/201_cbufferset_tbl.test.sql
+++ b/mobilitydb/test/cbuffer/queries/201_cbufferset_tbl.test.sql
@@ -114,3 +114,12 @@ SELECT MAX(hashExtended(s, 1)) FROM tbl_cbufferset;
 SELECT numValues(setUnion(cb)) FROM tbl_cbuffer;
 
 -------------------------------------------------------------------------------
+-- The value-and-set directions of the difference and the intersection return
+-- a set, which is what the functions behind them build
+-------------------------------------------------------------------------------
+
+SELECT asText(setMinus(cbuffer 'Cbuffer(Point(1 1),0.5)', cbufferset '{"Cbuffer(Point(2 2),0.5)"}'));
+SELECT asText(setIntersection(cbuffer 'Cbuffer(Point(1 1),0.5)', cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),0.5)"}'));
+SELECT asText(setIntersection(cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),0.5)"}', cbuffer 'Cbuffer(Point(1 1),0.5)'));
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/expected/050_set_tbl.test.out
+++ b/mobilitydb/test/geo/expected/050_set_tbl.test.out
@@ -387,3 +387,39 @@ SELECT numValues(setUnion(g)) FROM tbl_geom_point WHERE NOT ST_IsEmpty(g);
         99
 (1 row)
 
+SELECT asText(setMinus(geometry 'Point(1 1)', geomset '{"Point(2 2)"}'));
+     astext     
+----------------
+ {"POINT(1 1)"}
+(1 row)
+
+SELECT asText(setIntersection(geometry 'Point(1 1)', geomset '{"Point(1 1)", "Point(2 2)"}'));
+     astext     
+----------------
+ {"POINT(1 1)"}
+(1 row)
+
+SELECT asText(setIntersection(geomset '{"Point(1 1)", "Point(2 2)"}', geometry 'Point(1 1)'));
+     astext     
+----------------
+ {"POINT(1 1)"}
+(1 row)
+
+SELECT asText(setMinus(geography 'Point(1 1)', geogset '{"Point(2 2)"}'));
+     astext     
+----------------
+ {"POINT(1 1)"}
+(1 row)
+
+SELECT asText(setIntersection(geography 'Point(1 1)', geogset '{"Point(1 1)", "Point(2 2)"}'));
+     astext     
+----------------
+ {"POINT(1 1)"}
+(1 row)
+
+SELECT asText(setIntersection(geogset '{"Point(1 1)", "Point(2 2)"}', geography 'Point(1 1)'));
+     astext     
+----------------
+ {"POINT(1 1)"}
+(1 row)
+

--- a/mobilitydb/test/geo/queries/050_set_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/050_set_tbl.test.sql
@@ -169,3 +169,15 @@ SELECT MAX(hash(g)) FROM tbl_geogset;
 SELECT numValues(setUnion(g)) FROM tbl_geom_point WHERE NOT ST_IsEmpty(g);
 
 -------------------------------------------------------------------------------
+-- The value-and-set directions of the difference and the intersection return
+-- a set, which is what the functions behind them build
+-------------------------------------------------------------------------------
+
+SELECT asText(setMinus(geometry 'Point(1 1)', geomset '{"Point(2 2)"}'));
+SELECT asText(setIntersection(geometry 'Point(1 1)', geomset '{"Point(1 1)", "Point(2 2)"}'));
+SELECT asText(setIntersection(geomset '{"Point(1 1)", "Point(2 2)"}', geometry 'Point(1 1)'));
+SELECT asText(setMinus(geography 'Point(1 1)', geogset '{"Point(2 2)"}'));
+SELECT asText(setIntersection(geography 'Point(1 1)', geogset '{"Point(1 1)", "Point(2 2)"}'));
+SELECT asText(setIntersection(geogset '{"Point(1 1)", "Point(2 2)"}', geography 'Point(1 1)'));
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
+++ b/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
@@ -223,3 +223,21 @@ SELECT numValues(setUnion(jb)) FROM tbl_jsonb;
        100
 (1 row)
 
+SELECT setMinus(jsonb '{"a": 1}', jsonbset '{"{\"b\": 2}"}');
+    setminus    
+----------------
+ {"{\"a\": 1}"}
+(1 row)
+
+SELECT setIntersection(jsonb '{"a": 1}', jsonbset '{"{\"a\": 1}", "{\"b\": 2}"}');
+ setintersection 
+-----------------
+ 
+(1 row)
+
+SELECT setIntersection(jsonbset '{"{\"a\": 1}", "{\"b\": 2}"}', jsonb '{"a": 1}');
+ setintersection 
+-----------------
+ 
+(1 row)
+

--- a/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
+++ b/mobilitydb/test/json/queries/450_jsonbset_tbl.test.sql
@@ -119,3 +119,12 @@ SELECT MAX(hashExtended(s, 1)) FROM tbl_jsonbset;
 SELECT numValues(setUnion(jb)) FROM tbl_jsonb;
 
 -------------------------------------------------------------------------------
+-- The value-and-set directions of the difference and the intersection return
+-- a set, which is what the functions behind them build
+-------------------------------------------------------------------------------
+
+SELECT setMinus(jsonb '{"a": 1}', jsonbset '{"{\"b\": 2}"}');
+SELECT setIntersection(jsonb '{"a": 1}', jsonbset '{"{\"a\": 1}", "{\"b\": 2}"}');
+SELECT setIntersection(jsonbset '{"{\"a\": 1}", "{\"b\": 2}"}', jsonb '{"a": 1}');
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/npoint/expected/301_npointset_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/301_npointset_tbl.test.out
@@ -193,3 +193,21 @@ SELECT numValues(setUnion(np)) FROM tbl_npoint;
        100
 (1 row)
 
+SELECT setMinus(npoint 'Npoint(1,0.5)', npointset '{"Npoint(2,0.5)"}');
+     setminus      
+-------------------
+ {"NPoint(1,0.5)"}
+(1 row)
+
+SELECT setIntersection(npoint 'Npoint(1,0.5)', npointset '{"Npoint(1,0.5)", "Npoint(2,0.5)"}');
+  setintersection  
+-------------------
+ {"NPoint(1,0.5)"}
+(1 row)
+
+SELECT setIntersection(npointset '{"Npoint(1,0.5)", "Npoint(2,0.5)"}', npoint 'Npoint(1,0.5)');
+  setintersection  
+-------------------
+ {"NPoint(1,0.5)"}
+(1 row)
+

--- a/mobilitydb/test/npoint/queries/301_npointset_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/301_npointset_tbl.test.sql
@@ -113,3 +113,12 @@ SELECT MAX(hashExtended(n, 1)) FROM tbl_npointset;
 SELECT numValues(setUnion(np)) FROM tbl_npoint;
 
 -------------------------------------------------------------------------------
+-- The value-and-set directions of the difference and the intersection return
+-- a set, which is what the functions behind them build
+-------------------------------------------------------------------------------
+
+SELECT setMinus(npoint 'Npoint(1,0.5)', npointset '{"Npoint(2,0.5)"}');
+SELECT setIntersection(npoint 'Npoint(1,0.5)', npointset '{"Npoint(1,0.5)", "Npoint(2,0.5)"}');
+SELECT setIntersection(npointset '{"Npoint(1,0.5)", "Npoint(2,0.5)"}', npoint 'Npoint(1,0.5)');
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/expected/101_poseset_tbl.test.out
+++ b/mobilitydb/test/pose/expected/101_poseset_tbl.test.out
@@ -175,3 +175,21 @@ SELECT numValues(setUnion(pose)) FROM tbl_pose2d;
        100
 (1 row)
 
+SELECT asText(setMinus(pose 'Pose(Point(1 1),0.5)', poseset '{"Pose(Point(2 2),0.5)"}'));
+          astext          
+--------------------------
+ {"Pose(POINT(1 1),0.5)"}
+(1 row)
+
+SELECT asText(setIntersection(pose 'Pose(Point(1 1),0.5)', poseset '{"Pose(Point(1 1),0.5)", "Pose(Point(2 2),0.5)"}'));
+          astext          
+--------------------------
+ {"Pose(POINT(1 1),0.5)"}
+(1 row)
+
+SELECT asText(setIntersection(poseset '{"Pose(Point(1 1),0.5)", "Pose(Point(2 2),0.5)"}', pose 'Pose(Point(1 1),0.5)'));
+          astext          
+--------------------------
+ {"Pose(POINT(1 1),0.5)"}
+(1 row)
+

--- a/mobilitydb/test/pose/queries/101_poseset_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/101_poseset_tbl.test.sql
@@ -112,3 +112,12 @@ SELECT MAX(hash(s)) FROM tbl_poseset2d;
 SELECT numValues(setUnion(pose)) FROM tbl_pose2d;
 
 -------------------------------------------------------------------------------
+-- The value-and-set directions of the difference and the intersection return
+-- a set, which is what the functions behind them build
+-------------------------------------------------------------------------------
+
+SELECT asText(setMinus(pose 'Pose(Point(1 1),0.5)', poseset '{"Pose(Point(2 2),0.5)"}'));
+SELECT asText(setIntersection(pose 'Pose(Point(1 1),0.5)', poseset '{"Pose(Point(1 1),0.5)", "Pose(Point(2 2),0.5)"}'));
+SELECT asText(setIntersection(poseset '{"Pose(Point(1 1),0.5)", "Pose(Point(2 2),0.5)"}', pose 'Pose(Point(1 1),0.5)'));
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -1850,16 +1850,10 @@ def _setops_markers(family: str):
 
 
 # Per operation: the three directions as (signature, RETURNS, backing C symbol)
-# patterns over the family's (value {v}, set {s}) type pair. The RETURNS column is
-# the alpha-set (002_set_ops) spelling, which matches the C wrappers: every
-# direction dispatches through Setop_base_set / Setop_set_base / Setop_set_set
-# (mobilitydb/src/temporal/set_ops.c), all of which PG_RETURN_SET_P. A family
-# with `value_returns: true` instead declares the VALUE type on setMinus(value,
-# set) and on setIntersection(value, set)/(set, value) — geoset, cbufferset,
-# jsonbset, npointset, the pointcloud sets and poseset all do — mislabeling the
-# set datum those wrappers return. The override reproduces the committed
-# declarations verbatim; correcting them is an API-surface change left to its
-# own patch.
+# patterns over the family's (value {v}, set {s}) type pair. Every direction
+# dispatches through Setop_base_set / Setop_set_base / Setop_set_set
+# (mobilitydb/src/temporal/set_ops.c), all of which PG_RETURN_SET_P, so all
+# three declare the set type whatever the family.
 _SETOP_FNS = {
     "union": [
         ("setUnion({v}, {s})", "{s}", "Union_value_set"),
@@ -1889,22 +1883,14 @@ _SETOP_OPERATOR = ("CREATE OPERATOR {op} (\n"
                    ");")
 
 
-# The directions whose RETURNS a `value_returns: true` family declares as the
-# value type: op -> direction indexes into _SETOP_FNS[op].
-_SETOP_VALUE_RETS = {"union": (), "minus": (0,), "intersection": (0, 1)}
-
-
-def _setop_fns(op: str, pairs: list, value_returns: bool = False) -> str:
+def _setop_fns(op: str, pairs: list) -> str:
     """The three CREATE FUNCTIONs of one operation for every (value, set) pair:
     a pair's functions packed, consecutive pairs separated by one blank line."""
     tmpl = (TEMPLATES / "comparisons.sql.tmpl").read_text().rstrip("\n")
-    table = [(sig, "{v}" if value_returns and d in _SETOP_VALUE_RETS[op] else ret,
-              sym)
-             for d, (sig, ret, sym) in enumerate(_SETOP_FNS[op])]
     groups = ["\n".join(tmpl.replace("{SIG}", sig.format(v=v, s=s))
                             .replace("{RET}", ret.format(v=v, s=s))
                             .replace("{SYM}", sym)
-                        for sig, ret, sym in table)
+                        for sig, ret, sym in _SETOP_FNS[op])
               for v, s in pairs]
     return "\n\n".join(groups) + "\n"
 
@@ -1932,8 +1918,7 @@ def render_setops(fam: dict) -> str:
         if "lit" in blk:
             out += blk["lit"]
         elif "setfns" in blk:
-            out += _setop_fns(blk["setfns"], fam["pairs"],
-                              fam.get("value_returns", False))
+            out += _setop_fns(blk["setfns"], fam["pairs"])
         else:
             out += _setop_ops(blk["setops"], fam["pairs"])
     return out

--- a/tools/codegen/inherited/manifest.d/setop_families.yaml
+++ b/tools/codegen/inherited/manifest.d/setop_families.yaml
@@ -22,7 +22,6 @@ setop_families:
 - family: geoset
   file: mobilitydb/sql/geo/050_geoset.in.sql
   reference: true
-  value_returns: true
   begin: "CREATE FUNCTION setUnion(geometry,"
   end: "CREATE FUNCTION setDistance("
   pairs: [[geometry, geomset], [geography, geogset]]
@@ -43,7 +42,6 @@ setop_families:
 - family: cbufferset
   file: mobilitydb/sql/cbuffer/201_cbufferset.in.sql
   reference: true
-  value_returns: true
   begin: "CREATE FUNCTION setUnion(cbuffer,"
   end: "CREATE FUNCTION setDistance("
   pairs: [[cbuffer, cbufferset]]
@@ -84,7 +82,6 @@ setop_families:
 - family: jsonbset
   file: mobilitydb/sql/json/450_jsonbset.in.sql
   reference: true
-  value_returns: true
   begin: "CREATE FUNCTION setUnion(jsonb,"
   whole_file: true
   pairs: [[jsonb, jsonbset]]
@@ -105,7 +102,6 @@ setop_families:
 - family: npointset
   file: mobilitydb/sql/npoint/301_npointset.in.sql
   reference: true
-  value_returns: true
   begin: "CREATE FUNCTION setUnion(npoint,"
   end: "CREATE FUNCTION setDistance("
   pairs: [[npoint, npointset]]
@@ -126,7 +122,6 @@ setop_families:
 - family: pcpointset
   file: mobilitydb/sql/pointcloud/400_pcset.in.sql
   reference: true
-  value_returns: true
   begin: "CREATE FUNCTION setUnion(pcpoint,"
   begin_exact: true
   end: "\n * pcpatchset \u2014 Input / output\n"
@@ -147,7 +142,6 @@ setop_families:
 - family: pcpatchset
   file: mobilitydb/sql/pointcloud/400_pcset.in.sql
   reference: true
-  value_returns: true
   begin: "CREATE FUNCTION setUnion(pcpatch,"
   begin_exact: true
   whole_file: true
@@ -168,7 +162,6 @@ setop_families:
 - family: poseset
   file: mobilitydb/sql/pose/101_poseset.in.sql
   reference: true
-  value_returns: true
   begin: "CREATE FUNCTION setUnion(pose,"
   end: "CREATE FUNCTION setDistance("
   pairs: [[pose, poseset]]
@@ -190,9 +183,6 @@ setop_families:
 - family: posechainset
   file: mobilitydb/sql/posechain/551_posechainset.in.sql
   reference: true
-  # No `value_returns`: the three wrappers Setop_base_set / Setop_set_base /
-  # Setop_set_set all return a set, so every direction declares the set type,
-  # as the alpha sets of 002_set_ops.in.sql do.
   begin: "CREATE FUNCTION setUnion(posechain,"
   whole_file: true
   pairs: [[posechain, posechainset]]


### PR DESCRIPTION
`setMinus(value, set)` and both directions of `setIntersection` between a value and a set declare the base type where the functions behind them build a set. The three wrappers of `mobilitydb/src/temporal/set_ops.c` — `Setop_base_set`, `Setop_set_base` and `Setop_set_set` — all `PG_RETURN_SET_P`, so PostgreSQL reads a set datum as a value of the base type and answers whatever those bytes hold:

```
SELECT geometry 'Point(1 1)' * geomset '{"Point(1 1)", "Point(2 2)"}';
 SRID=731666;POINT(3.95e-322 0)

SELECT cbuffer 'Cbuffer(Point(1 1),0.5)' * cbufferset '{"Cbuffer(Point(1 1),0.5)"}';
 NOTICE:  SRID value 1194298 > SRID_MAXIMUM converted to 999493
 SRID=1194298;Cbuffer(POINT(3.95e-322 0),2.1219957915e-314)
```

Every direction declares the set type, which is what the alpha sets of `002_set_ops.in.sql` already declare: `setIntersection(integer, intset)` returns `intset`. This covers the 24 declarations of the eight pairs that spell the base type instead — geometry, geography, cbuffer, jsonb, npoint, pcpoint, pcpatch and pose with their sets. The intersection of a value and a set is then the singleton set holding it, or the empty set.

The generator carries the mislabelling as a per-family `value_returns` flag; the flag, the table of directions it applies to and the parameter threading it through `_setop_fns` go with the declarations they exist to reproduce.

The five families whose values are writable as literals cover the three corrected directions apiece. Adopting the outputs adds lines and moves none, so no query in the suite exercises any of these directions today, which is what leaves the declarations free to drift from the functions they name.

The two pointcloud sets have no set-level test file and their values resolve through the `pointcloud_formats` catalog, so their declarations are corrected without a query of their own.