### PR TITLE
Index the Z-axis position predicates of tpose and trgeometry

### DIFF
--- a/mobilitydb/sql/pose/116_tpose_indexes.in.sql
+++ b/mobilitydb/sql/pose/116_tpose_indexes.in.sql
@@ -110,6 +110,18 @@ CREATE OPERATOR CLASS tpose_rtree_ops
   OPERATOR  31    #&> (tpose, tstzspan),
   OPERATOR  31    #&> (tpose, stbox),
   OPERATOR  31    #&> (tpose, tpose),
+  -- overlaps or front
+  OPERATOR  32    &</ (tpose, stbox),
+  OPERATOR  32    &</ (tpose, tpose),
+  -- strictly front
+  OPERATOR  33    <</ (tpose, stbox),
+  OPERATOR  33    <</ (tpose, tpose),
+  -- strictly back
+  OPERATOR  34    />> (tpose, stbox),
+  OPERATOR  34    />> (tpose, tpose),
+  -- overlaps or back
+  OPERATOR  35    /&> (tpose, stbox),
+  OPERATOR  35    /&> (tpose, tpose),
   -- functions
   FUNCTION  1 tpose_gist_consistent(internal, tpose, smallint, oid, internal),
   FUNCTION  2 stbox_gist_union(internal, internal),
@@ -187,6 +199,18 @@ CREATE OPERATOR CLASS tpose_quadtree_ops
   OPERATOR  31    #&> (tpose, tstzspan),
   OPERATOR  31    #&> (tpose, stbox),
   OPERATOR  31    #&> (tpose, tpose),
+  -- overlaps or front
+  OPERATOR  32    &</ (tpose, stbox),
+  OPERATOR  32    &</ (tpose, tpose),
+  -- strictly front
+  OPERATOR  33    <</ (tpose, stbox),
+  OPERATOR  33    <</ (tpose, tpose),
+  -- strictly back
+  OPERATOR  34    />> (tpose, stbox),
+  OPERATOR  34    />> (tpose, tpose),
+  -- overlaps or back
+  OPERATOR  35    /&> (tpose, stbox),
+  OPERATOR  35    /&> (tpose, tpose),
   -- functions
   FUNCTION  1 stbox_spgist_config(internal, internal),
   FUNCTION  2 stbox_quadtree_choose(internal, internal),
@@ -263,6 +287,18 @@ CREATE OPERATOR CLASS tpose_kdtree_ops
   OPERATOR  31    #&> (tpose, tstzspan),
   OPERATOR  31    #&> (tpose, stbox),
   OPERATOR  31    #&> (tpose, tpose),
+  -- overlaps or front
+  OPERATOR  32    &</ (tpose, stbox),
+  OPERATOR  32    &</ (tpose, tpose),
+  -- strictly front
+  OPERATOR  33    <</ (tpose, stbox),
+  OPERATOR  33    <</ (tpose, tpose),
+  -- strictly back
+  OPERATOR  34    />> (tpose, stbox),
+  OPERATOR  34    />> (tpose, tpose),
+  -- overlaps or back
+  OPERATOR  35    /&> (tpose, stbox),
+  OPERATOR  35    /&> (tpose, tpose),
   -- functions
   FUNCTION  1 stbox_spgist_config(internal, internal),
   FUNCTION  2 stbox_kdtree_choose(internal, internal),

--- a/mobilitydb/sql/rgeo/173_trgeo_indexes.in.sql
+++ b/mobilitydb/sql/rgeo/173_trgeo_indexes.in.sql
@@ -110,6 +110,18 @@ CREATE OPERATOR CLASS trgeometry_rtree_ops
   OPERATOR  31    #&> (trgeometry, tstzspan),
   OPERATOR  31    #&> (trgeometry, stbox),
   OPERATOR  31    #&> (trgeometry, trgeometry),
+  -- overlaps or front
+  OPERATOR  32    &</ (trgeometry, stbox),
+  OPERATOR  32    &</ (trgeometry, trgeometry),
+  -- strictly front
+  OPERATOR  33    <</ (trgeometry, stbox),
+  OPERATOR  33    <</ (trgeometry, trgeometry),
+  -- strictly back
+  OPERATOR  34    />> (trgeometry, stbox),
+  OPERATOR  34    />> (trgeometry, trgeometry),
+  -- overlaps or back
+  OPERATOR  35    /&> (trgeometry, stbox),
+  OPERATOR  35    /&> (trgeometry, trgeometry),
   -- functions
   FUNCTION  1 trgeometry_gist_consistent(internal, trgeometry, smallint, oid, internal),
   FUNCTION  2 stbox_gist_union(internal, internal),
