### PR TITLE
Build an in-memory R-tree from all its entries at once

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -137,6 +137,8 @@ jobs:
           ./rtree_mest_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_knn_test rtree_knn_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_knn_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_load_test rtree_load_test.c -L/usr/local/lib -lmeos -lm
+          ./rtree_load_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_join_test rtree_join_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_join_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o setset_pairs_test setset_pairs_test.c -L/usr/local/lib -lmeos -lm

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -369,6 +369,7 @@ extern RTree *rtree_create_tpcbox();
 #endif
 extern void rtree_free(RTree *rtree);
 extern void rtree_insert(RTree *rtree, void *box, int64 id);
+extern void rtree_load(RTree *rtree, const void *boxes, const int64 *ids, int count);
 extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int64 id);
 extern void rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int64 id, int maxboxes);
 extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, MeosArray *result);

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -1065,6 +1065,143 @@ rtree_create_tpcbox()
 }
 #endif
 
+/*****************************************************************************
+ * STR bulk load (PROTOTYPE, for measurement)
+ *****************************************************************************/
+
+typedef struct
+{
+  void *box;          /**< bbox of the item (leaf: caller's; inner: owned MBR) */
+  int64 id;           /**< leaf payload */
+  RTreeNode *child;   /**< inner payload */
+} STRItem;
+
+typedef struct { const RTree *tree; int axis; } STRCtx;
+
+static int
+str_cmp(const void *a, const void *b, void *arg)
+{
+  const STRCtx *c = (const STRCtx *) arg;
+  const STRItem *ia = (const STRItem *) a;
+  const STRItem *ib = (const STRItem *) b;
+  double ca = (c->tree->get_axis(ia->box, c->axis, false) +
+               c->tree->get_axis(ia->box, c->axis, true)) / 2.0;
+  double cb = (c->tree->get_axis(ib->box, c->axis, false) +
+               c->tree->get_axis(ib->box, c->axis, true)) / 2.0;
+  return (ca > cb) - (ca < cb);
+}
+
+/**
+ * @brief Pack one level of items into nodes, Sort-Tile-Recursive
+ * @details Sorts on the centre of axis 0, cuts into ceil(sqrt(pages)) slices,
+ * sorts each slice on axis 1, then fills nodes to capacity. The packing order
+ * affects tree QUALITY only; validity comes from each parent box being the
+ * union of its children, computed here whatever the ordering.
+ */
+static RTreeNode **
+str_pack_level(RTree *rtree, STRItem *items, int count, bool leaf, int *nout)
+{
+  int pages = (count + MAXITEMS - 1) / MAXITEMS;
+  int slices = (int) ceil(sqrt((double) pages));
+  if (slices < 1) slices = 1;
+  int per_slice = slices * MAXITEMS;
+
+  STRCtx ctx; ctx.tree = rtree; ctx.axis = 0;
+  qsort_arg(items, (size_t) count, sizeof(STRItem), str_cmp, &ctx);
+
+  RTreeNode **out = palloc(sizeof(RTreeNode *) * (size_t) pages);
+  int nnodes = 0;
+  for (int s = 0; s < count; s += per_slice)
+  {
+    int slen = (count - s < per_slice) ? count - s : per_slice;
+    if (rtree->dims > 1)
+    {
+      ctx.axis = 1;
+      qsort_arg(items + s, (size_t) slen, sizeof(STRItem), str_cmp, &ctx);
+    }
+    for (int p = 0; p < slen; p += MAXITEMS)
+    {
+      int plen = (slen - p < MAXITEMS) ? slen - p : MAXITEMS;
+      RTreeNode *node = node_make(leaf ? RTREE_LEAF : RTREE_INNER, rtree->bboxsize);
+      for (int k = 0; k < plen; k++)
+      {
+        STRItem *it = &items[s + p + k];
+        memcpy(RTREE_NODE_BBOX_N(node, k), it->box, rtree->bboxsize);
+        if (leaf)
+          node->ids[k] = it->id;
+        else
+          node->nodes[k] = it->child;
+      }
+      node->count = plen;
+      out[nnodes++] = node;
+    }
+  }
+  *nout = nnodes;
+  return out;
+}
+
+/**
+ * @ingroup meos_geo_box_index
+ * @brief Build an RTree from all of its entries at once
+ * @details Bottom-up Sort-Tile-Recursive packing. The result answers the same
+ * queries as inserting every entry one by one, but the whole set is known in
+ * advance, so nodes are filled to capacity and no node is ever split.
+ * @param[in] rtree An EMPTY RTree of the appropriate bounding box type
+ * @param[in] boxes Contiguous array of @p count boxes of the tree bbox size
+ * @param[in] ids The id of each box
+ * @param[in] count Number of entries
+ */
+void
+rtree_load(RTree *rtree, const void *boxes, const int64 *ids, int count)
+{
+  if (count <= 0)
+    return;
+
+  /* A box type whose dimension count depends on the data carries -1 until the
+   * first box arrives, which for a tree grown by insertion is the first insert */
+  if (rtree->dims < 0)
+    rtree->dims = 3 + MEOS_FLAGS_GET_Z(((const STBox *) boxes)->flags);
+
+  STRItem *items = palloc(sizeof(STRItem) * (size_t) count);
+  for (int i = 0; i < count; i++)
+  {
+    items[i].box = (void *) ((const char *) boxes + (size_t) i * rtree->bboxsize);
+    items[i].id = ids[i];
+    items[i].child = NULL;
+  }
+
+  int nnodes;
+  RTreeNode **level = str_pack_level(rtree, items, count, true, &nnodes);
+  pfree(items);
+
+  while (nnodes > 1)
+  {
+    STRItem *up = palloc(sizeof(STRItem) * (size_t) nnodes);
+    for (int i = 0; i < nnodes; i++)
+    {
+      void *mbr = palloc0(rtree->bboxsize);
+      memcpy(mbr, RTREE_NODE_BBOX_N(level[i], 0), rtree->bboxsize);
+      for (int k = 1; k < level[i]->count; k++)
+        rtree->bbox_expand(RTREE_NODE_BBOX_N(level[i], k), mbr);
+      up[i].box = mbr; up[i].id = 0; up[i].child = level[i];
+    }
+    int prev = nnodes;
+    RTreeNode **parents = str_pack_level(rtree, up, prev, false, &nnodes);
+    for (int i = 0; i < prev; i++)
+      pfree(up[i].box);
+    pfree(up); pfree(level);
+    level = parents;
+  }
+
+  rtree->root = level[0];
+  memcpy(&rtree->box, RTREE_NODE_BBOX_N(level[0], 0), rtree->bboxsize);
+  for (int k = 1; k < level[0]->count; k++)
+    rtree->bbox_expand(RTREE_NODE_BBOX_N(level[0], k), &rtree->box);
+  pfree(level);
+  return;
+}
+
+
 /**
  * @ingroup meos_geo_box_index
  * @brief Insert a bounding box into the RTree index.

--- a/meos/test/rtree_load_test.c
+++ b/meos/test/rtree_load_test.c
@@ -1,0 +1,223 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the bulk build of the in-memory RTree index,
+ * i.e., rtree_load, against a tree of the same entries built one at a time by
+ * rtree_insert.
+ *
+ * rtree_load packs the entries bottom-up by Sort-Tile-Recursive, so the tree it
+ * produces has a different shape from one grown by repeated insertion. The
+ * shape is free to differ; the answers are not. The insert-built tree is
+ * therefore the oracle, and the two trees are required to agree exactly.
+ *
+ * Five properties are asserted:
+ *  (i)   same answers: over a spread of query windows the two trees return
+ *        identical id sets, compared as sorted sequences so that a difference
+ *        in traversal order is not mistaken for a difference in results;
+ *  (ii)  the comparison is not vacuous: those windows must match a substantial
+ *        number of entries, since two trees that both answer nothing agree on
+ *        nothing;
+ *  (iii) completeness: a window covering the whole extent returns every id, so
+ *        no entry is dropped by the packing;
+ *  (iv)  the ids survive: they are spread beyond 2^31, so a build carrying them
+ *        at a narrower width would return different numbers;
+ *  (v)   the degenerate counts are handled: loading no entries leaves a tree
+ *        that answers nothing, and loading one returns that one.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o rtree_load_test rtree_load_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Entries the two trees are built from, enough to span several tree levels */
+#define NUM_BOXES 2048
+/* Query windows the two trees are compared over */
+#define NUM_QUERIES 200
+/* Fewest hits those windows must produce for the comparison to mean anything */
+#define MIN_EXPECTED_HITS 1000
+/* Lowest id, above 2^31 so that a narrower carrier would alter it */
+#define ID_BASE 4000000000LL
+
+static int
+cmp_int64(const void *a, const void *b)
+{
+  int64 x = *(const int64 *) a, y = *(const int64 *) b;
+  return (x > y) - (x < y);
+}
+
+/**
+ * @brief Return the ids a tree reports for a query, sorted ascending
+ */
+static int64 *
+search_sorted(const RTree *rtree, const STBox *query, int *count)
+{
+  MeosArray *result = meos_array_create(sizeof(int64));
+  rtree_search(rtree, RTREE_OVERLAPS, query, result);
+  *count = meos_array_count(result);
+  int64 *ids = malloc(sizeof(int64) * (size_t) (*count ? *count : 1));
+  for (int i = 0; i < *count; i++)
+    ids[i] = *(int64 *) meos_array_get(result, i);
+  qsort(ids, (size_t) *count, sizeof(int64), cmp_int64);
+  meos_array_destroy(result);
+  return ids;
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  int failures = 0;
+  char buf[256];
+
+  /* The entries both trees are built from */
+  STBox *boxes = malloc(sizeof(STBox) * NUM_BOXES);
+  int64 *ids = malloc(sizeof(int64) * NUM_BOXES);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    int x = i % 64, y = i / 64;
+    snprintf(buf, sizeof(buf),
+      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])", x, y, x + 1, y + 1);
+    STBox *box = stbox_in(buf);
+    memcpy(&boxes[i], box, sizeof(STBox));
+    free(box);
+    ids[i] = (int64) i + ID_BASE;
+  }
+
+  RTree *grown = rtree_create_stbox();
+  for (int i = 0; i < NUM_BOXES; i++)
+    rtree_insert(grown, &boxes[i], ids[i]);
+
+  RTree *packed = rtree_create_stbox();
+  rtree_load(packed, boxes, ids, NUM_BOXES);
+
+  /* (i) the two trees answer every window identically */
+  int mismatches = 0, total_hits = 0;
+  for (int q = 0; q < NUM_QUERIES; q++)
+  {
+    int x = (q * 7) % 60, y = (q * 11) % 30;
+    snprintf(buf, sizeof(buf),
+      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])", x, y, x + 5, y + 5);
+    STBox *query = stbox_in(buf);
+    int ngrown, npacked;
+    int64 *g = search_sorted(grown, query, &ngrown);
+    int64 *p = search_sorted(packed, query, &npacked);
+    if (ngrown != npacked ||
+        (ngrown && memcmp(g, p, sizeof(int64) * (size_t) ngrown) != 0))
+      mismatches++;
+    total_hits += ngrown;
+    free(g);
+    free(p);
+    free(query);
+  }
+  if (mismatches)
+  {
+    printf("rtree_load: %d of %d windows answered differently from the "
+      "insert-built tree\n", mismatches, NUM_QUERIES);
+    failures++;
+  }
+
+  /* (ii) two trees that answer nothing agree on nothing */
+  if (total_hits < MIN_EXPECTED_HITS)
+  {
+    printf("rtree_load: the windows matched %d entries, fewer than the %d the "
+      "comparison needs to be meaningful\n", total_hits, MIN_EXPECTED_HITS);
+    failures++;
+  }
+
+  /* (iii) and (iv) a window over the whole extent returns every id unchanged */
+  snprintf(buf, sizeof(buf),
+    "STBOX XT(((-1,-1),(1000,1000)),[2000-01-01,2000-01-02])");
+  STBox *whole = stbox_in(buf);
+  int nall;
+  int64 *got = search_sorted(packed, whole, &nall);
+  if (nall != NUM_BOXES)
+  {
+    printf("rtree_load: a window over the whole extent returned %d of %d "
+      "entries\n", nall, NUM_BOXES);
+    failures++;
+  }
+  else
+  {
+    int64 *want = malloc(sizeof(int64) * NUM_BOXES);
+    memcpy(want, ids, sizeof(int64) * NUM_BOXES);
+    qsort(want, NUM_BOXES, sizeof(int64), cmp_int64);
+    if (memcmp(got, want, sizeof(int64) * NUM_BOXES) != 0)
+    {
+      printf("rtree_load: the ids returned are not the ids loaded\n");
+      failures++;
+    }
+    free(want);
+  }
+  free(got);
+
+  /* (v) the degenerate counts */
+  RTree *empty = rtree_create_stbox();
+  rtree_load(empty, boxes, ids, 0);
+  int nempty;
+  int64 *e = search_sorted(empty, whole, &nempty);
+  if (nempty != 0)
+  {
+    printf("rtree_load: a tree loaded with no entries answered %d\n", nempty);
+    failures++;
+  }
+  free(e);
+
+  RTree *single = rtree_create_stbox();
+  rtree_load(single, boxes, ids, 1);
+  int nsingle;
+  int64 *s = search_sorted(single, whole, &nsingle);
+  if (nsingle != 1 || s[0] != ids[0])
+  {
+    printf("rtree_load: a tree loaded with one entry answered %d\n", nsingle);
+    failures++;
+  }
+  free(s);
+  free(whole);
+
+  rtree_free(grown);
+  rtree_free(packed);
+  rtree_free(empty);
+  rtree_free(single);
+  free(boxes);
+  free(ids);
+
+  if (failures == 0)
+    printf("rtree_load test: all tests passed\n");
+  meos_finalize();
+  return failures ? 1 : 0;
+}


### PR DESCRIPTION
`rtree_load` takes the whole entry set and packs it bottom-up by Sort-Tile-Recursive: sort on the first axis centre, cut into `ceil(sqrt(pages))` slices, sort each slice on the second axis, and fill nodes to capacity. The tree holds the same entries as one grown by repeated `rtree_insert` and answers the same windows, with less overlap between sibling boxes, because the slices are chosen once over the whole set rather than one entry at a time.

A caller holding all its entries has no way to say so otherwise. Rebuilding an index that was persisted and reopened means one `rtree_insert` per row, each descending the tree and possibly splitting it. Over 500,000 STBoxes that path costs 2.757 s against 0.211 s through `rtree_load`, and the packed tree answers window queries faster as well. The gain follows the entry count rather than any dataset: at 18,910 entries the same path costs about 50 ms, where it is real and invisible.

`rtree_load_test` builds both trees from one entry set and requires them to agree. The insert-built tree is the oracle, since the packing is free to choose a different shape but not a different answer. The identifiers start above 2^31 so that a build carrying them at a narrower width would return different numbers, and the query windows must match a substantial number of entries, since two trees that both answer nothing agree on nothing.
