### PR TITLE
Settle a buffer junction only where the two offsets actually cross

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -3836,6 +3836,29 @@ buffer_pieces_meet(const BufferPiece *a, const BufferPiece *b, double vx,
 }
 
 /**
+ * @brief Return whether a point of a piece's support lies on the piece itself
+ * @details #buffer_pieces_meet answers where two offsets' SUPPORTS cross — two
+ * whole lines, or two whole circles. A crossing bounds the buffer only where
+ * it falls on the pieces those supports carry; one landing beyond an end
+ * belongs to a part of the support the offset never reaches.
+ */
+static bool
+buffer_piece_holds(const BufferPiece *piece, double x, double y)
+{
+  assert(piece);
+  if (piece->type == BUFFER_ARC)
+    return buffer_arc_contains_angle(piece,
+      atan2(y - piece->cy, x - piece->cx));
+  double dx = piece->x2 - piece->x1, dy = piece->y2 - piece->y1;
+  double length2 = dx * dx + dy * dy;
+  if (length2 <= FP_TOLERANCE)
+    return true;
+  double t = ((x - piece->x1) * dx + (y - piece->y1) * dy) / length2;
+  double tol = MEOS_EDGE_TOLERANCE / sqrt(length2);
+  return t >= -tol && t <= 1.0 + tol;
+}
+
+/**
  * @brief Offset a chain of edges onto one boundary
  * @details Every edge is offset on the given side, and consecutive offsets are
  * joined at the vertex between them: where the chain turns away from the
@@ -3898,10 +3921,19 @@ buffer_offset_edges(const MeosArray *edges, double radius, bool left,
     if (fabs(turn) <= FP_TOLERANCE)
       continue;
     double x, y;
-    if (! buffer_pieces_meet(&pieces[i], &pieces[next], e1->x2, e1->y2, &x, &y))
+    if (! buffer_pieces_meet(&pieces[i], &pieces[next], e1->x2, e1->y2, &x, &y)
+        || ! buffer_piece_holds(&pieces[i], x, y)
+        || ! buffer_piece_holds(&pieces[next], x, y))
     {
-      pfree(pieces); pfree(join);
-      return false;
+      /* The two offsets settle the junction where they cross, and a crossing
+       * of their supports that lies beyond an offset's own end is one neither
+       * ever reaches — as is the case of an offset into a turn tighter than
+       * the buffer distance, which parts from its neighbour instead. What
+       * spans the two is then the points at the buffer distance from the
+       * vertex they turn about, which is the join the other side of a turn is
+       * given */
+      join[i] = true;
+      continue;
     }
     buffer_piece_set_end(&pieces[i], x, y);
     buffer_piece_set_start(&pieces[next], x, y);


### PR DESCRIPTION
The point two consecutive offsets share is where their supports cross, and
buffer_pieces_meet answers that question about the supports: two whole lines,
or two whole circles. A crossing bounds the buffer only where it falls on the
pieces those supports carry. One landing beyond an end belongs to a part of the
support the offset never reaches, and trimming to it takes away boundary the
buffer has.

An offset into a turn tighter than the buffer distance leaves the same junction
unsettled the other way, its two offsets parting rather than crossing. Both are
answered by what spans them: the points at the buffer distance from the vertex
they turn about, which is the join the convex side of a turn is already given.

Over the 154 fixture geometries buffered by 5, checked against ST_Buffer of the
input densified to 1e-6 at quad_segs=128 within 1e-4 of the reference area:
geometries the buffer does not cover go 61 to 36, correct answers 87 to 108,
and wrong ones 6 to 10. CIRCULARSTRING goes 12 to 0 and COMPOUNDCURVE 14 to 5.

The four wrong answers this adds are geometries that decline beforehand, and
every one of them UNDER-covers, by between 0.04% and 3.4% of the reference
area, each a valid geometry and each a subset of it. They are the boundary
overlay rather than the junction: buffer_ring_resolve keeps a split piece when
the geometry is no nearer to its middle than the buffer distance, and a piece
that bounds the buffer is dropped there. Widening that test by a factor of a
thousand answers identically, so it is a classification rather than a
tolerance.

