### PR TITLE
Answer the adjacency of two boxes from every dimension they share

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -757,7 +757,7 @@ SELECT stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03])' ~=
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 					<para>Are the bounding boxes adjacent?</para>
 					<para><varname>box -|- box → boolean</varname></para>
-					<para>Two boxes are adjacent if they share <emphasis>n</emphasis> dimensions and their intersection is at most of <emphasis>n</emphasis>-1 dimensions.</para>
+					<para>Two boxes are adjacent if their extents meet in every dimension the boxes share and touch at a single value in at least one of them. A dimension in which the boxes are apart separates them whatever the remaining dimensions do.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,2),[2001-01-01,2001-01-02])' -|-
   tbox 'TBOXINT XT([2,3),[2001-01-02,2001-01-03])';

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -753,7 +753,7 @@ SELECT stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03])' ~=
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 					<para>¿Son los cuadros delimitadores adyacentes?</para>
 					<para><varname>box -|- box → boolean</varname></para>
-					<para>Dos cuadros delimitadores son adyacentes si comparten  <emphasis>n</emphasis> dimensiónes y si su intersección tiene como máximo <emphasis>n</emphasis>-1 dimensiónes.</para>
+					<para>Dos cuadros delimitadores son adyacentes si sus extensiones se encuentran en todas las dimensiones que los cuadros comparten y se tocan en un solo valor en al menos una de ellas. Una dimensión en la que los cuadros están separados los separa sea cual sea el comportamiento de las demás dimensiones.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXINT XT([1,2),[2001-01-01,2001-01-02])' -|-
   tbox 'TBOXINT XT([2,3),[2001-01-02,2001-01-03])';

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1911,6 +1911,24 @@ same_stbox_stbox(const STBox *box1, const STBox *box2)
 }
 
 /**
+ * @brief Return true if two spatial extents meet, that is, if they overlap or
+ * touch at a single coordinate, reporting the latter case
+ * @param[in] min1,max1 Bounds of the first extent
+ * @param[in] min2,max2 Bounds of the second extent
+ * @param[in,out] touch Set to true if the extents touch at a single coordinate
+ */
+static bool
+meet_extent_extent(double min1, double max1, double min2, double max2,
+  bool *touch)
+{
+  if (min1 > max2 || min2 > max1)
+    return false;
+  if (max1 == min2 || max2 == min1)
+    *touch = true;
+  return true;
+}
+
+/**
  * @ingroup meos_geo_box_topo
  * @brief Return true if the spatiotemporal boxes are adjacent
  * @param[in] box1,box2 Spatiotemporal boxes
@@ -1924,32 +1942,31 @@ adjacent_stbox_stbox(const STBox *box1, const STBox *box2)
   if (! topo_stbox_stbox_init(box1, box2, &hasx, &hasz, &hast, &geodetic))
     return false;
 
-  STBox inter;
-  if (! inter_stbox_stbox(box1, box2, &inter))
-    return false;
-
-  /* Boxes are adjacent if they share n dimensions and their intersection is
-   * at most of n-1 dimensions */
-  if (! hasx && hast)
-    return (inter.period.lower == inter.period.upper);
-  if (hasx && ! hast)
+  /* Boxes are adjacent if they meet in every common dimension and touch in at
+   * least one of them. The test is made dimension by dimension so that periods
+   * meeting at an excluded bound are kept: they are adjacent although they do
+   * not intersect */
+  bool touch = false;
+  if (hasx)
   {
-    if (hasz)
-      return (inter.xmin == inter.xmax || inter.ymin == inter.ymax ||
-           inter.zmin == inter.zmax);
-    else
-      return (inter.xmin == inter.xmax || inter.ymin == inter.ymax);
+    if (! meet_extent_extent(box1->xmin, box1->xmax, box2->xmin, box2->xmax,
+          &touch))
+      return false;
+    if (! meet_extent_extent(box1->ymin, box1->ymax, box2->ymin, box2->ymax,
+          &touch))
+      return false;
+    if (hasz && ! meet_extent_extent(box1->zmin, box1->zmax, box2->zmin,
+          box2->zmax, &touch))
+      return false;
   }
