### PR TITLE
Write the OGC GeoPose Composite Graph class

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1794,6 +1794,14 @@
 				</itemizedlist>
 			</sect3>
 			<sect3>
+				<title>Grafo compuesto OGC GeoPose</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tposechainarr_asGeoPose"><varname>asGeoPose</varname></link>: Escribe un documento de grafo compuesto OGC GeoPose</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+			<sect3>
 				<title>Funciones de restricción</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/es/temporal_pose_chains.xml
+++ b/doc/es/temporal_pose_chains.xml
@@ -601,6 +601,40 @@ SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tposechainarr_geopose">
+			<title>Grafo compuesto OGC GeoPose</title>
+			<itemizedlist>
+				<listitem xml:id="tposechainarr_asGeoPose">
+					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
+					<para>Escribe un documento de grafo compuesto OGC GeoPose</para>
+					<para><varname>asGeoPose(tposechain[],maxdecimaldigits integer=-1) &#8594; text</varname></para>
+					<para>Un documento de grafo es un conjunto de marcos y las transformaciones entre ellos, que es lo que contienen varias cadenas de poses que comparten su marco más exterior. La lista de marcos nombra el marco LTP-ENU tangente en ese eslabón más exterior seguido de los eslabones de cada cadena, y la lista de transformaciones nombra el padre y el hijo de cada arista por su posición en esa lista. Las aristas no llevan transformación propia; esta reside en los marcos que nombran.</para>
+					<para>El documento lleva un único tiempo de validez, por lo que se escribe a partir de cadenas leídas en uno y el mismo instante; <link linkend="tposechain_atTime"><varname>atTime</varname></link> las obtiene de valores más largos. Su lista de marcos contiene al menos dos marcos, que un solo eslabón de una sola cadena ya proporciona junto al marco tangente.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;PoseChain(
+    GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+    Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00',
+  tposechain 'SRID=4326;PoseChain(
+    GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+    Pose(Point Z(0 3 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00'], 6);
+/* {"validTime":1619588170083,"frameList":[{"authority":"/geopose/1.0",
+   "id":"/Extrinsic/LTP-ENU","parameters":"longitude=-122.3&amp;latitude=47.7&amp;
+   height=11&amp;crs=EPSG:4979"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&amp;
+   rotation=[1, 0, -1.38778e-17, 0]"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[2, 0, 0]&amp;
+   rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&amp;
+   rotation=[1, 0, -1.38778e-17, 0]"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 3, 0]&amp;
+   rotation=[1, 0, 0, 0]"}],"transformList":[{"link":[0,1]},{"link":[1,2]},
+   {"link":[0,3]},{"link":[3,4]}]} */
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tposechain_restrictions">
 			<title>Funciones de restricción</title>
 			<itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1805,6 +1805,14 @@
 				</itemizedlist>
 			</sect3>
 			<sect3>
+				<title>OGC GeoPose Composite Graph</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tposechainarr_asGeoPose"><varname>asGeoPose</varname></link>: Write an OGC GeoPose Composite Graph document</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+			<sect3>
 				<title>Restriction Functions</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/temporal_pose_chains.xml
+++ b/doc/temporal_pose_chains.xml
@@ -601,6 +601,40 @@ SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="tposechainarr_geopose">
+			<title>OGC GeoPose Composite Graph</title>
+			<itemizedlist>
+				<listitem xml:id="tposechainarr_asGeoPose">
+					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
+					<para>Write an OGC GeoPose Composite Graph document</para>
+					<para><varname>asGeoPose(tposechain[],maxdecimaldigits integer=-1) &#8594; text</varname></para>
+					<para>A Graph document is a set of frames and the transformations between them, which several pose chains sharing their outermost frame hold. The frame list names the LTP-ENU frame tangent at that outermost link followed by the links of every chain, and the transform list names the parent and the child of each edge by their position in that list. The edges carry no transformation of their own; it lives in the frames they name.</para>
+					<para>The document carries one valid time, so it is written from chains read at one and the same instant; <link linkend="tposechain_atTime"><varname>atTime</varname></link> obtains them from longer values. Its frame list holds at least two frames, which one link of one chain already gives beside the tangent frame.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;PoseChain(
+    GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+    Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00',
+  tposechain 'SRID=4326;PoseChain(
+    GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+    Pose(Point Z(0 3 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00'], 6);
+/* {"validTime":1619588170083,"frameList":[{"authority":"/geopose/1.0",
+   "id":"/Extrinsic/LTP-ENU","parameters":"longitude=-122.3&amp;latitude=47.7&amp;
+   height=11&amp;crs=EPSG:4979"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&amp;
+   rotation=[1, 0, -1.38778e-17, 0]"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[2, 0, 0]&amp;
+   rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&amp;
+   rotation=[1, 0, -1.38778e-17, 0]"},{"authority":"/geopose/1.0",
+   "id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 3, 0]&amp;
+   rotation=[1, 0, 0, 0]"}],"transformList":[{"link":[0,1]},{"link":[1,2]},
+   {"link":[0,3]},{"link":[3,4]}]} */
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="tposechain_restrictions">
 			<title>Restriction Functions</title>
 			<itemizedlist>

--- a/meos/include/meos_posechain.h
+++ b/meos/include/meos_posechain.h
@@ -155,6 +155,7 @@ extern PoseChain *posechain_transform_pipeline(const PoseChain *pc, const char *
 
 extern Temporal *tposechain_from_geopose(const char *json);
 extern char *tposechain_as_geopose(const Temporal *temp, int precision);
+extern char *tposechainarr_as_geopose(const Temporal **temparr, int count, int precision);
 
 /* Comparison functions */
 

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -2135,6 +2135,126 @@ tposechain_as_geopose(const Temporal *temp, int precision)
 }
 
 /**
+ * @ingroup meos_posechain_inout
+ * @brief Return the GeoPose Graph representation of an array of temporal pose
+ * chains
+ * @details A graph of frames is a set of pose chains sharing their outermost
+ * frame. The frame list holds that one topocentric frame followed by the links
+ * of every chain, and the transform list names the parent and the child of
+ * each edge by their position in that list: an edge from the outermost frame
+ * to the first link of a chain, and one between each pair of links after it.
+ * The edges carry no transformation, which lives in the frames they name.
+ * @param[in] temparr Array of temporal pose chains, each of a single instant
+ * @param[in] count Number of elements in the array
+ * @param[in] precision Maximum number of decimal digits
+ * @return On error return @p NULL
+ * @csqlfn #Tposechainarr_as_geopose()
+ */
+char *
+tposechainarr_as_geopose(const Temporal **temparr, int count, int precision)
+{
+  VALIDATE_NOT_NULL(temparr, NULL);
+  if (! ensure_positive(count))
+    return NULL;
+
+  /* A graph carries one valid time, so every chain is read at one instant and
+   * they agree on which */
+  TimestampTz t = 0;
+  for (int i = 0; i < count; i++)
+  {
+    const Temporal *temp = temparr[i];
+    VALIDATE_TPOSECHAIN(temp, NULL);
+    if (temp->subtype != TINSTANT)
+    {
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "A GeoPose Graph document carries one valid time, so it is written "
+        "from single instants; use atTime to obtain one");
+      return NULL;
+    }
+    TimestampTz ti = ((const TInstant *) temp)->t;
+    if (i == 0)
+      t = ti;
+    else if (ti != t)
+    {
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "The pose chains of a GeoPose Graph are read at one instant");
+      return NULL;
+    }
+  }
+
+  /* An inner frame cannot be topocentric, so a graph has ONE topocentric
+   * frame and every chain hangs from it: it is anchored at the outermost link
+   * of the first chain */
+  const PoseChain *first = DatumGetPoseChainP(
+    tinstant_value_p((const TInstant *) temparr[0]));
+  Pose *outer = posechain_pose_n(first, 1);
+  if (outer == NULL)
+    return NULL;
+  GeoPoseAnchor anchor;
+  double lon, lat, h, W, X, Y, Z;
+  if (! geopose_pose_components(outer, &lon, &lat, &h, &W, &X, &Y, &Z))
+  {
+    pfree(outer);
+    return NULL;
+  }
+  geopose_anchor_set(&anchor, GEOPOSE_DEG2RAD(lat), GEOPOSE_DEG2RAD(lon), h);
+  pfree(outer);
+
+  json_object *frames = json_object_new_array();
+  json_object *transforms = json_object_new_array();
+  json_object_array_add(frames,
+    geopose_outer_frame(GEOPOSE_ID_CHAIN_OUTER_FRAME, &anchor, precision));
+
+  /* The topocentric frame occupies position 0 and the links follow it */
+  int next = 1;
+  for (int i = 0; i < count; i++)
+  {
+    const PoseChain *pc = DatumGetPoseChainP(
+      tinstant_value_p((const TInstant *) temparr[i]));
+    int nlinks = posechain_num_poses(pc);
+    int parent = 0;
+    for (int j = 1; j <= nlinks; j++)
+    {
+      Pose *link = posechain_pose_n(pc, j);
+      if (link == NULL)
+      {
+        json_object_put(frames);
+        json_object_put(transforms);
+        return NULL;
+      }
+      /* The outermost link is read against the topocentric frame and every
+       * later one against the link before it */
+      json_object_array_add(frames, (j == 1) ?
+        geopose_inner_frame(GEOPOSE_ID_CHAIN_INNER_FRAME, &anchor, link,
+          precision) :
+        geopose_chain_link_frame(link, precision));
+      pfree(link);
+      json_object *pair = json_object_new_object();
+      json_object *edge = json_object_new_array();
+      json_object_array_add(edge, json_object_new_int(parent));
+      json_object_array_add(edge, json_object_new_int(next));
+      json_object_object_add(pair, "link", edge);
+      json_object_array_add(transforms, pair);
+      parent = next;
+      next++;
+    }
+  }
+
+  /* The frame list holds at least the two frames the class asks for: a pose
+   * chain carries at least one link, so the topocentric frame and the first
+   * link of the first chain already make two */
+  json_object *root = json_object_new_object();
+  json_object_object_add(root, "validTime",
+    json_object_new_int64(geopose_instant_out(t)));
+  json_object_object_add(root, "frameList", frames);
+  json_object_object_add(root, "transformList", transforms);
+  char *result = pstrdup(json_object_to_json_string_ext(root,
+    GEOPOSE_JSON_FLAGS));
+  json_object_put(root);
+  return result;
+}
+
+/**
  * @brief Build the pose of a link read in the axes of the link before it
  * @return On error return @p NULL
  */

--- a/mobilitydb/sql/posechain/552_tposechain.in.sql
+++ b/mobilitydb/sql/posechain/552_tposechain.in.sql
@@ -119,6 +119,14 @@ CREATE FUNCTION asGeoPose(tposechain, maxdecimaldigits int4 DEFAULT -1)
   AS 'MODULE_PATHNAME', 'Tposechain_as_geopose'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- A Composite Graph document is a set of pose chains sharing their outermost
+-- frame, so it is written from chains read at one and the same instant, and
+-- its frame list holds at least two frames.
+CREATE FUNCTION asGeoPose(tposechain[], maxdecimaldigits int4 DEFAULT -1)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Tposechainarr_as_geopose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 CREATE FUNCTION tposechainFromBinary(bytea)
   RETURNS tposechain
   AS 'MODULE_PATHNAME', 'Temporal_from_wkb'

--- a/mobilitydb/src/posechain/tposechain.c
+++ b/mobilitydb/src/posechain/tposechain.c
@@ -44,6 +44,7 @@
 #include "geo/tspatial.h"
 /* MobilityDB */
 #include "pg_temporal/temporal.h"
+#include "pg_temporal/type_util.h"
 #include "pg_geo/postgis.h"
 #include "pg_geo/tspatial.h"
 
@@ -183,6 +184,32 @@ Tposechain_as_geopose(PG_FUNCTION_ARGS)
   int precision = PG_GETARG_INT32(1);
   char *result = tposechain_as_geopose(temp, precision);
   PG_FREE_IF_COPY(temp, 0);
+  if (result == NULL) PG_RETURN_NULL();
+  text *result_text = cstring_to_text(result);
+  pfree(result);
+  PG_RETURN_TEXT_P(result_text);
+}
+
+PGDLLEXPORT Datum Tposechainarr_as_geopose(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tposechainarr_as_geopose);
+/**
+ * @ingroup mobilitydb_posechain_inout
+ * @brief Return the OGC GeoPose Composite Graph JSON representation of an
+ * array of temporal pose chains
+ * @sqlfn asGeoPose()
+ */
+Datum
+Tposechainarr_as_geopose(PG_FUNCTION_ARGS)
+{
+  ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
+  int precision = PG_GETARG_INT32(1);
+  ensure_not_empty_array(array);
+  int count;
+  Temporal **temparr = temparr_extract(array, &count);
+  char *result = tposechainarr_as_geopose((const Temporal **) temparr, count,
+    precision);
+  pfree(temparr);
+  PG_FREE_IF_COPY(array, 0);
   if (result == NULL) PG_RETURN_NULL();
   text *result_text = cstring_to_text(result);
   pfree(result);

--- a/mobilitydb/test/pose/schemas/GeoPose.Composite.Graph.Schema.json
+++ b/mobilitydb/test/pose/schemas/GeoPose.Composite.Graph.Schema.json
@@ -1,0 +1,72 @@
+{
+  "description": "Graph: An general structure modelling the pose relationship between frames (nodes) and transforms (edges) in a graph structure.",
+  "definitions": {
+    "FrameSpecification": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "authority": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
+        },
+        "parameters": {
+          "type": "string"
+        }
+      },
+      "required": [
+        "authority",
+        "id",
+        "parameters"
+      ]
+    },
+    "FrameTransformPair": {
+      "type": [
+        "object",
+        "null"
+      ],
+      "properties": {
+        "link": {
+          "type": [
+            "array",
+            "null"
+          ],
+          "items": {
+            "type": "integer"
+          }
+        }
+      },
+      "required": [
+        "link"
+      ]
+    }
+  },
+  "type": "object",
+  "properties": {
+    "validTime": {
+      "type": "integer"
+    },
+    "frameList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FrameSpecification"
+      },
+      "minItems": 2
+    },
+    "transformList": {
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/FrameTransformPair"
+      },
+      "minItems": 1
+    }
+  },
+  "required": [
+    "validTime",
+    "frameList",
+    "transformList"
+  ]
+}

