### PR TITLE
Answer a nearest-neighbour scan over an all-the-same SP-GiST node

### DIFF
--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -583,10 +583,15 @@ stbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
       /* Report that all nodes should be visited */
       out->nNodes = in->nNodes;
       out->nodeNumbers = palloc(sizeof(int) * in->nNodes);
+      if (in->norderbys > 0)
+      {
+        out->traversalValues = palloc(sizeof(void *) * in->nNodes);
+        out->distances = palloc(sizeof(double *) * in->nNodes);
+      }
       for (i = 0; i < in->nNodes; i++)
       {
         out->nodeNumbers[i] = i;
-        if (in->norderbys > 0 && in->nNodes > 0)
+        if (in->norderbys > 0)
         {
           /* Use parent node box as traversalValue */
           old_ctx = MemoryContextSwitchTo(in->traversalMemoryContext);
@@ -597,11 +602,12 @@ stbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
           double *distances = palloc0(sizeof(double) * in->norderbys);
           out->distances[i] = distances;
           for (int j = 0; j < in->norderbys; j++)
-            distances[j] = distance_stbox_nodebox(&orderbys[i], nodebox);
-
-          pfree(orderbys);
+            distances[j] = distance_stbox_nodebox(&orderbys[j], nodebox);
         }
       }
+
+      if (in->norderbys > 0)
+        pfree(orderbys);
 
       PG_RETURN_VOID();
     }

--- a/mobilitydb/src/temporal/span_spgist.c
+++ b/mobilitydb/src/temporal/span_spgist.c
@@ -445,10 +445,15 @@ Span_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
       /* Report that all nodes should be visited */
       out->nNodes = in->nNodes;
       out->nodeNumbers = palloc(sizeof(int) * in->nNodes);
+      if (in->norderbys > 0)
+      {
+        out->traversalValues = palloc(sizeof(void *) * in->nNodes);
+        out->distances = palloc(sizeof(double *) * in->nNodes);
+      }
       for (i = 0; i < in->nNodes; i++)
       {
         out->nodeNumbers[i] = i;
-        if (in->norderbys > 0 && in->nNodes > 0)
+        if (in->norderbys > 0)
         {
           /* Use parent quadrant nodebox as traversalValue */
           old_ctx = MemoryContextSwitchTo(in->traversalMemoryContext);
@@ -460,10 +465,11 @@ Span_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
           out->distances[i] = distances;
           for (int j = 0; j < in->norderbys; j++)
             distances[j] = distance_span_nodespan(&orderbys[j], nodebox);
-
-          pfree(orderbys);
         }
       }
+
+      if (in->norderbys > 0)
+        pfree(orderbys);
 
       PG_RETURN_VOID();
     }

--- a/mobilitydb/src/temporal/tnumber_spgist.c
+++ b/mobilitydb/src/temporal/tnumber_spgist.c
@@ -478,10 +478,15 @@ tbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
       /* Report that all nodes should be visited */
       out->nNodes = in->nNodes;
       out->nodeNumbers = palloc(sizeof(int) * in->nNodes);
+      if (in->norderbys > 0)
+      {
+        out->traversalValues = palloc(sizeof(void *) * in->nNodes);
+        out->distances = palloc(sizeof(double *) * in->nNodes);
+      }
       for (i = 0; i < in->nNodes; i++)
       {
         out->nodeNumbers[i] = i;
-        if (in->norderbys > 0 && in->nNodes > 0)
+        if (in->norderbys > 0)
         {
           /* Use parent node box as traversalValue */
           old_ctx = MemoryContextSwitchTo(in->traversalMemoryContext);
@@ -493,10 +498,11 @@ tbox_spgist_inner_consistent(FunctionCallInfo fcinfo, SPGistIndexType idxtype)
           out->distances[i] = distances;
           for (int j = 0; j < in->norderbys; j++)
             distances[j] = distance_tbox_nodebox(&orderbys[j], nodebox);
-
-          pfree(orderbys);
         }
       }
