### PR TITLE
Answer the nearest approach distance where there is no distance to read

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2585,6 +2585,9 @@ nad_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
     return DBL_MAX;
 
   Temporal *dist = tdistance_trgeometry_geo(temp, gs);
+  if (dist == NULL)
+    return DBL_MAX;
+
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist);
   return result;
@@ -2619,6 +2622,14 @@ nad_trgeometry_stbox(const Temporal *temp, const STBox *box)
     (Temporal *) temp;
   /* Compute the result */
   Temporal *dist = tdistance_trgeometry_geo(temp, geo);
+  if (dist == NULL)
+  {
+    pfree(geo);
+    if (hast)
+      pfree(temp1);
+    return DBL_MAX;
+  }
+
   double result = DatumGetFloat8(temporal_min_value(dist));
   pfree(dist); pfree(geo);
   if (hast)

--- a/meos/test/trgeo_test.c
+++ b/meos/test/trgeo_test.c
@@ -44,6 +44,7 @@
  * @endcode
  */
 
+#include <float.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -241,6 +242,77 @@ int main(void)
     meos_errno_reset();
   }
   free(trgeo3); free(poseset1);
+
+  /* The nearest approach distance answers the sentinel of its return type
+   * where the temporal distance underneath it is not computed, rather than
+   * reading a value that is not there. Three inputs reach that: a geometry
+   * whose type the distance does not support, and a three-dimensional body
+   * against a point and against a box, which the planar computation declines */
+  static const char *trgeo4_in =
+    "Polygon((0 0,1 0,1 1,0 1,0 0));"
+    "[Pose(Point(0 0),0)@2001-01-01, Pose(Point(2 0),0)@2001-01-02]";
+  static const char *trgeo5_in =
+    "PolyhedralSurface(((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)));"
+    "[Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(2 0 0),1,0,0,0)@2001-01-02]";
+
+  Temporal *trgeo4 = trgeometry_in(trgeo4_in);
+  Temporal *trgeo5 = trgeometry_in(trgeo5_in);
+  GSERIALIZED *coll = geom_in("GeometryCollection(Point(9 9))", -1);
+  GSERIALIZED *point3d = geom_in("Point(9 9 9)", -1);
+  GSERIALIZED *point2d = geom_in("Point(9 9)", -1);
+  STBox *box3d = stbox_in("STBOX ZT(((5,5,5),(6,6,6)),[2001-01-01, 2001-01-02])");
+  if (! trgeo4 || ! trgeo5 || ! coll || ! point3d || ! point2d || ! box3d)
+  {
+    printf("FAILED: could not build the nearest approach distance arguments\n");
+    result = 1;
+  }
+  else
+  {
+    meos_errno_reset();
+    if (nad_trgeometry_geo(trgeo4, coll) != DBL_MAX || meos_errno() == 0)
+    {
+      printf("FAILED: nad_trgeometry_geo(trgeometry, collection)\n");
+      result = 1;
+    }
+    else
+      printf("OK: nad_trgeometry_geo(trgeometry, collection) answers the "
+        "sentinel, errno %d\n", meos_errno());
+
+    meos_errno_reset();
+    if (nad_trgeometry_geo(trgeo5, point3d) != DBL_MAX || meos_errno() == 0)
+    {
+      printf("FAILED: nad_trgeometry_geo(3D trgeometry, 3D point)\n");
+      result = 1;
+    }
+    else
+      printf("OK: nad_trgeometry_geo(3D trgeometry, 3D point) answers the "
+        "sentinel, errno %d\n", meos_errno());
+
+    meos_errno_reset();
+    if (nad_trgeometry_stbox(trgeo5, box3d) != DBL_MAX || meos_errno() == 0)
+    {
+      printf("FAILED: nad_trgeometry_stbox(3D trgeometry, 3D box)\n");
+      result = 1;
+    }
+    else
+      printf("OK: nad_trgeometry_stbox(3D trgeometry, 3D box) answers the "
+        "sentinel, errno %d\n", meos_errno());
+
+    /* A computable distance still answers it */
+    meos_errno_reset();
+    double nad = nad_trgeometry_geo(trgeo4, point2d);
+    if (nad == DBL_MAX || meos_errno() != 0)
+    {
+      printf("FAILED: nad_trgeometry_geo(trgeometry, point) answered the "
+        "sentinel, errno %d\n", meos_errno());
+      result = 1;
+    }
+    else
+      printf("OK: nad_trgeometry_geo(trgeometry, point): %g\n", nad);
+    meos_errno_reset();
+  }
+  free(trgeo4); free(trgeo5); free(coll); free(point3d); free(point2d);
+  free(box3d);
 
   /* Finalize MEOS */
   meos_finalize();


### PR DESCRIPTION
Two of the trgeometry nearest approach distances read the temporal distance
without asking whether it is computed. `nad_trgeometry_geo` and
`nad_trgeometry_stbox` pass the result of `tdistance_trgeometry_geo` straight
to `temporal_min_value`, which asserts on a null argument:

```
trgeo_test: temporal.c:2213: temporal_min_value: Assertion `temp' failed
```

Their two siblings test the result first and answer `DBL_MAX`:
`nad_trgeometry_tpoint` and `nad_trgeometry_trgeometry` both carry

```c
  Temporal *dist = tdistance_trgeometry_tpoint(temp1, temp2);
  if (dist == NULL)
    return DBL_MAX;
```

which is what the two functions here gain. `DBL_MAX` is the sentinel they
already return from their own validity guard, and the wrappers in
`mobilitydb/src/rgeo/trgeo_distance.c` already map it to SQL NULL.

Three inputs reach the null: a geometry collection, whose type the distance
declines, and a three-dimensional body against a point and against a box,
which the planar computation declines.

`meos_error(ERROR, ...)` carries no return-or-not contract. Its own
documentation states that it returns to the caller whenever an error handler
is installed, which `meos_initialize_error_handler` lets any program do, and
instructs a caller never to assume the call did not return. Reading the
sentinel is what that asks for.

### What moves

No expected output. In the extension `ereport` at `ERROR` does not return, so
those inputs raise the same error either way; the check is what a program
embedding the library needs. `meos/test/trgeo_test.c`, which the MEOS
workflow compiles and runs, carries the three inputs and a control that
answers a real distance.