### PR TITLE
Index the position predicates of the point cloud box

### DIFF
--- a/mobilitydb/sql/pointcloud/412_tpcbox_spgist.in.sql
+++ b/mobilitydb/sql/pointcloud/412_tpcbox_spgist.in.sql
@@ -29,16 +29,48 @@ CREATE FUNCTION tpcbox_spgist_compress(internal)
 
 CREATE OPERATOR CLASS tpcbox_quadtree_ops
   DEFAULT FOR TYPE tpcbox USING spgist AS
+  -- strictly left
+  OPERATOR  1    << (tpcbox, tpcbox),
+  -- overlaps or left
+  OPERATOR  2    &< (tpcbox, tpcbox),
   -- overlaps
   OPERATOR  3    && (tpcbox, tpcbox),
+  -- overlaps or right
+  OPERATOR  4    &> (tpcbox, tpcbox),
+  -- strictly right
+  OPERATOR  5    >> (tpcbox, tpcbox),
   -- same
   OPERATOR  6    ~= (tpcbox, tpcbox),
   -- contains
   OPERATOR  7    @> (tpcbox, tpcbox),
   -- contained by
   OPERATOR  8    <@ (tpcbox, tpcbox),
+  -- overlaps or below
+  OPERATOR  9    &<| (tpcbox, tpcbox),
+  -- strictly below
+  OPERATOR  10   <<| (tpcbox, tpcbox),
+  -- strictly above
+  OPERATOR  11   |>> (tpcbox, tpcbox),
+  -- overlaps or above
+  OPERATOR  12   |&> (tpcbox, tpcbox),
   -- adjacent
   OPERATOR  17   -|- (tpcbox, tpcbox),
+  -- overlaps or before
+  OPERATOR  28   &<# (tpcbox, tpcbox),
+  -- strictly before
+  OPERATOR  29   <<# (tpcbox, tpcbox),
+  -- strictly after
+  OPERATOR  30   #>> (tpcbox, tpcbox),
+  -- overlaps or after
+  OPERATOR  31   #&> (tpcbox, tpcbox),
+  -- overlaps or front
+  OPERATOR  32   &</ (tpcbox, tpcbox),
+  -- strictly front
+  OPERATOR  33   <</ (tpcbox, tpcbox),
+  -- strictly back
+  OPERATOR  34   />> (tpcbox, tpcbox),
+  -- overlaps or back
+  OPERATOR  35   /&> (tpcbox, tpcbox),
   -- functions
   FUNCTION  1    stbox_spgist_config(internal, internal),
   FUNCTION  2    stbox_quadtree_choose(internal, internal),
@@ -49,16 +81,48 @@ CREATE OPERATOR CLASS tpcbox_quadtree_ops
 
 CREATE OPERATOR CLASS tpcbox_kdtree_ops
   FOR TYPE tpcbox USING spgist AS
+  -- strictly left
+  OPERATOR  1    << (tpcbox, tpcbox),
+  -- overlaps or left
+  OPERATOR  2    &< (tpcbox, tpcbox),
   -- overlaps
   OPERATOR  3    && (tpcbox, tpcbox),
+  -- overlaps or right
+  OPERATOR  4    &> (tpcbox, tpcbox),
+  -- strictly right
+  OPERATOR  5    >> (tpcbox, tpcbox),
   -- same
   OPERATOR  6    ~= (tpcbox, tpcbox),
   -- contains
   OPERATOR  7    @> (tpcbox, tpcbox),
   -- contained by
   OPERATOR  8    <@ (tpcbox, tpcbox),
+  -- overlaps or below
+  OPERATOR  9    &<| (tpcbox, tpcbox),
+  -- strictly below
+  OPERATOR  10   <<| (tpcbox, tpcbox),
+  -- strictly above
+  OPERATOR  11   |>> (tpcbox, tpcbox),
+  -- overlaps or above
+  OPERATOR  12   |&> (tpcbox, tpcbox),
   -- adjacent
   OPERATOR  17   -|- (tpcbox, tpcbox),
+  -- overlaps or before
+  OPERATOR  28   &<# (tpcbox, tpcbox),
+  -- strictly before
+  OPERATOR  29   <<# (tpcbox, tpcbox),
+  -- strictly after
+  OPERATOR  30   #>> (tpcbox, tpcbox),
+  -- overlaps or after
+  OPERATOR  31   #&> (tpcbox, tpcbox),
+  -- overlaps or front
+  OPERATOR  32   &</ (tpcbox, tpcbox),
+  -- strictly front
+  OPERATOR  33   <</ (tpcbox, tpcbox),
+  -- strictly back
+  OPERATOR  34   />> (tpcbox, tpcbox),
+  -- overlaps or back
+  OPERATOR  35   /&> (tpcbox, tpcbox),
   -- functions
   FUNCTION  1    stbox_spgist_config(internal, internal),
   FUNCTION  2    stbox_kdtree_choose(internal, internal),

--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -813,6 +813,13 @@ Stbox_spgist_leaf_consistent(PG_FUNCTION_ARGS)
     const ScanKeyData *scankey = &in->scankeys[i];
     Datum value = scankey->sk_argument;
     MeosType type = oid_meostype(scankey->sk_subtype);
