### PR TITLE
Set the manual version from the entity and bump it to 1.4

### DIFF
--- a/doc/es/mobilitydb-manual.xml
+++ b/doc/es/mobilitydb-manual.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE book [
 
-<!ENTITY last_release_version "1.3">
+<!ENTITY last_release_version "1.4">
 
 <!ENTITY introduction SYSTEM "introduction.xml">
 <!ENTITY set_span_types SYSTEM "set_span_types.xml">

--- a/doc/mobilitydb-manual.xml
+++ b/doc/mobilitydb-manual.xml
@@ -10,7 +10,7 @@
 -->
 <!DOCTYPE book [
 
-<!ENTITY last_release_version "1.3">
+<!ENTITY last_release_version "1.4">
 
 <!ENTITY introduction SYSTEM "introduction.xml">
 <!ENTITY set_span_types SYSTEM "set_span_types.xml">
@@ -73,7 +73,7 @@
   xmlns:xl="http://www.w3.org/1999/xlink"
   xmlns:mml="https://www.w3.org/1998/Math/MathML" version="5.0" xml:lang="en">
 	<bookinfo>
-		<title>MobilityDB 1.3 User's Manual</title>
+		<title>MobilityDB &last_release_version; User's Manual</title>
 		<author>
 			<firstname>Esteban</firstname>
 			<surname>Zimányi</surname>


### PR DESCRIPTION
The manual title reports version 1.3 while `mobdb_version.txt` declares 1.4.

The English manual declares a `last_release_version` entity for this purpose but hard-codes the version in its title, so the entity and the title can drift apart. The Spanish manual already references the entity.

This uses the entity in the English title, as the Spanish one does, and sets it to 1.4 in both files, so a release needs one edit rather than three.

Both manuals parse under `xmllint --noent`, and the titles expand to "MobilityDB 1.4 User's Manual" and "MobilityDB 1.4 Manual de usuario".

A further step is to generate the entity from `mobdb_version.txt` via `configure_file` so it cannot go stale; that interacts with the `po2xml` pipeline in `genxmlfiles.sh` and belongs in a separate change.