-  else
+  if (hast)
   {
-    if (hasz)
-      return (inter.xmin == inter.xmax || inter.ymin == inter.ymax ||
-           inter.zmin == inter.zmax ||
-           inter.period.lower == inter.period.upper);
-    else
-      return (inter.xmin == inter.xmax || inter.ymin == inter.ymax ||
-           inter.period.lower == inter.period.upper);
+    if (adjacent_span_span(&box1->period, &box2->period))
+      touch = true;
+    else if (! overlaps_span_span(&box1->period, &box2->period))
+      return false;
   }
+  return touch;
 }
 
 /*****************************************************************************

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -1631,12 +1631,23 @@ adjacent_tbox_tbox(const TBox *box1, const TBox *box2)
   if (! ensure_valid_tbox_tbox(box1, box2, &hasx, &hast))
     return false;
 
-  /* Boxes are adjacent if they are adjacent in at least one dimension */
+  /* Boxes are adjacent if they meet in every common dimension and touch in at
+   * least one of them. A dimension in which the boxes are apart separates them
+   * whatever the remaining dimensions do, so an adjacency in one dimension is
+   * an adjacency of the boxes only when the others at least overlap */
   bool adjx = false, adjt = false;
   if (hasx)
+  {
     adjx = adjacent_span_span(&box1->span, &box2->span);
+    if (! adjx && ! overlaps_span_span(&box1->span, &box2->span))
+      return false;
+  }
   if (hast)
+  {
     adjt = adjacent_span_span(&box1->period, &box2->period);
+    if (! adjt && ! overlaps_span_span(&box1->period, &box2->period))
+      return false;
+  }
   return (adjx || adjt);
 }
 

--- a/mobilitydb/test/cbuffer/expected/208_tcbuffer_topops.test.out
+++ b/mobilitydb/test/cbuffer/expected/208_tcbuffer_topops.test.out
@@ -841,7 +841,7 @@ SELECT stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))' -|- tcbuffer 'SRID=5676;Cb
 SELECT stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))' -|- tcbuffer 'SRID=5676;{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.7)@2000-01-03}';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))' -|- tcbuffer 'SRID=5676;[Cbuffer(Point(1 1),0.4)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(1 1),0.7)@2000-01-03]';
@@ -853,7 +853,7 @@ SELECT stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))' -|- tcbuffer 'SRID=5676;[C
 SELECT stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))' -|- tcbuffer 'SRID=5676;{[Cbuffer(Point(1 1),0.4)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(1 1),0.7)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01' -|- tstzspan '[2000-01-01,2000-01-02]';
@@ -889,7 +889,7 @@ SELECT tcbuffer 'SRID=5676;Cbuffer(Point(1 1),0.5)@2000-01-01' -|- stbox 'SRID=5
 SELECT tcbuffer 'SRID=5676;{Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(2 2),0.5)@2000-01-02, Cbuffer(Point(1 1),0.7)@2000-01-03}' -|- stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tcbuffer 'SRID=5676;[Cbuffer(Point(1 1),0.4)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(1 1),0.7)@2000-01-03]' -|- stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))';
@@ -901,7 +901,7 @@ SELECT tcbuffer 'SRID=5676;[Cbuffer(Point(1 1),0.4)@2000-01-01, Cbuffer(Point(1 
 SELECT tcbuffer 'SRID=5676;{[Cbuffer(Point(1 1),0.4)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02, Cbuffer(Point(1 1),0.7)@2000-01-03],[Cbuffer(Point(3 3),0.5)@2000-01-04, Cbuffer(Point(3 3),0.5)@2000-01-05]}' -|- stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01' -|- tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01';

--- a/mobilitydb/test/cbuffer/expected/216_tcbuffer_indexes_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/216_tcbuffer_indexes_tbl.test.out
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
  count 
 -------
-    38
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
@@ -188,7 +188,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
  count 
 -------
-    29
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]' <<# temp;
@@ -258,7 +258,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
  count 
 -------
-    38
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
@@ -360,7 +360,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
  count 
 -------
-    29
+     0
 (1 row)
 
 DROP INDEX IF EXISTS tbl_tcbuffer_big_quadtree_idx;
@@ -418,7 +418,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= tcbuffer 'SRID=3812;[Cbuffer
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
  count 
 -------
-    38
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp << tcbuffer 'SRID=3812;[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(50 50), 5)@2001-12-31]';
@@ -520,7 +520,7 @@ SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp ~= stbox 'SRID=3812;STBOX XT(((
 SELECT COUNT(*) FROM tbl_tcbuffer_big WHERE temp -|- stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-01-01, 2001-12-31])';
  count 
 -------