+#if POINTCLOUD
+    /* The leaf value of a point cloud box keeps its bounds and drops the
+     * schema identifier the operator also compares, so the answer is a
+     * superset of the operator's and every strategy is rechecked */
+    if (type == T_TPCBOX)
+      out->recheck = true;
+#endif /* POINTCLOUD */
     tspatial_spgist_get_stbox(value, type, &box);
     result = stbox_index_leaf_consistent(key, &box, strategy);
 

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox_tbl.test.out
@@ -148,6 +148,41 @@ SELECT COUNT(*) AS seq_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
          0
 (1 row)
 
+SELECT COUNT(*) AS seq_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ seq_left 
+----------
+       11
+(1 row)
+
+SELECT COUNT(*) AS seq_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ seq_overleft 
+--------------
+           16
+(1 row)
+
+SELECT COUNT(*) AS seq_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ seq_above 
+-----------
+        46
+(1 row)
+
+SELECT COUNT(*) AS seq_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ seq_front 
+-----------
+         0
+(1 row)
+
+SELECT COUNT(*) AS seq_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ seq_before 
+------------
+          0
+(1 row)
+
 SET enable_seqscan = off;
 SET
 SET enable_indexscan = on;
@@ -161,6 +196,41 @@ SELECT COUNT(*) AS quadtree_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
               0
 (1 row)
 
+SELECT COUNT(*) AS quadtree_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ quadtree_left 
+---------------
+            11
+(1 row)
+
+SELECT COUNT(*) AS quadtree_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ quadtree_overleft 
+-------------------
+                16
+(1 row)
+
+SELECT COUNT(*) AS quadtree_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ quadtree_above 
+----------------
+             46
+(1 row)
+
+SELECT COUNT(*) AS quadtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ quadtree_front 
+----------------
+              0
+(1 row)
+
+SELECT COUNT(*) AS quadtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ quadtree_before 
+-----------------
+               0
+(1 row)
+
 DROP INDEX tbl_tpcbox_quadtree_idx;
 DROP INDEX
 CREATE INDEX tbl_tpcbox_kdtree_idx ON tbl_tpcbox USING spgist(b tpcbox_kdtree_ops);
@@ -172,6 +242,41 @@ SELECT COUNT(*) AS kdtree_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
             0
 (1 row)
 
+SELECT COUNT(*) AS kdtree_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ kdtree_left 
+-------------
+          11
+(1 row)
+
+SELECT COUNT(*) AS kdtree_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ kdtree_overleft 
+-----------------
+              16
+(1 row)
+
+SELECT COUNT(*) AS kdtree_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ kdtree_above 
+--------------
+           46
+(1 row)
+
+SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ kdtree_front 
+--------------
+            0
+(1 row)
+
+SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ kdtree_before 
+---------------
+             0
+(1 row)
+
 DROP INDEX tbl_tpcbox_kdtree_idx;
 DROP INDEX
 RESET enable_seqscan;
@@ -180,3 +285,18 @@ RESET enable_indexscan;
 RESET
 RESET enable_bitmapscan;
 RESET
+CREATE TABLE tbl_tpcbox_pcid AS
+  SELECT 1 AS k, tpcbox_zt(20, 0, 0, 30, 10, 10,
+    tstzspan '[2001-01-01, 2001-12-31]', 2, 0) AS b;
+SELECT 1
+CREATE INDEX tbl_tpcbox_pcid_quadtree_idx ON tbl_tpcbox_pcid USING spgist(b);
+CREATE INDEX
+SET enable_seqscan = off;
+SET
+SELECT COUNT(*) FROM tbl_tpcbox_pcid WHERE b >> tpcbox_zt(0, 0, 0, 10, 10, 10,
+  tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+ERROR:  Operation on TPCBox values with different schemas: 2 vs 1
+RESET enable_seqscan;
+RESET
+DROP TABLE tbl_tpcbox_pcid;
+DROP TABLE

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
@@ -109,19 +109,61 @@ SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS seq_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS seq_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS seq_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS seq_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS seq_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS quadtree_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS quadtree_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS quadtree_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS quadtree_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS quadtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS quadtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 DROP INDEX tbl_tpcbox_quadtree_idx;
 
 CREATE INDEX tbl_tpcbox_kdtree_idx ON tbl_tpcbox USING spgist(b tpcbox_kdtree_ops);
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS kdtree_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS kdtree_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS kdtree_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 DROP INDEX tbl_tpcbox_kdtree_idx;
 RESET enable_seqscan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
+
+-- The index key of a box keeps its bounds and drops the schema identifier,
+-- so a box of another schema is answered by the operator on the value.
+CREATE TABLE tbl_tpcbox_pcid AS
+  SELECT 1 AS k, tpcbox_zt(20, 0, 0, 30, 10, 10,
+    tstzspan '[2001-01-01, 2001-12-31]', 2, 0) AS b;
+CREATE INDEX tbl_tpcbox_pcid_quadtree_idx ON tbl_tpcbox_pcid USING spgist(b);
+SET enable_seqscan = off;
+SELECT COUNT(*) FROM tbl_tpcbox_pcid WHERE b >> tpcbox_zt(0, 0, 0, 10, 10, 10,
+  tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+RESET enable_seqscan;
+DROP TABLE tbl_tpcbox_pcid;
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The quad-tree and k-d tree operator classes of tpcbox list the twenty position strategies of the three space axes and of time that its R-tree class lists, so a position query over a column of point cloud boxes is answered by an index scan. The leaf value of such an index keeps the bounds of the box and drops the schema identifier that the operators also compare, so the leaf consistent function of the family marks a point cloud box for recheck under every strategy and the index answer is the answer of the operator on the value.