### PR TITLE
Name the tolerance MEOS compares its own geometry against

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -68,13 +68,23 @@ typedef enum
 } EdgeType;
 
 /**
- * @brief Tolerance under which two coordinates of an edge are the same point
- * @details The edge kernels compare coordinates against this value. MEOS owns
- * it rather than reading the tolerance of a PostGIS internal header, which
- * two headers of that library define differently, so the value an edge kernel
- * compares against does not depend on the order a caller includes them in
+ * @brief Tolerance under which planar geometry reads two quantities as the same
+ * @details Coordinates, the parameter along a segment, a determinant and a
+ * duration are all compared against this value. MEOS owns it rather than
+ * reading the tolerance of a PostGIS internal header, which two headers of
+ * that library define differently, so what a kernel compares against does not
+ * depend on the order a caller includes them in. It carries the value
+ * `liblwgeom_internal.h` states for planar work.
+ * @note Distinct from `MEOS_EPSILON`, which reads two modelled quantities as
+ * equal at 1e-06 and is what the `MEOS_FP_*` comparisons are built on. That one
+ * is a fraction of a duration, bounded below by the microsecond a `TimestampTz`
+ * resolves, while this one is the rounding of coordinate arithmetic.
+ * @note `FP_TOLERANCE` survives where MEOS hands a tolerance to PostGIS or runs
+ * a copy of its code, so that those calls keep tracking the value PostGIS means
+ * -- including the smaller one `lwgeodetic.h` states for spherical work.
  */
-#define MEOS_EDGE_TOLERANCE 1e-12
+#define MEOS_GEOM_TOLERANCE 1e-12
+
 
 /**
  * @brief Structure keeping a geometry edge
@@ -160,7 +170,7 @@ geom_ring_is_convex(const POINTARRAY *pa)
     getPoint4d_p(pa, (i + 2) % n, &c);
     double turn = (b.x - a.x) * (c.y - b.y) - (b.y - a.y) * (c.x - b.x);
     /* The tolerance liblwgeom uses for a coordinate comparison */
-    if (fabs(turn) <= 1e-12)
+    if (fabs(turn) <= MEOS_GEOM_TOLERANCE)
       continue;
     int current = turn > 0.0 ? 1 : -1;
     if (sign == 0)
