### PR TITLE
Record the MSYS2 package versions the Windows jobs build against

### DIFF
--- a/.github/actions/msys2-toolchain-report/action.yml
+++ b/.github/actions/msys2-toolchain-report/action.yml
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: PostgreSQL
+
+name: Record the MSYS2 toolchain
+description: >
+  Write the versions of the installed MSYS2 packages into the job log, so that a
+  Windows build which fails with no commit behind it can be compared against the
+  last one that succeeded. The Windows workflows install whatever the MSYS2
+  repository currently holds, so two runs minutes apart compile against
+  different headers, and the package set is the only place that difference is
+  visible.
+
+runs:
+  using: composite
+  steps:
+    - name: Record the MSYS2 toolchain
+      shell: msys2 {0}
+      run: |
+        # The digest answers the first question a red Windows build raises --
+        # has the toolchain moved since the run that passed? -- from one line,
+        # without reading the package list. The list follows it, so that a diff
+        # between two runs also names which packages moved.
+        packages=$(pacman -Q | sort)
+        printf 'toolchain-digest: %s\n' \
+          "$(printf '%s\n' "$packages" | sha256sum | cut -c1-16)"
+        printf 'toolchain-packages: %s\n' "$(printf '%s\n' "$packages" | wc -l)"
+        printf 'compiler: %s\n' "$(gcc -dumpversion)"
+        echo '::group::Installed MSYS2 packages'
+        printf '%s\n' "$packages"
+        echo '::endgroup::'

--- a/.github/workflows/windows_msys2.yml
+++ b/.github/workflows/windows_msys2.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - '.github/workflows/windows_msys2.yml'
+      - '.github/actions/msys2-toolchain-report/**'
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
@@ -15,6 +16,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/windows_msys2.yml'
+      - '.github/actions/msys2-toolchain-report/**'
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
@@ -46,6 +48,8 @@ jobs:
             mingw-w64-ucrt-x86_64-ninja
             mingw-w64-ucrt-x86_64-postgresql
             mingw-w64-ucrt-x86_64-postgis
+
+      - uses: ./.github/actions/msys2-toolchain-report
 
       - name: Configure
         run: |

--- a/.github/workflows/windows_msys2_meos.yml
+++ b/.github/workflows/windows_msys2_meos.yml
@@ -19,6 +19,7 @@ on:
   push:
     paths:
       - '.github/workflows/windows_msys2_meos.yml'
+      - '.github/actions/msys2-toolchain-report/**'
       - 'cmake/**'
       - 'meos/**'
       - 'pgtypes/**'
@@ -28,6 +29,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/windows_msys2_meos.yml'
+      - '.github/actions/msys2-toolchain-report/**'
       - 'cmake/**'
       - 'meos/**'
       - 'pgtypes/**'
@@ -61,6 +63,8 @@ jobs:
             mingw-w64-ucrt-x86_64-geos
             mingw-w64-ucrt-x86_64-proj
             mingw-w64-ucrt-x86_64-tzdata
+
+      - uses: ./.github/actions/msys2-toolchain-report
 
       - name: Resolve native timezone data path
         run: |


### PR DESCRIPTION
The Windows workflows install whatever the MSYS2 repository currently holds, so two runs minutes apart compile against different headers. When a Windows build turns red, the run carries no record of the toolchain it used, and recovering it means reading the install step of both runs line by line and diffing 160-odd package lines by hand.

This reads the installed package set into the log:

```
toolchain-digest: b469390e9d353caf
toolchain-packages: 295
compiler: 16.1.0
> Installed MSYS2 packages          (collapsed group)
```

The digest answers the first question a red build raises — has the toolchain moved since the run that passed? — from one line. The list follows it, collapsed, so a comparison between two runs also names which packages differ.

The step is a composite action because both Windows workflows need it, which is what `.github/actions/apt-resilient` already does for the Linux jobs. Its directory is added to the path filters of both workflows, so a later change to the action re-runs the jobs that depend on it.

Nothing is pinned. A toolchain the users do not have is not the one worth building against, and freezing it would hide an incompatibility rather than report it — the point here is that the change is visible when it happens.

The script is exercised in a UCRT64 shell against the current packages:

```
mingw-w64-ucrt-x86_64-crt 14.0.0.r302.gd7f3c5201-1
mingw-w64-ucrt-x86_64-headers 14.0.0.r302.gd7f3c5201-1
```
