### PR TITLE
Name the number of poses of a temporal chain as its base type does

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1756,7 +1756,7 @@
 				<title>Funciones de acceso</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="numLinks"><varname>numLinks</varname></link>: Devuelve el número de eslabones que tiene todo valor de una cadena de poses temporal</para>
+						<para><link linkend="tposechain_numPoses"><varname>numPoses</varname></link>: Devuelve el número de eslabones que tiene todo valor de una cadena de poses temporal</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="tposechain_getValue"><varname>getValue</varname>, <varname>getValues</varname>, <varname>timeSpan</varname></link>: Devuelve el valor de un instante temporal, el conjunto de valores o el lapso de tiempo</para>

--- a/doc/es/temporal_pose_chains.xml
+++ b/doc/es/temporal_pose_chains.xml
@@ -463,13 +463,13 @@ SELECT asEWKT(round((tposechain
 		<sect2 xml:id="tposechain_accessors">
 			<title>Funciones de acceso</title>
 			<itemizedlist>
-				<listitem xml:id="numLinks">
-					<indexterm significance="normal"><primary><varname>numLinks</varname></primary></indexterm>
+				<listitem xml:id="tposechain_numPoses">
+					<indexterm significance="normal"><primary><varname>numPoses</varname></primary></indexterm>
 					<para>Devuelve el número de eslabones que tiene todo valor de una cadena de poses temporal</para>
-					<para><varname>numLinks(tposechain) → integer</varname></para>
+					<para><varname>numPoses(tposechain) → integer</varname></para>
 					<para>El número es el mismo en todo instante, por lo que un instante responde por todo el valor.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT numLinks(tposechain
+SELECT numPoses(tposechain
   'PoseChain(Pose(Point(0 0), 0), Pose(Point(10 0), 0))@2001-01-01');
 -- 2
 </programlisting>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1767,7 +1767,7 @@
 				<title>Accessor Functions</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="numLinks"><varname>numLinks</varname></link>: Return the number of links every value of a temporal pose chain holds</para>
+						<para><link linkend="tposechain_numPoses"><varname>numPoses</varname></link>: Return the number of links every value of a temporal pose chain holds</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="tposechain_getValue"><varname>getValue</varname>, <varname>getValues</varname>, <varname>timeSpan</varname></link>: Return the value of a temporal instant, the set of values, or the time span</para>

--- a/doc/temporal_pose_chains.xml
+++ b/doc/temporal_pose_chains.xml
@@ -463,13 +463,13 @@ SELECT asEWKT(round((tposechain
 		<sect2 xml:id="tposechain_accessors">
 			<title>Accessor Functions</title>
 			<itemizedlist>
-				<listitem xml:id="numLinks">
-					<indexterm significance="normal"><primary><varname>numLinks</varname></primary></indexterm>
+				<listitem xml:id="tposechain_numPoses">
+					<indexterm significance="normal"><primary><varname>numPoses</varname></primary></indexterm>
 					<para>Return the number of links every value of a temporal pose chain holds</para>
-					<para><varname>numLinks(tposechain) → integer</varname></para>
+					<para><varname>numPoses(tposechain) → integer</varname></para>
 					<para>The number is the same at every instant, so one instant answers for the whole value.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT numLinks(tposechain
+SELECT numPoses(tposechain
   'PoseChain(Pose(Point(0 0), 0), Pose(Point(10 0), 0))@2001-01-01');
 -- 2
 </programlisting>

--- a/meos/include/meos_posechain.h
+++ b/meos/include/meos_posechain.h
@@ -224,7 +224,7 @@ extern Temporal *tposechain_to_tpose(const Temporal *temp);
 
 /* Accessor functions */
 
-extern int tposechain_num_links(const Temporal *temp);
+extern int tposechain_num_poses(const Temporal *temp);
 
 /* Ever/always and temporal comparison functions */
 

--- a/meos/src/posechain/tposechain.c
+++ b/meos/src/posechain/tposechain.c
@@ -380,7 +380,7 @@ tposechain_to_tpose(const Temporal *temp)
   lfinfo.argtype[0] = temptype_basetype(temp->temptype);
   lfinfo.restype = T_TPOSE;
   lfinfo.reslinear = MEOS_FLAGS_LINEAR_INTERP(temp->flags) &&
-    tposechain_num_links(temp) == 1;
+    tposechain_num_poses(temp) == 1;
   return tfunc_temporal(temp, &lfinfo);
 }
 
@@ -396,10 +396,10 @@ tposechain_to_tpose(const Temporal *temp)
  * answers for the whole value.
  * @param[in] temp Temporal pose chain
  * @return On error return @p INT_MAX
- * @csqlfn #Tposechain_num_links()
+ * @csqlfn #Tposechain_num_poses()
  */
 int
-tposechain_num_links(const Temporal *temp)
+tposechain_num_poses(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPOSECHAIN(temp, INT_MAX);

--- a/mobilitydb/datagen/posechain/random_posechain.sql
+++ b/mobilitydb/datagen/posechain/random_posechain.sql
@@ -213,7 +213,7 @@ WITH temp AS (
   SELECT k, random_tposechain2d_discseq(-100, 100, -100, 100, radians(-pi()),
     radians(pi()), '2001-01-01', '2001-12-31', 10, 1, 5, 1, 10) AS ti
   FROM generate_series(1,10) k )
-SELECT DISTINCT numLinks(ti) IS NOT NULL FROM temp;
+SELECT DISTINCT numPoses(ti) IS NOT NULL FROM temp;
 */
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/sql/posechain/552_tposechain.in.sql
+++ b/mobilitydb/sql/posechain/552_tposechain.in.sql
@@ -250,9 +250,9 @@ CREATE CAST (tposechain AS tpose) WITH FUNCTION tpose(tposechain);
  ******************************************************************************/
 -- Specific accessors for temporal pose chains
 
-CREATE FUNCTION numLinks(tposechain)
+CREATE FUNCTION numPoses(tposechain)
   RETURNS integer
-  AS 'MODULE_PATHNAME', 'Tposechain_num_links'
+  AS 'MODULE_PATHNAME', 'Tposechain_num_poses'
   LANGUAGE C IMMUTABLE STRICT;
 
 /******************************************************************************/

--- a/mobilitydb/src/posechain/tposechain.c
+++ b/mobilitydb/src/posechain/tposechain.c
@@ -129,18 +129,18 @@ Tposechain_to_tpose(PG_FUNCTION_ARGS)
  * Accessor functions
  *****************************************************************************/
 
-PGDLLEXPORT Datum Tposechain_num_links(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tposechain_num_links);
+PGDLLEXPORT Datum Tposechain_num_poses(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tposechain_num_poses);
 /**
  * @ingroup mobilitydb_posechain_accessor
  * @brief Return the number of links every value of a temporal pose chain holds
- * @sqlfn numLinks()
+ * @sqlfn numPoses()
  */
 Datum
-Tposechain_num_links(PG_FUNCTION_ARGS)
+Tposechain_num_poses(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  int result = tposechain_num_links(temp);
+  int result = tposechain_num_poses(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_INT32(result);
 }

--- a/mobilitydb/test/posechain/expected/552_tposechain.test.out
+++ b/mobilitydb/test/posechain/expected/552_tposechain.test.out
@@ -84,8 +84,8 @@ SELECT asEWKT(round((tposechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(10 0)
  Pose(POINT(10 0),0)@Sat Jan 01 00:00:00 2000 PST
 (1 row)
 
-SELECT numLinks(tposechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(10 0), 0))@2000-01-01');
- numlinks 
+SELECT numPoses(tposechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(10 0), 0))@2000-01-01');
+ numposes 
 ----------
         2
 (1 row)

--- a/mobilitydb/test/posechain/expected/552_tposechain_tbl.test.out
+++ b/mobilitydb/test/posechain/expected/552_tposechain_tbl.test.out
@@ -27,7 +27,7 @@ SELECT COUNT(*) FROM tbl_tposechain WHERE tposechainFromHexEWKB(asHexEWKB(temp))
      0
 (1 row)
 
-SELECT MIN(numLinks(temp)), MAX(numLinks(temp)) FROM tbl_tposechain;
+SELECT MIN(numPoses(temp)), MAX(numPoses(temp)) FROM tbl_tposechain;
  min | max 
 -----+-----
    1 |   5

--- a/mobilitydb/test/posechain/expected/554_tposechain_compops_tbl.test.out
+++ b/mobilitydb/test/posechain/expected/554_tposechain_compops_tbl.test.out
@@ -54,7 +54,7 @@ SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2 WHERE t1.temp %= t2.pc;
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2
-WHERE numPoses(t2.pc) <> numLinks(t1.temp);
+WHERE numPoses(t2.pc) <> numPoses(t1.temp);
  count 
 -------
  63443

--- a/mobilitydb/test/posechain/queries/552_tposechain.test.sql
+++ b/mobilitydb/test/posechain/queries/552_tposechain.test.sql
@@ -90,7 +90,7 @@ SELECT asEWKT(round((tposechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(10 0)
 -- Accessors
 -------------------------------------------------------------------------------
 
-SELECT numLinks(tposechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(10 0), 0))@2000-01-01');
+SELECT numPoses(tposechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(10 0), 0))@2000-01-01');
 SELECT tempSubtype(tposechain 'PoseChain(Pose(Point(0 0), 0))@2000-01-01');
 SELECT interp(tposechain '[PoseChain(Pose(Point(0 0), 0))@2000-01-01, PoseChain(Pose(Point(1 1), 0))@2000-01-02]');
 SELECT asEWKT(getValue(tposechain 'PoseChain(Pose(Point(0 0), 0))@2000-01-01'));

--- a/mobilitydb/test/posechain/queries/552_tposechain_tbl.test.sql
+++ b/mobilitydb/test/posechain/queries/552_tposechain_tbl.test.sql
@@ -50,7 +50,7 @@ SELECT COUNT(*) FROM tbl_tposechain WHERE tposechainFromHexEWKB(asHexEWKB(temp))
 -- Accessors
 -------------------------------------------------------------------------------
 
-SELECT MIN(numLinks(temp)), MAX(numLinks(temp)) FROM tbl_tposechain;
+SELECT MIN(numPoses(temp)), MAX(numPoses(temp)) FROM tbl_tposechain;
 SELECT DISTINCT tempSubtype(temp) FROM tbl_tposechain ORDER BY 1;
 SELECT DISTINCT SRID(temp) FROM tbl_tposechain;
 SELECT MIN(numInstants(temp)), MAX(numInstants(temp)) FROM tbl_tposechain;

--- a/mobilitydb/test/posechain/queries/554_tposechain_compops_tbl.test.sql
+++ b/mobilitydb/test/posechain/queries/554_tposechain_compops_tbl.test.sql
@@ -55,6 +55,6 @@ SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2 WHERE t1.temp %= t2.pc;
 -- The join does span differing counts, so the answers above are false rather
 -- than absent
 SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2
-WHERE numPoses(t2.pc) <> numLinks(t1.temp);
+WHERE numPoses(t2.pc) <> numPoses(t1.temp);
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
`tposechain_num_links` returns `posechain_num_poses` of the chain the value
holds, so one quantity carries two public names across the two types of one
family:

```sql
SELECT COUNT(*) FROM tbl_tposechain t1, tbl_posechain t2
WHERE numPoses(t2.pc) <> numLinks(t1.temp);
```

That line compares the same quantity to itself through two spellings.

### Which name stays

The base type's. It is what the family says everywhere else — `posechain`,
`pose(posechain)`, `poseN(posechain, n)`, `numPoses(posechain)` — and a chain
of poses counts poses. `numLinks` is the only `link` word on the public SQL
surface.

### What follows the SQL name

The MEOS export `tposechain_num_links` becomes `tposechain_num_poses`, the
wrapper `Tposechain_num_links` becomes `Tposechain_num_poses`, and the
`@csqlfn` tag follows the wrapper, so the catalog keeps attributing the
function and the generated bindings carry one name rather than two.

The reference appendixes are regenerated with `tools/doc/gen_reference.py`
rather than edited; `--check` reports both languages up to date. The temporal
chapter entry takes the `tposechain_` anchor prefix its sibling accessors
carry, and the base entry keeps `posechain_numPoses`, so each language holds
one anchor per entry.

Fifteen files, 29 insertions and 29 deletions. `git grep -i numlinks` over the
tree returns nothing.
