### PR TITLE
Answer the area a convex body covers between its placements

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -135,6 +135,42 @@ extern bool meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
   bool *result);
 extern bool de9im_match(const char matrix[10], const char pattern[10]);
 extern int point_in_polygon(double x, double y, Edge **edges, int nedges);
+/**
+ * @brief Return true if a polygon ring turns the same way at every vertex,
+ * which is what makes it convex
+ * @details The cross product of two consecutive edges is signed by the turn
+ * they make, so a ring whose turns all carry one sign is convex, and one
+ * change of sign is a vertex the ring is concave at. A ring of fewer than
+ * three distinct vertices bounds no area and is not convex.
+ * @note Defined here so that every caller inlines it, the buffer engine
+ * included, rather than reaching it through a call across files.
+ */
+static inline bool
+geom_ring_is_convex(const POINTARRAY *pa)
+{
+  if (! pa || pa->npoints < 4)
+    return false;
+  uint32_t n = pa->npoints - 1;
+  int sign = 0;
+  for (uint32_t i = 0; i < n; i++)
+  {
+    POINT4D a, b, c;
+    getPoint4d_p(pa, i, &a);
+    getPoint4d_p(pa, (i + 1) % n, &b);
+    getPoint4d_p(pa, (i + 2) % n, &c);
+    double turn = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x);
+    /* The tolerance liblwgeom uses for a coordinate comparison */
+    if (fabs(turn) <= 1e-12)
+      continue;
+    int current = turn > 0.0 ? 1 : -1;
+    if (sign == 0)
+      sign = current;
+    else if (sign != current)
+      return false;
+  }
+  return sign != 0;
+}
+
 extern bool relate_point_on_boundary(double x, double y, Edge **edges,
   int nedges);
 extern int relate_point_in_area(double x, double y, Edge **edges, int nedges);

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -3541,38 +3541,6 @@ buffer_ring_outward_left(const POINTARRAY *pa)
   return buffer_ring_area(pa) < 0.0;
 }
 
-/**
- * @brief Return true if a polygon ring is convex
- * @details Every vertex of a convex ring turns the same way. Contracting such
- * a ring past its own width leaves nothing, whereas a ring that is not convex
- * may instead fall apart into several surfaces, which only the boundary
- * overlay can name.
- */
-static bool
-buffer_ring_is_convex(const POINTARRAY *pa)
-{
-  assert(pa);
-  if (pa->npoints < 4)
-    return false;
-  uint32_t n = pa->npoints - 1;
-  int sign = 0;
-  for (uint32_t i = 0; i < n; i++)
-  {
-    POINT4D a, b, c;
-    getPoint4d_p(pa, i, &a);
-    getPoint4d_p(pa, (i + 1) % n, &b);
-    getPoint4d_p(pa, (i + 2) % n, &c);
-    double turn = buffer_cross(b.x - a.x, b.y - a.y, c.x - b.x, c.y - b.y);
-    if (fabs(turn) <= FP_TOLERANCE)
-      continue;
-    int current = turn > 0.0 ? 1 : -1;
-    if (sign == 0)
-      sign = current;
-    else if (sign != current)
-      return false;
-  }
-  return sign != 0;
-}
 
 /**
  * @brief Construct the offset of a polygon ring
@@ -4731,7 +4699,7 @@ meos_buffer_line_offset(const LWLINE *line, double radius,
       mitre_limit, srid);
     if (inner)
       buffer_curvepoly_add_ring(result, inner);
-    else if (! buffer_ring_is_convex(ring))
+    else if (! geom_ring_is_convex(ring))
     {
       /* The hole is uncovered rather than absent: contracting a ring that is
        * not convex may leave several holes, which the boundary overlay has to
@@ -5217,7 +5185,7 @@ meos_buffer_poly(const LWPOLY *poly, double radius, JoinStyle join_style,
     join_style, mitre_limit, srid);
   if (! exterior)
     /* A convex ring contracted past its own width leaves nothing */
-    return (inward && buffer_ring_is_convex(poly->rings[0])) ?
+    return (inward && geom_ring_is_convex(poly->rings[0])) ?
       lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0)) : NULL;
 
   /* Construct the curved polygon */

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -55,6 +55,7 @@
 #include <meos_internal.h>
 #include <meos_internal_geo.h>
 #include <meos_rgeo.h>