-    29
+     0
 (1 row)
 
 DROP INDEX IF EXISTS tbl_tcbuffer_big_kdtree_idx;

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -1075,6 +1075,36 @@ SELECT tstzspan '[2000-01-01, 2000-01-02]'::stbox -|- tstzspan '[2000-01-02, 200
  t
 (1 row)
 
+SELECT stbox 'STBOX XT(((1,1),(5,5)),[2000-01-01,2000-01-05))' -|- stbox 'STBOX XT(((1,1),(5,5)),[2000-01-05,2000-01-09])';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT stbox 'STBOX XT(((1,1),(5,5)),[2000-01-01,2000-01-05])' -|- stbox 'STBOX XT(((5,1),(9,5)),[2000-06-01,2000-06-05])';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT stbox 'STBOX X((1,1),(5,5))' -|- stbox 'STBOX X((3,3),(3,3))';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT stbox 'STBOX X((1,1),(5,5))' -|- stbox 'STBOX X((5,1),(9,5))';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT stbox 'STBOX X((1,1),(5,5))' -|- stbox 'STBOX X((5,5),(9,9))';
+ ?column? 
+----------
+ t
+(1 row)
+
 /* Errors */
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' && stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
 ERROR:  Operation on mixed planar and geodetic coordinates

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -301,6 +301,15 @@ SELECT same(stbox 'STBOX X((1.0,1.0),(2.0,2.0))', stbox 'STBOX XT(((1.0,2.0),(1.
 SELECT stbox 'STBOX Z((0 0 0),(2 2 2))' -|- stbox 'STBOX Z((1 1 1),(3 3 3))';
 SELECT tstzspan '[2000-01-01, 2000-01-02]'::stbox -|- tstzspan '[2000-01-02, 2000-01-03]'::stbox;
 
+-- Adjacency reads every dimension the boxes share and asks one of them to
+-- touch: periods meeting at an excluded bound are adjacent as their spans are,
+-- while a box lying inside another only meets it
+SELECT stbox 'STBOX XT(((1,1),(5,5)),[2000-01-01,2000-01-05))' -|- stbox 'STBOX XT(((1,1),(5,5)),[2000-01-05,2000-01-09])';
+SELECT stbox 'STBOX XT(((1,1),(5,5)),[2000-01-01,2000-01-05])' -|- stbox 'STBOX XT(((5,1),(9,5)),[2000-06-01,2000-06-05])';
+SELECT stbox 'STBOX X((1,1),(5,5))' -|- stbox 'STBOX X((3,3),(3,3))';
+SELECT stbox 'STBOX X((1,1),(5,5))' -|- stbox 'STBOX X((5,1),(9,5))';
+SELECT stbox 'STBOX X((1,1),(5,5))' -|- stbox 'STBOX X((5,5),(9,9))';
+
 /* Errors */
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' && stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' @> stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';

--- a/mobilitydb/test/npoint/expected/317_tnpoint_indexes_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/317_tnpoint_indexes_tbl.test.out
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001
 SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
  count 
 -------
-     3
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp << tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
@@ -216,7 +216,7 @@ SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001
 SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
  count 
 -------
-     3
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp << tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
@@ -322,7 +322,7 @@ SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp ~= tnpoint '[Npoint(1, 0.2)@2001
 SELECT COUNT(*) FROM tbl_tnpoint_big WHERE temp -|- tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.5)@2001-12-31]';
  count 
 -------
-     3
+     0
 (1 row)
 
 DROP INDEX IF EXISTS tbl_tnpoint_big_kdtree_idx;

--- a/mobilitydb/test/pose/expected/110_tpose_indexes_tbl.test.out
+++ b/mobilitydb/test/pose/expected/110_tpose_indexes_tbl.test.out
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM tbl_tpose2d WHERE temp ~= tpose 'SRID=3812;[Pose(Point(0 0)
 SELECT COUNT(*) FROM tbl_tpose2d WHERE temp -|- tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
  count 
 -------
-     2
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tpose2d WHERE temp << tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
@@ -192,7 +192,7 @@ SELECT COUNT(*) FROM tbl_tpose2d WHERE temp ~= tpose 'SRID=3812;[Pose(Point(0 0)
 SELECT COUNT(*) FROM tbl_tpose2d WHERE temp -|- tpose 'SRID=3812;[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
  count 
 -------
