### PR TITLE
Answer the equality of two geometries from the native intersection matrix

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2519,6 +2519,9 @@ geom_intersection2d_coll(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @ingroup meos_geo_base_comp
  * @brief Return true if the geometries/geographies are equal, false otherwise
  * @param[in] gs1,gs2 Geometries/geographies
+ * @details The answer is read from the native DE-9IM intersection matrix, so a
+ * circular arc is met on its own circle rather than on the chords a
+ * linearization would put in its place
  * @note PostGIS function: @p ST_Equals(PG_FUNCTION_ARGS)
  */
 int
@@ -2551,43 +2554,26 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
   /*
    * Short-circuit: if gs1 and gs2 are binary-equivalent, we can return
-   * TRUE.  This is much faster than doing the comparison using GEOS.
+   * TRUE.  This is much faster than computing the intersection matrix.
    */
   if (VARSIZE(gs1) == VARSIZE(gs2) && ! memcmp(gs1, gs2, VARSIZE(gs1)))
       return 1;
 
-  GEOSContextHandle_t ctx = geos_get_context();
-
-  GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
-  if (! geos1)
+  /* Two geometries are equal where their interiors meet, neither interior
+   * reaches the exterior of the other and neither boundary does, which is the
+   * pattern the standard gives ST_Equals */
+  LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
+  LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
+  char matrix[10];
+  bool covered = meos_relate(geom1, geom2, matrix);
+  lwgeom_free(geom1); lwgeom_free(geom2);
+  if (! covered)
   {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "First argument geometry could not be converted to GEOS");
-    /* Clean up the global context */
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "Equality of the geometries is not supported");
     return -1;
   }
-
-  GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
-  if (! geos2)
-  {
-    GEOSGeom_destroy_r(ctx, geos1);
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "Second argument geometry could not be converted to GEOS");
-    return -1;
-  }
-
-  int result = GEOSEquals_r(ctx, geos1, geos2);
-  GEOSGeom_destroy_r(ctx, geos1);
-  GEOSGeom_destroy_r(ctx, geos2);
-
-  if (result == 2)
-  {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "GEOS equals() threw an error !");
-    return -1;
-  }
-
-  return result;
+  return de9im_match(matrix, "T*F**FFF*") ? 1 : 0;
 }
 
 /*****************************************************************************

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -276,11 +276,11 @@ datum_eq(Datum l, Datum r, MeosType type)
       GSERIALIZED *gs1 = DatumGetGserializedP(l);
       GSERIALIZED *gs2 = DatumGetGserializedP(r);
       /* Fast path: equality of two points reduces to exact coordinate
-       * equality, avoiding a conversion to GEOS. This keeps GEOS out of the
-       * temporal-distance hot path, where the lifting turning-point loop tests
-       * segment constancy via datum_eq. Uses the exact point equality
-       * (datum_point_eq, not the FP-tolerant _same) to preserve the exact
-       * semantics of geo_equals */
+       * equality, avoiding the intersection matrix. This keeps the relate
+       * engine out of the temporal-distance hot path, where the lifting
+       * turning-point loop tests segment constancy via datum_eq. Uses the
+       * exact point equality (datum_point_eq, not the FP-tolerant _same) to
+       * preserve the exact semantics of geo_equals */
       if (gserialized_get_type(gs1) == POINTTYPE &&
           gserialized_get_type(gs2) == POINTTYPE)
         return datum_point_eq(l, r);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -167,6 +167,35 @@ int main(void)
   free(coll); free(away); free(through);
   meos_errno_reset();
 
+  /* Equality is read from the native DE-9IM matrix, so two circular strings
+   * describing the SAME arc through DIFFERENT defining points are equal. The
+   * three points lie on the circle of centre (0 0) and radius 5, which they
+   * determine exactly, so the answer rests on the arcs rather than on the
+   * rounding of a circumcentre. A linearization answers about the chords and
+   * calls the two different */
+  GSERIALIZED *arc1 = geom_in("Circularstring(5 0,4 3,0 5)", -1);
+  GSERIALIZED *arc2 = geom_in("Circularstring(5 0,3 4,0 5)", -1);
+  assert(arc1 != NULL); assert(arc2 != NULL);
+  meos_errno_reset();
+  int arc_eq = geo_equals(arc1, arc2);
+  printf("geo_equals(Circularstring(5 0,4 3,0 5), "
+    "Circularstring(5 0,3 4,0 5)): %d, errno %d\n", arc_eq, meos_errno());
+  assert(arc_eq == 1);
+  assert(meos_errno() == 0);
+  /* The same arc read backwards is the same point set */
+  GSERIALIZED *arc3 = geom_in("Circularstring(0 5,3 4,5 0)", -1);
+  assert(arc3 != NULL);
+  assert(geo_equals(arc1, arc3) == 1);
+  /* A part of that arc is not the whole of it, and a polyline on the three
+   * points is not the arc through them */
+  GSERIALIZED *part = geom_in("Circularstring(5 0,4 3,3 4)", -1);
+  GSERIALIZED *chords = geom_in("Linestring(5 0,4 3,0 5)", -1);
+  assert(part != NULL); assert(chords != NULL);
+  assert(geo_equals(arc1, part) == 0);
+  assert(geo_equals(arc1, chords) == 0);
+  free(arc1); free(arc2); free(arc3); free(part); free(chords);
+  meos_errno_reset();
+
   /* A malformed box3d returns NULL and sets the error status */
   meos_errno_reset();
   BOX3D *bad_box3d = box3d_in("BOX3D(1 2 3)");


### PR DESCRIPTION
`geo_equals` reads the equality of two geometries from the native DE-9IM
intersection matrix, matching the pattern the standard gives `ST_Equals`,
`T*F**FFF*`.

The engine answers a circular arc on its own circle, so two circular strings
describing the same arc through different defining points are equal, and the arc
through three points is distinct from the polyline on them. A linearization
answers about the chords instead and separates the first pair while joining the
second.

The bounding-box and binary-equivalence short-circuits stand ahead of the
matrix, so it runs only for a pair sharing a box and differing in its bytes.
A geometry outside the coverage of `geom_meos_supported` — a polyhedral surface
or a TIN — raises `MEOS_ERR_FEATURE_NOT_SUPPORTED`.

Over the 160 geometries of the `tbl_geometry` fixture, self-joined into 12880
pairs: of the 5050 pairs whose operands both linearize, the answer agrees with
`GEOSEquals` on 5050, with no decline, no asymmetric pair, and no geometry
unequal to itself. The remaining 7830 hold a circular string, a compound curve
or a curve polygon.

`meos/test/geo_test.c` carries the discriminating case on the circle of radius 5
about the origin, whose defining points are exact, so the answer rests on the
arcs rather than on the rounding of a circumcentre.
