### PR TITLE
Answer the distance from a rigid geometry to a line

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -1074,6 +1074,19 @@ solve_s_poly_tpoly(LWPOLY *poly1, LWPOLY *poly2, Pose *poly_pose_s,
 }
 
 /**
+ * @brief Return true if the ring of @p poly describes a segment, that is, two
+ * vertices whose two edges traverse the same points in opposite directions
+ * @details Each vertex of such a ring has ONE adjacent edge, reached either way
+ * round, so the two roots that a vertex-exit test computes for it are the same
+ * event and their coincidence carries no meaning.
+ */
+static inline bool
+ring_is_segment(const LWPOLY *poly)
+{
+  return poly->rings[0]->npoints == 3;
+}
+
+/**
  * @brief Find the next change in closest feature
  */
 static int
@@ -1110,7 +1123,8 @@ vertex_vertex_tpoly_poly(LWPOLY *poly1, Pose *pose_start, Pose *pose_end,
     return MEOS_DISJOINT;
   /* Intersection through vertex */
   else if (((ratio_1 != 2 || ratio_2 != 2) && fabs(ratio_1 - ratio_2) < MEOS_EPSILON)
-        || ((ratio_3 != 2 || ratio_4 != 2) && fabs(ratio_3 - ratio_4) < MEOS_EPSILON))
+        || (! ring_is_segment(poly2) && (ratio_3 != 2 || ratio_4 != 2) &&
+            fabs(ratio_3 - ratio_4) < MEOS_EPSILON))
     return MEOS_INTERSECT;
   /* Go to next closest feature */
   else if (ratio_1 <= ratio_2 && ratio_1 <= ratio_3 && ratio_1 <= ratio_4)
@@ -1932,6 +1946,54 @@ dist2d_trgeoseq_multi(const TSequence *seq, const GSERIALIZED *gs,
   return result;
 }
 
+static GSERIALIZED *
+line_segment_ring(const LWLINE *line, uint32_t i, int32_t srid)
+{
+  POINT4D a, b;
+  getPoint4d_p(line->points, i, &a);
+  getPoint4d_p(line->points, i + 1, &b);
+  POINTARRAY **rings = lwalloc(sizeof(POINTARRAY *));
+  rings[0] = ptarray_construct_empty(0, 0, 3);
+  ptarray_append_point(rings[0], &a, LW_TRUE);
+  ptarray_append_point(rings[0], &b, LW_TRUE);
+  ptarray_append_point(rings[0], &a, LW_TRUE);
+  LWPOLY *poly = lwpoly_construct(srid, NULL, 1, rings);
+  GSERIALIZED *result = geo_serialize((LWGEOM *) poly);
+  lwpoly_free(poly);
+  return result;
+}
+
+static TSequence *
+dist2d_trgeoseq_line(const TSequence *seq, const GSERIALIZED *gs,
+  const GSERIALIZED *ref_gs)
+{
+  LWGEOM *geom = lwgeom_from_gserialized(gs);
+  const LWLINE *line = lwgeom_as_lwline(geom);
+  int32_t srid = gserialized_get_srid(gs);
+  TSequence *result = NULL;
+  for (uint32_t i = 0; i + 1 < line->points->npoints; i++)
+  {
+    GSERIALIZED *ring = line_segment_ring(line, i, srid);
+    TSequence *dist = dist2d_trgeoseq_poly(seq, ring, ref_gs);
+    pfree(ring);
+    if (! dist)
+    {
+      if (result) pfree(result);
+      lwgeom_free(geom);
+      return NULL;
+    }
+    if (! result) result = dist;
+    else
+    {
+      TSequence *min = tfloatseq_min_tfloatseq(result, dist);
+      pfree(result); pfree(dist);
+      result = min;
+    }
+  }
+  lwgeom_free(geom);
+  return result;
+}
+
 /**
  * @brief
  */
