### PR TITLE
Order a point cloud value by nearest approach from an SP-GiST index

### DIFF
--- a/mobilitydb/sql/pointcloud/440_tpc_spgist.in.sql
+++ b/mobilitydb/sql/pointcloud/440_tpc_spgist.in.sql
@@ -54,6 +54,8 @@ CREATE OPERATOR CLASS tpcbox_quadtree_ops
   OPERATOR  12   |&> (tpcbox, tpcbox),
   -- adjacent
   OPERATOR  17   -|- (tpcbox, tpcbox),
+  -- nearest approach distance
+  OPERATOR  25   |=| (tpcbox, tpcbox) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28   &<# (tpcbox, tpcbox),
   -- strictly before
@@ -106,6 +108,8 @@ CREATE OPERATOR CLASS tpcbox_kdtree_ops
   OPERATOR  12   |&> (tpcbox, tpcbox),
   -- adjacent
   OPERATOR  17   -|- (tpcbox, tpcbox),
+  -- nearest approach distance
+  OPERATOR  25   |=| (tpcbox, tpcbox) FOR ORDER BY pg_catalog.float_ops,
   -- overlaps or before
   OPERATOR  28   &<# (tpcbox, tpcbox),
   -- strictly before
@@ -194,6 +198,9 @@ CREATE OPERATOR CLASS tpcpoint_quadtree_ops
   OPERATOR  34   />> (tpcpoint, tpcpoint),
   OPERATOR  35   /&> (tpcpoint, tpcbox),
   OPERATOR  35   /&> (tpcpoint, tpcpoint),
