### PR TITLE
Answer the same operations from either in-memory index

### DIFF
--- a/.github/workflows/meos-smoke.yml
+++ b/.github/workflows/meos-smoke.yml
@@ -58,6 +58,18 @@ jobs:
           export MEOS_BUILD_DIR=/usr/local/lib
           ./meos/test/run_smoketests.sh
 
+      # Building an index from a whole entry set releases the nodes the index
+      # holds, which the assertions cannot see and only a leak check reports
+      - name: Run the index builds under valgrind
+        run: |
+          cd meos/test
+          for t in rtree_load_test sptree_load_test; do
+            gcc -Wall -Werror=implicit-function-declaration -g \
+              -I/usr/local/include -o $t $t.c -L/usr/local/lib -lmeos -lm
+            valgrind --leak-check=full --errors-for-leak-kinds=definite \
+              --error-exitcode=1 ./$t
+          done
+
       - name: Upload valgrind logs on failure
         if: failure()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -141,6 +141,10 @@ jobs:
           ./rtree_knn_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_load_test rtree_load_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_load_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o sptree_load_test sptree_load_test.c -L/usr/local/lib -lmeos -lm
+          ./sptree_load_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o index_position_test index_position_test.c -L/usr/local/lib -lmeos -lm
+          ./index_position_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_join_test rtree_join_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_join_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o setset_pairs_test setset_pairs_test.c -L/usr/local/lib -lmeos -lm

--- a/meos/examples/rtree_example.c
+++ b/meos/examples/rtree_example.c
@@ -78,7 +78,7 @@ random_int(int min, int max)
  * @param[in] predicate Brute-force predicate matching the search operation
  */
 static void