@@ -1954,6 +2016,12 @@ dist2d_trgeoseq_geo(const TSequence *seq, const GSERIALIZED *gs,
       break;
     case MULTIPOLYGONTYPE:
       result = dist2d_trgeoseq_multi(seq, gs, ref_gs, &dist2d_trgeoseq_poly);
+      break;
+    case LINETYPE:
+      result = dist2d_trgeoseq_line(seq, gs, ref_gs);
+      break;
+    case MULTILINETYPE:
+      result = dist2d_trgeoseq_multi(seq, gs, ref_gs, &dist2d_trgeoseq_line);
       break;
     default:
       meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,

--- a/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
@@ -302,3 +302,75 @@ SELECT round(nearestApproachDistance(
  2.000000
 (1 row)
 
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(5 3,6 4)'))::numeric, 6);
+  round   
+----------
+ 2.000000
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(-5 3,20 3)'))::numeric, 6);
+  round   
+----------
+ 2.000000
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(-5 9,4 9,4 3,20 3)'))::numeric, 6);
+  round   
+----------
+ 2.000000
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(4 3,20 3)'))::numeric, 6);
+  round   
+----------
+ 2.000000
+(1 row)
+
+SELECT round(nearestApproachDistance(
+  trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.14159265)@2001-01-02]',
+  geometry 'Linestring(0 3,1 4)')::numeric, 6);
+  round   
+----------
+ 0.938447
+(1 row)
+
+SELECT getTimestamp(nearestApproachInstant(
+  trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.14159265)@2001-01-02]',
+  geometry 'Linestring(0 3,1 4)')) <@ tstzspan '(2001-01-01, 2001-01-02)';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'MultiLinestring((5 3,6 4),(0 -9,10 -9))'))::numeric, 6);
+  round   
+----------
+ 2.000000
+(1 row)
+
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'MultiLinestring((5 3,6 4),EMPTY)'))::numeric, 6);
+  round   
+----------
+ 2.000000
+(1 row)
+
+SELECT ST_AsText(ST_SnapToGrid(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(-5 3,20 3)'), 0.000001));
+      st_astext      
+---------------------
+ LINESTRING(2 1,2 3)
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
@@ -204,4 +204,40 @@ SELECT round(nearestApproachDistance(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
   geometry 'MultiPolygon(((5 3,6 3,6 4,5 4,5 3)),((100 100,101 100,101 101,100 101,100 100)))')::numeric, 6);
 
+-- A line target: the distance to a line is the minimum over its segments, each
+-- of which is a convex set whose two vertices share one edge
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(5 3,6 4)'))::numeric, 6);
+-- The closest point of the line is interior to a segment, not an endpoint
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(-5 3,20 3)'))::numeric, 6);
+-- A line of several segments answers as the nearest of its segments does
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(-5 9,4 9,4 3,20 3)'))::numeric, 6);
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(4 3,20 3)'))::numeric, 6);
+-- A rotating body against a line: the nearest approach lies strictly inside
+-- the motion
+SELECT round(nearestApproachDistance(
+  trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.14159265)@2001-01-02]',
+  geometry 'Linestring(0 3,1 4)')::numeric, 6);
+SELECT getTimestamp(nearestApproachInstant(
+  trgeometry 'Polygon((-2 -0.5,2 -0.5,2 0.5,-2 0.5,-2 -0.5));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),3.14159265)@2001-01-02]',
+  geometry 'Linestring(0 3,1 4)')) <@ tstzspan '(2001-01-01, 2001-01-02)';
+-- A multi-component line, and an empty component that is ignored
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'MultiLinestring((5 3,6 4),(0 -9,10 -9))'))::numeric, 6);
+SELECT round(minValue(tDistance(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'MultiLinestring((5 3,6 4),EMPTY)'))::numeric, 6);
+-- The shortest line to a line joins the body and the line themselves
+SELECT ST_AsText(ST_SnapToGrid(shortestLine(
+  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'Linestring(-5 3,20 3)'), 0.000001));
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The distance between a temporal rigid geometry and a `LINESTRING` or a `MULTILINESTRING` raises
`Unsupported geometry type`, so `tDistance`, `nearestApproachDistance`, `nearestApproachInstant` and
`shortestLine` all decline a line target:

```
SELECT tDistance(
  trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
  geometry 'Linestring(5 3,6 4)');
ERROR:  Unsupported geometry type: LineString
```

The distance to a line is the pointwise minimum of the distances to its segments, folded the way the
distance to a multi-component geometry already is. A segment carries exactly the features the
closest-feature walk measures against: a ring of two vertices whose two edges traverse the same
points in opposite directions gives one edge whose two sides are the outer side of each direction,
and two vertices adjacent to that edge either way round.

A vertex of such a ring has one adjacent edge rather than two, so the two roots that the vertex-exit
test computes for it are the same event. Reading their coincidence as an intersection through the
vertex ends the walk at the first vertex it reaches and leaves the rest of the segment on a stale
feature pair, which answers a nearest approach above the true one.

Measured against a brute-force scan of the motion refined to one millisecond, over 40 randomly
generated rotating-and-translating configurations, the largest amount by which the answer exceeds
the true nearest approach is 6.9e-5, which is the same figure the polygon kernel gives on the same
configurations and the same scan. Over 120 randomly generated lines of two segments, the answer
equals the smaller of the answers for the two segments taken separately, to the last bit.
