### PR TITLE
Copy the point arrays a union hands back to its caller

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -820,8 +820,10 @@ buffer_areal_collection(const LWGEOM *geom1, const LWGEOM *geom2)
   assert(geom1); assert(geom2);
   int32_t srid = lwgeom_get_srid(geom1);
   LWGEOM **geoms = palloc(sizeof(LWGEOM *) * 2);
-  geoms[0] = lwgeom_clone(geom1);
-  geoms[1] = lwgeom_clone(geom2);
+  /* The caller releases both operands once it holds the answer, and
+   * lwgeom_clone shares their point arrays rather than copying them */
+  geoms[0] = lwgeom_clone_deep(geom1);
+  geoms[1] = lwgeom_clone_deep(geom2);
   LWCOLLECTION *result = lwcollection_construct(MULTISURFACETYPE, srid,
     NULL, 2, geoms);
   return lwcollection_as_lwgeom(result);
@@ -855,10 +857,10 @@ buffer_areal_union_simple(const LWGEOM *geom1, const LWGEOM *geom2,
 
   /* A contains B */
   if (buffer_areal_contains(geom1, geom2))
-    return lwgeom_clone(geom1);
+    return lwgeom_clone_deep(geom1);
   /* B contains A */
   if (buffer_areal_contains(geom2, geom1))
-    return lwgeom_clone(geom2);
+    return lwgeom_clone_deep(geom2);
 
   /* If the boundaries do not intersect, the geometries are disjoint */
   if (! buffer_geometries_intersect(geom1, geom2))


### PR DESCRIPTION
buffer_areal_union_simple answers three of its cases by handing back one of
its two operands: the containing one where either contains the other, and a
collection of both where they are disjoint. It builds each answer with
lwgeom_clone, whose contract liblwgeom states as "Serialized point lists are
not copied" — the answer shares the operands' point arrays rather than owning
them.

buffer_union_components then releases both operands the moment it holds the
answer, which frees the arrays the answer is made of. What the answer reports
from that point on is whatever the allocator leaves behind, and a coordinate
of 4.66e-310 beside one of 1.59e+248 is what that looks like.

The four sites copy the point arrays instead.

Nothing on the fixture reaches it today: over the 154 geometries buffered by 5
valgrind reports 0 errors both before and after, and the answers are unchanged
— 10 geometries the buffer does not cover, 131 correct, the GEOS relate suite
at 154 of 154. The defect is reachable rather than reached, and a candidate
change to the containment test brings a geometry back with those coordinates,
which is how the ownership comes to be read at all.

