### PR TITLE
Span a polygon ring's parted offsets rather than declining the ring

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -3552,17 +3552,31 @@ buffer_ring(const POINTARRAY *source, double radius, bool outward_left,
     bool convex = outward_left ? turn < -FP_TOLERANCE : turn > FP_TOLERANCE;
 
     POINT2D enter = incoming, leave = outgoing;
+    bool bridge = false;
     if (! convex)
     {
+      /* The two offsets of a vertex the buffered side is concave at cross, and
+       * the crossing is the point the boundary passes through — while it lies
+       * on both of them. The two offset LINES always cross; a crossing further
+       * from the vertex than either segment is long lies beyond an offset's
+       * own end, so neither ever reaches it, and the boundary runs through the
+       * points at the buffer distance from the vertex instead */
       POINT2D crossing;
       if (! buffer_line_intersection(incoming, in_dx, in_dy, outgoing, out_dx,
           out_dy, &crossing))
+        bridge = true;
+      else
       {
-        pfree(points); pfree(nx); pfree(ny);
-        lwgeom_free(lwcompound_as_lwgeom(ring));
-        return NULL;
+        double in_len = hypot(in_dx, in_dy), out_len = hypot(out_dx, out_dy);
+        double ux = crossing.x - points[i].x, uy = crossing.y - points[i].y;
+        double back = -(ux * in_dx + uy * in_dy) / in_len;
+        double ahead = (ux * out_dx + uy * out_dy) / out_len;
+        if (back > in_len + MEOS_EDGE_TOLERANCE ||
+            ahead > out_len + MEOS_EDGE_TOLERANCE)
+          bridge = true;
+        else
+          enter = leave = crossing;
       }
-      enter = leave = crossing;
     }
 
     if (! started)
@@ -3576,28 +3590,14 @@ buffer_ring(const POINTARRAY *source, double radius, bool outward_left,
        * opposite to the segment it comes from has been consumed: the ring is
        * contracted past its own width there and bounds no surface, which the
        * boundary overlay would have to resolve. */
-      if ((enter.x - cursor.x) * in_dx + (enter.y - cursor.y) * in_dy <
-          -FP_TOLERANCE)
-      {
-        pfree(points); pfree(nx); pfree(ny);
-        lwgeom_free(lwcompound_as_lwgeom(ring));
-        return NULL;
-      }
       buffer_add_segment(ring, srid, cursor, enter);
     }
-    if (convex)
+    if (convex || bridge)
       buffer_add_join(ring, srid, points[i], incoming, outgoing, radius,
         join_style, mitre_limit, true);
     cursor = leave;
   }
   /* The offset of the segment closing the ring */
-  if ((first.x - cursor.x) * (points[0].x - points[n - 1].x) +
-      (first.y - cursor.y) * (points[0].y - points[n - 1].y) < -FP_TOLERANCE)
-  {
-    pfree(points); pfree(nx); pfree(ny);
-    lwgeom_free(lwcompound_as_lwgeom(ring));
-    return NULL;
-  }
   buffer_add_segment(ring, srid, cursor, first);
 
   pfree(points); pfree(nx); pfree(ny);
@@ -5105,7 +5105,11 @@ meos_buffer_poly(const LWPOLY *poly, double radius, JoinStyle join_style,
     lwgeom_free(geom);
     return lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0));
   }
-  return geom;
+  /* A ring turning tighter than the buffer distance carries offsets that run
+   * into one another, and what a crossing encloses lies inside the buffer
+   * rather than on its boundary */
+  return inward ? geom :
+    buffer_ring_resolved(geom, (const LWGEOM *) poly, radius, srid);
 }
 
 /*****************************************************************************


### PR DESCRIPTION
A ring's boundary passes through the point the two offsets of a vertex share,
which buffer_ring reads as the crossing of the two offset LINES. Two lines
always cross, but the two offset SEGMENTS reach the crossing only while it lies
no further from the vertex than either of them is long. Where they do not, the
ring runs backwards over an offset it has already drawn, and the two checks
that catch it decline the whole ring.

What spans the two offsets there is the points at the buffer distance from the
vertex they turn about, which is the join the convex side of a turn is already
given. Offsets that then run into one another leave a loop lying inside the
buffer rather than on its boundary, and naming what such a crossing leaves is
what buffer_ring_resolve does, so the ring is resolved as a curve's is.

Over the 154 fixture geometries buffered by 5, checked against ST_Buffer of the
input densified to 1e-6 at quad_segs=128 within 1e-4 of the reference area:
geometries the buffer does not cover go 61 to 41 and correct answers 87 to 101,
every POLYGON and MULTIPOLYGON among them answered.

Wrong answers go 6 to 12. The six this adds are MULTIPOLYGON geometries that
decline beforehand, and each answers a surface short of the reference by
between 0.011% and 0.55% of its area, every one a valid geometry and every one
a subset of it. They are the boundary overlay rather than the ring:
buffer_ring_resolve keeps a split piece when the geometry is no nearer to its
middle than the buffer distance, and a piece that bounds the buffer is dropped
there. Widening that test by a factor of a thousand answers identically, so it
is a classification rather than a tolerance, and the same shortfall reaches
COMPOUNDCURVE geometries through the curve path.

