### PR TITLE
Measure the nearest approach of a box column on the value itself

### DIFF
--- a/mobilitydb/sql/cbuffer/216_tcbuffer_indexes.in.sql
+++ b/mobilitydb/sql/cbuffer/216_tcbuffer_indexes.in.sql
@@ -39,6 +39,11 @@ CREATE FUNCTION tcbuffer_gist_consistent(internal, tcbuffer, smallint, oid, inte
   AS 'MODULE_PATHNAME', 'Stbox_gist_consistent'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tcbuffer_gist_distance(internal, tcbuffer, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************/
 
 CREATE OPERATOR CLASS tcbuffer_rtree_ops
@@ -115,7 +120,7 @@ CREATE OPERATOR CLASS tcbuffer_rtree_ops
   FUNCTION  5 stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6 stbox_gist_picksplit(internal, internal),
   FUNCTION  7 stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8 stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8 tcbuffer_gist_distance(internal, tcbuffer, smallint, oid, internal);
 
 /******************************************************************************/
 

--- a/mobilitydb/sql/geo/073_tgeo_gist.in.sql
+++ b/mobilitydb/sql/geo/073_tgeo_gist.in.sql
@@ -70,6 +70,11 @@ CREATE FUNCTION tspatial_gist_compress(internal)
 
 /******************************************************************************/
 
+CREATE FUNCTION tgeometry_gist_distance(internal, tgeometry, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE OPERATOR CLASS tgeometry_rtree_ops
   DEFAULT FOR TYPE tgeometry USING gist AS
   STORAGE stbox,
@@ -156,7 +161,12 @@ CREATE OPERATOR CLASS tgeometry_rtree_ops
   FUNCTION  5  stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6  stbox_gist_picksplit(internal, internal),
   FUNCTION  7  stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8  stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8  tgeometry_gist_distance(internal, tgeometry, smallint, oid, internal);
+
+CREATE FUNCTION tgeography_gist_distance(internal, tgeography, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR CLASS tgeography_rtree_ops
   DEFAULT FOR TYPE tgeography USING gist AS
@@ -208,6 +218,6 @@ CREATE OPERATOR CLASS tgeography_rtree_ops
   FUNCTION  5  stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6  stbox_gist_picksplit(internal, internal),
   FUNCTION  7  stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8  stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8  tgeography_gist_distance(internal, tgeography, smallint, oid, internal);
 
 /******************************************************************************/

--- a/mobilitydb/sql/geo/073_tpoint_gist.in.sql
+++ b/mobilitydb/sql/geo/073_tpoint_gist.in.sql
@@ -137,6 +137,11 @@ CREATE FUNCTION tgeogpoint_gist_consistent(internal, tgeogpoint, smallint, oid, 
   AS 'MODULE_PATHNAME', 'Stbox_gist_consistent'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tgeompoint_gist_distance(internal, tgeompoint, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE OPERATOR CLASS tgeompoint_rtree_ops
   DEFAULT FOR TYPE tgeompoint USING gist AS
   STORAGE stbox,
@@ -223,7 +228,12 @@ CREATE OPERATOR CLASS tgeompoint_rtree_ops
   FUNCTION  5  stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6  stbox_gist_picksplit(internal, internal),
   FUNCTION  7  stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8  stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8  tgeompoint_gist_distance(internal, tgeompoint, smallint, oid, internal);
+
+CREATE FUNCTION tgeogpoint_gist_distance(internal, tgeogpoint, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR CLASS tgeogpoint_rtree_ops
   DEFAULT FOR TYPE tgeogpoint USING gist AS
@@ -275,6 +285,6 @@ CREATE OPERATOR CLASS tgeogpoint_rtree_ops
   FUNCTION  5  stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6  stbox_gist_picksplit(internal, internal),
   FUNCTION  7  stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8  stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8  tgeogpoint_gist_distance(internal, tgeogpoint, smallint, oid, internal);
 
 /******************************************************************************/

--- a/mobilitydb/sql/npoint/316_tnpoint_indexes.in.sql
+++ b/mobilitydb/sql/npoint/316_tnpoint_indexes.in.sql
@@ -41,6 +41,11 @@ CREATE FUNCTION tnpoint_gist_consistent(internal, tnpoint, smallint, oid, intern
   AS 'MODULE_PATHNAME', 'Stbox_gist_consistent'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tnpoint_gist_distance(internal, tnpoint, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************/
 
 CREATE OPERATOR CLASS tnpoint_rtree_ops
@@ -117,7 +122,7 @@ CREATE OPERATOR CLASS tnpoint_rtree_ops
   FUNCTION  5 stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6 stbox_gist_picksplit(internal, internal),
   FUNCTION  7 stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8 stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8 tnpoint_gist_distance(internal, tnpoint, smallint, oid, internal);
 
 /******************************************************************************/
 

--- a/mobilitydb/sql/pose/116_tpose_indexes.in.sql
+++ b/mobilitydb/sql/pose/116_tpose_indexes.in.sql
@@ -41,6 +41,11 @@ CREATE FUNCTION tpose_gist_consistent(internal, tpose, smallint, oid, internal)
   AS 'MODULE_PATHNAME', 'Stbox_gist_consistent'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION tpose_gist_distance(internal, tpose, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************/
 
 CREATE OPERATOR CLASS tpose_rtree_ops
@@ -129,7 +134,7 @@ CREATE OPERATOR CLASS tpose_rtree_ops
   FUNCTION  5 stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6 stbox_gist_picksplit(internal, internal),
   FUNCTION  7 stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8 stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8 tpose_gist_distance(internal, tpose, smallint, oid, internal);
 
 /******************************************************************************/
 

--- a/mobilitydb/sql/rgeo/173_trgeo_indexes.in.sql
+++ b/mobilitydb/sql/rgeo/173_trgeo_indexes.in.sql
@@ -41,6 +41,11 @@ CREATE FUNCTION trgeometry_gist_consistent(internal, trgeometry, smallint, oid, 
   AS 'MODULE_PATHNAME', 'Stbox_gist_consistent'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION trgeometry_gist_distance(internal, trgeometry, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************/
 
 CREATE OPERATOR CLASS trgeometry_rtree_ops
@@ -129,7 +134,7 @@ CREATE OPERATOR CLASS trgeometry_rtree_ops
   FUNCTION  5 stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6 stbox_gist_picksplit(internal, internal),
   FUNCTION  7 stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8 stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8 trgeometry_gist_distance(internal, trgeometry, smallint, oid, internal);
 
 /******************************************************************************/
 

--- a/mobilitydb/src/geo/tspatial_gist.c
+++ b/mobilitydb/src/geo/tspatial_gist.c
@@ -380,14 +380,15 @@ Stbox_gist_same(PG_FUNCTION_ARGS)
  * GiST distance method
  *****************************************************************************/
 
-PGDLLEXPORT Datum Stbox_gist_distance(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Stbox_gist_distance);
 /**
- * @brief GiST distance for spatiotemporal values
- * @note Take in a query and an entry and return the "distance" between them
-*/
-Datum
-Stbox_gist_distance(PG_FUNCTION_ARGS)
+ * @brief Return the distance between the bounding box of an index entry and a
+ * query, in the last argument whether the leaf entries must be rechecked
+ * @param[in] fcinfo Catalog information about the external function
+ * @param[in] boxcolumn True when the index is built over a column of
+ *   spatiotemporal boxes, so that a leaf key is the value itself
+ */
+static Datum
+stbox_gist_distance(FunctionCallInfo fcinfo, bool boxcolumn)
 {
   GISTENTRY *entry = (GISTENTRY *) PG_GETARG_POINTER(0);
   Oid typid = PG_GETARG_OID(3);
@@ -395,23 +396,49 @@ Stbox_gist_distance(PG_FUNCTION_ARGS)
   STBox *key = (STBox *) DatumGetPointer(entry->key);
   if (! key)
     PG_RETURN_FLOAT8(DBL_MAX);
+  MeosType type = oid_meostype(typid);
 
-  /* The index is lossy for leaf levels */
+  /* A leaf key of a column of boxes is the value itself, so its distance to a
+   * query box is the one the operator computes. Every other pairing measures
+   * a bounding box against a value and bounds the distance from below, which
+   * the recheck of the leaf entries settles */
   if (GIST_LEAF(entry))
-    *recheck = true;
+    *recheck = ! (boxcolumn && type == T_STBOX);
 
   /* Transform the query into a box */
   STBox query;
-  if (! tspatial_gist_get_stbox(fcinfo, &query, oid_meostype(typid)))
+  if (! tspatial_gist_get_stbox(fcinfo, &query, type))
     PG_RETURN_FLOAT8(DBL_MAX);
 
-  /* Since we only have boxes we return the minimum possible distance,
-   * and let the recheck sort things out in the case of leaves */
   double distance = nad_stbox_stbox(key, &query);
   if (distance < 0)
     PG_RETURN_FLOAT8(DBL_MAX);
 
   PG_RETURN_FLOAT8(distance);
+}
+
+PGDLLEXPORT Datum Stbox_gist_distance(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Stbox_gist_distance);
+/**
+ * @brief GiST distance for spatiotemporal boxes
+ * @note Take in a query and an entry and return the "distance" between them
+*/
+Datum
+Stbox_gist_distance(PG_FUNCTION_ARGS)
+{
+  return stbox_gist_distance(fcinfo, true);
+}
+
+PGDLLEXPORT Datum Tspatial_gist_distance(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tspatial_gist_distance);
+/**
+ * @brief GiST distance for spatiotemporal values
+ * @note Take in a query and an entry and return the "distance" between them
+*/
+Datum
+Tspatial_gist_distance(PG_FUNCTION_ARGS)
+{
+  return stbox_gist_distance(fcinfo, false);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -2056,6 +2056,24 @@ DROP INDEX tbl_stbox_notime_kdtree_idx;
 DROP INDEX
 DROP TABLE tbl_stbox_notime;
 DROP TABLE
+DROP INDEX IF EXISTS tbl_stbox3d_rtree_idx;
+NOTICE:  index "tbl_stbox3d_rtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_stbox3d_rtree_idx ON tbl_stbox3d USING GIST(b);
+CREATE INDEX
+WITH test AS (
+  SELECT b |=| stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_stbox3d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+ 46.677487
+ 63.491113
+ 89.960123
+(3 rows)
+
+DROP INDEX tbl_stbox3d_rtree_idx;
+DROP INDEX
 DROP INDEX IF EXISTS tbl_stbox3d_quadtree_idx;
 NOTICE:  index "tbl_stbox3d_quadtree_idx" does not exist, skipping
 DROP INDEX

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -615,6 +615,14 @@ DROP TABLE tbl_stbox_notime;
 -- Nearest approach ordering answered by the space-partitioning indexes
 -------------------------------------------------------------------------------
 
+DROP INDEX IF EXISTS tbl_stbox3d_rtree_idx;
+CREATE INDEX tbl_stbox3d_rtree_idx ON tbl_stbox3d USING GIST(b);
+WITH test AS (
+  SELECT b |=| stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_stbox3d ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_stbox3d_rtree_idx;
+
 DROP INDEX IF EXISTS tbl_stbox3d_quadtree_idx;
 CREATE INDEX tbl_stbox3d_quadtree_idx ON tbl_stbox3d USING SPGIST(b);
 WITH test AS (

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -142,7 +142,7 @@ no subtype currently routes `aggfuncs` through the `subtypes:` track. Live templ
 | posops | `posops.sql.tmpl` | **GENERATED** |
 | spatialrels | `spatialrels.c.tmpl` + `spatialrels.sql.tmpl` | **GENERATED** (ever/always) |
 | boxops (C) | `boxops.c.tmpl` | **GENERATED** (box-type axis) |
-| gist / spgist / indexes | `gist/spgist/indexes.sql.tmpl` | **GENERATED** (index infra) — `indexes.sql.tmpl` carries the Z-axis strategies 32-35 under `-- @IF front_back`, the same additive flag `posops.sql.tmpl` uses to declare the Z operators, so a family declares and indexes that axis from one manifest key |
+| gist / spgist / indexes | `gist/spgist/indexes.sql.tmpl` | **GENERATED** (index infra) — `indexes.sql.tmpl` carries the Z-axis strategies 32-35 under `-- @IF front_back`, the same additive flag `posops.sql.tmpl` uses to declare the Z operators, so a family declares and indexes that axis from one manifest key. It also declares the family's own consistent and distance support functions, `{TEMP}_gist_consistent` and `{TEMP}_gist_distance`, each over the implementation the spatiotemporal families share |
 | aggfuncs | `aggregates.sql.tmpl` | **GENERATED** — whole-file per family via the separate `aggregate_families` axis (§4b), not the `subtypes:` track |
 | spatialfuncs | — | reserved position, **HAND** |
 | distance | — | reserved position, **HAND** |
@@ -933,9 +933,9 @@ Three facts bound which declarations carry the clause:
   a filter in that operand order instead of rewriting it into a different
   question.
 - **A family whose opclass does not index a strategy keeps the predicate as a
-  filter**, the operator lookup finding no member. `tpose` and `trgeometry`
-  declare the Z-axis operators while their GiST opclass indexes none of them,
-  so the Z predicates of those two families are filters.
+  filter**, the operator lookup finding no member. The Z-axis strategies reach
+  the opclass of a three-dimensional family through the `front_back` key of §6,
+  so `tpose` and `trgeometry` answer their Z predicates from the index.
 - **The temporal pointcloud types carry no clause.** Their bounding box is a
   `TPCBox` and no scalar conversion to it exists to build an index expression
   from, so a clause there could never fire.

--- a/tools/codegen/inherited/templates/indexes.sql.tmpl
+++ b/tools/codegen/inherited/templates/indexes.sql.tmpl
@@ -39,6 +39,11 @@ CREATE FUNCTION {TEMP}_gist_consistent(internal, {TEMP}, smallint, oid, internal
   AS 'MODULE_PATHNAME', 'Stbox_gist_consistent'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE FUNCTION {TEMP}_gist_distance(internal, {TEMP}, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tspatial_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************/
 
 CREATE OPERATOR CLASS {TEMP}_rtree_ops
@@ -129,7 +134,7 @@ CREATE OPERATOR CLASS {TEMP}_rtree_ops
   FUNCTION  5 stbox_gist_penalty(internal, internal, internal),
   FUNCTION  6 stbox_gist_picksplit(internal, internal),
   FUNCTION  7 stbox_gist_same(stbox, stbox, internal),
-  FUNCTION  8 stbox_gist_distance(internal, stbox, smallint, oid, internal);
+  FUNCTION  8 {TEMP}_gist_distance(internal, {TEMP}, smallint, oid, internal);
 
 /******************************************************************************/
 


### PR DESCRIPTION
A leaf entry of an index built over a column of spatiotemporal boxes holds the box itself, so its distance to a query box is the distance the operator computes and the entry needs no recheck, which is what an index-only scan requires of an ordering. Every other pairing measures a bounding box against a value and keeps its recheck: each temporal spatial family declares its own distance support function beside the consistent one it already declares, in the shape the index template carries, and the shared implementation of the families answers under its own name.