### PR TITLE
Answer the orientation quaternion of a planar pose

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1338,7 +1338,7 @@
 						<para><link linkend="pose_point"><varname>point</varname></link>: Devuelve el punto</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="pose_quaternion"><varname>quaternion</varname></link>: Devuelve el cuaternión de orientación de una pose 3D</para>
+						<para><link linkend="pose_quaternion"><varname>quaternion</varname></link>: Devuelve el cuaternión de orientación de una pose</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -247,12 +247,14 @@ SELECT ST_AsText(point(pose 'Pose(Point(1 1), 0.3)'));
 
 				<listitem xml:id="pose_quaternion">
 					<indexterm significance="normal"><primary><varname>quaternion</varname></primary></indexterm>
-					<para>Devuelve el cuaternión de orientación de una pose 3D</para>
-					<para><varname>quaternion(pose3D) → quaternion</varname></para>
-					<para>Las componentes se devuelven en el orden <varname>W</varname>, <varname>X</varname>, <varname>Y</varname>, <varname>Z</varname>, la convención de Hamilton en la que la pose las almacena. Esta es una de las dos codificaciones de orientación que prescribe el estándar OGC GeoPose v1.0; la otra, yaw / pitch / roll, la proporcionan <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> y <varname>roll</varname>. Una pose 2D no tiene cuaternión y la función emite un error para ella; su orientación es el ángulo único que devuelve <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>.</para>
+					<para>Devuelve el cuaternión de orientación de una pose</para>
+					<para><varname>quaternion(pose) → quaternion</varname></para>
+					<para>Las componentes se devuelven en el orden <varname>W</varname>, <varname>X</varname>, <varname>Y</varname>, <varname>Z</varname>, la convención de Hamilton en la que una pose 3D las almacena. Esta es una de las dos codificaciones de orientación que prescribe el estándar OGC GeoPose v1.0; la otra, yaw / pitch / roll, la proporciona <link linkend="pose_ypr"><varname>ypr</varname></link>. Ambas están definidas para las dos dimensiones: la orientación de una pose 2D es un giro alrededor de la vertical local por su ángulo almacenado, de modo que coloca la mitad de ese ángulo en <varname>W</varname> y <varname>Z</varname> y deja <varname>X</varname> e <varname>Y</varname> en cero. Este es el cuaternión que un documento GeoPose Basic-Quaternion lleva para una pose plana.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
 -- (0,0,0,1)
