### PR TITLE
Read a circular string returning to its first point as the circle it is

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -194,6 +194,39 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
   /* Twice the signed area of the triangle; zero when the points are collinear */
   double d = 2 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by));
 
+  /* A circular string returning to the point it starts from is a full circle,
+   * and the three points of one are collinear, so the circumcentre below
+   * cannot be read from them. The middle point is the one opposite, and the
+   * two points split the circle into the two half circles the arcs of an edge
+   * hold exactly. This is the shape #lwcircle_make gives a circle */
+  if (fabs(ax - cx) <= FP_TOLERANCE && fabs(ay - cy) <= FP_TOLERANCE &&
+      (fabs(ax - bx) > FP_TOLERANCE || fabs(ay - by) > FP_TOLERANCE))
+  {
+    double mx = (ax + bx) / 2, my = (ay + by) / 2;
+    double radius = hypot(ax - mx, ay - my);
+    double theta_a = atan2(ay - my, ax - mx);
+    double theta_b = atan2(by - my, bx - mx);
+    const double sx[2] = {ax, bx}, sy[2] = {ay, by};
+    const double ex[2] = {bx, ax}, ey[2] = {by, ay};
+    const double t0[2] = {theta_a, theta_b}, t1[2] = {theta_b, theta_a};
+    for (int i = 0; i < 2; i++)
+    {
+      Edge e;
+      e.cx = mx; e.cy = my; e.radius = radius;
+      e.x1 = sx[i]; e.y1 = sy[i];
+      e.x2 = ex[i]; e.y2 = ey[i];
+      e.theta0 = t0[i]; e.theta1 = t1[i];
+      /* Both halves are traversed the same way, so together they cover the
+       * circle rather than the same half twice */
+      e.ccw = true;
+      e.dx = e.dy = e.length = 0;
+      e.etype = arc_etype;
+      arc_set_bbox(&e);
+      meos_array_add(edges, &e);
+    }
+    return;
+  }
+
   /* Collinear points: emit straight line edges */
   if (fabs(d) < FP_TOLERANCE)
   {


### PR DESCRIPTION
A circular string whose third point repeats its first is a full circle, and the three points of one
are collinear: the circumcentre of the arc cannot be read from them, so the edge decomposition takes
them for three collinear points and gives the geometry two straight edges along the diameter.

Every question answered from that decomposition then reads a circle as a segment travelled twice,
which encloses nothing. `CURVEPOLYGON(CIRCULARSTRING(-1 0,1 0,-1 0))` against `POINT(0.5 0)` answers
`FF20F1FF2` where `ST_Relate` answers `0F2FF1FF2`: a point at the centre of a circle comes back
outside it.

The middle point of such a string is the point opposite the first, so the two of them split the
circle into the two half circles an edge holds exactly, and the decomposition gives one edge for
each.

This is the shape `lwcircle_make` gives a circle, which is the geometry of a circular buffer and the
geometry the native buffer of a point returns, so the reach is wider than the relate matrix:
`geom_spatialrel` sends every (multi)polygon and (multi)point pair through `meos_point_in_polygon`.