### PR TITLE
Read two computations of one boundary node as the one node they are

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -1258,6 +1258,26 @@ buffer_components_relation(const LWGEOM *geom1, const LWGEOM *geom2)
  *****************************************************************************/
 
 /**
+ * @brief Return how far apart two computations of ONE boundary node may lie
+ * @details Where two boundaries meet at a shallow angle their crossing is
+ * ill-conditioned: moving either curve by the rounding of its own arithmetic
+ * moves the crossing by the SQUARE ROOT of that rounding, so two routes to the
+ * same node — one boundary's arc against the other's offset, and the mirror of
+ * it — answer points that far apart. Deduplicating a node set at the tolerance
+ * a coordinate is STORED to therefore keeps one node twice, and the piece
+ * between the two copies is a sliver belonging to no boundary.
+ */
+static double
+buffer_node_tolerance(double x, double y)
+{
+  /* The square root of the double epsilon, scaled by the coordinates, and
+   * never below the tolerance an exactly computed node is placed to */
+  double scale = Max(fabs(x), fabs(y));
+  double tol = 5.0e-8 * Max(scale, 1.0);
+  return Max(tol, MEOS_EDGE_TOLERANCE);
+}
+
+/**
  * @brief Add an intersection point to an array.
  * @details Duplicate points are ignored. This is important because
  * adjacent buffer segments may report the same topological node.
@@ -1270,8 +1290,8 @@ buffer_intersections_add(MeosArray *array, double x, double y)
   for (uint32_t i = 0; i < array->count; i++)
   {
     const POINT2D *point = (POINT2D *) meos_array_get(array, i);
-    if (fabs(point->x - x) <= FP_TOLERANCE && 
-        fabs(point->y - y) <= FP_TOLERANCE)
+    double tol = buffer_node_tolerance(x, y);
+    if (fabs(point->x - x) <= tol && fabs(point->y - y) <= tol)
       return;
   }
   POINT2D new;
@@ -1290,7 +1310,8 @@ buffer_add_intersection_point(MeosArray *points, double x, double y)
   for (uint32_t i = 0; i < points->count; i++)
   {
     const POINT2D *p = (const POINT2D *) meos_array_get(points, i);
-    if (fabs(p->x - x) <= FP_TOLERANCE && fabs(p->y - y) <= FP_TOLERANCE)
+    double tol = buffer_node_tolerance(x, y);
+    if (fabs(p->x - x) <= tol && fabs(p->y - y) <= tol)
       return;
   }
   POINT2D point;


### PR DESCRIPTION
A buffer boundary node is deduplicated against the tolerance a coordinate is
STORED to, an absolute 1e-12. That is the wrong quantity: what matters is the
tolerance a node can be COMPUTED to, and where two boundaries meet at a shallow
angle their crossing is ill-conditioned — moving either curve by the rounding
of its own arithmetic moves the crossing by the square root of that rounding.
Two routes to the same node, one boundary's arc against the other's offset and
the mirror of it, then answer points far enough apart to be kept as two.

The node set carries the node twice, both boundaries are split at both copies,
and the piece between them is a sliver belonging to no boundary. The union of
the two components cannot be chained through it and the whole geometry reports
as not covered. Buffering two components that share an endpoint is what reaches
it: their round caps are arcs of one circle about that endpoint, so the meeting
is tangential by construction.

The tolerance follows the coordinates rather than the representation. Two
boundaries tangent to within double precision separate quadratically, so their
crossing is resolvable only beyond the square root of the rounding times the
scale, which is 5e-8 of the coordinate magnitude here and never below the
tolerance an exactly computed node is placed to.

Over the 154 fixture geometries buffered by 5, checked against ST_Buffer of the
input densified to 1e-6 at quad_segs=128 within 1e-4 of the reference area,
geometries the buffer does not cover go 14 to 10 and correct answers 127 to
131, with the wrong answers unchanged in count and in membership. The GEOS
relate suite stays at 154 of 154.

The figure is a threshold rather than a fit: the same 10 and 131 come out at
1e-7 and at 5e-7, so a tolerance ten times wider closes nothing further.

