### PR TITLE
Write and read the OGC GeoPose Composite Chain class

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1786,6 +1786,14 @@
 				</itemizedlist>
 			</sect3>
 			<sect3>
+				<title>Cadena compuesta OGC GeoPose</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tposechain_asGeoPose"><varname>asGeoPose</varname>, <varname>tposechainFromGeoPose</varname></link>: Escribe o lee un documento de cadena compuesta OGC GeoPose</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+			<sect3>
 				<title>Funciones de restricción</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/es/temporal_pose_chains.xml
+++ b/doc/es/temporal_pose_chains.xml
@@ -573,6 +573,34 @@ SELECT asEWKT(round(transformPipeline(tposechain
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tposechain_geopose">
+			<title>Cadena compuesta OGC GeoPose</title>
+			<itemizedlist>
+				<listitem xml:id="tposechain_asGeoPose">
+					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tposechainFromGeoPose</varname></primary></indexterm>
+					<para>Escribe o lee un documento de cadena compuesta OGC GeoPose</para>
+					<para><varname>asGeoPose(tposechain,maxdecimaldigits integer=-1) &#8594; text</varname></para>
+					<para><varname>tposechainFromGeoPose(text) &#8594; tposechain</varname></para>
+					<para>Un documento de cadena es un marco exterior y una secuencia de transformaciones que alcanza un marco interior final, que es lo que contiene una cadena de poses. El documento nombra el marco LTP-ENU tangente en la posición del eslabón exterior y una transformación por eslabón: la primera lleva ese marco tangente al marco propio del eslabón exterior, y cada una posterior es el eslabón tal como se almacena, leído en los ejes de su padre.</para>
+					<para>El documento lleva un único tiempo de validez, por lo que se escribe a partir de un solo instante; <link linkend="tposechain_atTime"><varname>atTime</varname></link> obtiene uno de un valor más largo. Su cadena de marcos contiene al menos dos marcos, por lo que una cadena de un solo eslabón no tiene documento de cadena.</para>
+					<para>La clase de cadena nombra sus dos marcos <varname>/Extrinsic/LTP-ENU</varname> e <varname>/Intrinsic/Translate-Rotate</varname>, mientras que las clases Advanced, Series y Stream nombran esos mismos dos marcos <varname>LTP-ENU</varname> y <varname>RotateTranslate</varname>. Un documento se escribe con el par que usa su propia clase, y cualquiera de los dos pares se acepta al leer.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(
+  GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+  Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00', 6);
+/* {"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0",
+   "id":"/Extrinsic/LTP-ENU","parameters":"longitude=-122.3&amp;latitude=47.7&amp;
+   height=11&amp;crs=EPSG:4979"},"frameChain":[{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&amp;
+   rotation=[1, 0, -1.38778e-17, 0]"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[2, 0, 0]&amp;
+   rotation=[1, 0, 0, 0]"}]} */
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tposechain_restrictions">
 			<title>Funciones de restricción</title>
 			<itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1797,6 +1797,14 @@
 				</itemizedlist>
 			</sect3>
 			<sect3>
+				<title>OGC GeoPose Composite Chain</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tposechain_asGeoPose"><varname>asGeoPose</varname>, <varname>tposechainFromGeoPose</varname></link>: Write or read an OGC GeoPose Composite Chain document</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+			<sect3>
 				<title>Restriction Functions</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/temporal_pose_chains.xml
+++ b/doc/temporal_pose_chains.xml
@@ -573,6 +573,34 @@ SELECT asEWKT(round(transformPipeline(tposechain
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tposechain_geopose">
+			<title>OGC GeoPose Composite Chain</title>
+			<itemizedlist>
+				<listitem xml:id="tposechain_asGeoPose">
+					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>tposechainFromGeoPose</varname></primary></indexterm>
+					<para>Write or read an OGC GeoPose Composite Chain document</para>
+					<para><varname>asGeoPose(tposechain,maxdecimaldigits integer=-1) &#8594; text</varname></para>
+					<para><varname>tposechainFromGeoPose(text) &#8594; tposechain</varname></para>
+					<para>A Chain document is an outer frame and a sequence of transformations reaching a final innermost frame, which is what a pose chain holds. The document names the LTP-ENU frame tangent at the outer link's position and one transformation per link: the first takes that tangent frame to the outer link's own frame, and each later one is the link as it is stored, read in the axes of its parent.</para>
+					<para>The document carries one valid time, so it is written from a single instant; <link linkend="tposechain_atTime"><varname>atTime</varname></link> obtains one from a longer value. Its frame chain holds at least two frames, so a chain of one link has no Chain document.</para>
+					<para>The Chain class names its two frames <varname>/Extrinsic/LTP-ENU</varname> and <varname>/Intrinsic/Translate-Rotate</varname>, where the Advanced, Series and Stream classes name the same two frames <varname>LTP-ENU</varname> and <varname>RotateTranslate</varname>. A document is written with the pair its own class uses, and either pair is accepted on reading.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(
+  GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+  Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00', 6);
+/* {"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0",
+   "id":"/Extrinsic/LTP-ENU","parameters":"longitude=-122.3&amp;latitude=47.7&amp;
+   height=11&amp;crs=EPSG:4979"},"frameChain":[{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&amp;
+   rotation=[1, 0, -1.38778e-17, 0]"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[2, 0, 0]&amp;
+   rotation=[1, 0, 0, 0]"}]} */
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tposechain_restrictions">
 			<title>Restriction Functions</title>
 			<itemizedlist>

--- a/meos/include/meos_posechain.h
+++ b/meos/include/meos_posechain.h
@@ -147,6 +147,15 @@ extern PoseChain *posechain_set_srid(const PoseChain *pc, int32_t srid);
 extern PoseChain *posechain_transform(const PoseChain *pc, int32_t srid_to);
 extern PoseChain *posechain_transform_pipeline(const PoseChain *pc, const char *pipeline, int32_t srid_to, bool is_forward);
 
+/*****************************************************************************
+ * Functions for temporal pose chains
+ *****************************************************************************/
+
+/* OGC GeoPose input/output functions for temporal pose chains */
+
+extern Temporal *tposechain_from_geopose(const char *json);
+extern char *tposechain_as_geopose(const Temporal *temp, int precision);
+
 /* Comparison functions */
 
 extern bool posechain_eq(const PoseChain *pc1, const PoseChain *pc2);

--- a/meos/include/pose/pose_geopose.h
+++ b/meos/include/pose/pose_geopose.h
@@ -57,7 +57,8 @@
  * entry points of its own. A Series carries a quaternion in every inner frame
  * and offers no orientation choice.
  *
- * The Chain and Graph classes are not implemented.
+ * The Chain class is written from a temporal pose chain, whose links are the
+ * nested frames it names. The Graph class is not implemented.
  */
 typedef enum
 {

--- a/meos/include/posechain/doxygen_meos_posechain.h
+++ b/meos/include/posechain/doxygen_meos_posechain.h
@@ -35,6 +35,34 @@
  * @defgroup meos_posechain_set Functions for pose chain sets
  * @ingroup meos_posechain
  * @brief Functions for pose chain sets
+ *
+ * @defgroup meos_posechain_inout Input and output functions
+ * @ingroup meos_posechain
+ * @brief Input and output functions for temporal pose chains
+ *
+ * @defgroup meos_posechain_constructor Constructor functions
+ * @ingroup meos_posechain
+ * @brief Constructor functions for temporal pose chains
+ *
+ * @defgroup meos_posechain_conversion Conversion functions
+ * @ingroup meos_posechain
+ * @brief Conversion functions for temporal pose chains
+ *
+ * @defgroup meos_posechain_accessor Accessor functions
+ * @ingroup meos_posechain
+ * @brief Accessor functions for temporal pose chains
+ *
+ * @defgroup meos_posechain_comp Comparison functions
+ * @ingroup meos_posechain
+ * @brief Comparison functions for temporal pose chains
+ *
+ *   @defgroup meos_posechain_comp_ever Ever and always comparison functions
+ *   @ingroup meos_posechain_comp
+ *   @brief Ever and always comparison functions for temporal pose chains
+ *
+ *   @defgroup meos_posechain_comp_temp Temporal comparison functions
+ *   @ingroup meos_posechain_comp
+ *   @brief Temporal comparison functions for temporal pose chains
  */
 
 /*****************************************************************************/
@@ -63,6 +91,10 @@
  * @defgroup meos_posechain_base_srid Spatial reference system functions
  * @ingroup meos_posechain_base
  * @brief Spatial reference system functions for static pose chains
+ *
+ * @defgroup meos_posechain_base_bbox Bounding box functions
+ * @ingroup meos_posechain_base
+ * @brief Bounding box functions for static pose chains
  *
  * @defgroup meos_posechain_base_comp Comparison functions
  * @ingroup meos_posechain_base

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -106,6 +106,10 @@
 #include "temporal/type_util.h"     /* pfree_array */
 #include "pose/pose.h"
 #include "pose/pose_geopose.h"
+#if POSECHAIN
+  #include <meos_posechain.h>
+  #include "posechain/posechain.h"
+#endif
 
 /*****************************************************************************
  * Helpers
@@ -132,6 +136,13 @@
 #define GEOPOSE_AUTHORITY       "/geopose/1.0"
 #define GEOPOSE_ID_OUTER_FRAME  "LTP-ENU"
 #define GEOPOSE_ID_INNER_FRAME  "RotateTranslate"
+/* The Chain class names the same two frames differently: its normative
+ * instance writes `/Extrinsic/LTP-ENU` and `/Intrinsic/Translate-Rotate`
+ * where the Advanced, Series and Stream instances write the bare pair above,
+ * under the one authority. A document is written with the pair its own class
+ * uses, and a Chain is read accepting either. */
+#define GEOPOSE_ID_CHAIN_OUTER_FRAME  "/Extrinsic/LTP-ENU"
+#define GEOPOSE_ID_CHAIN_INNER_FRAME  "/Intrinsic/Translate-Rotate"
 
 /**
  * @brief Return true if @p srid names the WGS-84 geographic frame the
@@ -1051,7 +1062,8 @@ geopose_transition_model_interp(json_object *tm)
  * @return On error return @p NULL
  */
 static json_object *
-geopose_inner_frame(const GeoPoseAnchor *anchor, const Pose *pose,
+geopose_inner_frame(const char *id, const GeoPoseAnchor *anchor,
+  const Pose *pose,
   int precision)
 {
   double lon, lat, h, W, X, Y, Z;
@@ -1079,7 +1091,7 @@ geopose_inner_frame(const GeoPoseAnchor *anchor, const Pose *pose,
   snprintf(params, sizeof(params),
     "translation=[%s, %s, %s]&rotation=[%s, %s, %s, %s]",
     be, bn, bu, bw, bx, by, bz);
-  return geopose_frame_spec(GEOPOSE_ID_INNER_FRAME, params);
+  return geopose_frame_spec(id, params);
 }
 
 /**
@@ -1087,7 +1099,8 @@ geopose_inner_frame(const GeoPoseAnchor *anchor, const Pose *pose,
  * anchor's tangent point.
  */
 static json_object *
-geopose_outer_frame(const GeoPoseAnchor *anchor, int precision)
+geopose_outer_frame(const char *id, const GeoPoseAnchor *anchor,
+  int precision)
 {
   char blon[64], blat[64], bh[64];
   geopose_str_double(blon, sizeof(blon), GEOPOSE_RAD2DEG(anchor->lon_rad),
@@ -1103,7 +1116,7 @@ geopose_outer_frame(const GeoPoseAnchor *anchor, int precision)
   snprintf(params, sizeof(params),
     "longitude=%s&latitude=%s&height=%s&crs=EPSG:%d",
     blon, blat, bh, GEOPOSE_SRID_WGS84_3D);
-  return geopose_frame_spec(GEOPOSE_ID_OUTER_FRAME, params);
+  return geopose_frame_spec(id, params);
 }
 
 /**
@@ -1129,7 +1142,7 @@ pose_to_geopose_advanced(const Pose *pose, int precision)
 
   json_object *root = json_object_new_object();
   json_object_object_add(root, "frameSpecification",
-    geopose_outer_frame(&anchor, precision));
+    geopose_outer_frame(GEOPOSE_ID_OUTER_FRAME, &anchor, precision));
   json_object *jq = json_object_new_object();
   json_object_object_add(jq, "x", geopose_new_double(X, precision));
   json_object_object_add(jq, "y", geopose_new_double(Y, precision));
@@ -1248,7 +1261,7 @@ tpose_to_geopose_series(const Temporal *temp, bool regular, int precision)
   json_object *arr = json_object_new_array();
   for (int i = 0; i < count; i++)
   {
-    json_object *frame = geopose_inner_frame(&anchor,
+    json_object *frame = geopose_inner_frame(GEOPOSE_ID_INNER_FRAME, &anchor,
       DatumGetPoseP(tinstant_value_p(instants[i])), precision);
     if (frame == NULL)
     {
@@ -1276,7 +1289,7 @@ tpose_to_geopose_series(const Temporal *temp, bool regular, int precision)
     json_object_object_add(root, "interPoseDuration",
       json_object_new_int64(duration));
   json_object_object_add(root, "outerFrame",
-    geopose_outer_frame(&anchor, precision));
+    geopose_outer_frame(GEOPOSE_ID_OUTER_FRAME, &anchor, precision));
   json_object_object_add(root, regular ? "innerFrameSeries" :
     "innerFrameAndTimeSeries", arr);
   json_object_object_add(root, "trailer", geopose_series_trailer(count));
@@ -1617,7 +1630,7 @@ geopose_stream_header_obj(const Temporal *temp, const GeoPoseAnchor *anchor,
   json_object_object_add(res, "transitionModel",
     geopose_transition_model(MEOS_FLAGS_GET_INTERP(temp->flags)));
   json_object_object_add(res, "outerFrame",
-    geopose_outer_frame(anchor, precision));
+    geopose_outer_frame(GEOPOSE_ID_OUTER_FRAME, anchor, precision));
   return res;
 }
 
@@ -1629,7 +1642,7 @@ static json_object *
 geopose_stream_element_obj(const GeoPoseAnchor *anchor, const TInstant *inst,
   int precision)
 {
-  json_object *frame = geopose_inner_frame(anchor,
+  json_object *frame = geopose_inner_frame(GEOPOSE_ID_INNER_FRAME, anchor,
     DatumGetPoseP(tinstant_value_p(inst)), precision);
   if (frame == NULL)
     return NULL;
@@ -1997,5 +2010,230 @@ tpose_from_geopose(const char *json)
   json_object_put(root);
   return result;
 }
+
+#if POSECHAIN
+/*****************************************************************************
+ * OGC GeoPose Composite Chain class
+ *
+ * A Chain document names an outer frame and a sequence of transformations
+ * reaching a final innermost frame, which is what a pose chain holds: its
+ * outer link is placed in a topocentric frame and every later link is a rigid
+ * transformation read in the axes of the link before it.
+ *****************************************************************************/
+
+/**
+ * @brief Build the FrameSpecification of a link that is read in the axes of
+ * the link before it
+ * @details Only the outer link names a frame, so every later link travels as
+ * the translation and rotation it stores, with no geodesy applied.
+ */
+static json_object *
+geopose_chain_link_frame(const Pose *pose, int precision)
+{
+  bool hasz = MEOS_FLAGS_GET_Z(pose->flags);
+  double x = pose->data[0], y = pose->data[1], z = hasz ? pose->data[2] : 0.0;
+  double W, X, Y, Z;
+  if (hasz)
+  {
+    W = pose->data[3]; X = pose->data[4];
+    Y = pose->data[5]; Z = pose->data[6];
+  }
+  else
+  {
+    /* A planar link turns about the vertical axis by its stored angle */
+    double half = pose->data[2] / 2.0;
+    W = cos(half); X = 0.0; Y = 0.0; Z = sin(half);
+  }
+  char bx[64], by[64], bz[64], bw[64], bqx[64], bqy[64], bqz[64];
+  geopose_str_double(bx, sizeof(bx), x, precision);
+  geopose_str_double(by, sizeof(by), y, precision);
+  geopose_str_double(bz, sizeof(bz), z, precision);
+  geopose_str_double(bw, sizeof(bw), W, precision);
+  geopose_str_double(bqx, sizeof(bqx), X, precision);
+  geopose_str_double(bqy, sizeof(bqy), Y, precision);
+  geopose_str_double(bqz, sizeof(bqz), Z, precision);
+  char params[512];
+  snprintf(params, sizeof(params),
+    "translation=[%s, %s, %s]&rotation=[%s, %s, %s, %s]",
+    bx, by, bz, bw, bqx, bqy, bqz);
+  return geopose_frame_spec(GEOPOSE_ID_CHAIN_INNER_FRAME, params);
+}
+
+/**
+ * @ingroup meos_posechain_inout
+ * @brief Return the OGC GeoPose Composite Chain JSON representation of a
+ * temporal pose chain
+ * @details The document carries the valid time of the instant, the LTP-ENU
+ * frame tangent at the outer link's position, and one transformation per
+ * link. The first of them takes that tangent frame to the outer link's own
+ * frame; each later one is the link as it is stored, read in the axes of its
+ * parent.
+ * @param[in] temp Temporal pose chain holding a single instant
+ * @param[in] precision Maximum number of decimal digits
+ * @return On error return @p NULL
+ * @csqlfn #Tposechain_as_geopose()
+ */
+char *
+tposechain_as_geopose(const Temporal *temp, int precision)
+{
+  VALIDATE_TPOSECHAIN(temp, NULL);
+  if (temp->subtype != TINSTANT)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "A GeoPose Chain document carries one valid time, so it is written "
+      "from a single instant; use atTime to obtain one");
+    return NULL;
+  }
+  const TInstant *inst = (const TInstant *) temp;
+  const PoseChain *pc = DatumGetPoseChainP(tinstant_value_p(inst));
+  int count = posechain_num_poses(pc);
+  if (count < 2)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "A GeoPose Chain frame chain holds at least two frames, and the pose "
+      "chain holds %d", count);
+    return NULL;
+  }
+  Pose *outer = posechain_pose_n(pc, 1);
+  if (outer == NULL)
+    return NULL;
+  GeoPoseAnchor anchor;
+  double lon, lat, h, W, X, Y, Z;
+  if (! geopose_pose_components(outer, &lon, &lat, &h, &W, &X, &Y, &Z))
+  {
+    pfree(outer);
+    return NULL;
+  }
+  geopose_anchor_set(&anchor, GEOPOSE_DEG2RAD(lat), GEOPOSE_DEG2RAD(lon), h);
+
+  json_object *root = json_object_new_object();
+  json_object_object_add(root, "validTime",
+    json_object_new_int64(geopose_instant_out(inst->t)));
+  json_object_object_add(root, "outerFrame",
+    geopose_outer_frame(GEOPOSE_ID_CHAIN_OUTER_FRAME, &anchor, precision));
+  json_object *chain = json_object_new_array();
+  json_object_array_add(chain,
+    geopose_inner_frame(GEOPOSE_ID_CHAIN_INNER_FRAME, &anchor, outer,
+      precision));
+  pfree(outer);
+  for (int i = 2; i <= count; i++)
+  {
+    Pose *link = posechain_pose_n(pc, i);
+    if (link == NULL)
+    {
+      json_object_put(root); json_object_put(chain);
+      return NULL;
+    }
+    json_object_array_add(chain, geopose_chain_link_frame(link, precision));
+    pfree(link);
+  }
+  json_object_object_add(root, "frameChain", chain);
+  char *result = pstrdup(json_object_to_json_string_ext(root,
+    GEOPOSE_JSON_FLAGS));
+  json_object_put(root);
+  return result;
+}
+
+/**
+ * @brief Build the pose of a link read in the axes of the link before it
+ * @return On error return @p NULL
+ */
+static Pose *
+geopose_chain_link_pose(json_object *frame)
+{
+  const char *params = geopose_frame_parameters(frame, "frame chain element");
+  if (params == NULL)
+    return NULL;
+  double t[3], r[4];
+  if (! geopose_param_list(geopose_param_find(params, "translation"), 3, t) ||
+      ! geopose_param_list(geopose_param_find(params, "rotation"), 4, r))
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "GeoPose Chain frame chain element parameters must carry a 3-element "
+      "'translation' and a 4-element 'rotation'");
+    return NULL;
+  }
+  return pose_make_3d(t[0], t[1], t[2], r[0], r[1], r[2], r[3], false,
+    SRID_UNKNOWN);
+}
+
+/**
+ * @ingroup meos_posechain_inout
+ * @brief Return a temporal pose chain from an OGC GeoPose Composite Chain
+ * JSON document
+ * @param[in] json GeoPose Chain document
+ * @return On error return @p NULL
+ * @csqlfn #Tposechain_from_geopose()
+ */
+Temporal *
+tposechain_from_geopose(const char *json)
+{
+  VALIDATE_NOT_NULL(json, NULL);
+  json_tokener *tok = json_tokener_new();
+  json_object *root = json_tokener_parse_ex(tok, json, -1);
+  enum json_tokener_error err = json_tokener_get_error(tok);
+  json_tokener_free(tok);
+  if (root == NULL || err != json_tokener_success)
+  {
+    if (root != NULL) json_object_put(root);
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Cannot parse the GeoPose Chain document");
+    return NULL;
+  }
+  json_object *jtime = geopose_find_member(root, "validTime");
+  json_object *jchain = geopose_find_member(root, "frameChain");
+  if (jtime == NULL || ! json_object_is_type(jtime, json_type_int) ||
+      jchain == NULL || ! json_object_is_type(jchain, json_type_array))
+  {
+    json_object_put(root);
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "A GeoPose Chain document carries an integer 'validTime' and an array "
+      "'frameChain'");
+    return NULL;
+  }
+  int count = (int) json_object_array_length(jchain);
+  if (count < 2)
+  {
+    json_object_put(root);
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "A GeoPose Chain frame chain holds at least two frames, and the "
+      "document carries %d", count);
+    return NULL;
+  }
+  GeoPoseAnchor anchor;
+  if (! geopose_anchor_from_json(root, &anchor))
+  {
+    json_object_put(root);
+    return NULL;
+  }
+  Pose **poses = palloc(sizeof(Pose *) * count);
+  int nposes = 0;
+  bool failed = false;
+  for (int i = 0; i < count; i++)
+  {
+    json_object *frame = json_object_array_get_idx(jchain, i);
+    Pose *pose = (i == 0) ?
+      geopose_pose_from_inner_frame(&anchor, frame) :
+      geopose_chain_link_pose(frame);
+    if (pose == NULL) { failed = true; break; }
+    poses[nposes++] = pose;
+  }
+  Temporal *result = NULL;
+  if (! failed)
+  {
+    PoseChain *pc = posechain_make((const Pose **) poses, count);
+    if (pc != NULL)
+    {
+      result = (Temporal *) tinstant_make_free(PointerGetDatum(pc),
+        T_TPOSECHAIN, geopose_instant_in(json_object_get_int64(jtime)));
+    }
+  }
+  for (int i = 0; i < nposes; i++)
+    pfree(poses[i]);
+  pfree(poses);
+  json_object_put(root);
+  return result;
+}
+#endif /* POSECHAIN */
 
 /*****************************************************************************/

--- a/mobilitydb/sql/posechain/552_tposechain.in.sql
+++ b/mobilitydb/sql/posechain/552_tposechain.in.sql
@@ -106,6 +106,19 @@ CREATE FUNCTION tposechainFromMFJSON(text)
   AS 'MODULE_PATHNAME', 'Temporal_from_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tposechainFromGeoPose(text)
+  RETURNS tposechain
+  AS 'MODULE_PATHNAME', 'Tposechain_from_geopose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- A Composite Chain document carries one valid time, so it is written
+-- from a single instant, and its frame chain holds at least two frames.
+-- maxdecimaldigits: significant digits to keep; -1 = lossless
+CREATE FUNCTION asGeoPose(tposechain, maxdecimaldigits int4 DEFAULT -1)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tposechain_as_geopose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION tposechainFromBinary(bytea)
   RETURNS tposechain
   AS 'MODULE_PATHNAME', 'Temporal_from_wkb'

--- a/mobilitydb/src/posechain/tposechain.c
+++ b/mobilitydb/src/posechain/tposechain.c
@@ -34,6 +34,7 @@
 
 /* PostgreSQL */
 #include <postgres.h>
+#include <pgtypes.h>                  /* text_to_cstring / cstring_to_text */
 #include <fmgr.h>
 #include <utils/array.h>
 /* MEOS */
@@ -141,6 +142,51 @@ Tposechain_num_links(PG_FUNCTION_ARGS)
   int result = tposechain_num_links(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_INT32(result);
+}
+
+/*****************************************************************************
+ * OGC GeoPose Composite Chain input/output
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Tposechain_from_geopose(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tposechain_from_geopose);
+/**
+ * @ingroup mobilitydb_posechain_inout
+ * @brief Return a temporal pose chain from an OGC GeoPose Composite Chain
+ * JSON document
+ * @sqlfn tposechainFromGeoPose()
+ */
+Datum
+Tposechain_from_geopose(PG_FUNCTION_ARGS)
+{
+  text *json_text = PG_GETARG_TEXT_P(0);
+  char *json = text_to_cstring(json_text);
+  Temporal *result = tposechain_from_geopose(json);
+  pfree(json);
+  PG_FREE_IF_COPY(json_text, 0);
+  if (result == NULL) PG_RETURN_NULL();
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Tposechain_as_geopose(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tposechain_as_geopose);
+/**
+ * @ingroup mobilitydb_posechain_inout
+ * @brief Return the OGC GeoPose Composite Chain JSON representation of a
+ * temporal pose chain
+ * @sqlfn asGeoPose()
+ */
+Datum
+Tposechain_as_geopose(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  int precision = PG_GETARG_INT32(1);
+  char *result = tposechain_as_geopose(temp, precision);
+  PG_FREE_IF_COPY(temp, 0);
+  if (result == NULL) PG_RETURN_NULL();
+  text *result_text = cstring_to_text(result);
+  pfree(result);
+  PG_RETURN_TEXT_P(result_text);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/test/pose/schemas/GeoPose.Composite.Chain.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Composite.Chain.Schema.json
@@ -1,0 +1,67 @@
+{
+  "description": "Chain: An outer frame and a sequence of transformations to a final innermost frame.",
+  "definitions": {
+    "FrameSpecification": {
+      "type": "object",
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    },
+    "FrameSpecification-1": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "validTime": {
+      "type": "integer"
+    },
+    "outerFrame": {
+      "$ref": "#/definitions/FrameSpecification"
+    },
+    "frameChain": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FrameSpecification-1"
+      },
+      "minItems": 2
+    }
+  },
+  "required": [
+    "validTime",
+    "outerFrame",
+    "frameChain"
+  ]
+}

--- a/mobilitydb/test/pose/schemas/README.md
+++ b/mobilitydb/test/pose/schemas/README.md
@@ -48,10 +48,10 @@ added to the static encoding is reported rather than quietly narrowing what
 MobilityDB can claim. The conformance test suite exercises the permissive form,
 which is the one a claim is made against.
 
-Four schemas published at the same place are deliberately absent.
-`GeoPose.Composite.Chain.Schema.json` and `GeoPose.Composite.Graph.Schema.json`
-describe the two conformance classes MobilityDB does not implement, and belong
-here as soon as it emits a document of one of them.
+Three schemas published at the same place are deliberately absent.
+`GeoPose.Composite.Graph.Schema.json` describes the one conformance class
+MobilityDB does not implement, and belongs here as soon as it emits a document
+of it.
 `GeoPose.Basic.Euler.Schema.json` describes a flat `longitude`/`latitude`/
 `height`/`rotations` form that is not one of the eight conformance classes and
 that no MobilityDB encoding produces. `GeoPose.Composite.Sequence.Stream.Header.Schema.json`

--- a/mobilitydb/test/posechain/expected/555_tposechain_geopose.test.out
+++ b/mobilitydb/test/posechain/expected/555_tposechain_geopose.test.out
@@ -1,0 +1,46 @@
+SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+  Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00', 6);
+                                                                                                                                                                                                                       asgeopose                                                                                                                                                                                                                       
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=-122.3&latitude=47.7&height=11&crs=EPSG:4979"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, -1.38778e-17, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[2, 0, 0]&rotation=[1, 0, 0, 0]"}]}
+(1 row)
+
+SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(GeodPose(Point Z(8 47 100), 1, 0, 0, 0),
+  Pose(Point Z(1 0 0), 1, 0, 0, 0), Pose(Point Z(0 3 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00', 6);
+                                                                                                                                                                                                                                                                                 asgeopose                                                                                                                                                                                                                                                                                 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100&crs=EPSG:4979"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 2.77556e-17, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[1, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 3, 0]&rotation=[1, 0, 0, 0]"}]}
+(1 row)
+
+WITH test(doc) AS (
+  SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+    Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00', 9) )
+SELECT asEWKT(round(tposechainFromGeoPose(doc), 6)) FROM test;
+                                                             asewkt                                                             
+--------------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;PoseChain(GeodPose(POINT Z (-122.3 47.7 11),1,0,0,0),Pose(POINT Z (2 0 0),1,0,0,0))@Tue Apr 27 22:36:10.083 2021 PDT
+(1 row)
+
+SELECT asEWKT(round(tposechainFromGeoPose(
+  '{"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=-122.3&latitude=47.7&height=11&crs=EPSG:4979"},"frameChain":[{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[2, 0, 0]&rotation=[1, 0, 0, 0]"}]}'), 6));
+                                                             asewkt                                                             
+--------------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;PoseChain(GeodPose(POINT Z (-122.3 47.7 11),1,0,0,0),Pose(POINT Z (2 0 0),1,0,0,0))@Tue Apr 27 22:36:10.083 2021 PDT
+(1 row)
+
+SELECT asGeoPose(tposechain 'SRID=4326;{PoseChain(GeodPose(Point Z(8 47 100), 1, 0, 0, 0),
+  Pose(Point Z(1 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10+00,
+  PoseChain(GeodPose(Point Z(8 48 100), 1, 0, 0, 0),
+  Pose(Point Z(1 0 0), 1, 0, 0, 0))@2021-04-28 05:36:20+00}', 6);
+ERROR:  A GeoPose Chain document carries one valid time, so it is written from a single instant; use atTime to obtain one
+SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(GeodPose(Point Z(8 47 100), 1, 0, 0, 0))@2021-04-28 05:36:10+00', 6);
+ERROR:  A GeoPose Chain frame chain holds at least two frames, and the pose chain holds 1
+SELECT tposechainFromGeoPose(
+  '{"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"}]}');
+ERROR:  A GeoPose Chain frame chain holds at least two frames, and the document carries 1
+SELECT tposechainFromGeoPose(
+  '{"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[1, 0, 0]&rotation=[1, 0, 0, 0]"}]}');
+ERROR:  A GeoPose Chain document carries an integer 'validTime' and an array 'frameChain'
+SELECT tposechainFromGeoPose(
+  '{"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"scale=2"}]}');
+ERROR:  GeoPose Chain frame chain element parameters must carry a 3-element 'translation' and a 4-element 'rotation'

--- a/mobilitydb/test/posechain/queries/555_tposechain_geopose.test.sql
+++ b/mobilitydb/test/posechain/queries/555_tposechain_geopose.test.sql
@@ -1,0 +1,82 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- OGC GeoPose Composite Chain
+-- A chain is an outer frame and a sequence of transformations reaching a
+-- final innermost frame, which is what a pose chain holds.
+-------------------------------------------------------------------------------
+
+-- The document names the tangent frame at the outer link and one
+-- transformation per link. The first takes that frame to the outer link's
+-- own frame, so it translates by nothing.
+SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+  Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00', 6);
+
+-- A third link is read in the axes of the second
+SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(GeodPose(Point Z(8 47 100), 1, 0, 0, 0),
+  Pose(Point Z(1 0 0), 1, 0, 0, 0), Pose(Point Z(0 3 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00', 6);
+
+-- The round trip returns the chain it was written from
+WITH test(doc) AS (
+  SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+    Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00', 9) )
+SELECT asEWKT(round(tposechainFromGeoPose(doc), 6)) FROM test;
+
+-- Reading accepts the bare frame identifiers the other classes write as well
+SELECT asEWKT(round(tposechainFromGeoPose(
+  '{"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"LTP-ENU","parameters":"longitude=-122.3&latitude=47.7&height=11&crs=EPSG:4979"},"frameChain":[{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"RotateTranslate","parameters":"translation=[2, 0, 0]&rotation=[1, 0, 0, 0]"}]}'), 6));
+
+-------------------------------------------------------------------------------
+-- Errors
+-------------------------------------------------------------------------------
+
+-- A chain document carries one valid time, so it is written from an instant
+SELECT asGeoPose(tposechain 'SRID=4326;{PoseChain(GeodPose(Point Z(8 47 100), 1, 0, 0, 0),
+  Pose(Point Z(1 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10+00,
+  PoseChain(GeodPose(Point Z(8 48 100), 1, 0, 0, 0),
+  Pose(Point Z(1 0 0), 1, 0, 0, 0))@2021-04-28 05:36:20+00}', 6);
+
+-- A frame chain holds at least two frames
+SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(GeodPose(Point Z(8 47 100), 1, 0, 0, 0))@2021-04-28 05:36:10+00', 6);
+
+-- So does a document being read
+SELECT tposechainFromGeoPose(
+  '{"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"}]}');
+
+-- A document missing its valid time is not a chain
+SELECT tposechainFromGeoPose(
+  '{"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[1, 0, 0]&rotation=[1, 0, 0, 0]"}]}');
+
+-- A frame chain element carries a translation and a rotation
+SELECT tposechainFromGeoPose(
+  '{"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"scale=2"}]}');
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -70,6 +70,10 @@ Temporal<T>              temporal_type      = ALL temporal types            (cat
   hand-written beside its nine siblings and carries the spatial reference
   system alone — `SRID`, `setSRID`, `transform` and `transformPipeline`, each
   reading the outer link, which is the only link that names a frame.
+  `555_tposechain_geopose.in.sql` has no file of its own: the OGC GeoPose
+  Composite Chain entries `asGeoPose(tposechain, …)` and
+  `tposechainFromGeoPose` are a `lit:` block of the `representations` axis, as
+  the pose family's GeoPose entries are.
   ⛔ The family carries no distance, no spatial relationships and no index
   file: a pose chain has no distance function, and the ordering operator waits
   on the kNN question.

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -305,6 +305,7 @@ representation_families:
     - FromText
     - FromEWKT
     - FromMFJSON
+  - lit: "CREATE FUNCTION tposechainFromGeoPose(text)\n  RETURNS tposechain\n  AS 'MODULE_PATHNAME', 'Tposechain_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- A Composite Chain document carries one valid time, so it is written\n-- from a single instant, and its frame chain holds at least two frames.\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(tposechain, maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tposechain_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
   - ops:
     - FromBinary
     - FromEWKB

--- a/tools/scripts/check_geopose_conformance.py
+++ b/tools/scripts/check_geopose_conformance.py
@@ -47,9 +47,14 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # The normative schemas, retrieved from schemas.opengis.net.
 SCHEMA_DIR = os.path.join(ROOT, 'mobilitydb', 'test', 'pose', 'schemas')
 
-# The expected output holding the emitted documents.
-EXPECTED = os.path.join(ROOT, 'mobilitydb', 'test', 'pose', 'expected',
-    '103_pose_geopose.test.out')
+# The expected outputs holding the emitted documents, one per family that
+# writes a conformance class.
+EXPECTED = [
+    os.path.join(ROOT, 'mobilitydb', 'test', 'pose', 'expected',
+        '103_pose_geopose.test.out'),
+    os.path.join(ROOT, 'mobilitydb', 'test', 'posechain', 'expected',
+        '555_tposechain_geopose.test.out'),
+]
 
 # A document is recognised by the member that only its class carries, tried in
 # this order so that a Series is never mistaken for the Basic document of its
@@ -67,6 +72,11 @@ CLASSES = [
     # per pose. `outerFrame` comes after the two Series members because a
     # Series carries an outer frame as well, and its own member names it more
     # precisely; a stream header is what is left holding only an outer frame.
+    # A Chain names an outer frame as well, so the member holding its own
+    # sequence of transformations comes before the one a stream header is
+    # left holding alone.
+    ('frameChain', 'Chain',
+        'GeoPose.Composite.Chain.Schema.json'),
     ('streamElement', 'Stream element',
         'GeoPose.Composite.Sequence.StreamElement.Schema.json'),
     ('outerFrame', 'Stream header',
@@ -98,7 +108,7 @@ STRICT = ('Basic-Quaternion', 'validTime',
 # wherever they appear rather than demanded here; `meos/test/geopose_test.c` is
 # what exercises them.
 REQUIRED = ('Regular Series', 'Irregular Series', 'Basic-Quaternion',
-    'Basic-YPR', 'Advanced', 'Stream')
+    'Basic-YPR', 'Advanced', 'Stream', 'Chain')
 
 TYPES = {
     'object': dict,
@@ -208,10 +218,11 @@ def documents(path):
 def main():
     listing = '--list' in sys.argv[1:]
 
-    if not os.path.isfile(EXPECTED):
-        print('check_geopose_conformance: no expected output at %s' %
-            os.path.relpath(EXPECTED, ROOT))
-        return 1
+    for path in EXPECTED:
+        if not os.path.isfile(path):
+            print('check_geopose_conformance: no expected output at %s' %
+                os.path.relpath(path, ROOT))
+            return 1
 
     schemas = {}
     for _, name, filename in CLASSES:
@@ -236,7 +247,7 @@ def main():
     failed = 0
     strict = 0
     seen = {}
-    for doc in documents(EXPECTED):
+    for doc in [d for path in EXPECTED for d in documents(path)]:
         name, _ = classify(doc)
         if name is None:
             continue
@@ -259,7 +270,7 @@ def main():
 
     if not total:
         print('check_geopose_conformance: no GeoPose document found in %s' %
-            os.path.relpath(EXPECTED, ROOT))
+            ', '.join(os.path.relpath(p, ROOT) for p in EXPECTED))
         return 1
 
     missing = [name for name in REQUIRED if name not in seen]


### PR DESCRIPTION
`asGeoPose(tposechain, maxdecimaldigits)` writes an OGC GeoPose Composite Chain
document and `tposechainFromGeoPose(text)` reads one, taking the conformance
classes MobilityDB covers to seven of the eight.

### The value the class describes

A Chain document is an outer frame and a sequence of transformations reaching a
final innermost frame, which is what a pose chain holds: its outer link is
placed in a topocentric frame and every later link is a rigid transformation
read in the axes of the link before it.

The document names the LTP-ENU frame tangent at the outer link's position and
one transformation per link. The first takes that tangent frame to the outer
link's own frame, so it translates by nothing; each later one is the link as it
is stored.

### What the normative schema requires

`GeoPose.Composite.Chain.Schema.json` requires `validTime`, so a document is
written from a single instant, and requires two frames in `frameChain`, so a
chain of one link has no Chain document. Each is an error naming what it needs,
`atTime` among them.

### The frame identifiers

The Chain class names its two frames `/Extrinsic/LTP-ENU` and
`/Intrinsic/Translate-Rotate`, where the Advanced, Series and Stream classes
name the same two frames `LTP-ENU` and `RotateTranslate` under the one
authority `/geopose/1.0`. A document is written with the pair its own class
uses, and either pair is accepted on reading. The two frame builders take the
identifier to write, which is the whole of the difference between the classes:
the geodesy, the parameter grammar `translation=[…]&rotation=[…]` and the
reverse conversion are the ones the Series uses.

### Conformance

The normative schema joins the vendored schemas under its OGC licence, bytes
unmodified, and `check_geopose_conformance.py` requires a Chain document among
the ones it validates, reading the documents of each family that writes a class.
The 34 documents it holds conform, 2 of them Chain.

### Also

The temporal pose chain doxygen groups are defined: the six the temporal
functions name and the bounding-box group of the static type.
