### PR TITLE
Give the temporal distance of a rigid geometry the interpolation of its input

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -843,7 +843,7 @@ dist2d_trgeoseq_point(const TSequence *seq, const GSERIALIZED *gs)
       tda.arr[i].t);
   TSequence *result = tsequence_make_free(instants, tda.count,
     seq->period.lower_inc, seq->period.upper_inc,
-    MEOS_FLAGS_LINEAR_INTERP(seq->flags), NORMALIZE);
+    MEOS_FLAGS_GET_INTERP(seq->flags), NORMALIZE);
 
   lwpoly_free(poly);
   lwpoint_free(point);
@@ -1814,7 +1814,7 @@ dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs)
       tda.arr[i].t);
   TSequence *result = tsequence_make_free(instants, tda.count,
     seq->period.lower_inc, seq->period.upper_inc,
-    MEOS_FLAGS_LINEAR_INTERP(seq->flags), NORMALIZE);
+    MEOS_FLAGS_GET_INTERP(seq->flags), NORMALIZE);
 
   lwpoly_free(poly1); lwpoly_free(poly2);
   free_cfp_array(&cfpa); free_tdist_array(&tda);
@@ -2003,7 +2003,7 @@ dist2d_trgeoseq_trgeoseq(const TSequence *seq1, const TSequence *seq2,
       tda.arr[i].t);
   TSequence *result = tsequence_make_free(instants, tda.count,
     seq1->period.lower_inc, seq1->period.upper_inc,
-    MEOS_FLAGS_LINEAR_INTERP(seq1->flags), NORMALIZE);
+    MEOS_FLAGS_GET_INTERP(seq1->flags), NORMALIZE);
 
   lwpoly_free(poly1); lwpoly_free(poly2);
   free_cfp_array(&cfpa); free_tdist_array(&tda);
@@ -2099,7 +2099,7 @@ trgeoseq_translate_by_tpoint(const TSequence *pseq, const TSequence *qseq,
       TSEQUENCE_INST_N(qseq, i), ref_gs);
   return trgeoseq_make_free(ref_gs, instants, pseq->count,
     pseq->period.lower_inc, pseq->period.upper_inc,
-    MEOS_FLAGS_LINEAR_INTERP(pseq->flags), NORMALIZE);
+    MEOS_FLAGS_GET_INTERP(pseq->flags), NORMALIZE);
 }
 
 /**

--- a/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
@@ -118,3 +118,27 @@ SELECT getTimestamp(nearestApproachInstant(
  t
 (1 row)
 
+SELECT interp(tDistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Point(0 5)'));
+ interp 
+--------
+ Linear
+(1 row)
+
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Point(0 5)'), '2001-01-01 12:00')::numeric, 6);
+  round   
+----------
+ 7.385165
+(1 row)
+
+SELECT interp(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'));
+ interp 
+--------
+ Linear
+(1 row)
+

--- a/mobilitydb/test/rgeo/expected/169_trgeo_distance_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/169_trgeo_distance_trgeo.test.out
@@ -65,3 +65,11 @@ SELECT getTimestamp(nearestApproachInstant(
  t
 (1 row)
 
+SELECT interp(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 0),0)@2001-01-01, Pose(Point(14 0),0)@2001-01-02]'));
+ interp 
+--------
+ Linear
+(1 row)
+

--- a/mobilitydb/test/rgeo/expected/172_trgeo_distance_tpoint.test.out
+++ b/mobilitydb/test/rgeo/expected/172_trgeo_distance_tpoint.test.out
@@ -46,3 +46,11 @@ SELECT round(minValue(
  2.000000
 (1 row)
 
+SELECT interp(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  tgeompoint '[Point(5 3)@2001-01-01, Point(5 3)@2001-01-02]'));
+ interp 
+--------
+ Linear
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
@@ -106,4 +106,17 @@ SELECT getTimestamp(nearestApproachInstant(
   trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.141592653589793)@2001-01-02]',
   geometry 'Polygon((0 3,1 3,1 4,0 4,0 3))')) <@ tstzspan '(2001-01-01, 2001-01-02)';
 
+-- The temporal distance of a moving rigid geometry is linear, as it is in every
+-- other spatial family: it has a value at every instant of the motion, not only
+-- at the closest-feature transitions and the interior extrema
+SELECT interp(tDistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Point(0 5)'));
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Point(0 5)'), '2001-01-01 12:00')::numeric, 6);
+SELECT interp(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'));
+
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/queries/169_trgeo_distance_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/169_trgeo_distance_trgeo.test.sql
@@ -78,4 +78,9 @@ SELECT round(minValue(
 SELECT getTimestamp(nearestApproachInstant(
   trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.141592653589793)@2001-01-02]',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 3),0)@2001-01-01, Pose(Point(0 3),0)@2001-01-02]')) <@ tstzspan '(2001-01-01, 2001-01-02)';
+-- The temporal distance between two moving rigid geometries is linear
+SELECT interp(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 0),0)@2001-01-01, Pose(Point(14 0),0)@2001-01-02]'));
+
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/queries/172_trgeo_distance_tpoint.test.sql
+++ b/mobilitydb/test/rgeo/queries/172_trgeo_distance_tpoint.test.sql
@@ -65,4 +65,10 @@ SELECT round(minValue(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]' <->
   tgeompoint '[Point(5 3)@2001-01-01, Point(5 3)@2001-01-02]')::numeric, 6);
 
+-- The temporal distance between a moving rigid geometry and a temporal point is
+-- linear
+SELECT interp(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  tgeompoint '[Point(5 3)@2001-01-01, Point(5 3)@2001-01-02]'));
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
`tDistance` on a temporal rigid geometry returned a discrete temporal float:

```
SELECT interp(tDistance(
  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
  geometry 'Point(0 5)'));
 interp
--------
 Discrete
```

It carried a value only at the closest-feature transitions and the interior extrema, and
`valueAtTimestamp` answered nothing anywhere else. The four sequence constructors of the rgeo
distance kernels passed `MEOS_FLAGS_LINEAR_INTERP`, a `bool`, where the parameter is an
`interpType`, and `DISCRETE` is 1.

`tgeompoint` and `tcbuffer` both answer `Linear` for the same query shape.