@@ -246,7 +256,7 @@ extern bool *pointarr_find_splits(const POINT2D **points, int npoints,
  * - 0 <= t0 <= 1
  * - 0 <= t1 <= 1
  * - t0 <= t1
- * - Overlap must satisfy: t1 - t0 > MEOS_EDGE_TOLERANCE
+ * - Overlap must satisfy: t1 - t0 > MEOS_GEOM_TOLERANCE
  * @param[in] ax,ay Coordinates of the first point defining the first segment
  * @param[in] rx,ry Vector AB
  * @param[in] cx,cy,dx,dy Coordinates of the points defining the second segment
@@ -269,17 +279,17 @@ linesegm_intersect(double ax, double ay, double rx, double ry,
   double rxs = rx * sy - ry * sx;
 
   /* Collinear / parallel */
-  if (fabs(rxs) < MEOS_EDGE_TOLERANCE)
+  if (fabs(rxs) < MEOS_GEOM_TOLERANCE)
   {
     /* Is point C aligned with segment AB? */
     double qpxr = qpx * ry - qpy * rx;
     /* If qpxr != 0: parallel, if qpxr == 0: collinear */
-    if (fabs(qpxr) > MEOS_EDGE_TOLERANCE)
+    if (fabs(qpxr) > MEOS_GEOM_TOLERANCE)
       return res;
 
     /* Collinear case */
     double r2 = rx * rx + ry * ry;
-    if (r2 < MEOS_EDGE_TOLERANCE)
+    if (r2 < MEOS_GEOM_TOLERANCE)
       return res;
 
     double t0 = (qpx * rx + qpy * ry) / r2;
@@ -295,7 +305,7 @@ linesegm_intersect(double ax, double ay, double rx, double ry,
     if (t0 < 0) t0 = 0;
     if (t1 > 1) t1 = 1;
 
-    if (fabs(t1 - t0) < MEOS_EDGE_TOLERANCE)
+    if (fabs(t1 - t0) < MEOS_GEOM_TOLERANCE)
     {
       res.type = INTERSECT_POINT;
       res.t0 = t0;
@@ -312,13 +322,13 @@ linesegm_intersect(double ax, double ay, double rx, double ry,
   double t = (qpx * sy - qpy * sx) / rxs;
   double u = (qpx * ry - qpy * rx) / rxs;
 
-  if (t < -MEOS_EDGE_TOLERANCE || t > 1 + MEOS_EDGE_TOLERANCE ||
-      u < -MEOS_EDGE_TOLERANCE || u > 1 + MEOS_EDGE_TOLERANCE)
+  if (t < -MEOS_GEOM_TOLERANCE || t > 1 + MEOS_GEOM_TOLERANCE ||
+      u < -MEOS_GEOM_TOLERANCE || u > 1 + MEOS_GEOM_TOLERANCE)
     return res;
 
   /* Clamp values */
-  if (fabs(t) < MEOS_EDGE_TOLERANCE) t = 0;
-  if (fabs(t - 1) < MEOS_EDGE_TOLERANCE) t = 1;
+  if (fabs(t) < MEOS_GEOM_TOLERANCE) t = 0;
+  if (fabs(t - 1) < MEOS_GEOM_TOLERANCE) t = 1;
 
   res.type = INTERSECT_POINT;
   res.t0 = t;
@@ -343,7 +353,7 @@ arc_contains_angle(const Edge *e, double phi)
   double off = e->ccw ?
     angle_normalize(phi - e->theta0) :
     angle_normalize(e->theta0 - phi);
-  return off <= sweep + MEOS_EDGE_TOLERANCE;
+  return off <= sweep + MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -378,7 +388,7 @@ static inline bool
 point_on_arc(double px, double py, const Edge *e)
 {
   double d = hypot(px - e->cx, py - e->cy);
-  if (fabs(d - e->radius) > MEOS_EDGE_TOLERANCE)
+  if (fabs(d - e->radius) > MEOS_GEOM_TOLERANCE)
     return false;
   return arc_contains_angle(e, atan2(py - e->cy, px - e->cx));
 }
@@ -402,7 +412,7 @@ arcsegm_intersect(double ax, double ay, double rx, double ry, const Edge *e,
 {
   double aa = rx * rx + ry * ry;
   /* Degenerate (zero-length) trajectory segment */
-  if (aa < MEOS_EDGE_TOLERANCE)
+  if (aa < MEOS_GEOM_TOLERANCE)
     return 0;
 
   double wx = ax - e->cx, wy = ay - e->cy;
@@ -433,14 +443,14 @@ arcsegm_intersect(double ax, double ay, double rx, double ry, const Edge *e,
   int nroots = 0;
   roots[nroots++] = (-bb - sq) / (2 * aa);
   /* Distinct second root only when the line is not tangent */
-  if (sq > MEOS_EDGE_TOLERANCE)
+  if (sq > MEOS_GEOM_TOLERANCE)
     roots[nroots++] = (-bb + sq) / (2 * aa);
 
   int n = 0;
   for (int k = 0; k < nroots; k++)
   {
     double t = roots[k];
-    if (t < -MEOS_EDGE_TOLERANCE || t > 1 + MEOS_EDGE_TOLERANCE)
+    if (t < -MEOS_GEOM_TOLERANCE || t > 1 + MEOS_GEOM_TOLERANCE)
       continue;
     if (t < 0) t = 0;
     if (t > 1) t = 1;
@@ -469,9 +479,9 @@ arcarc_intersect(const Edge *e1, const Edge *e2)
   double r1 = e1->radius, r2 = e2->radius;
 
   /* Concentric supporting circles */
-  if (d < MEOS_EDGE_TOLERANCE)
+  if (d < MEOS_GEOM_TOLERANCE)
   {
-    if (fabs(r1 - r2) > MEOS_EDGE_TOLERANCE)
+    if (fabs(r1 - r2) > MEOS_GEOM_TOLERANCE)
       return false;
     /* Same circle: the arcs meet iff their spans share an endpoint angle */
     return arc_contains_angle(e2, e1->theta0) ||
@@ -480,7 +490,7 @@ arcarc_intersect(const Edge *e1, const Edge *e2)
       arc_contains_angle(e1, e2->theta1);
   }
   /* Circles too far apart or one strictly inside the other */
-  if (d > r1 + r2 + MEOS_EDGE_TOLERANCE || d < fabs(r1 - r2) - MEOS_EDGE_TOLERANCE)
+  if (d > r1 + r2 + MEOS_GEOM_TOLERANCE || d < fabs(r1 - r2) - MEOS_GEOM_TOLERANCE)
     return false;
 
   double a = (d * d + r1 * r1 - r2 * r2) / (2 * d);
@@ -500,7 +510,7 @@ arcarc_intersect(const Edge *e1, const Edge *e2)
         arc_contains_angle(e2, atan2(py - e2->cy, px - e2->cx)))
       return true;
     /* A tangency has a single candidate point */
-    if (h < MEOS_EDGE_TOLERANCE)
+    if (h < MEOS_GEOM_TOLERANCE)
       break;
   }
   return false;
@@ -526,25 +536,25 @@ point_on_segment(double px, double py, double x1, double y1, double x2,
   double aby = y2 - y1;
 
   /* Fast bounding-box rejection */
-  if ((px < fmin(x1, x2) - MEOS_EDGE_TOLERANCE) ||
-      (px > fmax(x1, x2) + MEOS_EDGE_TOLERANCE) ||
-      (py < fmin(y1, y2) - MEOS_EDGE_TOLERANCE) ||
-      (py > fmax(y1, y2) + MEOS_EDGE_TOLERANCE))
+  if ((px < fmin(x1, x2) - MEOS_GEOM_TOLERANCE) ||
+      (px > fmax(x1, x2) + MEOS_GEOM_TOLERANCE) ||
+      (py < fmin(y1, y2) - MEOS_GEOM_TOLERANCE) ||
+      (py > fmax(y1, y2) + MEOS_GEOM_TOLERANCE))
     return false;
 
   /* Collinearity check via cross product */
   double cross = apx * aby - apy * abx;
-  if (fabs(cross) > MEOS_EDGE_TOLERANCE)
+  if (fabs(cross) > MEOS_GEOM_TOLERANCE)
     return false;
 
   /* Projection check via dot product */
   double dot = apx * abx + apy * aby;
-  if (dot < -MEOS_EDGE_TOLERANCE)
+  if (dot < -MEOS_GEOM_TOLERANCE)
     return false;
 
   /* Check if P lies between A and B */
   double ab2 = abx * abx + aby * aby;
-  if (dot > ab2 + MEOS_EDGE_TOLERANCE)
+  if (dot > ab2 + MEOS_GEOM_TOLERANCE)
     return false;
   return true;
 }

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -45,6 +45,7 @@
 #include "temporal/spanset.h"
 #include "temporal/tnumber_mathfuncs.h"
 #include "temporal/type_util.h"
+#include "geo/geo_funcs.h"
 #include "geo/tgeo_spatialfuncs.h"
 #include "geo/tgeo_tempspatialrels.h"
 #include "geo/tspatial_parser.h"
@@ -179,7 +180,7 @@ tcbuffersegm_dwithin_turnpt(Datum start1, Datum end1, Datum start2, Datum end2,
   double duration = (double)(upper - lower);
 
   /* Tolerance threshold for floating-point comparison */
-  if (duration <= FP_TOLERANCE)
+  if (duration <= MEOS_GEOM_TOLERANCE)
   {
     *t1 = *t2 = 0;
     return 0;
@@ -207,16 +208,16 @@ tcbuffersegm_dwithin_turnpt(Datum start1, Datum end1, Datum start2, Datum end2,
 
   /* Linear case */
   double d1;
-  if (delta >= -FP_TOLERANCE)
+  if (delta >= -MEOS_GEOM_TOLERANCE)
   {
     double t_cand1, t_cand2;
-    if (a == 0 && fabs(b) >= FP_TOLERANCE)
+    if (a == 0 && fabs(b) >= MEOS_GEOM_TOLERANCE)
     {
       t_cand1 = -c / b;
-      if (t_cand1 >= -FP_TOLERANCE && t_cand1 <= duration + FP_TOLERANCE)
+      if (t_cand1 >= -MEOS_GEOM_TOLERANCE && t_cand1 <= duration + MEOS_GEOM_TOLERANCE)
       {
         d1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand1);
-        if (fabs(d1 - d) < FP_TOLERANCE) roots[nroots++] = t_cand1;
+        if (fabs(d1 - d) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand1;
       }
     }
     /* Quadratic case */
@@ -225,16 +226,16 @@ tcbuffersegm_dwithin_turnpt(Datum start1, Datum end1, Datum start2, Datum end2,
       double sqrt_delta = sqrt(fmax(0.0, delta));
       t_cand1 = (-b - sqrt_delta) / (2*a);
       t_cand2 = (-b + sqrt_delta) / (2*a);
-      if (t_cand1 >= -FP_TOLERANCE && t_cand1 <= duration + FP_TOLERANCE)
+      if (t_cand1 >= -MEOS_GEOM_TOLERANCE && t_cand1 <= duration + MEOS_GEOM_TOLERANCE)
       {
         d1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand1);
-        if (fabs(d1 - d) < FP_TOLERANCE) roots[nroots++] = t_cand1;
+        if (fabs(d1 - d) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand1;
       }
-      if (fabs(t_cand2 - t_cand1) > FP_TOLERANCE && t_cand2 >= -FP_TOLERANCE &&
-          t_cand2 <= duration + FP_TOLERANCE)
+      if (fabs(t_cand2 - t_cand1) > MEOS_GEOM_TOLERANCE && t_cand2 >= -MEOS_GEOM_TOLERANCE &&
+          t_cand2 <= duration + MEOS_GEOM_TOLERANCE)
       {
         d1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand2);
-        if (fabs(d1 - d) < FP_TOLERANCE) roots[nroots++] = t_cand2;
+        if (fabs(d1 - d) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand2;
       }
     }
   }
@@ -249,7 +250,7 @@ tcbuffersegm_dwithin_turnpt(Datum start1, Datum end1, Datum start2, Datum end2,
     TimestampTz t = lower + (TimestampTz) roots[i];
     if (t > lower && t < upper)
     {
-      if (nvalid == 0 || fabs(roots[i] - valid[nvalid - 1]) > FP_TOLERANCE)
+      if (nvalid == 0 || fabs(roots[i] - valid[nvalid - 1]) > MEOS_GEOM_TOLERANCE)
         valid[nvalid++] = roots[i];
     }
   }
@@ -304,7 +305,7 @@ tcbuffersegm_tdwithin_turnpt(Datum start1, Datum end1, Datum start2,
   const POINT2D *spt2 = cbuffer_point2d_p(sv2);
   const POINT2D *ept2 = cbuffer_point2d_p(ev2);
   double duration = (double) (upper - lower);
-  if (duration <= FP_TOLERANCE)
+  if (duration <= MEOS_GEOM_TOLERANCE)
   {
     *t1 = *t2 = 0;
     return 0;
@@ -322,16 +323,16 @@ tcbuffersegm_tdwithin_turnpt(Datum start1, Datum end1, Datum start2,
   double delta = b * b - 4 * a * c;
   double roots[2];
   int nroots = 0;
-  if (delta >= -FP_TOLERANCE)
+  if (delta >= -MEOS_GEOM_TOLERANCE)
   {
     double t_cand1, d1;
-    if (a == 0 && fabs(b) >= FP_TOLERANCE)
+    if (a == 0 && fabs(b) >= MEOS_GEOM_TOLERANCE)
     {
       t_cand1 = -c / b;
-      if (t_cand1 >= -FP_TOLERANCE && t_cand1 <= duration + FP_TOLERANCE)
+      if (t_cand1 >= -MEOS_GEOM_TOLERANCE && t_cand1 <= duration + MEOS_GEOM_TOLERANCE)
       {
         d1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand1);
-        if (fabs(d1 - d) < FP_TOLERANCE) roots[nroots++] = t_cand1;
+        if (fabs(d1 - d) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand1;
       }
     }
     else
@@ -339,16 +340,16 @@ tcbuffersegm_tdwithin_turnpt(Datum start1, Datum end1, Datum start2,
       double sqrt_delta = sqrt(fmax(0.0, delta));
       t_cand1 = (-b - sqrt_delta) / (2 * a);
       double t_cand2 = (-b + sqrt_delta) / (2 * a);
-      if (t_cand1 >= -FP_TOLERANCE && t_cand1 <= duration + FP_TOLERANCE)
+      if (t_cand1 >= -MEOS_GEOM_TOLERANCE && t_cand1 <= duration + MEOS_GEOM_TOLERANCE)
       {
         d1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand1);
-        if (fabs(d1 - d) < FP_TOLERANCE) roots[nroots++] = t_cand1;
+        if (fabs(d1 - d) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand1;
       }
-      if (fabs(t_cand2 - t_cand1) > FP_TOLERANCE && t_cand2 >= -FP_TOLERANCE &&
-          t_cand2 <= duration + FP_TOLERANCE)
+      if (fabs(t_cand2 - t_cand1) > MEOS_GEOM_TOLERANCE && t_cand2 >= -MEOS_GEOM_TOLERANCE &&
+          t_cand2 <= duration + MEOS_GEOM_TOLERANCE)
       {
         d1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand2);
-        if (fabs(d1 - d) < FP_TOLERANCE) roots[nroots++] = t_cand2;
+        if (fabs(d1 - d) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand2;
       }
     }
   }
@@ -358,9 +359,9 @@ tcbuffersegm_tdwithin_turnpt(Datum start1, Datum end1, Datum start2,
   }
   /* Within status at the two segment endpoints */
   bool win_lower = (tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr,
-    0.0) <= d + FP_TOLERANCE);
+    0.0) <= d + MEOS_GEOM_TOLERANCE);
   bool win_upper = (tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr,
-    duration) <= d + FP_TOLERANCE);
+    duration) <= d + MEOS_GEOM_TOLERANCE);
   double tstart, tend;
   if (nroots == 0)
   {
@@ -395,7 +396,7 @@ tcbuffersegm_tdwithin_turnpt(Datum start1, Datum end1, Datum start2,
     /* Two crossings: within between them */
     tstart = roots[0]; tend = roots[1];
   }
-  if (tend - tstart < FP_TOLERANCE)
+  if (tend - tstart < MEOS_GEOM_TOLERANCE)
   {
     *t1 = *t2 = lower + (TimestampTz) tstart;
     return 1;
@@ -442,7 +443,7 @@ tcbuffersegm_contains_turnpt(Datum start1, Datum end1, Datum start2,
   const POINT2D *spt2 = cbuffer_point2d_p(sv2);
   const POINT2D *ept2 = cbuffer_point2d_p(ev2);
   double duration = (double) (upper - lower);
-  if (duration <= FP_TOLERANCE)
+  if (duration <= MEOS_GEOM_TOLERANCE)
   {
     *t1 = *t2 = 0;
     return 0;
@@ -463,16 +464,16 @@ tcbuffersegm_contains_turnpt(Datum start1, Datum end1, Datum start2,
   double delta = b * b - 4 * a * c;
   double roots[2];
   int nroots = 0;
-  if (delta >= -FP_TOLERANCE)
+  if (delta >= -MEOS_GEOM_TOLERANCE)
   {
     double t_cand1, g1;
-    if (a == 0 && fabs(b) >= FP_TOLERANCE)
+    if (a == 0 && fabs(b) >= MEOS_GEOM_TOLERANCE)
     {
       t_cand1 = -c / b;
-      if (t_cand1 >= -FP_TOLERANCE && t_cand1 <= duration + FP_TOLERANCE)
+      if (t_cand1 >= -MEOS_GEOM_TOLERANCE && t_cand1 <= duration + MEOS_GEOM_TOLERANCE)
       {
         g1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand1);
-        if (fabs(g1) < FP_TOLERANCE) roots[nroots++] = t_cand1;
+        if (fabs(g1) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand1;
       }
     }
     else
@@ -480,16 +481,16 @@ tcbuffersegm_contains_turnpt(Datum start1, Datum end1, Datum start2,
       double sqrt_delta = sqrt(fmax(0.0, delta));
       t_cand1 = (-b - sqrt_delta) / (2 * a);
       double t_cand2 = (-b + sqrt_delta) / (2 * a);
-      if (t_cand1 >= -FP_TOLERANCE && t_cand1 <= duration + FP_TOLERANCE)
+      if (t_cand1 >= -MEOS_GEOM_TOLERANCE && t_cand1 <= duration + MEOS_GEOM_TOLERANCE)
       {
         g1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand1);
-        if (fabs(g1) < FP_TOLERANCE) roots[nroots++] = t_cand1;
+        if (fabs(g1) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand1;
       }
-      if (fabs(t_cand2 - t_cand1) > FP_TOLERANCE && t_cand2 >= -FP_TOLERANCE &&
-          t_cand2 <= duration + FP_TOLERANCE)
+      if (fabs(t_cand2 - t_cand1) > MEOS_GEOM_TOLERANCE && t_cand2 >= -MEOS_GEOM_TOLERANCE &&
+          t_cand2 <= duration + MEOS_GEOM_TOLERANCE)
       {
         g1 = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, t_cand2);
-        if (fabs(g1) < FP_TOLERANCE) roots[nroots++] = t_cand2;
+        if (fabs(g1) < MEOS_GEOM_TOLERANCE) roots[nroots++] = t_cand2;
       }
     }
   }
@@ -503,10 +504,10 @@ tcbuffersegm_contains_turnpt(Datum start1, Datum end1, Datum start2,
   double g_lower = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr, 0.0);
   double g_upper = tcbuffersegm_distance_at_time(dx0, dy0, vx, vy, r0, vr,
     duration);
-  bool in_lower = is_strict ? (g_lower < - FP_TOLERANCE) :
-    (g_lower <= FP_TOLERANCE);
-  bool in_upper = is_strict ? (g_upper < - FP_TOLERANCE) :
-    (g_upper <= FP_TOLERANCE);
+  bool in_lower = is_strict ? (g_lower < - MEOS_GEOM_TOLERANCE) :
+    (g_lower <= MEOS_GEOM_TOLERANCE);
+  bool in_upper = is_strict ? (g_upper < - MEOS_GEOM_TOLERANCE) :
+    (g_upper <= MEOS_GEOM_TOLERANCE);
   double tstart, tend;
   if (nroots == 0)
   {
@@ -544,7 +545,7 @@ tcbuffersegm_contains_turnpt(Datum start1, Datum end1, Datum start2,
   {
     tstart = roots[0]; tend = roots[1];
   }
-  if (tend - tstart < FP_TOLERANCE)
+  if (tend - tstart < MEOS_GEOM_TOLERANCE)
   {
     *t1 = *t2 = lower + (TimestampTz) tstart;
     return 1;
@@ -593,7 +594,7 @@ tcbuffersegm_distance_turnpt(Datum start1, Datum end1, Datum start2,
   /* Centres that keep their separation leave an affine gap, whose extrema are
    * the endpoints the caller already reads */
   double s = dx * dx + dy * dy;
-  if (s <= FP_TOLERANCE)
+  if (s <= MEOS_GEOM_TOLERANCE)
     return 0;
   double q = dx * dx0 + dy * dy0;
   double e = dx0 * dx0 + dy0 * dy0;

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -43,6 +43,7 @@
 #include "temporal/tinstant.h"
 #include "temporal/tsequence.h"
 #include "temporal/tsequenceset.h"
+#include "geo/geo_funcs.h"
 #include "geo/stbox.h"
 #include "geo/tgeo.h"
 #include "geo/tgeo_distance.h"
@@ -1546,7 +1547,7 @@ tcbufferseg_sg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   for (int i = 0; i < nc && nout < maxout; i++)
   {
     double t = cand[i];
-    if (t <= 0.0 || t >= 1.0 || (nout > 0 && t - last <= 1e-12))
+    if (t <= 0.0 || t >= 1.0 || (nout > 0 && t - last <= MEOS_GEOM_TOLERANCE))
       continue;
     double cx = cx1 + (cx2 - cx1) * t, cy = cy1 + (cy2 - cy1) * t;
     double r = r1 + (r2 - r1) * t;
@@ -1614,7 +1615,7 @@ tcbuffer_disc_seg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
   double A = a - s * s, B = b - 2 * m * s, C = c - m * m;
   double cand[2];
   int ncand = 0;
-  if (fabs(A) > 1e-12)
+  if (fabs(A) > MEOS_GEOM_TOLERANCE)
   {
     double disc = B * B - 4 * A * C;
     if (disc >= 0)
@@ -1624,7 +1625,7 @@ tcbuffer_disc_seg_roots(const Cbuffer *cb1, const Cbuffer *cb2,
       cand[ncand++] = (-B + sq) / (2 * A);
     }
   }
-  else if (fabs(B) > 1e-12)
+  else if (fabs(B) > MEOS_GEOM_TOLERANCE)
     cand[ncand++] = -C / B;
   int n = 0;
   for (int i = 0; i < ncand && n < maxout; i++)

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -201,7 +201,7 @@ buffer_line_intersection(POINT2D p, double rx, double ry, POINT2D q,
 {
   assert(result);
   double denominator = buffer_cross(rx, ry, sx, sy);
-  if (fabs(denominator) <= FP_TOLERANCE)
+  if (fabs(denominator) <= MEOS_GEOM_TOLERANCE)
     return false;
   double qpx = q.x - p.x;
   double qpy = q.y - p.y;
@@ -237,7 +237,7 @@ buffer_make_arc(int32_t srid, double cx, double cy, double radius,
     sweep = angle_normalize(end_angle - start_angle);
   else
     sweep = angle_normalize(start_angle - end_angle);
-  if (sweep <= FP_TOLERANCE)
+  if (sweep <= MEOS_GEOM_TOLERANCE)
     return NULL;
 
   /* A CIRCSTRING arc is represented by three points.
@@ -269,7 +269,7 @@ static void
 buffer_add_segment(LWCOMPOUND *curve, int32_t srid, POINT2D p1, POINT2D p2)
 {
   assert(curve);
-  if (hypot(p2.x - p1.x, p2.y - p1.y) <= FP_TOLERANCE)
+  if (hypot(p2.x - p1.x, p2.y - p1.y) <= MEOS_GEOM_TOLERANCE)
     return;
   LWLINE *line = buffer_make_segment(srid, p1, p2);
   lwcompound_add_lwgeom(curve, lwline_as_lwgeom(line));
@@ -287,7 +287,7 @@ buffer_add_arc(LWCOMPOUND *curve, int32_t srid, double cx, double cy,
   double sweep = ccw ? 
     angle_normalize(end_angle - start_angle) :
     angle_normalize(start_angle - end_angle);
-  if (sweep <= FP_TOLERANCE)
+  if (sweep <= MEOS_GEOM_TOLERANCE)
     return;
 
   /* PostGIS circular strings use three points per arc and an individual
@@ -346,7 +346,7 @@ buffer_add_mitre_join(LWCOMPOUND *curve, int32_t srid, POINT2D vertex,
   double r2y = p2.y - vertex.y;
   double l1 = hypot(r1x, r1y);
   double l2 = hypot(r2x, r2y);
-  if (l1 <= FP_TOLERANCE || l2 <= FP_TOLERANCE)
+  if (l1 <= MEOS_GEOM_TOLERANCE || l2 <= MEOS_GEOM_TOLERANCE)
     return false;
   r1x /= l1;
   r1y /= l1;
@@ -356,7 +356,7 @@ buffer_add_mitre_join(LWCOMPOUND *curve, int32_t srid, POINT2D vertex,
   if (! buffer_line_intersection(p1, r1x, r1y, p2, r2x, r2y, &intersection))
     return false;
   double length = hypot(intersection.x - vertex.x, intersection.y - vertex.y);
-  if (length > radius * mitre_limit + FP_TOLERANCE)
+  if (length > radius * mitre_limit + MEOS_GEOM_TOLERANCE)
     return false;
   buffer_add_segment(curve, srid, p1, intersection);
   buffer_add_segment(curve, srid, intersection, p2);
@@ -1024,7 +1024,7 @@ buffer_boundary_intersection(const Edge *e1, const Edge *e2)
 static inline bool
 buffer_nodes_equal(double x1, double y1, double x2, double y2)
 {
-  return fabs(x1 - x2) <= FP_TOLERANCE && fabs(y1 - y2) <= FP_TOLERANCE;
+  return fabs(x1 - x2) <= MEOS_GEOM_TOLERANCE && fabs(y1 - y2) <= MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -1085,11 +1085,11 @@ buffer_segment_parameter(const BufferPiece *piece, double x, double y)
   double dy = piece->y2 - piece->y1;
   if (fabs(dx) >= fabs(dy))
   {
-    if (fabs(dx) <= FP_TOLERANCE)
+    if (fabs(dx) <= MEOS_GEOM_TOLERANCE)
       return 0.0;
     return (x - piece->x1) / dx;
   }
-  if (fabs(dy) <= FP_TOLERANCE)
+  if (fabs(dy) <= MEOS_GEOM_TOLERANCE)
     return 0.0;
   return (y - piece->y1) / dy;
 }
@@ -1132,7 +1132,7 @@ buffer_boundary_representative_point(const LWGEOM *geom, double *x, double *y)
         sweep = angle_normalize(edge->theta1 - edge->theta0);
       else
         sweep = angle_normalize(edge->theta0 - edge->theta1);
-      if (sweep <= FP_TOLERANCE)
+      if (sweep <= MEOS_GEOM_TOLERANCE)
         continue;
       double theta;
       if (edge->ccw)
@@ -1163,10 +1163,10 @@ buffer_containment_epsilon(const LWGEOM *geom)
     double dx = box->xmax - box->xmin;
     double dy = box->ymax - box->ymin;
     double scale = fmax(dx, dy);
-    if (scale > FP_TOLERANCE)
-      return fmax(scale * MEOS_EPSILON, FP_TOLERANCE * 10.0);
+    if (scale > MEOS_GEOM_TOLERANCE)
+      return fmax(scale * MEOS_EPSILON, MEOS_GEOM_TOLERANCE * 10.0);
   }
-  return FP_TOLERANCE * 10.0;
+  return MEOS_GEOM_TOLERANCE * 10.0;
 }
 
 /**
@@ -1184,7 +1184,7 @@ buffer_edge_normals(const Edge *edge, double *nx, double *ny)
     double dx = edge->x2 - edge->x1;
     double dy = edge->y2 - edge->y1;
     double length = hypot(dx, dy);
-    if (length <= FP_TOLERANCE)
+    if (length <= MEOS_GEOM_TOLERANCE)
       return false;
     *nx = -dy / length;
     *ny = dx / length;
@@ -1199,7 +1199,7 @@ buffer_edge_normals(const Edge *edge, double *nx, double *ny)
       sweep = angle_normalize(edge->theta1 - edge->theta0);
     else
       sweep = angle_normalize(edge->theta0 - edge->theta1);
-    if (sweep <= FP_TOLERANCE)
+    if (sweep <= MEOS_GEOM_TOLERANCE)
       return false;
     double theta;
     if (edge->ccw)
@@ -1352,7 +1352,7 @@ buffer_node_tolerance(double x, double y)
    * never below the tolerance an exactly computed node is placed to */
   double scale = Max(fabs(x), fabs(y));
   double tol = 5.0e-8 * Max(scale, 1.0);
-  return Max(tol, MEOS_EDGE_TOLERANCE);
+  return Max(tol, MEOS_GEOM_TOLERANCE);
 }
 
 /**
@@ -1468,9 +1468,9 @@ buffer_collect_arc_arc_intersections(const Edge *e1, const Edge *e2,
   /* Concentric circles.
    * Coincident arcs are not split here. Their common endpoints are
    * already existing boundary nodes and will be handled separately. */
-  if (d < FP_TOLERANCE)
+  if (d < MEOS_GEOM_TOLERANCE)
   {
-    if (fabs(r1 - r2) > FP_TOLERANCE)
+    if (fabs(r1 - r2) > MEOS_GEOM_TOLERANCE)
       return;
 
     /* Same supporting circle. Add common endpoints. */
@@ -1494,7 +1494,7 @@ buffer_collect_arc_arc_intersections(const Edge *e1, const Edge *e2,
   }
 
   /* Circles that cannot intersect */
-  if (d > r1 + r2 + FP_TOLERANCE || d < fabs(r1 - r2) - FP_TOLERANCE)
+  if (d > r1 + r2 + MEOS_GEOM_TOLERANCE || d < fabs(r1 - r2) - MEOS_GEOM_TOLERANCE)
     return;
 
   /* Distance from the first centre to the radical-line foot */
@@ -1522,7 +1522,7 @@ buffer_collect_arc_arc_intersections(const Edge *e1, const Edge *e2,
     if (arc_contains_angle(e1, phi1) && arc_contains_angle(e2, phi2))
       buffer_add_intersection_point(points, x, y);
     /* Tangency gives only one point */
-    if (h <= FP_TOLERANCE)
+    if (h <= MEOS_GEOM_TOLERANCE)
       break;
   }
 }
@@ -1545,7 +1545,7 @@ buffer_angle_on_arc(double theta, double theta0, double theta1, bool ccw)
     sweep = angle_normalize(theta0 - theta1);
     delta = angle_normalize(theta0 - theta);
   }
-  return delta <= sweep + FP_TOLERANCE;
+  return delta <= sweep + MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -1570,7 +1570,7 @@ buffer_point_on_arc(const BufferPiece *arc, double x, double y)
 static bool
 buffer_values_equal(double a, double b)
 {
-  return fabs(a - b) <= FP_TOLERANCE;
+  return fabs(a - b) <= MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -1649,7 +1649,7 @@ buffer_arc_contains_angle(const BufferPiece *arc, double theta)
     position = buffer_normalize_angle(theta - start);
   else
     position = buffer_normalize_angle(start - theta);
-  return position <= sweep + FP_TOLERANCE;
+  return position <= sweep + MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -1789,13 +1789,13 @@ buffer_piece_contains_point(const BufferPiece *piece, POINT2D *point)
     /* Collinearity test */
     double cross = buffer_cross(dx, dy, px, py);
     double scale = fmax(1.0, hypot(dx, dy) * hypot(px, py));
-    if (fabs(cross) > FP_TOLERANCE * scale)
+    if (fabs(cross) > MEOS_GEOM_TOLERANCE * scale)
       return false;
     /* Bounding-box test */
-    if (point->x < fmin(piece->x1, piece->x2) - FP_TOLERANCE ||
-        point->x > fmax(piece->x1, piece->x2) + FP_TOLERANCE ||
-        point->y < fmin(piece->y1, piece->y2) - FP_TOLERANCE ||
-        point->y > fmax(piece->y1, piece->y2) + FP_TOLERANCE)
+    if (point->x < fmin(piece->x1, piece->x2) - MEOS_GEOM_TOLERANCE ||
+        point->x > fmax(piece->x1, piece->x2) + MEOS_GEOM_TOLERANCE ||
+        point->y < fmin(piece->y1, piece->y2) - MEOS_GEOM_TOLERANCE ||
+        point->y > fmax(piece->y1, piece->y2) + MEOS_GEOM_TOLERANCE)
       return false;
     return true;
   }
@@ -1807,7 +1807,7 @@ buffer_piece_contains_point(const BufferPiece *piece, POINT2D *point)
     double distance = hypot(dx, dy);
     /* First check that the point is on the supporting circle */
     if (fabs(distance - piece->radius) >
-        FP_TOLERANCE * fmax(1.0, piece->radius))
+        MEOS_GEOM_TOLERANCE * fmax(1.0, piece->radius))
       return false;
     /* Then check that its angle lies within the finite arc */
     return buffer_point_on_arc(piece, point->x, point->y);
@@ -1851,7 +1851,7 @@ buffer_split_point_add(BufferSplitPoint *points, uint32_t *count,
   double tol = buffer_node_tolerance(point->x, point->y);
   for (uint32_t i = 0; i < *count; i++)
   {
-    if (fabs(points[i].parameter - parameter) <= FP_TOLERANCE ||
+    if (fabs(points[i].parameter - parameter) <= MEOS_GEOM_TOLERANCE ||
         (fabs(points[i].point.x - point->x) <= tol &&
          fabs(points[i].point.y - point->y) <= tol))
       return;
@@ -1887,7 +1887,7 @@ buffer_split_segment(const BufferPiece *piece, const MeosArray *intersections,
       continue;
     double parameter = buffer_segment_parameter(piece, point->x, point->y);
     /* Ignore nodes outside the segment due to numerical noise */
-    if (parameter < -FP_TOLERANCE || parameter > 1.0 + FP_TOLERANCE)
+    if (parameter < -MEOS_GEOM_TOLERANCE || parameter > 1.0 + MEOS_GEOM_TOLERANCE)
       continue;
     if (parameter < 0.0)
       parameter = 0.0;
@@ -1902,7 +1902,7 @@ buffer_split_segment(const BufferPiece *piece, const MeosArray *intersections,
   {
     POINT2D p1 = points[i].point;
     POINT2D p2 = points[i + 1].point;
-    if (hypot(p2.x - p1.x, p2.y - p1.y) <= FP_TOLERANCE)
+    if (hypot(p2.x - p1.x, p2.y - p1.y) <= MEOS_GEOM_TOLERANCE)
       continue;
     BufferPiece split;
     memset(&split, 0, sizeof(BufferPiece));
@@ -1940,7 +1940,7 @@ buffer_split_arc(const BufferPiece *piece, const MeosArray *intersections,
       continue;
     double parameter = buffer_arc_parameter(piece, point);
     /* Ignore nodes outside the finite arc */
-    if (parameter < -FP_TOLERANCE || parameter > sweep + FP_TOLERANCE)
+    if (parameter < -MEOS_GEOM_TOLERANCE || parameter > sweep + MEOS_GEOM_TOLERANCE)
       continue;
     if (parameter < 0.0)
       parameter = 0.0;
@@ -1964,7 +1964,7 @@ buffer_split_arc(const BufferPiece *piece, const MeosArray *intersections,
       theta_end = piece->theta1 - points[i + 1].parameter;
     }
     double sub_sweep = points[i + 1].parameter - points[i].parameter;
-    if (sub_sweep <= FP_TOLERANCE)
+    if (sub_sweep <= MEOS_GEOM_TOLERANCE)
       continue;
 
     /* Use the actual sorted intersection coordinates as endpoints.
@@ -2093,7 +2093,7 @@ buffer_piece_midpoint(const BufferPiece *piece, POINT2D *point)
   if (piece->type == BUFFER_ARC)
   {
     double sweep = buffer_arc_sweep(piece);
-    if (sweep <= FP_TOLERANCE)
+    if (sweep <= MEOS_GEOM_TOLERANCE)
       return false;
     double theta;
     if (piece->ccw)
@@ -2167,7 +2167,7 @@ buffer_piece_side_points(const BufferPiece *piece, double epsilon,
   else if (piece->type == BUFFER_ARC)
   {
     double sweep = buffer_arc_sweep(piece);
-    if (sweep <= FP_TOLERANCE)
+    if (sweep <= MEOS_GEOM_TOLERANCE)
       return false;
     double theta;
     if (piece->ccw)
@@ -2191,7 +2191,7 @@ buffer_piece_side_points(const BufferPiece *piece, double epsilon,
     return false;
   }
   double length = hypot(tx, ty);
-  if (length <= FP_TOLERANCE)
+  if (length <= MEOS_GEOM_TOLERANCE)
     return false;
   tx /= length;
   ty /= length;
@@ -2227,9 +2227,9 @@ buffer_piece_interior_side(const BufferPiece *piece, const LWGEOM *geom)
     scale = piece->radius;
   else
     scale = hypot(dx, dy);
-  if (scale <= FP_TOLERANCE)
+  if (scale <= MEOS_GEOM_TOLERANCE)
     scale = 1.0;
-  double epsilon = fmax(FP_TOLERANCE * 100.0, scale * 1.0e-8);
+  double epsilon = fmax(MEOS_GEOM_TOLERANCE * 100.0, scale * 1.0e-8);
   for (int attempt = 0; attempt < 4; attempt++)
   {
     POINT2D left, right;
@@ -2442,8 +2442,8 @@ buffer_select_union_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
 static bool
 buffer_points_equal(POINT2D p1, POINT2D p2)
 {
-  return fabs(p1.x - p2.x) <= FP_TOLERANCE &&
-    fabs(p1.y - p2.y) <= FP_TOLERANCE;
+  return fabs(p1.x - p2.x) <= MEOS_GEOM_TOLERANCE &&
+    fabs(p1.y - p2.y) <= MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -3123,7 +3123,7 @@ buffer_normalize_ring_orientation(BufferRingInfo *info, int32_t srid)
   assert(info); assert(info->ring); assert(info->pieces);
   double area =
     buffer_ring_signed_area(info->pieces);
-  if (fabs(area) <= FP_TOLERANCE)
+  if (fabs(area) <= MEOS_GEOM_TOLERANCE)
     return false;
   /* Even depth = shell = CCW
    * Odd depth  = hole  = CW */
@@ -3593,7 +3593,7 @@ buffer_ring(const POINTARRAY *source, double radius, bool outward_left,
     double dx = points[next].x - points[i].x;
     double dy = points[next].y - points[i].y;
     double len = hypot(dx, dy);
-    if (len <= FP_TOLERANCE)
+    if (len <= MEOS_GEOM_TOLERANCE)
     {
       pfree(points); pfree(nx); pfree(ny);
       return NULL;
@@ -3626,7 +3626,7 @@ buffer_ring(const POINTARRAY *source, double radius, bool outward_left,
     double turn = buffer_cross(in_dx, in_dy, out_dx, out_dy);
     /* The buffered side is convex at the vertex when the ring turns away
      * from it, which is a right turn when that side is the left one */
-    bool convex = outward_left ? turn < -FP_TOLERANCE : turn > FP_TOLERANCE;
+    bool convex = outward_left ? turn < -MEOS_GEOM_TOLERANCE : turn > MEOS_GEOM_TOLERANCE;
 
     POINT2D enter = incoming, leave = outgoing;
     bool bridge = false;
@@ -3648,8 +3648,8 @@ buffer_ring(const POINTARRAY *source, double radius, bool outward_left,
         double ux = crossing.x - points[i].x, uy = crossing.y - points[i].y;
         double back = -(ux * in_dx + uy * in_dy) / in_len;
         double ahead = (ux * out_dx + uy * out_dy) / out_len;
-        if (back > in_len + MEOS_EDGE_TOLERANCE ||
-            ahead > out_len + MEOS_EDGE_TOLERANCE)
+        if (back > in_len + MEOS_GEOM_TOLERANCE ||
+            ahead > out_len + MEOS_GEOM_TOLERANCE)
           bridge = true;
         else
           enter = leave = crossing;
@@ -3709,7 +3709,7 @@ buffer_offset_edge(const Edge *edge, double radius, bool left,
   if (edge->etype == EDGE_POLYSEG || edge->etype == EDGE_LINESEG)
   {
     double length = hypot(edge->x2 - edge->x1, edge->y2 - edge->y1);
-    if (length <= FP_TOLERANCE)
+    if (length <= MEOS_GEOM_TOLERANCE)
       return false;
     double nx = -(edge->y2 - edge->y1) / length;
     double ny =  (edge->x2 - edge->x1) / length;
@@ -3736,11 +3736,11 @@ buffer_offset_edge(const Edge *edge, double radius, bool left,
      * drops it; it is built rather than refused so that the ring it belongs
      * to is closed and the rest of it can be read */
     double half = 0.0;
-    if (r <= FP_TOLERANCE)
+    if (r <= MEOS_GEOM_TOLERANCE)
     {
       r = -r;
       half = M_PI;
-      if (r <= FP_TOLERANCE)
+      if (r <= MEOS_GEOM_TOLERANCE)
         return false;
     }
     piece->type = BUFFER_ARC;
@@ -3873,7 +3873,7 @@ buffer_pieces_meet(const BufferPiece *a, const BufferPiece *b, double vx,
     const BufferPiece *arc = a->type == BUFFER_SEGMENT ? b : a;
     double dx = line->x2 - line->x1, dy = line->y2 - line->y1;
     double length = hypot(dx, dy);
-    if (length <= FP_TOLERANCE)
+    if (length <= MEOS_GEOM_TOLERANCE)
       return false;
     dx /= length;
     dy /= length;
@@ -3881,7 +3881,7 @@ buffer_pieces_meet(const BufferPiece *a, const BufferPiece *b, double vx,
     double t = (arc->cx - line->x1) * dx + (arc->cy - line->y1) * dy;
     double px = line->x1 + t * dx, py = line->y1 + t * dy;
     double gap = hypot(arc->cx - px, arc->cy - py);
-    if (gap > arc->radius + FP_TOLERANCE)
+    if (gap > arc->radius + MEOS_GEOM_TOLERANCE)
       return false;
     double half = arc->radius * arc->radius - gap * gap;
     half = half > 0.0 ? sqrt(half) : 0.0;
@@ -3895,9 +3895,9 @@ buffer_pieces_meet(const BufferPiece *a, const BufferPiece *b, double vx,
   /* Two circular supports meet on their radical line */
   double dx = b->cx - a->cx, dy = b->cy - a->cy;
   double distance = hypot(dx, dy);
-  if (distance <= FP_TOLERANCE ||
-      distance > a->radius + b->radius + FP_TOLERANCE ||
-      distance < fabs(a->radius - b->radius) - FP_TOLERANCE)
+  if (distance <= MEOS_GEOM_TOLERANCE ||
+      distance > a->radius + b->radius + MEOS_GEOM_TOLERANCE ||
+      distance < fabs(a->radius - b->radius) - MEOS_GEOM_TOLERANCE)
     return false;
   double along = (distance * distance + a->radius * a->radius -
     b->radius * b->radius) / (2 * distance);
@@ -3928,10 +3928,10 @@ buffer_piece_holds(const BufferPiece *piece, double x, double y)
       atan2(y - piece->cy, x - piece->cx));
   double dx = piece->x2 - piece->x1, dy = piece->y2 - piece->y1;
   double length2 = dx * dx + dy * dy;
-  if (length2 <= FP_TOLERANCE)
+  if (length2 <= MEOS_GEOM_TOLERANCE)
     return true;
   double t = ((x - piece->x1) * dx + (y - piece->y1) * dy) / length2;
-  double tol = MEOS_EDGE_TOLERANCE / sqrt(length2);
+  double tol = MEOS_GEOM_TOLERANCE / sqrt(length2);
   return t >= -tol && t <= 1.0 + tol;
 }
 
@@ -3989,13 +3989,13 @@ buffer_offset_edges(const MeosArray *edges, double radius, bool left,
     double turn = buffer_cross(in_dx, in_dy, out_dx, out_dy);
     /* The buffered side is convex at the vertex when the chain turns away
      * from it, which is a right turn when that side is the left one */
-    if (left ? turn < -FP_TOLERANCE : turn > FP_TOLERANCE)
+    if (left ? turn < -MEOS_GEOM_TOLERANCE : turn > MEOS_GEOM_TOLERANCE)
     {
       join[i] = true;
       continue;
     }
     /* Tangent edges continue into each other */
-    if (fabs(turn) <= FP_TOLERANCE)
+    if (fabs(turn) <= MEOS_GEOM_TOLERANCE)
       continue;
     double x, y;
     if (! buffer_pieces_meet(&pieces[i], &pieces[next], e1->x2, e1->y2, &x, &y)
@@ -4260,7 +4260,7 @@ buffer_ring_resolve(const LWGEOM *raw, const MeosArray *edges, double radius,
    * the buffer rather than on its boundary. The distance is read at the
    * middle of the piece, which the splitting above leaves wholly on one side
    * of the question */
-  double tol = Max(MEOS_EDGE_TOLERANCE, radius * 1.0e-9);
+  double tol = Max(MEOS_GEOM_TOLERANCE, radius * 1.0e-9);
   MeosArray *keep = meos_array_create(sizeof(BufferPiece));
   for (int i = 0; i < meos_array_count(split); i++)
   {
@@ -4661,7 +4661,7 @@ meos_buffer_line_offset(const LWLINE *line, double radius,
   {
     if (nvalid == 0 ||
         hypot(points[i].x - points[nvalid - 1].x,
-              points[i].y - points[nvalid - 1].y) >  FP_TOLERANCE)
+              points[i].y - points[nvalid - 1].y) >  MEOS_GEOM_TOLERANCE)
     {
       points[nvalid++] = points[i];
     }
@@ -4777,7 +4777,7 @@ meos_buffer_line_offset(const LWLINE *line, double radius,
          ((mitre).y - points[i].y) * dy[(i) - 1]),                            \
         (((mitre).x - points[i].x) * dx[i] +                                  \
          ((mitre).y - points[i].y) * dy[i]))                                  \
-     <= Min(len[(i) - 1], len[i]) + MEOS_EDGE_TOLERANCE)
+     <= Min(len[(i) - 1], len[i]) + MEOS_GEOM_TOLERANCE)
 
   /* Construct the outer boundary as a compound curve */
   LWCOMPOUND *ring = lwcompound_construct_empty(srid, 0, 0);
@@ -4791,7 +4791,7 @@ meos_buffer_line_offset(const LWLINE *line, double radius,
     /* A left turn leaves the left side concave, so its offset segments cross
      * and the join belongs to the right side, and conversely */
     double turn = buffer_cross(dx[i - 1], dy[i - 1], dx[i], dy[i]);
-    if (turn < -FP_TOLERANCE || ! BUFFER_MITRE_ON_SEGMENTS(left[i], i))
+    if (turn < -MEOS_GEOM_TOLERANCE || ! BUFFER_MITRE_ON_SEGMENTS(left[i], i))
     {
       POINT2D p1 = buffer_point_offset(points[i].x, points[i].y, nx[i - 1],
         ny[i - 1], radius);
@@ -4836,7 +4836,7 @@ meos_buffer_line_offset(const LWLINE *line, double radius,
   for (int i = (int) npoints - 2; i > 0; i--)
   {
     double turn = buffer_cross(dx[i - 1], dy[i - 1], dx[i], dy[i]);
-    if (turn > FP_TOLERANCE || ! BUFFER_MITRE_ON_SEGMENTS(right[i], i))
+    if (turn > MEOS_GEOM_TOLERANCE || ! BUFFER_MITRE_ON_SEGMENTS(right[i], i))
     {
       POINT2D p1 = buffer_point_offset(points[i].x, points[i].y, -nx[i],
         -ny[i], radius);
@@ -4940,7 +4940,7 @@ meos_buffer_line_split(const LWLINE *line, double radius, JoinStyle join_style,
     getPoint4d_p(line->points, i, &point);
     if (nvalid == 0 ||
         hypot(point.x - points[nvalid - 1].x,
-              point.y - points[nvalid - 1].y) > FP_TOLERANCE)
+              point.y - points[nvalid - 1].y) > MEOS_GEOM_TOLERANCE)
     {
       points[nvalid].x = point.x;
       points[nvalid].y = point.y;
@@ -5147,7 +5147,7 @@ buffer_ring_encloses_no_area(const LWCOMPOUND *ring, int32_t srid)
   MeosArray *pieces = meos_array_create(sizeof(BufferPiece));
   LWGEOM *geom = lwcurvepoly_as_lwgeom(probe);
   bool result = ! buffer_pieces_from_geometry(geom, pieces) ||
-    fabs(buffer_ring_signed_area(pieces)) <= FP_TOLERANCE;
+    fabs(buffer_ring_signed_area(pieces)) <= MEOS_GEOM_TOLERANCE;
   meos_array_destroy(pieces);
   lwgeom_free(geom);
   return result;
@@ -5430,7 +5430,7 @@ buffer_areal_is_degenerate(const LWGEOM *geom)
   {
     const LWPOLY *poly = (const LWPOLY *) geom;
     return poly->nrings == 0 ||
-      fabs(buffer_ring_area(poly->rings[0])) <= FP_TOLERANCE;
+      fabs(buffer_ring_area(poly->rings[0])) <= MEOS_GEOM_TOLERANCE;
   }
   if (geom->type == MULTIPOLYGONTYPE)
   {

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -199,8 +199,8 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
    * cannot be read from them. The middle point is the one opposite, and the
    * two points split the circle into the two half circles the arcs of an edge
    * hold exactly. This is the shape #lwcircle_make gives a circle */
-  if (fabs(ax - cx) <= FP_TOLERANCE && fabs(ay - cy) <= FP_TOLERANCE &&
-      (fabs(ax - bx) > FP_TOLERANCE || fabs(ay - by) > FP_TOLERANCE))
+  if (fabs(ax - cx) <= MEOS_GEOM_TOLERANCE && fabs(ay - cy) <= MEOS_GEOM_TOLERANCE &&
+      (fabs(ax - bx) > MEOS_GEOM_TOLERANCE || fabs(ay - by) > MEOS_GEOM_TOLERANCE))
   {
     double mx = (ax + bx) / 2, my = (ay + by) / 2;
     double radius = hypot(ax - mx, ay - my);
@@ -228,7 +228,7 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
   }
 
   /* Collinear points: emit straight line edges */
-  if (fabs(d) < FP_TOLERANCE)
+  if (fabs(d) < MEOS_GEOM_TOLERANCE)
   {
     const double px[3] = {ax, bx, cx}, py[3] = {ay, by, cy};
     for (int i = 0; i < 2; i++)
@@ -912,7 +912,7 @@ add_edge_points(const Edge *e, POINT2D *points, uint32_t *npoints)
 {
   assert(e); assert(points); assert(npoints);
   add_point(points, npoints, e->x1, e->y1);
-  if (fabs(e->x2 - e->x1) > FP_TOLERANCE || fabs(e->y2 - e->y1) > FP_TOLERANCE)
+  if (fabs(e->x2 - e->x1) > MEOS_GEOM_TOLERANCE || fabs(e->y2 - e->y1) > MEOS_GEOM_TOLERANCE)
     add_point(points, npoints, e->x2, e->y2);
 }
 
@@ -1230,7 +1230,7 @@ hull_arc_holds(const HullFeature *f, double phi)
   double off = f->ccw ?
     angle_normalize(phi - f->theta0) :
     angle_normalize(f->theta0 - phi);
-  return off <= sweep + MEOS_EDGE_TOLERANCE;
+  return off <= sweep + MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -1325,7 +1325,7 @@ hull_directions(const HullFeature *feats, int nfeats, double **result)
       double c = (feats[j].is_arc ? feats[j].radius : 0.0) -
         (feats[i].is_arc ? feats[i].radius : 0.0);
       double h = hypot(a, b);
-      if (h <= MEOS_EDGE_TOLERANCE || fabs(c) > h)
+      if (h <= MEOS_GEOM_TOLERANCE || fabs(c) > h)
         continue;
       double ratio = c / h;
       /* The end of an arc lies on its own circle, so the two features reach
@@ -1334,8 +1334,8 @@ hull_directions(const HullFeature *feats, int nfeats, double **result)
        * moves it far enough to leave a sliver between the arc and the point
        * that ends it, so the ratio is read as the one it is */
       double base = atan2(b, a);
-      double off = (ratio >= 1.0 - MEOS_EDGE_TOLERANCE) ? 0.0 :
-        ((ratio <= -1.0 + MEOS_EDGE_TOLERANCE) ? M_PI : acos(ratio));
+      double off = (ratio >= 1.0 - MEOS_GEOM_TOLERANCE) ? 0.0 :
+        ((ratio <= -1.0 + MEOS_GEOM_TOLERANCE) ? M_PI : acos(ratio));
       hull_add_direction(base + off, dirs, &ndirs);
       hull_add_direction(base - off, dirs, &ndirs);
     }
@@ -1346,7 +1346,7 @@ hull_directions(const HullFeature *feats, int nfeats, double **result)
   /* Remove the directions that repeat the one before them */
   int nuniq = 0;
   for (int i = 0; i < ndirs; i++)
-    if (nuniq == 0 || dirs[i] - dirs[nuniq - 1] > MEOS_EDGE_TOLERANCE)
+    if (nuniq == 0 || dirs[i] - dirs[nuniq - 1] > MEOS_GEOM_TOLERANCE)
       dirs[nuniq++] = dirs[i];
   *result = dirs;
   return nuniq;
@@ -1428,8 +1428,8 @@ hull_snap_to_vertex(const HullFeature *feats, int nfeats, double *x, double *y)
 {
   for (int i = 0; i < nfeats; i++)
     if (! feats[i].is_arc &&
-        fabs(feats[i].x - *x) <= MEOS_EDGE_TOLERANCE &&
-        fabs(feats[i].y - *y) <= MEOS_EDGE_TOLERANCE)
+        fabs(feats[i].x - *x) <= MEOS_GEOM_TOLERANCE &&
+        fabs(feats[i].y - *y) <= MEOS_GEOM_TOLERANCE)
     {
       *x = feats[i].x;
       *y = feats[i].y;
@@ -1494,7 +1494,7 @@ hull_boundary(const HullFeature *feats, int nfeats, int *npieces)
     double a = dirs[idx];
     double b = dirs[(start + k + len) % ndirs];
     double sweep = angle_normalize(b - a);
-    if (sweep <= MEOS_EDGE_TOLERANCE)
+    if (sweep <= MEOS_GEOM_TOLERANCE)
       sweep = 2 * M_PI;
     const HullFeature *f = &feats[which[idx]];
     double sx, sy, ex, ey, mx = 0, my = 0;
@@ -1520,7 +1520,7 @@ hull_boundary(const HullFeature *feats, int nfeats, int *npieces)
       firstx = sx; firsty = sy;
       started = true;
     }
-    else if (hypot(sx - prevx, sy - prevy) > MEOS_EDGE_TOLERANCE)
+    else if (hypot(sx - prevx, sy - prevy) > MEOS_GEOM_TOLERANCE)
     {
       /* The segment joining the previous support to this one */
       result[n].x1 = prevx; result[n].y1 = prevy;
@@ -1535,7 +1535,7 @@ hull_boundary(const HullFeature *feats, int nfeats, int *npieces)
        * ways of naming one point */
       sx = prevx; sy = prevy;
     }
-    if (f->is_arc && hypot(ex - sx, ey - sy) > MEOS_EDGE_TOLERANCE)
+    if (f->is_arc && hypot(ex - sx, ey - sy) > MEOS_GEOM_TOLERANCE)
     {
       result[n].x1 = sx; result[n].y1 = sy;
       result[n].xm = mx; result[n].ym = my;
@@ -1550,7 +1550,7 @@ hull_boundary(const HullFeature *feats, int nfeats, int *npieces)
   /* Close the ring on the point it starts from */
   if (started && n > 0)
   {
-    if (hypot(firstx - prevx, firsty - prevy) > MEOS_EDGE_TOLERANCE)
+    if (hypot(firstx - prevx, firsty - prevy) > MEOS_GEOM_TOLERANCE)
     {
       result[n].x1 = prevx; result[n].y1 = prevy;
       result[n].x2 = firstx; result[n].y2 = firsty;
@@ -1749,7 +1749,7 @@ mrr_arc(const LWGEOM *geom, const MeosArray *edges)
       best_area = area;
       best_phi = cand[i];
     }
-    if (i + 1 >= ncand || cand[i + 1] - cand[i] <= MEOS_EDGE_TOLERANCE)
+    if (i + 1 >= ncand || cand[i + 1] - cand[i] <= MEOS_GEOM_TOLERANCE)
       continue;
     /* The stretch between two consecutive directions carries no change of
      * support, so the area is smooth over it and is searched by narrowing the
@@ -1780,7 +1780,7 @@ mrr_arc(const LWGEOM *geom, const MeosArray *edges)
      * hull is as wide every way, a circle being the plainest case, so a
      * direction the support changes in is kept over one the search lands on
      * unless it is genuinely smaller */
-    if (area < best_area - fabs(best_area) * 1e-12)
+    if (area < best_area - fabs(best_area) * MEOS_GEOM_TOLERANCE)
     {
       best_area = area;
       best_phi = phi;
@@ -1916,7 +1916,7 @@ meos_oriented_envelope(const LWGEOM *geom)
     const POINT2D *b = &hull[(i + 1) % nhull];
     double dx = b->x - a->x;
     double dy = b->y - a->y;
-    if (hypot(dx, dy) <= FP_TOLERANCE)
+    if (hypot(dx, dy) <= MEOS_GEOM_TOLERANCE)
       continue;
     double angle = atan2(dy, dx);
     angle = fmod(angle, M_PI);
@@ -3430,7 +3430,7 @@ relate_dimension(const LWGEOM *geom)
 static inline bool
 relate_same_point(double x1, double y1, double x2, double y2)
 {
-  return fabs(x1 - x2) <= MEOS_EDGE_TOLERANCE && fabs(y1 - y2) <= MEOS_EDGE_TOLERANCE;
+  return fabs(x1 - x2) <= MEOS_GEOM_TOLERANCE && fabs(y1 - y2) <= MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -3865,7 +3865,7 @@ relate_arc_parameter(const Edge *e, double x, double y)
     sweep = angle_normalize(e->theta0 - e->theta1);
     off = angle_normalize(e->theta0 - phi);
   }
-  if (sweep < MEOS_EDGE_TOLERANCE)
+  if (sweep < MEOS_GEOM_TOLERANCE)
     return 0.0;
   double t = off / sweep;
   if (t < 0.0)
@@ -3906,7 +3906,7 @@ relate_edge_point(const Edge *e, double t, double *x, double *y)
 static void
 relate_add_parameter(double t, double *params, int *nparams, int maxparams)
 {
-  if (t < -MEOS_EDGE_TOLERANCE || t > 1.0 + MEOS_EDGE_TOLERANCE)
+  if (t < -MEOS_GEOM_TOLERANCE || t > 1.0 + MEOS_GEOM_TOLERANCE)
     return;
   if (t < 0.0)
     t = 0.0;
@@ -3918,7 +3918,7 @@ relate_add_parameter(double t, double *params, int *nparams, int maxparams)
    * edges meet. */
   for (int i = 0; i < *nparams; i++)
   {
-    if (fabs(params[i] - t) <= MEOS_EDGE_TOLERANCE)
+    if (fabs(params[i] - t) <= MEOS_GEOM_TOLERANCE)
       return;
   }
   if (*nparams < maxparams)
@@ -3931,9 +3931,9 @@ relate_add_parameter(double t, double *params, int *nparams, int maxparams)
 static bool
 relate_same_circle(const Edge *a, const Edge *b)
 {
-  return fabs(a->cx - b->cx) <= MEOS_EDGE_TOLERANCE &&
-         fabs(a->cy - b->cy) <= MEOS_EDGE_TOLERANCE &&
-         fabs(a->radius - b->radius) <= MEOS_EDGE_TOLERANCE;
+  return fabs(a->cx - b->cx) <= MEOS_GEOM_TOLERANCE &&
+         fabs(a->cy - b->cy) <= MEOS_GEOM_TOLERANCE &&
+         fabs(a->radius - b->radius) <= MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -3988,7 +3988,7 @@ relate_arcs_overlap(const Edge *a, const Edge *b)
   {
     for (int j = i + 1; j < np;)
     {
-      if (fabs(p[i] - p[j]) <= MEOS_EDGE_TOLERANCE)
+      if (fabs(p[i] - p[j]) <= MEOS_GEOM_TOLERANCE)
       {
         for (int k = j; k < np - 1; k++)
           p[k] = p[k + 1];
@@ -4004,7 +4004,7 @@ relate_arcs_overlap(const Edge *a, const Edge *b)
   {
     for (int j = i + 1; j < np; j++)
     {
-      if (fabs(p[j] - p[i]) <= MEOS_EDGE_TOLERANCE)
+      if (fabs(p[j] - p[i]) <= MEOS_GEOM_TOLERANCE)
         continue;
       double tm = (p[i] + p[j]) * 0.5;
       double x, y;
@@ -4032,9 +4032,9 @@ relate_arc_arc_points(const Edge *a, const Edge *b, double x[2], double y[2],
   double d = hypot(dx, dy);
 
   /* Coincident supporting circles */
-  if (d <= MEOS_EDGE_TOLERANCE)
+  if (d <= MEOS_GEOM_TOLERANCE)
   {
-    if (fabs(a->radius - b->radius) > MEOS_EDGE_TOLERANCE)
+    if (fabs(a->radius - b->radius) > MEOS_GEOM_TOLERANCE)
       return 0;
     if (relate_arcs_overlap(a, b))
     {
@@ -4060,8 +4060,8 @@ relate_arc_arc_points(const Edge *a, const Edge *b, double x[2], double y[2],
   }
 
   /* Disjoint supporting circles */
-  if (d > a->radius + b->radius + MEOS_EDGE_TOLERANCE ||
-      d < fabs(a->radius - b->radius) - MEOS_EDGE_TOLERANCE)
+  if (d > a->radius + b->radius + MEOS_GEOM_TOLERANCE ||
+      d < fabs(a->radius - b->radius) - MEOS_GEOM_TOLERANCE)
     return 0;
   double aa = (d * d + a->radius * a->radius - b->radius * b->radius) /
     (2.0 * d);
@@ -4093,7 +4093,7 @@ relate_arc_arc_points(const Edge *a, const Edge *b, double x[2], double y[2],
     x[n] = px;
     y[n] = py;
     n++;
-    if (h <= MEOS_EDGE_TOLERANCE)
+    if (h <= MEOS_GEOM_TOLERANCE)
       break;
   }
   return n;
@@ -4242,7 +4242,7 @@ static void
 relate_linear_area_interval(const Edge *line, double t0, double t1,
   Edge **area_edges, int narea, MeosDE9IM *m)
 {
-  if (t1 - t0 <= MEOS_EDGE_TOLERANCE)
+  if (t1 - t0 <= MEOS_GEOM_TOLERANCE)
     return;
   double tm = (t0 + t1) * 0.5;
   double x, y;
@@ -4326,19 +4326,19 @@ relate_intervals_cover(RelateInterval *intervals, int count)
     return false;
   qsort(intervals, (size_t) count, sizeof(RelateInterval),
     relate_interval_cmp);
-  if (intervals[0].t0 > MEOS_EDGE_TOLERANCE)
+  if (intervals[0].t0 > MEOS_GEOM_TOLERANCE)
     return false;
   double reach = intervals[0].t1;
   for (int i = 1; i < count; i++)
   {
-    if (reach >= 1.0 - MEOS_EDGE_TOLERANCE)
+    if (reach >= 1.0 - MEOS_GEOM_TOLERANCE)
       break;
-    if (intervals[i].t0 > reach + MEOS_EDGE_TOLERANCE)
+    if (intervals[i].t0 > reach + MEOS_GEOM_TOLERANCE)
       return false;
     if (intervals[i].t1 > reach)
       reach = intervals[i].t1;
   }
-  return reach >= 1.0 - MEOS_EDGE_TOLERANCE;
+  return reach >= 1.0 - MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -4371,7 +4371,7 @@ relate_arc_overlap_ranges(const Edge *a, const Edge *b, RelateInterval *out)
   int count = 0;
   for (int i = 0; i + 1 < np; i++)
   {
-    if (p[i + 1] - p[i] <= MEOS_EDGE_TOLERANCE)
+    if (p[i + 1] - p[i] <= MEOS_GEOM_TOLERANCE)
       continue;
     /* A piece is covered when its midpoint is on the other arc */
     double x, y;
@@ -4712,7 +4712,7 @@ relate_linear_area(const LWGEOM *line_geom, const LWGEOM *area_geom,
       qsort(bparams, nbparams, sizeof(double), relate_area_parameter_cmp);
       for (int k = 0; k < nbparams - 1; k++)
       {
-        if (bparams[k + 1] - bparams[k] <= MEOS_EDGE_TOLERANCE)
+        if (bparams[k + 1] - bparams[k] <= MEOS_GEOM_TOLERANCE)
           continue;
         double x, y;
         relate_area_edge_point(boundary, (bparams[k] + bparams[k + 1]) * 0.5,
@@ -4750,7 +4750,7 @@ relate_linear_area(const LWGEOM *line_geom, const LWGEOM *area_geom,
     int nuniq = 0;
     for (int j = 0; j < nparams; j++)
     {
-      if (nuniq == 0 || fabs(params[j] - params[nuniq - 1]) > MEOS_EDGE_TOLERANCE)
+      if (nuniq == 0 || fabs(params[j] - params[nuniq - 1]) > MEOS_GEOM_TOLERANCE)
       {
         params[nuniq++] = params[j];
       }
@@ -4932,13 +4932,13 @@ relate_area_edge_parameter(const Edge *e, double x, double y)
     double dy = e->y2 - e->y1;
     if (fabs(dx) >= fabs(dy))
     {
-      if (fabs(dx) <= MEOS_EDGE_TOLERANCE)
+      if (fabs(dx) <= MEOS_GEOM_TOLERANCE)
         return 0.0;
       return (x - e->x1) / dx;
     }
     else
     {
-      if (fabs(dy) <= MEOS_EDGE_TOLERANCE)
+      if (fabs(dy) <= MEOS_GEOM_TOLERANCE)
         return 0.0;
       return (y - e->y1) / dy;
     }
@@ -4953,7 +4953,7 @@ static void
 relate_area_add_parameter(double t, double *params, int *nparams,
   int maxparams)
 {
-  if (t < -MEOS_EDGE_TOLERANCE || t > 1.0 + MEOS_EDGE_TOLERANCE)
+  if (t < -MEOS_GEOM_TOLERANCE || t > 1.0 + MEOS_GEOM_TOLERANCE)
     return;
   if (t < 0.0)
     t = 0.0;
@@ -4961,7 +4961,7 @@ relate_area_add_parameter(double t, double *params, int *nparams,
     t = 1.0;
   for (int i = 0; i < *nparams; i++)
   {
-    if (fabs(params[i] - t) <= MEOS_EDGE_TOLERANCE)
+    if (fabs(params[i] - t) <= MEOS_GEOM_TOLERANCE)
       return;
   }
   if (*nparams < maxparams)
@@ -5156,7 +5156,7 @@ relate_area_edge_intervals(const Edge *edge, Edge **other_edges, int nother,
   int nuniq = 0;
   for (int i = 0; i < nparams; i++)
   {
-    if (nuniq == 0 || fabs(params[i] - params[nuniq - 1]) > MEOS_EDGE_TOLERANCE)
+    if (nuniq == 0 || fabs(params[i] - params[nuniq - 1]) > MEOS_GEOM_TOLERANCE)
     {
       params[nuniq++] = params[i];
     }
@@ -5165,7 +5165,7 @@ relate_area_edge_intervals(const Edge *edge, Edge **other_edges, int nother,
   /* Classify each open interval */
   for (int i = 0; i < nuniq - 1; i++)
   {
-    if (params[i + 1] - params[i] <= MEOS_EDGE_TOLERANCE)
+    if (params[i + 1] - params[i] <= MEOS_GEOM_TOLERANCE)
       continue;
     double t = (params[i] + params[i + 1]) * 0.5;
     double x, y;
@@ -5315,7 +5315,7 @@ relate_area_edge_interior_point(const Edge *e, Edge **edges, int nedges,
       }
     }
     double len = hypot(tx, ty);
-    if (len <= MEOS_EDGE_TOLERANCE)
+    if (len <= MEOS_GEOM_TOLERANCE)
       return false;
     tx /= len;
     ty /= len;
@@ -5328,7 +5328,7 @@ relate_area_edge_interior_point(const Edge *e, Edge **edges, int nedges,
     /* The tolerance is deliberately small relative to the edge
      * length. This is only used to obtain an interior witness
      * point; all actual intersections remain exact. */
-    double eps = fmax(MEOS_EDGE_TOLERANCE * 10.0, len * 1e-9);
+    double eps = fmax(MEOS_GEOM_TOLERANCE * 10.0, len * 1e-9);
     double qx = px + eps * nx;
     double qy = py + eps * ny;
     if (relate_point_in_area(qx, qy, edges, nedges) == 0)
@@ -5639,7 +5639,7 @@ relate_clearance(double x, double y, const RelateComp *comps, int ncomp)
     for (int j = 0; j < comps[i].nedges; j++)
     {
       double d = relate_edge_distance(x, y, comps[i].edges[j]);
-      if (d <= MEOS_EDGE_TOLERANCE)
+      if (d <= MEOS_GEOM_TOLERANCE)
         continue;
       if (result < 0 || d < result)
         result = d;
@@ -5709,9 +5709,9 @@ relate_same_portion(const Edge *a, const Edge *b)
   if (a->etype != b->etype)
     return false;
   if (a->etype == EDGE_POLYARC &&
-      (fabs(a->cx - b->cx) > MEOS_EDGE_TOLERANCE ||
-       fabs(a->cy - b->cy) > MEOS_EDGE_TOLERANCE ||
-       fabs(a->radius - b->radius) > MEOS_EDGE_TOLERANCE))
+      (fabs(a->cx - b->cx) > MEOS_GEOM_TOLERANCE ||
+       fabs(a->cy - b->cy) > MEOS_GEOM_TOLERANCE ||
+       fabs(a->radius - b->radius) > MEOS_GEOM_TOLERANCE))
     return false;
   /* The two components may traverse the portion in opposite directions */
   return (relate_same_point(a->x1, a->y1, b->x1, b->y1) &&
@@ -5792,7 +5792,7 @@ relate_union_edges(const LWGEOM *geom)
     for (int k = 0; k < nparams - 1; k++)
     {
       double t0 = params[k], t1 = params[k + 1];
-      if (t1 - t0 <= MEOS_EDGE_TOLERANCE)
+      if (t1 - t0 <= MEOS_GEOM_TOLERANCE)
         continue;
       if (relate_portion_inside_union(e, (t0 + t1) * 0.5, comps, ncomp))
         continue;
@@ -5954,8 +5954,8 @@ relate_any_edge_parameter(const Edge *e, double x, double y)
     return relate_arc_parameter(e, x, y);
   double dx = e->x2 - e->x1, dy = e->y2 - e->y1;
   if (fabs(dx) >= fabs(dy))
-    return fabs(dx) <= MEOS_EDGE_TOLERANCE ? 0.0 : (x - e->x1) / dx;
-  return fabs(dy) <= MEOS_EDGE_TOLERANCE ? 0.0 : (y - e->y1) / dy;
+    return fabs(dx) <= MEOS_GEOM_TOLERANCE ? 0.0 : (x - e->x1) / dx;
+  return fabs(dy) <= MEOS_GEOM_TOLERANCE ? 0.0 : (y - e->y1) / dy;
 }
 
 /**
@@ -6032,7 +6032,7 @@ relate_comp_covered(const LWGEOM *comp, const RelateComp *comps, int ncomp,
     qsort(params, nparams, sizeof(double), relate_area_parameter_cmp);
     for (int k = 0; k < nparams - 1 && result; k++)
     {
-      if (params[k + 1] - params[k] <= MEOS_EDGE_TOLERANCE)
+      if (params[k + 1] - params[k] <= MEOS_GEOM_TOLERANCE)
         continue;
       double x, y;
       relate_edge_point(e, (params[k] + params[k + 1]) * 0.5, &x, &y);
@@ -6340,8 +6340,8 @@ relate_point_on_edge(double x, double y, const Edge *e)
   switch (e->etype)
   {
     case EDGE_POINT:
-      return fabs(x - e->x1) <= MEOS_EDGE_TOLERANCE &&
-        fabs(y - e->y1) <= MEOS_EDGE_TOLERANCE;
+      return fabs(x - e->x1) <= MEOS_GEOM_TOLERANCE &&
+        fabs(y - e->y1) <= MEOS_GEOM_TOLERANCE;
     case EDGE_LINEARC:
     case EDGE_POLYARC:
       return point_on_arc(x, y, e);
@@ -6450,10 +6450,10 @@ relate_edges_intersect(Edge **e1, int n1, Edge **e2, int n2)
       const Edge *b = e2[j];
       if (b->etype == EDGE_POINT)
         continue;
-      if (a->xmax < b->xmin - MEOS_EDGE_TOLERANCE ||
-          b->xmax < a->xmin - MEOS_EDGE_TOLERANCE ||
-          a->ymax < b->ymin - MEOS_EDGE_TOLERANCE ||
-          b->ymax < a->ymin - MEOS_EDGE_TOLERANCE)
+      if (a->xmax < b->xmin - MEOS_GEOM_TOLERANCE ||
+          b->xmax < a->xmin - MEOS_GEOM_TOLERANCE ||
+          a->ymax < b->ymin - MEOS_GEOM_TOLERANCE ||
+          b->ymax < a->ymin - MEOS_GEOM_TOLERANCE)
         continue;
       if (relate_edges_meet(a, b))
         return true;
@@ -6523,10 +6523,10 @@ relate_edges_cover(Edge **e1, int n1, Edge **e2, int n2)
     for (int i = 0; i < n1; i++)
     {
       const Edge *o = e1[i];
-      if (e->xmax < o->xmin - MEOS_EDGE_TOLERANCE ||
-          o->xmax < e->xmin - MEOS_EDGE_TOLERANCE ||
-          e->ymax < o->ymin - MEOS_EDGE_TOLERANCE ||
-          o->ymax < e->ymin - MEOS_EDGE_TOLERANCE)
+      if (e->xmax < o->xmin - MEOS_GEOM_TOLERANCE ||
+          o->xmax < e->xmin - MEOS_GEOM_TOLERANCE ||
+          e->ymax < o->ymin - MEOS_GEOM_TOLERANCE ||
+          o->ymax < e->ymin - MEOS_GEOM_TOLERANCE)
         continue;
       double ix[2], iy[2];
       int nint = relate_any_edge_intersection(e, o, ix, iy);
@@ -6548,7 +6548,7 @@ relate_edges_cover(Edge **e1, int n1, Edge **e2, int n2)
     qsort(params, nparams, sizeof(double), relate_area_parameter_cmp);
     for (int k = 0; k < nparams - 1 && result; k++)
     {
-      if (params[k + 1] - params[k] <= MEOS_EDGE_TOLERANCE)
+      if (params[k + 1] - params[k] <= MEOS_GEOM_TOLERANCE)
         continue;
       double x, y;
       relate_edge_point(e, (params[k] + params[k + 1]) * 0.5, &x, &y);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -4236,7 +4236,7 @@ distance_point2d(POINT2D a, POINT2D b)
 static inline bool
 mec_inside(POINT2D p, Circle c)
 {
-  return distance_point2d(p, c.center) <= c.radius + 1e-12;
+  return distance_point2d(p, c.center) <= c.radius + MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -4270,7 +4270,7 @@ mec_circle3(POINT2D a, POINT2D b, POINT2D c)
    * uninitialised — cppcheck flags this as `uninitvar`, and a downstream
    * caller that ignored circ.radius == -1 would read garbage. */
   Circle circ = { .center = {0.0, 0.0}, .radius = 0.0 };
-  if (fabs(G) < 1e-12)
+  if (fabs(G) < MEOS_GEOM_TOLERANCE)
   {
     circ.radius = -1;
     return circ;

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -41,6 +41,7 @@
 #include <utils/timestamp.h>
 /* PostGIS */
 #include <lwgeodetic_tree.h>
+
 #include <measures.h>
 #include <measures3d.h>
 /* MEOS */
@@ -181,7 +182,7 @@ dist_geom_arc_contains_angle(const DistEdge *e, double phi)
     dist_angle_norm(e->at1 - e->at0) : dist_angle_norm(e->at0 - e->at1);
   double off = e->accw ?
     dist_angle_norm(phi - e->at0) : dist_angle_norm(e->at0 - phi);
-  return off <= sweep + FP_TOLERANCE;
+  return off <= sweep + MEOS_GEOM_TOLERANCE;
 }
 
 /**
@@ -229,7 +230,7 @@ dist_segs_add_arc(double ax, double ay, double bx, double by, double cx,
   }
   /* Twice the signed area of triangle ABC; zero => collinear */
   double d = 2.0 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by));
-  if (fabs(d) < FP_TOLERANCE)
+  if (fabs(d) < MEOS_GEOM_TOLERANCE)
   {
     /* Collinear: two straight segments A->B, B->C */
     for (int seg = 0; seg < 2; seg++)
@@ -419,7 +420,7 @@ dist_poly_seg_raycross(const DistEdge *s, double x, double y,
      * ray that only grazes the circle tangentially does not cross. */
     const double dyc = y - s->acy;
     const double h2 = s->arad * s->arad - dyc * dyc;
-    if (h2 <= FP_TOLERANCE)
+    if (h2 <= MEOS_GEOM_TOLERANCE)
       return;
     const double h = sqrt(h2);
     const double xhit[2] = {s->acx - h, s->acx + h};
@@ -436,10 +437,10 @@ dist_poly_seg_raycross(const DistEdge *s, double x, double y,
        * arc endpoint (a ring junction on the ray) is owned by this edge only if
        * the arc interior rises above the ray there; an interior crossing is
        * always transversal and always counted. */
-      const bool at_ep0 = fabs(xi - s->x1) < FP_TOLERANCE && 
-        fabs(y - s->y1) < FP_TOLERANCE;
-      const bool at_ep1 = fabs(xi - s->x2) < FP_TOLERANCE && 
-        fabs(y - s->y2) < FP_TOLERANCE;
+      const bool at_ep0 = fabs(xi - s->x1) < MEOS_GEOM_TOLERANCE && 
+        fabs(y - s->y1) < MEOS_GEOM_TOLERANCE;
+      const bool at_ep1 = fabs(xi - s->x2) < MEOS_GEOM_TOLERANCE && 
+        fabs(y - s->y2) < MEOS_GEOM_TOLERANCE;
       if (at_ep0 || at_ep1)
       {
         const double theta_e = at_ep0 ? s->at0 : s->at1;
@@ -873,7 +874,7 @@ dist_geom_closest_on_arc(double px, double py, const DistEdge *e,
 {
   double vx = px - e->acx, vy = py - e->acy;
   double vl = hypot(vx, vy);
-  if (vl > FP_TOLERANCE && dist_geom_arc_contains_angle(e, atan2(vy, vx)))
+  if (vl > MEOS_GEOM_TOLERANCE && dist_geom_arc_contains_angle(e, atan2(vy, vx)))
   {
     *qx = e->acx + vx * (e->arad / vl);
     *qy = e->acy + vy * (e->arad / vl);
@@ -1307,7 +1308,7 @@ dist_segm_shortestline(double cx1, double cy1, double r1, double cx2,
         double vx = qx - ccx, vy = qy - ccy;
         double vl = sqrt(vx * vx + vy * vy);
         double pxp, pyp;
-        if (vl <= FP_TOLERANCE || m <= 0.0)
+        if (vl <= MEOS_GEOM_TOLERANCE || m <= 0.0)
         {
           /* Overlap or centre on the edge: degenerate line at the contact */
           pxp = qx; pyp = qy;

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -89,7 +89,7 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
    * height near its own: it is moved until no vertex sits on it, which leaves
    * no crossing for two edges to share and no rule to reconcile */
   double ry = y;
-  double bump = MEOS_EDGE_TOLERANCE * 4.0;
+  double bump = MEOS_GEOM_TOLERANCE * 4.0;
   for (int attempt = 0; attempt < 8; attempt++)
   {
     bool shared = false;
@@ -127,7 +127,7 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
        * r stands for a distance of r times that tolerance, so an end of a
        * large arc reaches the ray from far further off than an end of a
        * segment does */
-      double tol = MEOS_EDGE_TOLERANCE;
+      double tol = MEOS_GEOM_TOLERANCE;
       if (e->etype == EDGE_POLYARC && e->radius > 1.0)
         tol *= e->radius;
       if (fabs(e->y1 - ry) <= tol || fabs(e->y2 - ry) <= tol)
@@ -151,7 +151,7 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
          * tangentially (h2 ~ 0) does not cross the boundary */
         const double dyc = ry - e->cy;
         const double h2 = e->radius * e->radius - dyc * dyc;
-        if (h2 <= MEOS_EDGE_TOLERANCE)
+        if (h2 <= MEOS_GEOM_TOLERANCE)
           continue;
         const double h = sqrt(h2);
         const double xhit[2] = {e->cx - h, e->cx + h};
@@ -178,11 +178,11 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
 
       /* Boundary check, which reads the point itself rather than the ray */
       const double cross = dx * dyp - dy * dxp;
-      if (fabs(cross) < MEOS_EDGE_TOLERANCE)
+      if (fabs(cross) < MEOS_GEOM_TOLERANCE)
       {
         const double dot = dxp * dx + dyp * dy;
-        if (dot >= -MEOS_EDGE_TOLERANCE &&
-            dot <= (e->length) + MEOS_EDGE_TOLERANCE)
+        if (dot >= -MEOS_GEOM_TOLERANCE &&
+            dot <= (e->length) + MEOS_GEOM_TOLERANCE)
           return 1;
       }
 
@@ -232,8 +232,8 @@ intervals_from_points(const POINT2D *a, const POINT2D *b, Edge **edges,
   /* Improve performance by removing the division inside the loop */
   bool use_x = fabs(dx) >= fabs(dy);
   double inv = use_x ?
-    ((fabs(dx) > FP_TOLERANCE) ? 1.0 / dx : 0.0) :
-    ((fabs(dy) > FP_TOLERANCE) ? 1.0 / dy : 0.0);
+    ((fabs(dx) > MEOS_GEOM_TOLERANCE) ? 1.0 / dx : 0.0) :
+    ((fabs(dy) > MEOS_GEOM_TOLERANCE) ? 1.0 / dy : 0.0);
 
   /* The segment stands still */
   if (inv == 0.0)
@@ -243,8 +243,8 @@ intervals_from_points(const POINT2D *a, const POINT2D *b, Edge **edges,
       const Edge *e = edges[i];
       if (e->etype != EDGE_POINT)
         continue;
-      if (fabs(a->x - e->x1) < FP_TOLERANCE &&
-          fabs(a->y - e->y1) < FP_TOLERANCE)
+      if (fabs(a->x - e->x1) < MEOS_GEOM_TOLERANCE &&
+          fabs(a->y - e->y1) < MEOS_GEOM_TOLERANCE)
       {
         Span in;
         span_set(Float8GetDatum(0.0), Float8GetDatum(1.0), true, true,
@@ -267,13 +267,13 @@ intervals_from_points(const POINT2D *a, const POINT2D *b, Edge **edges,
     /* Solve parameter t */
     double t = use_x ? (e->x1 - a->x) * inv : (e->y1 - a->y) * inv;
     /* Check bounds */
-    if (t < -FP_TOLERANCE || t > 1.0 + FP_TOLERANCE)
+    if (t < -MEOS_GEOM_TOLERANCE || t > 1.0 + MEOS_GEOM_TOLERANCE)
       continue;
 
     /* Reconstruct point and add interval */
     double x = a->x + t * dx;
     double y = a->y + t * dy;
-    if (fabs(x - e->x1) < FP_TOLERANCE && fabs(y - e->y1) < FP_TOLERANCE)
+    if (fabs(x - e->x1) < MEOS_GEOM_TOLERANCE && fabs(y - e->y1) < MEOS_GEOM_TOLERANCE)
     {
       Span in;
       span_set(Float8GetDatum(t), Float8GetDatum(t), true, true,
@@ -354,8 +354,8 @@ intervals_from_lines(const POINT2D *a, const POINT2D *b, Edge **edges,
         continue;
 
       /* Fast bbox check first */
-      if (mx < e->xmin - FP_TOLERANCE || mx > e->xmax + FP_TOLERANCE ||
-          my < e->ymin - FP_TOLERANCE || my > e->ymax + FP_TOLERANCE)
+      if (mx < e->xmin - MEOS_GEOM_TOLERANCE || mx > e->xmax + MEOS_GEOM_TOLERANCE ||
+          my < e->ymin - MEOS_GEOM_TOLERANCE || my > e->ymax + MEOS_GEOM_TOLERANCE)
         continue;
 
       if (point_on_segment(mx, my, e->x1, e->y1, e->x2, e->y2))
@@ -528,7 +528,7 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
       if (r.type == INTERSECT_POINT)
       {
         double t = r.t0;
-        if (t >= -FP_TOLERANCE && t <= 1.0 + FP_TOLERANCE)
+        if (t >= -MEOS_GEOM_TOLERANCE && t <= 1.0 + MEOS_GEOM_TOLERANCE)
           meos_array_add(events, &t);
       }
     }
@@ -538,7 +538,7 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
       double t[2];
       int n = arcsegm_intersect(ax, ay, rx, ry, e, t);
       for (int k = 0; k < n; k++)
-        if (t[k] >= -FP_TOLERANCE && t[k] <= 1.0 + FP_TOLERANCE)
+        if (t[k] >= -MEOS_GEOM_TOLERANCE && t[k] <= 1.0 + MEOS_GEOM_TOLERANCE)
           meos_array_add(events, &t[k]);
     }
   }
@@ -557,7 +557,7 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
   for (int i = 0; i < (int) events->count; i++)
   {
     if (i == 0 ||
-        fabs(evtarr[i] - evtarr[newcount - 1]) > FP_TOLERANCE)
+        fabs(evtarr[i] - evtarr[newcount - 1]) > MEOS_GEOM_TOLERANCE)
     {
       evtarr[newcount++] = evtarr[i];
     }
@@ -572,7 +572,7 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
   {
     double ta = evtarr[i];
     double tb = evtarr[i + 1];
-    if (tb - ta <= FP_TOLERANCE)
+    if (tb - ta <= MEOS_GEOM_TOLERANCE)
       continue;
 
     /* Midpoint test */
@@ -633,7 +633,7 @@ point_inter_points_lines(const POINT2D *a, Edge **edges, int nedges)
     const Edge *e = edges[i];
     if (e->etype == EDGE_POINT)
     {
-      if (fabs(e->x1 - ax) < FP_TOLERANCE && fabs(e->y1 - ay) < FP_TOLERANCE)
+      if (fabs(e->x1 - ax) < MEOS_GEOM_TOLERANCE && fabs(e->y1 - ay) < MEOS_GEOM_TOLERANCE)
         return true;
     }
     else if (e->etype == EDGE_LINESEG)
@@ -805,14 +805,14 @@ tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
       Span s;
       double lower = DatumGetFloat8(intervarr[j].lower);
       double upper = DatumGetFloat8(intervarr[j].upper);
-      if (fabs(upper - lower) < FP_TOLERANCE)
+      if (fabs(upper - lower) < MEOS_GEOM_TOLERANCE)
       {
         /* Remove intersection points on exclusive lower and upper bounds */
-        if (! lower_inc && fabs(lower) < FP_TOLERANCE &&
-            fabs(upper) < FP_TOLERANCE)
+        if (! lower_inc && fabs(lower) < MEOS_GEOM_TOLERANCE &&
+            fabs(upper) < MEOS_GEOM_TOLERANCE)
           continue;
-        if (! upper_inc && fabs(lower - 1.0) < FP_TOLERANCE &&
-            fabs(upper - 1.0) < FP_TOLERANCE)
+        if (! upper_inc && fabs(lower - 1.0) < MEOS_GEOM_TOLERANCE &&
+            fabs(upper - 1.0) < MEOS_GEOM_TOLERANCE)
           continue;
 
         /* Interpolate only if 0 < lower/upper < 1 */
@@ -959,8 +959,8 @@ static bool
 edge_intersect(const Edge *e1, const Edge *e2)
 {
   /* Bounding-box reject */
-  if (e1->xmax < e2->xmin - FP_TOLERANCE || e2->xmax < e1->xmin - FP_TOLERANCE ||
-      e1->ymax < e2->ymin - FP_TOLERANCE || e2->ymax < e1->ymin - FP_TOLERANCE)
+  if (e1->xmax < e2->xmin - MEOS_GEOM_TOLERANCE || e2->xmax < e1->xmin - MEOS_GEOM_TOLERANCE ||
+      e1->ymax < e2->ymin - MEOS_GEOM_TOLERANCE || e2->ymax < e1->ymin - MEOS_GEOM_TOLERANCE)
     return false;
 
   bool arc1 = (e1->etype == EDGE_LINEARC || e1->etype == EDGE_POLYARC);
@@ -968,8 +968,8 @@ edge_intersect(const Edge *e1, const Edge *e2)
 
   /* A point edge meets another edge only by lying on it */
   if (e1->etype == EDGE_POINT && e2->etype == EDGE_POINT)
-    return fabs(e1->x1 - e2->x1) < FP_TOLERANCE &&
-      fabs(e1->y1 - e2->y1) < FP_TOLERANCE;
+    return fabs(e1->x1 - e2->x1) < MEOS_GEOM_TOLERANCE &&
+      fabs(e1->y1 - e2->y1) < MEOS_GEOM_TOLERANCE;
   if (e1->etype == EDGE_POINT)
     return arc2 ? point_on_arc(e1->x1, e1->y1, e2) :
       point_on_segment(e1->x1, e1->y1, e2->x1, e2->y1, e2->x2, e2->y2);
@@ -1149,7 +1149,7 @@ edges_contain_point(double px, double py, Edge **edges, int nedges,
     const Edge *e = edges[i];
     if (e->etype == EDGE_POINT)
     {
-      if (fabs(px - e->x1) < FP_TOLERANCE && fabs(py - e->y1) < FP_TOLERANCE)
+      if (fabs(px - e->x1) < MEOS_GEOM_TOLERANCE && fabs(py - e->y1) < MEOS_GEOM_TOLERANCE)
         return true;
     }
     else if (e->etype == EDGE_LINEARC || e->etype == EDGE_POLYARC)
@@ -1211,7 +1211,7 @@ segment_within_closure(const Edge *e, Edge **aedges, int na, bool has_area)
   bool result = true;
   for (int i = 0; i < nt - 1 && result; i++)
   {
-    if (ts[i + 1] - ts[i] < FP_TOLERANCE)
+    if (ts[i + 1] - ts[i] < MEOS_GEOM_TOLERANCE)
       continue;
     double tm = 0.5 * (ts[i] + ts[i + 1]);
     double mx = e->x1 + tm * e->dx, my = e->y1 + tm * e->dy;
@@ -1546,7 +1546,7 @@ point_seg_dist2(double px, double py, double x1, double y1, double x2,
 {
   const double ux = x2 - x1, uy = y2 - y1;
   const double l2 = ux * ux + uy * uy;
-  if (l2 < FP_TOLERANCE)
+  if (l2 < MEOS_GEOM_TOLERANCE)
   {
     const double dx = px - x1, dy = py - y1;
     return dx * dx + dy * dy;
@@ -1628,13 +1628,13 @@ point_geom_within(double px, double py, Edge **edges, int nedges,
     for (int i = 0; i < nc; i++)
       if (point_edge_dist2(px, py,
             edges[*(int64 *) meos_array_get(rtree_results, i)]) <=
-          d2 + FP_TOLERANCE)
+          d2 + MEOS_GEOM_TOLERANCE)
         return true;
   }
   else
   {
     for (int i = 0; i < nedges; i++)
-      if (point_edge_dist2(px, py, edges[i]) <= d2 + FP_TOLERANCE)
+      if (point_edge_dist2(px, py, edges[i]) <= d2 + MEOS_GEOM_TOLERANCE)
         return true;
   }
   return point_in_polygon_impl(px, py, edges, nedges, rtree, srid, xmax) ?
@@ -1648,7 +1648,7 @@ point_geom_within(double px, double py, Edge **edges, int nedges,
 static void
 add_within_root(double t, MeosArray *ev)
 {
-  if (t > -FP_TOLERANCE && t < 1.0 + FP_TOLERANCE)
+  if (t > -MEOS_GEOM_TOLERANCE && t < 1.0 + MEOS_GEOM_TOLERANCE)
   {
     if (t < 0.0) t = 0.0; else if (t > 1.0) t = 1.0;
     meos_array_add(ev, &t);
@@ -1662,9 +1662,9 @@ add_within_root(double t, MeosArray *ev)
 static void
 add_within_quad_roots(double A, double B, double C, MeosArray *ev)
 {
-  if (fabs(A) < FP_TOLERANCE)
+  if (fabs(A) < MEOS_GEOM_TOLERANCE)
   {
-    if (fabs(B) > FP_TOLERANCE)
+    if (fabs(B) > MEOS_GEOM_TOLERANCE)
       add_within_root(-C / B, ev);
     return;
   }
@@ -1715,11 +1715,11 @@ within_roots_from_edge(double ax, double ay, double rx, double ry,
        * perpendicular distance is (k0 + t k1) / sqrt(l2) */
       const double ux = e->x2 - e->x1, uy = e->y2 - e->y1;
       const double l2 = ux * ux + uy * uy;
-      if (l2 > FP_TOLERANCE)
+      if (l2 > MEOS_GEOM_TOLERANCE)
       {
         const double k0 = w0x * uy - w0y * ux;
         const double k1 = rx * uy - ry * ux;
-        if (fabs(k1) > FP_TOLERANCE)
+        if (fabs(k1) > MEOS_GEOM_TOLERANCE)
         {
           const double off = dist * sqrt(l2);
           add_within_root((off - k0) / k1, ev);
@@ -1796,7 +1796,7 @@ intervals_within_edges(const POINT2D *a, const POINT2D *b, Edge **sel_edges,
   int newcount = 0;
   double *ev = (double *) events->elems;
   for (int i = 0; i < (int) events->count; i++)
-    if (i == 0 || fabs(ev[i] - ev[newcount - 1]) > FP_TOLERANCE)
+    if (i == 0 || fabs(ev[i] - ev[newcount - 1]) > MEOS_GEOM_TOLERANCE)
       ev[newcount++] = ev[i];
   events->count = newcount;
 
@@ -1804,7 +1804,7 @@ intervals_within_edges(const POINT2D *a, const POINT2D *b, Edge **sel_edges,
   for (int i = 0; i < (int) events->count - 1; i++)
   {
     const double ta = ev[i], tb = ev[i + 1];
-    if (tb - ta <= FP_TOLERANCE)
+    if (tb - ta <= MEOS_GEOM_TOLERANCE)
       continue;
     const double tm = 0.5 * (ta + tb);
     const double x = ax + tm * rx, y = ay + tm * ry;
@@ -1940,14 +1940,14 @@ tpointseq_dwithin_edges(const TSequence *seq, Edge **edges, int nedges,
       Span s;
       double lower = DatumGetFloat8(intervarr[j].lower);
       double upper = DatumGetFloat8(intervarr[j].upper);
-      if (fabs(upper - lower) < FP_TOLERANCE)
+      if (fabs(upper - lower) < MEOS_GEOM_TOLERANCE)
       {
         /* Remove within points on exclusive lower and upper bounds */
-        if (! lower_inc && fabs(lower) < FP_TOLERANCE &&
-            fabs(upper) < FP_TOLERANCE)
+        if (! lower_inc && fabs(lower) < MEOS_GEOM_TOLERANCE &&
+            fabs(upper) < MEOS_GEOM_TOLERANCE)
           continue;
-        if (! upper_inc && fabs(lower - 1.0) < FP_TOLERANCE &&
-            fabs(upper - 1.0) < FP_TOLERANCE)
+        if (! upper_inc && fabs(lower - 1.0) < MEOS_GEOM_TOLERANCE &&
+            fabs(upper - 1.0) < MEOS_GEOM_TOLERANCE)
           continue;
         TimestampTz t = (lower == 0.0) ?
           inst1->t : inst1->t + (TimestampTz) (duration * lower);
@@ -2161,7 +2161,7 @@ point_geom_dist(double px, double py, Edge **edges, int nedges)
       best = d2;
   }
   /* On (or numerically on) the boundary: distance is zero */
-  if (best <= FP_TOLERANCE)
+  if (best <= MEOS_GEOM_TOLERANCE)
     return 0.0;
   /* Strictly inside a filled polygon: distance is zero. The horizontal-ray
    * even-odd test of #point_in_polygon miscounts when the query height aligns
@@ -2196,7 +2196,7 @@ distance_cands_from_edge(double ax, double ay, double rx, double ry,
 {
   const double A = rx * rx + ry * ry;
   /* Constant (zero-length) trajectory segment: no interior turning point */
-  if (A < FP_TOLERANCE)
+  if (A < MEOS_GEOM_TOLERANCE)
     return;
   switch (e->etype)
   {
@@ -2216,15 +2216,15 @@ distance_cands_from_edge(double ax, double ay, double rx, double ry,
       add_within_root(-(w1x * rx + w1y * ry) / A, ev);
       const double ux = e->x2 - e->x1, uy = e->y2 - e->y1;
       const double l2 = ux * ux + uy * uy;
-      if (l2 > FP_TOLERANCE)
+      if (l2 > MEOS_GEOM_TOLERANCE)
       {
         /* Perpendicular-foot time (moving point on the supporting line) */
         const double k1 = rx * uy - ry * ux;
-        if (fabs(k1) > FP_TOLERANCE)
+        if (fabs(k1) > MEOS_GEOM_TOLERANCE)
           add_within_root(-(w0x * uy - w0y * ux) / k1, ev);
         /* Foot-parameter region boundaries (s = 0 and s = 1) */
         const double ru = rx * ux + ry * uy;
-        if (fabs(ru) > FP_TOLERANCE)
+        if (fabs(ru) > MEOS_GEOM_TOLERANCE)
         {
           const double w0u = w0x * ux + w0y * uy;
           add_within_root(-w0u / ru, ev);
@@ -2254,11 +2254,11 @@ distance_cands_from_edge(double ax, double ay, double rx, double ry,
        * arc endpoints) */
       const double d0x = e->x1 - e->cx, d0y = e->y1 - e->cy;
       const double den0 = rx * d0y - ry * d0x;
-      if (fabs(den0) > FP_TOLERANCE)
+      if (fabs(den0) > MEOS_GEOM_TOLERANCE)
         add_within_root(-(wx * d0y - wy * d0x) / den0, ev);
       const double d1x = e->x2 - e->cx, d1y = e->y2 - e->cy;
       const double den1 = rx * d1y - ry * d1x;
-      if (fabs(den1) > FP_TOLERANCE)
+      if (fabs(den1) > MEOS_GEOM_TOLERANCE)
         add_within_root(-(wx * d1y - wy * d1x) / den1, ev);
       return;
     }
@@ -2319,9 +2319,9 @@ tpointseq_distance_geom(const TSequence *seq, Edge **edges, int nedges)
     for (int k = 0; k < (int) events->count; k++)
     {
       const double p = ev[k];
-      if (p <= FP_TOLERANCE || p >= 1.0 - FP_TOLERANCE)
+      if (p <= MEOS_GEOM_TOLERANCE || p >= 1.0 - MEOS_GEOM_TOLERANCE)
         continue;
-      if (k > 0 && fabs(p - ev[k - 1]) < FP_TOLERANCE)
+      if (k > 0 && fabs(p - ev[k - 1]) < MEOS_GEOM_TOLERANCE)
         continue;
       TimestampTz t = inst1->t + (TimestampTz) (duration * p);
       /* Keep the instants strictly increasing and off the segment endpoints */

--- a/meos/src/rgeo/trgeo_geom_clip.c
+++ b/meos/src/rgeo/trgeo_geom_clip.c
@@ -57,6 +57,7 @@
  * `doc/rfc/trgeo_geom_clip_design_m2.md` (M2) for derivations.
  */
 
+#include "geo/geo_funcs.h"
 #include "rgeo/trgeo_geom_clip.h"
 
 /* C */
@@ -77,9 +78,6 @@
  *****************************************************************************/
 
 /* Floating-point tolerance — matches the convention in tpoint_geom_clip.c */
-#ifndef FP_TOLERANCE
-#define FP_TOLERANCE 1e-12
-#endif
 
 /* M2: below this absolute angular delta (radians) we use a Taylor
  * closed-form solver; above it we fall back to numerical bisection. */
@@ -112,12 +110,12 @@ double_cmp(const void *a, const void *b)
 
 /**
  * @brief Append a critical t to an events buffer if it lies in [0, 1].
- * Tolerance-aware: out-of-range values within FP_TOLERANCE are clamped.
+ * Tolerance-aware: out-of-range values within MEOS_GEOM_TOLERANCE are clamped.
  */
 static inline void
 push_event(double t, double *events, int *nevents, int cap)
 {
-  if (t < -FP_TOLERANCE || t > 1.0 + FP_TOLERANCE)
+  if (t < -MEOS_GEOM_TOLERANCE || t > 1.0 + MEOS_GEOM_TOLERANCE)
     return;
   if (t < 0.0) t = 0.0;
   if (t > 1.0) t = 1.0;
@@ -137,21 +135,21 @@ segments_intersect(double sax, double say, double sbx, double sby,
   double sx = pbx - pax, sy = pby - pay;
   double rxs = rx * sy - ry * sx;
   double qpx = pax - sax, qpy = pay - say;
-  if (fabs(rxs) < FP_TOLERANCE)
+  if (fabs(rxs) < MEOS_GEOM_TOLERANCE)
   {
     double qpxr = qpx * ry - qpy * rx;
-    if (fabs(qpxr) > FP_TOLERANCE) return false;
+    if (fabs(qpxr) > MEOS_GEOM_TOLERANCE) return false;
     double r2 = rx * rx + ry * ry;
-    if (r2 < FP_TOLERANCE) return false;
+    if (r2 < MEOS_GEOM_TOLERANCE) return false;
     double t0 = (qpx * rx + qpy * ry) / r2;
     double t1 = t0 + (sx * rx + sy * ry) / r2;
     if (t0 > t1) { double tmp = t0; t0 = t1; t1 = tmp; }
-    return (t1 >= -FP_TOLERANCE && t0 <= 1.0 + FP_TOLERANCE);
+    return (t1 >= -MEOS_GEOM_TOLERANCE && t0 <= 1.0 + MEOS_GEOM_TOLERANCE);
   }
   double t = (qpx * sy - qpy * sx) / rxs;
   double u = (qpx * ry - qpy * rx) / rxs;
-  return (t >= -FP_TOLERANCE && t <= 1.0 + FP_TOLERANCE &&
-          u >= -FP_TOLERANCE && u <= 1.0 + FP_TOLERANCE);
+  return (t >= -MEOS_GEOM_TOLERANCE && t <= 1.0 + MEOS_GEOM_TOLERANCE &&
+          u >= -MEOS_GEOM_TOLERANCE && u <= 1.0 + MEOS_GEOM_TOLERANCE);
 }
 
 /**
@@ -203,7 +201,7 @@ segment_intersects_polygon(double sax, double say, double sbx, double sby,
 }
 
 /**
- * @brief Drop near-duplicate values within FP_TOLERANCE.
+ * @brief Drop near-duplicate values within MEOS_GEOM_TOLERANCE.
  * Operates in place on the sorted `events` array.
  */
 static int
@@ -212,7 +210,7 @@ dedup_sorted(double *events, int n)
   int nuniq = 0;
   for (int k = 0; k < n; k++)
   {
-    if (nuniq == 0 || fabs(events[k] - events[nuniq - 1]) > FP_TOLERANCE)
+    if (nuniq == 0 || fabs(events[k] - events[nuniq - 1]) > MEOS_GEOM_TOLERANCE)
       events[nuniq++] = events[k];
   }
   return nuniq;
@@ -239,13 +237,13 @@ walk_events_and_emit(const double *events, int nuniq,
   {
     double t_a = events[k];
     double t_b = events[k + 1];
-    if (t_b - t_a <= FP_TOLERANCE)
+    if (t_b - t_a <= MEOS_GEOM_TOLERANCE)
       continue;
     double t_m = 0.5 * (t_a + t_b);
     if (intersects(t_m, ctx))
     {
       if (nout > 0 &&
-          fabs(DatumGetFloat8(out[nout - 1].upper) - t_a) <= FP_TOLERANCE)
+          fabs(DatumGetFloat8(out[nout - 1].upper) - t_a) <= MEOS_GEOM_TOLERANCE)
         out[nout - 1].upper = Float8GetDatum(t_b);
       else
       {
@@ -281,13 +279,13 @@ solve_m1_endpoint_on_edge(double ax, double ay, double dxd, double dyd,
   double ex = px2 - px1;
   double ey = py2 - py1;
   double det = -ex * dyd + dxd * ey;
-  if (fabs(det) < FP_TOLERANCE)
+  if (fabs(det) < MEOS_GEOM_TOLERANCE)
     return false;
   double rhs_x = px1 - ax;
   double rhs_y = py1 - ay;
   double s = (rhs_x * dyd - dxd * rhs_y) / det;
   double t = (-ex * rhs_y + rhs_x * ey) / det;
-  if (s < -FP_TOLERANCE || s > 1.0 + FP_TOLERANCE)
+  if (s < -MEOS_GEOM_TOLERANCE || s > 1.0 + MEOS_GEOM_TOLERANCE)
     return false;
   *t_out = t;
   return true;
@@ -305,13 +303,13 @@ solve_m1_p_on_movingedge(double px, double py,
   double ux = b1x - a1x;
   double uy = b1y - a1y;
   double det = ux * dyd - dxd * uy;
-  if (fabs(det) < FP_TOLERANCE)
+  if (fabs(det) < MEOS_GEOM_TOLERANCE)
     return false;
   double rhs_x = px - a1x;
   double rhs_y = py - a1y;
   double u = (rhs_x * dyd - dxd * rhs_y) / det;
   double t = (ux * rhs_y - rhs_x * uy) / det;
-  if (u < -FP_TOLERANCE || u > 1.0 + FP_TOLERANCE)
+  if (u < -MEOS_GEOM_TOLERANCE || u > 1.0 + MEOS_GEOM_TOLERANCE)
     return false;
   *t_out = t;
   return true;
@@ -348,8 +346,8 @@ trgeo_geom_clip_polygon(const POINT2D *a1, const POINT2D *b1,
   double dyd_a = a2->y - a1->y;
   double dxd_b = b2->x - b1->x;
   double dyd_b = b2->y - b1->y;
-  if (fabs(dxd_a - dxd_b) > FP_TOLERANCE ||
-      fabs(dyd_a - dyd_b) > FP_TOLERANCE)
+  if (fabs(dxd_a - dxd_b) > MEOS_GEOM_TOLERANCE ||
+      fabs(dyd_a - dyd_b) > MEOS_GEOM_TOLERANCE)
     return -1;
   double dxd = dxd_a, dyd = dyd_a;
 
@@ -564,7 +562,7 @@ solve_m2_numerical(residual_fn f, void *state, double *roots, int max_roots)
   {
     double cur_t = (double) i / TRGEO_GEOM_CLIP_BISECT_BINS;
     double cur_v = f(cur_t, state);
-    if (fabs(cur_v) < FP_TOLERANCE)
+    if (fabs(cur_v) < MEOS_GEOM_TOLERANCE)
     {
       roots[n++] = cur_t;
       prev_t = cur_t;
@@ -579,7 +577,7 @@ solve_m2_numerical(residual_fn f, void *state, double *roots, int max_roots)
       {
         double m = 0.5 * (a + b);
         double fm = f(m, state);
-        if (fabs(fm) < FP_TOLERANCE) { a = b = m; break; }
+        if (fabs(fm) < MEOS_GEOM_TOLERANCE) { a = b = m; break; }
         if ((fa < 0 && fm > 0) || (fa > 0 && fm < 0))
           b = m;
         else { a = m; fa = fm; }
@@ -617,10 +615,10 @@ solve_m2_taylor_endpoint_on_edge(const EndpointEdgeState *s, double *root)
   double ery = s->e2y - s->e1y;
   double a0 = (ex0 - s->e1x) * ery - (ey0 - s->e1y) * erx;
   double a1 = ex_slope * ery - ey_slope * erx;
-  if (fabs(a1) < FP_TOLERANCE)
+  if (fabs(a1) < MEOS_GEOM_TOLERANCE)
     return 0;
   double t = -a0 / a1;
-  if (t < -FP_TOLERANCE || t > 1.0 + FP_TOLERANCE)
+  if (t < -MEOS_GEOM_TOLERANCE || t > 1.0 + MEOS_GEOM_TOLERANCE)
     return 0;
   if (t < 0.0) t = 0.0;
   if (t > 1.0) t = 1.0;
@@ -663,7 +661,7 @@ trgeo_geom_clip_polygon_posed(const POINT2D *p_a_local,
     return -1;
 
   /* Pure-translation fast path: delegate to M1. */
-  if (fabs(th2 - th1) < FP_TOLERANCE)
+  if (fabs(th2 - th1) < MEOS_GEOM_TOLERANCE)
   {
     POINT2D a1, b1, a2, b2;
     double c1 = cos(th1), si1 = sin(th1);

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -93,9 +93,6 @@
  * ignored by the M1 clip), raises an honest FEATURE_NOT_SUPPORTED error.
  *****************************************************************************/
 
-/* Floating-point tolerance for the pure-translation / rotation test;
- * matches the FP_TOLERANCE convention in trgeo_geom_clip.c */
-#define TRGEO_RESTRICT_TOLERANCE 1e-12
 
 /**
  * @brief Return true if any polygon component of an LWGEOM carries an
@@ -232,7 +229,7 @@ segment_overlap_spans(const GSERIALIZED *ref, const Pose *pose1,
   int nuniq = 0;
   for (int k = 0; k < nevents; k++)
     if (nuniq == 0 ||
-        fabs(events[k] - events[nuniq - 1]) > TRGEO_RESTRICT_TOLERANCE)
+        fabs(events[k] - events[nuniq - 1]) > MEOS_GEOM_TOLERANCE)
       events[nuniq++] = events[k];
 
   /* Classify each inter-event sub-interval by an exact GEOS overlap test at
@@ -243,7 +240,7 @@ segment_overlap_spans(const GSERIALIZED *ref, const Pose *pose1,
   for (int k = 0; k < nuniq - 1; k++)
   {
     double ta = events[k], tb = events[k + 1];
-    if (tb - ta <= TRGEO_RESTRICT_TOLERANCE)
+    if (tb - ta <= MEOS_GEOM_TOLERANCE)
       continue;
     double tm = 0.5 * (ta + tb);
     Pose *posem = posesegm_interpolate(pose1, pose2, tm);
@@ -406,7 +403,7 @@ trgeo_overlap_spanset(const Temporal *temp, const GSERIALIZED *gs,
         const Pose *pose1 = DatumGetPoseP(tinstant_value_p(inst1));
         const Pose *pose2 = DatumGetPoseP(tinstant_value_p(inst2));
         /* Pure-translation guard: any rotation is honestly not implemented. */
-        if (fabs(pose2->data[2] - pose1->data[2]) > TRGEO_RESTRICT_TOLERANCE)
+        if (fabs(pose2->data[2] - pose1->data[2]) > MEOS_GEOM_TOLERANCE)
         {
           pfree(spans);
           if (temp->subtype == TSEQUENCESET)


### PR DESCRIPTION
`FP_TOLERANCE` names two different numbers. `liblwgeom_internal.h` states it as 1e-12 for planar work, and `lwgeodetic.h` overrides it to 5e-14 for spherical work:

```c
/* Override tolerance for geodetic */
#ifdef FP_TOLERANCE
#undef FP_TOLERANCE
#define FP_TOLERANCE 5e-14
#endif
```

So the value a kernel compares against follows the order its caller reached those headers in, rather than the geometry it is reading. `trgeo_geom_clip.c` carried a third definition of its own, guarded by `#ifndef`, which yields to whichever value an include happens to bring first.

### What MEOS owns

`MEOS_GEOM_TOLERANCE` holds the 1e-12 that every one of these call sites already compiles against, so a coordinate, the parameter along a segment, a determinant and a duration are read against a value the file states rather than one it inherits.

It absorbs the earlier `MEOS_EDGE_TOLERANCE`, which named the edge kernels while most of these sites compare something else, together with the private definitions in `trgeo_geom_clip.c` and `trgeo_spatialfuncs.c` and the remaining bare 1e-12 literals. 294 sites carry the name; no private tolerance definition remains.

### What PostGIS keeps

`FP_TOLERANCE` survives at four call sites, each one handing a tolerance to PostGIS or running a copy of its code:

| site | what it is |
| --- | --- |
| `tgeo_distance.c` ×2 | the tolerance argument of `circ_tree_distance_tree_internal` and `geography_tree_shortestline` |
| `postgis_funcs.c:3173` | the tolerance the spheroid distance reads |
| `tpoint_spatialfuncs.c:3035` | inside the `ptarray_distance_spheroid` transcription |

Those track the value PostGIS means, including the smaller one it states for spherical work, which the last of them is the single site to read.

### What is untouched

`MEOS_EPSILON` keeps its name and its value. It reads two modelled quantities as equal at 1e-06, is what the `MEOS_FP_*` comparisons are built on, and is bounded below by the microsecond a `TimestampTz` resolves across a segment of a second. Its 106 call sites divide across general equality, normalised fractions, coordinates and angles, so no one purpose names it better than the generic one does.

### Equivalence

Every converted site already compiles against 1e-12, so the answers are the same ones and no expected output changes.
