### PR TITLE
Match a DE-9IM pattern against the native intersection matrix

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -130,7 +130,7 @@ extern LWGEOM *meos_oriented_envelope(const LWGEOM *geom);
 extern bool meos_is_simple(const LWGEOM *geom, bool *result);
 extern bool meos_relate(const LWGEOM *g1, const LWGEOM *g2, char result[10]);
 extern bool meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2,
-  const char *pattern);
+  const char *pattern, bool *result);
 extern bool meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
   bool *result);
 extern bool de9im_match(const char matrix[10], const char pattern[10]);

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -6373,14 +6373,24 @@ meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
 }
 
 /**
- * @brief Return true if two geometries satisfy a DE-9IM pattern
+ * @brief Return whether two geometries satisfy a DE-9IM pattern
+ * @param[in] g1,g2 Geometries
+ * @param[in] pattern DE-9IM pattern, in the alphabet #de9im_match reads
+ * @param[out] result True if the geometries satisfy the pattern
+ * @return True if the pair is covered, which is what #geom_meos_supported
+ * answers of each geometry. A false return means the pair is outside that
+ * coverage, @b not that the pattern fails, so a caller must answer it another
+ * way rather than read @p result
  */
 bool
-meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2, const char *pattern)
+meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2, const char *pattern,
+  bool *result)
 {
+  assert(result);
   char matrix[10];
   if (! meos_relate(g1, g2, matrix))
     return false;
-  return de9im_match(matrix, pattern);
+  *result = de9im_match(matrix, pattern);
+  return true;
 }
 /*****************************************************************************/

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1989,6 +1989,9 @@ geom_disjoint2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * by a pattern
  * @param[in] gs1,gs2 Geometries
  * @param[in] p Pattern
+ * @details The pattern is matched against the native DE-9IM intersection
+ * matrix, so a circular arc is met on its own circle rather than on the chords
+ * a linearization would put in its place, and an empty operand meets nothing
  * @note PostGIS function: @p relate_pattern(PG_FUNCTION_ARGS)
  * Note also the the pattern may be modified in the function
  */
@@ -2000,48 +2003,25 @@ geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *p)
   if (! ensure_valid_geo_geo(gs1, gs2) || ! ensure_not_geodetic_geo(gs1))
     return false;
 
-  /* TODO handle empty */
-
-  GEOSContextHandle_t ctx = geos_get_context();
-
-  GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
-  if (!geos1)
-  {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "First argument geometry could not be converted to GEOS");
-    return false;
-  }
-  GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
-  if (!geos2)
-  {
-    GEOSGeom_destroy_r(ctx, geos1);
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "Second argument geometry could not be converted to GEOS");
-    return false;
-  }
-
-  /*
-  ** Need to make sure 't' and 'f' are upper-case before handing to GEOS
-  */
+  /* The pattern alphabet is upper case */
   for (size_t i = 0; i < strlen(p); i++ )
   {
     if ( p[i] == 't' ) p[i] = 'T';
     if ( p[i] == 'f' ) p[i] = 'F';
   }
 
-  char result = GEOSRelatePattern_r(ctx, geos1, geos2, p);
-  GEOSGeom_destroy_r(ctx, geos1);
-  GEOSGeom_destroy_r(ctx, geos2);
-
-  /* GEOS reports a failure as 2, which is the pattern reporting nothing. The
-   * answer is false, the one every other failure of this function gives */
-  if (result == 2)
+  LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
+  LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
+  bool result;
+  bool covered = meos_relate_pattern(geom1, geom2, p, &result);
+  lwgeom_free(geom1); lwgeom_free(geom2);
+  if (! covered)
   {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "GEOSRelatePattern returned error");
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "The relationship of the geometries is not supported");
     return false;
   }
-  return (bool) result;
+  return result;
 }
 
 /**

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -135,11 +135,10 @@ int main(void)
   assert(strcmp(str_srid, "BOX3D(1 1 1,5 5 5)") == 0);
   free(str_srid); free(box_srid);
 
-  /* A geometry relationship that GEOS cannot evaluate reports the failure and
-   * answers false. GEOS rejects a collection of mixed dimensions, and under
-   * this handler the relationship returns rather than ending the process, so
-   * the value it gives is the one a language binding reads. A line far from
-   * the collection must not come back as containing it */
+  /* A pattern is matched against the native matrix, which relates a collection
+   * of mixed dimensions like any other geometry, so the answer carries no
+   * error status. A line far from the collection does not meet it, and a line
+   * through it meets it in their interiors */
   GSERIALIZED *coll = geom_in(
     "GeometryCollection(Point(0 0),Linestring(2 2,3 3))", -1);
   assert(coll != NULL);
