### PR TITLE
Answer a span set as its bounding span answers

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -345,7 +345,7 @@
 						<para><link linkend="setspan_containedby"><varname>&lt;@</varname></link>: ¿Está el primer valor contenido en el segundo?</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="setspan_adjacent"><varname>-|-</varname></link>: ¿Es el primer valor adyacente al segundo?</para>
+						<para><link linkend="setspan_adjacent"><varname>-|-</varname></link>: ¿Es el primer valor adyacente al segundo? Dos valores son adyacentes cuando se tocan sin solaparse, es decir, cuando comparten una frontera y no tienen ningún valor en común en ella. Para los tipos base continuos <varname>float</varname> y <varname>timestamptz</varname>, un límite compartido es ese contacto. Para los tipos base discretos <varname>int</varname>, <varname>bigint</varname> y <varname>date</varname>, cuyos rangos se almacenan en forma normal, significa valores consecutivos.</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -1048,6 +1048,10 @@ SELECT tstzspan '[2001-01-01, 2001-01-05)' * tstzspan '[2001-01-03, 2001-01-07)'
 		<sect2>
 			<title>Operaciones topológicas</title>
 			<para>A continuación se presentan los operadores topológicos disponibles para los tipos de conjunto y de rango.</para>
+
+			<para>Un valor, el rango que contiene únicamente ese valor y el conjunto de rangos que contiene únicamente ese rango denotan el mismo conjunto, al igual que un rango y el conjunto de rangos que contiene únicamente a él. Todas las operaciones dan la misma respuesta para todas estas escrituras.</para>
+
+			<para>Un conjunto de rangos es una unión de rangos disjuntos. Las operaciones <varname>&amp;&amp;</varname>, <varname>@&gt;</varname>, <varname>&lt;@</varname> y <varname>~=</varname> responden sobre el valor mismo, por lo que un valor que cae en un hueco de un conjunto de rangos no está contenido en él. La operación <varname>-|-</varname> y las operaciones de posición de la sección siguiente responden sobre la <emphasis>caja delimitadora</emphasis> del valor, el rango más pequeño que lo contiene: los huecos de un conjunto de rangos no son fronteras de él.</para>
 		<itemizedlist>
 				<listitem xml:id="setspan_overlaps">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
@@ -1097,19 +1101,34 @@ SELECT tstzspan '[2001-02-01, 2001-03-01)' &lt;@ tstzspan '[2001-01-01, 2001-05-
 
 				<listitem xml:id="setspan_adjacent">
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
-					<para>¿Es el primer valor adyacente al segundo?</para>
+					<para>¿Es el primer valor adyacente al segundo? Dos valores son adyacentes cuando se tocan sin solaparse, es decir, cuando comparten una frontera y no tienen ningún valor en común en ella. Para los tipos base continuos <varname>float</varname> y <varname>timestamptz</varname>, un límite compartido es ese contacto. Para los tipos base discretos <varname>int</varname>, <varname>bigint</varname> y <varname>date</varname>, cuyos rangos se almacenan en forma normal, significa valores consecutivos.</para>
 					<para><varname>spans -|- spans → boolean</varname></para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT intspan '[2, 6)' -|- intspan '[6, 7)';
 -- true
-SELECT floatspan '[2, 5)' -|- floatspan '(5, 6)';
+SELECT intspan '[1, 5]' -|- intspan '[6, 10]';
+-- true
+SELECT intspan '[1, 5]' -|- intspan '[5, 10]';
 -- false
+SELECT floatspan '[2, 5)' -|- floatspan '(5, 6)';
+-- true
+SELECT floatspan '[1, 5]' -|- floatspan '[5, 9]';
+-- true
 SELECT floatspanset '{[2, 3],[4, 5)}' -|- floatspan '(5, 6)';
 -- true
-SELECT tstzspan '[2001-01-01, 2001-01-05)' -|- tstzset '{2001-01-05, 2001-01-07}';
--- true
 SELECT tstzspanset '{[2001-01-01, 2001-01-02]}' -|- tstzspan '[2001-01-02, 2001-01-03)';
+-- true
+</programlisting>
+					<para>Un conjunto de rangos responde como su caja delimitadora, y las tres escrituras de un valor coinciden:</para>
+					<programlisting language="sql" xml:space="preserve">
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 3;
 -- false
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspan '[3,3]';
+-- false
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspanset '{[3,3]}';
+-- false
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 12;
+-- true
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -345,7 +345,7 @@
 						<para><link linkend="setspan_containedby"><varname>&lt;@</varname></link>: Is the first value contained by the second one?</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="setspan_adjacent"><varname>-|-</varname></link>: Is the first value adjacent to the second one?</para>
