### PR TITLE
Carry the row identifier at its full width into an R-tree node

### DIFF
--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -727,7 +727,7 @@ node_split(RTree *rtree, RTreeNode *node, void *box, RTreeNode **right_out)
  */
 static void
 node_insert(RTree *rtree, void *node_bounding_box, RTreeNode *node,
-  void *new_box, int id, bool *split)
+  void *new_box, int64 id, bool *split)
 {
   if (node->node_type == RTREE_LEAF)
   {

--- a/meos/test/rtree_span_test.c
+++ b/meos/test/rtree_span_test.c
@@ -162,6 +162,64 @@ test_floatspan_rtree(void)
   rtree_free(rtree);
 }
 
+/**
+ * @brief Test that an identifier wider than 32 bits survives the index
+ * @details The identifier a caller attaches to a box is an int64. A carrier
+ * narrower than that anywhere on the insert path changes the value rather than
+ * losing the entry, so the box is still found and only the identifier reported
+ * for it is wrong.
+ */
+static void
+test_id_width(void)
+{
+  RTree *rtree = rtree_create_intspan();
+  /* Ids above 2^31, so a 32-bit carrier would report different numbers */
+  const int64 ids[] = {4000000000LL, 4000000001LL, INT64_C(1) << 40};
+  const int nids = (int) (sizeof(ids) / sizeof(ids[0]));
+  Span **spans = malloc(nids * sizeof(Span *));
+  for (int i = 0; i < nids; i++)
+  {
+    spans[i] = intspan_make(i * 10, i * 10 + 5, true, false);
+    rtree_insert(rtree, spans[i], ids[i]);
+  }
+
+  Span *query = intspan_make(-100, 1000, true, false);
+  MeosArray *result = meos_array_create(sizeof(int64));
+  int count = rtree_search(rtree, RTREE_OVERLAPS, query, result);
+
+  printf("Identifier width (%d spans, ids above 2^31):\n", nids);
+  if (count != nids)
+  {
+    printf("  the query returned %d of %d entries\n", count, nids);
+    failures++;
+  }
+  else
+  {
+    for (int i = 0; i < count; i++)
+    {
+      int64 got = *(int64 *) meos_array_get(result, i);
+      bool found = false;
+      for (int k = 0; k < nids; k++)
+        if (ids[k] == got) found = true;
+      if (! found)
+      {
+        printf("  the index reported id %lld, which was never inserted\n",
+          (long long) got);
+        failures++;
+        break;
+      }
+    }
+    if (! failures)
+      printf("  all %d identifiers came back unchanged\n", nids);
+  }
+
+  for (int i = 0; i < nids; i++)
+    free(spans[i]);
+  free(spans); free(query);
+  meos_array_destroy(result);
+  rtree_free(rtree);
+}
+
 int
 main(void)
 {
@@ -170,6 +228,7 @@ main(void)
 
   test_intspan_rtree();
   test_floatspan_rtree();
+  test_id_width();
 
   meos_finalize();
 


### PR DESCRIPTION
`rtree_insert` takes an `int64` identifier and an R-tree node stores `int64`, while `node_insert` between them takes an `int`. An identifier of 2^31 or more is therefore truncated on its way into the node.

The entry itself is stored and found correctly, so every count and every window answer is right and only the number reported for the entry changes. A caller that fetches a row by the identifier the index returns reads a different row, or none.

`test_id_width` inserts three identifiers above 2^31, one of them 2^40, and requires every identifier the search reports to be one that was inserted. Against the narrower carrier it reports `-294967296` for `4000000000`.

The R-tree tests insert the loop variable as the identifier, and `rtree_span_test` uses it as an array subscript, so none of them can carry a value that large — which is why the width had no coverage behind it.