+SELECT quaternion(pose 'Pose(Point(1 1), 0)');
+-- (1,0,0,0)
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -1362,7 +1364,7 @@ SELECT yaw(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475
 					<indexterm significance="normal"><primary><varname>ypr</varname></primary></indexterm>
 					<para>Devuelve la orientación de una pose como una terna yaw / pitch / roll, en radianes</para>
 					<para><varname>ypr(pose) → ypr</varname></para>
-					<para>Esta es la codificación Basic-YPR de la orientación en OGC GeoPose, la contraparte de <link linkend="pose_quaternion"><varname>quaternion</varname></link>, y devuelve los tres ángulos que <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> y <varname>roll</varname> responden de uno en uno. A diferencia de <varname>quaternion</varname>, que lee una codificación que solo almacena una pose 3D, está definida para ambas dimensiones: una pose 2D gira por su ángulo almacenado y no cabecea ni alabea. Los ángulos están en radianes, mientras que la codificación JSON de GeoPose los escribe en grados.</para>
+					<para>Esta es la codificación Basic-YPR de la orientación en OGC GeoPose, la contraparte de <link linkend="pose_quaternion"><varname>quaternion</varname></link>, y devuelve los tres ángulos que <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> y <varname>roll</varname> responden de uno en uno. Al igual que <varname>quaternion</varname>, está definida para ambas dimensiones: una pose 2D gira por su ángulo almacenado y no cabecea ni alabea. Los ángulos están en radianes, mientras que la codificación JSON de GeoPose los escribe en grados.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ypr(pose 'Pose(Point(1 1), 0.5)');
 -- (0.5,0,0)

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1338,7 +1338,7 @@
 						<para><link linkend="pose_point"><varname>point</varname></link>: Return the point</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="pose_quaternion"><varname>quaternion</varname></link>: Return the orientation quaternion of a 3D pose</para>
+						<para><link linkend="pose_quaternion"><varname>quaternion</varname></link>: Return the orientation quaternion of a pose</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -254,12 +254,14 @@ SELECT ST_AsText(point(pose 'Pose(Point(1 1), 0.3)'));
 
 				<listitem xml:id="pose_quaternion">
 					<indexterm significance="normal"><primary><varname>quaternion</varname></primary></indexterm>
-					<para>Return the orientation quaternion of a 3D pose</para>
-					<para><varname>quaternion(pose3D) → quaternion</varname></para>
-					<para>The components are returned in the order <varname>W</varname>, <varname>X</varname>, <varname>Y</varname>, <varname>Z</varname>, the Hamilton convention in which the pose stores them. This is one of the two orientation encodings the OGC GeoPose v1.0 standard prescribes; the other, yaw / pitch / roll, is given by <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> and <varname>roll</varname>. A 2D pose has no quaternion and the function emits an error for it; its orientation is the single angle returned by <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>.</para>
+					<para>Return the orientation quaternion of a pose</para>
+					<para><varname>quaternion(pose) → quaternion</varname></para>
+					<para>The components are returned in the order <varname>W</varname>, <varname>X</varname>, <varname>Y</varname>, <varname>Z</varname>, the Hamilton convention in which a 3D pose stores them. This is one of the two orientation encodings the OGC GeoPose v1.0 standard prescribes; the other, yaw / pitch / roll, is given by <link linkend="pose_ypr"><varname>ypr</varname></link>. Both are defined for both dimensions: the orientation of a 2D pose is a turn about the local vertical by its stored angle, so it puts half that angle in <varname>W</varname> and <varname>Z</varname> and leaves <varname>X</varname> and <varname>Y</varname> at zero. This is the quaternion a GeoPose Basic-Quaternion document carries for a planar pose.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
 -- (0,0,0,1)
+SELECT quaternion(pose 'Pose(Point(1 1), 0)');
+-- (1,0,0,0)
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -1377,7 +1379,7 @@ SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
 					<indexterm significance="normal"><primary><varname>ypr</varname></primary></indexterm>
 					<para>Return the orientation of a pose as a yaw / pitch / roll triple, in radians</para>
 					<para><varname>ypr(pose) → ypr</varname></para>
-					<para>This is the OGC GeoPose Basic-YPR encoding of the orientation, the counterpart of <link linkend="pose_quaternion"><varname>quaternion</varname></link>, and it returns the three angles <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> and <varname>roll</varname> answer one at a time. Unlike <varname>quaternion</varname>, which reads an encoding only a 3D pose stores, it is defined for both dimensions: a 2D pose yaws by its stored angle and neither pitches nor rolls. The angles are in radians, where the GeoPose JSON encoding writes them in degrees.</para>
+					<para>This is the OGC GeoPose Basic-YPR encoding of the orientation, the counterpart of <link linkend="pose_quaternion"><varname>quaternion</varname></link>, and it returns the three angles <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> and <varname>roll</varname> answer one at a time. Like <varname>quaternion</varname>, it is defined for both dimensions: a 2D pose yaws by its stored angle and neither pitches nor rolls. The angles are in radians, where the GeoPose JSON encoding writes them in degrees.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ypr(pose 'Pose(Point(1 1), 0.5)');
 -- (0.5,0,0)

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1321,12 +1321,15 @@ datum_pose_roll(Datum pose)
 
 /**
  * @ingroup meos_pose_base_accessor
- * @brief Return the orientation quaternion of a 3D pose
+ * @brief Return the orientation quaternion of a pose
  * @details The four components are returned in the order @p W, @p X, @p Y,
- * @p Z, the Hamilton convention in which the pose stores them. The
- * yaw / pitch / roll encoding of the same orientation, the other
+ * @p Z, the Hamilton convention in which a 3D pose stores them. This is
+ * defined for both dimensions: the orientation of a 2D pose is a turn about
+ * the local vertical by its stored angle, which is the quaternion
+ * @p (cos(theta/2), 0, 0, sin(theta/2)) that the GeoPose encoder writes for
+ * it. The yaw / pitch / roll encoding of the same orientation, the other
  * representation the OGC GeoPose standard prescribes, is returned by
- * #pose_yaw(), #pose_pitch() and #pose_roll().
+ * #pose_ypr().
  * @param[in] pose Pose
  * @param[out] count Number of elements in the output array
  * @return On error return @p NULL
@@ -1340,14 +1343,18 @@ pose_quaternion(const Pose *pose, int *count)
   *count = 0;
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(pose, NULL);
-  if (! ensure_has_Z(T_POSE, pose->flags))
-    return NULL;
 
   double *result = palloc(sizeof(double) * 4);
-  result[0] = pose->data[3];
-  result[1] = pose->data[4];
-  result[2] = pose->data[5];
-  result[3] = pose->data[6];
+  if (! MEOS_FLAGS_GET_Z(pose->flags))
+    pose_ypr_to_quaternion(pose->data[2], 0.0, 0.0, &result[0], &result[1],
+      &result[2], &result[3]);
+  else
+  {
+    result[0] = pose->data[3];
+    result[1] = pose->data[4];
+    result[2] = pose->data[5];
+    result[3] = pose->data[6];
+  }
   *count = 4;
   return result;
 }
@@ -1358,11 +1365,10 @@ pose_quaternion(const Pose *pose, int *count)
  * in radians
  * @details The three angles are returned in the order @p yaw, @p pitch,
  * @p roll, the ZYX intrinsic Tait-Bryan decomposition the OGC GeoPose
- * Basic-YPR conformance class prescribes. Unlike #pose_quaternion(), which
- * reads an encoding only a 3D pose stores, this is defined for both
- * dimensions: a 2D pose yaws by its stored angle and neither pitches nor
- * rolls. The angles are in radians, where the GeoPose JSON encoding
- * writes them in degrees.
+ * Basic-YPR conformance class prescribes. Like #pose_quaternion(), the other
+ * encoding the standard prescribes, this is defined for both dimensions: a
+ * 2D pose yaws by its stored angle and neither pitches nor rolls. The angles
+ * are in radians, where the GeoPose JSON encoding writes them in degrees.
  * @param[in] pose Pose
  * @param[out] count Number of elements in the output array
  * @return On error return @p NULL

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -2039,11 +2039,8 @@ geopose_chain_link_frame(const Pose *pose, int precision)
     Y = pose->data[5]; Z = pose->data[6];
   }
   else
-  {
     /* A planar link turns about the vertical axis by its stored angle */
-    double half = pose->data[2] / 2.0;
-    W = cos(half); X = 0.0; Y = 0.0; Z = sin(half);
-  }
+    pose_ypr_to_quaternion(pose->data[2], 0.0, 0.0, &W, &X, &Y, &Z);
   char bx[64], by[64], bz[64], bw[64], bqx[64], bqy[64], bqz[64];
   geopose_str_double(bx, sizeof(bx), x, precision);
   geopose_str_double(by, sizeof(by), y, precision);

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -559,7 +559,7 @@ PGDLLEXPORT Datum Pose_quaternion(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Pose_quaternion);
 /**
  * @ingroup mobilitydb_pose_base_accessor
- * @brief Return the orientation quaternion of a 3D pose
+ * @brief Return the orientation quaternion of a pose
  * @sqlfn quaternion()
  */
 Datum

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -175,8 +175,31 @@ SELECT quaternion(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)');
  (0.5,0.5,0.5,0.5)
 (1 row)
 