--- a/mobilitydb/test/posechain/expected/555_tposechain_geopose.test.out
+++ b/mobilitydb/test/posechain/expected/555_tposechain_geopose.test.out
@@ -44,3 +44,35 @@ ERROR:  A GeoPose Chain document carries an integer 'validTime' and an array 'fr
 SELECT tposechainFromGeoPose(
   '{"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"scale=2"}]}');
 ERROR:  GeoPose Chain frame chain element parameters must carry a 3-element 'translation' and a 4-element 'rotation'
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0), Pose(Point(0 1 0), 1, 0, 0, 0))@2000-01-01',
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(0 0 1), 1, 0, 0, 0), Pose(Point(2 0 0), 1, 0, 0, 0))@2000-01-01'
+], 6);
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             asgeopose                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                             
+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"validTime":946713600000,"frameList":[{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100&crs=EPSG:4979"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 2.77556e-17, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[1, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 1, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 2.77556e-17, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 1]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[2, 0, 0]&rotation=[1, 0, 0, 0]"}],"transformList":[{"link":[0,1]},{"link":[1,2]},{"link":[2,3]},{"link":[0,4]},{"link":[4,5]},{"link":[5,6]}]}
+(1 row)
+
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0))@2000-01-01'
+], 6);
+                                                                                                                                                                                                                                    asgeopose                                                                                                                                                                                                                                    
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"validTime":946713600000,"frameList":[{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100&crs=EPSG:4979"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 2.77556e-17, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[1, 0, 0]&rotation=[1, 0, 0, 0]"}],"transformList":[{"link":[0,1]},{"link":[1,2]}]}
+(1 row)
+
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;[PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0))@2000-01-01, PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(2 0 0), 1, 0, 0, 0))@2000-01-02]'
+], 6);
+ERROR:  A GeoPose Graph document carries one valid time, so it is written from single instants; use atTime to obtain one
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0))@2000-01-01',
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(2 0 0), 1, 0, 0, 0))@2000-01-02'
+], 6);
+ERROR:  The pose chains of a GeoPose Graph are read at one instant
+SELECT asGeoPose(ARRAY[]::tposechain[], 6);
+ERROR:  The input array cannot be empty
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=3812;PoseChain(Pose(Point(1 2 3), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0))@2000-01-01'
+], 6);
+ERROR:  GeoPose JSON requires a geodetic pose, got a planar one

