### PR TITLE
Give the Spanish manual the applyPose entry its index projects from

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1616,6 +1616,14 @@
 				</itemizedlist>
 			</sect3>
 			<sect3>
+				<title>Transformación rígida cuerpo↔mundo</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pose_applyPose"><varname>applyPose</varname></link>: Aplica la transformación de cuerpo rígido codificada por una pose (la correspondencia <emphasis>cuerpo al mundo</emphasis> de OGC GeoPose) a una geometría en el marco del cuerpo, produciendo la geometría correspondiente en el marco del mundo</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+			<sect3>
 				<title>E/S JSON temporal</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -1443,7 +1443,11 @@ SELECT geoPoseFrameIsGeographic(1), geoPoseFrameIsGeographic(2);
 
 		<sect2 xml:id="pose_geopose_apply">
 			<title>Transformación rígida cuerpo↔mundo</title>
-			<para>La función <varname>applyPose</varname> aplica la transformación de cuerpo rígido codificada por una pose (la correspondencia <emphasis>cuerpo al mundo</emphasis> de OGC GeoPose) a una geometría en el marco del cuerpo, produciendo la geometría correspondiente en el marco del mundo. La transformación es</para>
+			<itemizedlist>
+			<listitem xml:id="pose_applyPose">
+			<indexterm significance="normal"><primary><varname>applyPose</varname></primary></indexterm>
+			<para>Aplica la transformación de cuerpo rígido codificada por una pose (la correspondencia <emphasis>cuerpo al mundo</emphasis> de OGC GeoPose) a una geometría en el marco del cuerpo, produciendo la geometría correspondiente en el marco del mundo</para>
+			<para>La transformación es</para>
 			<programlisting xml:space="preserve" format="linespecific">
 world = R(q) · body + p
 </programlisting>
@@ -1492,6 +1496,8 @@ SELECT asEWKT(round(applyPose(pose 'Pose(Point(1 0 0), 1, 0, 0, 0)',
   pose 'Pose(Point(0 0 5), 1, 0, 0, 0)'), 6));
 -- Pose(POINT Z (1 0 5),1,0,0,0)
 </programlisting>
+			</listitem>
+			</itemizedlist>
 		</sect2>
 
 		<sect2 xml:id="pose_geopose_temporal_io">


### PR DESCRIPTION
A manual entry is a `listitem` carrying its indexterms, its one-liner and its syntax, and the reference index is the projection of those. The Spanish section on the rigid body-to-world transform holds its prose and examples as bare paragraphs, so it anchors nothing and projects nothing: `applyPose` is described in the Spanish chapter and absent from the Spanish index, which the English one carries.

The section is an entry anchored at `pose_applyPose`, opening with the indexterm, the one-liner and the six signatures, and the Spanish index is regenerated from it.

Both manuals project 764 chapter entries into 770 appendix rows, and `gen_reference.py --check` reports `[OK]` for each. The English files are untouched.

Documentation only.