+  -- nearest approach distance
+  OPERATOR  25   |=| (tpcpoint, tpcbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25   |=| (tpcpoint, tpcpoint) FOR ORDER BY pg_catalog.float_ops,
   FUNCTION  1    stbox_spgist_config(internal, internal),
   FUNCTION  2    stbox_quadtree_choose(internal, internal),
   FUNCTION  3    stbox_quadtree_picksplit(internal, internal),
@@ -258,6 +265,9 @@ CREATE OPERATOR CLASS tpcpoint_kdtree_ops
   OPERATOR  34   />> (tpcpoint, tpcpoint),
   OPERATOR  35   /&> (tpcpoint, tpcbox),
   OPERATOR  35   /&> (tpcpoint, tpcpoint),
+  -- nearest approach distance
+  OPERATOR  25   |=| (tpcpoint, tpcbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25   |=| (tpcpoint, tpcpoint) FOR ORDER BY pg_catalog.float_ops,
   FUNCTION  1    stbox_spgist_config(internal, internal),
   FUNCTION  2    stbox_kdtree_choose(internal, internal),
   FUNCTION  3    stbox_kdtree_picksplit(internal, internal),
@@ -322,6 +332,9 @@ CREATE OPERATOR CLASS tpcpatch_quadtree_ops
   OPERATOR  34   />> (tpcpatch, tpcpatch),
   OPERATOR  35   /&> (tpcpatch, tpcbox),
   OPERATOR  35   /&> (tpcpatch, tpcpatch),
+  -- nearest approach distance
+  OPERATOR  25   |=| (tpcpatch, tpcbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25   |=| (tpcpatch, tpcpatch) FOR ORDER BY pg_catalog.float_ops,
   FUNCTION  1    stbox_spgist_config(internal, internal),
   FUNCTION  2    stbox_quadtree_choose(internal, internal),
   FUNCTION  3    stbox_quadtree_picksplit(internal, internal),
@@ -386,6 +399,9 @@ CREATE OPERATOR CLASS tpcpatch_kdtree_ops
   OPERATOR  34   />> (tpcpatch, tpcpatch),
   OPERATOR  35   /&> (tpcpatch, tpcbox),
   OPERATOR  35   /&> (tpcpatch, tpcpatch),
+  -- nearest approach distance
+  OPERATOR  25   |=| (tpcpatch, tpcbox) FOR ORDER BY pg_catalog.float_ops,
+  OPERATOR  25   |=| (tpcpatch, tpcpatch) FOR ORDER BY pg_catalog.float_ops,
   FUNCTION  1    stbox_spgist_config(internal, internal),
   FUNCTION  2    stbox_kdtree_choose(internal, internal),
   FUNCTION  3    stbox_kdtree_picksplit(internal, internal),

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox_tbl.test.out
@@ -277,6 +277,18 @@ SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
              0
 (1 row)
 
+WITH test AS (
+  SELECT b |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcbox ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round    
+------------
+ 181.658966
+ 185.207489
+  187.62816
+(3 rows)
+
 DROP INDEX tbl_tpcbox_kdtree_idx;
 DROP INDEX
 RESET enable_seqscan;

--- a/mobilitydb/test/pointcloud/expected/440_tpc_spgist_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/440_tpc_spgist_tbl.test.out
@@ -94,6 +94,72 @@ RESET enable_indexscan;
 RESET
 RESET enable_bitmapscan;
 RESET
+CREATE INDEX tbl_tpcpoint_knn_quadtree_idx ON tbl_tpcpoint USING spgist(temp);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round    
+------------
+ 179.348355
+ 179.369079
+ 189.113301
+(3 rows)
+
+DROP INDEX tbl_tpcpoint_knn_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpcpoint_knn_kdtree_idx ON tbl_tpcpoint
+  USING spgist(temp tpcpoint_kdtree_ops);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round    
+------------
+ 179.348355
+ 179.369079
+ 189.113301
+(3 rows)
+
+DROP INDEX tbl_tpcpoint_knn_kdtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpcpatch_knn_quadtree_idx ON tbl_tpcpatch USING spgist(temp);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tpcbox_xt(200, 200, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round    
+------------
+ 142.497643
+  142.56829
+  142.95671
+(3 rows)
+
+DROP INDEX tbl_tpcpatch_knn_quadtree_idx;
+DROP INDEX
+CREATE INDEX tbl_tpcpatch_knn_kdtree_idx ON tbl_tpcpatch
+  USING spgist(temp tpcpatch_kdtree_ops);
+CREATE INDEX
+WITH test AS (
+  SELECT temp |=| tpcbox_xt(200, 200, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+   round    
+------------
+ 142.497643
+  142.56829
+  142.95671
+(3 rows)
+
+DROP INDEX tbl_tpcpatch_knn_kdtree_idx;
+DROP INDEX
 CREATE TABLE tbl_tpcpoint_big_allthesame AS
   SELECT k, tpcpoint(PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), timeSpan(temp)) AS temp
   FROM tbl_tpcpoint WHERE temp IS NOT NULL;

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
@@ -149,6 +149,11 @@ SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+WITH test AS (
+  SELECT b |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcbox ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tpcbox_kdtree_idx;
 RESET enable_seqscan;
 RESET enable_indexscan;

--- a/mobilitydb/test/pointcloud/queries/440_tpc_spgist_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/440_tpc_spgist_tbl.test.sql
@@ -102,6 +102,44 @@ RESET enable_indexscan;
 RESET enable_bitmapscan;
 
 -------------------------------------------------------------------------------
+-- Nearest approach ordering answered by the space-partitioning indexes
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_tpcpoint_knn_quadtree_idx ON tbl_tpcpoint USING spgist(temp);
+WITH test AS (
+  SELECT temp |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_tpcpoint_knn_quadtree_idx;
+
+CREATE INDEX tbl_tpcpoint_knn_kdtree_idx ON tbl_tpcpoint
+  USING spgist(temp tpcpoint_kdtree_ops);
+WITH test AS (
+  SELECT temp |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_tpcpoint_knn_kdtree_idx;
+
+CREATE INDEX tbl_tpcpatch_knn_quadtree_idx ON tbl_tpcpatch USING spgist(temp);
+WITH test AS (
+  SELECT temp |=| tpcbox_xt(200, 200, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_tpcpatch_knn_quadtree_idx;
+
+CREATE INDEX tbl_tpcpatch_knn_kdtree_idx ON tbl_tpcpatch
+  USING spgist(temp tpcpatch_kdtree_ops);
+WITH test AS (
+  SELECT temp |=| tpcbox_xt(200, 200, 210, 210,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+DROP INDEX tbl_tpcpatch_knn_kdtree_idx;
+
+-------------------------------------------------------------------------------
 -- Coverage of all the same and order by logic in SP-GiST indexes
 
 CREATE TABLE tbl_tpcpoint_big_allthesame AS


### PR DESCRIPTION
The quad-tree and k-d tree operator classes of tpcbox, tpcpoint and tpcpatch list the nearest approach distance operator their R-tree class lists, so an ordering by that distance is answered by a space-partitioning index as it is by the R-tree. The inner and leaf consistent functions of the family compute the distances of a node and of a leaf, so the classes need no support function for them.