@@ -187,6 +199,18 @@ CREATE OPERATOR CLASS trgeometry_quadtree_ops
   OPERATOR  31    #&> (trgeometry, tstzspan),
   OPERATOR  31    #&> (trgeometry, stbox),
   OPERATOR  31    #&> (trgeometry, trgeometry),
+  -- overlaps or front
+  OPERATOR  32    &</ (trgeometry, stbox),
+  OPERATOR  32    &</ (trgeometry, trgeometry),
+  -- strictly front
+  OPERATOR  33    <</ (trgeometry, stbox),
+  OPERATOR  33    <</ (trgeometry, trgeometry),
+  -- strictly back
+  OPERATOR  34    />> (trgeometry, stbox),
+  OPERATOR  34    />> (trgeometry, trgeometry),
+  -- overlaps or back
+  OPERATOR  35    /&> (trgeometry, stbox),
+  OPERATOR  35    /&> (trgeometry, trgeometry),
   -- functions
   FUNCTION  1 stbox_spgist_config(internal, internal),
   FUNCTION  2 stbox_quadtree_choose(internal, internal),
@@ -263,6 +287,18 @@ CREATE OPERATOR CLASS trgeometry_kdtree_ops
   OPERATOR  31    #&> (trgeometry, tstzspan),
   OPERATOR  31    #&> (trgeometry, stbox),
   OPERATOR  31    #&> (trgeometry, trgeometry),
+  -- overlaps or front
+  OPERATOR  32    &</ (trgeometry, stbox),
+  OPERATOR  32    &</ (trgeometry, trgeometry),
+  -- strictly front
+  OPERATOR  33    <</ (trgeometry, stbox),
+  OPERATOR  33    <</ (trgeometry, trgeometry),
+  -- strictly back
+  OPERATOR  34    />> (trgeometry, stbox),
+  OPERATOR  34    />> (trgeometry, trgeometry),
+  -- overlaps or back
+  OPERATOR  35    /&> (trgeometry, stbox),
+  OPERATOR  35    /&> (trgeometry, trgeometry),
   -- functions
   FUNCTION  1 stbox_spgist_config(internal, internal),
   FUNCTION  2 stbox_kdtree_choose(internal, internal),

--- a/mobilitydb/test/pose/expected/110_tpose_indexes_tbl.test.out
+++ b/mobilitydb/test/pose/expected/110_tpose_indexes_tbl.test.out
@@ -321,3 +321,114 @@ SELECT round(distance, 6) FROM test;
 
 DROP INDEX tbl_tpose2d_quadtree_idx;
 DROP INDEX