-SELECT quaternion(pose 'Pose(Point(1 1),0.5)');
-ERROR:  The pose must have Z dimension
+SELECT quaternion(pose 'Pose(Point(1 1), 0)');
+ quaternion 
+------------
+ (1,0,0,0)
+(1 row)
+
+SELECT round((quaternion(pose 'Pose(Point(1 1),0.5)')).W::numeric, 6),
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).X,
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).Y,
+  round((quaternion(pose 'Pose(Point(1 1),0.5)')).Z::numeric, 6);
+  round   | x | y |  round   
+----------+---+---+----------
+ 0.968912 | 0 | 0 | 0.247404
+(1 row)
+
+SELECT round(yaw(pose(ST_MakePoint(1, 1, 0),
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).W,
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).X,
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).Y,
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).Z))::numeric, 6) = 0.5;
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT ypr(pose 'Pose(Point(1 1),0.5)');
     ypr    
 -----------

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -90,17 +90,32 @@ SELECT yaw(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
 SELECT pitch(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
 SELECT roll(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
 
--- The orientation quaternion of a 3D pose, in the stored (W, X, Y, Z)
--- Hamilton order. A 2D pose has no quaternion.
+-- The orientation quaternion of a pose, in the (W, X, Y, Z) Hamilton order a
+-- 3D pose stores. Defined for both dimensions: the orientation of a 2D pose
+-- is a turn about the local vertical by its stored angle, which is the
+-- quaternion the GeoPose Basic-Quaternion encoder writes for it.
 SELECT quaternion(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)');
 SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
 -- A 120-degree turn about (1 1 1). Its components are exactly
 -- representable, so the unit-norm renormalization leaves them alone and
 -- the output carries no libm-dependent trailing digits.
 SELECT quaternion(pose 'Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)');
-\set VERBOSITY terse
-SELECT quaternion(pose 'Pose(Point(1 1),0.5)');
-\set VERBOSITY default
+-- An unturned 2D pose carries the identity quaternion exactly.
+SELECT quaternion(pose 'Pose(Point(1 1), 0)');
+-- A turned 2D pose puts half its angle in W and Z and leaves X and Y at
+-- zero, since it neither pitches nor rolls. The two turning components are
+-- bounded because the cosine and sine of a general angle drift across libm.
+SELECT round((quaternion(pose 'Pose(Point(1 1),0.5)')).W::numeric, 6),
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).X,
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).Y,
+  round((quaternion(pose 'Pose(Point(1 1),0.5)')).Z::numeric, 6);
+-- The two encodings answer one orientation: the yaw read back from the
+-- quaternion of a 2D pose is the angle that pose stores.
+SELECT round(yaw(pose(ST_MakePoint(1, 1, 0),
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).W,
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).X,
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).Y,
+  (quaternion(pose 'Pose(Point(1 1),0.5)')).Z))::numeric, 6) = 0.5;
 
 -- The same orientation in the other GeoPose encoding. Defined for both
 -- dimensions: a 2D pose yaws by its stored angle and neither pitches nor
