### PR TITLE
Order a spatiotemporal box by nearest approach from an SP-GiST index

### DIFF
--- a/mobilitydb/sql/geo/074_tpoint_spgist.in.sql
+++ b/mobilitydb/sql/geo/074_tpoint_spgist.in.sql
@@ -80,6 +80,12 @@ CREATE OPERATOR CLASS stbox_quadtree_ops
   OPERATOR  17    -|- (stbox, stbox),
   OPERATOR  17    -|- (stbox, tgeompoint),
   OPERATOR  17    -|- (stbox, tgeogpoint),
+  -- nearest approach distance
+  OPERATOR  25    |=| (stbox, stbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, tgeompoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, tgeogpoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, geometry) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, geography) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (stbox, stbox),
   OPERATOR  28    &<# (stbox, tgeompoint),
@@ -163,6 +169,12 @@ CREATE OPERATOR CLASS stbox_kdtree_ops
   OPERATOR  17    -|- (stbox, stbox),
   OPERATOR  17    -|- (stbox, tgeompoint),
   OPERATOR  17    -|- (stbox, tgeogpoint),
+  -- nearest approach distance
+  OPERATOR  25    |=| (stbox, stbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, tgeompoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, tgeogpoint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, geometry) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (stbox, geography) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (stbox, stbox),
   OPERATOR  28    &<# (stbox, tgeompoint),

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -2056,3 +2056,39 @@ DROP INDEX tbl_stbox_notime_kdtree_idx;
 DROP INDEX
 DROP TABLE tbl_stbox_notime;
 DROP TABLE
+DROP INDEX IF EXISTS tbl_stbox3d_quadtree_idx;
+NOTICE:  index "tbl_stbox3d_quadtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_stbox3d_quadtree_idx ON tbl_stbox3d USING SPGIST(b);
+CREATE INDEX
+WITH test AS (
+  SELECT b |=| stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_stbox3d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 46.677487
+ 63.491113
+ 89.960123
+(3 rows)
+
+DROP INDEX tbl_stbox3d_quadtree_idx;
+DROP INDEX
+DROP INDEX IF EXISTS tbl_stbox3d_kdtree_idx;
+NOTICE:  index "tbl_stbox3d_kdtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_stbox3d_kdtree_idx ON tbl_stbox3d USING SPGIST(b stbox_kdtree_ops);
+CREATE INDEX
+WITH test AS (
+  SELECT b |=| stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_stbox3d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 46.677487
+ 63.491113
+ 89.960123
+(3 rows)
+
+DROP INDEX tbl_stbox3d_kdtree_idx;
+DROP INDEX

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -612,3 +612,23 @@ DROP INDEX tbl_stbox_notime_kdtree_idx;
 DROP TABLE tbl_stbox_notime;
 
 -------------------------------------------------------------------------------
+-- Nearest approach ordering answered by the space-partitioning indexes
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_stbox3d_quadtree_idx;
+CREATE INDEX tbl_stbox3d_quadtree_idx ON tbl_stbox3d USING SPGIST(b);
+WITH test AS (
+  SELECT b |=| stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_stbox3d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_stbox3d_quadtree_idx;
+
+DROP INDEX IF EXISTS tbl_stbox3d_kdtree_idx;
+CREATE INDEX tbl_stbox3d_kdtree_idx ON tbl_stbox3d USING SPGIST(b stbox_kdtree_ops);
+WITH test AS (
+  SELECT b |=| stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_stbox3d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_stbox3d_kdtree_idx;
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
The quad-tree and k-d tree operator classes of stbox carry the nearest approach distance operator against a box, a temporal point, a geometry and a geography, so an ordering by that distance over a column of boxes is answered by a space-partitioning index as it is by the R-tree class of the same type. The inner and leaf consistent functions of the family compute the ordering distances of a node and of a leaf.