### PR TITLE
Read a segment tangent to a circle at its own start as touching it once

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -378,8 +378,15 @@ arcsegm_intersect(double ax, double ay, double rx, double ry, const Edge *e,
    * it against that rounding rather than against zero keeps a touch one root:
    * against zero it becomes two roots a square root of the rounding apart,
    * which is a node pair far enough apart to be taken for two, and the sliver
-   * between them is not a piece of any boundary */
-  double eps = 1e-14 * (fabs(bb * bb) + fabs(4 * aa * cc));
+   * between them is not a piece of any boundary.
+   * Both terms VANISH where the segment starts on the circle and runs
+   * tangent to it there, which is what the offset of an edge leaving a vertex
+   * does against the round cap about that vertex, so a rounding read from them
+   * alone degenerates to zero and protects nothing. The quantities they are
+   * differences OF do not vanish: cc subtracts two of size radius squared, and
+   * bb is twice a product of size w by the segment direction */
+  double eps = 1e-14 * (fabs(bb * bb) + fabs(4 * aa * cc) +
+    aa * (wx * wx + wy * wy + e->radius * e->radius));
   if (disc < -eps)
     return 0;
   if (disc <= eps)


### PR DESCRIPTION
The discriminant of the segment-circle quadratic is a difference of two
quantities of like size, so a tangency reaches zero only to their rounding, and
arcsegm_intersect reads it against a rounding taken from those two terms. Both
of them VANISH together in one configuration: a segment that starts ON the
circle and runs tangent to it there has w of the radius and w perpendicular to
the direction, so cc and bb are each zero and the rounding derived from them is
zero as well. It then protects nothing, the residual noise of the difference is
taken for a real discriminant, and the touch answers two roots a square root of
that noise apart.

The quantities the two terms are differences OF do not vanish, and they are
what the rounding follows: cc subtracts two quantities of the size of the
radius squared, and bb is twice a product of w with the segment direction.

The configuration is structural rather than unlucky. The offset of an edge
leaving a vertex begins on the round cap about that vertex and leaves it at a
right angle to the radius, so every pair of buffered components sharing an
endpoint meets it. What the two roots leave is a node pair 6e-8 apart where
the topology has one node, and the two boundary slivers between them belong to
no boundary, so the union of the two components cannot be chained into a
surface and the whole geometry is reported as not covered.

Buffering MULTILINESTRING((0 0,30 0),(0 0,13 1)) by 5 is the smallest case.

Over the 154 fixture geometries buffered by 5, checked against ST_Buffer of the
input densified to 1e-6 at quad_segs=128 within 1e-4 of the reference area,
geometries the buffer does not cover go 15 to 14 and correct answers 126 to
127, with the wrong answers unchanged in count and in membership. The kernel is
shared with the clipping engine, isSimple and the hull, and the GEOS relate
suite stays at 154 of 154.

