### PR TITLE
Parse the Windows stat override before the headers that pre-empt it

### DIFF
--- a/meos/src/geo/clip_clipper2.cpp
+++ b/meos/src/geo/clip_clipper2.cpp
@@ -34,6 +34,25 @@
  * LWPOLY exterior — this is how Clipper2 represents nested polygon hierarchies.
  *****************************************************************************/
 
+/* PostgreSQL's win32_port.h defines its own `struct stat` (to get a 64-bit
+ * st_size on Windows) after neutralising the UCRT one with
+ *   #define stat microsoft_native_stat ... #include <sys/stat.h>
+ * as its own comment says: "We must pull in sys/stat.h before this part, else
+ * our overrides lose."  That only holds while nothing has already parsed
+ * <sys/stat.h> unmangled.  Since mingw-w64 r302, <wchar.h> includes
+ * <sys/stat.h>, and libstdc++'s <cwchar> pulls in <wchar.h> -- so the Clipper2
+ * headers below would define the UCRT `struct stat` first and win32_port.h
+ * would then redefine it.  Reordering cannot fix this: postgres.h first breaks
+ * std::bind (see below).  Instead run PostgreSQL's own prologue here, ahead of
+ * any C++ header, so the invariant it documents still holds. */
+#ifdef _WIN32
+#define fstat microsoft_native_fstat
+#define stat microsoft_native_stat
+#include <sys/stat.h>
+#undef fstat
+#undef stat
+#endif
+
 /* C++ standard library and Clipper2 must come first: PostgreSQL's
  * win32_port.h on MSYS2/MinGW redefines socket primitives like
  * bind/socket/select as macros, which mangles std::bind and similar


### PR DESCRIPTION
Both Windows jobs fail on master compiling `meos/src/geo/clip_clipper2.cpp`:

```
win32_port.h:254:8: error: redefinition of 'struct stat'
```

`win32_port.h` substitutes its own `struct stat`, so that `st_size` is 64 bit on Windows, for the one the UCRT declares. It renames the UCRT declaration out of the way before reading it:

```c
/* needed before sys/stat hacking below: */
#define fstat microsoft_native_fstat
#define stat microsoft_native_stat
#include <sys/stat.h>
#undef fstat
#undef stat
```

Its comment names the condition this rests on: `sys/stat.h` has to be pulled in before that part, or the overrides lose. The substitution therefore holds only where nothing has read `<sys/stat.h>` under its own name first.

In mingw-w64 r302, `<wchar.h>` reads `<sys/stat.h>`, and libstdc++ reads `<wchar.h>` from `<cwchar>`. Clipper2 reads `<cwchar>` from `clipper.core.h`, so in this file the UCRT declaration reaches the compiler unrenamed ahead of `win32_port.h`, which then declares `struct stat` a second time:

```
clipper.h:13 -> clipper.core.h:16 -> <cwchar>:49 -> <wchar.h>:19 -> sys/stat.h:95   struct stat
clip_clipper2.cpp:48 -> clip_clipper2.h:33 -> port.h:24 -> win32_port.h:254         redefinition
```

The two jobs meet it in two different copies of that header — `windows` in the MSYS2 PostgreSQL headers, `meos-windows` in the vendored `pgtypes/port/win32_port.h` — so the fix belongs in the translation unit both of them compile.

Reading `<postgres.h>` first is not an alternative: `win32_port.h` also defines `bind`, `socket` and `select` as macros, which is what the ordering already in the file guards `std::bind` against. This reads PostgreSQL's own prologue ahead of every C++ header instead, so the condition it documents holds again. The block sits inside `#ifdef _WIN32`.

Built on Windows against the r302 headers that break master:

| target | result |
| --- | --- |
| `libmeos`, mirroring `windows_msys2_meos.yml` | 301/301, `libmeos.dll` |
| PG extension, mirroring `windows_msys2.yml` | 323/323, `libMobilityDB-1.4.dll` |

Master is red on both Windows jobs independently of any open pull request, so this is not specific to a branch.
