### PR TITLE
Carry the distance at every turning point of a folded distance

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -1905,6 +1905,48 @@ tfloatseq_min_tfloatseq(const TSequence *seq1, const TSequence *seq2)
 }
 
 /**
+ * @brief Return @p dist carrying the distance at each of its instants
+ * @details A fold of per-component distances answers the minimum of two
+ * piecewise-linear curves. Where the two cross, neither component carries a
+ * turning point of its own, so both values come from interpolation; each
+ * interpolation lies above its own convex curve, and the minimum of the two
+ * lies above the distance. Every instant of a folded sequence therefore takes
+ * the distance from the body placed at that instant to the whole geometry,
+ * which is the value a turning point stands for.
+ * @param[in] dist Folded distance sequence, consumed
+ * @param[in] seq Temporal rigid geometry the distance is computed from
+ * @param[in] gs Geometry the distance is computed to
+ * @param[in] ref_gs Reference geometry of @p seq
+ */
+static TSequence *
+dist2d_seq_exact_values(TSequence *dist, const TSequence *seq,
+  const GSERIALIZED *gs, const GSERIALIZED *ref_gs)
+{
+  TInstant **instants = palloc(sizeof(TInstant *) * dist->count);
+  for (int i = 0; i < dist->count; i++)
+  {
+    const TInstant *inst = TSEQUENCE_INST_N(dist, i);
+    Datum pose;
+    /* The folded sequence spans the period of the rigid geometry, so the pose
+     * is there; where a bound makes it absent the folded value stands */
+    if (! tsequence_value_at_timestamptz(seq, inst->t, false, &pose))
+    {
+      instants[i] = tinstant_copy(inst);
+      continue;
+    }
+    GSERIALIZED *body = pose_apply_geo(DatumGetPoseP(pose), ref_gs);
+    instants[i] = tinstant_make(Float8GetDatum(geom_distance2d(body, gs)),
+      T_TFLOAT, inst->t);
+    pfree(body); pfree(DatumGetPointer(pose));
+  }
+  TSequence *result = tsequence_make_free(instants, dist->count,
+    dist->period.lower_inc, dist->period.upper_inc,
+    MEOS_FLAGS_GET_INTERP(dist->flags), NORMALIZE);
+  pfree(dist);
+  return result;
+}
+
+/**
  * @brief Return the temporal distance between a temporal rigid geometry
  * sequence and a multi-component geometry
  * @details The distance to a multi-component geometry is the pointwise minimum
@@ -1916,7 +1958,7 @@ dist2d_trgeoseq_multi(const TSequence *seq, const GSERIALIZED *gs,
   const GSERIALIZED *, const GSERIALIZED *))
 {
   TSequence *result = NULL;
-  int count = geo_num_geos(gs);
+  int count = geo_num_geos(gs), nfolds = 0;
   for (int i = 1; i <= count; i++)
   {
     GSERIALIZED *comp = geo_geo_n(gs, i);
@@ -1941,9 +1983,10 @@ dist2d_trgeoseq_multi(const TSequence *seq, const GSERIALIZED *gs,
       TSequence *min = tfloatseq_min_tfloatseq(result, dist);
       pfree(result); pfree(dist);
       result = min;
+      nfolds++;
     }
   }
-  return result;
+  return nfolds ? dist2d_seq_exact_values(result, seq, gs, ref_gs) : result;
 }
 
 static GSERIALIZED *
@@ -1971,6 +2014,7 @@ dist2d_trgeoseq_line(const TSequence *seq, const GSERIALIZED *gs,
   const LWLINE *line = lwgeom_as_lwline(geom);
   int32_t srid = gserialized_get_srid(gs);
   TSequence *result = NULL;
+  int nfolds = 0;
   for (uint32_t i = 0; i + 1 < line->points->npoints; i++)
   {
     GSERIALIZED *ring = line_segment_ring(line, i, srid);
@@ -1988,10 +2032,11 @@ dist2d_trgeoseq_line(const TSequence *seq, const GSERIALIZED *gs,
       TSequence *min = tfloatseq_min_tfloatseq(result, dist);
       pfree(result); pfree(dist);
       result = min;
+      nfolds++;
     }
   }
   lwgeom_free(geom);
-  return result;
+  return nfolds ? dist2d_seq_exact_values(result, seq, gs, ref_gs) : result;
 }
 
 /**

--- a/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
@@ -243,7 +243,7 @@ SELECT round(tDistance(
   geometry 'MultiPoint(0 5,11 5)'), 6);
                                                   round                                                  
 ---------------------------------------------------------------------------------------------------------
- [4@Mon Jan 01 00:00:00 2001 PST, 7.385165@Mon Jan 01 12:00:00 2001 PST, 4@Tue Jan 02 00:00:00 2001 PST]
+ [4@Mon Jan 01 00:00:00 2001 PST, 6.403124@Mon Jan 01 12:00:00 2001 PST, 4@Tue Jan 02 00:00:00 2001 PST]
 (1 row)
 
 SELECT round(tDistance(
@@ -251,7 +251,7 @@ SELECT round(tDistance(
   geometry 'MultiPolygon(((0 5,1 5,1 6,0 6,0 5)),((11 5,12 5,12 6,11 6,11 5)))'), 6);
                                                                         round                                                                        
 -----------------------------------------------------------------------------------------------------------------------------------------------------
- [4@Mon Jan 01 00:00:00 2001 PST, 4@Mon Jan 01 02:24:00.00864 2001 PST, 6.984288@Mon Jan 01 13:25:15.82016 2001 PST, 4@Tue Jan 02 00:00:00 2001 PST]
+ [4@Mon Jan 01 00:00:00 2001 PST, 4@Mon Jan 01 02:24:00.00864 2001 PST, 5.952269@Mon Jan 01 13:25:15.82016 2001 PST, 4@Tue Jan 02 00:00:00 2001 PST]
 (1 row)
 
 SELECT round(minValue(tDistance(
@@ -372,5 +372,27 @@ SELECT ST_AsText(ST_SnapToGrid(shortestLine(
       st_astext      
 ---------------------
  LINESTRING(2 1,2 3)
+(1 row)
+
+SELECT round(abs(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'MultiPoint(0 5,11 5)'), '2001-01-01 12:00')
+  - ST_Distance(valueAtTimestamp(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  '2001-01-01 12:00'), geometry 'MultiPoint(0 5,11 5)'))::numeric, 9);
+    round    
+-------------
+ 0.000000000
+(1 row)
+
+SELECT round(abs(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'MultiLinestring((0 5,0 6),(11 5,11 6))'), '2001-01-01 12:00')
+  - ST_Distance(valueAtTimestamp(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  '2001-01-01 12:00'), geometry 'MultiLinestring((0 5,0 6),(11 5,11 6))'))::numeric, 9);
+    round    
+-------------
+ 0.000000000
 (1 row)
 

--- a/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
@@ -240,4 +240,21 @@ SELECT ST_AsText(ST_SnapToGrid(shortestLine(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
   geometry 'Linestring(-5 3,20 3)'), 0.000001));
 
+-- Every turning point of a folded distance carries the distance at that
+-- instant. Where two components cross, neither carries a turning point of its
+-- own, so a minimum taken over their interpolations would sit above the value
+-- the geometry-geometry distance answers there
+SELECT round(abs(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'MultiPoint(0 5,11 5)'), '2001-01-01 12:00')
+  - ST_Distance(valueAtTimestamp(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  '2001-01-01 12:00'), geometry 'MultiPoint(0 5,11 5)'))::numeric, 9);
+SELECT round(abs(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  geometry 'MultiLinestring((0 5,0 6),(11 5,11 6))'), '2001-01-01 12:00')
+  - ST_Distance(valueAtTimestamp(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
+  '2001-01-01 12:00'), geometry 'MultiLinestring((0 5,0 6),(11 5,11 6))'))::numeric, 9);
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The distance to a multi-component geometry and the distance to a line are the pointwise minimum of
the distances to the components. Each component distance is a piecewise-linear sequence: exact at
its own turning points, interpolated between them. Where two components cross, neither carries a
turning point of its own, so the minimum is taken over two interpolated values. A component
distance is the square root of a quadratic and so convex, its interpolation lies above it, and the
minimum of two such values lies above the distance. The fold plants a turning point at the crossing
carrying that value, and a turning point stands for the distance at its instant:

```
SELECT round(tDistance(
  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
  geometry 'MultiPoint(0 5,11 5)'), 6);
 [4@2001-01-01, 7.385165@2001-01-01 12:00, 4@2001-01-02]
```

At that crossing the body spans x in [5,6] and the nearer point is at (0,5), so the distance is
sqrt(5^2 + 4^2) = 6.403124.

The minimum over the sequence keeps its value, since each component attains its own minimum at one
of its own turning points, so `nearestApproachDistance`, `nearestApproachInstant` and `|=|` answer
the same. What the crossing reaches is every reader of the temporal float itself:
`valueAtTimestamp`, `startValue`, the values the sequence carries.

Every instant of a folded sequence takes the distance from the body placed at that instant to the
whole geometry. The fold keeps locating the turning points; only the values it carries at them
change, and only where a fold happens: a geometry of one component takes no recompute at all.

Two committed expected values move, each to the distance a geometry-geometry distance answers at
that instant: 7.385165 to 6.403124 for the MultiPoint above, and 6.984288 to 5.952269 for the
MultiPolygon beside it, where the body spans x in [5.5917, 6.5917] and the nearer component lies at
x in [11,12], giving sqrt(4.4083^2 + 4^2).

Over 100 randomly generated folded distances carrying 676 turning points, the largest difference
between the value at a turning point and the distance between the placed body and the geometry is
zero. Over 60 randomly generated component pairs, the nearest approach distance to the pair equals
the smaller of the two nearest approach distances. Over 40 full days of AIS trips against a
twenty-component target, the nearest approach distances are identical and the query takes 131s
against 132s.
