### PR TITLE
Answer the bounding box of a temporal pose chain instant

### DIFF
--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -62,6 +62,7 @@
 #endif 
 #if POSECHAIN
   #include "posechain/posechain.h"
+  #include "posechain/tposechain_boxops.h"
 #endif
 #if RGEO
   #include "pose/pose.h"
@@ -460,6 +461,10 @@ tspatial_set_stbox(const Temporal *temp, STBox *result)
 #if POSE
       else if (temp->temptype == T_TPOSE)
         tposeinst_set_stbox((TInstant *) temp, result);
+#endif
+#if POSECHAIN
+      else if (temp->temptype == T_TPOSECHAIN)
+        tposechaininst_set_stbox((TInstant *) temp, result);
 #endif
 #if QUADBIN
       else if (temp->temptype == T_TQUADBIN)

--- a/mobilitydb/test/posechain/expected/552_tposechain.test.out
+++ b/mobilitydb/test/posechain/expected/552_tposechain.test.out
@@ -138,3 +138,21 @@ SELECT tposechain 'PoseChain(Pose(Point(0 0), 0))@2000-01-01' <> tposechain 'Pos
  t
 (1 row)
 
+SELECT stbox(tposechain 'PoseChain(Pose(Point(1 2), 0), Pose(Point(3 4), 0))@2000-01-01');
+                                        stbox                                         
+--------------------------------------------------------------------------------------
+ STBOX XT(((1,2),(4,6)),[Sat Jan 01 00:00:00 2000 PST, Sat Jan 01 00:00:00 2000 PST])
+(1 row)
+
+SELECT stbox(tposechain '{PoseChain(Pose(Point(1 2), 0))@2000-01-01, PoseChain(Pose(Point(5 6), 0))@2000-01-02}');
+                                        stbox                                         
+--------------------------------------------------------------------------------------
+ STBOX XT(((1,2),(5,6)),[Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST])
+(1 row)
+
+SELECT stbox(tposechain '[PoseChain(Pose(Point(1 2), 0))@2000-01-01, PoseChain(Pose(Point(5 6), 0))@2000-01-02]');
+                                        stbox                                         
+--------------------------------------------------------------------------------------
+ STBOX XT(((1,2),(5,6)),[Sat Jan 01 00:00:00 2000 PST, Sun Jan 02 00:00:00 2000 PST])
+(1 row)
+

--- a/mobilitydb/test/posechain/queries/552_tposechain.test.sql
+++ b/mobilitydb/test/posechain/queries/552_tposechain.test.sql
@@ -109,3 +109,15 @@ SELECT tposechain 'PoseChain(Pose(Point(0 0), 0))@2000-01-01' = tposechain 'Pose
 SELECT tposechain 'PoseChain(Pose(Point(0 0), 0))@2000-01-01' <> tposechain 'PoseChain(Pose(Point(1 1), 0))@2000-01-01';
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Bounding box
+-- The box of a chain covers the composed position of every prefix, so an
+-- instant carries the reach of the whole chain and not only of its last link
+-------------------------------------------------------------------------------
+
+SELECT stbox(tposechain 'PoseChain(Pose(Point(1 2), 0), Pose(Point(3 4), 0))@2000-01-01');
+SELECT stbox(tposechain '{PoseChain(Pose(Point(1 2), 0))@2000-01-01, PoseChain(Pose(Point(5 6), 0))@2000-01-02}');
+SELECT stbox(tposechain '[PoseChain(Pose(Point(1 2), 0))@2000-01-01, PoseChain(Pose(Point(5 6), 0))@2000-01-02]');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
`tspatial_set_stbox` dispatches the instant case over the spatial families one
by one, and posechain is absent from that chain, so the bounding box of a
`tposechain` instant raises `Unknown spatiotemporal type: tposechain` instead
of answering:

```sql
SELECT stbox(tposechain 'PoseChain(Pose(Point(1 2), 0), Pose(Point(3 4), 0))@2000-01-01');
ERROR:  Unknown spatiotemporal type: tposechain
```

Every operator that reads a bounding box is affected, which is the whole
topological and positional surface of the type for an instant value. A
sequence and a sequence set answer through a shared path and are unaffected,
which is why the type ships this way.

The kernel it needs already exists and is already reached from the other
dispatcher: `tposechaininst_set_stbox`, which `tspatialinst_set_stbox` in
`tgeo_boxops.c` calls beside every sibling family. This adds the branch that
names it here too, and the include that declares it.

The box of a chain covers the composed position of every prefix, so the test
asserts an instant of a two-link chain spanning both — `(1,2)` and the
composition `(4,6)` — and the sequence and sequence-set forms beside it. No
existing expected output moves; the harvested diff is additions only.
