### PR TITLE
Read the reference geometry of a rigid geometry from the temporal value

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -747,10 +747,10 @@ edge_vertex_tpoly_point(LWPOLY *poly, Pose *pose_start, Pose *pose_end,
  * @brief
  */
 TSequence *
-dist2d_trgeoseq_point(const TSequence *seq, const GSERIALIZED *gs)
+dist2d_trgeoseq_point(const TSequence *seq, const GSERIALIZED *gs,
+  const GSERIALIZED *ref_gs)
 {
   /* TODO: Add check and code for stepwise seq */
-  const GSERIALIZED *ref_gs = trgeoseq_geom_p(seq);
 
   /* TODO: check that polygon is convex */
   LWPOLY *poly = lwgeom_as_lwpoly(lwgeom_from_gserialized(ref_gs));
@@ -1685,10 +1685,10 @@ trgeoseq_segment_index(const TSequence *seq, TimestampTz t)
  * @brief
  */
 TSequence *
-dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs)
+dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs,
+  const GSERIALIZED *ref_gs)
 {
   /* TODO: Add check and code for stepwise seq */
-  const GSERIALIZED *ref_gs = trgeoseq_geom_p(seq);
 
   /* TODO: check that both polygons are convex */
   LWPOLY *poly1 = lwgeom_as_lwpoly(lwgeom_from_gserialized(ref_gs));
@@ -1830,17 +1830,18 @@ dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs)
  * @brief
  */
 TSequence *
-dist2d_trgeoseq_geo(const TSequence *seq, const GSERIALIZED *gs)
+dist2d_trgeoseq_geo(const TSequence *seq, const GSERIALIZED *gs,
+  const GSERIALIZED *ref_gs)
 {
   uint32_t gs_type = gserialized_get_type(gs);
   TSequence *result = NULL;
   switch (gs_type)
   {
     case POINTTYPE:
-      result = dist2d_trgeoseq_point(seq, gs);
+      result = dist2d_trgeoseq_point(seq, gs, ref_gs);
       break;
     case POLYGONTYPE:
-      result = dist2d_trgeoseq_poly(seq, gs);
+      result = dist2d_trgeoseq_poly(seq, gs, ref_gs);
       break;
     default:
       meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
@@ -1854,11 +1855,12 @@ dist2d_trgeoseq_geo(const TSequence *seq, const GSERIALIZED *gs)
  * @brief
  */
 TSequenceSet *
-dist2d_trgeoseqset_geo(const TSequenceSet *ss, const GSERIALIZED *gs)
+dist2d_trgeoseqset_geo(const TSequenceSet *ss, const GSERIALIZED *gs,
+  const GSERIALIZED *ref_gs)
 {
   TSequence **sequences = palloc(sizeof(TSequence *) * ss->count);
   for (int i = 0; i < ss->count; i++)
-    sequences[i] = dist2d_trgeoseq_geo(TSEQUENCESET_SEQ_N(ss, i), gs);
+    sequences[i] = dist2d_trgeoseq_geo(TSEQUENCESET_SEQ_N(ss, i), gs, ref_gs);
   return tsequenceset_make_free(sequences, ss->count, NORMALIZE);
 }
 
@@ -2054,15 +2056,21 @@ tdistance_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
     return NULL;
   }
 
+  /* The reference geometry of the rigid body is invariant in time; read it
+   * from the temporal value because a sequence set stores it once and not in
+   * each of its composing sequences */
+  const GSERIALIZED *ref_gs = trgeo_geom_p(temp);
+
   Temporal *result;
   assert(temptype_subtype(temp->subtype));
   if (temp->subtype == TINSTANT)
     result = (Temporal *) dist2d_trgeoinst_geo((const TInstant *) temp, gs);
   else if (temp->subtype == TSEQUENCE)
-    result = (Temporal *) dist2d_trgeoseq_geo((const TSequence *) temp, gs);
+    result = (Temporal *) dist2d_trgeoseq_geo((const TSequence *) temp, gs,
+      ref_gs);
   else /* temp->subtype == TSEQUENCESET */
     result = (Temporal *) dist2d_trgeoseqset_geo((const TSequenceSet *) temp,
-      gs);
+      gs, ref_gs);
   return result;
 }
 

--- a/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
@@ -206,3 +206,35 @@ SELECT ST_AsText(shortestLine(
  LINESTRING(5 1,5 3)
 (1 row)
 
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(10 0),0)@2001-01-04]}',
+  geometry 'Point(5 3)'))::numeric, 6);
+  round   
+----------
+ 2.000000
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(10 0),0)@2001-01-04]}',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'))::numeric, 6);
+  round   
+----------
+ 2.000000
+(1 row)
+
+SELECT numSequences(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(10 0),0)@2001-01-04]}',
+  geometry 'Point(5 3)'));
+ numsequences 
+--------------
+            2
+(1 row)
+
+SELECT round(nearestApproachDistance(
+  trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.14159265)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(5 0),0)@2001-01-04]}',
+  geometry 'Polygon((0 3,1 3,1 4,0 4,0 3))')::numeric, 6);
+  round   
+----------
+ 0.938447
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
@@ -150,4 +150,20 @@ SELECT ST_AsText(shortestLine(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
   geometry 'Point(5 3)'));
 
+-- A rigid geometry given as a sequence set: the reference geometry is stored
+-- once by the sequence set and not by its composing sequences, so it is read
+-- from the temporal value and passed down to every sequence
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(10 0),0)@2001-01-04]}',
+  geometry 'Point(5 3)'))::numeric, 6);
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(10 0),0)@2001-01-04]}',
+  geometry 'Polygon((5 3,6 3,6 4,5 4,5 3))'))::numeric, 6);
+SELECT numSequences(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(10 0),0)@2001-01-04]}',
+  geometry 'Point(5 3)'));
+SELECT round(nearestApproachDistance(
+  trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.14159265)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(5 0),0)@2001-01-04]}',
+  geometry 'Polygon((0 3,1 3,1 4,0 4,0 3))')::numeric, 6);
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
`tDistance` between a temporal rigid geometry and a geometry crashes the server whenever the rigid
geometry is a sequence set of more than one sequence:

```
SELECT minValue(tDistance(
  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02],[Pose(Point(0 0),0)@2001-01-03, Pose(Point(10 0),0)@2001-01-04]}',
  geometry 'Point(5 3)'));
server closed the connection unexpectedly
```

`dist2d_trgeoseqset_geo` hands each composing sequence to `dist2d_trgeoseq_geo`, which reads the
reference geometry with `trgeoseq_geom_p`. A sequence set stores the reference geometry once and
its composing sequences hold the temporal pose alone, so that accessor addresses memory past the
end of the sequence. A sequence set of a single sequence normalizes to a sequence and so never
reaches it.

This change reads the reference geometry once from the temporal value and passes it down, as the
distance between two rigid geometries and the distance to a temporal point already do.