+#include "geo/geo_funcs.h"
 #include "geo/stbox.h"
 #include "geo/tgeo_spatialfuncs.h"
 #include "rgeo/trgeo.h"
@@ -1151,6 +1152,62 @@ trgeo_trav_adaptive(const Temporal *temp, const TInstant *inst_a,
  * terminate at depth 0 with two samples (start and end). The unary
  * union dissolves any redundant overlap between samples.
  */
+/**
+ * @brief Return true if the reference geometry of a temporal rigid geometry is
+ * a convex body
+ * @details Convexity is a property of the reference geometry, which is one
+ * geometry for the whole value, so it is read once rather than per segment.
+ * A body carrying an inner ring is not convex.
+ */
+static bool
+trgeo_ref_is_convex(const GSERIALIZED *gs)
+{
+  LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+  bool result = false;
+  if (lwgeom->type == POLYGONTYPE && ((LWPOLY *) lwgeom)->nrings == 1)
+    result = geom_ring_is_convex(((LWPOLY *) lwgeom)->rings[0]);
+  lwgeom_free(lwgeom);
+  return result;
+}
+
+/**
+ * @brief Return the region a convex body covers between two of its placements
+ * @details Every point of a convex body travels within the hull of the two
+ * placements, each vertex moving along a straight segment, so that hull is
+ * what the body covers between them. The hull also contains the two
+ * placements it spans, so a sweep replaces them rather than joining them.
+ */
+static GSERIALIZED *
+trgeo_convex_sweep(const GSERIALIZED *a, const GSERIALIZED *b)
+{
+  LWGEOM *lw_a = lwgeom_from_gserialized(a);
+  LWGEOM *lw_b = lwgeom_from_gserialized(b);
+  POINTARRAY *ra = ((LWPOLY *) lw_a)->rings[0];
+  POINTARRAY *rb = ((LWPOLY *) lw_b)->rings[0];
+  POINTARRAY *pa = ptarray_construct_empty(0, 0, ra->npoints + rb->npoints);
+  POINT4D p = {0, 0, 0, 0};
+  for (uint32_t i = 0; i < ra->npoints; i++)
+  {
+    const POINT2D *q = getPoint2d_cp(ra, i);
+    p.x = q->x; p.y = q->y;
+    ptarray_append_point(pa, &p, LW_TRUE);
+  }
+  for (uint32_t i = 0; i < rb->npoints; i++)
+  {
+    const POINT2D *q = getPoint2d_cp(rb, i);
+    p.x = q->x; p.y = q->y;
+    ptarray_append_point(pa, &p, LW_TRUE);
+  }
+  LWGEOM *line = lwline_as_lwgeom(lwline_construct(gserialized_get_srid(a),
+    NULL, pa));
+  GSERIALIZED *gs = geo_serialize(line);
+  lwgeom_free(line);
+  lwgeom_free(lw_a); lwgeom_free(lw_b);
+  GSERIALIZED *result = geom_convex_hull(gs);
+  pfree(gs);
+  return result;
+}
+
 GSERIALIZED *
 trgeometry_traversed_area(const Temporal *temp, bool unary_union)
 {
@@ -1176,6 +1233,38 @@ trgeometry_traversed_area(const Temporal *temp, bool unary_union)
   for (int i = 0; i + 1 < n_insts; i++)
     trgeo_trav_adaptive(temp, insts[i], insts[i + 1], 0,
       &geoms, &n_geoms, &cap);
+
+  /* The samples are the placements the body passes through; the area it
+   * traverses is what it covers BETWEEN them as well. A convex body covers
+   * the hull of each consecutive pair, which is the case the traversed area
+   * is defined for; a body with a concavity keeps the placements alone, as
+   * its hull would close a concavity the body never reaches.
+   * Only the united form answers the traversed area. The collection form
+   * enumerates the placements themselves, which the ever/always spatial
+   * relationships read one by one to tell the two quantifiers apart, so a
+   * region spanning several placements would answer `always` for a body that
+   * only ever passes through. */
+  if (unary_union && n_geoms > 1 && trgeo_ref_is_convex(trgeo_geom_p(temp)))
+  {
+    GSERIALIZED **swept = palloc(sizeof(GSERIALIZED *) * (n_geoms - 1));
+    int n_swept = 0;
+    for (int i = 0; i + 1 < n_geoms; i++)
+    {
+      GSERIALIZED *hull = trgeo_convex_sweep(geoms[i], geoms[i + 1]);
+      if (hull)
+        swept[n_swept++] = hull;
+    }
+    if (n_swept > 0)
+    {
+      for (int i = 0; i < n_geoms; i++)
+        pfree(geoms[i]);
+      pfree(geoms);
+      geoms = swept;
+      n_geoms = n_swept;
+    }
+    else
+      pfree(swept);
+  }
 
   GSERIALIZED *result;
   if (n_geoms == 1)

--- a/mobilitydb/test/rgeo/expected/164_trgeo_spatialfuncs.test.out
+++ b/mobilitydb/test/rgeo/expected/164_trgeo_spatialfuncs.test.out
@@ -7,9 +7,9 @@ SELECT ST_AsText(round(traversedArea(
 
 SELECT ST_AsText(round(traversedArea(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2026-01-01, Pose(Point(2 0),0)@2026-01-02]', TRUE), 6));
-                           st_astext                           
----------------------------------------------------------------
- MULTIPOLYGON(((0 1,1 1,1 0,0 0,0 1)),((2 1,3 1,3 0,2 0,2 1)))
+           st_astext            
+--------------------------------
+ POLYGON((0 0,0 1,3 1,3 0,0 0))
 (1 row)
 
 SELECT asText(round(centroid(


### PR DESCRIPTION
The area a rigid geometry traverses holds the placements it passes through and nothing of what it covers between them, so a unit square carried from x=0 to x=2 answers two disjoint squares with a hole across the middle of its own journey:

```sql
SELECT ST_AsText(traversedArea(
  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2000-01-01, Pose(Point(2 0),0)@2000-01-02]',
  TRUE));
-- MULTIPOLYGON(((0 1,1 1,1 0,0 0,0 1)),((2 1,3 1,3 0,2 0,2 1)))
```

The samples the function collects already carry the assumption the answer needs, its own comment stating that the convex hull of two endpoint polygons equals the swept ribbon, but it takes no hull: it hands the placements to a union, and the union of two disjoint squares is two disjoint squares.

### The construction

Every point of a convex body travels within the hull of two consecutive placements, each vertex moving along a straight segment, so that hull is what the body covers between them. Each consecutive pair contributes it. The square above answers `POLYGON((0 0,0 1,3 1,3 0,0 0))`, and a 10 by 10 body translated by 4 covers 10 by 14.

This is the construction Chapter 4 describes for a convex body: the planar graph it builds over the edges of the start placement, the edges of the end placement and the segments its vertices travel along bounds exactly that hull.

A body carrying a concavity keeps the answer it has. Its hull would close the concavity, which is a place the body never reaches, and the area such a body traverses is a question of its own — Chapter 4 answers it by decomposing the body into convex parts, which is work this does not do.

Only the united form answers the traversed area. The collection form enumerates the placements themselves, which the ever and always spatial relationships read one by one to tell the two quantifiers apart, so it keeps them: a region spanning several placements answers `always` for a body that only ever passes through.

The hull is the native one, so a sweep reaches no GEOS. The convexity of a ring is read through the predicate the buffer engine already carries, which moves to a header so that both callers inline it rather than reaching it through a call across files.

### Accuracy

The hull is exact where the body translates. Where it turns, a vertex travels an arc and the hull spans the chord, so the answer covers a little more than the body reaches, by an amount the rotation across a sample interval bounds. The samples are already subdivided while that rotation is large.

### Measured

| case | answer |
| --- | --- |
| unit square, x=0 to x=2 | `POLYGON((0 0,0 1,3 1,3 0,0 0))` |
| 10 by 10 body, translated by 4 | `POLYGON((0 0,0 10,14 10,14 0,0 0))`, an area of 140 |
| body with a concavity | unchanged, the gap between its placements stays uncovered |
| one instant | unchanged, its own placement |

`154_trgeo_spatialrels` is unchanged, so the ever and always relationships answer as they did. `164_trgeo_spatialfuncs` carries the corrected answer above.
