### PR TITLE
Join the bodies themselves in the shortest line of a rigid geometry

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2467,13 +2467,13 @@ shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
     return NULL;
   
   Temporal *dist = tdistance_trgeometry_geo(temp, gs);
+  if (dist == NULL)
+    return NULL;
   const TInstant *inst = temporal_min_inst_p(dist);
   /* Timestamp t may be at an exclusive bound */
   Datum value;
   trgeo_value_at_timestamptz(temp, inst->t, false, &value);
-  LWGEOM *line = (LWGEOM *) lwline_make(value, PointerGetDatum(gs));
-  GSERIALIZED *result = geo_serialize(line);
-  lwgeom_free(line);
+  GSERIALIZED *result = geom_shortestline2d(DatumGetGserializedP(value), gs);
   pfree(DatumGetPointer(value)); pfree(dist);
   return result;
 }
@@ -2500,9 +2500,8 @@ shortestline_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
   Datum value1, value2;
   trgeo_value_at_timestamptz(temp1, inst->t, false, &value1);
   temporal_value_at_timestamptz(temp2, inst->t, false, &value2);
-  LWGEOM *line = (LWGEOM *) lwline_make(value1, value2);
-  GSERIALIZED *result = geo_serialize(line);
-  lwgeom_free(line);
+  GSERIALIZED *result = geom_shortestline2d(DatumGetGserializedP(value1),
+    DatumGetGserializedP(value2));
   pfree(DatumGetPointer(value1)); pfree(DatumGetPointer(value2)); pfree(dist);
   return result;
 }
@@ -2529,9 +2528,8 @@ shortestline_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
   Datum value1, value2;
   trgeo_value_at_timestamptz(temp1, inst->t, false, &value1);
   trgeo_value_at_timestamptz(temp2, inst->t, false, &value2);
-  LWGEOM *line = (LWGEOM *) lwline_make(value1, value2);
-  GSERIALIZED *result = geo_serialize(line);
-  lwgeom_free(line);
+  GSERIALIZED *result = geom_shortestline2d(DatumGetGserializedP(value1),
+    DatumGetGserializedP(value2));
   pfree(DatumGetPointer(value1)); pfree(DatumGetPointer(value2)); pfree(dist);
   return result;
 }

--- a/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
@@ -190,3 +190,19 @@ SELECT interp(tDistance(
  Linear
 (1 row)
 
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'));
+      st_astext      
+---------------------
+ LINESTRING(5 1,5 3)
+(1 row)
+
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Point(5 3)'));
+      st_astext      
+---------------------
+ LINESTRING(5 1,5 3)
+(1 row)
+

--- a/mobilitydb/test/rgeo/expected/169_trgeo_distance_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/169_trgeo_distance_trgeo.test.out
@@ -73,3 +73,11 @@ SELECT interp(tDistance(
  Linear
 (1 row)
 
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 0),0)@2001-01-01, Pose(Point(14 0),0)@2001-01-02]'));
+       st_astext       
+-----------------------
+ LINESTRING(12 0,14 0)
+(1 row)
+

--- a/mobilitydb/test/rgeo/expected/172_trgeo_distance_tpoint.test.out
+++ b/mobilitydb/test/rgeo/expected/172_trgeo_distance_tpoint.test.out
@@ -54,3 +54,11 @@ SELECT interp(tDistance(
  Linear
 (1 row)
 
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  tgeompoint '[Point(5 3)@2001-01-01, Point(5 3)@2001-01-02]'));
+      st_astext      
+---------------------
+ LINESTRING(5 1,5 3)
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
@@ -141,4 +141,13 @@ SELECT interp(tDistance(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
   geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'));
 
+-- The shortest line joins the body and the geometry themselves, not the two
+-- geometries read as if they were points
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'));
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Point(5 3)'));
+
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/queries/169_trgeo_distance_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/169_trgeo_distance_trgeo.test.sql
@@ -83,4 +83,9 @@ SELECT interp(tDistance(
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 0),0)@2001-01-01, Pose(Point(14 0),0)@2001-01-02]'));
 
+-- The shortest line joins the two bodies themselves
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 0),0)@2001-01-01, Pose(Point(14 0),0)@2001-01-02]'));
+
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/queries/172_trgeo_distance_tpoint.test.sql
+++ b/mobilitydb/test/rgeo/queries/172_trgeo_distance_tpoint.test.sql
@@ -71,4 +71,9 @@ SELECT interp(tDistance(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
   tgeompoint '[Point(5 3)@2001-01-01, Point(5 3)@2001-01-02]'));
 
+-- The shortest line joins the body itself and the point
+SELECT ST_AsText(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  tgeompoint '[Point(5 3)@2001-01-01, Point(5 3)@2001-01-02]'));
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
`shortestLine` on a temporal rigid geometry answered a line with denormal coordinates:

```
SELECT ST_AsText(shortestLine(
  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'));
 LINESTRING(2.5e-323 3,2.5e-323 5)
```

The three shortest-line functions of the rgeo family built their result with `lwline_make`, which
reads a point out of each of its two arguments. They passed the placed body geometry, so the
coordinates came from whatever the polygon header holds at the offset of a point. The length of
that line matched the nearest approach distance only by accident.

The line is now the shortest line between the two geometries, as `shortestline_tgeo_geo` already
answers it. The distance to a geometry also stops dereferencing a null temporal distance, as its
two siblings already did.
