### PR TITLE
Let the value-domain predicates reach the GiST and SP-GiST indexes

### DIFF
--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -156,6 +156,7 @@ typedef enum
   TEMPORALTYPE,
   TNUMBERTYPE,
   TSPATIALTYPE,
+  SPANTYPE,
 } TemporalFamily;
 
 /** Enumeration for the set operations of span and temporal types */

--- a/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
+++ b/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
@@ -347,10 +347,12 @@ CREATE OPERATOR CLASS cbufferset_hash_ops
 CREATE FUNCTION contains(cbufferset, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(cbufferset, cbufferset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -371,10 +373,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(cbuffer, cbufferset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(cbufferset, cbufferset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -395,6 +399,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(cbufferset, cbufferset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/geo/050_geoset.in.sql
+++ b/mobilitydb/sql/geo/050_geoset.in.sql
@@ -628,18 +628,22 @@ CREATE OPERATOR CLASS geogset_hash_ops
 CREATE FUNCTION contains(geomset, geometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(geomset, geomset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(geogset, geography)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(geogset, geogset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -672,18 +676,22 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(geometry, geomset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(geomset, geomset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(geography, geogset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(geogset, geogset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -716,10 +724,12 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(geomset, geomset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(geogset, geogset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/geo/051_stbox.in.sql
+++ b/mobilitydb/sql/geo/051_stbox.in.sql
@@ -458,66 +458,82 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION left(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION below(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Below_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbelow(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbelow_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION above(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Above_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overabove(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overabove_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION front(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Front_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overfront(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overfront_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION back(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Back_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overback(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overback_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (

--- a/mobilitydb/sql/geo/062_tgeo_posops.in.sql
+++ b/mobilitydb/sql/geo/062_tgeo_posops.in.sql
@@ -581,18 +581,22 @@ CREATE OPERATOR #&> (
 CREATE FUNCTION left(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION below(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
@@ -633,18 +637,22 @@ CREATE FUNCTION overback(tgeometry, tgeometry)
 CREATE FUNCTION before(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(inst1 tgeometry, inst2 tgeometry)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (

--- a/mobilitydb/sql/geo/062_tpoint_posops.in.sql
+++ b/mobilitydb/sql/geo/062_tpoint_posops.in.sql
@@ -581,18 +581,22 @@ CREATE OPERATOR #&> (
 CREATE FUNCTION left(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION below(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
@@ -633,18 +637,22 @@ CREATE FUNCTION overback(tgeompoint, tgeompoint)
 CREATE FUNCTION before(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(inst1 tgeompoint, inst2 tgeompoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_tspatial_tspatial'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (

--- a/mobilitydb/sql/h3/251_h3indexset.in.sql
+++ b/mobilitydb/sql/h3/251_h3indexset.in.sql
@@ -301,10 +301,12 @@ CREATE AGGREGATE setUnion(h3indexset) (
 CREATE FUNCTION contains(h3indexset, h3index)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(h3indexset, h3indexset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -327,10 +329,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(h3index, h3indexset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(h3indexset, h3indexset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -353,6 +357,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(h3indexset, h3indexset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/json/450_jsonbset.in.sql
+++ b/mobilitydb/sql/json/450_jsonbset.in.sql
@@ -311,10 +311,12 @@ CREATE OPERATOR CLASS jsonbset_hash_ops
 CREATE FUNCTION contains(jsonbset, jsonb)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(jsonbset, jsonbset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -333,10 +335,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(jsonb, jsonbset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(jsonbset, jsonbset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -355,6 +359,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(jsonbset, jsonbset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/npoint/301_npointset.in.sql
+++ b/mobilitydb/sql/npoint/301_npointset.in.sql
@@ -336,10 +336,12 @@ CREATE OPERATOR CLASS npointset_hash_ops
 CREATE FUNCTION contains(npointset, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(npointset, npointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -360,10 +362,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(npoint, npointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(npointset, npointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -384,6 +388,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(npointset, npointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/npoint/306_tnpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/npoint/306_tnpoint_spatialfuncs.in.sql
@@ -81,6 +81,7 @@ CREATE FUNCTION minusStbox(tnpoint, stbox, bool DEFAULT TRUE)
 CREATE FUNCTION same(npoint, npoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Npoint_same'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -543,10 +543,12 @@ CREATE OPERATOR CLASS pcpointset_hash_ops
 CREATE FUNCTION contains(pcpointset, pcpoint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(pcpointset, pcpointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -563,10 +565,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(pcpoint, pcpointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(pcpointset, pcpointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -583,6 +587,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(pcpointset, pcpointset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -918,10 +923,12 @@ CREATE OPERATOR CLASS pcpatchset_hash_ops
 CREATE FUNCTION contains(pcpatchset, pcpatch)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(pcpatchset, pcpatchset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -938,10 +945,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(pcpatch, pcpatchset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(pcpatchset, pcpatchset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -958,6 +967,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(pcpatchset, pcpatchset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
+++ b/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
@@ -349,51 +349,67 @@ CREATE OPERATOR CLASS tpcbox_btree_ops
 
 CREATE FUNCTION left(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Left_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overleft_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Right_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overright_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION below(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Below_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbelow(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overbelow_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION above(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Above_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overabove(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overabove_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION front(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Front_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overfront(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overfront_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION back(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Back_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overback(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overback_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Before_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overbefore_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'After_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overafter_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (

--- a/mobilitydb/sql/pose/101_poseset.in.sql
+++ b/mobilitydb/sql/pose/101_poseset.in.sql
@@ -358,10 +358,12 @@ CREATE OPERATOR CLASS poseset_hash_ops
 CREATE FUNCTION contains(poseset, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(poseset, poseset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -382,10 +384,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(pose, poseset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(poseset, poseset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -406,6 +410,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(poseset, poseset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/posechain/551_posechainset.in.sql
+++ b/mobilitydb/sql/posechain/551_posechainset.in.sql
@@ -358,10 +358,12 @@ CREATE OPERATOR CLASS posechainset_hash_ops
 CREATE FUNCTION contains(posechainset, posechain)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(posechainset, posechainset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -382,10 +384,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(posechain, posechainset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(posechainset, posechainset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -406,6 +410,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(posechainset, posechainset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/quadbin/351_quadbinset.in.sql
+++ b/mobilitydb/sql/quadbin/351_quadbinset.in.sql
@@ -301,10 +301,12 @@ CREATE AGGREGATE setUnion(quadbinset) (
 CREATE FUNCTION contains(quadbinset, quadbin)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(quadbinset, quadbinset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -327,10 +329,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(quadbin, quadbinset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(quadbinset, quadbinset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -353,6 +357,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(quadbinset, quadbinset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (

--- a/mobilitydb/sql/temporal/002_set_ops.in.sql
+++ b/mobilitydb/sql/temporal/002_set_ops.in.sql
@@ -32,6 +32,11 @@
  * @brief Operators for set types
  */
 
+CREATE FUNCTION span_supportfn(internal)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Span_supportfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * Operators
  ******************************************************************************/
@@ -39,50 +44,62 @@
 CREATE FUNCTION contains(intset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(intset, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(bigintset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(bigintset, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(floatset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(floatset, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(textset, text)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(textset, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(dateset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(dateset, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tstzset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tstzset, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -159,50 +176,62 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(integer, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(intset, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(bigint, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(bigintset, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(float, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(floatset, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(text, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(textset, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(date, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(dateset, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(timestamptz, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tstzset, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -279,26 +308,32 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(intset, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(bigintset, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(floatset, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(textset, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(dateset, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tstzset, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -341,74 +376,92 @@ CREATE OPERATOR && (
 CREATE FUNCTION left(integer, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(intset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(intset, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigint, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigintset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigintset, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(float, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(floatset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(floatset, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(text, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(textset, text)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(textset, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(date, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(dateset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(dateset, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(timestamptz, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzset, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (
@@ -519,74 +572,92 @@ CREATE OPERATOR <<# (
 CREATE FUNCTION right(integer, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(intset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(intset, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigint, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigintset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigintset, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(float, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(floatset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(floatset, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(text, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(textset, text)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(textset, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(date, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(dateset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(dateset, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(timestamptz, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzset, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR >> (
@@ -697,74 +768,92 @@ CREATE OPERATOR #>> (
 CREATE FUNCTION overleft(integer, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(intset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(intset, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigint, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigintset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigintset, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(float, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(floatset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(floatset, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(text, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(textset, text)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(textset, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(date, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(dateset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(dateset, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(timestamptz, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzset, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &< (
@@ -860,74 +949,92 @@ CREATE OPERATOR &<# (
 CREATE FUNCTION overright(integer, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(intset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(intset, intset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigint, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigintset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigintset, bigintset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(float, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(floatset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(floatset, floatset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(text, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(textset, text)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(textset, textset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(date, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(dateset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(dateset, dateset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(timestamptz, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_value_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_set_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzset, tstzset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_set_set'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &> (

--- a/mobilitydb/sql/temporal/005_span_ops.in.sql
+++ b/mobilitydb/sql/temporal/005_span_ops.in.sql
@@ -39,10 +39,12 @@
 CREATE FUNCTION contains(intspan, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(intspan, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -61,10 +63,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contains(bigintspan, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(bigintspan, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -83,10 +87,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contains(floatspan, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(floatspan, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -105,10 +111,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contains(datespan, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(datespan, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -127,10 +135,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contains(tstzspan, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tstzspan, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -151,10 +161,12 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(integer, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(intspan, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -173,10 +185,12 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION contained(bigint, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(bigintspan, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -195,10 +209,12 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION contained(float, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(floatspan, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -217,10 +233,12 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION contained(date, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(datespan, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -239,10 +257,12 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION contained(timestamptz, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tstzspan, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -263,6 +283,7 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(intspan, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -275,6 +296,7 @@ CREATE OPERATOR && (
 CREATE FUNCTION overlaps(bigintspan, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -287,6 +309,7 @@ CREATE OPERATOR && (
 CREATE FUNCTION overlaps(floatspan, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -299,6 +322,7 @@ CREATE OPERATOR && (
 CREATE FUNCTION overlaps(datespan, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -311,6 +335,7 @@ CREATE OPERATOR && (
 CREATE FUNCTION overlaps(tstzspan, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -325,14 +350,17 @@ CREATE OPERATOR && (
 CREATE FUNCTION adjacent(integer, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(intspan, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(intspan, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -357,14 +385,17 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION adjacent(bigint, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(bigintspan, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(bigintspan, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -389,14 +420,17 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION adjacent(float, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(floatspan, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(floatspan, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -421,14 +455,17 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION adjacent(date, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(datespan, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(datespan, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -453,14 +490,17 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION adjacent(timestamptz, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tstzspan, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tstzspan, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -489,14 +529,17 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION left(integer, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(intspan, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(intspan, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (
@@ -521,14 +564,17 @@ CREATE OPERATOR << (
 CREATE FUNCTION left(bigint, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigintspan, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigintspan, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (
@@ -553,14 +599,17 @@ CREATE OPERATOR << (
 CREATE FUNCTION left(float, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(floatspan, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(floatspan, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (
@@ -585,14 +634,17 @@ CREATE OPERATOR << (
 CREATE FUNCTION before(date, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespan, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespan, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <<# (
@@ -617,14 +669,17 @@ CREATE OPERATOR <<# (
 CREATE FUNCTION before(timestamptz, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspan, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspan, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <<# (
@@ -651,14 +706,17 @@ CREATE OPERATOR <<# (
 CREATE FUNCTION right(integer, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(intspan, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(intspan, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR >> (
@@ -683,14 +741,17 @@ CREATE OPERATOR >> (
 CREATE FUNCTION right(bigint, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigintspan, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigintspan, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR >> (
@@ -715,14 +776,17 @@ CREATE OPERATOR >> (
 CREATE FUNCTION right(float, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(floatspan, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(floatspan, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR >> (
@@ -747,14 +811,17 @@ CREATE OPERATOR >> (
 CREATE FUNCTION after(date, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespan, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespan, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #>> (
@@ -779,14 +846,17 @@ CREATE OPERATOR #>> (
 CREATE FUNCTION after(timestamptz, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspan, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspan, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #>> (
@@ -813,14 +883,17 @@ CREATE OPERATOR #>> (
 CREATE FUNCTION overleft(integer, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(intspan, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(intspan, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &< (
@@ -842,14 +915,17 @@ CREATE OPERATOR &< (
 CREATE FUNCTION overleft(bigint, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigintspan, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigintspan, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &< (
@@ -871,14 +947,17 @@ CREATE OPERATOR &< (
 CREATE FUNCTION overleft(float, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(floatspan, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(floatspan, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &< (
@@ -900,14 +979,17 @@ CREATE OPERATOR &< (
 CREATE FUNCTION overbefore(date, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespan, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespan, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &<# (
@@ -929,14 +1011,17 @@ CREATE OPERATOR &<# (
 CREATE FUNCTION overbefore(timestamptz, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspan, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspan, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &<# (
@@ -960,14 +1045,17 @@ CREATE OPERATOR &<# (
 CREATE FUNCTION overright(integer, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(intspan, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(intspan, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &> (
@@ -989,14 +1077,17 @@ CREATE OPERATOR &> (
 CREATE FUNCTION overright(bigint, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigintspan, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigintspan, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &> (
@@ -1018,14 +1109,17 @@ CREATE OPERATOR &> (
 CREATE FUNCTION overright(float, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(floatspan, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(floatspan, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &> (
@@ -1047,14 +1141,17 @@ CREATE OPERATOR &> (
 CREATE FUNCTION overafter(date, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespan, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespan, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #&> (
@@ -1076,14 +1173,17 @@ CREATE OPERATOR #&> (
 CREATE FUNCTION overafter(timestamptz, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_value_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspan, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_span_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspan, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_span_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #&> (

--- a/mobilitydb/sql/temporal/009_spanset_ops.in.sql
+++ b/mobilitydb/sql/temporal/009_spanset_ops.in.sql
@@ -60,18 +60,22 @@ CREATE FUNCTION tprecision(tstzspanset, duration interval,
 CREATE FUNCTION contains(intspan, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(intspanset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(intspanset, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(intspanset, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -102,18 +106,22 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contains(bigintspan, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(bigintspanset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(bigintspanset, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(bigintspanset, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -144,18 +152,22 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contains(floatspan, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(floatspanset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(floatspanset, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(floatspanset, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -186,18 +198,22 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contains(datespan, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(datespanset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(datespanset, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(datespanset, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -228,18 +244,22 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contains(tstzspan, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tstzspanset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tstzspanset, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tstzspanset, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
@@ -272,18 +292,22 @@ CREATE OPERATOR @> (
 CREATE FUNCTION contained(integer, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(intspan, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(intspanset, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(intspanset, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -314,18 +338,22 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION contained(bigint, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(bigintspan, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(bigintspanset, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(bigintspanset, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -356,18 +384,22 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION contained(float, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(floatspan, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(floatspanset, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(floatspanset, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -398,18 +430,22 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION contained(date, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(datespan, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(datespanset, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(datespanset, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -440,18 +476,22 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION contained(timestamptz, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tstzspan, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tstzspanset, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tstzspanset, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (
@@ -484,14 +524,17 @@ CREATE OPERATOR <@ (
 CREATE FUNCTION overlaps(intspan, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(intspanset, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(intspanset, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -516,14 +559,17 @@ CREATE OPERATOR && (
 CREATE FUNCTION overlaps(bigintspan, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(bigintspanset, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(bigintspanset, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -548,14 +594,17 @@ CREATE OPERATOR && (
 CREATE FUNCTION overlaps(floatspan, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(floatspanset, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(floatspanset, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -580,14 +629,17 @@ CREATE OPERATOR && (
 CREATE FUNCTION overlaps(datespan, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(datespanset, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(datespanset, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -612,14 +664,17 @@ CREATE OPERATOR && (
 CREATE FUNCTION overlaps(tstzspan, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tstzspanset, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tstzspanset, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (
@@ -646,22 +701,27 @@ CREATE OPERATOR && (
 CREATE FUNCTION left(integer, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(intspan, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(intspanset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(intspanset, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(intspanset, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (
@@ -698,22 +758,27 @@ CREATE OPERATOR << (
 CREATE FUNCTION left(bigint, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigintspan, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigintspanset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigintspanset, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(bigintspanset, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (
@@ -750,22 +815,27 @@ CREATE OPERATOR << (
 CREATE FUNCTION left(float, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(floatspan, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(floatspanset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(floatspanset, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION left(floatspanset, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (
@@ -802,22 +872,27 @@ CREATE OPERATOR << (
 CREATE FUNCTION before(date, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespan, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespanset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespanset, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(datespanset, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <<# (
@@ -854,22 +929,27 @@ CREATE OPERATOR <<# (
 CREATE FUNCTION before(timestamptz, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspan, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspanset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspanset, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tstzspanset, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <<# (
@@ -908,22 +988,27 @@ CREATE OPERATOR <<# (
 CREATE FUNCTION right(integer, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(intspan, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(intspanset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(intspanset, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(intspanset, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR >> (
@@ -960,22 +1045,27 @@ CREATE OPERATOR >> (
 CREATE FUNCTION right(bigint, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigintspan, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigintspanset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigintspanset, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(bigintspanset, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR >> (
@@ -1012,22 +1102,27 @@ CREATE OPERATOR >> (
 CREATE FUNCTION right(float, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(floatspan, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(floatspanset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(floatspanset, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(floatspanset, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR >> (
@@ -1064,22 +1159,27 @@ CREATE OPERATOR >> (
 CREATE FUNCTION after(date, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespan, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespanset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespanset, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(datespanset, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #>> (
@@ -1116,22 +1216,27 @@ CREATE OPERATOR #>> (
 CREATE FUNCTION after(timestamptz, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspan, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspanset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspanset, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tstzspanset, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #>> (
@@ -1170,22 +1275,27 @@ CREATE OPERATOR #>> (
 CREATE FUNCTION overleft(integer, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(intspan, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(intspanset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(intspanset, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(intspanset, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &< (
@@ -1217,22 +1327,27 @@ CREATE OPERATOR &< (
 CREATE FUNCTION overleft(bigint, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigintspan, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigintspanset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigintspanset, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(bigintspanset, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &< (
@@ -1264,22 +1379,27 @@ CREATE OPERATOR &< (
 CREATE FUNCTION overleft(float, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(floatspan, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(floatspanset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(floatspanset, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(floatspanset, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &< (
@@ -1311,22 +1431,27 @@ CREATE OPERATOR &< (
 CREATE FUNCTION overbefore(date, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespan, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespanset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespanset, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(datespanset, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &<# (
@@ -1358,22 +1483,27 @@ CREATE OPERATOR &<# (
 CREATE FUNCTION overbefore(timestamptz, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspan, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspanset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspanset, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tstzspanset, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &<# (
@@ -1407,22 +1537,27 @@ CREATE OPERATOR &<# (
 CREATE FUNCTION overright(integer, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(intspan, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(intspanset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(intspanset, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(intspanset, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &> (
@@ -1454,22 +1589,27 @@ CREATE OPERATOR &> (
 CREATE FUNCTION overright(bigint, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigintspan, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigintspanset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigintspanset, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(bigintspanset, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &> (
@@ -1501,22 +1641,27 @@ CREATE OPERATOR &> (
 CREATE FUNCTION overright(float, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(floatspan, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(floatspanset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(floatspanset, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(floatspanset, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR &> (
@@ -1548,22 +1693,27 @@ CREATE OPERATOR &> (
 CREATE FUNCTION overafter(date, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespan, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespanset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespanset, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(datespanset, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #&> (
@@ -1595,22 +1745,27 @@ CREATE OPERATOR #&> (
 CREATE FUNCTION overafter(timestamptz, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspan, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspanset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspanset, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tstzspanset, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR #&> (
@@ -1644,22 +1799,27 @@ CREATE OPERATOR #&> (
 CREATE FUNCTION adjacent(integer, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(intspan, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(intspanset, integer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(intspanset, intspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(intspanset, intspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -1696,22 +1856,27 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION adjacent(bigint, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(bigintspan, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(bigintspanset, bigint)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(bigintspanset, bigintspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(bigintspanset, bigintspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -1748,22 +1913,27 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION adjacent(float, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(floatspan, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(floatspanset, float)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(floatspanset, floatspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(floatspanset, floatspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -1800,22 +1970,27 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION adjacent(date, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(datespan, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(datespanset, date)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(datespanset, datespan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(datespanset, datespanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (
@@ -1852,22 +2027,27 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION adjacent(timestamptz, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_value_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tstzspan, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_span_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tstzspanset, timestamptz)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_value'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tstzspanset, tstzspan)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_span'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tstzspanset, tstzspanset)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_spanset_spanset'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (

--- a/mobilitydb/sql/temporal/021_tbox.in.sql
+++ b/mobilitydb/sql/temporal/021_tbox.in.sql
@@ -463,34 +463,42 @@ CREATE OPERATOR -|- (
 CREATE FUNCTION left(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Left_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overleft(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overleft_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION right(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Right_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overright(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overright_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION before(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Before_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overbefore(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overbefore_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION after(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'After_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overafter(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overafter_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR << (

--- a/mobilitydb/src/temporal/temporal_supportfn.c
+++ b/mobilitydb/src/temporal/temporal_supportfn.c
@@ -176,6 +176,17 @@ static const uint16_t CommutedIndex[] =
   [RIGHT_IDX]                    = RTRightStrategyNumber, \
   [OVERRIGHT_IDX]                = RTOverRightStrategyNumber
 
+/* A value-domain type IS its own bounding box, so a portable predicate over it
+ * answers the operator its own opclass declares, with no conversion. The array
+ * carries both axes: a time span answers the before/after family and a number
+ * span the left/right one, and the axis a given span does not have simply finds
+ * no operator and keeps the predicate as a filter */
+static const int16 SpanStrategies[] =
+{
+  TIME_PORTABLE_STRATEGIES,
+  AXIS1_PORTABLE_STRATEGIES,
+};
+
 /* The bounding box of an alpha type is a `tstzspan`, so its portable surface is
  * the time dimension alone */
 static const int16 TemporalStrategies[] =
@@ -260,6 +271,13 @@ static const IndexableFunction TemporalIndexableFunctions[] =
   {NULL, 0, 0, 0}
 };
 
+static const IndexableFunction SpanIndexableFunctions[] =
+{
+  TIME_PORTABLE_FUNCTIONS,
+  AXIS1_PORTABLE_FUNCTIONS,
+  {NULL, 0, 0, 0}
+};
+
 static const IndexableFunction TNumberIndexableFunctions[] = {
   /* Ever/always comparison functions */
   {"eeq", EVER_EQ_IDX, 2, 0},
@@ -301,9 +319,22 @@ static const IndexableFunction TSpatialIndexableFunctions[] = {
   {NULL, 0, 0, 0}
 };
 
+/**
+ * @brief Return true if the type belongs to the value domain, whose types are
+ * their own bounding box and answer the operators over themselves
+ */
+static bool
+span_sel_type(MeosType type)
+{
+  return span_basetype(type) || set_spantype(type) || span_type(type) ||
+    spanset_type(type);
+}
+
 static int16
 temporal_get_strategy_by_type(MeosType temptype, uint16_t index)
 {
+  if (span_sel_type(temptype) || bbox_type(temptype))
+    return SpanStrategies[index];
   if (talpha_type(temptype))
     return TemporalStrategies[index];
   if (tnumber_type(temptype))
@@ -508,12 +539,18 @@ temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
   Node *ret = NULL;
   Oid leftoid, rightoid, operid;
 
+  assert (tempfamily == SPANTYPE || tempfamily == TEMPORALTYPE ||
+    tempfamily == TNUMBERTYPE || tempfamily == TSPATIALTYPE );
+
   /* Return estimated selectivity */
-  assert (tempfamily == TEMPORALTYPE || tempfamily == TNUMBERTYPE ||
-    tempfamily == TSPATIALTYPE );
   if (IsA(rawreq, SupportRequestSelectivity))
   {
     SupportRequestSelectivity *req = (SupportRequestSelectivity *) rawreq;
+    /* A value-domain type is not one of the bounding-box classes the temporal
+     * estimators are written for, and its own operators declare `span_sel`.
+     * The request is declined so the predicate keeps the estimate it has */
+    if (tempfamily == SPANTYPE)
+      PG_RETURN_POINTER((Node *) NULL);
     leftoid = exprType(linitial(req->args));
     rightoid = exprType(lsecond(req->args));
     MeosType ltype = oid_meostype(leftoid);
@@ -569,7 +606,9 @@ temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
       IndexableFunction idxfn = {NULL, 0, 0, 0};
       Oid opfamilyoid = req->opfamily; /* Operator family of the index */
       const IndexableFunction *funcarr = NULL;
-      if (tempfamily == TEMPORALTYPE)
+      if (tempfamily == SPANTYPE)
+        funcarr = SpanIndexableFunctions;
+      else if (tempfamily == TEMPORALTYPE)
         funcarr = TemporalIndexableFunctions;
       else if (tempfamily == TNUMBERTYPE)
         funcarr = TNumberIndexableFunctions;
@@ -667,7 +706,7 @@ temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
        * `tpcbox` and no scalar conversion to it exists to build the index
        * expression from; they keep the default of no rewrite */
       exproid = rightoid;
-      if (bbox_type(righttype))
+      if (span_sel_type(righttype) || bbox_type(righttype))
         /* Already a bounding box, and the one the operator is declared
          * against: a time-dimension predicate of a spatial or number family
          * takes a `tstzspan` on its other side, not that family's own box */
@@ -726,7 +765,7 @@ temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
       {
         Expr *expr;
         FuncExpr *bboxexpr;
-        if (bbox_type(righttype))
+        if (span_sel_type(righttype) || bbox_type(righttype))
           bboxexpr = (FuncExpr *) rightarg;
         else
           bboxexpr = makeBboxExpr(rightarg, rightoid, exproid, funcoid);
@@ -757,6 +796,17 @@ temporal_supportfn(FunctionCallInfo fcinfo, TemporalFamily tempfamily)
   }
 
   PG_RETURN_POINTER(ret);
+}
+
+PGDLLEXPORT Datum Span_supportfn(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Span_supportfn);
+/**
+ * @brief Support function for the value-domain types
+ */
+Datum
+Span_supportfn(PG_FUNCTION_ARGS)
+{
+  return temporal_supportfn(fcinfo, SPANTYPE);
 }
 
 PGDLLEXPORT Datum Temporal_supportfn(PG_FUNCTION_ARGS);

--- a/mobilitydb/test/temporal/expected/010_span_ops_supportfn_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/010_span_ops_supportfn_tbl.test.out
@@ -1,0 +1,1100 @@
+DROP INDEX IF EXISTS tbl_intset_rtree_idx;
+NOTICE:  index "tbl_intset_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_intspan_rtree_idx;
+NOTICE:  index "tbl_intspan_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_intspanset_rtree_idx;
+NOTICE:  index "tbl_intspanset_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzset_rtree_idx;
+NOTICE:  index "tbl_tstzset_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzspan_rtree_idx;
+NOTICE:  index "tbl_tstzspan_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzspanset_rtree_idx;
+NOTICE:  index "tbl_tstzspanset_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_intset_quadtree_idx;
+NOTICE:  index "tbl_intset_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_intspan_quadtree_idx;
+NOTICE:  index "tbl_intspan_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_intspanset_quadtree_idx;
+NOTICE:  index "tbl_intspanset_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzset_quadtree_idx;
+NOTICE:  index "tbl_tstzset_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzspan_quadtree_idx;
+NOTICE:  index "tbl_tstzspan_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzspanset_quadtree_idx;
+NOTICE:  index "tbl_tstzspanset_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_intset_kdtree_idx;
+NOTICE:  index "tbl_intset_kdtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_intspan_kdtree_idx;
+NOTICE:  index "tbl_intspan_kdtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_intspanset_kdtree_idx;
+NOTICE:  index "tbl_intspanset_kdtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzset_kdtree_idx;
+NOTICE:  index "tbl_tstzset_kdtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzspan_kdtree_idx;
+NOTICE:  index "tbl_tstzspan_kdtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tstzspanset_kdtree_idx;
+NOTICE:  index "tbl_tstzspanset_kdtree_idx" does not exist, skipping
+DROP INDEX
+DROP TABLE IF EXISTS test_spansupport;
+NOTICE:  table "test_spansupport" does not exist, skipping
+DROP TABLE
+CREATE TABLE test_spansupport(
+  func TEXT,
+  leftarg TEXT,
+  rightarg TEXT,
+  no_idx BIGINT,
+  rtree_idx BIGINT,
+  quadtree_idx BIGINT,
+  kdtree_idx BIGINT
+);
+CREATE TABLE
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overlaps(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contains(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contained(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'left', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE left(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overleft', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overleft(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'right', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE right(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overright', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overright(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overlaps(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contains(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contained(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'left', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE left(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overleft', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overleft(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'right', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE right(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overright', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overright(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE adjacent(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'left', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE left(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overleft', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'right', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE right(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overright', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'left', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE left(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overleft', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'right', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE right(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overright', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overlaps(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contains(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contained(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'before', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE before(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overbefore', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overbefore(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'after', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE after(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overafter', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overafter(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overlaps(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contains(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contained(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'before', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE before(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overbefore', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overbefore(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'after', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE after(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overafter', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overafter(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE adjacent(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'before', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overbefore', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'after', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overafter', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'before', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overbefore', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'after', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overafter', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t);
+INSERT 0 1
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t);
+INSERT 0 1
+CREATE INDEX tbl_intset_rtree_idx ON tbl_intset USING GIST(i);
+CREATE INDEX
+CREATE INDEX tbl_intspan_rtree_idx ON tbl_intspan USING GIST(i);
+CREATE INDEX
+CREATE INDEX tbl_intspanset_rtree_idx ON tbl_intspanset USING GIST(i);
+CREATE INDEX
+CREATE INDEX tbl_tstzset_rtree_idx ON tbl_tstzset USING GIST(t);
+CREATE INDEX
+CREATE INDEX tbl_tstzspan_rtree_idx ON tbl_tstzspan USING GIST(t);
+CREATE INDEX
+CREATE INDEX tbl_tstzspanset_rtree_idx ON tbl_tstzspanset USING GIST(t);
+CREATE INDEX
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+DROP INDEX tbl_intset_rtree_idx;
+DROP INDEX
+DROP INDEX tbl_intspan_rtree_idx;
+DROP INDEX
+DROP INDEX tbl_intspanset_rtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzset_rtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzspan_rtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzspanset_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_intset_quadtree_idx ON tbl_intset USING SPGIST(i);
+CREATE INDEX
+CREATE INDEX tbl_intspan_quadtree_idx ON tbl_intspan USING SPGIST(i);
+CREATE INDEX
+CREATE INDEX tbl_intspanset_quadtree_idx ON tbl_intspanset USING SPGIST(i);
+CREATE INDEX
+CREATE INDEX tbl_tstzset_quadtree_idx ON tbl_tstzset USING SPGIST(t);
+CREATE INDEX
+CREATE INDEX tbl_tstzspan_quadtree_idx ON tbl_tstzspan USING SPGIST(t);
+CREATE INDEX
+CREATE INDEX tbl_tstzspanset_quadtree_idx ON tbl_tstzspanset USING SPGIST(t);
+CREATE INDEX
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+DROP INDEX tbl_intset_quadtree_idx;
+DROP INDEX
+DROP INDEX tbl_intspan_quadtree_idx;
+DROP INDEX
+DROP INDEX tbl_intspanset_quadtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzset_quadtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzspan_quadtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzspanset_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_intset_kdtree_idx ON tbl_intset USING SPGIST(i intset_kdtree_ops);
+CREATE INDEX
+CREATE INDEX tbl_intspan_kdtree_idx ON tbl_intspan USING SPGIST(i intspan_kdtree_ops);
+CREATE INDEX
+CREATE INDEX tbl_intspanset_kdtree_idx ON tbl_intspanset USING SPGIST(i intspanset_kdtree_ops);
+CREATE INDEX
+CREATE INDEX tbl_tstzset_kdtree_idx ON tbl_tstzset USING SPGIST(t tstzset_kdtree_ops);
+CREATE INDEX
+CREATE INDEX tbl_tstzspan_kdtree_idx ON tbl_tstzspan USING SPGIST(t tstzspan_kdtree_ops);
+CREATE INDEX
+CREATE INDEX tbl_tstzspanset_kdtree_idx ON tbl_tstzspanset USING SPGIST(t tstzspanset_kdtree_ops);
+CREATE INDEX
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE 1
+DROP INDEX tbl_intset_kdtree_idx;
+DROP INDEX
+DROP INDEX tbl_intspan_kdtree_idx;
+DROP INDEX
+DROP INDEX tbl_intspanset_kdtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzset_kdtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzspan_kdtree_idx;
+DROP INDEX
+DROP INDEX tbl_tstzspanset_kdtree_idx;
+DROP INDEX
+SELECT count(*) FILTER (WHERE no_idx > 0) AS matching, count(*) AS pairs
+FROM test_spansupport;
+ matching | pairs 
+----------+-------
+       54 |    62
+(1 row)
+
+SELECT func, leftarg, rightarg FROM test_spansupport
+WHERE no_idx = 0 ORDER BY func, leftarg, rightarg;
+   func    |  leftarg   |  rightarg   
+-----------+------------+-------------
+ adjacent  | intspanset | intspanset
+ adjacent  | tstzspan   | tstzspanset
+ contained | tstzspan   | tstzspanset
+ contains  | intspan    | intspanset
+ contains  | tstzspan   | tstzspanset
+ left      | intspanset | intspanset
+ overlaps  | tstzspan   | tstzspanset
+ right     | intspanset | intspanset
+(8 rows)
+
+SELECT * FROM test_spansupport
+WHERE no_idx <> rtree_idx OR no_idx <> quadtree_idx OR no_idx <> kdtree_idx OR
+  no_idx IS NULL OR rtree_idx IS NULL OR quadtree_idx IS NULL OR kdtree_idx IS NULL
+ORDER BY func, leftarg, rightarg;
+ func | leftarg | rightarg | no_idx | rtree_idx | quadtree_idx | kdtree_idx 
+------+---------+----------+--------+-----------+--------------+------------
+(0 rows)
+
+DROP TABLE test_spansupport;
+DROP TABLE

--- a/mobilitydb/test/temporal/queries/010_span_ops_supportfn_tbl.test.sql
+++ b/mobilitydb/test/temporal/queries/010_span_ops_supportfn_tbl.test.sql
@@ -1,0 +1,823 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+
+-------------------------------------------------------------------------------
+-- Tests of the support function for the value-domain portable predicates.
+-- A predicate written in function form must answer exactly what it answers
+-- without an index, whichever index the planner rewrites it into.
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_intset_rtree_idx;
+DROP INDEX IF EXISTS tbl_intspan_rtree_idx;
+DROP INDEX IF EXISTS tbl_intspanset_rtree_idx;
+DROP INDEX IF EXISTS tbl_tstzset_rtree_idx;
+DROP INDEX IF EXISTS tbl_tstzspan_rtree_idx;
+DROP INDEX IF EXISTS tbl_tstzspanset_rtree_idx;
+
+DROP INDEX IF EXISTS tbl_intset_quadtree_idx;
+DROP INDEX IF EXISTS tbl_intspan_quadtree_idx;
+DROP INDEX IF EXISTS tbl_intspanset_quadtree_idx;
+DROP INDEX IF EXISTS tbl_tstzset_quadtree_idx;
+DROP INDEX IF EXISTS tbl_tstzspan_quadtree_idx;
+DROP INDEX IF EXISTS tbl_tstzspanset_quadtree_idx;
+
+DROP INDEX IF EXISTS tbl_intset_kdtree_idx;
+DROP INDEX IF EXISTS tbl_intspan_kdtree_idx;
+DROP INDEX IF EXISTS tbl_intspanset_kdtree_idx;
+DROP INDEX IF EXISTS tbl_tstzset_kdtree_idx;
+DROP INDEX IF EXISTS tbl_tstzspan_kdtree_idx;
+DROP INDEX IF EXISTS tbl_tstzspanset_kdtree_idx;
+
+-------------------------------------------------------------------------------
+
+DROP TABLE IF EXISTS test_spansupport;
+CREATE TABLE test_spansupport(
+  func TEXT,
+  leftarg TEXT,
+  rightarg TEXT,
+  no_idx BIGINT,
+  rtree_idx BIGINT,
+  quadtree_idx BIGINT,
+  kdtree_idx BIGINT
+);
+
+-------------------------------------------------------------------------------
+
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overlaps(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contains(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contained(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'left', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE left(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overleft', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overleft(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'right', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE right(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overright', 'intset', 'intset', COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overright(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overlaps(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contains(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contained(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'left', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE left(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overleft', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overleft(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'right', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE right(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overright', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overright(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'intspan', 'intspan', COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE adjacent(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'left', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE left(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overleft', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'right', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE right(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overright', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'intspanset', 'intspanset', COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'left', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE left(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overleft', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'right', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE right(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overright', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'intspan', 'intspanset', COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overlaps(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contains(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contained(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'before', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE before(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overbefore', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overbefore(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'after', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE after(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overafter', 'tstzset', 'tstzset', COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overafter(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overlaps(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contains(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contained(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'before', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE before(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overbefore', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overbefore(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'after', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE after(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overafter', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overafter(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'tstzspan', 'tstzspan', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE adjacent(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'before', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overbefore', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'after', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overafter', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'tstzspanset', 'tstzspanset', COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overlaps', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contains', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'contained', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'before', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overbefore', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'after', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'overafter', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t);
+INSERT INTO test_spansupport(func, leftarg, rightarg, no_idx)
+SELECT 'adjacent', 'tstzspan', 'tstzspanset', COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t);
+
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_intset_rtree_idx ON tbl_intset USING GIST(i);
+CREATE INDEX tbl_intspan_rtree_idx ON tbl_intspan USING GIST(i);
+CREATE INDEX tbl_intspanset_rtree_idx ON tbl_intspanset USING GIST(i);
+CREATE INDEX tbl_tstzset_rtree_idx ON tbl_tstzset USING GIST(t);
+CREATE INDEX tbl_tstzspan_rtree_idx ON tbl_tstzspan USING GIST(t);
+CREATE INDEX tbl_tstzspanset_rtree_idx ON tbl_tstzspanset USING GIST(t);
+
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+
+DROP INDEX tbl_intset_rtree_idx;
+DROP INDEX tbl_intspan_rtree_idx;
+DROP INDEX tbl_intspanset_rtree_idx;
+DROP INDEX tbl_tstzset_rtree_idx;
+DROP INDEX tbl_tstzspan_rtree_idx;
+DROP INDEX tbl_tstzspanset_rtree_idx;
+
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_intset_quadtree_idx ON tbl_intset USING SPGIST(i);
+CREATE INDEX tbl_intspan_quadtree_idx ON tbl_intspan USING SPGIST(i);
+CREATE INDEX tbl_intspanset_quadtree_idx ON tbl_intspanset USING SPGIST(i);
+CREATE INDEX tbl_tstzset_quadtree_idx ON tbl_tstzset USING SPGIST(t);
+CREATE INDEX tbl_tstzspan_quadtree_idx ON tbl_tstzspan USING SPGIST(t);
+CREATE INDEX tbl_tstzspanset_quadtree_idx ON tbl_tstzspanset USING SPGIST(t);
+
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+
+DROP INDEX tbl_intset_quadtree_idx;
+DROP INDEX tbl_intspan_quadtree_idx;
+DROP INDEX tbl_intspanset_quadtree_idx;
+DROP INDEX tbl_tstzset_quadtree_idx;
+DROP INDEX tbl_tstzspan_quadtree_idx;
+DROP INDEX tbl_tstzspanset_quadtree_idx;
+
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_intset_kdtree_idx ON tbl_intset USING SPGIST(i intset_kdtree_ops);
+CREATE INDEX tbl_intspan_kdtree_idx ON tbl_intspan USING SPGIST(i intspan_kdtree_ops);
+CREATE INDEX tbl_intspanset_kdtree_idx ON tbl_intspanset USING SPGIST(i intspanset_kdtree_ops);
+CREATE INDEX tbl_tstzset_kdtree_idx ON tbl_tstzset USING SPGIST(t tstzset_kdtree_ops);
+CREATE INDEX tbl_tstzspan_kdtree_idx ON tbl_tstzspan USING SPGIST(t tstzspan_kdtree_ops);
+CREATE INDEX tbl_tstzspanset_kdtree_idx ON tbl_tstzspanset USING SPGIST(t tstzspanset_kdtree_ops);
+
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intset t1, tbl_intset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intset' AND rightarg = 'intset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspan t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspanset t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspanset' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overlaps(t1.i, t2.i) )
+WHERE func = 'overlaps' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contains(t1.i, t2.i) )
+WHERE func = 'contains' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE contained(t1.i, t2.i) )
+WHERE func = 'contained' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE left(t1.i, t2.i) )
+WHERE func = 'left' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overleft(t1.i, t2.i) )
+WHERE func = 'overleft' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE right(t1.i, t2.i) )
+WHERE func = 'right' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE overright(t1.i, t2.i) )
+WHERE func = 'overright' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_intspan t1, tbl_intspanset t2 WHERE adjacent(t1.i, t2.i) )
+WHERE func = 'adjacent' AND leftarg = 'intspan' AND rightarg = 'intspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzset t1, tbl_tstzset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzset' AND rightarg = 'tstzset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspan t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspan';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspanset t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspanset' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overlaps(t1.t, t2.t) )
+WHERE func = 'overlaps' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contains(t1.t, t2.t) )
+WHERE func = 'contains' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE contained(t1.t, t2.t) )
+WHERE func = 'contained' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE before(t1.t, t2.t) )
+WHERE func = 'before' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overbefore(t1.t, t2.t) )
+WHERE func = 'overbefore' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE after(t1.t, t2.t) )
+WHERE func = 'after' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE overafter(t1.t, t2.t) )
+WHERE func = 'overafter' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+UPDATE test_spansupport
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tstzspan t1, tbl_tstzspanset t2 WHERE adjacent(t1.t, t2.t) )
+WHERE func = 'adjacent' AND leftarg = 'tstzspan' AND rightarg = 'tstzspanset';
+
+DROP INDEX tbl_intset_kdtree_idx;
+DROP INDEX tbl_intspan_kdtree_idx;
+DROP INDEX tbl_intspanset_kdtree_idx;
+DROP INDEX tbl_tstzset_kdtree_idx;
+DROP INDEX tbl_tstzspan_kdtree_idx;
+DROP INDEX tbl_tstzspanset_kdtree_idx;
+
+-------------------------------------------------------------------------------
+
+-- The pairs that match at least one row: a mismatch test over predicates
+-- that match nothing would hold vacuously
+SELECT count(*) FILTER (WHERE no_idx > 0) AS matching, count(*) AS pairs
+FROM test_spansupport;
+
+-- and the pairs the fixture leaves unexercised, named
+SELECT func, leftarg, rightarg FROM test_spansupport
+WHERE no_idx = 0 ORDER BY func, leftarg, rightarg;
+
+SELECT * FROM test_spansupport
+WHERE no_idx <> rtree_idx OR no_idx <> quadtree_idx OR no_idx <> kdtree_idx OR
+  no_idx IS NULL OR rtree_idx IS NULL OR quadtree_idx IS NULL OR kdtree_idx IS NULL
+ORDER BY func, leftarg, rightarg;
+
+DROP TABLE test_spansupport;
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -928,6 +928,40 @@ Three facts bound which declarations carry the clause:
   `TPCBox` and no scalar conversion to it exists to build an index expression
   from, so a clause there could never fire.
 
+### 10.6 The value domain is its own bounding box
+
+A set, span, span set or bounding-box type needs no conversion to be indexed: it
+IS the value the opclass stores. Its portable predicates therefore carry a
+fourth entry point, `span_supportfn`, over the same shared
+`temporal_supportfn(fcinfo, tempfamily)` under the `SPANTYPE` family, and the
+box-building step is skipped — the operand is passed through as-is.
+
+`SpanStrategies[]` carries **both** axes, because one array serves types whose
+single dimension is spelled differently: a time span answers the
+`before`/`after` family and a number span the `left`/`right` one. The axis a
+given span does not have simply finds no operator for its strategy and keeps the
+predicate as a filter, so no per-type table is needed.
+
+The gate is `span_sel_type() || bbox_type()`. ⛔ The `bbox_type` half is not
+redundant: `tbox` and `stbox` have GiST opclasses of their own, so a predicate
+written over a bare box is indexable in exactly the same as-is way. Note the
+consequence of the operand being passed through unchanged — for a `tstzspan`
+the `bbox_type` and `span_sel_type` halves would both accept it, which is why
+`bbox_type` is tested second.
+
+The generator attaches the clause through `_with_span_support()`, wired into
+`_spanfile_fns`, `_spanfile_group`, `_topop_fns` and `_posop_fns`. ⛔ It is
+deliberately **not** wired into `comparisons.sql.tmpl`: that template is shared
+by ten other surfaces, and the equality predicates it renders are not the
+portable spellings of a bounding-box operator.
+
+⛔ `span_supportfn(internal)` must be declared **before** the first file that
+uses it in bundle order — the SQL files concatenate in sorted filename order, so
+the declaration lives at the head of `002_set_ops.in.sql`, above the generated
+region rather than inside it. A `CREATE EXTENSION` is the only thing that
+catches a misplacement; the build never parses the bundle.
+
+
 ---
 
 ### Legend

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -2020,10 +2020,11 @@ def _topop_sel(fam: dict, idx: int) -> str:
 def _topop_fns(op: str, pairs: list) -> str:
     """The predicate's CREATE FUNCTIONs for every (value, set) pair, all packed."""
     tmpl = (TEMPLATES / "comparisons.sql.tmpl").read_text().rstrip("\n")
-    return "\n".join(tmpl.replace("{SIG}", sig.format(v=v, s=s))
-                         .replace("{RET}", "boolean").replace("{SYM}", sym)
-                     for v, s in pairs
-                     for sig, sym in _TOPOP_FNS[op]) + "\n"
+    return _with_span_support(
+        "\n".join(tmpl.replace("{SIG}", sig.format(v=v, s=s))
+                      .replace("{RET}", "boolean").replace("{SYM}", sym)
+                  for v, s in pairs
+                  for sig, sym in _TOPOP_FNS[op]) + "\n")
 
 
 def _topop_ops(op: str, fam: dict) -> str:
@@ -2152,7 +2153,7 @@ def _posop_fns(pos: str, fam: dict) -> str:
                                                  f"{r.format(v=v, s=s)})")
                                .replace("{RET}", "boolean")
                                .replace("{SYM}", f"{name.capitalize()}_{dsym}"))
-    return "\n".join(out) + "\n"
+    return _with_span_support("\n".join(out) + "\n")
 
 
 def _posop_ops(pos: str, fam: dict) -> str:
@@ -2874,6 +2875,28 @@ def _spanfile_sub(text: str, tok: dict) -> str:
     return text
 
 
+# A portable bounding-box predicate over a value-domain type answers the operator
+# its own opclass declares, so it carries the support function that rewrites it
+# into that operator. The clause is inserted into the shared four-line skeleton
+# here rather than added to the skeleton itself, which a dozen other surfaces
+# render and which carries no support function.
+_SPAN_PORTABLE = {"overlaps", "contains", "contained", "adjacent", "same",
+                  "before", "after", "overbefore", "overafter",
+                  "left", "right", "overleft", "overright"}
+
+
+def _with_span_support(text: str) -> str:
+    """Add the value-domain support clause to every portable predicate in the
+    rendered functions, leaving every other declaration untouched."""
+    out = []
+    for decl in text.split("CREATE FUNCTION "):
+        if decl and decl.split("(", 1)[0].strip().lower() in _SPAN_PORTABLE:
+            decl = decl.replace("  LANGUAGE C",
+                                "  SUPPORT span_supportfn\n  LANGUAGE C", 1)
+        out.append(decl)
+    return "CREATE FUNCTION ".join(out)
+
+
 def _spanfile_fns(blk: dict, fam: dict) -> str:
     """One CREATE FUNCTION template emitted per instantiation, packed."""
     tmpl = (TEMPLATES / "comparisons.sql.tmpl").read_text().rstrip("\n")
@@ -2885,7 +2908,7 @@ def _spanfile_fns(blk: dict, fam: dict) -> str:
         out.append(tmpl.replace("{SIG}", _spanfile_sub(spec["sig"], tok))
                        .replace("{RET}", _spanfile_sub(spec["ret"], tok))
                        .replace("{SYM}", spec["sym"]))
-    return "\n".join(out) + "\n"
+    return _with_span_support("\n".join(out) + "\n")
 
 
 def _spanfile_group(blk: dict, fam: dict) -> str:
@@ -2908,7 +2931,7 @@ def _spanfile_group(blk: dict, fam: dict) -> str:
         clusters.append("\n".join(parts))
     # A type's whole cluster precedes the next type's, separated by `sep`
     # (default: packed; the I/O sections separate clusters by one blank line).
-    return (("\n" + blk.get("sep", "")).join(clusters)) + "\n"
+    return _with_span_support((("\n" + blk.get("sep", "")).join(clusters)) + "\n")
 
 
 def _spanfile_stmts(blk: dict, fam: dict) -> str:


### PR DESCRIPTION
The portable functions on sets, spans, span sets and bounding boxes carry a SUPPORT function that rewrites overlaps, contains, contained, adjacent, same and the position predicates into the equivalent indexable operator, so a predicate written in function form is answered by an index scan instead of a sequential scan. A value-domain type is its own bounding box, so the operand is passed through as-is; the rewrite consults pg_operator.oprcom for the commuted form, and declines when the operator family holds no member for the strategy.