### PR TITLE
Run the workflows that depend on a composite action when it changes

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/check-code.yml'
+      - '.github/actions/apt-resilient/**'
       - 'datagen/**'
       - 'doc/**'
       - 'meos/**'

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - '.github/workflows/clang.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
@@ -15,6 +16,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/clang.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'

--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -12,6 +12,7 @@ on:
   push:
     paths:
       - '.github/workflows/cppcheck.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'meos/src/**'
@@ -21,6 +22,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/cppcheck.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'CMakeLists.txt'
       - 'meos/src/**'

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -7,6 +7,7 @@ on:
   push:
     paths:
       - '.github/workflows/generate_docs.yml'
+      - '.github/actions/apt-resilient/**'
       - 'doc/**'
     branches:
       - 'master'

--- a/.github/workflows/meos-smoke.yml
+++ b/.github/workflows/meos-smoke.yml
@@ -5,6 +5,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/meos-smoke.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'pgtypes/**'
@@ -14,6 +15,7 @@ on:
   push:
     paths:
       - '.github/workflows/meos-smoke.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'pgtypes/**'

--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -5,6 +5,7 @@ on:
   push:
     paths:
       - '.github/workflows/meos.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
@@ -17,6 +18,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/meos.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'

--- a/.github/workflows/meos_locale.yml
+++ b/.github/workflows/meos_locale.yml
@@ -19,6 +19,7 @@ on:
   push:
     paths:
       - '.github/workflows/meos_locale.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'pgtypes/**'
@@ -29,6 +30,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/meos_locale.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'pgtypes/**'

--- a/.github/workflows/meos_utf8_smoke.yml
+++ b/.github/workflows/meos_utf8_smoke.yml
@@ -24,6 +24,7 @@ on:
   push:
     paths:
       - '.github/workflows/meos_utf8_smoke.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'pgtypes/**'
@@ -34,6 +35,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/meos_utf8_smoke.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'pgtypes/**'

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -11,6 +11,7 @@ on:
   push:
     paths:
       - '.github/workflows/pgversion.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'
@@ -22,6 +23,7 @@ on:
   pull_request:
     paths:
       - '.github/workflows/pgversion.yml'
+      - '.github/actions/apt-resilient/**'
       - 'cmake/**'
       - 'meos/**'
       - 'mobilitydb/**'


### PR DESCRIPTION
Each workflow lists its own file in its path filters, so that editing the workflow runs it:

```yaml
  pull_request:
    paths:
      - '.github/workflows/cppcheck.yml'
      - 'cmake/**'
```

The composite action a workflow calls is a second file it depends on, and it is not listed. A change confined to `.github/actions/apt-resilient` therefore matches no filter in any of the workflows that call it, none of those jobs run, and the edit reaches the default branch having never been executed once.

This adds the action's directory beside each workflow's own entry, in the nine workflows that both call it and filter on paths:

`check-code`, `clang`, `cppcheck`, `generate_docs`, `meos-smoke`, `meos`, `meos_locale`, `meos_utf8_smoke`, `pgversion` — 16 entries, since most filter on `push` and `pull_request` alike.

`codeql.yml` calls the action too and stays as it is: it declares no path filter, so it already runs whatever changes.

The `<dir>/**` form is the one the same filters already use for `cmake/**` and `meos/**`, and the one the Windows workflows carry for their own composite action.
