### PR TITLE
Join a hole of a buffer surface to the surface that fills it

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -838,6 +838,75 @@ buffer_union_crossing(const LWGEOM *geom1, const LWGEOM *geom2,
   bool *touching);
 
 /**
+ * @brief Return whether a geometry covers a hole of another one
+ * @details A hole is not part of the surface carrying it, so a geometry that
+ * covers one adds area to it. Where the two boundaries do not cross, one point
+ * of the hole's own ring says where the whole ring lies, and a hole the inner
+ * geometry reaches at all is a hole it contains entirely.
+ */
+static bool
+buffer_covers_hole(const LWGEOM *hole, const LWGEOM *inner)
+{
+  assert(hole); assert(inner);
+  double hx, hy;
+  if (! buffer_areal_representative_point(hole, &hx, &hy))
+    return false;
+  return buffer_areal_contains_point(inner, hx, hy);
+}
+
+/**
+ * @brief Return a surface with every hole another geometry fills removed
+ * @details The union of a surface with one that lies inside it is the surface
+ * itself, except where the inner one covers a hole: the hole belongs to
+ * neither until then, and covering it joins it to the surface around it. The
+ * inner geometry's boundary does not cross the outer one's, so it contains
+ * every hole it reaches, and dropping that hole's ring is the whole of the
+ * union.
+ * @return A deep copy of @p outer carrying only the holes @p inner leaves
+ * empty, and NULL where @p outer is not a surface this understands
+ */
+static LWGEOM *
+buffer_outer_without_filled_holes(const LWGEOM *outer, const LWGEOM *inner,
+  int32_t srid)
+{
+  assert(outer); assert(inner);
+  if (outer->type == MULTISURFACETYPE || outer->type == COLLECTIONTYPE)
+  {
+    const LWCOLLECTION *col = (const LWCOLLECTION *) outer;
+    LWCOLLECTION *result = lwcollection_construct_empty(outer->type, srid,
+      0, 0);
+    for (uint32_t i = 0; i < col->ngeoms; i++)
+    {
+      LWGEOM *part = col->geoms[i] ?
+        buffer_outer_without_filled_holes(col->geoms[i], inner, srid) : NULL;
+      if (! part)
+      {
+        lwgeom_free(lwcollection_as_lwgeom(result));
+        return NULL;
+      }
+      lwcollection_add_lwgeom(result, part);
+    }
+    return lwcollection_as_lwgeom(result);
+  }
+  if (outer->type == CURVEPOLYTYPE)
+  {
+    const LWCURVEPOLY *poly = (const LWCURVEPOLY *) outer;
+    if (poly->nrings == 0)
+      return lwgeom_clone_deep(outer);
+    LWCURVEPOLY *result = lwcurvepoly_construct_empty(srid, 0, 0);
+    lwcurvepoly_add_ring(result, lwgeom_clone_deep(poly->rings[0]));
+    for (uint32_t i = 1; i < poly->nrings; i++)
+    {
+      if (! poly->rings[i] || buffer_covers_hole(poly->rings[i], inner))
+        continue;
+      lwcurvepoly_add_ring(result, lwgeom_clone_deep(poly->rings[i]));
+    }
+    return lwcurvepoly_as_lwgeom(result);
+  }
+  return NULL;
+}
+
+/**
  * @brief Return the union of two areal geometries for the
  * disjoint/containment cases.
  * @details The following cases are handled exactly:
@@ -855,12 +924,19 @@ buffer_areal_union_simple(const LWGEOM *geom1, const LWGEOM *geom2,
   assert(geom1); assert(geom2); assert(touching);
   *touching = false;
 
-  /* A contains B */
+  /* One inside the other: the answer is the outer surface, and the holes of
+   * it that the inner one covers are joined to the surface around them */
+  int32_t srid = lwgeom_get_srid(geom1);
   if (buffer_areal_contains(geom1, geom2))
-    return lwgeom_clone_deep(geom1);
-  /* B contains A */
+  {
+    LWGEOM *filled = buffer_outer_without_filled_holes(geom1, geom2, srid);
+    return filled ? filled : lwgeom_clone_deep(geom1);
+  }
   if (buffer_areal_contains(geom2, geom1))
-    return lwgeom_clone_deep(geom2);
+  {
+    LWGEOM *filled = buffer_outer_without_filled_holes(geom2, geom1, srid);
+    return filled ? filled : lwgeom_clone_deep(geom2);
+  }
 
   /* If the boundaries do not intersect, the geometries are disjoint */
   if (! buffer_geometries_intersect(geom1, geom2))


### PR DESCRIPTION
The union of two areal buffers answers the outer one where it contains the
inner one. A hole belongs to neither surface until something covers it, so that
answer is right only while the inner surface leaves every hole of the outer one
empty. Where it fills one, the hole is joined to the surface around it and the
union is larger than the outer surface by exactly that hole.

buffer_areal_contains reads one representative point of the inner geometry and
asks that the two boundaries do not cross. A surface ENCLOSING a hole of the
outer one passes both, because its own boundary then lies wholly in the outer
surface, so the union hands back the outer surface unchanged and the hole
survives. What the answer loses is a region the input covers, which is a
geometry the buffer of a geometry does not contain.

The boundaries do not cross, so a hole the inner surface reaches at all is a
hole it contains entirely, and the union is the outer surface carrying only the
holes the inner one leaves empty. One point of each hole's own ring says which
those are.

The measured union step: a surface of area 296.837 and no holes against one of
6147.015 with four holes answers 6147.015 with four holes, byte for byte the
second, where the union is 6147.668 — the missing 0.653 is the hole the first
one fills. A MULTIPOLYGON of 24 parts and no interior ring buffers to a surface
with four holes where ST_Buffer gives three.

Over the 154 fixture geometries buffered by 5, checked against ST_Buffer of the
input densified to 1e-6 at quad_segs=128 within 1e-4 of the reference area,
correct answers go 131 to 137 and wrong ones 13 to 7, every MULTIPOLYGON and
MULTILINESTRING among them answering exactly and only COMPOUNDCURVE left. The
geometries the buffer does not cover stay at 10, since this corrects an answer
rather than reaching a new one, and the GEOS relate suite stays at 154 of 154.

A buffer covers the geometry it is taken of, which needs no reference
implementation to check: ST_Covers(buffer, input) holds on all 144 answers,
against 7 that fail it beforehand.


Stacked on #2100, which the union of two surfaces sharing point arrays rests on: the answer this builds from the outer surface is released by the caller together with the operands it is made of.
