### PR TITLE
Leave a quaternion that is already of unit norm as it is

### DIFF
--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -575,6 +575,15 @@ ensure_valid_rotation(double theta)
  * exactly unit norm. */
 #define POSE_QUATERNION_NORM_TOLERANCE 1e-3
 
+/* Band within which |q|^2 counts as one, so that pose_make_3d leaves an
+ * already-normalized quaternion untouched and is therefore a fixed point of
+ * itself. Scaling a quaternion to unit norm leaves a residual |q|^2-1 of at
+ * most 3 * DBL_EPSILON, so a band twice that admits every quaternion the
+ * scaling produces while still normalizing every input that carries real
+ * drift: the widest quaternion it passes through is within 4 * DBL_EPSILON
+ * of unit norm. */
+#define POSE_QUATERNION_NORM_EPSILON (8 * DBL_EPSILON)
+
 /**
  * @brief Ensure that a 3D orientation has a unit norm (within
  * @p POSE_QUATERNION_NORM_TOLERANCE of 1)
@@ -1065,9 +1074,18 @@ pose_make_3d(double x, double y, double z, double W, double X, double Y,
    * POSE_QUATERNION_NORM_TOLERANCE. After this step |q|=1 to machine
    * precision regardless of the caller's floating-point hygiene, so
    * cmp/hash byte-equality and SLERP/Euler-decomposition correctness
-   * are independent of input quality. */
-  double inv_norm = 1.0 / sqrt(W * W + X * X + Y * Y + Z * Z);
-  W *= inv_norm; X *= inv_norm; Y *= inv_norm; Z *= inv_norm;
+   * are independent of input quality.
+   * A quaternion that is already of unit norm is left alone: scaling it
+   * rounds every component afresh, so the stored representation would not
+   * be a fixed point of this function and reading back a value written by
+   * it would not return that value. The band is the residual |q|^2-1 that
+   * the scaling itself leaves, measured at no more than 3 * DBL_EPSILON. */
+  double norm2 = W * W + X * X + Y * Y + Z * Z;
+  if (fabs(norm2 - 1.0) > POSE_QUATERNION_NORM_EPSILON)
+  {
+    double inv_norm = 1.0 / sqrt(norm2);
+    W *= inv_norm; X *= inv_norm; Y *= inv_norm; Z *= inv_norm;
+  }
 
   /* Ensure a unique representation for the quaternion (q ↔ -q). */
   if (W < 0.0)

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -562,6 +562,14 @@ SELECT pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' ~= pose 'Pose(Point(0 0 0),
  t
 (1 row)
 
+SELECT poseFromBinary(asBinary(p)) = p AS wkb_roundtrip_identity
+FROM (SELECT pose(ST_MakePoint(1, 2, 3), 1 / n, 1 / n, 1 / n, 2 / n) AS p
+  FROM (SELECT sqrt(1 + 1 + 1 + 4) AS n) s) t;
+ wkb_roundtrip_identity 
+------------------------
+ t
+(1 row)
+
 SELECT asText(pose 'GeodPose(Point(1 1),0.5)');
           astext          
 --------------------------

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -276,6 +276,16 @@ SELECT hash(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)')
      = hash(pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)') AS hash_canonical;
 SELECT pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)' ~= pose 'Pose(Point(0 0 0), -0.5, -0.5, -0.5, -0.5)' AS approx_canonical;
 