+						<para><link linkend="setspan_adjacent"><varname>-|-</varname></link>: Is the first value adjacent to the second one? Two values are adjacent when they touch without overlapping, that is, when they share a boundary and have no value in common inside it. For the continuous base types <varname>float</varname> and <varname>timestamptz</varname> a shared bound is such a touch. For the discrete base types <varname>int</varname>, <varname>bigint</varname> and <varname>date</varname>, whose spans are stored in normal form, it means consecutive values.</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -1040,6 +1040,10 @@ SELECT tstzspan '[2001-01-01, 2001-01-05)' * tstzspan '[2001-01-03, 2001-01-07)'
 			<title>Topological Operations</title>
 			<para>The topological operations available for the set and span types are given next.</para>
 
+			<para>A value, the span containing only that value, and the span set containing only that span denote the same set, and so do a span and the span set containing only it. Every operation gives the same answer for all of these spellings.</para>
+
+			<para>A span set is a union of disjoint spans. The operations <varname>&amp;&amp;</varname>, <varname>@&gt;</varname>, <varname>&lt;@</varname> and <varname>~=</varname> answer on the value itself, so a value that falls in a hole of a span set is not contained in it. The operation <varname>-|-</varname> and the position operations of the next section answer on the <emphasis>bounding span</emphasis> of the value, the smallest span containing it: the holes of a span set are not boundaries of it.</para>
+
 			<itemizedlist>
 				<listitem xml:id="setspan_overlaps">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
@@ -1088,17 +1092,34 @@ SELECT floatspanset '{[1,2],[3,4]}' &lt;@ floatspan '[1, 6]';
 
 				<listitem xml:id="setspan_adjacent">
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
-					<para>Is the first value adjacent to the second one?</para>
+					<para>Is the first value adjacent to the second one? Two values are adjacent when they touch without overlapping, that is, when they share a boundary and have no value in common inside it. For the continuous base types <varname>float</varname> and <varname>timestamptz</varname> a shared bound is such a touch. For the discrete base types <varname>int</varname>, <varname>bigint</varname> and <varname>date</varname>, whose spans are stored in normal form, it means consecutive values.</para>
 					<para><varname>spans -|- spans → boolean</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[2, 6)' -|- intspan '[6, 7)';
 -- true
-SELECT floatspan '[2, 5)' -|- floatspan '(5, 6)';
+SELECT intspan '[1, 5]' -|- intspan '[6, 10]';
+-- true
+SELECT intspan '[1, 5]' -|- intspan '[5, 10]';
 -- false
+SELECT floatspan '[2, 5)' -|- floatspan '(5, 6)';
+-- true
+SELECT floatspan '[1, 5]' -|- floatspan '[5, 9]';
+-- true
 SELECT floatspanset '{[2, 3],[4, 5)}' -|- floatspan '(5, 6)';
 -- true
 SELECT tstzspanset '{[2001-01-01, 2001-01-02]}' -|- tstzspan '[2001-01-02, 2001-01-03)';