+ANALYZE tbl_tpose3d;
+ANALYZE
+DROP INDEX IF EXISTS tbl_tpose3d_rtree_idx;
+NOTICE:  index "tbl_tpose3d_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tpose3d_quadtree_idx;
+NOTICE:  index "tbl_tpose3d_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tpose3d_kdtree_idx;
+NOTICE:  index "tbl_tpose3d_kdtree_idx" does not exist, skipping
+DROP INDEX
+DROP TABLE IF EXISTS test_zaxis;
+NOTICE:  table "test_zaxis" does not exist, skipping
+DROP TABLE
+CREATE TABLE test_zaxis(
+  op TEXT,
+  no_idx BIGINT,
+  rtree_idx BIGINT,
+  quadtree_idx BIGINT,
+  kdtree_idx BIGINT
+);
+CREATE TABLE
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '<</', COUNT(*) FROM tbl_tpose3d WHERE temp <</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT 0 1
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '&</', COUNT(*) FROM tbl_tpose3d WHERE temp &</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT 0 1
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '/>>', COUNT(*) FROM tbl_tpose3d WHERE temp />> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT 0 1
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '/&>', COUNT(*) FROM tbl_tpose3d WHERE temp /&> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT 0 1
+CREATE INDEX tbl_tpose3d_rtree_idx ON tbl_tpose3d USING GIST(temp);
+CREATE INDEX
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp <</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE 1
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp &</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE 1
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp />> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE 1
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp /&> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+UPDATE 1
+DROP INDEX tbl_tpose3d_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpose3d_quadtree_idx ON tbl_tpose3d USING SPGIST(temp);
+CREATE INDEX
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp <</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE 1
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp &</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE 1
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp />> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE 1
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp /&> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+UPDATE 1
+DROP INDEX tbl_tpose3d_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpose3d_kdtree_idx ON tbl_tpose3d USING SPGIST(temp tpose_kdtree_ops);
+CREATE INDEX
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp <</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE 1
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp &</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE 1
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp />> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE 1
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp /&> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+UPDATE 1
+DROP INDEX tbl_tpose3d_kdtree_idx;
+DROP INDEX
+SELECT count(*) FILTER (WHERE no_idx > 0) AS matching, count(*) AS ops
+FROM test_zaxis;
+ matching | ops 
+----------+-----
+        4 |   4
+(1 row)
+
+SELECT * FROM test_zaxis
+WHERE no_idx <> rtree_idx OR no_idx <> quadtree_idx OR no_idx <> kdtree_idx OR
+  no_idx IS NULL OR rtree_idx IS NULL OR quadtree_idx IS NULL OR kdtree_idx IS NULL
+ORDER BY op;
+ op | no_idx | rtree_idx | quadtree_idx | kdtree_idx 
+----+--------+-----------+--------------+------------
+(0 rows)
+
+DROP TABLE test_zaxis;
+DROP TABLE

--- a/mobilitydb/test/pose/queries/110_tpose_indexes_tbl.test.sql
+++ b/mobilitydb/test/pose/queries/110_tpose_indexes_tbl.test.sql
@@ -148,3 +148,96 @@ SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tpose2d_quadtree_idx;
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- 5. Z-axis position operators on tbl_tpose3d
+-------------------------------------------------------------------------------
+
+ANALYZE tbl_tpose3d;
+
+DROP INDEX IF EXISTS tbl_tpose3d_rtree_idx;
+DROP INDEX IF EXISTS tbl_tpose3d_quadtree_idx;
+DROP INDEX IF EXISTS tbl_tpose3d_kdtree_idx;
+
+DROP TABLE IF EXISTS test_zaxis;
+CREATE TABLE test_zaxis(
+  op TEXT,
+  no_idx BIGINT,
+  rtree_idx BIGINT,
+  quadtree_idx BIGINT,
+  kdtree_idx BIGINT
+);
+
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '<</', COUNT(*) FROM tbl_tpose3d WHERE temp <</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '&</', COUNT(*) FROM tbl_tpose3d WHERE temp &</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '/>>', COUNT(*) FROM tbl_tpose3d WHERE temp />> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '/&>', COUNT(*) FROM tbl_tpose3d WHERE temp /&> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))';
+
+CREATE INDEX tbl_tpose3d_rtree_idx ON tbl_tpose3d USING GIST(temp);
+
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp <</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp &</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp />> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp /&> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+
+DROP INDEX tbl_tpose3d_rtree_idx;
+
+CREATE INDEX tbl_tpose3d_quadtree_idx ON tbl_tpose3d USING SPGIST(temp);
+
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp <</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp &</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp />> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp /&> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+
+DROP INDEX tbl_tpose3d_quadtree_idx;
+
+CREATE INDEX tbl_tpose3d_kdtree_idx ON tbl_tpose3d USING SPGIST(temp tpose_kdtree_ops);
+
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp <</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp &</ stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp />> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_tpose3d WHERE temp /&> stbox 'SRID=3812;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+
+DROP INDEX tbl_tpose3d_kdtree_idx;
+
+-- the operators that match at least one row: a mismatch test over
+-- predicates that match nothing would hold vacuously
+SELECT count(*) FILTER (WHERE no_idx > 0) AS matching, count(*) AS ops
+FROM test_zaxis;
+
+SELECT * FROM test_zaxis
+WHERE no_idx <> rtree_idx OR no_idx <> quadtree_idx OR no_idx <> kdtree_idx OR
+  no_idx IS NULL OR rtree_idx IS NULL OR quadtree_idx IS NULL OR kdtree_idx IS NULL
+ORDER BY op;
+
+DROP TABLE test_zaxis;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/expected/162_trgeo_indexes_tbl.test.out
+++ b/mobilitydb/test/rgeo/expected/162_trgeo_indexes_tbl.test.out
@@ -228,3 +228,114 @@ ANALYZE tbl_trgeometry_big_allthesame;
 ANALYZE
 DROP TABLE tbl_trgeometry_big_allthesame;
 DROP TABLE
