### PR TITLE
Join two temporal geometries by the line between the geometries themselves

### DIFF
--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2975,12 +2975,30 @@ shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
   Datum value1, value2;
   temporal_value_at_timestamptz(temp1, tmin, false, &value1);
   temporal_value_at_timestamptz(temp2, tmin, false, &value2);
-  LWGEOM *line = (LWGEOM *) lwline_make(value1, value2);
-  GSERIALIZED *result = geo_serialize(line);
+  const GSERIALIZED *gs1 = DatumGetGserializedP(value1);
+  const GSERIALIZED *gs2 = DatumGetGserializedP(value2);
+  GSERIALIZED *result;
+  if (gserialized_get_type(gs1) == POINTTYPE &&
+      gserialized_get_type(gs2) == POINTTYPE)
+  {
+    /* The shortest line between two points is the line joining them, and
+     * building it directly carries a Z that the geodetic shortest line, which
+     * answers on the spheroid and so in two dimensions, would drop */
+    LWGEOM *line = (LWGEOM *) lwline_make(value1, value2);
+    result = geo_serialize(line);
+    lwgeom_free(line);
+  }
+  /* The values of a temporal geometry carry extent, so what joins them is the
+   * shortest line between the two of them, over the dispatch
+   * #shortestline_tgeo_geo makes for the same pair of arguments */
+  else if (MEOS_FLAGS_GET_GEODETIC(temp1->flags))
+    result = geography_shortestline_internal(gs1, gs2, true);
+  else
+    result = MEOS_FLAGS_GET_Z(temp1->flags) ?
+      geom_shortestline3d(gs1, gs2) : geom_shortestline2d(gs1, gs2);
   pfree(DatumGetPointer(value1)); pfree(DatumGetPointer(value2));
   if (dist)
     pfree(dist);
-  lwgeom_free(line);
   return result;
 }
 

