### PR TITLE
Order a temporal number box by nearest approach from an index

### DIFF
--- a/mobilitydb/sql/temporal/043_temporal_gist.in.sql
+++ b/mobilitydb/sql/temporal/043_temporal_gist.in.sql
@@ -155,6 +155,11 @@ CREATE OPERATOR CLASS tbox_rtree_ops
   OPERATOR  17    -|- (tbox, tint),
   OPERATOR  17    -|- (tbox, tbigint),
   OPERATOR  17    -|- (tbox, tfloat),
+  -- nearest approach distance
+  OPERATOR  25    |=| (tbox, tbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tbigint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tfloat) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tbox, tbox),
   OPERATOR  28    &<# (tbox, tint),
@@ -224,6 +229,11 @@ CREATE OPERATOR CLASS tbool_rtree_ops
   FUNCTION  7  span_gist_same(tstzspan, tstzspan, internal);
 
 /******************************************************************************/
+
+CREATE FUNCTION tint_gist_distance(internal, tint, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tnumber_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR CLASS tint_rtree_ops
   DEFAULT FOR TYPE tint USING gist AS
@@ -295,9 +305,14 @@ CREATE OPERATOR CLASS tint_rtree_ops
   FUNCTION  5  tbox_gist_penalty(internal, internal, internal),
   FUNCTION  6  tbox_gist_picksplit(internal, internal),
   FUNCTION  7  tbox_gist_same(tbox, tbox, internal),
-  FUNCTION  8  tbox_gist_distance(internal, tbox, smallint, oid, internal);
+  FUNCTION  8  tint_gist_distance(internal, tint, smallint, oid, internal);
 
 /******************************************************************************/
+
+CREATE FUNCTION tbigint_gist_distance(internal, tbigint, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tnumber_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR CLASS tbigint_rtree_ops
   DEFAULT FOR TYPE tbigint USING gist AS
@@ -369,9 +384,14 @@ CREATE OPERATOR CLASS tbigint_rtree_ops
   FUNCTION  5  tbox_gist_penalty(internal, internal, internal),
   FUNCTION  6  tbox_gist_picksplit(internal, internal),
   FUNCTION  7  tbox_gist_same(tbox, tbox, internal),
-  FUNCTION  8  tbox_gist_distance(internal, tbox, smallint, oid, internal);
+  FUNCTION  8  tbigint_gist_distance(internal, tbigint, smallint, oid, internal);
 
 /******************************************************************************/
+
+CREATE FUNCTION tfloat_gist_distance(internal, tfloat, smallint, oid, internal)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Tnumber_gist_distance'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR CLASS tfloat_rtree_ops
   DEFAULT FOR TYPE tfloat USING gist AS
@@ -443,7 +463,7 @@ CREATE OPERATOR CLASS tfloat_rtree_ops
   FUNCTION  5  tbox_gist_penalty(internal, internal, internal),
   FUNCTION  6  tbox_gist_picksplit(internal, internal),
   FUNCTION  7  tbox_gist_same(tbox, tbox, internal),
-  FUNCTION  8  tbox_gist_distance(internal, tbox, smallint, oid, internal);
+  FUNCTION  8  tfloat_gist_distance(internal, tfloat, smallint, oid, internal);
 
 /******************************************************************************/
 

--- a/mobilitydb/sql/temporal/044_temporal_spgist.in.sql
+++ b/mobilitydb/sql/temporal/044_temporal_spgist.in.sql
@@ -108,6 +108,11 @@ CREATE OPERATOR CLASS tbox_quadtree_ops
   OPERATOR  17    -|- (tbox, tint),
   OPERATOR  17    -|- (tbox, tbigint),
   OPERATOR  17    -|- (tbox, tfloat),
+  -- nearest approach distance
+  OPERATOR  25    |=| (tbox, tbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tbigint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tfloat) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tbox, tbox),
   OPERATOR  28    &<# (tbox, tint),
@@ -199,6 +204,11 @@ CREATE OPERATOR CLASS tbox_kdtree_ops
   OPERATOR  17    -|- (tbox, tint),
   OPERATOR  17    -|- (tbox, tbigint),
   OPERATOR  17    -|- (tbox, tfloat),
+  -- nearest approach distance
+  OPERATOR  25    |=| (tbox, tbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tbigint) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25    |=| (tbox, tfloat) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28    &<# (tbox, tbox),
   OPERATOR  28    &<# (tbox, tint),

--- a/mobilitydb/src/temporal/tnumber_gist.c
+++ b/mobilitydb/src/temporal/tnumber_gist.c
@@ -1016,23 +1016,28 @@ Tbox_gist_same(PG_FUNCTION_ARGS)
  * GiST distance method
  *****************************************************************************/
 
-PGDLLEXPORT Datum Tbox_gist_distance(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tbox_gist_distance);
 /**
- * @brief GiST support distance function that takes in a query and an entry and
- * returns the "distance" between them
-*/
-Datum
-Tbox_gist_distance(PG_FUNCTION_ARGS)
+ * @brief Return the distance between the bounding box of an index entry and a
+ * query, in the last argument whether the leaf entries must be rechecked
+ * @param[in] fcinfo Catalog information about the external function
+ * @param[in] boxcolumn True when the index is built over a column of temporal
+ *   boxes, so that a leaf key is the value itself
+ */
+static Datum
+tbox_gist_distance(FunctionCallInfo fcinfo, bool boxcolumn)
 {
   GISTENTRY *entry = (GISTENTRY *) PG_GETARG_POINTER(0);
   Oid typid = PG_GETARG_OID(3);
   bool *recheck = (bool *) PG_GETARG_POINTER(4);
   TBox *key = (TBox *) DatumGetPointer(entry->key);
+  MeosType type = oid_meostype(typid);
 
-  /* The index is lossy for leaf levels */
+  /* A leaf key of a column of boxes is the value itself, so its distance to a
+   * query box is the one the operator computes. Every other pairing measures a
+   * bounding box against a value and bounds the distance from below, which the
+   * recheck of the leaf entries settles */
   if (key && GIST_LEAF(entry))
-    *recheck = true;
+    *recheck = ! (boxcolumn && type == T_TBOX);
 
   /* Transform the query into a box. The distance is unknown when there is no
    * key or the query is not a box, and the maximum orders those entries after
@@ -1040,7 +1045,7 @@ Tbox_gist_distance(PG_FUNCTION_ARGS)
    * as the GiST framework reads the result of its distance method as a
    * double and rejects a null one */
   TBox query;
-  if (! key || ! tnumber_gist_get_tbox(fcinfo, &query, oid_meostype(typid)))
+  if (! key || ! tnumber_gist_get_tbox(fcinfo, &query, type))
     PG_RETURN_FLOAT8(DBL_MAX);
 
   /* Since we only have boxes we'll return the minimum possible distance,
@@ -1050,6 +1055,30 @@ Tbox_gist_distance(PG_FUNCTION_ARGS)
   double distance = distance_double(nad_tbox_tbox(key, &query),
     key->span.basetype);
   PG_RETURN_FLOAT8(distance);
+}
+
+PGDLLEXPORT Datum Tbox_gist_distance(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tbox_gist_distance);
+/**
+ * @brief GiST distance for temporal boxes
+ * @note Take in a query and an entry and return the "distance" between them
+ */
+Datum
+Tbox_gist_distance(PG_FUNCTION_ARGS)
+{
+  return tbox_gist_distance(fcinfo, true);
+}
+
+PGDLLEXPORT Datum Tnumber_gist_distance(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tnumber_gist_distance);
+/**
+ * @brief GiST distance for temporal numbers
+ * @note Take in a query and an entry and return the "distance" between them
+ */
+Datum
+Tnumber_gist_distance(PG_FUNCTION_ARGS)
+{
+  return tbox_gist_distance(fcinfo, false);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/test/temporal/expected/021_tbox.test.out
+++ b/mobilitydb/test/temporal/expected/021_tbox.test.out
@@ -1505,3 +1505,57 @@ SELECT hashExtended(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])', 1);
  2841424149611304447
 (1 row)
 
+DROP INDEX IF EXISTS tbl_tboxfloat_rtree_idx;
+NOTICE:  index "tbl_tboxfloat_rtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tboxfloat_rtree_idx ON tbl_tboxfloat USING GIST(b);
+CREATE INDEX
+WITH test AS (
+  SELECT b |=| tbox 'TBOXFLOAT XT([1.0,2.0],[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tboxfloat ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+  3.084295
+ 19.606267
+  25.17485
+(3 rows)
+
+DROP INDEX tbl_tboxfloat_rtree_idx;
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tboxfloat_quadtree_idx;
+NOTICE:  index "tbl_tboxfloat_quadtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tboxfloat_quadtree_idx ON tbl_tboxfloat USING SPGIST(b);
+CREATE INDEX
+WITH test AS (
+  SELECT b |=| tbox 'TBOXFLOAT XT([1.0,2.0],[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tboxfloat ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+  3.084295
+ 19.606267
+  25.17485
+(3 rows)
+
+DROP INDEX tbl_tboxfloat_quadtree_idx;
+DROP INDEX
+DROP INDEX IF EXISTS tbl_tboxfloat_kdtree_idx;
+NOTICE:  index "tbl_tboxfloat_kdtree_idx" does not exist, skipping
+DROP INDEX
+CREATE INDEX tbl_tboxfloat_kdtree_idx ON tbl_tboxfloat USING SPGIST(b tbox_kdtree_ops);
+CREATE INDEX
+WITH test AS (
+  SELECT b |=| tbox 'TBOXFLOAT XT([1.0,2.0],[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tboxfloat ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round   
+-----------
+  3.084295
+ 19.606267
+  25.17485
+(3 rows)
+
+DROP INDEX tbl_tboxfloat_kdtree_idx;
+DROP INDEX

--- a/mobilitydb/test/temporal/queries/021_tbox.test.sql
+++ b/mobilitydb/test/temporal/queries/021_tbox.test.sql
@@ -462,3 +462,33 @@ SELECT hash(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])');
 SELECT hashExtended(tbox 'TBOXFLOAT XT([1.0,1.0],[2000-01-02,2000-01-02])', 1);
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Nearest approach ordering answered by the indexes
+-------------------------------------------------------------------------------
+
+DROP INDEX IF EXISTS tbl_tboxfloat_rtree_idx;
+CREATE INDEX tbl_tboxfloat_rtree_idx ON tbl_tboxfloat USING GIST(b);
+WITH test AS (
+  SELECT b |=| tbox 'TBOXFLOAT XT([1.0,2.0],[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tboxfloat ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_tboxfloat_rtree_idx;
+
+DROP INDEX IF EXISTS tbl_tboxfloat_quadtree_idx;
+CREATE INDEX tbl_tboxfloat_quadtree_idx ON tbl_tboxfloat USING SPGIST(b);
+WITH test AS (
+  SELECT b |=| tbox 'TBOXFLOAT XT([1.0,2.0],[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tboxfloat ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_tboxfloat_quadtree_idx;
+
+DROP INDEX IF EXISTS tbl_tboxfloat_kdtree_idx;
+CREATE INDEX tbl_tboxfloat_kdtree_idx ON tbl_tboxfloat USING SPGIST(b tbox_kdtree_ops);
+WITH test AS (
+  SELECT b |=| tbox 'TBOXFLOAT XT([1.0,2.0],[2001-06-01, 2001-07-01])' AS distance
+  FROM tbl_tboxfloat ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_tboxfloat_kdtree_idx;
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
The R-tree, quad-tree and k-d tree operator classes of tbox carry the nearest approach distance operator against a box, a temporal integer, a temporal big integer and a temporal float, so an ordering by that distance over a column of boxes is answered by an index scan. A leaf entry of such an index holds the box itself, so its distance to a query box is the distance the operator computes and the entry needs no recheck; the temporal number families measure a bounding box against a value and keep their recheck under their own distance support function.