+ANALYZE tbl_trgeometry3d;
+ANALYZE
+DROP INDEX IF EXISTS tbl_trgeometry3d_rtree_idx;
+NOTICE:  index "tbl_trgeometry3d_rtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_trgeometry3d_quadtree_idx;
+NOTICE:  index "tbl_trgeometry3d_quadtree_idx" does not exist, skipping
+DROP INDEX
+DROP INDEX IF EXISTS tbl_trgeometry3d_kdtree_idx;
+NOTICE:  index "tbl_trgeometry3d_kdtree_idx" does not exist, skipping
+DROP INDEX
+DROP TABLE IF EXISTS test_zaxis;
+NOTICE:  table "test_zaxis" does not exist, skipping
+DROP TABLE
+CREATE TABLE test_zaxis(
+  op TEXT,
+  no_idx BIGINT,
+  rtree_idx BIGINT,
+  quadtree_idx BIGINT,
+  kdtree_idx BIGINT
+);
+CREATE TABLE
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '<</', COUNT(*) FROM tbl_trgeometry3d WHERE temp <</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT 0 1
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '&</', COUNT(*) FROM tbl_trgeometry3d WHERE temp &</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT 0 1
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '/>>', COUNT(*) FROM tbl_trgeometry3d WHERE temp />> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT 0 1
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '/&>', COUNT(*) FROM tbl_trgeometry3d WHERE temp /&> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT 0 1
+CREATE INDEX tbl_trgeometry3d_rtree_idx ON tbl_trgeometry3d USING GIST(temp);
+CREATE INDEX
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp <</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE 1
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp &</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE 1
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp />> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE 1
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp /&> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+UPDATE 1
+DROP INDEX tbl_trgeometry3d_rtree_idx;
+DROP INDEX
+CREATE INDEX tbl_trgeometry3d_quadtree_idx ON tbl_trgeometry3d USING SPGIST(temp);
+CREATE INDEX
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp <</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE 1
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp &</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE 1
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp />> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE 1
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp /&> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+UPDATE 1
+DROP INDEX tbl_trgeometry3d_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_trgeometry3d_kdtree_idx ON tbl_trgeometry3d USING SPGIST(temp trgeometry_kdtree_ops);
+CREATE INDEX
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp <</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE 1
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp &</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE 1
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp />> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE 1
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp /&> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+UPDATE 1
+DROP INDEX tbl_trgeometry3d_kdtree_idx;
+DROP INDEX
+SELECT count(*) FILTER (WHERE no_idx > 0) AS matching, count(*) AS ops
+FROM test_zaxis;
+ matching | ops 
+----------+-----
+        4 |   4
+(1 row)
+
+SELECT * FROM test_zaxis
+WHERE no_idx <> rtree_idx OR no_idx <> quadtree_idx OR no_idx <> kdtree_idx OR
+  no_idx IS NULL OR rtree_idx IS NULL OR quadtree_idx IS NULL OR kdtree_idx IS NULL
+ORDER BY op;
+ op | no_idx | rtree_idx | quadtree_idx | kdtree_idx 
+----+--------+-----------+--------------+------------
+(0 rows)
+
+DROP TABLE test_zaxis;
+DROP TABLE

--- a/mobilitydb/test/rgeo/queries/162_trgeo_indexes_tbl.test.sql
+++ b/mobilitydb/test/rgeo/queries/162_trgeo_indexes_tbl.test.sql
@@ -117,3 +117,96 @@ ANALYZE tbl_trgeometry_big_allthesame;
 -- EXPLAIN ANALYZE
 
 DROP TABLE tbl_trgeometry_big_allthesame;
