### PR TITLE
Name the box topological predicates by their portable spelling

### DIFF
--- a/mobilitydb/sql/geo/051_stbox.in.sql
+++ b/mobilitydb/sql/geo/051_stbox.in.sql
@@ -399,53 +399,58 @@ AS 'MODULE_PATHNAME', 'Tspatial_joinsel'
 * Topological operators
 *****************************************************************************/
 
-CREATE FUNCTION stbox_contains(stbox, stbox)
+CREATE FUNCTION contains(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION stbox_contained(stbox, stbox)
+CREATE FUNCTION contained(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION stbox_overlaps(stbox, stbox)
+CREATE FUNCTION overlaps(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION stbox_same(stbox, stbox)
+CREATE FUNCTION same(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION stbox_adjacent(stbox, stbox)
+CREATE FUNCTION adjacent(stbox, stbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_stbox_stbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = stbox_contains,
+  PROCEDURE = contains,
   LEFTARG = stbox, RIGHTARG = stbox,
   COMMUTATOR = <@,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = stbox_contained,
+  PROCEDURE = contained,
   LEFTARG = stbox, RIGHTARG = stbox,
   COMMUTATOR = @>,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 CREATE OPERATOR && (
-  PROCEDURE = stbox_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = stbox, RIGHTARG = stbox,
   COMMUTATOR = &&,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 CREATE OPERATOR ~= (
-  PROCEDURE = stbox_same,
+  PROCEDURE = same,
   LEFTARG = stbox, RIGHTARG = stbox,
   COMMUTATOR = ~=,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 CREATE OPERATOR -|- (
-  PROCEDURE = stbox_adjacent,
+  PROCEDURE = adjacent,
   LEFTARG = stbox, RIGHTARG = stbox,
   COMMUTATOR = -|-,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel

--- a/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
+++ b/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
@@ -238,44 +238,49 @@ CREATE OPERATOR * (
  * Topological predicates
  ******************************************************************************/
 
-CREATE FUNCTION tpcbox_contains(tpcbox, tpcbox)
+CREATE FUNCTION contains(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Contains_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_contained(tpcbox, tpcbox)
+CREATE FUNCTION contained(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Contained_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_overlaps(tpcbox, tpcbox)
+CREATE FUNCTION overlaps(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Overlaps_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_same(tpcbox, tpcbox)
+CREATE FUNCTION same(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Same_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_adjacent(tpcbox, tpcbox)
+CREATE FUNCTION adjacent(tpcbox, tpcbox)
   RETURNS boolean AS 'MODULE_PATHNAME', 'Adjacent_tpcbox_tpcbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = tpcbox_contains,
+  PROCEDURE = contains,
   LEFTARG = tpcbox, RIGHTARG = tpcbox,
   COMMUTATOR = <@
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = tpcbox_contained,
+  PROCEDURE = contained,
   LEFTARG = tpcbox, RIGHTARG = tpcbox,
   COMMUTATOR = @>
 );
 CREATE OPERATOR && (
-  PROCEDURE = tpcbox_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = tpcbox, RIGHTARG = tpcbox,
   COMMUTATOR = &&
 );
 CREATE OPERATOR ~= (
-  PROCEDURE = tpcbox_same,
+  PROCEDURE = same,
   LEFTARG = tpcbox, RIGHTARG = tpcbox,
   COMMUTATOR = ~=
 );
 CREATE OPERATOR -|- (
-  PROCEDURE = tpcbox_adjacent,
+  PROCEDURE = adjacent,
   LEFTARG = tpcbox, RIGHTARG = tpcbox,
   COMMUTATOR = -|-
 );

--- a/mobilitydb/sql/temporal/021_tbox.in.sql
+++ b/mobilitydb/sql/temporal/021_tbox.in.sql
@@ -404,53 +404,58 @@ CREATE FUNCTION tnumber_joinsel(internal, oid, internal, smallint, internal)
  * Topological operators
  *****************************************************************************/
 
-CREATE FUNCTION tbox_contains(tbox, tbox)
+CREATE FUNCTION contains(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tbox_contained(tbox, tbox)
+CREATE FUNCTION contained(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tbox_overlaps(tbox, tbox)
+CREATE FUNCTION overlaps(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tbox_same(tbox, tbox)
+CREATE FUNCTION same(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tbox_adjacent(tbox, tbox)
+CREATE FUNCTION adjacent(tbox, tbox)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tbox_tbox'
+  SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (
-  PROCEDURE = tbox_contains,
+  PROCEDURE = contains,
   LEFTARG = tbox, RIGHTARG = tbox,
   COMMUTATOR = <@,
   RESTRICT = tnumber_sel, JOIN = tnumber_joinsel
 );
 CREATE OPERATOR <@ (
-  PROCEDURE = tbox_contained,
+  PROCEDURE = contained,
   LEFTARG = tbox, RIGHTARG = tbox,
   COMMUTATOR = @>,
   RESTRICT = tnumber_sel, JOIN = tnumber_joinsel
 );
 CREATE OPERATOR && (
-  PROCEDURE = tbox_overlaps,
+  PROCEDURE = overlaps,
   LEFTARG = tbox, RIGHTARG = tbox,
   COMMUTATOR = &&,
   RESTRICT = tnumber_sel, JOIN = tnumber_joinsel
 );
 CREATE OPERATOR ~= (
-  PROCEDURE = tbox_same,
+  PROCEDURE = same,
   LEFTARG = tbox, RIGHTARG = tbox,
   COMMUTATOR = ~=,
   RESTRICT = tnumber_sel, JOIN = tnumber_joinsel
 );
 CREATE OPERATOR -|- (
-  PROCEDURE = tbox_adjacent,
+  PROCEDURE = adjacent,
   LEFTARG = tbox, RIGHTARG = tbox,
   COMMUTATOR = -|-,
   RESTRICT = tnumber_sel, JOIN = tnumber_joinsel

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -1033,6 +1033,36 @@ SELECT stbox 'STBOX Z((1.0,1.0,1.0),(2.0,2.0,2.0))' ~= stbox 'STBOX Z((1.0,1.0,1
  f
 (1 row)
 
+SELECT overlaps(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+ overlaps 
+----------
+ t
+(1 row)
+
+SELECT contains(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+ contains 
+----------
+ t
+(1 row)
+
+SELECT contained(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+ contained 
+-----------
+ f
+(1 row)
+
+SELECT adjacent(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+ adjacent 
+----------
+ t
+(1 row)
+
+SELECT same(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+ same 
+------
+ f
+(1 row)
+
 SELECT stbox 'STBOX Z((0 0 0),(2 2 2))' -|- stbox 'STBOX Z((1 1 1),(3 3 3))';
  ?column? 
 ----------

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -291,6 +291,13 @@ SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' -|- stbox 'STBOX XT(((1.0,2.0),(1.0,
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' ~= stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])';
 SELECT stbox 'STBOX Z((1.0,1.0,1.0),(2.0,2.0,2.0))' ~= stbox 'STBOX Z((1.0,1.0,1.0),(2.0,2.0,3.0))';
 
+-- The portable spelling of each operator above answers the same
+SELECT overlaps(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+SELECT contains(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+SELECT contained(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+SELECT adjacent(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+SELECT same(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2000-01-01,2000-01-01])');
+
 SELECT stbox 'STBOX Z((0 0 0),(2 2 2))' -|- stbox 'STBOX Z((1 1 1),(3 3 3))';
 SELECT tstzspan '[2000-01-01, 2000-01-02]'::stbox -|- tstzspan '[2000-01-02, 2000-01-03]'::stbox;
 

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -170,8 +170,38 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 1, 0);
  t
 (1 row)
 
+SELECT contains(tpcbox(0, 0, 10, 10, 1, 0), tpcbox(2, 2, 8, 8, 1, 0));
+ contains 
+----------
+ t
+(1 row)
+
+SELECT contained(tpcbox(2, 2, 8, 8, 1, 0), tpcbox(0, 0, 10, 10, 1, 0));
+ contained 
+-----------
+ t
+(1 row)
+
+SELECT overlaps(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(3, 3, 10, 10, 1, 0));
+ overlaps 
+----------
+ t
+(1 row)
+
+SELECT same(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(0, 0, 5, 5, 1, 0));
+ same 
+------
+ t
+(1 row)
+
 SELECT tpcbox(0, 0, 5, 5, 1, 0)  -|- tpcbox(5, 0, 10, 5, 1, 0);
  ?column? 
+----------
+ f
+(1 row)
+
+SELECT adjacent(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(5, 0, 10, 5, 1, 0));
+ adjacent 
 ----------
  f
 (1 row)

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -82,7 +82,14 @@ SELECT tpcbox(2, 2, 8, 8, 1, 0)   <@ tpcbox(0, 0, 10, 10, 1, 0);
 SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(3, 3, 10, 10, 1, 0);
 SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(50, 50, 60, 60, 1, 0);
 SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 1, 0);
+
+-- The portable spelling of each operator above answers the same
+SELECT contains(tpcbox(0, 0, 10, 10, 1, 0), tpcbox(2, 2, 8, 8, 1, 0));
+SELECT contained(tpcbox(2, 2, 8, 8, 1, 0), tpcbox(0, 0, 10, 10, 1, 0));
+SELECT overlaps(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(3, 3, 10, 10, 1, 0));
+SELECT same(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(0, 0, 5, 5, 1, 0));
 SELECT tpcbox(0, 0, 5, 5, 1, 0)  -|- tpcbox(5, 0, 10, 5, 1, 0);
+SELECT adjacent(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(5, 0, 10, 5, 1, 0));
 
 -------------------------------------------------------------------------------
 -- Topological predicates — pcid mismatch always returns false

--- a/mobilitydb/test/temporal/expected/021_tbox.test.out
+++ b/mobilitydb/test/temporal/expected/021_tbox.test.out
@@ -883,6 +883,36 @@ SELECT tstzspan '[2000-01-01,2000-01-02]'::tbox -|- tstzspan '[2000-01-02, 2000-
  t
 (1 row)
 
+SELECT overlaps(tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+ overlaps 
+----------
+ t
+(1 row)
+
+SELECT contains(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+ contains 
+----------
+ f
+(1 row)
+
+SELECT contained(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+ contained 
+-----------
+ f
+(1 row)
+
+SELECT adjacent(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+ adjacent 
+----------
+ t
+(1 row)
+
+SELECT same(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+ same 
+------
+ f
+(1 row)
+
 /* Errors */
 SELECT tbox 'TBOXFLOAT X([1,2])' && tbox 'TBOX T([2000-01-01,2000-01-02])';
 ERROR:  The temporal values must have at least one common dimension

--- a/mobilitydb/test/temporal/queries/021_tbox.test.sql
+++ b/mobilitydb/test/temporal/queries/021_tbox.test.sql
@@ -270,6 +270,13 @@ SELECT tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])' ~= tbox 'TBOXFLO
 
 SELECT tstzspan '[2000-01-01,2000-01-02]'::tbox -|- tstzspan '[2000-01-02, 2000-01-03]'::tbox;
 
+-- The portable spelling of each operator above answers the same
+SELECT overlaps(tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+SELECT contains(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+SELECT contained(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+SELECT adjacent(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+SELECT same(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
+
 /* Errors */
 SELECT tbox 'TBOXFLOAT X([1,2])' && tbox 'TBOX T([2000-01-01,2000-01-02])';
 SELECT tbox 'TBOXFLOAT X([1,2])' @> tbox 'TBOX T([2000-01-01,2000-01-02])';


### PR DESCRIPTION
The topological predicates between two bounding boxes are callable as contains, contained, overlaps, same and adjacent on tbox, stbox and tpcbox, the spelling their @sqlfn tag already declares and the one their position siblings in the same files carry, so every bounding-box operator has the bare named function the portable dialect documents. They carry the SUPPORT function that answers them from the index.