+-- true
+</programlisting>
+					<para>A span set answers as its bounding span, and the three spellings of a value agree:</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 3;
 -- false
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspan '[3,3]';
+-- false
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspanset '{[3,3]}';
+-- false
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 12;
+-- true
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -343,10 +343,11 @@ overlaps_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
 inline bool
 adjacent_spanset_value(const SpanSet *ss, Datum value)
 {
-  /* A span set and a value are adjacent if and only if the first or the last
-   * span is adjacent to the value */
-  return adjacent_span_value(SPANSET_SP_N(ss, 0), value) ||
-         adjacent_span_value(SPANSET_SP_N(ss, ss->count - 1), value);
+  /* A span set is adjacent to a value as its bounding span is: the holes of
+   * the set are not boundaries of it, so a value inside one is no more
+   * adjacent to the set than a value inside a span is adjacent to that span.
+   * This is what the span and the span set forms of the operator answer */
+  return adjacent_span_value(&ss->span, value);
 }
 
 /**
@@ -375,18 +376,8 @@ adjacent_spanset_span(const SpanSet *ss, const Span *s)
   if (! ensure_valid_spanset_span(ss, s))
     return false;
 
-  /* Singleton span set */
-  if (ss->count == 1)
-    return adjacent_span_span(SPANSET_SP_N(ss, 0), s);
-
-  const Span *s1 = SPANSET_SP_N(ss, 0);
-  const Span *s2 = SPANSET_SP_N(ss, ss->count - 1);
-  /*
-   * Two spans A..B and C..D are adjacent if and only if
-   * B is adjacent to C, or D is adjacent to A.
-   */
-  return (s2->upper == s->lower && s2->upper_inc != s->lower_inc) ||
-         (s->upper == s1->lower && s->upper_inc != s1->lower_inc);
+  /* A span set is adjacent to a span as its bounding span is */
+  return adjacent_span_span(&ss->span, s);
 }
 
 /**
@@ -415,22 +406,8 @@ adjacent_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)
   if (! ensure_valid_spanset_spanset(ss1, ss2))
     return false;
 
-  /* Singleton span set */
-  if (ss1->count == 1)
-    return adjacent_spanset_span(ss2, SPANSET_SP_N(ss1, 0));
-  if (ss2->count == 1)
-    return adjacent_spanset_span(ss1, SPANSET_SP_N(ss2, 0));
-
-  const Span *starts1 = SPANSET_SP_N(ss1, 0);
-  const Span *ends1 = SPANSET_SP_N(ss1, ss1->count - 1);
-  const Span *starts2 = SPANSET_SP_N(ss2, 0);
-  const Span *ends2 = SPANSET_SP_N(ss2, ss2->count - 1);
-  /*
-   * Two spans A..B and C..D are adjacent if and only if
-   * B is adjacent to C, or D is adjacent to A.
-   */
-  return (ends1->upper == starts2->lower && ends1->upper_inc != starts2->lower_inc) ||
-    (ends2->upper == starts1->lower && ends2->upper_inc != starts1->lower_inc);
+  /* Two span sets are adjacent as their bounding spans are */
+  return adjacent_span_span(&ss1->span, &ss2->span);
 }
 
 /*****************************************************************************

--- a/mobilitydb/test/temporal/expected/005_span_ops.test.out
+++ b/mobilitydb/test/temporal/expected/005_span_ops.test.out
@@ -52,6 +52,102 @@ SELECT floatspan '[1, 3]' -|- floatspan '[1, 3]';
  f
 (1 row)
 
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 3;
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspan '[3,3]';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspanset '{[3,3]}';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 12;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspan '[12,12]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspanset '{[12,12]}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- 3.0;
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- floatspan '[3,3]';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- floatspanset '{[3,3]}';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- 12.0;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- floatspan '[12,12]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- floatspanset '{[12,12]}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT floatspan '[1,5]' -|- floatspan '[5,9]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT floatspanset '{[1,5]}' -|- floatspan '[5,9]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT intspan '[1,5]' -|- intspan '[6,10]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT intspan '[1,5]' -|- intspan '[5,10]';
+ ?column? 
+----------
+ f
+(1 row)
+
 SELECT floatspan '[1, 2]' = floatspan '[1, 2]';
  ?column? 
 ----------

--- a/mobilitydb/test/temporal/expected/012_spanset_indexes_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/012_spanset_indexes_tbl.test.out
@@ -27,7 +27,7 @@ SELECT COUNT(*) FROM tbl_intspanset WHERE i @> 50;
 SELECT COUNT(*) FROM tbl_intspanset WHERE i -|- 50;
  count 
 -------
-     2
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_intspanset WHERE i << 15;
@@ -229,7 +229,7 @@ SELECT COUNT(*) FROM tbl_intspanset WHERE i @> 50;
 SELECT COUNT(*) FROM tbl_intspanset WHERE i -|- 50;
  count 
 -------
-     2
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_intspanset WHERE i << 15;

--- a/mobilitydb/test/temporal/queries/005_span_ops.test.sql
+++ b/mobilitydb/test/temporal/queries/005_span_ops.test.sql
@@ -51,6 +51,34 @@ SELECT 1.0 -|- floatspan '(1, 3]';
 SELECT floatspan '[1, 3]' -|- 1.0;
 SELECT floatspan '[1, 3]' -|- floatspan '[1, 3]';
 
+-- A value, the span holding only that value and the span set holding only
+-- that span are the same set: the three spellings answer alike. A span set
+-- answers as its bounding span, so a bound inside a hole is not a boundary.
+
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 3;
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspan '[3,3]';
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspanset '{[3,3]}';
+
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 12;
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspan '[12,12]';
+SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspanset '{[12,12]}';
+
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- 3.0;
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- floatspan '[3,3]';
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- floatspanset '{[3,3]}';
+
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- 12.0;
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- floatspan '[12,12]';
+SELECT floatspanset '{[1,3], [5,8], [10,12]}' -|- floatspanset '{[12,12]}';
+
+-- A span and the span set holding only it answer alike, and a shared bound
+-- is a touch for a continuous type and consecutive values for a discrete one
+
+SELECT floatspan '[1,5]' -|- floatspan '[5,9]';
+SELECT floatspanset '{[1,5]}' -|- floatspan '[5,9]';
+SELECT intspan '[1,5]' -|- intspan '[6,10]';
+SELECT intspan '[1,5]' -|- intspan '[5,10]';
+
 -------------------------------------------------------------------------------
 
 SELECT floatspan '[1, 2]' = floatspan '[1, 2]';


### PR DESCRIPTION
A value, the span holding only that value and the span set holding only that span are one set, as are a span and the span set holding only it, so every operation answers alike for the three spellings. The adjacency of a span set is the adjacency of its bounding span: the holes between its spans are not boundaries of it, which is what the position operations of a span set and the bounding box of every temporal type already read. The three forms of the operator build that span and call the rule of a span, so a set of one span takes the path of the span itself. The manual carries the rule beside the operator in both languages, with the examples the operator answers.