@@ -152,9 +151,7 @@ int main(void)
   printf("geom_relate_pattern(away, collection): %d, errno %d\n", rel,
     rel_errno);
   assert(rel == false);
-  assert(rel_errno != 0);
-  /* A pair GEOS does evaluate keeps its answer: a line through the collection
-   * meets it in their interiors */
+  assert(rel_errno == 0);
   GSERIALIZED *through = geom_in("Linestring(0 0,3 3)", -1);
   assert(through != NULL);
   meos_errno_reset();
@@ -164,7 +161,19 @@ int main(void)
     errno_ok);
   assert(rel_ok == true);
   assert(errno_ok == 0);
-  free(coll); free(away); free(through);
+  /* A geometry the edge decomposition does not reach reports the failure and
+   * answers false, so the value a language binding reads is the safe one */
+  GSERIALIZED *tin = geom_in(
+    "Tin(((0 0,0 1,1 1,0 0)),((0 0,1 0,1 1,0 0)))", -1);
+  assert(tin != NULL);
+  meos_errno_reset();
+  bool rel_tin = geom_relate_pattern(through, tin, patt);
+  int errno_tin = meos_errno();
+  printf("geom_relate_pattern(line, tin): %d, errno %d\n", rel_tin,
+    errno_tin);
+  assert(rel_tin == false);
+  assert(errno_tin != 0);
+  free(coll); free(away); free(through); free(tin);
   meos_errno_reset();
 
   /* Equality is read from the native DE-9IM matrix, so two circular strings

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -1,7 +1,7 @@
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eContains(g, temp);
  count 
 -------
-  1606
+  1605
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aContains(g, temp);
@@ -13,7 +13,7 @@ SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE aContains(g, temp);
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eContains(temp, g);
  count 
 -------
-  1606
+  1605
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE aContains(temp, g);

--- a/mobilitydb/test/geo/expected/072_tgeo_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tgeo_tempspatialrels_tbl.test.out
@@ -19,7 +19,7 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE tContains(t1.temp,
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tContains(g, temp) ?= true <> eContains(g, temp);
  count 
 -------
-   831
+   830
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tCovers(g, temp) IS NOT NULL;


### PR DESCRIPTION
`geom_relate_pattern` matches a DE-9IM pattern against the native intersection
matrix.

The engine answers a circular arc on its own circle rather than on the chords a
linearization puts in its place, it relates a geometry collection of mixed
dimensions like any other geometry, and an empty operand meets nothing. A
geometry the edge decomposition does not reach, a polyhedral surface or a TIN,
raises `MEOS_ERR_FEATURE_NOT_SUPPORTED`.

`meos_relate_pattern` takes the shape of its two siblings `meos_relate` and
`meos_spatialrel`: the return reports whether the pair is covered and an out
parameter carries the answer, so a pair outside the coverage is distinct from a
pattern that does not match.

Over the 160 geometries of the `tbl_geometry` fixture, self-joined into 12880
pairs, on the pattern the ever-relationships ask for, `T********`: of the 5050
pairs whose operands both linearize, the answer agrees with `GEOSRelatePattern`
on 5050, with no decline and no asymmetric pair. The remaining 7830 hold a
circular string, a compound curve or a curve polygon.

Two expected outputs move, both for one pair of the ever-contains join between
`tbl_geometry` and `tbl_tgeometry`: `eContains` counts 1606 to 1605 in each
direction in `070_tgeo_spatialrels_tbl`, and the count of rows where `tContains`
disagrees with `eContains` 831 to 830 in `072_tgeo_tempspatialrels_tbl`, so the
temporal and the ever answers agree on one pair more. The pair is geometry 140,
a compound curve, against the fourteenth and fifteenth values of temporal
geometry 82, a line segment. Three nearly collinear points of that compound
curve define a circle of radius 2211.95 about (1945.19, 1235.62) whose arc
sweeps 359.78 degrees. Both ends of the line segment lie inside that circle, by
0.213 and by 6.388, and within the angular span of the arc, so the segment lies
wholly inside the circle and the arc does not meet it. A linearization at 32
segments per quadrant carries a sagitta of 0.666, which reaches past the nearer
end and crosses it.

`meos/test/geo_test.c` asserts the collection the pattern answers without an
error status, and the TIN it declines.
