### PR TITLE
Split a boundary piece at a node only where the node is not one of its ends

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -1762,10 +1762,20 @@ buffer_split_point_add(BufferSplitPoint *points, uint32_t *count,
 {
   assert(points); assert(count); assert(point);
   /* Duplicate parameters correspond either to duplicate intersection
-   * nodes or to an intersection occurring at an existing endpoint */
+   * nodes or to an intersection occurring at an existing endpoint.
+   * The parameter is normalised along the piece, so the SAME node reads a
+   * parameter that differs by the distance between the two copies divided by
+   * the piece's length, which is far above the tolerance a coordinate is
+   * stored to. The points are therefore compared where they lie, at the
+   * tolerance one boundary node is placed to. The piece's own ends are added
+   * first, so a node that is one of them keeps the piece's own geometry and
+   * splits nothing off it */
+  double tol = buffer_node_tolerance(point->x, point->y);
   for (uint32_t i = 0; i < *count; i++)
   {
-    if (fabs(points[i].parameter - parameter) <= FP_TOLERANCE)
+    if (fabs(points[i].parameter - parameter) <= FP_TOLERANCE ||
+        (fabs(points[i].point.x - point->x) <= tol &&
+         fabs(points[i].point.y - point->y) <= tol))
       return;
   }
   if (*count >= capacity)


### PR DESCRIPTION
A boundary piece is split at every node lying on it, and the split points are
deduplicated by their parameter along the piece against the tolerance a
coordinate is stored to. The parameter is normalised by the piece's length, so
the SAME node computed twice — once as one boundary's arc against the other's
offset, once as the mirror of that — reads two parameters differing by the
distance between the two copies divided by that length: 1.165e-6 over 3.7, or
3.1e-7, three hundred thousand times the tolerance they are compared against.

Both copies therefore become split points, and the piece is cut into a stub of
1.165e-6 between them. Two boundaries meeting tangentially leave such a stub on
each of them, no chain passes through one, and the surfaces they belong to are
reported as not covered.

The split points are compared where they lie instead, at the tolerance one
boundary node is placed to. A piece's own ends are added before any node, so a
node that is one of them keeps the piece's own geometry and splits nothing off
it, which is what leaves no gap behind.

Over the 154 fixture geometries buffered by 5, checked against ST_Buffer of the
input densified to 1e-6 at quad_segs=128 within 1e-4 of the reference area,
geometries the buffer does not cover go 10 to 3 and correct answers 131 to 137.
The GEOS relate suite stays at 154 of 154.

Wrong answers go 13 to 14. The one added is a MULTILINESTRING short of the
reference by 0.99% of its area, a valid geometry and a subset of it, and it
belongs to the class the containment invariant ST_Covers(buffer, input)
already separates: a hole that the union of two component buffers leaves
unfilled, which buffer_areal_contains reports as containment because it reads
one representative point and two boundaries that do not cross.


That one wrong answer is the hole #2101 joins to the surface filling it. With both applied the fixture answers 151 of 154 geometries, 144 of them correct and the 7 wrong ones all COMPOUNDCURVE, and every answer covers the geometry it is taken of.