+
+-------------------------------------------------------------------------------
+-- 5. Z-axis position operators on tbl_trgeometry3d
+-------------------------------------------------------------------------------
+
+ANALYZE tbl_trgeometry3d;
+
+DROP INDEX IF EXISTS tbl_trgeometry3d_rtree_idx;
+DROP INDEX IF EXISTS tbl_trgeometry3d_quadtree_idx;
+DROP INDEX IF EXISTS tbl_trgeometry3d_kdtree_idx;
+
+DROP TABLE IF EXISTS test_zaxis;
+CREATE TABLE test_zaxis(
+  op TEXT,
+  no_idx BIGINT,
+  rtree_idx BIGINT,
+  quadtree_idx BIGINT,
+  kdtree_idx BIGINT
+);
+
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '<</', COUNT(*) FROM tbl_trgeometry3d WHERE temp <</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '&</', COUNT(*) FROM tbl_trgeometry3d WHERE temp &</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '/>>', COUNT(*) FROM tbl_trgeometry3d WHERE temp />> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))';
+INSERT INTO test_zaxis(op, no_idx)
+SELECT '/&>', COUNT(*) FROM tbl_trgeometry3d WHERE temp /&> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))';
+
+CREATE INDEX tbl_trgeometry3d_rtree_idx ON tbl_trgeometry3d USING GIST(temp);
+
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp <</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp &</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp />> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE test_zaxis
+SET rtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp /&> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+
+DROP INDEX tbl_trgeometry3d_rtree_idx;
+
+CREATE INDEX tbl_trgeometry3d_quadtree_idx ON tbl_trgeometry3d USING SPGIST(temp);
+
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp <</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp &</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp />> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE test_zaxis
+SET quadtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp /&> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+
+DROP INDEX tbl_trgeometry3d_quadtree_idx;
+
+CREATE INDEX tbl_trgeometry3d_kdtree_idx ON tbl_trgeometry3d USING SPGIST(temp trgeometry_kdtree_ops);
+
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp <</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '<</';
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp &</ stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '&</';
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp />> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/>>';
+UPDATE test_zaxis
+SET kdtree_idx = ( SELECT COUNT(*) FROM tbl_trgeometry3d WHERE temp /&> stbox 'SRID=5676;STBOX Z((-50,-50,-50),(50,50,50))' )
+WHERE op = '/&>';
+
+DROP INDEX tbl_trgeometry3d_kdtree_idx;
+
+-- the operators that match at least one row: a mismatch test over
+-- predicates that match nothing would hold vacuously
+SELECT count(*) FILTER (WHERE no_idx > 0) AS matching, count(*) AS ops
+FROM test_zaxis;
+
+SELECT * FROM test_zaxis
+WHERE no_idx <> rtree_idx OR no_idx <> quadtree_idx OR no_idx <> kdtree_idx OR
+  no_idx IS NULL OR rtree_idx IS NULL OR quadtree_idx IS NULL OR kdtree_idx IS NULL
+ORDER BY op;
+
+DROP TABLE test_zaxis;
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -142,10 +142,18 @@ no subtype currently routes `aggfuncs` through the `subtypes:` track. Live templ
 | posops | `posops.sql.tmpl` | **GENERATED** |
 | spatialrels | `spatialrels.c.tmpl` + `spatialrels.sql.tmpl` | **GENERATED** (ever/always) |
 | boxops (C) | `boxops.c.tmpl` | **GENERATED** (box-type axis) |
-| gist / spgist / indexes | `gist/spgist/indexes.sql.tmpl` | **GENERATED** (index infra) |
+| gist / spgist / indexes | `gist/spgist/indexes.sql.tmpl` | **GENERATED** (index infra) — `indexes.sql.tmpl` carries the Z-axis strategies 32-35 under `-- @IF front_back`, the same additive flag `posops.sql.tmpl` uses to declare the Z operators, so a family declares and indexes that axis from one manifest key |
 | aggfuncs | `aggregates.sql.tmpl` | **GENERATED** — whole-file per family via the separate `aggregate_families` axis (§4b), not the `subtypes:` track |
 | spatialfuncs | — | reserved position, **HAND** |
 | distance | — | reserved position, **HAND** |