-     2
+     0
 (1 row)
 
 DROP INDEX IF EXISTS tbl_tpose2d_quadtree_idx;

--- a/mobilitydb/test/posechain/expected/558_tposechain_topops_tbl.test.out
+++ b/mobilitydb/test/posechain/expected/558_tposechain_topops_tbl.test.out
@@ -25,7 +25,7 @@ SELECT COUNT(*) FROM tbl_tposechain t1, tbl_tposechain t2 WHERE t1.temp ~= t2.te
 SELECT COUNT(*) FROM tbl_tposechain t1, tbl_tposechain t2 WHERE t1.temp -|- t2.temp;
  count 
 -------
-   132
+   116
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tposechain t1, tbl_tposechain t2

--- a/mobilitydb/test/rgeo/expected/156_trgeo_topops.test.out
+++ b/mobilitydb/test/rgeo/expected/156_trgeo_topops.test.out
@@ -805,13 +805,13 @@ SELECT stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))' -|- trgeometry 'SRID=5676;
 SELECT stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))' -|- trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1),0.4)@2000-01-01, Pose(Point(1 1),0.5)@2000-01-02, Pose(Point(1 1),0.7)@2000-01-03]';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))' -|- trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1),0.4)@2000-01-01, Pose(Point(1 1),0.5)@2000-01-02, Pose(Point(1 1),0.7)@2000-01-03],[Pose(Point(3 3),0.5)@2000-01-04, Pose(Point(3 3),0.5)@2000-01-05]}';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1),0.5)@2000-01-01' -|- tstzspan '[2000-01-01,2000-01-02]';
@@ -853,13 +853,13 @@ SELECT trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1),0.5)@20
 SELECT trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1),0.4)@2000-01-01, Pose(Point(1 1),0.5)@2000-01-02, Pose(Point(1 1),0.7)@2000-01-03]' -|- stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1),0.4)@2000-01-01, Pose(Point(1 1),0.5)@2000-01-02, Pose(Point(1 1),0.7)@2000-01-03],[Pose(Point(3 3),0.5)@2000-01-04, Pose(Point(3 3),0.5)@2000-01-05]}' -|- stbox 'SRID=5676;STBOX X((1.0,2.0),(1.0,2.0))';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1),0.5)@2000-01-01' -|- trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1),0.5)@2000-01-01';

--- a/mobilitydb/test/rgeo/expected/162_trgeo_indexes_tbl.test.out
+++ b/mobilitydb/test/rgeo/expected/162_trgeo_indexes_tbl.test.out
@@ -86,7 +86,7 @@ SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp ~= trgeometry 'SRID=5676;Polygo
 SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp -|- trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';
  count 
 -------
-     2
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_trgeometry2d WHERE temp << trgeometry 'SRID=5676;Polygon((1 1,2 2,3 1,1 1));[Pose(Point(0 0), 0.1)@2001-01-01, Pose(Point(50 50), 0.5)@2001-12-31]';

--- a/mobilitydb/test/temporal/expected/021_tbox.test.out
+++ b/mobilitydb/test/temporal/expected/021_tbox.test.out
@@ -883,6 +883,36 @@ SELECT tstzspan '[2000-01-01,2000-01-02]'::tbox -|- tstzspan '[2000-01-02, 2000-
  t
 (1 row)
 