-verify_search(const char *name, const RTree *rtree, RTreeSearchOp op,
+verify_search(const char *name, const RTree *rtree, IndexSearchOp op,
   const void *query, const char *boxes, size_t bboxsize, MeosArray *ids,
   bool (*predicate)(const void *, const void *))
 {
@@ -181,11 +181,11 @@ test_floatspan(MeosArray *ids)
 
   printf("FLOATSPAN:\n");
   Span *query = floatspan_in("[0, 100]");
-  verify_search("overlaps", rtree, RTREE_OVERLAPS, query,
+  verify_search("overlaps", rtree, INDEX_OVERLAPS, query,
     (char *) boxes, sizeof(Span), ids, overlaps_span_wrapper);
-  verify_search("contains", rtree, RTREE_CONTAINS, query,
+  verify_search("contains", rtree, INDEX_CONTAINS, query,
     (char *) boxes, sizeof(Span), ids, contains_span_wrapper);
-  verify_search("contained by", rtree, RTREE_CONTAINED_BY, query,
+  verify_search("contained by", rtree, INDEX_CONTAINED_BY, query,
     (char *) boxes, sizeof(Span), ids, contained_span_wrapper);
 
   free(query);
@@ -219,11 +219,11 @@ test_tstzspan(MeosArray *ids)
   /* Query covers ~100/1000 = 10% of the time range */
   Span *query = tstzspan_in(
     "[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00]");
-  verify_search("overlaps", rtree, RTREE_OVERLAPS, query,
+  verify_search("overlaps", rtree, INDEX_OVERLAPS, query,
     (char *) boxes, sizeof(Span), ids, overlaps_span_wrapper);
-  verify_search("contains", rtree, RTREE_CONTAINS, query,
+  verify_search("contains", rtree, INDEX_CONTAINS, query,
     (char *) boxes, sizeof(Span), ids, contains_span_wrapper);
-  verify_search("contained by", rtree, RTREE_CONTAINED_BY, query,
+  verify_search("contained by", rtree, INDEX_CONTAINED_BY, query,
     (char *) boxes, sizeof(Span), ids, contained_span_wrapper);
 
   free(query);
@@ -259,11 +259,11 @@ test_tbox(MeosArray *ids)
   printf("TBOX:\n");
   TBox *query = tbox_in(
     "TBOX XT([0,100],[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00])");
-  verify_search("overlaps", rtree, RTREE_OVERLAPS, query,
+  verify_search("overlaps", rtree, INDEX_OVERLAPS, query,
     (char *) boxes, sizeof(TBox), ids, overlaps_tbox_wrapper);
-  verify_search("contains", rtree, RTREE_CONTAINS, query,
+  verify_search("contains", rtree, INDEX_CONTAINS, query,
     (char *) boxes, sizeof(TBox), ids, contains_tbox_wrapper);
-  verify_search("contained by", rtree, RTREE_CONTAINED_BY, query,
+  verify_search("contained by", rtree, INDEX_CONTAINED_BY, query,
     (char *) boxes, sizeof(TBox), ids, contained_tbox_wrapper);
 
   free(query);
@@ -302,11 +302,11 @@ test_stbox(MeosArray *ids)
   STBox *query = stbox_in(
     "SRID=25832;STBOX XT(((0 0),(100 100)),"
     "[2020-01-01 00:00:00+00, 2020-01-01 01:40:00+00])");
-  verify_search("overlaps", rtree, RTREE_OVERLAPS, query,
+  verify_search("overlaps", rtree, INDEX_OVERLAPS, query,
     (char *) boxes, sizeof(STBox), ids, overlaps_stbox_wrapper);
-  verify_search("contains", rtree, RTREE_CONTAINS, query,
+  verify_search("contains", rtree, INDEX_CONTAINS, query,
     (char *) boxes, sizeof(STBox), ids, contains_stbox_wrapper);
-  verify_search("contained by", rtree, RTREE_CONTAINED_BY, query,
+  verify_search("contained by", rtree, INDEX_CONTAINED_BY, query,
     (char *) boxes, sizeof(STBox), ids, contained_stbox_wrapper);
 
   free(query);
@@ -356,7 +356,7 @@ test_temporal(MeosArray *ids)
 
   /* Index search via temporal API */
   clock_t t = clock();
-  int index_count = rtree_search_temporal(rtree, RTREE_OVERLAPS, query, ids);
+  int index_count = rtree_search_temporal(rtree, INDEX_OVERLAPS, query, ids);
   double index_time = (double)(clock() - t) / CLOCKS_PER_SEC;
 
   /* Brute-force search */

--- a/meos/examples/rtree_mest_example.c
+++ b/meos/examples/rtree_mest_example.c
@@ -266,7 +266,7 @@ int main(void)
     total_truth += truth_count;
 
     /* Single-box filter: the probe's single MBR */
-    int single_count = rtree_search_temporal(single, RTREE_OVERLAPS, probe,
+    int single_count = rtree_search_temporal(single, INDEX_OVERLAPS, probe,
       ids);
     for (int i = 0; i < NUM_TRIPS; i++)
       seen[i] = false;
@@ -287,7 +287,7 @@ int main(void)
 
     /* Invariant (iv): the maxboxes <= 1 index reproduces the single-box
      * candidate set exactly */
-    int deg_count = rtree_search_temporal_dedup(degenerate, RTREE_OVERLAPS,
+    int deg_count = rtree_search_temporal_dedup(degenerate, INDEX_OVERLAPS,
       probe, 1, ids);
     assert(deg_count == single_count);
     for (int k = 0; k < deg_count; k++)
@@ -301,7 +301,7 @@ int main(void)
     int prev_count = single_count;
     for (int m = 0; m < NUM_MAXBOXES; m++)
     {
-      int cand = rtree_search_temporal_dedup(mest[m], RTREE_OVERLAPS, probe,
+      int cand = rtree_search_temporal_dedup(mest[m], INDEX_OVERLAPS, probe,
         MAXBOXES[m], ids);
       for (int i = 0; i < NUM_TRIPS; i++)
         seen[i] = false;

--- a/meos/include/geo/doxygen_meos_geo.h
+++ b/meos/include/geo/doxygen_meos_geo.h
@@ -243,10 +243,6 @@
  * @defgroup meos_geo_box_comp Comparison functions
  * @ingroup meos_geo_box
  * @brief Comparison functions for spatiotemporal boxes
- *
- * @defgroup meos_geo_box_index Index functions
- * @ingroup meos_geo_box
- * @brief In-memory RTree index for spatiotemporal boxes
  */
 
 /*****************************************************************************/

--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -341,14 +341,32 @@ extern void meos_array_destroy_free(MeosArray *array);
 /*****************************************************************************/
 
 /**
- * @brief Enumeration that defines the search operations for an RTree.
+ * @brief Enumeration that defines the search operations of an in-memory index
+ * @details The RTree and the space-partitioning index answer the same
+ * operations, so the operations carry the name of neither.
  */
 typedef enum
 {
-  RTREE_OVERLAPS,      /**< Find stored boxes that overlap the query */
-  RTREE_CONTAINS,      /**< Find stored boxes that contain the query */
-  RTREE_CONTAINED_BY   /**< Find stored boxes contained by the query */
-} RTreeSearchOp;
+  INDEX_OVERLAPS,      /**< Find stored boxes that overlap the query */
+  INDEX_CONTAINS,      /**< Find stored boxes that contain the query */
+  INDEX_CONTAINED_BY,  /**< Find stored boxes contained by the query */
+  INDEX_LEFT,          /**< Find stored boxes strictly left of the query */
+  INDEX_OVERLEFT,      /**< Find stored boxes that do not extend to the right of the query */
+  INDEX_RIGHT,         /**< Find stored boxes strictly right of the query */
+  INDEX_OVERRIGHT,     /**< Find stored boxes that do not extend to the left of the query */
+  INDEX_BELOW,         /**< Find stored boxes strictly below the query */
+  INDEX_OVERBELOW,     /**< Find stored boxes that do not extend above the query */
+  INDEX_ABOVE,         /**< Find stored boxes strictly above the query */
+  INDEX_OVERABOVE,     /**< Find stored boxes that do not extend below the query */
+  INDEX_FRONT,         /**< Find stored boxes strictly in front of the query */
+  INDEX_OVERFRONT,     /**< Find stored boxes that do not extend behind the query */
+  INDEX_BACK,          /**< Find stored boxes strictly behind the query */
+  INDEX_OVERBACK,      /**< Find stored boxes that do not extend in front of the query */
+  INDEX_BEFORE,        /**< Find stored boxes strictly before the query */
+  INDEX_OVERBEFORE,    /**< Find stored boxes that do not extend after the query */
+  INDEX_AFTER,         /**< Find stored boxes strictly after the query */
+  INDEX_OVERAFTER      /**< Find stored boxes that do not extend before the query */
+} IndexSearchOp;
 
 /**
  * Structure for the in-memory Rtree index
@@ -368,14 +386,17 @@ extern RTree *rtree_create_stbox();
 extern RTree *rtree_create_tpcbox();
 #endif
 extern void rtree_free(RTree *rtree);
-extern void rtree_insert(RTree *rtree, void *box, int64 id);
-extern void rtree_load(RTree *rtree, const void *boxes, const int64 *ids, int count);
-extern void rtree_insert_temporal(RTree *rtree, const Temporal *temp, int64 id);
-extern void rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int64 id, int maxboxes);
-extern int rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query, MeosArray *result);
-extern int rtree_join(const RTree *rtree1, const RTree *rtree2, RTreeSearchOp op, MeosArray *result);
-extern int rtree_search_temporal(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
-extern int rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
+extern int rtree_num_entries(const RTree *rtree);
+extern int64 rtree_mem_size(const RTree *rtree);
+extern int rtree_height(const RTree *rtree);
+extern bool rtree_insert(RTree *rtree, void *box, int64 id);
+extern bool rtree_load(RTree *rtree, const void *boxes, const int64 *ids, int count);
+extern bool rtree_insert_temporal(RTree *rtree, const Temporal *temp, int64 id);
+extern bool rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int64 id, int maxboxes);
+extern int rtree_search(const RTree *rtree, IndexSearchOp op, const void *query, MeosArray *result);
+extern int rtree_join(const RTree *rtree1, const RTree *rtree2, IndexSearchOp op, MeosArray *result);
+extern int rtree_search_temporal(const RTree *rtree, IndexSearchOp op, const Temporal *temp, MeosArray *result);
+extern int rtree_search_temporal_dedup(const RTree *rtree, IndexSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
 
 /**
  * Cursor for a nearest-neighbour scan of an in-memory Rtree index
@@ -414,12 +435,16 @@ extern SPTree *sptree_create_stbox(SPTreeKind kind);
 extern SPTree *sptree_create_tpcbox(SPTreeKind kind);
 #endif
 extern void sptree_free(SPTree *sptree);
-extern void sptree_insert(SPTree *sptree, void *box, int64 id);
-extern void sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int64 id);
-extern void sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int64 id, int maxboxes);
-extern int sptree_search(const SPTree *sptree, RTreeSearchOp op, const void *query, MeosArray *result);
-extern int sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op, const Temporal *temp, MeosArray *result);
-extern int sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
+extern int sptree_num_entries(const SPTree *sptree);
+extern int64 sptree_mem_size(const SPTree *sptree);
+extern int sptree_height(const SPTree *sptree);
+extern bool sptree_insert(SPTree *sptree, void *box, int64 id);
+extern bool sptree_load(SPTree *sptree, const void *boxes, const int64 *ids, int count);
+extern bool sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int64 id);
+extern bool sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int64 id, int maxboxes);
+extern int sptree_search(const SPTree *sptree, IndexSearchOp op, const void *query, MeosArray *result);
+extern int sptree_search_temporal(const SPTree *sptree, IndexSearchOp op, const Temporal *temp, MeosArray *result);
+extern int sptree_search_temporal_dedup(const SPTree *sptree, IndexSearchOp op, const Temporal *temp, int maxboxes, MeosArray *result);
 
 /**
  * Cursor for a nearest-neighbour scan of an in-memory space-partitioning index

--- a/meos/include/temporal/doxygen_meos.h
+++ b/meos/include/temporal/doxygen_meos.h
@@ -418,6 +418,30 @@
  * @ingroup meos_temporal
  * @brief Index functions for temporal types
  *
+ * @details The in-memory indexes are the R-tree and the space-partitioning
+ * tree. They expose the same operations under the same contract, and differ
+ * only in the tree that is built for it: `rtree_create_*` builds an R-tree,
+ * `sptree_create_*` a quad-tree or a k-d tree according to the kind it is
+ * given.
+ *
+ * - An index is filled by `_insert`, `_insert_temporal` and
+ *   `_insert_temporal_split`, or built from a whole entry set at once by
+ *   `_load`, and the two ways of filling it answer alike. The shape of the
+ *   tree differs, since a build that knows every entry in advance chooses the
+ *   depth rather than following the order the entries arrive in, but the set
+ *   of ids a query returns does not.
+ * - An index is append-only: there is no removal entry point, and an entry
+ *   stays until the index is rebuilt or freed. A caller that has to hide an
+ *   entry filters the ids a search returns.
+ * - `_load` therefore has a second use beyond speed. It leaves the index
+ *   holding exactly the entries it is given, releasing whatever the index
+ *   held, so it is the way an index that has grown stale is rebuilt from the
+ *   entries a caller keeps. Loading no entries leaves an empty index.
+ * - An index that has been loaded is indistinguishable from a freshly created
+ *   one of the same type: the same queries answer the same, and it can be
+ *   filled further by `_insert`.
+ * - `_free` releases the index and everything it holds.
+ *
  * @defgroup meos_temporal_spatial_rel_ever Ever/always spatial relationship functions
  * @ingroup meos_temporal
  * @brief Ever/always spatial relationship functions for temporal types

--- a/meos/include/temporal/temporal_rtree.h
+++ b/meos/include/temporal/temporal_rtree.h
@@ -91,6 +91,9 @@ struct RTree
   void (*bbox_expand)(const void *, void *);
   bool (*bbox_contains)(const void *, const void *);
   bool (*bbox_overlaps)(const void *, const void *);
+  /** Position of the first box with respect to the second one, for the
+   * operations that order a dimension. NULL for a box type with none */
+  bool (*bbox_position)(const void *, const void *, IndexSearchOp);
   char box[];
 };
 

--- a/meos/include/temporal/temporal_sptree.h
+++ b/meos/include/temporal/temporal_sptree.h
@@ -99,9 +99,12 @@ struct SPTree
     uint8 quadrant, void *next);
   void (*kdtree_next)(const void *nodebox, const void *centroid, uint8 node,
     int level, void *next);
+  /** Smallest box covering every box a region holds, which is what a second
+   * region is compared against when two trees are descended together */
+  void (*nodebox_envelope)(const void *nodebox, void *out);
   bool (*inner_consistent)(const void *nodebox, const void *query,
-    RTreeSearchOp op);
-  bool (*leaf_consistent)(const void *key, const void *query, RTreeSearchOp op);
+    IndexSearchOp op);
+  bool (*leaf_consistent)(const void *key, const void *query, IndexSearchOp op);
 };
 
 /*****************************************************************************/

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -802,7 +802,7 @@ tcbuffer_disc_within_dist(double cx, double cy, double r, double dist,
   STBox query;
   stbox_set(true, false, false, 0, sxmin - dist, sxmax + dist, symin - dist,
     symax + dist, 0, 0, NULL, &query);
-  int nc = rtree_search(g->rtree, RTREE_OVERLAPS, &query, dist_pip_results);
+  int nc = rtree_search(g->rtree, INDEX_OVERLAPS, &query, dist_pip_results);
   for (int j = 0; j < nc; j++)
   {
     const DistEdge *ed =
@@ -1320,7 +1320,7 @@ tcbufferseg_within_ctx(const Cbuffer *cb1, const Cbuffer *cb2, double dist,
   STBox query;
   stbox_set(true, false, false, 0, cxmin - reach, cxmax + reach, cymin - reach,
     cymax + reach, 0, 0, NULL, &query);
-  int ncand = rtree_search(ctx->g.rtree, RTREE_OVERLAPS, &query,
+  int ncand = rtree_search(ctx->g.rtree, INDEX_OVERLAPS, &query,
     dist_pip_results);
   for (int j = 0; j < ncand; j++)
   {
@@ -1416,7 +1416,7 @@ tcbuffer_disc_signed_boundary(double cx, double cy, double r,
   STBox query;
   stbox_set(true, false, false, 0, cx - reach, cx + reach, cy - reach,
     cy + reach, 0, 0, NULL, &query);
-  int nc = rtree_search(g->rtree, RTREE_OVERLAPS, &query, dist_pip_results);
+  int nc = rtree_search(g->rtree, INDEX_OVERLAPS, &query, dist_pip_results);
   for (int j = 0; j < nc; j++)
   {
     const DistEdge *ed =
@@ -1525,7 +1525,7 @@ tcbufferseg_sg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   STBox query;
   stbox_set(true, false, false, 0, cxmin - rmax, cxmax + rmax, cymin - rmax,
     cymax + rmax, 0, 0, NULL, &query);
-  int ncand = rtree_search(ctx->g.rtree, RTREE_OVERLAPS, &query,
+  int ncand = rtree_search(ctx->g.rtree, INDEX_OVERLAPS, &query,
     dist_pip_results);
   for (int j = 0; j < ncand; j++)
   {

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1011,7 +1011,7 @@ dist_geom_point_inside(double x, double y, const DistGeom *g)
   {
     STBox query;
     stbox_set(true, false, false, 0, x, g->xmax, y, y, 0, 0, NULL, &query);
-    int nc = rtree_search(g->rtree, RTREE_OVERLAPS, &query, dist_pip_results);
+    int nc = rtree_search(g->rtree, INDEX_OVERLAPS, &query, dist_pip_results);
     for (int j = 0; j < nc; j++)
       dist_poly_seg_raycross(
         &g->segs[*(int64 *) meos_array_get(dist_pip_results, j)], x, y,

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -2240,7 +2240,7 @@ setset_box_pairs(const STBox *bb1, int count1, const STBox *bb2, int count2,
     rtree_insert(rtree2, (void *) &bb2[j], j);
 
   MeosArray *found = meos_array_create(sizeof(int64));
-  int n = rtree_join(rtree1, rtree2, RTREE_OVERLAPS, found);
+  int n = rtree_join(rtree1, rtree2, INDEX_OVERLAPS, found);
   int *result = NULL;
   if (n > 0)
   {

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -107,7 +107,7 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
       STBox query;
       double xhi = (x > xmax) ? x : xmax;
       stbox_set(true, false, false, srid, x, xhi, ry, ry, 0, 0, NULL, &query);
-      n = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
+      n = rtree_search(rtree, INDEX_OVERLAPS, &query, rtree_results);
     }
     for (int i = 0; i < n && ! shared; i++)
     {
@@ -685,7 +685,7 @@ tpointinst_clip_edges(const TInstant *inst, Edge **edges, int nedges,
     stbox_set(true, false, false, srid, a->x, a->x, a->y, a->y, 0, 0, NULL,
       &query);
     /* Query the R-tree */
-    int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
+    int cand_nedges = rtree_search(rtree, INDEX_OVERLAPS, &query, rtree_results);
 
     /* Convert the result of an R-tree look up into an edge pointer array */
     for (int j = 0; j < cand_nedges; j++)
@@ -763,7 +763,7 @@ tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
         Max(a->x, b->x), Min(a->y, b->y), Max(a->y, b->y),
         0, 0, NULL, &query);
       /* Query the R-tree */
-      int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
+      int cand_nedges = rtree_search(rtree, INDEX_OVERLAPS, &query, rtree_results);
 
       /* Convert the result of an R-tree look up into an edge pointer array */
       for (int j = 0; j < cand_nedges; j++)
@@ -1059,7 +1059,7 @@ geo_intersects2d_ctx(const GSERIALIZED *gs, const void *ctxv)
       STBox query;
       stbox_set(true, false, false, ctx->srid, e->xmin, e->xmax, e->ymin,
         e->ymax, 0, 0, NULL, &query);
-      int nc = rtree_search(ctx->rtree, RTREE_OVERLAPS, &query, rtree_results);
+      int nc = rtree_search(ctx->rtree, INDEX_OVERLAPS, &query, rtree_results);
       for (int j = 0; j < nc; j++)
         ctx->cand_edges[j] =
           ctx->edge_ptrs[*(int64 *) meos_array_get(rtree_results, j)];
@@ -1624,7 +1624,7 @@ point_geom_within(double px, double py, Edge **edges, int nedges,
     STBox query;
     stbox_set(true, false, false, srid, px - dist, px + dist, py - dist,
       py + dist, 0, 0, NULL, &query);
-    int nc = rtree_search(rtree, RTREE_OVERLAPS, &query, rtree_results);
+    int nc = rtree_search(rtree, INDEX_OVERLAPS, &query, rtree_results);
     for (int i = 0; i < nc; i++)
       if (point_edge_dist2(px, py,
             edges[*(int64 *) meos_array_get(rtree_results, i)]) <=
@@ -1902,7 +1902,7 @@ tpointseq_dwithin_edges(const TSequence *seq, Edge **edges, int nedges,
       stbox_set(true, false, false, srid, Min(a->x, b->x) - dist,
         Max(a->x, b->x) + dist, Min(a->y, b->y) - dist,
         Max(a->y, b->y) + dist, 0, 0, NULL, &query);
-      int cand_nedges = rtree_search(rtree, RTREE_OVERLAPS, &query,
+      int cand_nedges = rtree_search(rtree, INDEX_OVERLAPS, &query,
         rtree_results);
       for (int j = 0; j < cand_nedges; j++)
         cand_edges[j] = edges[*(int64 *) meos_array_get(rtree_results, j)];

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -35,6 +35,7 @@
 
 /* C */
 #include <stdlib.h>
+#include <limits.h>
 #include <math.h>
 /* MEOS */
 #include <meos.h>
@@ -49,6 +50,7 @@
 #include "temporal/tbox.h"
 #include "temporal/temporal.h"
 #include "temporal/type_util.h"
+#include "geo/geo_funcs.h"
 #include "temporal/temporal_rtree.h"
 
 /*****************************************************************************
@@ -324,6 +326,147 @@ bbox_overlaps_tpcbox(const void *box1, const void *box2)
   return true;
 }
 #endif
+
+/*****************************************************************************
+ * Position of one box with respect to another
+ *
+ * An operation that orders a dimension is answered at a leaf by the operator
+ * of the box type, and at an inner node by the same operator read the other
+ * way round. A node holds every entry of its subtree, so an entry can lie on
+ * one side of the query only when the node itself reaches that side: an entry
+ * left of the query needs a node that is not entirely to its right, and so on
+ * for each pair. The pairing is an involution, which #index_op_dual gives.
+ *****************************************************************************/
+
+/**
+ * @brief Return the operation whose negation, read against a node, tells
+ * whether the subtree can hold an entry satisfying @p op
+ */
+static IndexSearchOp
+index_op_dual(IndexSearchOp op)
+{
+  switch (op)
+  {
+    case INDEX_LEFT:       return INDEX_OVERRIGHT;
+    case INDEX_OVERRIGHT:  return INDEX_LEFT;
+    case INDEX_OVERLEFT:   return INDEX_RIGHT;
+    case INDEX_RIGHT:      return INDEX_OVERLEFT;
+    case INDEX_BELOW:      return INDEX_OVERABOVE;
+    case INDEX_OVERABOVE:  return INDEX_BELOW;
+    case INDEX_OVERBELOW:  return INDEX_ABOVE;
+    case INDEX_ABOVE:      return INDEX_OVERBELOW;
+    case INDEX_FRONT:      return INDEX_OVERBACK;
+    case INDEX_OVERBACK:   return INDEX_FRONT;
+    case INDEX_OVERFRONT:  return INDEX_BACK;
+    case INDEX_BACK:       return INDEX_OVERFRONT;
+    case INDEX_BEFORE:     return INDEX_OVERAFTER;
+    case INDEX_OVERAFTER:  return INDEX_BEFORE;
+    case INDEX_OVERBEFORE: return INDEX_AFTER;
+    case INDEX_AFTER:      return INDEX_OVERBEFORE;
+    default:               return op;
+  }
+}
+
+/**
+ * @brief Return `true` if a span is positioned with respect to another one as
+ * @p op asks, `false` otherwise
+ * @details A span orders one dimension, so only the value operations apply
+ * @param[in] box1,box2 Span values
+ * @param[in] op Position operation
+ */
+static bool
+bbox_position_span(const void *box1, const void *box2, IndexSearchOp op)
+{
+  const Span *s1 = (const Span *) box1;
+  const Span *s2 = (const Span *) box2;
+  switch (op)
+  {
+    case INDEX_LEFT:      return left_span_span(s1, s2);
+    case INDEX_OVERLEFT:  return overleft_span_span(s1, s2);
+    case INDEX_RIGHT:     return right_span_span(s1, s2);
+    case INDEX_OVERRIGHT: return overright_span_span(s1, s2);
+    default:              return false;
+  }
+}
+
+/**
+ * @brief Return `true` if a temporal box is positioned with respect to another
+ * one as @p op asks, `false` otherwise
+ * @details A temporal box orders a value dimension and a time dimension
+ * @param[in] box1,box2 TBox values
+ * @param[in] op Position operation
+ */
+static bool
+bbox_position_tbox(const void *box1, const void *box2, IndexSearchOp op)
+{
+  const TBox *b1 = (const TBox *) box1;
+  const TBox *b2 = (const TBox *) box2;
+  switch (op)
+  {
+    case INDEX_LEFT:       return left_tbox_tbox(b1, b2);
+    case INDEX_OVERLEFT:   return overleft_tbox_tbox(b1, b2);
+    case INDEX_RIGHT:      return right_tbox_tbox(b1, b2);
+    case INDEX_OVERRIGHT:  return overright_tbox_tbox(b1, b2);
+    case INDEX_BEFORE:     return before_tbox_tbox(b1, b2);
+    case INDEX_OVERBEFORE: return overbefore_tbox_tbox(b1, b2);
+    case INDEX_AFTER:      return after_tbox_tbox(b1, b2);
+    case INDEX_OVERAFTER:  return overafter_tbox_tbox(b1, b2);
+    default:               return false;
+  }
+}
+
+/**
+ * @brief Return `true` if a spatiotemporal box is positioned with respect to
+ * another one as @p op asks, `false` otherwise
+ * @param[in] box1,box2 STBox values
+ * @param[in] op Position operation
+ */
+static bool
+bbox_position_stbox(const void *box1, const void *box2, IndexSearchOp op)
+{
+  const STBox *b1 = (const STBox *) box1;
+  const STBox *b2 = (const STBox *) box2;
+  switch (op)
+  {
+    case INDEX_LEFT:       return left_stbox_stbox(b1, b2);
+    case INDEX_OVERLEFT:   return overleft_stbox_stbox(b1, b2);
+    case INDEX_RIGHT:      return right_stbox_stbox(b1, b2);
+    case INDEX_OVERRIGHT:  return overright_stbox_stbox(b1, b2);
+    case INDEX_BELOW:      return below_stbox_stbox(b1, b2);
+    case INDEX_OVERBELOW:  return overbelow_stbox_stbox(b1, b2);
+    case INDEX_ABOVE:      return above_stbox_stbox(b1, b2);
+    case INDEX_OVERABOVE:  return overabove_stbox_stbox(b1, b2);
+    case INDEX_FRONT:      return front_stbox_stbox(b1, b2);
+    case INDEX_OVERFRONT:  return overfront_stbox_stbox(b1, b2);
+    case INDEX_BACK:       return back_stbox_stbox(b1, b2);
+    case INDEX_OVERBACK:   return overback_stbox_stbox(b1, b2);
+    case INDEX_BEFORE:     return before_stbox_stbox(b1, b2);
+    case INDEX_OVERBEFORE: return overbefore_stbox_stbox(b1, b2);
+    case INDEX_AFTER:      return after_stbox_stbox(b1, b2);
+    case INDEX_OVERAFTER:  return overafter_stbox_stbox(b1, b2);
+    default:               return false;
+  }
+}
+
+#if POINTCLOUD
+/**
+ * @brief Return `true` if a TPCBox is positioned with respect to another one
+ * as @p op asks, `false` otherwise
+ * @details A TPCBox carries the same spatial and temporal bounds as an STBox
+ * plus a trailing point cloud identifier, which orders no dimension, so the
+ * position is the one the projected boxes hold
+ * @param[in] box1,box2 TPCBox values
+ * @param[in] op Position operation
+ */
+static bool
+bbox_position_tpcbox(const void *box1, const void *box2, IndexSearchOp op)
+{
+  STBox sbox1, sbox2;
+  tpcbox_set_stbox((const TPCBox *) box1, &sbox1);
+  tpcbox_set_stbox((const TPCBox *) box2, &sbox2);
+  return bbox_position_stbox(&sbox1, &sbox2, op);
+}
+#endif /* POINTCLOUD */
 
 /*****************************************************************************
  * Rtree functions
@@ -780,18 +923,21 @@ node_insert(RTree *rtree, void *node_bounding_box, RTreeNode *node,
  */
 static bool
 leaf_consistent(const RTree *rtree, const void *key, const void *query,
-  RTreeSearchOp op)
+  IndexSearchOp op)
 {
   switch (op)
   {
-    case RTREE_OVERLAPS:
+    case INDEX_OVERLAPS:
       return rtree->bbox_overlaps(key, query);
-    case RTREE_CONTAINS:
+    case INDEX_CONTAINS:
       return rtree->bbox_contains(key, query);
-    case RTREE_CONTAINED_BY:
+    case INDEX_CONTAINED_BY:
       return rtree->bbox_contains(query, key);
+    default:
+      /* An entry satisfies a position operation as the box type answers it */
+      return rtree->bbox_position ?
+        rtree->bbox_position(key, query, op) : false;
   }
-  return false;
 }
 
 /**
@@ -804,17 +950,21 @@ leaf_consistent(const RTree *rtree, const void *key, const void *query,
  */
 static bool
 inner_consistent(const RTree *rtree, const void *key, const void *query,
-  RTreeSearchOp op)
+  IndexSearchOp op)
 {
   switch (op)
   {
-    case RTREE_OVERLAPS:
-    case RTREE_CONTAINED_BY:
+    case INDEX_OVERLAPS:
+    case INDEX_CONTAINED_BY:
       return rtree->bbox_overlaps(key, query);
-    case RTREE_CONTAINS:
+    case INDEX_CONTAINS:
       return rtree->bbox_contains(key, query);
+    default:
+      /* The subtree can hold an entry on one side of the query only when the
+       * node itself reaches that side, which the dual operation denies */
+      return rtree->bbox_position ?
+        ! rtree->bbox_position(key, query, index_op_dual(op)) : false;
   }
-  return false;
 }
 
 /**
@@ -826,7 +976,7 @@ inner_consistent(const RTree *rtree, const void *key, const void *query,
  * @param[out] result MeosArray to collect matching IDs
  */
 static void
-node_search(const RTree *rtree, const RTreeNode *node, RTreeSearchOp op,
+node_search(const RTree *rtree, const RTreeNode *node, IndexSearchOp op,
   const void *query, MeosArray *result)
 {
   for (int i = 0; i < node->count; ++i)
@@ -869,7 +1019,7 @@ node_search(const RTree *rtree, const RTreeNode *node, RTreeSearchOp op,
 static void
 node_join(const RTree *rtree1, const RTreeNode *node1, const void *box1,
   const RTree *rtree2, const RTreeNode *node2, const void *box2,
-  RTreeSearchOp op, MeosArray *result)
+  IndexSearchOp op, MeosArray *result)
 {
   if (box1 && box2 && ! rtree1->bbox_overlaps(box1, box2))
     return;
@@ -937,6 +1087,7 @@ rtree_create(MeosType bboxtype)
     rtree->bbox_expand = &bbox_expand_span;
     rtree->bbox_contains = &bbox_contains_span;
     rtree->bbox_overlaps = &bbox_overlaps_span;
+    rtree->bbox_position = &bbox_position_span;
   }
   else if (bboxtype == T_TBOX)
   {
@@ -945,6 +1096,7 @@ rtree_create(MeosType bboxtype)
     rtree->bbox_expand = &bbox_expand_tbox;
     rtree->bbox_contains = &bbox_contains_tbox;
     rtree->bbox_overlaps = &bbox_overlaps_tbox;
+    rtree->bbox_position = &bbox_position_tbox;
   }
 #if POINTCLOUD
   else if (bboxtype == T_TPCBOX)
@@ -956,6 +1108,7 @@ rtree_create(MeosType bboxtype)
     rtree->bbox_expand = &bbox_expand_tpcbox;
     rtree->bbox_contains = &bbox_contains_tpcbox;
     rtree->bbox_overlaps = &bbox_overlaps_tpcbox;
+    rtree->bbox_position = &bbox_position_tpcbox;
   }
 #endif
   else /* bboxtype == T_STBOX */
@@ -967,6 +1120,7 @@ rtree_create(MeosType bboxtype)
     rtree->bbox_expand = &bbox_expand_stbox;
     rtree->bbox_contains = &bbox_contains_stbox;
     rtree->bbox_overlaps = &bbox_overlaps_stbox;
+    rtree->bbox_position = &bbox_position_stbox;
   }
   rtree->bboxtype = bboxtype;
   rtree->bboxsize = bboxsize;
@@ -1066,8 +1220,12 @@ rtree_create_tpcbox()
 #endif
 
 /*****************************************************************************
- * STR bulk load (PROTOTYPE, for measurement)
+ * Build from a whole entry set
  *****************************************************************************/
+
+/* The build releases the nodes the tree holds, which the recursive release
+ * below it does */
+static void node_free(RTreeNode *node);
 
 typedef struct
 {
@@ -1141,21 +1299,68 @@ str_pack_level(RTree *rtree, STRItem *items, int count, bool leaf, int *nout)
 }
 
 /**
- * @ingroup meos_geo_box_index
+ * @brief Return true if a box may enter or query an RTree, report an error
+ * otherwise
+ * @details A tree holds boxes of one SRID: the first entry fixes it, and a box
+ * of another one is an error rather than a coercion. The check belongs here,
+ * at the entry point, so that every comparison the descent makes can assume it
+ */
+static bool
+ensure_valid_rtree_box(const RTree *rtree, const void *box)
+{
+  if (! rtree->root)
+    return true;
+  if (rtree->bboxtype == T_STBOX)
+    return ensure_same_srid(((const STBox *) rtree->box)->srid,
+      ((const STBox *) box)->srid);
+#if POINTCLOUD
+  if (rtree->bboxtype == T_TPCBOX)
+  {
+    STBox s1, s2;
+    tpcbox_set_stbox((const TPCBox *) rtree->box, &s1);
+    tpcbox_set_stbox((const TPCBox *) box, &s2);
+    return ensure_same_srid(s1.srid, s2.srid);
+  }
+#endif /* POINTCLOUD */
+  return true;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
  * @brief Build an RTree from all of its entries at once
  * @details Bottom-up Sort-Tile-Recursive packing. The result answers the same
  * queries as inserting every entry one by one, but the whole set is known in
  * advance, so nodes are filled to capacity and no node is ever split.
- * @param[in] rtree An EMPTY RTree of the appropriate bounding box type
+ *
+ * The tree ends up holding exactly the entries given, whatever it holds on
+ * entry, so this is both the fast first build and the only way to make an
+ * index smaller: an index has no removal entry point, and a caller that has to
+ * drop entries rebuilds from the ones it keeps. Loading no entries leaves an
+ * empty tree.
+ * @param[in] rtree An RTree of the appropriate bounding box type
  * @param[in] boxes Contiguous array of @p count boxes of the tree bbox size
  * @param[in] ids The id of each box
  * @param[in] count Number of entries
  */
-void
+bool
 rtree_load(RTree *rtree, const void *boxes, const int64 *ids, int count)
 {
+  /* Ensure the validity of the arguments */
+  if (! ensure_not_null((void *) rtree) || ! ensure_not_null((void *) boxes) ||
+      ! ensure_not_null((void *) ids) || ! ensure_valid_rtree_box(rtree, boxes))
+    return false;
+
+  /* The packing assigns the root, so the nodes the tree holds are released
+   * before it does, and are released whatever the number of entries given: an
+   * empty entry set leaves an empty tree rather than the previous one */
+  if (rtree->root)
+  {
+    node_free(rtree->root);
+    rtree->root = NULL;
+  }
+
   if (count <= 0)
-    return;
+    return true;
 
   /* A box type whose dimension count depends on the data carries -1 until the
    * first box arrives, which for a tree grown by insertion is the first insert */
@@ -1198,12 +1403,12 @@ rtree_load(RTree *rtree, const void *boxes, const int64 *ids, int count)
   for (int k = 1; k < level[0]->count; k++)
     rtree->bbox_expand(RTREE_NODE_BBOX_N(level[0], k), &rtree->box);
   pfree(level);
-  return;
+  return true;
 }
 
 
 /**
- * @ingroup meos_geo_box_index
+ * @ingroup meos_temporal_box_index
  * @brief Insert a bounding box into the RTree index.
  * @note The parameter `id` is used for the search function, when a match
  * is found the id will be returned. The bounding box will be copied into the
@@ -1212,9 +1417,14 @@ rtree_load(RTree *rtree, const void *boxes, const int64 *ids, int count)
  * @param[in] box The bounding box to be inserted
  * @param[in] id The id of the box being inserted
  */
-void
+bool
 rtree_insert(RTree *rtree, void *box, int64 id)
 {
+  /* Ensure the validity of the arguments */
+  if (! ensure_not_null((void *) rtree) || ! ensure_not_null((void *) box) ||
+      ! ensure_valid_rtree_box(rtree, box))
+    return false;
+
   while (1)
   {
     if (! rtree->root)
@@ -1230,7 +1440,7 @@ rtree_insert(RTree *rtree, void *box, int64 id)
     if (! split)
     {
       rtree->bbox_expand(box, &rtree->box);
-      return;
+      return true;
     }
     RTreeNode *new_root = node_make(RTREE_INNER, rtree->bboxsize);
     RTreeNode *right;
@@ -1243,29 +1453,35 @@ rtree_insert(RTree *rtree, void *box, int64 id)
     rtree->root = new_root;
     rtree->root->count = 2;
   }
-  return;
+  return true;
 }
 
 /**
- * @ingroup meos_geo_box_index
+ * @ingroup meos_temporal_box_index
  * @brief Search an RTree with a bounding box, collecting matching IDs into
  * a MeosArray
  * @details The result array is reset before the search. After the call,
  * use the returned count and #meos_array_get to read the matching IDs.
  * The same array can be reused across multiple searches without reallocating.
  * @param[in] rtree The RTree to query
- * @param[in] op The search operation: @p RTREE_OVERLAPS finds boxes that
- * overlap the query, @p RTREE_CONTAINS finds boxes that contain the query,
- * @p RTREE_CONTAINED_BY finds boxes contained by the query
+ * @param[in] op The search operation: @p INDEX_OVERLAPS finds boxes that
+ * overlap the query, @p INDEX_CONTAINS finds boxes that contain the query,
+ * @p INDEX_CONTAINED_BY finds boxes contained by the query
  * @param[in] query The bounding box that serves as query
  * @param[out] result MeosArray of int to collect matching IDs (created by the
  * caller with `meos_array_create(sizeof(int64))`)
  * @return Number of matching IDs
  */
 int
-rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
+rtree_search(const RTree *rtree, IndexSearchOp op, const void *query,
   MeosArray *result)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rtree, INT_MAX); VALIDATE_NOT_NULL(query, INT_MAX);
+  VALIDATE_NOT_NULL(result, INT_MAX);
+  if (! ensure_valid_rtree_box(rtree, query))
+    return INT_MAX;
+
   meos_array_reset(result);
   if (rtree->root)
     node_search(rtree, rtree->root, op, query, result);
@@ -1273,7 +1489,7 @@ rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
 }
 
 /**
- * @ingroup meos_geo_box_index
+ * @ingroup meos_temporal_box_index
  * @brief Join two RTrees, collecting the ids of every qualifying pair into a
  * MeosArray
  * @details Descends both trees at once, skipping the entries of a subtree pair
@@ -1284,16 +1500,16 @@ rtree_search(const RTree *rtree, RTreeSearchOp op, const void *query,
  * entry of @p rtree1 followed by the entry of @p rtree2, so pair `k` is read
  * with #meos_array_get at positions `2 * k` and `2 * k + 1`.
  * @param[in] rtree1,rtree2 The RTrees to join, of the same bounding box type
- * @param[in] op The join operation: @p RTREE_OVERLAPS pairs entries that
- * overlap, @p RTREE_CONTAINS pairs entries of @p rtree1 that contain an entry
- * of @p rtree2, @p RTREE_CONTAINED_BY pairs entries of @p rtree1 contained by
+ * @param[in] op The join operation: @p INDEX_OVERLAPS pairs entries that
+ * overlap, @p INDEX_CONTAINS pairs entries of @p rtree1 that contain an entry
+ * of @p rtree2, @p INDEX_CONTAINED_BY pairs entries of @p rtree1 contained by
  * an entry of @p rtree2
  * @param[out] result MeosArray of int to collect the ids (created by the caller
  * with `meos_array_create(sizeof(int64))`)
  * @return Number of qualifying pairs, half the number of collected ids
  */
 int
-rtree_join(const RTree *rtree1, const RTree *rtree2, RTreeSearchOp op,
+rtree_join(const RTree *rtree1, const RTree *rtree2, IndexSearchOp op,
   MeosArray *result)
 {
   assert(rtree1->bboxtype == rtree2->bboxtype);
@@ -1316,17 +1532,17 @@ rtree_join(const RTree *rtree1, const RTree *rtree2, RTreeSearchOp op,
  * @param[in] temp The temporal value to be inserted
  * @param[in] id The id of the temporal value being inserted
  */
-void
+bool
 rtree_insert_temporal(RTree *rtree, const Temporal *temp, int64 id)
 {
   if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
-    return;
+    return false;
   /* Use a stack buffer large enough for any MEOS bounding box type */
   bboxunion buf;
   memset(&buf, 0, sizeof(buf));
   temporal_set_bbox(temp, &buf);
   rtree_insert(rtree, &buf, id);
-  return;
+  return true;
 }
 
 /**
@@ -1342,7 +1558,7 @@ rtree_insert_temporal(RTree *rtree, const Temporal *temp, int64 id)
  * @return Number of matching IDs
  */
 int
-rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
+rtree_search_temporal(const RTree *rtree, IndexSearchOp op,
   const Temporal *temp, MeosArray *result)
 {
   if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
@@ -1395,20 +1611,20 @@ rtree_search_temporal(const RTree *rtree, RTreeSearchOp op,
  * values `<= 1` degenerate to the single minimum bounding box
  * @see rtree_insert_temporal
  */
-void
+bool
 rtree_insert_temporal_split(RTree *rtree, const Temporal *temp, int64 id,
   int maxboxes)
 {
   if (! ensure_bbox_temporal_compatible(rtree->bboxtype, temp))
-    return;
+    return false;
   int count;
   void *boxes = bbox_temporal_split_boxes(rtree->bboxtype, rtree->bboxsize, temp, maxboxes, &count);
   if (! boxes)
-    return;
+    return true;
   for (int i = 0; i < count; i++)
     rtree_insert(rtree, (char *) boxes + (size_t) i * rtree->bboxsize, id);
   pfree(boxes);
-  return;
+  return true;
 }
 
 /**
@@ -1446,7 +1662,7 @@ rtree_id_cmp(const void *a, const void *b)
 }
 
 int
-rtree_search_temporal_dedup(const RTree *rtree, RTreeSearchOp op,
+rtree_search_temporal_dedup(const RTree *rtree, IndexSearchOp op,
   const Temporal *temp, int maxboxes, MeosArray *result)
 {
   meos_array_reset(result);
@@ -1641,7 +1857,7 @@ nn_heap_pop(RTreeNNCursor *cursor)
 }
 
 /**
- * @ingroup meos_geo_box_index
+ * @ingroup meos_temporal_box_index
  * @brief Open a nearest-neighbour cursor that yields the ids stored in an
  * RTree in order of increasing distance to a query bounding box
  * @details The cursor performs an incremental best-first traversal: repeated
@@ -1683,7 +1899,7 @@ rtree_nn_cursor_open(const RTree *rtree, const void *query)
 }
 
 /**
- * @ingroup meos_geo_box_index
+ * @ingroup meos_temporal_box_index
  * @brief Advance a nearest-neighbour cursor to the next closest id
  * @details Returns the next id in order of increasing distance to the query
  * box. When @p id_out or @p dist_out is not @p NULL it receives the id and its
@@ -1737,7 +1953,7 @@ rtree_nn_cursor_next(RTreeNNCursor *cursor, int64 *id_out, double *dist_out)
 }
 
 /**
- * @ingroup meos_geo_box_index
+ * @ingroup meos_temporal_box_index
  * @brief Close a nearest-neighbour cursor and free its resources
  * @param[in] cursor The cursor to close; @p NULL is ignored
  */
@@ -1770,6 +1986,97 @@ node_free(RTreeNode *node)
       node_free(node->nodes[i]);
   }
   pfree(node);
+}
+
+/*****************************************************************************
+ * What an index holds
+ *
+ * An RTree is an opaque handle, so the size and the shape of the tree are
+ * reported by the index itself rather than read from its layout. A consumer
+ * accounting for the memory an index holds, or a test asserting that a build
+ * chooses the depth rather than following the order the entries arrive in,
+ * asks here.
+ *****************************************************************************/
+
+/**
+ * @brief Accumulate the entries, the bytes and the depth of a subtree
+ */
+static void
+node_stats(const RTreeNode *node, size_t bboxsize, int level, int *entries,
+  int64 *bytes, int *height)
+{
+  *bytes += (int64) (sizeof(RTreeNode) + bboxsize * MAXITEMS);
+  if (level > *height)
+    *height = level;
+  if (node->node_type == RTREE_LEAF)
+  {
+    *entries += node->count;
+    return;
+  }
+  for (int i = 0; i < node->count; i++)
+    node_stats(node->nodes[i], bboxsize, level + 1, entries, bytes, height);
+  return;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Return the number of entries an RTree holds
+ * @param[in] rtree The RTree
+ * @return On error return @p INT_MAX
+ */
+int
+rtree_num_entries(const RTree *rtree)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rtree, INT_MAX);
+  if (! rtree->root)
+    return 0;
+  int entries = 0, height = 0;
+  int64 bytes = 0;
+  node_stats(rtree->root, rtree->bboxsize, 1, &entries, &bytes, &height);
+  return entries;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Return the number of bytes an RTree holds
+ * @details The nodes of the tree and the tree itself, which is what a caller
+ * accounting for the memory of an index reports
+ * @param[in] rtree The RTree
+ * @return On error return @p INT64_MAX
+ */
+int64
+rtree_mem_size(const RTree *rtree)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rtree, INT64_MAX);
+  int64 bytes = (int64) (sizeof(RTree) + rtree->bboxsize);
+  if (rtree->root)
+  {
+    int entries = 0, height = 0;
+    node_stats(rtree->root, rtree->bboxsize, 1, &entries, &bytes, &height);
+  }
+  return bytes;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Return the number of levels an RTree holds
+ * @details An empty tree has no levels and a tree whose root is a leaf has one
+ * @param[in] rtree The RTree
+ * @return On error return @p INT_MAX
+ */
+int
+rtree_height(const RTree *rtree)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rtree, INT_MAX);
+  if (! rtree->root)
+    return 0;
+  int entries = 0, height = 0;
+  int64 bytes = 0;
+  node_stats(rtree->root, rtree->bboxsize, 1, &entries, &bytes, &height);
+  return height;
 }
 
 /**

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -42,17 +42,20 @@
 
 /* C */
 #include <stdlib.h>
+#include <limits.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_geo.h>
 #include <meos_internal.h>
 #if POINTCLOUD
   #include <meos_pointcloud.h>
+  #include "pointcloud/tpc_boxops.h"
 #endif
 #include "temporal/temporal.h"
 #include "temporal/span_index.h"
 #include "temporal/tbox_index.h"
 #include "geo/stbox_index.h"
+#include "geo/geo_funcs.h"
 #include "temporal/temporal_sptree.h"
 
 /*****************************************************************************
@@ -113,27 +116,59 @@ span_kdtree_next(const void *nodebox, const void *centroid, uint8 node,
     node, level, (SpanNode *) next);
 }
 
-static bool
-span_inner_consistent(const void *nodebox, const void *query, RTreeSearchOp op)
+/**
+ * @brief Fill a span with the smallest one covering every span of a region
+ * @details The lower bounds of a region are held by its left corner and the
+ * upper bounds by its right one, so the covering span reads one from each
+ */
+static void
+span_nodebox_envelope(const void *nodebox, void *out)
 {
   const SpanNode *n = (const SpanNode *) nodebox;
-  const Span *q = (const Span *) query;
-  if (op == RTREE_CONTAINS)
-    return contain2D(n, q);
-  /* RTREE_OVERLAPS and RTREE_CONTAINED_BY prune on overlap */
-  return overlap2D(n, q);
+  Span *o = (Span *) out;
+  memcpy(o, &n->left, sizeof(Span));
+  o->upper = n->right.upper;
+  o->upper_inc = n->right.upper_inc;
+  return;
 }
 
 static bool
-span_leaf_consistent(const void *key, const void *query, RTreeSearchOp op)
+span_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
+{
+  const SpanNode *n = (const SpanNode *) nodebox;
+  const Span *q = (const Span *) query;
+  switch (op)
+  {
+    case INDEX_CONTAINS:
+      return contain2D(n, q);
+    case INDEX_LEFT:      return ! overRight2D(n, q);
+    case INDEX_OVERLEFT:  return ! right2D(n, q);
+    case INDEX_RIGHT:     return ! overLeft2D(n, q);
+    case INDEX_OVERRIGHT: return ! left2D(n, q);
+    default:
+      /* INDEX_OVERLAPS and INDEX_CONTAINED_BY prune on overlap */
+      return overlap2D(n, q);
+  }
+}
+
+static bool
+span_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
 {
   const Span *k = (const Span *) key;
   const Span *q = (const Span *) query;
-  if (op == RTREE_CONTAINS)
-    return contains_span_span(k, q);
-  if (op == RTREE_CONTAINED_BY)
-    return contains_span_span(q, k);
-  return overlaps_span_span(k, q);
+  switch (op)
+  {
+    case INDEX_CONTAINS:      return contains_span_span(k, q);
+    case INDEX_CONTAINED_BY:  return contains_span_span(q, k);
+    case INDEX_OVERLAPS:      return overlaps_span_span(k, q);
+    case INDEX_LEFT:          return left_span_span(k, q);
+    case INDEX_OVERLEFT:      return overleft_span_span(k, q);
+    case INDEX_RIGHT:         return right_span_span(k, q);
+    case INDEX_OVERRIGHT:     return overright_span_span(k, q);
+    default:
+      /* A span has one dimension, which the value operations order */
+      return false;
+  }
 }
 
 /*****************************************************************************
@@ -169,26 +204,66 @@ tbox_kdtree_next(const void *nodebox, const void *centroid, uint8 node,
     node, level, (TboxNode *) next);
 }
 
-static bool
-tbox_inner_consistent(const void *nodebox, const void *query, RTreeSearchOp op)
+/**
+ * @brief Fill a temporal box with the smallest one covering every box of a
+ * region
+ */
+static void
+tbox_nodebox_envelope(const void *nodebox, void *out)
 {
   const TboxNode *n = (const TboxNode *) nodebox;
-  const TBox *q = (const TBox *) query;
-  if (op == RTREE_CONTAINS)
-    return contain4D(n, q);
-  return overlap4D(n, q);
+  TBox *o = (TBox *) out;
+  memcpy(o, &n->left, sizeof(TBox));
+  o->span.upper = n->right.span.upper;
+  o->period.upper = n->right.period.upper;
+  return;
 }
 
 static bool
-tbox_leaf_consistent(const void *key, const void *query, RTreeSearchOp op)
+tbox_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
+{
+  const TboxNode *n = (const TboxNode *) nodebox;
+  const TBox *q = (const TBox *) query;
+  switch (op)
+  {
+    case INDEX_CONTAINS:
+      return contain4D(n, q);
+    case INDEX_LEFT:       return ! overRight4D(n, q);
+    case INDEX_OVERLEFT:   return ! right4D(n, q);
+    case INDEX_RIGHT:      return ! overLeft4D(n, q);
+    case INDEX_OVERRIGHT:  return ! left4D(n, q);
+    case INDEX_BEFORE:     return ! overAfter4D(n, q);
+    case INDEX_OVERBEFORE: return ! after4D(n, q);
+    case INDEX_AFTER:      return ! overBefore4D(n, q);
+    case INDEX_OVERAFTER:  return ! before4D(n, q);
+    default:
+      /* INDEX_OVERLAPS and INDEX_CONTAINED_BY prune on overlap */
+      return overlap4D(n, q);
+  }
+}
+
+static bool
+tbox_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
 {
   const TBox *k = (const TBox *) key;
   const TBox *q = (const TBox *) query;
-  if (op == RTREE_CONTAINS)
-    return contains_tbox_tbox(k, q);
-  if (op == RTREE_CONTAINED_BY)
-    return contains_tbox_tbox(q, k);
-  return overlaps_tbox_tbox(k, q);
+  switch (op)
+  {
+    case INDEX_CONTAINS:      return contains_tbox_tbox(k, q);
+    case INDEX_CONTAINED_BY:  return contains_tbox_tbox(q, k);
+    case INDEX_OVERLAPS:      return overlaps_tbox_tbox(k, q);
+    case INDEX_LEFT:          return left_tbox_tbox(k, q);
+    case INDEX_OVERLEFT:      return overleft_tbox_tbox(k, q);
+    case INDEX_RIGHT:         return right_tbox_tbox(k, q);
+    case INDEX_OVERRIGHT:     return overright_tbox_tbox(k, q);
+    case INDEX_BEFORE:        return before_tbox_tbox(k, q);
+    case INDEX_OVERBEFORE:    return overbefore_tbox_tbox(k, q);
+    case INDEX_AFTER:         return after_tbox_tbox(k, q);
+    case INDEX_OVERAFTER:     return overafter_tbox_tbox(k, q);
+    default:
+      /* A temporal box has no spatial dimension to be below or in front of */
+      return false;
+  }
 }
 
 /*****************************************************************************
@@ -230,26 +305,86 @@ stbox_kdtree_next(const void *nodebox, const void *centroid, uint8 node,
     node, level, (STboxNode *) next);
 }
 
-static bool
-stbox_inner_consistent(const void *nodebox, const void *query, RTreeSearchOp op)
+/**
+ * @brief Fill a spatiotemporal box with the smallest one covering every box of
+ * a region
+ */
+static void
+stbox_nodebox_envelope(const void *nodebox, void *out)
 {
   const STboxNode *n = (const STboxNode *) nodebox;
-  const STBox *q = (const STBox *) query;
-  if (op == RTREE_CONTAINS)
-    return contain8D(n, q);
-  return overlap8D(n, q);
+  STBox *o = (STBox *) out;
+  memcpy(o, &n->left, sizeof(STBox));
+  o->xmax = n->right.xmax;
+  o->ymax = n->right.ymax;
+  o->zmax = n->right.zmax;
+  o->period.upper = n->right.period.upper;
+  return;
 }
 
 static bool
-stbox_leaf_consistent(const void *key, const void *query, RTreeSearchOp op)
+stbox_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
+{
+  const STboxNode *n = (const STboxNode *) nodebox;
+  const STBox *q = (const STBox *) query;
+  switch (op)
+  {
+    case INDEX_CONTAINS:
+      return contain8D(n, q);
+    case INDEX_OVERLAPS:
+    case INDEX_CONTAINED_BY:
+      return overlap8D(n, q);
+    /* A region can hold a box on one side of the query only when the region
+     * itself reaches that side, which is the negation of the opposite
+     * relation. The same descent the SP-GiST operator classes make */
+    case INDEX_LEFT:       return ! overRight8D(n, q);
+    case INDEX_OVERLEFT:   return ! right8D(n, q);
+    case INDEX_RIGHT:      return ! overLeft8D(n, q);
+    case INDEX_OVERRIGHT:  return ! left8D(n, q);
+    case INDEX_BELOW:      return ! overAbove8D(n, q);
+    case INDEX_OVERBELOW:  return ! above8D(n, q);
+    case INDEX_ABOVE:      return ! overBelow8D(n, q);
+    case INDEX_OVERABOVE:  return ! below8D(n, q);
+    case INDEX_FRONT:      return ! overBack8D(n, q);
+    case INDEX_OVERFRONT:  return ! back8D(n, q);
+    case INDEX_BACK:       return ! overFront8D(n, q);
+    case INDEX_OVERBACK:   return ! front8D(n, q);
+    case INDEX_BEFORE:     return ! overAfter8D(n, q);
+    case INDEX_OVERBEFORE: return ! after8D(n, q);
+    case INDEX_AFTER:      return ! overBefore8D(n, q);
+    case INDEX_OVERAFTER:  return ! before8D(n, q);
+  }
+  return false;
+}
+
+static bool
+stbox_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
 {
   const STBox *k = (const STBox *) key;
   const STBox *q = (const STBox *) query;
-  if (op == RTREE_CONTAINS)
-    return contains_stbox_stbox(k, q);
-  if (op == RTREE_CONTAINED_BY)
-    return contains_stbox_stbox(q, k);
-  return overlaps_stbox_stbox(k, q);
+  switch (op)
+  {
+    case INDEX_CONTAINS:      return contains_stbox_stbox(k, q);
+    case INDEX_CONTAINED_BY:  return contains_stbox_stbox(q, k);
+    case INDEX_OVERLAPS:      return overlaps_stbox_stbox(k, q);
+    case INDEX_LEFT:          return left_stbox_stbox(k, q);
+    case INDEX_OVERLEFT:      return overleft_stbox_stbox(k, q);
+    case INDEX_RIGHT:         return right_stbox_stbox(k, q);
+    case INDEX_OVERRIGHT:     return overright_stbox_stbox(k, q);
+    case INDEX_BELOW:         return below_stbox_stbox(k, q);
+    case INDEX_OVERBELOW:     return overbelow_stbox_stbox(k, q);
+    case INDEX_ABOVE:         return above_stbox_stbox(k, q);
+    case INDEX_OVERABOVE:     return overabove_stbox_stbox(k, q);
+    case INDEX_FRONT:         return front_stbox_stbox(k, q);
+    case INDEX_OVERFRONT:     return overfront_stbox_stbox(k, q);
+    case INDEX_BACK:          return back_stbox_stbox(k, q);
+    case INDEX_OVERBACK:      return overback_stbox_stbox(k, q);
+    case INDEX_BEFORE:        return before_stbox_stbox(k, q);
+    case INDEX_OVERBEFORE:    return overbefore_stbox_stbox(k, q);
+    case INDEX_AFTER:         return after_stbox_stbox(k, q);
+    case INDEX_OVERAFTER:     return overafter_stbox_stbox(k, q);
+  }
+  return false;
 }
 
 #if POINTCLOUD
@@ -310,6 +445,7 @@ sptree_create(MeosType bboxtype, SPTreeKind kind)
     sptree->nodebox_init = &span_nodebox_init;
     sptree->quadtree_next = &span_quadtree_next;
     sptree->kdtree_next = &span_kdtree_next;
+    sptree->nodebox_envelope = &span_nodebox_envelope;
     sptree->inner_consistent = &span_inner_consistent;
     sptree->leaf_consistent = &span_leaf_consistent;
   }
@@ -322,6 +458,7 @@ sptree_create(MeosType bboxtype, SPTreeKind kind)
     sptree->nodebox_init = &tbox_nodebox_init;
     sptree->quadtree_next = &tbox_quadtree_next;
     sptree->kdtree_next = &tbox_kdtree_next;
+    sptree->nodebox_envelope = &tbox_nodebox_envelope;
     sptree->inner_consistent = &tbox_inner_consistent;
     sptree->leaf_consistent = &tbox_leaf_consistent;
   }
@@ -340,6 +477,7 @@ sptree_create(MeosType bboxtype, SPTreeKind kind)
     sptree->nodebox_init = &stbox_nodebox_init;
     sptree->quadtree_next = &stbox_quadtree_next;
     sptree->kdtree_next = &stbox_kdtree_next;
+    sptree->nodebox_envelope = &stbox_nodebox_envelope;
     sptree->inner_consistent = &stbox_inner_consistent;
     sptree->leaf_consistent = &stbox_leaf_consistent;
   }
@@ -355,6 +493,7 @@ sptree_create(MeosType bboxtype, SPTreeKind kind)
     sptree->nodebox_init = &stbox_nodebox_init;
     sptree->quadtree_next = &stbox_quadtree_next;
     sptree->kdtree_next = &stbox_kdtree_next;
+    sptree->nodebox_envelope = &stbox_nodebox_envelope;
     sptree->inner_consistent = &stbox_inner_consistent;
     sptree->leaf_consistent = &stbox_leaf_consistent;
   }
@@ -485,18 +624,92 @@ spnode_make(const SPTree *sptree, const void *box, int64 id)
 }
 
 /**
+ * @brief Return the number of dimensions a box type carries, for a type that
+ * determines it from the data rather than from the type
+ * @details An STBox tree partitions on 6 dimensions for 2D+T and on 8 for
+ * 3D+T, so the dimensions, the bit each level narrows and the number of
+ * children per node are all read from the first box the tree receives.
+ */
+static void
+sptree_set_dims(SPTree *sptree, const void *box)
+{
+  sptree->dims = sptree->box_dims(box);
+  sptree->kd_bits = (sptree->dims == 8) ? STBOX_KD_BITS_Z : STBOX_KD_BITS;
+  sptree->nchild = (sptree->kind == SPTREE_QUADTREE) ? (1 << sptree->dims) : 2;
+  return;
+}
+
+/**
+ * @brief Return the child slot a box occupies under a node at a given level
+ * @details A quad-tree slot is the whole quadrant of the box with respect to
+ * the centroid. A k-d tree slot is the single bit of that quadrant carrying
+ * the dimension the search narrows at this level, so that the region a search
+ * descends into is the region the box was partitioned by.
+ * @param[in] sptree The SPTree
+ * @param[in] centroid The bounding box held by the node
+ * @param[in] box The bounding box being placed or sought
+ * @param[in] level The depth of the node
+ */
+static int
+spnode_child(const SPTree *sptree, const void *centroid, const void *box,
+  int level)
+{
+  uint8 quadrant = sptree->get_quadrant(centroid, box);
+  return (sptree->kind == SPTREE_QUADTREE) ? (int) quadrant :
+    (int) ((quadrant >> sptree->kd_bits[level % sptree->dims]) & 1);
+}
+
+/**
+ * @brief Return true if a box may enter or query an SPTree, report an error
+ * otherwise
+ * @details A tree holds boxes of one SRID: the first entry fixes it, and a box
+ * of another one is an error rather than a coercion. The check belongs here,
+ * at the entry point, so that every comparison the descent makes can assume it
+ */
+static bool
+ensure_valid_sptree_box(const SPTree *sptree, const void *box)
+{
+  if (! sptree->root)
+    return true;
+  if (sptree->bboxtype == T_STBOX)
+    return ensure_same_srid(((const STBox *) sptree->root->centroid)->srid,
+      ((const STBox *) box)->srid);
+#if POINTCLOUD
+  if (sptree->bboxtype == T_TPCBOX)
+  {
+    /* A tpcbox tree holds its centroids already projected to STBox, so only
+     * the incoming box is projected here */
+    STBox s;
+    tpcbox_set_stbox((const TPCBox *) box, &s);
+    return ensure_same_srid(((const STBox *) sptree->root->centroid)->srid,
+      s.srid);
+  }
+#endif /* POINTCLOUD */
+  return true;
+}
+
+/**
  * @ingroup meos_temporal_box_index
  * @brief Insert a bounding box into an in-memory space-partitioning index
  * @details The box is stored at the first empty child slot reached while
  * descending from the root by quadrant. Equal boxes chain through the first
  * child, so the search still finds every id.
+ *
+ * The depth a box reaches depends on the order the boxes arrive in, so a tree
+ * grown from an ordered set is deep and prunes little. #sptree_load builds the
+ * same index from a whole entry set at once and chooses the depth itself.
  * @param[in] sptree The SPTree previously initialized
  * @param[in] box The bounding box to insert
  * @param[in] id The id associated with the box
  */
-void
+bool
 sptree_insert(SPTree *sptree, void *box, int64 id)
 {
+  /* Ensure the validity of the arguments */
+  if (! ensure_not_null((void *) sptree) || ! ensure_not_null((void *) box) ||
+      ! ensure_valid_sptree_box(sptree, box))
+    return false;
+
   /* Project the incoming box into the internal box type (TPCBox: STBox) */
   bboxunion proj;
   if (sptree->project)
@@ -504,30 +717,306 @@ sptree_insert(SPTree *sptree, void *box, int64 id)
     sptree->project(box, &proj);
     box = &proj;
   }
-  /* Determine the deferred dimensions from the first box (STBox: 6 for 2D+T,
-   * 8 for 3D+T) and hence the number of children per node */
   if (sptree->dims < 0)
-  {
-    sptree->dims = sptree->box_dims(box);
-    sptree->kd_bits = (sptree->dims == 8) ? STBOX_KD_BITS_Z : STBOX_KD_BITS;
-    sptree->nchild = (sptree->kind == SPTREE_QUADTREE) ?
-      (1 << sptree->dims) : 2;
-  }
+    sptree_set_dims(sptree, box);
   SPNode **slot = &sptree->root;
   int level = 0;
   while (*slot != NULL)
   {
-    uint8 quadrant = sptree->get_quadrant((*slot)->centroid, box);
-    /* Store the box under the bit of the dimension the search narrows at this
-     * level, so that the region a search descends into is the region the box
-     * was partitioned by */
-    int child = (sptree->kind == SPTREE_QUADTREE) ? (int) quadrant :
-      (int) ((quadrant >> sptree->kd_bits[level % sptree->dims]) & 1);
-    slot = &(*slot)->children[child];
+    slot = &(*slot)->children[spnode_child(sptree, (*slot)->centroid, box,
+      level)];
     level++;
   }
   *slot = spnode_make(sptree, box, id);
+  return true;
+}
+
+/*****************************************************************************
+ * Build from a whole entry set
+ *****************************************************************************/
+
+/* The build releases the nodes the tree holds, which the recursive release
+ * below it does */
+static void spnode_free(const SPTree *sptree, SPNode *node);
+
+/**
+ * @brief The entries a build is arranging, and the scratch it arranges them in
+ * @details The boxes are held in the internal box type and are permuted in
+ * place, each permutation carrying its id along, so that the entries of a
+ * subtree occupy a contiguous range and a node is described by a position and
+ * a count.
+ */
+typedef struct
+{
+  SPTree *sptree;
+  char *boxes;        /**< The entries, in the internal box type */
+  int64 *ids;         /**< The id of each entry, permuted with the boxes */
+  void *tmpbox;       /**< Holds one box while two entries are exchanged */
+  void *pivotbox;     /**< Holds the box a selection compares against */
+  char *scratchboxes; /**< Receives one range while it is being bucketed */
+  int64 *scratchids;
+} SPBuild;
+
+/**
+ * @brief Return the address of the n-th box of an array of internal boxes
+ */
+static void *
+spbox_n(const SPTree *sptree, char *boxes, int n)
+{
+  return (void *) (boxes + (size_t) n * sptree->boxsize);
+}
+
+/**
+ * @brief Exchange two entries
+ */
+static void
+spitems_swap(SPBuild *build, int i, int j)
+{
+  const SPTree *sptree = build->sptree;
+  if (i == j)
+    return;
+  void *boxi = spbox_n(sptree, build->boxes, i);
+  void *boxj = spbox_n(sptree, build->boxes, j);
+  memcpy(build->tmpbox, boxi, sptree->boxsize);
+  memcpy(boxi, boxj, sptree->boxsize);
+  memcpy(boxj, build->tmpbox, sptree->boxsize);
+  int64 id = build->ids[i];
+  build->ids[i] = build->ids[j];
+  build->ids[j] = id;
   return;
+}
+
+/**
+ * @brief Return true if @p box is above @p base on the dimension a quadrant
+ * bit carries
+ * @details The order is the one the tree itself partitions by: the quadrant of
+ * @p box with respect to @p base carries the bit exactly when @p box is above
+ * @p base on that dimension. Reading it in both directions distinguishes the
+ * boxes that tie on the dimension from those that are below.
+ */
+static bool
+spbox_above(const SPTree *sptree, const void *box, const void *base, uint8 bit)
+{
+  return ((sptree->get_quadrant(base, box) >> bit) & 1) != 0;
+}
+
+/**
+ * @brief Reorder a range so that the entry at position @p k is the one the
+ * dimension of @p bit orders there
+ * @details Every entry before @p k is then no higher on that dimension and
+ * every entry after it is no lower, which is all a build needs to choose a
+ * centroid that halves the range. The entries that tie with the one compared
+ * against are gathered in one pass, so a range that ties throughout is
+ * recognised at once rather than peeled one entry at a time.
+ * @param[in] build The entries being arranged
+ * @param[in] from,count The range
+ * @param[in] k Position, relative to @p from, to settle
+ * @param[in] bit Quadrant bit carrying the dimension to order on
+ */
+static void
+spitems_select(SPBuild *build, int from, int count, int k, uint8 bit)
+{
+  const SPTree *sptree = build->sptree;
+  int lo = from, hi = from + count - 1;
+  k += from;
+  while (lo < hi)
+  {
+    /* Compare against the middle entry of the range, held aside since its
+     * position takes part in the exchanges below */
+    spitems_swap(build, lo + (hi - lo) / 2, lo);
+    memcpy(build->pivotbox, spbox_n(sptree, build->boxes, lo),
+      sptree->boxsize);
+    /* Gather the range into the entries below the one compared against, those
+     * tying with it, and those above it */
+    int lt = lo, i = lo, gt = hi;
+    while (i <= gt)
+    {
+      const void *box = spbox_n(sptree, build->boxes, i);
+      if (spbox_above(sptree, build->pivotbox, box, bit))
+        spitems_swap(build, lt++, i++);
+      else if (spbox_above(sptree, box, build->pivotbox, bit))
+        spitems_swap(build, i, gt--);
+      else
+        i++;
+    }
+    if (k < lt)
+      hi = lt - 1;
+    else if (k > gt)
+      lo = gt + 1;
+    else
+      return;
+  }
+  return;
+}
+
+/**
+ * @brief Gather a range into contiguous buckets, one per child slot of a node
+ * @param[in] build The entries being arranged
+ * @param[in] from,count The range
+ * @param[in] centroid The bounding box held by the node
+ * @param[in] level The depth of the node
+ * @param[out] counts Number of entries of each child slot, in slot order
+ */
+static void
+spitems_bucket(SPBuild *build, int from, int count, const void *centroid,
+  int level, int *counts)
+{
+  const SPTree *sptree = build->sptree;
+  int nchild = sptree->nchild;
+  memset(counts, 0, (size_t) nchild * sizeof(int));
+  for (int i = 0; i < count; i++)
+    counts[spnode_child(sptree, centroid,
+      spbox_n(sptree, build->boxes, from + i), level)]++;
+  /* The first position of each bucket, which filling it then advances */
+  int *cursor = palloc((size_t) nchild * sizeof(int));
+  int offset = 0;
+  for (int c = 0; c < nchild; c++)
+  {
+    cursor[c] = offset;
+    offset += counts[c];
+  }
+  for (int i = 0; i < count; i++)
+  {
+    const void *box = spbox_n(sptree, build->boxes, from + i);
+    int pos = cursor[spnode_child(sptree, centroid, box, level)]++;
+    memcpy(spbox_n(sptree, build->scratchboxes, pos), box, sptree->boxsize);
+    build->scratchids[pos] = build->ids[from + i];
+  }
+  memcpy(spbox_n(sptree, build->boxes, from), build->scratchboxes,
+    (size_t) count * sptree->boxsize);
+  memcpy(build->ids + from, build->scratchids,
+    (size_t) count * sizeof(int64));
+  pfree(cursor);
+  return;
+}
+
+/**
+ * @brief Build the subtree holding a range of entries
+ * @details The centroid is the entry the level's dimension orders in the
+ * middle, so a k-d node hands half the range to each of its two children and
+ * the depth is logarithmic in the number of entries whatever order they
+ * arrive in. The remaining entries go to the child slot an insertion would
+ * descend into at this level, which is what makes the result a tree the search
+ * reads like any other.
+ *
+ * Entries that a slot cannot separate, equal boxes above all, descend as a
+ * chain, exactly as inserting them one by one produces.
+ * @param[in] build The entries being arranged
+ * @param[in] from,count The range
+ * @param[in] level The depth of the subtree root
+ */
+static SPNode *
+spnode_build(SPBuild *build, int from, int count, int level)
+{
+  SPTree *sptree = build->sptree;
+  if (count <= 0)
+    return NULL;
+
+  int mid = count / 2;
+  spitems_select(build, from, count, mid,
+    sptree->kd_bits[level % sptree->dims]);
+  SPNode *node = spnode_make(sptree,
+    spbox_n(sptree, build->boxes, from + mid), build->ids[from + mid]);
+
+  /* The node holds a copy of its centroid, so the entry it was taken from
+   * leaves the range through its end */
+  spitems_swap(build, from + mid, from + count - 1);
+  int rest = count - 1;
+  if (rest > 0)
+  {
+    int *counts = palloc((size_t) sptree->nchild * sizeof(int));
+    spitems_bucket(build, from, rest, node->centroid, level, counts);
+    int offset = 0;
+    for (int c = 0; c < sptree->nchild; c++)
+    {
+      if (counts[c] > 0)
+        node->children[c] = spnode_build(build, from + offset, counts[c],
+          level + 1);
+      offset += counts[c];
+    }
+    pfree(counts);
+  }
+  return node;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Build an in-memory space-partitioning index from all of its entries
+ * at once
+ * @details Top-down median partitioning. The result answers the same queries
+ * as inserting every entry one by one, but the whole set is known in advance,
+ * so each node halves what is left of its range on the dimension its level
+ * narrows and the depth no longer depends on the order the entries arrive in.
+ * The kind of tree given at creation is the kind that is built: a quad-tree
+ * node hands the entries to one of its @p 2^dims quadrant slots, a k-d tree
+ * node to one of its two.
+ *
+ * The tree ends up holding exactly the entries given, whatever it holds on
+ * entry, so this is both the fast first build and the only way to make an
+ * index smaller: an index has no removal entry point, and a caller that has to
+ * drop entries rebuilds from the ones it keeps. Loading no entries leaves an
+ * empty tree.
+ * @param[in] sptree An SPTree of the appropriate bounding box type
+ * @param[in] boxes Contiguous array of @p count boxes of the tree bbox size
+ * @param[in] ids The id of each box
+ * @param[in] count Number of entries
+ */
+bool
+sptree_load(SPTree *sptree, const void *boxes, const int64 *ids, int count)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_not_null((void *) sptree) || ! ensure_not_null((void *) boxes) ||
+      ! ensure_not_null((void *) ids) || ! ensure_valid_sptree_box(sptree, boxes))
+    return false;
+
+  /* The build assigns the root, so the nodes the tree holds are released
+   * before it does, and are released whatever the number of entries given: an
+   * empty entry set leaves an empty tree rather than the previous one */
+  if (sptree->root)
+  {
+    spnode_free(sptree, sptree->root);
+    sptree->root = NULL;
+  }
+
+  if (count <= 0)
+    return true;
+
+  /* A type indexed through a projection is given boxes of its own type and
+   * holds them as the type it partitions (TPCBox: STBox), so the entries are
+   * read at the stride of the type and held at the stride of the tree */
+  size_t insize = bbox_get_size(sptree->bboxtype);
+  SPBuild build;
+  build.sptree = sptree;
+  build.boxes = palloc((size_t) count * sptree->boxsize);
+  for (int i = 0; i < count; i++)
+  {
+    const void *in = (const char *) boxes + (size_t) i * insize;
+    void *out = spbox_n(sptree, build.boxes, i);
+    if (sptree->project)
+      sptree->project(in, out);
+    else
+      memcpy(out, in, sptree->boxsize);
+  }
+
+  if (sptree->dims < 0)
+    sptree_set_dims(sptree, build.boxes);
+
+  build.ids = palloc((size_t) count * sizeof(int64));
+  memcpy(build.ids, ids, (size_t) count * sizeof(int64));
+  build.tmpbox = palloc(sptree->boxsize);
+  build.pivotbox = palloc(sptree->boxsize);
+  build.scratchboxes = palloc((size_t) count * sptree->boxsize);
+  build.scratchids = palloc((size_t) count * sizeof(int64));
+
+  sptree->root = spnode_build(&build, 0, count, 0);
+
+  pfree(build.scratchids);
+  pfree(build.scratchboxes);
+  pfree(build.pivotbox);
+  pfree(build.tmpbox);
+  pfree(build.ids);
+  pfree(build.boxes);
+  return true;
 }
 
 /*****************************************************************************
@@ -546,7 +1035,7 @@ sptree_insert(SPTree *sptree, void *box, int64 id)
  */
 static void
 spnode_search(const SPTree *sptree, const SPNode *node, const void *nodebox,
-  RTreeSearchOp op, const void *query, int level, MeosArray *result)
+  IndexSearchOp op, const void *query, int level, MeosArray *result)
 {
   if (sptree->leaf_consistent(node->centroid, query, op))
   {
@@ -576,17 +1065,23 @@ spnode_search(const SPTree *sptree, const SPNode *node, const void *nodebox,
  * collecting matching ids into a MeosArray
  * @details The result array is reset before the search.
  * @param[in] sptree The SPTree to query
- * @param[in] op The search operation: @p RTREE_OVERLAPS finds boxes that
- * overlap the query, @p RTREE_CONTAINS finds boxes that contain the query,
- * @p RTREE_CONTAINED_BY finds boxes contained by the query
+ * @param[in] op The search operation: @p INDEX_OVERLAPS finds boxes that
+ * overlap the query, @p INDEX_CONTAINS finds boxes that contain the query,
+ * @p INDEX_CONTAINED_BY finds boxes contained by the query
  * @param[in] query The bounding box that serves as query
  * @param[out] result MeosArray of int to collect matching ids
  * @return Number of matching ids
  */
 int
-sptree_search(const SPTree *sptree, RTreeSearchOp op, const void *query,
+sptree_search(const SPTree *sptree, IndexSearchOp op, const void *query,
   MeosArray *result)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(sptree, INT_MAX); VALIDATE_NOT_NULL(query, INT_MAX);
+  VALIDATE_NOT_NULL(result, INT_MAX);
+  if (! ensure_valid_sptree_box(sptree, query))
+    return INT_MAX;
+
   /* Project the query box into the internal box type (TPCBox: STBox) */
   bboxunion proj;
   if (sptree->project)
@@ -625,17 +1120,17 @@ sptree_search(const SPTree *sptree, RTreeSearchOp op, const void *query,
  * @param[in] temp The temporal value to be inserted
  * @param[in] id The id of the temporal value being inserted
  */
-void
+bool
 sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int64 id)
 {
   if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
-    return;
+    return false;
   /* Use a stack buffer large enough for any MEOS bounding box type */
   bboxunion buf;
   memset(&buf, 0, sizeof(buf));
   temporal_set_bbox(temp, &buf);
   sptree_insert(sptree, &buf, id);
-  return;
+  return true;
 }
 
 /**
@@ -651,7 +1146,7 @@ sptree_insert_temporal(SPTree *sptree, const Temporal *temp, int64 id)
  * @return Number of matching ids
  */
 int
-sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op,
+sptree_search_temporal(const SPTree *sptree, IndexSearchOp op,
   const Temporal *temp, MeosArray *result)
 {
   if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
@@ -683,20 +1178,20 @@ sptree_search_temporal(const SPTree *sptree, RTreeSearchOp op,
  * @param[in] maxboxes Maximum number of bounding boxes produced for `temp`
  * @see sptree_insert_temporal
  */
-void
+bool
 sptree_insert_temporal_split(SPTree *sptree, const Temporal *temp, int64 id,
   int maxboxes)
 {
   if (! ensure_bbox_temporal_compatible(sptree->bboxtype, temp))
-    return;
+    return false;
   int count;
   void *boxes = bbox_temporal_split_boxes(sptree->bboxtype, sizeof(bboxunion), temp, maxboxes, &count);
   if (! boxes)
-    return;
+    return true;
   for (int i = 0; i < count; i++)
     sptree_insert(sptree, (char *) boxes + (size_t) i * sptree->boxsize, id);
   pfree(boxes);
-  return;
+  return true;
 }
 
 /**
@@ -729,7 +1224,7 @@ sptree_id_cmp(const void *a, const void *b)
 }
 
 int
-sptree_search_temporal_dedup(const SPTree *sptree, RTreeSearchOp op,
+sptree_search_temporal_dedup(const SPTree *sptree, IndexSearchOp op,
   const Temporal *temp, int maxboxes, MeosArray *result)
 {
   meos_array_reset(result);
@@ -792,6 +1287,89 @@ spnode_free(const SPTree *sptree, SPNode *node)
   pfree(node->children);
   pfree(node);
   return;
+}
+
+/*****************************************************************************
+ * What an index holds
+ *
+ * An SPTree is an opaque handle, so the size and the shape of the tree are
+ * reported by the index itself rather than read from its layout, as the RTree
+ * reports them.
+ *****************************************************************************/
+
+/**
+ * @brief Accumulate the entries, the bytes and the depth of a subtree
+ * @details Every node of a space-partitioning index holds one entry, its
+ * centroid, so the entries are the nodes
+ */
+static void
+spnode_stats(const SPTree *sptree, const SPNode *node, int level, int *entries,
+  int64 *bytes, int *height)
+{
+  if (! node)
+    return;
+  (*entries)++;
+  *bytes += (int64) (sizeof(SPNode) + sptree->boxsize +
+    (size_t) sptree->nchild * sizeof(SPNode *));
+  if (level > *height)
+    *height = level;
+  for (int i = 0; i < sptree->nchild; i++)
+    spnode_stats(sptree, node->children[i], level + 1, entries, bytes, height);
+  return;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Return the number of entries an SPTree holds
+ * @param[in] sptree The SPTree
+ * @return On error return @p INT_MAX
+ */
+int
+sptree_num_entries(const SPTree *sptree)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(sptree, INT_MAX);
+  int entries = 0, height = 0;
+  int64 bytes = 0;
+  spnode_stats(sptree, sptree->root, 1, &entries, &bytes, &height);
+  return entries;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Return the number of bytes an SPTree holds
+ * @details The nodes of the tree and the tree itself, which is what a caller
+ * accounting for the memory of an index reports
+ * @param[in] sptree The SPTree
+ * @return On error return @p INT64_MAX
+ */
+int64
+sptree_mem_size(const SPTree *sptree)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(sptree, INT64_MAX);
+  int entries = 0, height = 0;
+  int64 bytes = (int64) sizeof(SPTree);
+  spnode_stats(sptree, sptree->root, 1, &entries, &bytes, &height);
+  return bytes;
+}
+
+/**
+ * @ingroup meos_temporal_box_index
+ * @brief Return the number of levels an SPTree holds
+ * @details An empty tree has no levels and a tree of one entry has one
+ * @param[in] sptree The SPTree
+ * @return On error return @p INT_MAX
+ */
+int
+sptree_height(const SPTree *sptree)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(sptree, INT_MAX);
+  int entries = 0, height = 0;
+  int64 bytes = 0;
+  spnode_stats(sptree, sptree->root, 1, &entries, &bytes, &height);
+  return height;
 }
 
 /**

--- a/meos/test/index_position_test.c
+++ b/meos/test/index_position_test.c
@@ -1,0 +1,229 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the position search operations of the in-memory
+ * indexes, i.e., the operations that order a dimension, against the exact
+ * answer and across both index structures.
+ *
+ * An index answers a position operation by two different tests: an entry is
+ * accepted by the operator of the box type, and a subtree is descended when it
+ * can still hold such an entry. The second test is the one that can go wrong
+ * silently, because pruning a subtree that holds matches removes them from the
+ * answer without any other symptom.
+ *
+ * Every configuration is therefore compared against a brute-force answer
+ * computed without any index, and the three structures — the R-tree, the
+ * quad-tree and the k-d tree — are required to agree with it and with each
+ * other. Two properties are asserted per operation:
+ *  (i)   exactness: the index returns every box satisfying the operation and
+ *        no other;
+ *  (ii)  the comparison is not vacuous: over the query set the operation must
+ *        match a substantial number of entries, since an operation that
+ *        matches nothing is satisfied by an index that answers nothing.
+ *
+ * The fixture spreads the entries over both spatial dimensions independently
+ * and holds the time span of every box and every query equal, so that an index
+ * ordering the wrong dimension separates nothing and is caught; and the query
+ * boxes sit inside the extent of the data, so that a query beyond it does not
+ * make an operation trivially true or trivially false.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o index_position_test index_position_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+#define NUM_BOXES 1024
+#define NUM_QUERIES 40
+/* Fewest hits an operation must accumulate over the query set to count */
+#define MIN_HITS 200
+
+typedef struct
+{
+  IndexSearchOp op;
+  const char *name;
+  bool (*oracle)(const STBox *, const STBox *);
+} OpCase;
+
+static bool o_left(const STBox *a, const STBox *b) { return left_stbox_stbox(a, b); }
+static bool o_overleft(const STBox *a, const STBox *b) { return overleft_stbox_stbox(a, b); }
+static bool o_right(const STBox *a, const STBox *b) { return right_stbox_stbox(a, b); }
+static bool o_overright(const STBox *a, const STBox *b) { return overright_stbox_stbox(a, b); }
+static bool o_below(const STBox *a, const STBox *b) { return below_stbox_stbox(a, b); }
+static bool o_overbelow(const STBox *a, const STBox *b) { return overbelow_stbox_stbox(a, b); }
+static bool o_above(const STBox *a, const STBox *b) { return above_stbox_stbox(a, b); }
+static bool o_overabove(const STBox *a, const STBox *b) { return overabove_stbox_stbox(a, b); }
+
+static const OpCase OPS[] = {
+  { INDEX_LEFT,      "left",      o_left },
+  { INDEX_OVERLEFT,  "overleft",  o_overleft },
+  { INDEX_RIGHT,     "right",     o_right },
+  { INDEX_OVERRIGHT, "overright", o_overright },
+  { INDEX_BELOW,     "below",     o_below },
+  { INDEX_OVERBELOW, "overbelow", o_overbelow },
+  { INDEX_ABOVE,     "above",     o_above },
+  { INDEX_OVERABOVE, "overabove", o_overabove },
+};
+#define NUM_OPS (int) (sizeof(OPS) / sizeof(OPS[0]))
+
+static int
+cmp_int64(const void *a, const void *b)
+{
+  int64 x = *(const int64 *) a, y = *(const int64 *) b;
+  return (x > y) - (x < y);
+}
+
+static int
+random_int(int min, int max)
+{
+  return min + rand() % (max - min + 1);
+}
+
+static int64 *
+sorted_of(MeosArray *result, int *count)
+{
+  *count = meos_array_count(result);
+  int64 *ids = malloc(sizeof(int64) * (size_t) (*count ? *count : 1));
+  for (int i = 0; i < *count; i++)
+    ids[i] = *(int64 *) meos_array_get(result, i);
+  qsort(ids, (size_t) *count, sizeof(int64), cmp_int64);
+  return ids;
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  srand(1);
+  int failures = 0;
+  char buf[256];
+
+  STBox *boxes = malloc(sizeof(STBox) * NUM_BOXES);
+  int64 *ids = malloc(sizeof(int64) * NUM_BOXES);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    int x = random_int(0, 1000), y = random_int(0, 1000);
+    snprintf(buf, sizeof(buf),
+      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])",
+      x, y, x + 20, y + 20);
+    STBox *b = stbox_in(buf);
+    memcpy(&boxes[i], b, sizeof(STBox));
+    free(b);
+    ids[i] = (int64) i;
+  }
+
+  /* The three structures the operations must be answered by */
+  RTree *rt = rtree_create_stbox();
+  SPTree *quad = sptree_create_stbox(SPTREE_QUADTREE);
+  SPTree *kd = sptree_create_stbox(SPTREE_KDTREE);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    rtree_insert(rt, &boxes[i], ids[i]);
+    sptree_insert(quad, &boxes[i], ids[i]);
+    sptree_insert(kd, &boxes[i], ids[i]);
+  }
+
+  for (int o = 0; o < NUM_OPS; o++)
+  {
+    int wrong_rt = 0, wrong_quad = 0, wrong_kd = 0, hits = 0;
+    for (int q = 0; q < NUM_QUERIES; q++)
+    {
+      int x = random_int(100, 900), y = random_int(100, 900);
+      snprintf(buf, sizeof(buf),
+        "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])",
+        x, y, x + 40, y + 40);
+      STBox *query = stbox_in(buf);
+
+      /* The exact answer, computed without any index */
+      int64 *want = malloc(sizeof(int64) * NUM_BOXES);
+      int nwant = 0;
+      for (int i = 0; i < NUM_BOXES; i++)
+        if (OPS[o].oracle(&boxes[i], query))
+          want[nwant++] = ids[i];
+      qsort(want, (size_t) nwant, sizeof(int64), cmp_int64);
+      hits += nwant;
+
+      MeosArray *r = meos_array_create(sizeof(int64));
+      rtree_search(rt, OPS[o].op, query, r);
+      int n; int64 *got = sorted_of(r, &n);
+      if (n != nwant || (nwant && memcmp(got, want, sizeof(int64) * (size_t) nwant)))
+        wrong_rt++;
+      free(got); meos_array_destroy(r);
+
+      r = meos_array_create(sizeof(int64));
+      sptree_search(quad, OPS[o].op, query, r);
+      got = sorted_of(r, &n);
+      if (n != nwant || (nwant && memcmp(got, want, sizeof(int64) * (size_t) nwant)))
+        wrong_quad++;
+      free(got); meos_array_destroy(r);
+
+      r = meos_array_create(sizeof(int64));
+      sptree_search(kd, OPS[o].op, query, r);
+      got = sorted_of(r, &n);
+      if (n != nwant || (nwant && memcmp(got, want, sizeof(int64) * (size_t) nwant)))
+        wrong_kd++;
+      free(got); meos_array_destroy(r);
+
+      free(want); free(query);
+    }
+    if (wrong_rt || wrong_quad || wrong_kd)
+    {
+      printf("index position: %-10s answered something other than the exact "
+        "answer on  R-tree %d/%d  quad-tree %d/%d  k-d tree %d/%d\n",
+        OPS[o].name, wrong_rt, NUM_QUERIES, wrong_quad, NUM_QUERIES,
+        wrong_kd, NUM_QUERIES);
+      failures++;
+    }
+    if (hits < MIN_HITS)
+    {
+      printf("index position: %-10s matched %d entries over the query set, "
+        "fewer than the %d the comparison needs to be meaningful\n",
+        OPS[o].name, hits, MIN_HITS);
+      failures++;
+    }
+  }
+
+  rtree_free(rt);
+  sptree_free(quad);
+  sptree_free(kd);
+  free(boxes); free(ids);
+
+  if (failures == 0)
+    printf("index position test: all tests passed\n");
+  meos_finalize();
+  return failures ? 1 : 0;
+}

--- a/meos/test/rtree_join_test.c
+++ b/meos/test/rtree_join_test.c
@@ -127,15 +127,15 @@ cmp_pair(const void *a, const void *b)
 
 /* Return true if the pair of boxes satisfies the operation */
 static bool
-oracle(const STBox *box1, const STBox *box2, RTreeSearchOp op)
+oracle(const STBox *box1, const STBox *box2, IndexSearchOp op)
 {
   switch (op)
   {
-    case RTREE_OVERLAPS:
+    case INDEX_OVERLAPS:
       return overlaps_stbox_stbox(box1, box2);
-    case RTREE_CONTAINS:
+    case INDEX_CONTAINS:
       return contains_stbox_stbox(box1, box2);
-    default: /* RTREE_CONTAINED_BY */
+    default: /* INDEX_CONTAINED_BY */
       return contains_stbox_stbox(box2, box1);
   }
 }
@@ -145,7 +145,7 @@ oracle(const STBox *box1, const STBox *box2, RTreeSearchOp op)
  *****************************************************************************/
 
 static void
-test_stbox_join(RTreeSearchOp op, const char *opname, int count1, int count2,
+test_stbox_join(IndexSearchOp op, const char *opname, int count1, int count2,
   double minext1, double maxext1, int hours1, double minext2, double maxext2,
   int hours2)
 {
@@ -259,15 +259,15 @@ test_degenerate(void)
   RTree *empty1 = rtree_create_stbox();
   RTree *empty2 = rtree_create_stbox();
   check("empty joined with empty reports no pair",
-    rtree_join(empty1, empty2, RTREE_OVERLAPS, result) == 0);
+    rtree_join(empty1, empty2, INDEX_OVERLAPS, result) == 0);
 
   RTree *filled = rtree_create_stbox();
   STBox *box = stbox_in("STBOX XT(((0,0),(1,1)),[2000-01-01, 2000-01-02])");
   rtree_insert(filled, box, 0);
   check("empty joined with a filled index reports no pair",
-    rtree_join(empty1, filled, RTREE_OVERLAPS, result) == 0);
+    rtree_join(empty1, filled, INDEX_OVERLAPS, result) == 0);
   check("filled index joined with empty reports no pair",
-    rtree_join(filled, empty1, RTREE_OVERLAPS, result) == 0);
+    rtree_join(filled, empty1, INDEX_OVERLAPS, result) == 0);
 
   /* Two indexes whose boxes are far apart report no pair, and the same two
    * report their single pair once the boxes are made to overlap */
@@ -276,13 +276,13 @@ test_degenerate(void)
     "STBOX XT(((1000,1000),(1001,1001)),[2000-01-01, 2000-01-02])");
   rtree_insert(far, farbox, 0);
   check("indexes that share no box report no pair",
-    rtree_join(filled, far, RTREE_OVERLAPS, result) == 0);
+    rtree_join(filled, far, INDEX_OVERLAPS, result) == 0);
 
   RTree *near = rtree_create_stbox();
   STBox *nearbox = stbox_in(
     "STBOX XT(((0.5,0.5),(2,2)),[2000-01-01, 2000-01-02])");
   rtree_insert(near, nearbox, 7);
-  int n = rtree_join(filled, near, RTREE_OVERLAPS, result);
+  int n = rtree_join(filled, near, INDEX_OVERLAPS, result);
   check("a single overlapping pair is reported once", n == 1);
   check("the reported ids are the inserted ones", n == 1 &&
     *(int64 *) meos_array_get(result, 0) == 0 &&
@@ -295,7 +295,7 @@ test_degenerate(void)
     "STBOX XT(((0,0),(1,1)),[2001-01-01, 2001-01-02])");
   rtree_insert(later, laterbox, 0);
   check("boxes apart in time only are not reported",
-    rtree_join(filled, later, RTREE_OVERLAPS, result) == 0);
+    rtree_join(filled, later, INDEX_OVERLAPS, result) == 0);
 
   meos_array_destroy(result);
   free(box); free(farbox); free(nearbox); free(laterbox);
@@ -315,20 +315,20 @@ main(void)
   /* Comparable extents on both sides for overlaps; for the containment
    * operations the side that must hold the other is given the larger spatial
    * extent and the longer period */
-  test_stbox_join(RTREE_OVERLAPS, "overlaps", NUM_BOXES1, NUM_BOXES2,
+  test_stbox_join(INDEX_OVERLAPS, "overlaps", NUM_BOXES1, NUM_BOXES2,
     1.0, 150.0, 8, 1.0, 150.0, 8);
-  test_stbox_join(RTREE_CONTAINS, "contains", NUM_BOXES1, NUM_BOXES2,
+  test_stbox_join(INDEX_CONTAINS, "contains", NUM_BOXES1, NUM_BOXES2,
     60.0, 150.0, 12, 1.0, 8.0, 1);
-  test_stbox_join(RTREE_CONTAINED_BY, "contained by", NUM_BOXES1, NUM_BOXES2,
+  test_stbox_join(INDEX_CONTAINED_BY, "contained by", NUM_BOXES1, NUM_BOXES2,
     1.0, 8.0, 1, 60.0, 150.0, 12);
 
   /* Trees of equal height descend in step and never meet a leaf on one side
    * while the other still has inner nodes. A side holding at most MAXITEMS
    * boxes is a lone leaf, so pairing it with a taller tree reaches the two
    * branches that descend a single side, in both directions. */
-  test_stbox_join(RTREE_OVERLAPS, "overlaps, taller first", NUM_BOXES1,
+  test_stbox_join(INDEX_OVERLAPS, "overlaps, taller first", NUM_BOXES1,
     NUM_BOXES_LEAF, 1.0, 150.0, 8, 1.0, 150.0, 8);
-  test_stbox_join(RTREE_OVERLAPS, "overlaps, taller second", NUM_BOXES_LEAF,
+  test_stbox_join(INDEX_OVERLAPS, "overlaps, taller second", NUM_BOXES_LEAF,
     NUM_BOXES1, 1.0, 150.0, 8, 1.0, 150.0, 8);
   test_degenerate();
 

--- a/meos/test/rtree_load_test.c
+++ b/meos/test/rtree_load_test.c
@@ -50,7 +50,16 @@
  *  (iv)  the ids survive: they are spread beyond 2^31, so a build carrying them
  *        at a narrower width would return different numbers;
  *  (v)   the degenerate counts are handled: loading no entries leaves a tree
- *        that answers nothing, and loading one returns that one.
+ *        that answers nothing, and loading one returns that one;
+ *  (vi)  a load leaves the tree holding exactly the entries it is given,
+ *        whatever it holds when it is called, so an index is rebuilt from the
+ *        entries a caller keeps;
+ *  (vii) the entries a tree holds are released whatever the number given, so a
+ *        load of no entries empties a tree rather than leaving the ones it
+ *        held. This is the case that tells releasing the nodes apart from
+ *        assigning the root over them: wherever entries follow, the two answer
+ *        alike and differ only in what the run leaks, which valgrind reports
+ *        and an assertion cannot.
  *
  * The program can be built as follows
  * @code
@@ -72,6 +81,10 @@
 #define MIN_EXPECTED_HITS 1000
 /* Lowest id, above 2^31 so that a narrower carrier would alter it */
 #define ID_BASE 4000000000LL
+/* Entries a tree holds before it is loaded over */
+#define NUM_SEEDED 8
+/* Lowest seeded id, below every loaded id so that one left behind is visible */
+#define SEED_ID_BASE 1000000000LL
 
 static int
 cmp_int64(const void *a, const void *b)
@@ -87,7 +100,7 @@ static int64 *
 search_sorted(const RTree *rtree, const STBox *query, int *count)
 {
   MeosArray *result = meos_array_create(sizeof(int64));
-  rtree_search(rtree, RTREE_OVERLAPS, query, result);
+  rtree_search(rtree, INDEX_OVERLAPS, query, result);
   *count = meos_array_count(result);
   int64 *ids = malloc(sizeof(int64) * (size_t) (*count ? *count : 1));
   for (int i = 0; i < *count; i++)
@@ -207,12 +220,61 @@ main(void)
     failures++;
   }
   free(s);
+
+  /* (vi) a load leaves the tree holding exactly the entries given, whatever it
+   * holds when it is called. The seeded ids are below every loaded id, so an
+   * entry a rebuild fails to drop appears in the answer instead of hiding
+   * among the ids that are loaded again. */
+  RTree *rebuilt = rtree_create_stbox();
+  for (int i = 0; i < NUM_SEEDED; i++)
+    rtree_insert(rebuilt, &boxes[i], SEED_ID_BASE + (int64) i);
+  rtree_load(rebuilt, boxes, ids, NUM_BOXES);
+  int nrebuilt;
+  int64 *r = search_sorted(rebuilt, whole, &nrebuilt);
+  if (nrebuilt != NUM_BOXES)
+  {
+    printf("rtree_load: a tree holding %d entries answered %d after a load of "
+      "%d entries\n", NUM_SEEDED, nrebuilt, NUM_BOXES);
+    failures++;
+  }
+  else
+  {
+    int64 *want = malloc(sizeof(int64) * NUM_BOXES);
+    memcpy(want, ids, sizeof(int64) * NUM_BOXES);
+    qsort(want, NUM_BOXES, sizeof(int64), cmp_int64);
+    if (memcmp(r, want, sizeof(int64) * NUM_BOXES) != 0)
+    {
+      printf("rtree_load: a tree loaded over the entries it holds answers ids "
+        "it was not loaded with\n");
+      failures++;
+    }
+    free(want);
+  }
+  free(r);
+
+  /* (vii) the entries are released whatever the number given, so an empty
+   * entry set leaves an empty tree rather than the one it held */
+  RTree *emptied = rtree_create_stbox();
+  for (int i = 0; i < NUM_SEEDED; i++)
+    rtree_insert(emptied, &boxes[i], SEED_ID_BASE + (int64) i);
+  rtree_load(emptied, boxes, ids, 0);
+  int nemptied;
+  int64 *m = search_sorted(emptied, whole, &nemptied);
+  if (nemptied != 0)
+  {
+    printf("rtree_load: a tree holding %d entries answered %d after a load of "
+      "no entries\n", NUM_SEEDED, nemptied);
+    failures++;
+  }
+  free(m);
   free(whole);
 
   rtree_free(grown);
   rtree_free(packed);
   rtree_free(empty);
   rtree_free(single);
+  rtree_free(rebuilt);
+  rtree_free(emptied);
   free(boxes);
   free(ids);
 

--- a/meos/test/rtree_mest_test.c
+++ b/meos/test/rtree_mest_test.c
@@ -144,11 +144,11 @@ int main(void)
   MeosArray *mest_ids = meos_array_create(sizeof(int64));
   MeosArray *deg_ids = meos_array_create(sizeof(int64));
 
-  int single_count = rtree_search_temporal(rtree_single, RTREE_OVERLAPS,
+  int single_count = rtree_search_temporal(rtree_single, INDEX_OVERLAPS,
     query, single_ids);
-  int mest_count = rtree_search_temporal_dedup(rtree_mest, RTREE_OVERLAPS,
+  int mest_count = rtree_search_temporal_dedup(rtree_mest, INDEX_OVERLAPS,
     query, MAX_BOXES, mest_ids);
-  int deg_count = rtree_search_temporal_dedup(rtree_deg, RTREE_OVERLAPS,
+  int deg_count = rtree_search_temporal_dedup(rtree_deg, INDEX_OVERLAPS,
     query, 1, deg_ids);
 
   /* Membership bitsets */

--- a/meos/test/rtree_span_test.c
+++ b/meos/test/rtree_span_test.c
@@ -89,7 +89,7 @@ test_intspan_rtree(void)
   Span *query = intspan_make(qlo, qlo + 500, true, false);
 
   MeosArray *result = meos_array_create(sizeof(int64));
-  int count = rtree_search(rtree, RTREE_OVERLAPS, query, result);
+  int count = rtree_search(rtree, INDEX_OVERLAPS, query, result);
 
   bool *in_index = calloc(NUM_SPANS, sizeof(bool));
   for (int i = 0; i < count; i++)
@@ -135,7 +135,7 @@ test_floatspan_rtree(void)
   Span *query = floatspan_make(qlo, qlo + 50.0, true, false);
 
   MeosArray *result = meos_array_create(sizeof(int64));
-  int count = rtree_search(rtree, RTREE_OVERLAPS, query, result);
+  int count = rtree_search(rtree, INDEX_OVERLAPS, query, result);
 
   bool *in_index = calloc(NUM_SPANS, sizeof(bool));
   for (int i = 0; i < count; i++)
@@ -185,7 +185,7 @@ test_id_width(void)
 
   Span *query = intspan_make(-100, 1000, true, false);
   MeosArray *result = meos_array_create(sizeof(int64));
-  int count = rtree_search(rtree, RTREE_OVERLAPS, query, result);
+  int count = rtree_search(rtree, INDEX_OVERLAPS, query, result);
 
   printf("Identifier width (%d spans, ids above 2^31):\n", nids);
   if (count != nids)

--- a/meos/test/sptree_load_test.c
+++ b/meos/test/sptree_load_test.c
@@ -1,0 +1,509 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the build of the in-memory space-partitioning
+ * index from a whole entry set, i.e., sptree_load, for both kinds of tree.
+ *
+ * sptree_load partitions the entries top-down on the median of the dimension
+ * each level narrows, so the tree it produces has a different shape from one
+ * grown by repeated sptree_insert, whose depth follows the order the entries
+ * arrive in. The shape is free to differ; the answers are not.
+ *
+ * Two oracles are used rather than one. The exact set of boxes satisfying the
+ * operator is computed by brute force, so a build and a search that share a
+ * mistake cannot agree their way to a pass; and the insert-built tree is
+ * required to answer identically, so that the two builds of one index are held
+ * to one contract.
+ *
+ * Seven properties are asserted, for the quad-tree and for the k-d tree:
+ *  (i)    exactness: the tree returns every box satisfying the operator and no
+ *         other;
+ *  (ii)   the comparison is not vacuous: the windows must match a substantial
+ *         number of entries, since a tree that answers nothing and an oracle
+ *         that expects nothing agree on nothing;
+ *  (iii)  completeness: a window over the whole extent returns each loaded id
+ *         exactly once, so the partitioning neither drops an entry nor reports
+ *         one twice;
+ *  (iv)   an ordered entry set is answered exactly. This is the set that makes
+ *         insertion degenerate into a chain, and the one a build that halves
+ *         its range is written for;
+ *  (v)    an entry set that ties throughout is answered exactly. Equal boxes
+ *         cannot be separated by any dimension, so they descend as a chain,
+ *         and a build that expects every level to split does not terminate;
+ *  (vi)   the degenerate counts are handled: loading no entries leaves a tree
+ *         that answers nothing, and loading one returns that one;
+ *  (vii)  a load leaves the tree holding exactly the entries it is given,
+ *         whatever it holds when it is called, and releases what it held
+ *         whatever the number given, so a load of no entries empties a tree.
+ *
+ * The fixture is built so that a partitioning fault cannot pass unnoticed. The
+ * dimensions are uncorrelated and the temporal one is held constant across
+ * every box and every query, so a level that narrows the wrong dimension
+ * separates nothing; and the query windows are on the scale of the data, since
+ * a window covering the extent is accepted by every node and prunes nothing.
+ *
+ * The program can be built as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o sptree_load_test sptree_load_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* Entries the trees are built from, enough to span several tree levels */
+#define NUM_BOXES 2048
+/* Query windows the trees are compared over */
+#define NUM_QUERIES 100
+/* Fewest hits those windows must produce for the comparison to mean anything */
+#define MIN_EXPECTED_HITS 1000
+/* Lowest id, above 2^31 so that a narrower carrier would alter it */
+#define ID_BASE 4000000000LL
+/* Entries a tree holds before it is loaded over */
+#define NUM_SEEDED 8
+/* Lowest seeded id, below every loaded id so that one left behind is visible */
+#define SEED_ID_BASE 1000000000LL
+/* Half-width of a value span, and of a query window, in tenths */
+#define BOX_SPAN 200
+#define QUERY_SPAN 600
+
+static int
+cmp_int64(const void *a, const void *b)
+{
+  int64 x = *(const int64 *) a, y = *(const int64 *) b;
+  return (x > y) - (x < y);
+}
+
+static int
+random_int(int min, int max)
+{
+  return min + rand() % (max - min + 1);
+}
+
+/**
+ * @brief Return the time span every box and every query carries
+ * @details One span shared by the whole fixture: the temporal dimension
+ * therefore separates nothing, and every prune a search makes has to come from
+ * the value dimension
+ */
+static Span *
+constant_period(void)
+{
+  return tstzspan_make((TimestampTz) 0, (TimestampTz) 1000000000, true, false);
+}
+
+/**
+ * @brief Return a box whose value span starts at @p vlo tenths and whose time
+ * span is the one the whole fixture shares
+ */
+static TBox *
+make_tbox(int vlo, int vspan)
+{
+  Span *v = floatspan_make(vlo / 10.0, (vlo + vspan) / 10.0, true, false);
+  Span *t = constant_period();
+  TBox *box = tbox_make(v, t);
+  free(v); free(t);
+  return box;
+}
+
+/**
+ * @brief Return the ids a tree reports for a query, sorted ascending
+ */
+static int64 *
+search_sorted(const SPTree *sptree, const TBox *query, int *count)
+{
+  MeosArray *result = meos_array_create(sizeof(int64));
+  sptree_search(sptree, INDEX_OVERLAPS, query, result);
+  *count = meos_array_count(result);
+  int64 *ids = malloc(sizeof(int64) * (size_t) (*count ? *count : 1));
+  for (int i = 0; i < *count; i++)
+    ids[i] = *(int64 *) meos_array_get(result, i);
+  qsort(ids, (size_t) *count, sizeof(int64), cmp_int64);
+  meos_array_destroy(result);
+  return ids;
+}
+
+/**
+ * @brief Compare a loaded tree against the exact answer and against a tree
+ * grown one entry at a time, over a spread of selective windows
+ * @return Number of properties that do not hold
+ */
+static int
+test_answers(SPTreeKind kind, const char *kindname, TBox **boxes,
+  const int64 *ids, const char *shape)
+{
+  int failures = 0;
+  SPTree *grown = sptree_create_tbox(kind);
+  SPTree *loaded = sptree_create_tbox(kind);
+  TBox *flat = malloc(sizeof(TBox) * NUM_BOXES);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    sptree_insert(grown, boxes[i], ids[i]);
+    memcpy(&flat[i], boxes[i], sizeof(TBox));
+  }
+  sptree_load(loaded, flat, ids, NUM_BOXES);
+
+  /* (i), (ii) and the agreement of the two builds */
+  int wrong = 0, disagree = 0, total_hits = 0;
+  for (int q = 0; q < NUM_QUERIES; q++)
+  {
+    TBox *query = make_tbox(random_int(-10000, 10000), QUERY_SPAN);
+    int nloaded, ngrown;
+    int64 *l = search_sorted(loaded, query, &nloaded);
+    int64 *g = search_sorted(grown, query, &ngrown);
+
+    /* The exact answer, computed without either tree */
+    int64 *want = malloc(sizeof(int64) * NUM_BOXES);
+    int nwant = 0;
+    for (int i = 0; i < NUM_BOXES; i++)
+      if (overlaps_tbox_tbox(boxes[i], query))
+        want[nwant++] = ids[i];
+    qsort(want, (size_t) nwant, sizeof(int64), cmp_int64);
+
+    if (nloaded != nwant ||
+        (nwant && memcmp(l, want, sizeof(int64) * (size_t) nwant) != 0))
+      wrong++;
+    if (nloaded != ngrown ||
+        (ngrown && memcmp(l, g, sizeof(int64) * (size_t) ngrown) != 0))
+      disagree++;
+    total_hits += nwant;
+    free(want); free(l); free(g); free(query);
+  }
+  if (wrong)
+  {
+    printf("sptree_load: %s %s: %d of %d windows answered something other "
+      "than the exact answer\n", shape, kindname, wrong, NUM_QUERIES);
+    failures++;
+  }
+  if (disagree)
+  {
+    printf("sptree_load: %s %s: %d of %d windows answered differently from "
+      "the insert-built tree\n", shape, kindname, disagree, NUM_QUERIES);
+    failures++;
+  }
+  if (total_hits < MIN_EXPECTED_HITS)
+  {
+    printf("sptree_load: %s %s: the windows matched %d entries, fewer than "
+      "the %d the comparison needs to be meaningful\n", shape, kindname,
+      total_hits, MIN_EXPECTED_HITS);
+    failures++;
+  }
+
+  /* (iii) every loaded id comes back exactly once */
+  TBox *whole = make_tbox(-20000, 40000);
+  int nall;
+  int64 *got = search_sorted(loaded, whole, &nall);
+  if (nall != NUM_BOXES)
+  {
+    printf("sptree_load: %s %s: a window over the whole extent returned %d of "
+      "%d entries\n", shape, kindname, nall, NUM_BOXES);
+    failures++;
+  }
+  else
+  {
+    int64 *want = malloc(sizeof(int64) * NUM_BOXES);
+    memcpy(want, ids, sizeof(int64) * NUM_BOXES);
+    qsort(want, NUM_BOXES, sizeof(int64), cmp_int64);
+    if (memcmp(got, want, sizeof(int64) * NUM_BOXES) != 0)
+    {
+      printf("sptree_load: %s %s: the ids returned are not the ids loaded\n",
+        shape, kindname);
+      failures++;
+    }
+    free(want);
+  }
+  /* (iv) the build chooses the depth. An ordered entry set is the one that
+   * sends every insertion one level deeper, so a tree grown from it is a chain
+   * and a tree built from it is not. Comparing the two heights states the
+   * property the build exists for, which the answers alone cannot show. */
+  if (strcmp(shape, "ordered") == 0)
+  {
+    int h_grown = sptree_height(grown), h_loaded = sptree_height(loaded);
+    if (h_loaded >= h_grown)
+    {
+      printf("sptree_load: %s %s: an ordered entry set builds a tree of %d "
+        "levels against the %d of the tree grown from it, so the build does "
+        "not choose the depth\n", shape, kindname, h_loaded, h_grown);
+      failures++;
+    }
+  }
+
+  free(got); free(whole); free(flat);
+  sptree_free(grown);
+  sptree_free(loaded);
+  return failures;
+}
+
+/**
+ * @brief Check the entry counts a build has to single out, and that a build
+ * leaves the tree holding what it was given and nothing else
+ */
+static int
+test_contract(SPTreeKind kind, const char *kindname, TBox **boxes,
+  const int64 *ids)
+{
+  int failures = 0;
+  TBox *flat = malloc(sizeof(TBox) * NUM_BOXES);
+  for (int i = 0; i < NUM_BOXES; i++)
+    memcpy(&flat[i], boxes[i], sizeof(TBox));
+  TBox *whole = make_tbox(-20000, 40000);
+
+  /* (vi) the degenerate counts */
+  SPTree *empty = sptree_create_tbox(kind);
+  sptree_load(empty, flat, ids, 0);
+  int nempty;
+  int64 *e = search_sorted(empty, whole, &nempty);
+  if (nempty != 0)
+  {
+    printf("sptree_load: %s: a tree loaded with no entries answered %d\n",
+      kindname, nempty);
+    failures++;
+  }
+  free(e);
+
+  SPTree *single = sptree_create_tbox(kind);
+  sptree_load(single, flat, ids, 1);
+  int nsingle;
+  int64 *s = search_sorted(single, whole, &nsingle);
+  if (nsingle != 1 || s[0] != ids[0])
+  {
+    printf("sptree_load: %s: a tree loaded with one entry answered %d\n",
+      kindname, nsingle);
+    failures++;
+  }
+  free(s);
+
+  /* (vii) a load leaves the tree holding exactly the entries given. The seeded
+   * ids are below every loaded id, so an entry a rebuild fails to drop appears
+   * in the answer instead of hiding among the ids that are loaded again. */
+  SPTree *rebuilt = sptree_create_tbox(kind);
+  for (int i = 0; i < NUM_SEEDED; i++)
+    sptree_insert(rebuilt, boxes[i], SEED_ID_BASE + (int64) i);
+  sptree_load(rebuilt, flat, ids, NUM_BOXES);
+  int nrebuilt;
+  int64 *r = search_sorted(rebuilt, whole, &nrebuilt);
+  if (nrebuilt != NUM_BOXES)
+  {
+    printf("sptree_load: %s: a tree holding %d entries answered %d after a "
+      "load of %d entries\n", kindname, NUM_SEEDED, nrebuilt, NUM_BOXES);
+    failures++;
+  }
+  else
+  {
+    int64 *want = malloc(sizeof(int64) * NUM_BOXES);
+    memcpy(want, ids, sizeof(int64) * NUM_BOXES);
+    qsort(want, NUM_BOXES, sizeof(int64), cmp_int64);
+    if (memcmp(r, want, sizeof(int64) * NUM_BOXES) != 0)
+    {
+      printf("sptree_load: %s: a tree loaded over the entries it holds "
+        "answers ids it was not loaded with\n", kindname);
+      failures++;
+    }
+    free(want);
+  }
+  free(r);
+
+  /* The entries are released whatever the number given, so an empty entry set
+   * empties the tree rather than leaving the entries it held */
+  SPTree *emptied = sptree_create_tbox(kind);
+  for (int i = 0; i < NUM_SEEDED; i++)
+    sptree_insert(emptied, boxes[i], SEED_ID_BASE + (int64) i);
+  sptree_load(emptied, flat, ids, 0);
+  int nemptied;
+  int64 *m = search_sorted(emptied, whole, &nemptied);
+  if (nemptied != 0)
+  {
+    printf("sptree_load: %s: a tree holding %d entries answered %d after a "
+      "load of no entries\n", kindname, NUM_SEEDED, nemptied);
+    failures++;
+  }
+  free(m);
+
+  free(whole); free(flat);
+  sptree_free(empty);
+  sptree_free(single);
+  sptree_free(rebuilt);
+  sptree_free(emptied);
+  return failures;
+}
+
+/**
+ * @brief Check a bounding box type other than the one the fixture above is
+ * built from, so that the engine is exercised on a second number of dimensions
+ * and on the dimensions being read from the first box rather than being fixed
+ * when the tree is created
+ * @details Exactness against the brute-force answer is asserted, which is what
+ * a second family adds; the shapes of the entry set are covered by the
+ * temporal box above. The spatial extents are uncorrelated and the time span
+ * is shared by every box and every query, so a level narrowing the temporal
+ * dimension separates nothing, and the windows are on the scale of the data,
+ * so a window covering the extent cannot hide a subtree that is pruned wrongly.
+ */
+static int
+test_stbox(SPTreeKind kind, const char *kindname)
+{
+  int failures = 0;
+  char buf[256];
+  STBox *boxes = malloc(sizeof(STBox) * NUM_BOXES);
+  int64 *ids = malloc(sizeof(int64) * NUM_BOXES);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    int x = random_int(0, 1000), y = random_int(0, 1000);
+    snprintf(buf, sizeof(buf),
+      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])",
+      x, y, x + 20, y + 20);
+    STBox *box = stbox_in(buf);
+    memcpy(&boxes[i], box, sizeof(STBox));
+    free(box);
+    ids[i] = (int64) i + ID_BASE;
+  }
+
+  SPTree *loaded = sptree_create_stbox(kind);
+  sptree_load(loaded, boxes, ids, NUM_BOXES);
+
+  int wrong = 0, total_hits = 0;
+  for (int q = 0; q < NUM_QUERIES; q++)
+  {
+    int x = random_int(0, 1000), y = random_int(0, 1000);
+    snprintf(buf, sizeof(buf),
+      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])",
+      x, y, x + 60, y + 60);
+    STBox *query = stbox_in(buf);
+
+    MeosArray *result = meos_array_create(sizeof(int64));
+    sptree_search(loaded, INDEX_OVERLAPS, query, result);
+    int ngot = meos_array_count(result);
+    int64 *got = malloc(sizeof(int64) * (size_t) (ngot ? ngot : 1));
+    for (int i = 0; i < ngot; i++)
+      got[i] = *(int64 *) meos_array_get(result, i);
+    qsort(got, (size_t) ngot, sizeof(int64), cmp_int64);
+    meos_array_destroy(result);
+
+    int64 *want = malloc(sizeof(int64) * NUM_BOXES);
+    int nwant = 0;
+    for (int i = 0; i < NUM_BOXES; i++)
+      if (overlaps_stbox_stbox(&boxes[i], query))
+        want[nwant++] = ids[i];
+    qsort(want, (size_t) nwant, sizeof(int64), cmp_int64);
+
+    if (ngot != nwant ||
+        (nwant && memcmp(got, want, sizeof(int64) * (size_t) nwant) != 0))
+      wrong++;
+    total_hits += nwant;
+    free(got); free(want); free(query);
+  }
+  if (wrong)
+  {
+    printf("sptree_load: spatiotemporal box %s: %d of %d windows answered "
+      "something other than the exact answer\n", kindname, wrong, NUM_QUERIES);
+    failures++;
+  }
+  if (total_hits < MIN_EXPECTED_HITS)
+  {
+    printf("sptree_load: spatiotemporal box %s: the windows matched %d "
+      "entries, fewer than the %d the comparison needs to be meaningful\n",
+      kindname, total_hits, MIN_EXPECTED_HITS);
+    failures++;
+  }
+
+  sptree_free(loaded);
+  free(boxes); free(ids);
+  return failures;
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  srand(1);
+  int failures = 0;
+
+  const SPTreeKind kinds[2] = {SPTREE_QUADTREE, SPTREE_KDTREE};
+  const char *kindnames[2] = {"quad-tree", "k-d tree"};
+
+  /* The entry sets. The values are drawn independently of the ids, so an
+   * entry set is not ordered unless it is built to be. */
+  TBox **shuffled = malloc(NUM_BOXES * sizeof(TBox *));
+  TBox **ordered = malloc(NUM_BOXES * sizeof(TBox *));
+  TBox **tied = malloc(NUM_BOXES * sizeof(TBox *));
+  int64 *ids = malloc(sizeof(int64) * NUM_BOXES);
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    shuffled[i] = make_tbox(random_int(-10000, 10000), random_int(1, BOX_SPAN));
+    /* (iv) ascending, the set that makes insertion degenerate into a chain */
+    ordered[i] = make_tbox(-10000 + i * 9, BOX_SPAN);
+    /* (v) every box equal, the set no dimension can separate */
+    tied[i] = make_tbox(0, BOX_SPAN);
+    ids[i] = (int64) i + ID_BASE;
+  }
+
+  for (int k = 0; k < 2; k++)
+  {
+    failures += test_answers(kinds[k], kindnames[k], shuffled, ids, "shuffled");
+    failures += test_answers(kinds[k], kindnames[k], ordered, ids, "ordered");
+    failures += test_contract(kinds[k], kindnames[k], shuffled, ids);
+    failures += test_stbox(kinds[k], kindnames[k]);
+
+    /* (v) a set that ties throughout builds and answers every entry. The
+     * windows of test_answers would all match the whole set, so only the
+     * completeness of the answer is asserted here. */
+    TBox *flat = malloc(sizeof(TBox) * NUM_BOXES);
+    for (int i = 0; i < NUM_BOXES; i++)
+      memcpy(&flat[i], tied[i], sizeof(TBox));
+    SPTree *chain = sptree_create_tbox(kinds[k]);
+    sptree_load(chain, flat, ids, NUM_BOXES);
+    TBox *whole = make_tbox(-20000, 40000);
+    int nchain;
+    int64 *c = search_sorted(chain, whole, &nchain);
+    if (nchain != NUM_BOXES)
+    {
+      printf("sptree_load: %s: a set of %d equal boxes answered %d\n",
+        kindnames[k], NUM_BOXES, nchain);
+      failures++;
+    }
+    free(c); free(whole); free(flat);
+    sptree_free(chain);
+  }
+
+  for (int i = 0; i < NUM_BOXES; i++)
+  {
+    free(shuffled[i]); free(ordered[i]); free(tied[i]);
+  }
+  free(shuffled); free(ordered); free(tied); free(ids);
+
+  if (failures == 0)
+    printf("sptree_load test: all tests passed\n");
+  meos_finalize();
+  return failures ? 1 : 0;
+}

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -98,7 +98,7 @@ random_int(int min, int max)
  * satisfies the operator against the query.
  */
 static void
-compare(const char *label, const SPTree *sptree, RTreeSearchOp op,
+compare(const char *label, const SPTree *sptree, IndexSearchOp op,
   const void *query, const bool *truth)
 {
   MeosArray *result = meos_array_create(sizeof(int64));
@@ -154,9 +154,9 @@ test_intspan(SPTreeKind kind, const char *kindname)
   }
 
   printf("Integer span %s (%d random spans):\n", kindname, NUM_BOXES);
-  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
-  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
-  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+  compare("  overlaps    ", sptree, INDEX_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, INDEX_CONTAINS, query, co);
+  compare("  contained by", sptree, INDEX_CONTAINED_BY, query, cb);
 
   for (int i = 0; i < NUM_BOXES; i++)
     free(spans[i]);
@@ -193,9 +193,9 @@ test_floatspan(SPTreeKind kind, const char *kindname)
   }
 
   printf("Float span %s (%d random spans):\n", kindname, NUM_BOXES);
-  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
-  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
-  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+  compare("  overlaps    ", sptree, INDEX_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, INDEX_CONTAINS, query, co);
+  compare("  contained by", sptree, INDEX_CONTAINED_BY, query, cb);
 
   for (int i = 0; i < NUM_BOXES; i++)
     free(spans[i]);
@@ -243,9 +243,9 @@ test_tbox(SPTreeKind kind, const char *kindname)
   }
 
   printf("Temporal box %s (%d random boxes):\n", kindname, NUM_BOXES);
-  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
-  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
-  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+  compare("  overlaps    ", sptree, INDEX_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, INDEX_CONTAINS, query, co);
+  compare("  contained by", sptree, INDEX_CONTAINED_BY, query, cb);
 
   for (int i = 0; i < NUM_BOXES; i++)
     free(boxes[i]);
@@ -295,9 +295,9 @@ test_stbox(SPTreeKind kind, const char *kindname)
   }
 
   printf("Spatiotemporal box %s (%d random boxes):\n", kindname, NUM_BOXES);
-  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
-  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
-  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+  compare("  overlaps    ", sptree, INDEX_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, INDEX_CONTAINS, query, co);
+  compare("  contained by", sptree, INDEX_CONTAINED_BY, query, cb);
 
   for (int i = 0; i < NUM_BOXES; i++)
     free(boxes[i]);
@@ -353,9 +353,9 @@ test_tpcbox(SPTreeKind kind, const char *kindname)
   }
 
   printf("Pointcloud box %s (%d random boxes):\n", kindname, NUM_BOXES);
-  compare("  overlaps    ", sptree, RTREE_OVERLAPS, query, ov);
-  compare("  contains    ", sptree, RTREE_CONTAINS, query, co);
-  compare("  contained by", sptree, RTREE_CONTAINED_BY, query, cb);
+  compare("  overlaps    ", sptree, INDEX_OVERLAPS, query, ov);
+  compare("  contains    ", sptree, INDEX_CONTAINS, query, co);
+  compare("  contained by", sptree, INDEX_CONTAINED_BY, query, cb);
 
   for (int i = 0; i < NUM_BOXES; i++)
     free(boxes[i]);
@@ -413,11 +413,11 @@ test_mest(void)
   MeosArray *single_ids = meos_array_create(sizeof(int64));
   MeosArray *mest_ids = meos_array_create(sizeof(int64));
   MeosArray *deg_ids = meos_array_create(sizeof(int64));
-  int single_count = sptree_search_temporal(single, RTREE_OVERLAPS, query,
+  int single_count = sptree_search_temporal(single, INDEX_OVERLAPS, query,
     single_ids);
-  int mest_count = sptree_search_temporal_dedup(mest, RTREE_OVERLAPS, query,
+  int mest_count = sptree_search_temporal_dedup(mest, INDEX_OVERLAPS, query,
     MAX_BOXES, mest_ids);
-  int deg_count = sptree_search_temporal_dedup(deg, RTREE_OVERLAPS, query, 1,
+  int deg_count = sptree_search_temporal_dedup(deg, INDEX_OVERLAPS, query, 1,
     deg_ids);
 
   bool *in_single = calloc(NUM_TRIPS, sizeof(bool));
@@ -548,11 +548,11 @@ test_stbox_mest(void)
   MeosArray *single_ids = meos_array_create(sizeof(int64));
   MeosArray *mest_ids = meos_array_create(sizeof(int64));
   MeosArray *deg_ids = meos_array_create(sizeof(int64));
-  int single_count = sptree_search_temporal(single, RTREE_OVERLAPS, query,
+  int single_count = sptree_search_temporal(single, INDEX_OVERLAPS, query,
     single_ids);
-  int mest_count = sptree_search_temporal_dedup(mest, RTREE_OVERLAPS, query,
+  int mest_count = sptree_search_temporal_dedup(mest, INDEX_OVERLAPS, query,
     MAX_BOXES, mest_ids);
-  int deg_count = sptree_search_temporal_dedup(deg, RTREE_OVERLAPS, query, 1,
+  int deg_count = sptree_search_temporal_dedup(deg, INDEX_OVERLAPS, query, 1,
     deg_ids);
 
   bool *in_single = calloc(NUM_TRIPS, sizeof(bool));
@@ -877,7 +877,7 @@ selective(const char *label, const SPTree *sptree, const void *query,
   const bool *truth, int ntruth)
 {
   MeosArray *result = meos_array_create(sizeof(int64));
-  int count = sptree_search(sptree, RTREE_OVERLAPS, query, result);
+  int count = sptree_search(sptree, INDEX_OVERLAPS, query, result);
   bool *in_index = calloc(SEL_BOXES, sizeof(bool));
   for (int i = 0; i < count; i++)
     in_index[*(int64 *) meos_array_get(result, i)] = true;


### PR DESCRIPTION
The in-memory R-tree and the in-memory space-partitioning index expose the same operations. An index is filled entry by entry through `_insert`, or built from a whole entry set at once through `_load`; it answers the operations that order a dimension as well as the ones that compare extents; and it reports what it holds. Only the tree constructed differs: `rtree_create_*` builds an R-tree, `sptree_create_*` a quad-tree or a k-d tree according to the kind it is given.

`sptree_load` partitions the entries top-down, each level taking as its centroid the median of the entries on the dimension that level narrows, and handing the rest to the child slot an insertion would descend into. The depth then follows from the number of entries rather than from the order they arrive in, which matters more here than for the R-tree: `sptree_insert` stores a box at the first empty slot it reaches, so an index grown from an ordered set is a chain. Over 1024 ordered entries the built tree holds 17 levels where the grown one holds 1024, for the same entries in the same memory.

A build assigns the root of the index it fills, so it releases the nodes the index holds before it does, and releases them whatever the number of entries given. An index ends up holding exactly the entries it is given. That is what makes `_load` more than a fast first build: an index has no removal entry point, so rebuilding from the entries a caller keeps is the way an index that has grown stale is made smaller again, and a load of no entries empties it.

The operations that order a dimension are answered at an entry by the operator of the box type, and at an inner node by the same operator read the other way round: a node holds every entry of its subtree, so an entry lies on one side of the query only where the node itself reaches that side. The pairing is an involution, which is what lets one rule serve every dimension in both structures. The space-partitioning index answers them through the region predicates the SP-GiST operator classes use; the R-tree through the operators of its box type.

The search operations both indexes take are named for neither of them: `IndexSearchOp`, whose members carry the `INDEX_` prefix. The space-partitioning index has always taken this enumeration, so the R-tree name described the argument of one caller rather than the operations themselves.

An index reports what it holds through `rtree_num_entries`, `rtree_mem_size` and `rtree_height` and their space-partitioning counterparts, so a caller accounting for the memory of an index reads it rather than estimating it, and a test asserts the depth a build chooses rather than describing it.

A box entering or querying an index is validated once, at the entry point, so that every comparison the descent makes assumes it: an index holds boxes of one SRID, and a box of another one is an error rather than a coercion. The operations that can refuse a box report it, which a void return cannot.

`rtree_load_test`, `sptree_load_test` and `index_position_test` hold each structure to the entries it is given and to the exact answer. The position cases carry a brute-force oracle beside the two structures, so a build and a search that share a mistake cannot agree their way to a pass; their fixture keeps the temporal dimension constant across every box and every query and takes the windows on the scale of the data, so a level that narrows the wrong dimension separates nothing and a window covering the extent cannot hide a subtree pruned wrongly. Releasing the nodes is memory rather than an answer, so the smoke workflow runs the build programs under valgrind.