### PR TITLE
Measure the instant distance of a rigid geometry from its placed body

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -339,8 +339,13 @@ compute_dist2(POINT4D p, POINT4D vs, POINT4D ve)
 TInstant *
 dist2d_trgeoinst_geo(const TInstant *inst, const GSERIALIZED *gs)
 {
-  double dist = geom_distance2d(trgeoinst_geom_p(inst), gs);
-  return tinstant_make(Float8GetDatum(dist), T_FLOAT8, inst->t);
+  /* The reference geometry is the body at the origin; the distance is measured
+   * from the body placed by the pose of the instant */
+  GSERIALIZED *body = pose_apply_geo(DatumGetPoseP(tinstant_value_p(inst)),
+    trgeoinst_geom_p(inst));
+  double dist = geom_distance2d(body, gs);
+  pfree(body);
+  return tinstant_make(Float8GetDatum(dist), T_TFLOAT, inst->t);
 }
 
 /**

--- a/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
@@ -110,6 +110,54 @@ SELECT round(ST_Length(shortestLine(
  2.000000
 (1 row)
 
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  geometry 'Point(5 3)'))::numeric, 6);
+   round   
+-----------
+ 15.956633
+(1 row)
+
+SELECT round(ST_Distance(valueAtTimestamp(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  '2001-01-01'), geometry 'Point(5 3)')::numeric, 6);
+   round   
+-----------
+ 15.956633
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  geometry 'Linestring(5 3,6 4)'))::numeric, 6);
+   round   
+-----------
+ 14.611275
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'))::numeric, 6);
+   round   
+-----------
+ 14.611275
+(1 row)
+
+SELECT round(minValue(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01' <->
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))')::numeric, 6);
+   round   
+-----------
+ 14.611275
+(1 row)
+
+SELECT round(nearestApproachDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))')::numeric, 6);
+   round   
+-----------
+ 14.611275
+(1 row)
+
 SELECT getTimestamp(nearestApproachInstant(
   trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.141592653589793)@2001-01-02]',
   geometry 'Polygon((0 3,1 3,1 4,0 4,0 3))')) <@ tstzspan '(2001-01-01, 2001-01-02)';

--- a/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
@@ -100,6 +100,28 @@ SELECT round(ST_Length(shortestLine(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
   geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'))::numeric, 6);
 
+-- An instant rigid geometry: the distance is measured from the body placed by
+-- the pose of the instant, and it is answered for every geometry type because
+-- the instant case delegates to the geometry-geometry distance
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  geometry 'Point(5 3)'))::numeric, 6);
+SELECT round(ST_Distance(valueAtTimestamp(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  '2001-01-01'), geometry 'Point(5 3)')::numeric, 6);
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  geometry 'Linestring(5 3,6 4)'))::numeric, 6);
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'))::numeric, 6);
+SELECT round(minValue(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01' <->
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))')::numeric, 6);
+SELECT round(nearestApproachDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));Pose(Point(20 10),1.1)@2001-01-01',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))')::numeric, 6);
+
 -- The nearest approach instant of the rotating body lies strictly inside the
 -- motion, not at an endpoint
 SELECT getTimestamp(nearestApproachInstant(


### PR DESCRIPTION
`tDistance` between an instant temporal rigid geometry and a geometry fails:

```
SELECT tDistance(trgeometry(geometry 'Polygon((-11 -6,19 -6,29 0,19 6,-11 6,-11 -6))',
  pose 'Pose(Point(0 0),0)', timestamptz '2024-03-01 00:00:00+01'), geometry 'Point(50 40)');
ERROR:  type 11 is not a temporal type
```

`dist2d_trgeoinst_geo` passed the base type `T_FLOAT8` to `tinstant_make`, whose parameter is the
temporal type; type 11 is `T_FLOAT8`. Every sibling family passes `T_TFLOAT`.

The instant branch delegates to the geometry-geometry distance, so with the temporal type right it
answers for every geometry type, including the multi and linestring types that the sequence branch
still declines.