+
+⛔ **`front_back` reaches BOTH the operator declaration and the operator class.** It is an
+additive flag (`DEFAULT_FALSE_FLAGS` in `generate.py`), so a family opts in and every other
+family omits the block. The three-dimensional spatial families — `tpose`, `tposechain`,
+`trgeometry` — set it; `tgeometry`/`tgeompoint` carry the same strategies as the hand-written
+reference. A family that declares the Z operators without its opclass listing strategies
+32-35 keeps those predicates as a FILTER: the operator resolves, the plan never uses the
+index, and nothing errors — so the omission is invisible without reading `pg_amop`.
 
 **`topops.sql.tmpl`/`posops.sql.tmpl` serve two independent manifest tracks** that
 happen to share a template name: the `topop_families`/`posop_families` axes (§9,

--- a/tools/codegen/inherited/templates/indexes.sql.tmpl
+++ b/tools/codegen/inherited/templates/indexes.sql.tmpl
@@ -108,6 +108,20 @@ CREATE OPERATOR CLASS {TEMP}_rtree_ops
   OPERATOR  31    #&> ({TEMP}, tstzspan),
   OPERATOR  31    #&> ({TEMP}, stbox),
   OPERATOR  31    #&> ({TEMP}, {TEMP}),
+-- @IF front_back
+  -- overlaps or front
+  OPERATOR  32    &</ ({TEMP}, stbox),
+  OPERATOR  32    &</ ({TEMP}, {TEMP}),
+  -- strictly front
+  OPERATOR  33    <</ ({TEMP}, stbox),
+  OPERATOR  33    <</ ({TEMP}, {TEMP}),
+  -- strictly back
+  OPERATOR  34    />> ({TEMP}, stbox),
+  OPERATOR  34    />> ({TEMP}, {TEMP}),
+  -- overlaps or back
+  OPERATOR  35    /&> ({TEMP}, stbox),
+  OPERATOR  35    /&> ({TEMP}, {TEMP}),
+-- @ENDIF
   -- functions
   FUNCTION  1 {TEMP}_gist_consistent(internal, {TEMP}, smallint, oid, internal),
   FUNCTION  2 stbox_gist_union(internal, internal),
@@ -185,6 +199,20 @@ CREATE OPERATOR CLASS {TEMP}_quadtree_ops
   OPERATOR  31    #&> ({TEMP}, tstzspan),
   OPERATOR  31    #&> ({TEMP}, stbox),
   OPERATOR  31    #&> ({TEMP}, {TEMP}),
+-- @IF front_back
+  -- overlaps or front
+  OPERATOR  32    &</ ({TEMP}, stbox),
+  OPERATOR  32    &</ ({TEMP}, {TEMP}),
+  -- strictly front
+  OPERATOR  33    <</ ({TEMP}, stbox),
+  OPERATOR  33    <</ ({TEMP}, {TEMP}),
+  -- strictly back
+  OPERATOR  34    />> ({TEMP}, stbox),
+  OPERATOR  34    />> ({TEMP}, {TEMP}),
+  -- overlaps or back
+  OPERATOR  35    /&> ({TEMP}, stbox),
+  OPERATOR  35    /&> ({TEMP}, {TEMP}),
+-- @ENDIF
   -- functions
   FUNCTION  1 stbox_spgist_config(internal, internal),
   FUNCTION  2 stbox_quadtree_choose(internal, internal),
@@ -261,6 +289,20 @@ CREATE OPERATOR CLASS {TEMP}_kdtree_ops
   OPERATOR  31    #&> ({TEMP}, tstzspan),
   OPERATOR  31    #&> ({TEMP}, stbox),
   OPERATOR  31    #&> ({TEMP}, {TEMP}),
+-- @IF front_back
+  -- overlaps or front
+  OPERATOR  32    &</ ({TEMP}, stbox),
+  OPERATOR  32    &</ ({TEMP}, {TEMP}),
+  -- strictly front
+  OPERATOR  33    <</ ({TEMP}, stbox),
+  OPERATOR  33    <</ ({TEMP}, {TEMP}),
+  -- strictly back
+  OPERATOR  34    />> ({TEMP}, stbox),
+  OPERATOR  34    />> ({TEMP}, {TEMP}),
+  -- overlaps or back
+  OPERATOR  35    /&> ({TEMP}, stbox),
+  OPERATOR  35    /&> ({TEMP}, {TEMP}),
+-- @ENDIF
   -- functions
   FUNCTION  1 stbox_spgist_config(internal, internal),
   FUNCTION  2 stbox_kdtree_choose(internal, internal),


### PR DESCRIPTION
The index template carries the front and back strategies under the front_back flag, so an operator class of a three-dimensional spatial family lists them beside the strategies of the other two axes and the Z-axis operators the family declares are answered by an index scan rather than kept as a filter. The bounding box of those families is an stbox and its consistent function already answers those strategies.