--- a/mobilitydb/test/posechain/queries/555_tposechain_geopose.test.sql
+++ b/mobilitydb/test/posechain/queries/555_tposechain_geopose.test.sql
@@ -80,3 +80,41 @@ SELECT tposechainFromGeoPose(
   '{"validTime":1619588170083,"outerFrame":{"authority":"/geopose/1.0","id":"/Extrinsic/LTP-ENU","parameters":"longitude=8&latitude=47&height=100"},"frameChain":[{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"translation=[0, 0, 0]&rotation=[1, 0, 0, 0]"},{"authority":"/geopose/1.0","id":"/Intrinsic/Translate-Rotate","parameters":"scale=2"}]}');
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- OGC GeoPose Composite Graph
+-- A graph of frames is a set of pose chains sharing their outermost frame, so
+-- each chain contributes an edge from that frame to its first link and one
+-- between each pair of links after it. The edges carry no transformation,
+-- which lives in the frames they name.
+-------------------------------------------------------------------------------
+
+-- Two limbs off the one topocentric frame
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0), Pose(Point(0 1 0), 1, 0, 0, 0))@2000-01-01',
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(0 0 1), 1, 0, 0, 0), Pose(Point(2 0 0), 1, 0, 0, 0))@2000-01-01'
+], 6);
+
+-- A path is a graph of one limb
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0))@2000-01-01'
+], 6);
+
+-- Errors
+-- A graph carries one valid time, so a value holding several has none to write
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;[PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0))@2000-01-01, PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(2 0 0), 1, 0, 0, 0))@2000-01-02]'
+], 6);
+-- Chains read at different instants name no single valid time
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0))@2000-01-01',
+  tposechain 'SRID=4326;PoseChain(GeodPose(Point(8 47 100), 1, 0, 0, 0), Pose(Point(2 0 0), 1, 0, 0, 0))@2000-01-02'
+], 6);
+-- An empty array names no frame at all
+SELECT asGeoPose(ARRAY[]::tposechain[], 6);
+-- A projected frame has no conformant encoding
+SELECT asGeoPose(ARRAY[
+  tposechain 'SRID=3812;PoseChain(Pose(Point(1 2 3), 1, 0, 0, 0), Pose(Point(1 0 0), 1, 0, 0, 0))@2000-01-01'
+], 6);
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -71,9 +71,11 @@ Temporal<T>              temporal_type      = ALL temporal types            (cat
   system alone — `SRID`, `setSRID`, `transform` and `transformPipeline`, each
   reading the outer link, which is the only link that names a frame.
   `555_tposechain_geopose.in.sql` has no file of its own: the OGC GeoPose
-  Composite Chain entries `asGeoPose(tposechain, …)` and
-  `tposechainFromGeoPose` are a `lit:` block of the `representations` axis, as
-  the pose family's GeoPose entries are.
+  entries are a `lit:` block of the `representations` axis, as the pose
+  family's GeoPose entries are — the Composite Chain pair
+  `asGeoPose(tposechain, …)` and `tposechainFromGeoPose`, and the Composite
+  Graph writer `asGeoPose(tposechain[], …)`, which encodes a set of chains
+  sharing their outermost frame.
   ⛔ The family carries no distance, no spatial relationships and no index
   file: a pose chain has no distance function, and the ordering operator waits
   on the kNN question.

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -305,7 +305,7 @@ representation_families:
     - FromText
     - FromEWKT
     - FromMFJSON
-  - lit: "CREATE FUNCTION tposechainFromGeoPose(text)\n  RETURNS tposechain\n  AS 'MODULE_PATHNAME', 'Tposechain_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- A Composite Chain document carries one valid time, so it is written\n-- from a single instant, and its frame chain holds at least two frames.\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(tposechain, maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tposechain_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
+  - lit: "CREATE FUNCTION tposechainFromGeoPose(text)\n  RETURNS tposechain\n  AS 'MODULE_PATHNAME', 'Tposechain_from_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- A Composite Chain document carries one valid time, so it is written\n-- from a single instant, and its frame chain holds at least two frames.\n-- maxdecimaldigits: significant digits to keep; -1 = lossless\nCREATE FUNCTION asGeoPose(tposechain, maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tposechain_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- A Composite Graph document is a set of pose chains sharing their outermost\n-- frame, so it is written from chains read at one and the same instant, and\n-- its frame list holds at least two frames.\nCREATE FUNCTION asGeoPose(tposechain[], maxdecimaldigits int4 DEFAULT -1)\n  RETURNS text\n  AS 'MODULE_PATHNAME', 'Tposechainarr_as_geopose'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;"
   - ops:
     - FromBinary
     - FromEWKB

--- a/tools/scripts/check_geopose_conformance.py
+++ b/tools/scripts/check_geopose_conformance.py
@@ -77,6 +77,10 @@ CLASSES = [
     # left holding alone.
     ('frameChain', 'Chain',
         'GeoPose.Composite.Chain.Schema.json'),
+    # A graph names its frames in a list and its edges in another, and no other
+    # class carries either member, so `frameList` identifies it on its own.
+    ('frameList', 'Graph',
+        'GeoPose.Composite.Graph.Schema.json'),
     ('streamElement', 'Stream element',
         'GeoPose.Composite.Sequence.StreamElement.Schema.json'),
     ('outerFrame', 'Stream header',
@@ -108,7 +112,7 @@ STRICT = ('Basic-Quaternion', 'validTime',
 # wherever they appear rather than demanded here; `meos/test/geopose_test.c` is
 # what exercises them.
 REQUIRED = ('Regular Series', 'Irregular Series', 'Basic-Quaternion',
-    'Basic-YPR', 'Advanced', 'Stream', 'Chain')
+    'Basic-YPR', 'Advanced', 'Stream', 'Chain', 'Graph')
 
 TYPES = {
     'object': dict,


### PR DESCRIPTION
A Graph document is a set of frames and the transformations between them,
which several pose chains sharing their outermost frame hold: a frame graph is
a set of chains hanging from one topocentric frame. This writes it, which takes
the OGC GeoPose conformance surface to all eight classes.

### The mapping

`asGeoPose(tposechain[], maxdecimaldigits)`. The frame list names the LTP-ENU
frame tangent at the outermost link followed by the links of every chain, and
the transform list names the parent and the child of each edge by their
position in that list: an edge from the tangent frame to the first link of a
chain, and one between each pair of links after it. The edges carry no
transformation of their own, which the schema states by requiring of a
`FrameTransformPair` only its `link`, an array of integers.

The class needs no type of its own and no new geodesy. It writes the frame
specifications the Chain class already writes, through the same two emitters
and under the same two identifiers, so what is added is the frame and edge
bookkeeping and the validation around it.

### Why an array of temporal chains

The normative schema requires `validTime` alongside `frameList` and
`transformList`, as the Chain schema requires it alongside `outerFrame` and
`frameChain`. A document therefore takes its time from the data, which is what
the Chain class already does, so a Graph is written from chains read at a
single instant and they must agree on which.

Four preconditions carry their own message: a value of more than one instant,
chains read at different instants, an empty array, and a frame that is not
geodetic.

### Evidence

The emitted structure matches the normative instance
`Data/Examples/SolarPose/GeoPose.Composite.Graph.Instance.json`: two limbs off
frame 0, `transformList` a list of index pairs, the identifiers
`/Extrinsic/LTP-ENU` and `/Intrinsic/Translate-Rotate`, and the parameter
grammar `translation=[x, y, z]&rotation=[w, x, y, z]`.

The schema sits beside its siblings exactly as OGC publishes it, and
`check_geopose_conformance.py` demands a Graph document, so the class cannot
silently regress: 36 documents conform, Graph among them.

### A note for the Standards Working Group

That normative instance carries only `frameList` and `transformList`. It omits
`validTime`, which its own schema lists as required, so the reference document
does not validate against the reference schema. This joins the observations
already collected on the wiki.
