### PR TITLE
Leave no component out of the buffer of a multi-part geometry

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -4787,8 +4787,17 @@ meos_buffer_mline(const LWMLINE *mline, double radius, JoinStyle join_style,
 
     LWGEOM *buffer = meos_buffer_line((const LWLINE *) component, radius,
       join_style, cap_style, mitre_limit);
-    if (buffer)
-      buffers[count++] = buffer;
+    if (! buffer)
+    {
+      /* A component the buffer does not cover cannot be left out of the
+       * answer: what is left is a geometry smaller than the buffer asked
+       * for, valid and of the right shape and reported by nothing */
+      for (uint32_t j = 0; j < count; j++)
+        lwgeom_free(buffers[j]);
+      pfree(buffers);
+      return NULL;
+    }
+    buffers[count++] = buffer;
   }
 
   /* All components were empty */
@@ -4960,8 +4969,17 @@ meos_buffer_mpoly(const LWMPOLY *mpoly, double radius, JoinStyle join_style,
       continue;
     LWGEOM *buffer = meos_buffer_poly((const LWPOLY *) component, radius,
       join_style, cap_style, mitre_limit, false);
-    if (buffer)
-      buffers[count++] = buffer;
+    if (! buffer)
+    {
+      /* A component the buffer does not cover cannot be left out of the
+       * answer: what is left is a geometry smaller than the buffer asked
+       * for, valid and of the right shape and reported by nothing */
+      for (uint32_t j = 0; j < count; j++)
+        lwgeom_free(buffers[j]);
+      pfree(buffers);
+      return NULL;
+    }
+    buffers[count++] = buffer;
   }
 
   /* All components were empty */
@@ -5027,7 +5045,15 @@ meos_buffer_collection(const LWCOLLECTION *collection, double radius,
       buffer = meos_buffer(component, radius, join_style, cap_style,
         mitre_limit);
     if (! buffer)
-      continue;
+    {
+      /* A component the buffer does not cover cannot be left out of the
+       * answer: what is left is a geometry smaller than the buffer asked
+       * for, valid and of the right shape and reported by nothing */
+      for (uint32_t j = 0; j < count; j++)
+        lwgeom_free(buffers[j]);
+      pfree(buffers);
+      return NULL;
+    }
     /* Grow the output array if necessary */
     if (count == capacity)
     {


### PR DESCRIPTION
The buffer of a multi-part geometry is built by buffering every component and dissolving the results
together. A component whose buffer the engine does not cover is passed over and the remaining
components dissolved without it, so the answer is a geometry smaller than the buffer asked for:
valid, of the right shape, carrying the right number of surfaces, and reported by nothing.

Over the geometries of the fixture at distance 5, seventeen multipolygons answer a buffer between a
third and two thirds short of its area, the widest 1938 against 5865. Fifty-two components are
passed over across nineteen multipolygons, and fifty of the fifty-two are the exterior ring of a
single-ring, non-convex polygon buffered outward.

A component the buffer does not cover stops the whole geometry from being answered, which is what
every other geometry the buffer does not cover already does. The same passing over is in the
multiline and in the collection, and this carries to both.

The seventeen answers become seventeen geometries reported as not supported. Every answer that
agrees with a finely divided reference keeps agreeing with it.