+
+      if (in->norderbys > 0)
+        pfree(orderbys);
 
       PG_RETURN_VOID();
     }

--- a/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
+++ b/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
@@ -973,3 +973,29 @@ ANALYZE tbl_tgeompoint3D_big_allthesame;
 ANALYZE
 DROP TABLE tbl_tgeompoint3D_big_allthesame;
 DROP TABLE
+CREATE TABLE tbl_tgeompoint_allthesame AS
+  SELECT k, tgeompoint 'Point(5 5)@2001-01-01' AS temp
+  FROM generate_series(1, 1000) k;
+SELECT 1000
+CREATE INDEX tbl_tgeompoint_allthesame_quadtree_idx ON tbl_tgeompoint_allthesame
+  USING SPGIST(temp);
+CREATE INDEX
+ANALYZE tbl_tgeompoint_allthesame;
+ANALYZE
+SET enable_seqscan = off;
+SET
+WITH test AS (
+  SELECT temp |=| geometry 'Point(0 0)' AS distance
+  FROM tbl_tgeompoint_allthesame ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+  round   
+----------
+ 7.071068
+ 7.071068
+ 7.071068
+(3 rows)
+
+RESET enable_seqscan;
+RESET
+DROP TABLE tbl_tgeompoint_allthesame;
+DROP TABLE

--- a/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
@@ -308,3 +308,27 @@ DROP TABLE tbl_tgeompoint3D_big_allthesame;
 
 -------------------------------------------------------------------------------
 
+
+-------------------------------------------------------------------------------
+-- A quad-tree node whose children are all the same computes one ordering
+-- distance per ordering key from the parent node box. A table of identical
+-- values is what builds such a node.
+-------------------------------------------------------------------------------
+
+CREATE TABLE tbl_tgeompoint_allthesame AS
+  SELECT k, tgeompoint 'Point(5 5)@2001-01-01' AS temp
+  FROM generate_series(1, 1000) k;
+CREATE INDEX tbl_tgeompoint_allthesame_quadtree_idx ON tbl_tgeompoint_allthesame
+  USING SPGIST(temp);
+ANALYZE tbl_tgeompoint_allthesame;
+
+SET enable_seqscan = off;
+WITH test AS (
+  SELECT temp |=| geometry 'Point(0 0)' AS distance
+  FROM tbl_tgeompoint_allthesame ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+RESET enable_seqscan;
+
+DROP TABLE tbl_tgeompoint_allthesame;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/temporal/expected/011_span_indexes_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/011_span_indexes_tbl.test.out
@@ -1211,3 +1211,25 @@ ORDER BY op, leftarg, rightarg;
 
 DROP TABLE test_idxops;
 DROP TABLE
+CREATE TABLE tbl_tstzspan_allthesame AS
+  SELECT k, tstzspan '[2001-01-01, 2001-01-02]' AS t FROM generate_series(1, 1000) k;
+SELECT 1000
+CREATE INDEX tbl_tstzspan_allthesame_quadtree_idx ON tbl_tstzspan_allthesame
+  USING SPGIST(t);
+CREATE INDEX
+ANALYZE tbl_tstzspan_allthesame;
+ANALYZE
+SET enable_seqscan = off;
+SET
+SELECT t <-> timestamptz '2001-06-01' FROM tbl_tstzspan_allthesame ORDER BY 1 LIMIT 3;
+ ?column? 
+----------
+ 12956400
+ 12956400
+ 12956400
+(3 rows)
+
+RESET enable_seqscan;
+RESET
+DROP TABLE tbl_tstzspan_allthesame;
+DROP TABLE

--- a/mobilitydb/test/temporal/expected/044_temporal_indexes_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/044_temporal_indexes_tbl.test.out
@@ -2621,3 +2621,25 @@ SELECT temp |=| tbigint '[1@2001-06-01, 2@2001-07-01]' FROM tbl_tbigint_big ORDE
 
 DROP INDEX tbl_tbigint_big_kdtree_idx;
 DROP INDEX
+CREATE TABLE tbl_tfloat_allthesame AS
+  SELECT k, tfloat '5.5@2001-01-01' AS temp FROM generate_series(1, 1000) k;
+SELECT 1000
+CREATE INDEX tbl_tfloat_allthesame_quadtree_idx ON tbl_tfloat_allthesame
+  USING SPGIST(temp);
+CREATE INDEX
+ANALYZE tbl_tfloat_allthesame;
+ANALYZE
+SET enable_seqscan = off;
+SET
+SELECT temp |=| tfloat '1.5@2001-01-01' FROM tbl_tfloat_allthesame ORDER BY 1 LIMIT 3;
+ ?column? 
+----------
+        4
+        4
+        4
+(3 rows)
+
+RESET enable_seqscan;
+RESET
+DROP TABLE tbl_tfloat_allthesame;
+DROP TABLE

--- a/mobilitydb/test/temporal/queries/011_span_indexes_tbl.test.sql
+++ b/mobilitydb/test/temporal/queries/011_span_indexes_tbl.test.sql
@@ -817,3 +817,23 @@ ORDER BY op, leftarg, rightarg;
 DROP TABLE test_idxops;
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- A quad-tree node whose children are all the same computes one ordering
+-- distance per ordering key from the parent node span. A table of identical
+-- values is what builds such a node.
+-------------------------------------------------------------------------------
+
+CREATE TABLE tbl_tstzspan_allthesame AS
+  SELECT k, tstzspan '[2001-01-01, 2001-01-02]' AS t FROM generate_series(1, 1000) k;
+CREATE INDEX tbl_tstzspan_allthesame_quadtree_idx ON tbl_tstzspan_allthesame
+  USING SPGIST(t);
+ANALYZE tbl_tstzspan_allthesame;
+
+SET enable_seqscan = off;
+SELECT t <-> timestamptz '2001-06-01' FROM tbl_tstzspan_allthesame ORDER BY 1 LIMIT 3;
+RESET enable_seqscan;
+
+DROP TABLE tbl_tstzspan_allthesame;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/temporal/queries/044_temporal_indexes_tbl.test.sql
+++ b/mobilitydb/test/temporal/queries/044_temporal_indexes_tbl.test.sql
@@ -1984,3 +1984,23 @@ SELECT temp |=| tbigint '[1@2001-06-01, 2@2001-07-01]' FROM tbl_tbigint_big ORDE
 DROP INDEX tbl_tbigint_big_kdtree_idx;
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- A quad-tree node whose children are all the same computes one ordering
+-- distance per ordering key from the parent node box. A table of identical
+-- values is what builds such a node.
+-------------------------------------------------------------------------------
+
+CREATE TABLE tbl_tfloat_allthesame AS
+  SELECT k, tfloat '5.5@2001-01-01' AS temp FROM generate_series(1, 1000) k;
+CREATE INDEX tbl_tfloat_allthesame_quadtree_idx ON tbl_tfloat_allthesame
+  USING SPGIST(temp);
+ANALYZE tbl_tfloat_allthesame;
+
+SET enable_seqscan = off;
+SELECT temp |=| tfloat '1.5@2001-01-01' FROM tbl_tfloat_allthesame ORDER BY 1 LIMIT 3;
+RESET enable_seqscan;
+
+DROP TABLE tbl_tfloat_allthesame;
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
The inner consistent functions of the spatiotemporal, temporal number and span SP-GiST classes allocate the traversal-value and distance arrays of a node whose children are all the same, read each ordering key by its own index, and release the key array once the loop over the children is done, so a k-nearest-neighbour scan reaching such a node answers the ordering instead of terminating the backend. A table of identical values builds such a node, and one covers each of the three classes.