### PR TITLE
Write the sample document set a GeoPose submission carries

### DIFF
--- a/tools/scripts/check_geopose_conformance.py
+++ b/tools/scripts/check_geopose_conformance.py
@@ -6,10 +6,10 @@
 #
 """Validate the emitted GeoPose documents against the normative OGC schemas.
 
-MobilityDB implements six of the eight conformance classes of OGC GeoPose
-v1.0 (OGC 21-056r11): Basic-YPR, Basic-Quaternion, Advanced, the Regular and
-Irregular Composite Sequence Series, and the Stream.  Each class has a
-normative JSON schema, published under
+MobilityDB implements the eight conformance classes of OGC GeoPose v1.0
+(OGC 21-056r11): Basic-YPR, Basic-Quaternion, Advanced, the Regular and
+Irregular Composite Sequence Series, the Stream, the Chain and the Graph.
+Each class has a normative JSON schema, published under
 
     https://schemas.opengis.net/geopose/1.0/schemata/
 
@@ -33,6 +33,22 @@ below rather than delegated to a JSON Schema library.
 Usage:
   check_geopose_conformance.py           validate every document (CI guard)
   check_geopose_conformance.py --list    print the documents and their class
+  check_geopose_conformance.py --emit D  write one sample document per class
+                                         into the directory D
+
+A conformance submission carries a sample document per class it claims, named
+by the key the OGC test suite reads it under.  `--emit` writes that set from
+the documents this check already validates, so the submission carries the
+exact bytes the implementation produces, beside a manifest naming the class,
+the schema and the expected output each one comes from.  A document is written
+only once it satisfies its schema, so the set can never claim more than the
+check proves.
+
+The two incremental stream documents have no SQL surface of their own, and
+need none: a whole stream is `{header, streamElements[]}` written with the
+functions that write them, against the outer frame anchored at the same first
+instant, so each member IS the incremental document.  They are validated and
+sampled from the whole stream that carries them.
 
 Exit status is non-zero when a document does not satisfy its schema, or when
 a conformance class emits no document at all.
@@ -104,15 +120,37 @@ CLASSES = [
 STRICT = ('Basic-Quaternion', 'validTime',
     'GeoPose.Basic.Strict_Quaternion.Schema.json')
 
-# The classes the SQL surface writes, and which the expected output therefore
-# has to contain for this check to mean anything. A whole stream is among them:
-# a value a query already holds is written in one piece. The two INCREMENTAL
-# stream documents are written through the C API alone -- those are emitted a
-# piece at a time by a producer, which a query is not -- so they are validated
-# wherever they appear rather than demanded here; `meos/test/geopose_test.c` is
-# what exercises them.
+# The classes the expected output has to contain for this check to mean
+# anything. A whole stream is among them: a value a query already holds is
+# written in one piece. The two INCREMENTAL stream documents have no SQL
+# surface of their own -- a stream is emitted a piece at a time by a producer,
+# which a query is not -- but a whole stream is built FROM them, member for
+# member, so every one of them travels inside it and is demanded here too.
 REQUIRED = ('Regular Series', 'Irregular Series', 'Basic-Quaternion',
-    'Basic-YPR', 'Advanced', 'Stream', 'Chain', 'Graph')
+    'Basic-YPR', 'Advanced', 'Stream', 'Stream header', 'Stream element',
+    'Chain', 'Graph')
+
+# The name the OGC test suite reads a class's sample document under, which is
+# what `--emit` names the file. The suite tests seven classes and Irregular
+# Series is not among them -- the standard defines it, the suite has no section
+# for it -- so it carries no key and its sample is named after the class.
+SUITE_KEYS = {
+    'Basic-YPR': 'basicypr',
+    'Basic-Quaternion': 'basicquaternion',
+    'Advanced': 'advanced',
+    'Chain': 'chain',
+    'Graph': 'graph',
+    'Regular Series': 'seriesregular',
+    'Stream': 'streamrecord',
+    'Stream element': 'streamelement',
+    'Stream header': 'streamheader',
+    'Irregular Series': None,
+}
+
+# Irregular Series carries no suite key, so its sample is named the way the
+# suite names its sibling and the set reads uniformly.
+UNKEYED_NAMES = {'Irregular Series': 'seriesirregular'}
+
 
 TYPES = {
     'object': dict,
@@ -203,6 +241,24 @@ def classify(doc):
     return None, None
 
 
+def stream_parts(doc):
+    """Yield the incremental documents a whole stream is built from.
+
+    A whole stream is `{header, streamElements[]}`, and the encoder writes
+    both members with the functions that write the standalone documents,
+    against the outer frame anchored at the same first instant. Each member
+    is therefore the incremental document itself, so a stream carries one
+    header and one element per pose, and the two classes that have no SQL
+    surface of their own are validated and sampled from it.
+    """
+    header = doc.get('header')
+    if isinstance(header, dict):
+        yield 'Stream header', header
+    for elem in doc.get('streamElements') or []:
+        if isinstance(elem, dict):
+            yield 'Stream element', elem
+
+
 def documents(path):
     """Yield every JSON document emitted as a result row of the tests."""
     with open(path, encoding='utf-8') as f:
@@ -219,8 +275,67 @@ def documents(path):
                 yield doc
 
 
+def emit(directory, samples, strict_class, strict_file):
+    """Write one sample document per class into @p directory.
+
+    Each file is named by the key the OGC test suite reads its class under,
+    beside a manifest naming the class, the schema it satisfies and the
+    expected output the bytes come from.
+    """
+    try:
+        os.makedirs(directory, exist_ok=True)
+    except OSError as e:
+        print('check_geopose_conformance: cannot write to %s: %s' %
+            (directory, e))
+        return 1
+
+    entries = []
+    for name in sorted(samples):
+        doc, schema_file, source, is_strict = samples[name]
+        key = (SUITE_KEYS.get(name) or UNKEYED_NAMES.get(name) or
+            name.lower().replace(' ', ''))
+        filename = '%s.json' % key
+        with open(os.path.join(directory, filename), 'w',
+                encoding='utf-8') as f:
+            json.dump(doc, f, indent=2)
+            f.write('\n')
+        entry = {
+            'file': filename,
+            'class': name,
+            'suite_key': SUITE_KEYS.get(name),
+            'schema': schema_file,
+            'source': os.path.relpath(source, ROOT),
+        }
+        # The standard gives Basic-Quaternion a permissive and a strict schema
+        # and the suite tests the permissive one, so a submission has to name
+        # which form its sample takes.
+        if name == strict_class:
+            entry['strict_schema'] = strict_file if is_strict else None
+        entries.append(entry)
+
+    manifest = {'documents': entries}
+    with open(os.path.join(directory, 'manifest.json'), 'w',
+            encoding='utf-8') as f:
+        json.dump(manifest, f, indent=2)
+        f.write('\n')
+
+    print('check_geopose_conformance: wrote %d sample documents and a '
+        'manifest to %s' % (len(entries), directory))
+    for entry in entries:
+        print('  %-18s %s' % (entry['class'], entry['file']))
+    return 0
+
+
 def main():
-    listing = '--list' in sys.argv[1:]
+    argv = sys.argv[1:]
+    listing = '--list' in argv
+    directory = None
+    if '--emit' in argv:
+        i = argv.index('--emit')
+        if i + 1 >= len(argv) or argv[i + 1].startswith('--'):
+            print('check_geopose_conformance: --emit needs a directory')
+            return 1
+        directory = argv[i + 1]
 
     for path in EXPECTED:
         if not os.path.isfile(path):
@@ -251,7 +366,11 @@ def main():
     failed = 0
     strict = 0
     seen = {}
-    for doc in [d for path in EXPECTED for d in documents(path)]:
+    # The first conformant document of each class is the one `--emit` writes,
+    # which makes the sample set a function of the committed bytes alone.
+    samples = {}
+    schema_of = dict((name, filename) for _, name, filename in CLASSES)
+    for path, doc in [(p, d) for p in EXPECTED for d in documents(p)]:
         name, _ = classify(doc)
         if name is None:
             continue
@@ -259,9 +378,33 @@ def main():
         seen[name] = seen.get(name, 0) + 1
         errors = []
         validate(doc, schemas[name], schemas[name], '', errors)
+        is_strict = False
         if name == strict_class and strict_unless not in doc:
             validate(doc, strict_schema, strict_schema, '', errors)
             strict += 1
+            is_strict = not errors
+        if not errors and name not in samples:
+            samples[name] = (doc, schema_of[name], path, is_strict)
+        # A whole stream is the two incremental documents composed, so each
+        # one is validated in its own right rather than only as a member.
+        if name == 'Stream':
+            for sub, part in stream_parts(doc):
+                total += 1
+                seen[sub] = seen.get(sub, 0) + 1
+                sub_errors = []
+                validate(part, schemas[sub], schemas[sub], '', sub_errors)
+                if sub_errors:
+                    failed += 1
+                    print('check_geopose_conformance: a %s document is not '
+                        'conformant' % sub)
+                    for e in sub_errors:
+                        print('    %s' % e)
+                    print('    %s' % json.dumps(part)[:200])
+                elif sub not in samples:
+                    samples[sub] = (part, schema_of[sub], path, False)
+                if listing:
+                    print('  %-18s %s' %
+                        (sub, 'ok' if not sub_errors else 'INVALID'))
         if listing:
             print('  %-18s %s' % (name, 'ok' if not errors else 'INVALID'))
         if errors:
@@ -293,6 +436,9 @@ def main():
         'as well.' % (total,
         ', '.join('%s %d' % (n, c) for n, c in sorted(seen.items())),
         strict, strict_class))
+
+    if directory is not None:
+        return emit(directory, samples, strict_class, strict_file)
     return 0
 
 


### PR DESCRIPTION
A conformance submission carries one sample document per class it claims, named by the key the OGC test suite reads it under. `--emit <dir>` writes that set from the documents the check already validates, so the samples are the exact bytes the implementation produces rather than a hand extraction, beside a manifest naming each document's class, suite key, schema and the expected output it comes from.

```
$ check_geopose_conformance.py --emit doc/geopose-samples
check_geopose_conformance: 41 documents conform to the OGC GeoPose 1.0 schemas (...)
check_geopose_conformance: wrote 10 sample documents and a manifest to doc/geopose-samples
  Advanced           advanced.json
  Basic-Quaternion   basicquaternion.json
  Basic-YPR          basicypr.json
  Chain              chain.json
  Graph              graph.json
  Irregular Series   seriesirregular.json
  Regular Series     seriesregular.json
  Stream             streamrecord.json
  Stream element     streamelement.json
  Stream header      streamheader.json
```

### The set is complete

A whole stream is `{header, streamElements[]}` built with the functions that write the two incremental documents standalone, against the outer frame anchored at the same first instant, so each member is the incremental document. The stream header and the stream element are therefore validated in their own right and sampled from the stream that carries them, and both join the classes the check demands, so neither regresses unnoticed.

Irregular Series is emitted too. The suite has no section for it, so it carries no key and its manifest entry says so.

### What the set can claim

A document is written only once every document conforms and every required class is present, so the set can never claim more than the check proves. Dropping a required member from a stream element reports it both in its own right and inside the stream, and writes nothing; removing a class writes nothing.

The manifest records whether the Basic-Quaternion sample satisfies the strict schema as well as the permissive one the suite tests, which is the variant a claim has to name.