### PR TITLE
Answer a comparison against a pose chain of another length

### DIFF
--- a/meos/src/posechain/posechain.c
+++ b/meos/src/posechain/posechain.c
@@ -866,7 +866,10 @@ posechainsegm_interpolate(const PoseChain *start, const PoseChain *end,
  * @details Every link locates at the ratio the whole chain moves through, so
  * the value sits on the segment only where all of them agree on one ratio.
  * @note The function returns -1.0 when the value is not on the segment, which
- * is what the lifting infrastructure reads to decide there is no crossing
+ * is what the lifting infrastructure reads to decide there is no crossing. A
+ * chain holding another number of links is a different structure and so is
+ * never on the segment, while the two chains defining the segment are values
+ * of one temporal chain and must agree on that number
  */
 long double
 posechainsegm_locate(const PoseChain *start, const PoseChain *end,
@@ -874,8 +877,10 @@ posechainsegm_locate(const PoseChain *start, const PoseChain *end,
 {
   if (! ensure_valid_posechain_posechain(start, end) ||
       ! ensure_valid_posechain_posechain(start, value) ||
-      ! ensure_same_count_posechain(start, end) ||
-      ! ensure_same_count_posechain(start, value))
+      ! ensure_same_count_posechain(start, end))
+    return -1.0;
+
+  if (start->count != value->count)
     return -1.0;
 
   long double result = -1.0;

--- a/mobilitydb/test/posechain/expected/552_tposechain.test.out
+++ b/mobilitydb/test/posechain/expected/552_tposechain.test.out
@@ -30,6 +30,36 @@ SELECT tposechain '{PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Po
 ERROR:  Operation on pose chains of 1 and 2 links
 LINE 1: SELECT tposechain '{PoseChain(Pose(Point(0 0), 0))@2000-01-0...
                           ^
+SELECT tposechain 'PoseChain(Pose(Point(0 0), 0))@2000-01-01' ?= posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]' ?= posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]' %= posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))' ?= tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]' ?= posechain 'PoseChain(Pose(Point(0 0), 0))';
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT asEWKT(round(valueAtTimestamp(
   appendInstant(
     tposechain(posechain(ARRAY[pose(ST_Point(0,0), 0), pose(ST_Point(10,0), 0)]),

--- a/mobilitydb/test/posechain/expected/554_tposechain_compops_tbl.test.out
+++ b/mobilitydb/test/posechain/expected/554_tposechain_compops_tbl.test.out
@@ -41,17 +41,22 @@ WHERE (t1.temp < t2.temp)::int + (t1.temp = t2.temp)::int + (t1.temp > t2.temp):
      0
 (1 row)
 
-SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2
-WHERE numPoses(t2.pc) = numLinks(t1.temp) AND t1.temp ?= t2.pc;
+SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2 WHERE t1.temp ?= t2.pc;
+ count 
+-------
+     0
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2 WHERE t1.temp %= t2.pc;
  count 
 -------
      0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2
-WHERE numPoses(t2.pc) = numLinks(t1.temp) AND t1.temp %= t2.pc;
+WHERE numPoses(t2.pc) <> numLinks(t1.temp);
  count 
 -------
-     0
+ 63443
 (1 row)
 

--- a/mobilitydb/test/posechain/queries/552_tposechain.test.sql
+++ b/mobilitydb/test/posechain/queries/552_tposechain.test.sql
@@ -50,6 +50,19 @@ SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Po
 SELECT tposechain '{PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))@2000-01-02}';
 
 -------------------------------------------------------------------------------
+-- Comparison against a chain of another length
+-- A chain that holds another number of links is a different value, so a
+-- comparison against it answers false rather than refusing the question.
+-------------------------------------------------------------------------------
+
+SELECT tposechain 'PoseChain(Pose(Point(0 0), 0))@2000-01-01' ?= posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
+SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]' ?= posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
+SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]' %= posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
+SELECT posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))' ?= tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]';
+-- The same chain still compares equal where the lengths agree
+SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]' ?= posechain 'PoseChain(Pose(Point(0 0), 0))';
+
+-------------------------------------------------------------------------------
 -- Interpolation
 -- Every link interpolates as a pose does, linearly in position and along the
 -- shortest arc in rotation.

--- a/mobilitydb/test/posechain/queries/554_tposechain_compops_tbl.test.sql
+++ b/mobilitydb/test/posechain/queries/554_tposechain_compops_tbl.test.sql
@@ -47,11 +47,14 @@ WHERE (t1.temp < t2.temp)::int + (t1.temp = t2.temp)::int + (t1.temp > t2.temp):
 -- Ever and always comparison against a value
 -------------------------------------------------------------------------------
 
--- A comparison reaches the operator only where the two chains hold the same
--- number of links, an operation across differing counts being refused
+-- A chain of another length is simply not equal, so the whole cross join
+-- answers rather than refusing the pairs whose counts differ
+SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2 WHERE t1.temp ?= t2.pc;
+SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2 WHERE t1.temp %= t2.pc;
+
+-- The join does span differing counts, so the answers above are false rather
+-- than absent
 SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2
-WHERE numPoses(t2.pc) = numLinks(t1.temp) AND t1.temp ?= t2.pc;
-SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2
-WHERE numPoses(t2.pc) = numLinks(t1.temp) AND t1.temp %= t2.pc;
+WHERE numPoses(t2.pc) <> numLinks(t1.temp);
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
A chain holding a different number of links is a different value, so a
comparison against it is false rather than a question the type refuses.
`posechain_eq` already answers it that way and `posechain_cmp` orders a chain
before every chain that extends it, but the lifted `?=` and `%=` raise
instead, which makes the operators unusable over a table:

```sql
SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2
WHERE t1.temp ?= t2.pc;
-- ERROR:  Operation on pose chains of 4 and 5 links
```

63443 of the pairs in that join hold differing link counts, so the error is
reached by the great majority of them.

### The change

`posechainsegm_locate` already carries the total answer in its contract: it
returns -1.0 for a value that is not on the segment, which the lifting
infrastructure reads as no crossing. A chain of another length is never on the
segment, so it takes that path.

The two chains that DEFINE the segment keep the error. They are values of one
temporal chain, where an equal number of links is the invariant that makes the
link-wise interpolation definable, and the constructor tests continue to assert
it.

### What moves

Two expected outputs. `552_tposechain` gains the scalar cases, answering false
for an instant, a sequence, the always form and the reversed argument order,
with a matched-length case still answering true. `554_tposechain_compops_tbl`
drops the link-count prefilter its two cross joins needed and gains the count
of differing pairs, so the answers read as false rather than absent. The two
constructor errors are unchanged.