--- a/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
+++ b/mobilitydb/test/geo/expected/064_tgeo_distance.test.out
@@ -3789,6 +3789,42 @@ SELECT ST_AsText(shortestLine(tgeometry '[Point(2 2)@2000-01-01, Point(1 1)@2000
  LINESTRING(1 1,2 1)
 (1 row)
 
+SELECT ST_AsText(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]'));
+      st_astext      
+---------------------
+ LINESTRING(2 1,5 3)
+(1 row)
+
+SELECT ST_AsText(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((10 0,12 0,12 1,10 1,10 0))@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]'));
+      st_astext      
+---------------------
+ LINESTRING(2 1,5 3)
+(1 row)
+
+SELECT ST_AsText(shortestLine(tgeometry '[Linestring(0 0,2 2)@2001-01-01, Linestring(0 0,2 2)@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]'));
+      st_astext      
+---------------------
+ LINESTRING(2 2,5 3)
+(1 row)
+
+SELECT ST_AsText(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', tgeometry '[Point(5 3)@2001-01-01, Point(5 3)@2001-01-02]'));
+      st_astext      
+---------------------
+ LINESTRING(2 1,5 3)
+(1 row)
+
+SELECT ST_Length(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]')) = nearestApproachDistance(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ST_AsText(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'));
+      st_astext      
+---------------------
+ LINESTRING(2 1,5 3)
+(1 row)
+
 SELECT shortestline(tgeometry '{[Point(2 2)@2001-01-01, Point(2 2)@2001-01-02),[Point(1 1)@2001-01-03, Point(2 2)@2001-01-04]}', tgeometry '[Point(1 1)@2001-01-02, Point(1 1)@2001-01-03)');
  shortestline 
 --------------

--- a/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
+++ b/mobilitydb/test/geo/queries/064_tgeo_distance.test.sql
@@ -792,6 +792,17 @@ SELECT ST_AsText(shortestLine(tgeometry '{[Point(0 0)@2000-01-01, Point(2 0)@200
 SELECT ST_AsText(shortestLine(tgeometry '{[Point(0 0)@2000-01-01],(Point(1 1)@2000-01-02, Point(1 1)@2000-01-03)}','{[Point(1 3)@2000-01-01, Point(1 2)@2000-01-03]}'));
 SELECT ST_AsText(shortestLine(tgeometry '{[Point(1 1)@2000-01-01, Point(1 1)@2000-01-02),[Point(0 0)@2000-01-03]}','{[Point(1 3)@2000-01-01, Point(1 2)@2000-01-03]}'));
 SELECT ST_AsText(shortestLine(tgeometry '[Point(2 2)@2000-01-01, Point(1 1)@2000-01-02]', '[Point(4 1)@2000-01-01, Point(2 1)@2000-01-02]'));
+-- Values carrying extent: the line joins the two geometries, not two points.
+-- The line must be asserted by its text, since its LENGTH alone is satisfied by
+-- a line drawn between the wrong two points.
+SELECT ST_AsText(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]'));
+SELECT ST_AsText(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((10 0,12 0,12 1,10 1,10 0))@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]'));
+SELECT ST_AsText(shortestLine(tgeometry '[Linestring(0 0,2 2)@2001-01-01, Linestring(0 0,2 2)@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]'));
+SELECT ST_AsText(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', tgeometry '[Point(5 3)@2001-01-01, Point(5 3)@2001-01-02]'));
+-- A witness measures the distance it reports
+SELECT ST_Length(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]')) = nearestApproachDistance(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]');
+-- The two argument forms answer the same question
+SELECT ST_AsText(shortestLine(tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]', geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'));
 -- NULL
 SELECT shortestline(tgeometry '{[Point(2 2)@2001-01-01, Point(2 2)@2001-01-02),[Point(1 1)@2001-01-03, Point(2 2)@2001-01-04]}', tgeometry '[Point(1 1)@2001-01-02, Point(1 1)@2001-01-03)');
 SELECT shortestline(tgeometry '{[Point(1 1)@2001-01-01, Point(1 1)@2001-01-02),[Point(1 1)@2001-01-03, Point(2 2)@2001-01-04]}', tgeometry '{[Point(1 1)@2001-01-02, Point(1 1)@2001-01-03)}');


### PR DESCRIPTION
`shortestline_tgeo_tgeo` takes the value of each argument at the nearest approach instant and joins the two with `lwline_make`, which builds the line through two POINTS: it reads a point out of each argument with `datum_point4d`. The values of a temporal geometry are the geometries themselves, so for anything carrying extent the coordinates come from whatever the geometry's header holds where a point's would be, and the answer is a line through uninitialised bytes:

```sql
SELECT ST_AsText(shortestLine(
  tgeometry '[Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-01, Polygon((0 0,2 0,2 1,0 1,0 0))@2001-01-02]',
  tgeometry '[Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-01, Polygon((5 3,6 3,6 4,5 4,5 3))@2001-01-02]'));
-- LINESTRING(2.5e-323 0,2.5e-323 5)      nearestApproachDistance 3.605551
```

`2.5e-323` is a denormal. The same query with the second argument written as a plain geometry answers `LINESTRING(2 1,5 3)`, which is the line the temporal argument form answers here too, over the dispatch `shortestline_tgeo_geo` makes for that pair — `geography_shortestline_internal` when geodetic, `geom_shortestline3d` when Z, else `geom_shortestline2d`.

Two points keep the line joining them. It is the same line the dispatch returns for a planar pair, measured over twelve 2D, 3D and geodetic pairs including coincident points, a 1e-12 gap and 1e7 coordinates, and it carries a Z that the geodetic shortest line drops, since that one answers on the spheroid and so in two dimensions — which is why `shortestline_tgeo_geo` refuses a geodetic argument carrying Z. Without that guard the geodetic `tgeogpoint 'Point(-90 0 100)'` cases answer `LINESTRING(-90 0,0 -90)` where they answer `LINESTRING Z (-90 0 100,0 -90 100)`, losing a dimension the input carries.

The temporal point surface is untouched: `064_tpoint_distance`, `064_tpoint_distance_tbl`, `306_tnpoint_spatialfuncs`, `306_tnpoint_spatialfuncs_tbl`, `113_tpose_distance`, `168_trgeo_distance` and `210_tcbuffer_distance(_tbl)` all pass against their committed expected output.

The two other callers of `lwline_make` are correct and are left alone: `nai_tpointsegm_linear_geo1` builds the trajectory line of a temporal POINT segment, and the one in `meos/src/cbuffer/tcbuffer_spatialfuncs.c` is guarded on both radii being zero and fed `cbuffer_point(...)`.

Every committed `shortestLine(tgeometry, tgeometry)` case passes POINT values, where the kernel is correct, which is what lets this stand. The cases added carry extent, and they assert the line by its TEXT: its LENGTH alone is satisfied by a line drawn between the wrong two points, so the `length(shortestLine) == nad` identity passes over the garbage line.