+SELECT tbox 'TBOXFLOAT XT([1,5],[2000-01-01,2000-01-05])' -|- tbox 'TBOXFLOAT XT([5,9],[2000-06-01,2000-06-05])';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT tbox 'TBOXFLOAT XT([1,5],[2000-01-01,2000-01-05])' -|- tbox 'TBOXFLOAT XT([5,9],[2000-01-05,2000-01-09])';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tbox 'TBOXFLOAT XT([1,5],[2000-01-01,2000-01-09])' -|- tbox 'TBOXFLOAT XT([5,9],[2000-01-05,2000-01-12])';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tbox 'TBOXFLOAT X([1,5])' -|- tbox 'TBOXFLOAT X([5,9])';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tbox 'TBOXFLOAT X([1,5])' -|- tbox 'TBOXFLOAT X([3,9])';
+ ?column? 
+----------
+ f
+(1 row)
+
 SELECT overlaps(tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
  overlaps 
 ----------
@@ -945,7 +975,7 @@ SELECT COUNT(*) FROM tbl_tboxint t1, tbl_tboxint t2 WHERE t1.b <@ t2.b;
 SELECT COUNT(*) FROM tbl_tboxint t1, tbl_tboxint t2 WHERE t1.b -|- t2.b;
  count 
 -------
-    98
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tboxint t1, tbl_tboxint t2 WHERE t1.b ~= t2.b;

--- a/mobilitydb/test/temporal/expected/032_temporal_topops.test.out
+++ b/mobilitydb/test/temporal/expected/032_temporal_topops.test.out
@@ -4825,7 +4825,7 @@ SELECT COUNT(*) FROM tbl_tboxint t1, tbl_tboxint t2 WHERE t1.b ~= t2.b;
 SELECT COUNT(*) FROM tbl_tboxint t1, tbl_tboxint t2 WHERE t1.b -|- t2.b;
  count 
 -------
-    98
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tboxfloat t1, tbl_tboxfloat t2 WHERE t1.b && t2.b;

--- a/mobilitydb/test/temporal/expected/046_tnumber_selfuncs_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/046_tnumber_selfuncs_tbl.test.out
@@ -1195,31 +1195,31 @@ SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tstzspan '[2001-06-01, 2001-07-01]'
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tbox 'TBOXINT XT([1,3),[2000-01-01, 2000-01-03])';
  count 
 -------
-     6
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tint '1@2000-01-01';
  count 
 -------
-     2
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}';
  count 
 -------
-     6
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]';
  count 
 -------
-     6
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}';
  count 
 -------
-     2
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tfloat WHERE temp -|- floatspan '[1,3]';
@@ -3339,31 +3339,31 @@ SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tstzspan '[2001-06-01, 2001-07-01]'
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tbox 'TBOXINT XT([1,3),[2000-01-01, 2000-01-03])';
  count 
 -------
-     6
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tint '1@2000-01-01';
  count 
 -------
-     2
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}';
  count 
 -------
-     6
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]';
  count 
 -------
-     6
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tint WHERE temp -|- tint '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}';
  count 
 -------
-     2
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tfloat WHERE temp -|- floatspan '[1,3]';

--- a/mobilitydb/test/temporal/queries/021_tbox.test.sql
+++ b/mobilitydb/test/temporal/queries/021_tbox.test.sql
@@ -270,6 +270,14 @@ SELECT tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])' ~= tbox 'TBOXFLO
 
 SELECT tstzspan '[2000-01-01,2000-01-02]'::tbox -|- tstzspan '[2000-01-02, 2000-01-03]'::tbox;
 
+-- Adjacency reads every dimension the boxes share: a value bound they share
+-- while their periods lie apart leaves them apart
+SELECT tbox 'TBOXFLOAT XT([1,5],[2000-01-01,2000-01-05])' -|- tbox 'TBOXFLOAT XT([5,9],[2000-06-01,2000-06-05])';
+SELECT tbox 'TBOXFLOAT XT([1,5],[2000-01-01,2000-01-05])' -|- tbox 'TBOXFLOAT XT([5,9],[2000-01-05,2000-01-09])';
+SELECT tbox 'TBOXFLOAT XT([1,5],[2000-01-01,2000-01-09])' -|- tbox 'TBOXFLOAT XT([5,9],[2000-01-05,2000-01-12])';
+SELECT tbox 'TBOXFLOAT X([1,5])' -|- tbox 'TBOXFLOAT X([5,9])';
+SELECT tbox 'TBOXFLOAT X([1,5])' -|- tbox 'TBOXFLOAT X([3,9])';
+
 -- The portable spelling of each operator above answers the same
 SELECT overlaps(tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');
 SELECT contains(tbox 'TBOXFLOAT XT([1.0, 2.0],[2000-01-02, 2000-02-01])', tbox 'TBOXFLOAT XT([1.0,2.0],[2000-01-01,2000-01-02])');


### PR DESCRIPTION
Two boxes are adjacent when their extents meet in every dimension the boxes share and touch at a single value in at least one of them, so a dimension in which the boxes are apart separates them whatever the remaining dimensions do. The temporal and the spatiotemporal box answer alike, and periods that meet at an excluded bound are adjacent as the spans holding them are.