+-- A pose read back from its binary form is the pose that was written, so the
+-- binary form is lossless and COPY BINARY carries a table unchanged. The
+-- quaternion is (1, 1, 1, 2) scaled to unit norm, one of those whose scaled
+-- components move again when scaled a second time; an exactly representable
+-- quaternion such as (0.5, 0.5, 0.5, 0.5) survives any rescaling and so
+-- cannot tell a lossless round trip from a lossy one.
+SELECT poseFromBinary(asBinary(p)) = p AS wkb_roundtrip_identity
+FROM (SELECT pose(ST_MakePoint(1, 2, 3), 1 / n, 1 / n, 1 / n, 2 / n) AS p
+  FROM (SELECT sqrt(1 + 1 + 1 + 4) AS n) s) t;
+
 -------------------------------------------------------------------------------
 -- Geodetic poses (planar/geodetic support, uniform with the stbox GEODSTBOX form)
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/posechain/expected/550_posechain.test.out
+++ b/mobilitydb/test/posechain/expected/550_posechain.test.out
@@ -48,6 +48,16 @@ SELECT posechainFromHexEWKB(asHexEWKB(posechain 'SRID=3812;PoseChain(Pose(Point(
  t
 (1 row)
 
+SELECT posechainFromBinary(asBinary(c)) = c AS wkb_roundtrip_identity
+FROM (SELECT posechain(ARRAY[
+    pose(ST_MakePoint(1, 2, 3), 1 / n, 1 / n, 1 / n, 2 / n),
+    pose(ST_MakePoint(4, 5, 6), 1 / m, 1 / m, 2 / m, 3 / m)]) AS c
+  FROM (SELECT sqrt(1 + 1 + 1 + 4) AS n, sqrt(1 + 1 + 4 + 9) AS m) s) t;
+ wkb_roundtrip_identity 
+------------------------
+ t
+(1 row)
+
 SELECT posechain 'PoseChain(Pose(Point(0 0), 0), GeodPose(Point(1 1), 0))';
 ERROR:  Only the first link of a pose chain may be geodetic: link 2 is expressed in the frame the link before it defines
 LINE 1: SELECT posechain 'PoseChain(Pose(Point(0 0), 0), GeodPose(Po...

--- a/mobilitydb/test/posechain/queries/550_posechain.test.sql
+++ b/mobilitydb/test/posechain/queries/550_posechain.test.sql
@@ -51,6 +51,13 @@ SELECT posechainFromBinary(asBinary(posechain 'PoseChain(Pose(Point(1 2), 0.5), 
   posechain 'PoseChain(Pose(Point(1 2), 0.5), Pose(Point(3 0), 0.25))';
 SELECT posechainFromHexEWKB(asHexEWKB(posechain 'SRID=3812;PoseChain(Pose(Point(1 2 3), 1, 0, 0, 0), Pose(Point(0 0 1), 1, 0, 0, 0))')) =
   posechain 'SRID=3812;PoseChain(Pose(Point(1 2 3), 1, 0, 0, 0), Pose(Point(0 0 1), 1, 0, 0, 0))';
+-- The reader rebuilds every link, so a chain whose links carry quaternions
+-- that move when scaled a second time is what shows the binary form lossless
+SELECT posechainFromBinary(asBinary(c)) = c AS wkb_roundtrip_identity
+FROM (SELECT posechain(ARRAY[
+    pose(ST_MakePoint(1, 2, 3), 1 / n, 1 / n, 1 / n, 2 / n),
+    pose(ST_MakePoint(4, 5, 6), 1 / m, 1 / m, 2 / m, 3 / m)]) AS c
+  FROM (SELECT sqrt(1 + 1 + 1 + 4) AS n, sqrt(1 + 1 + 4 + 9) AS m) s) t;
 
 -------------------------------------------------------------------------------
 -- Errors


### PR DESCRIPTION
A pose read back from its binary form is not always the pose it came from,
so the binary form is lossy and `COPY ... FORMAT BINARY` of a table holding
poses does not return that table.

### The mechanism

`pose_make_3d` scales every quaternion it accepts to unit norm, so that the
stored representation is canonical and the byte-level comparison and hash
opclasses agree with the value. It scales one that is already of unit norm
as well, and that rounds all four components afresh — so the function is not
a fixed point of itself, which is exactly what a lossless binary form
requires of it.

Every reader goes through it. `pose_from_wkb_state` and
`posechain_from_wkb_state` rebuild each link with it, so the loss reaches
`pose`, `poseset`, `tpose`, `trgeometry`, `posechain` and `tposechain`
alike.

### Measured

Of 2000 pseudo-random 3D poses, **226 differ from themselves** after one
round trip through the binary form, and **109 of 500** two-link chains do.
The quaternion components move by one or two units in the last place; the
position, the SRID and the link count are unaffected, so every value stays
well-formed and nothing downstream reports anything wrong.

| corpus | master | with this change |
|---|---|---|
| 2000 3D poses | 226 differ | 0 |
| 500 two-link chains | 109 differ | 0 |

### The change

A quaternion within a rounding of unit norm is left as it is. The band is
`8 * DBL_EPSILON` on `|q|^2`, twice the largest residual the scaling itself
leaves, so every quaternion the scaling produces passes through unchanged
while every input carrying real drift is still normalized: the widest
quaternion stored without scaling is within `4 * DBL_EPSILON` of unit norm.

The tolerance on input is untouched — a quaternion further than `1e-3` from
unit norm is still refused, and one carrying drift inside that band is still
normalized on the way in.

### Tests

The round trip is asserted for a pose and for a chain, on quaternions whose
scaled components move again when scaled a second time. The cases already in
the suite use exactly representable quaternions such as
`(0.5, 0.5, 0.5, 0.5)` and `(1, 0, 0, 0)`, which survive any rescaling and so
cannot tell a lossless round trip from a lossy one. Both new assertions
answer false on master and true here.

No expected output in the suite moves.