@@ -118,7 +133,7 @@ SELECT round(degrees((ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)')).yaw)
 
 SELECT asText(round(pose 'Pose(Point(1.123456789 1.123456789), 0.123456789)', 6));
 
--- A 2D pose is returned unchanged (no quaternion to renormalize).
+-- A 2D pose is returned unchanged (it stores no quaternion to renormalize).
 SELECT asText(poseNormalize(pose 'Pose(Point(1 1), 0.5)'));
 -- A unit-norm 3D pose round-trips identically.
 SELECT asText(poseNormalize(pose 'Pose(Point(1 1 1), 1, 0, 0, 0)'));


### PR DESCRIPTION
The OGC GeoPose standard prescribes two orientation encodings for a pose, a unit quaternion and a yaw / pitch / roll triple, and each is defined for a pose of either dimension. The orientation of a 2D pose is a turn about the local vertical by its stored angle, so its quaternion carries half that angle in `W` and `Z` and leaves `X` and `Y` at zero.

`quaternion(pose)` answers that quaternion in both dimensions, as `ypr(pose)` answers the angles in both. The two are one orientation read two ways: the yaw decoded from a planar pose's quaternion is the angle that pose stores.

A single kernel produces it. `pose_ypr_to_quaternion` is what the GeoPose Basic-Quaternion encoder converts through, and the Chain link frame calls it as well, so one definition serves the accessor and both encoders. The documents the encoders write are unchanged.