### PR TITLE
Answer the shortest line of a temporal pose and a pose without a cast

### DIFF
--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -312,7 +312,7 @@ shortestline_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
  * pose and a temporal pose
  * @param[in] temp Temporal pose
  * @param[in] pose Pose
- * @csqlfn #Shortestline_tpose_pose()
+ * @csqlfn #Shortestline_tpose_pose() #Shortestline_pose_tpose()
  */
 GSERIALIZED *
 shortestline_tpose_pose(const Temporal *temp, const Pose *pose)

--- a/mobilitydb/sql/pose/110_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/110_tpose_distance.in.sql
@@ -256,8 +256,8 @@ CREATE FUNCTION shortestLine(stbox, tpose)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION shortestLine(pose, tpose)
   RETURNS geometry
-  AS 'SELECT @extschema@.shortestLine(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Shortestline_pose_tpose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tpose, geometry)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_tpose_geo'
@@ -268,8 +268,8 @@ CREATE FUNCTION shortestLine(tpose, stbox)
   LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tpose, pose)
   RETURNS geometry
-  AS 'SELECT @extschema@.shortestLine($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Shortestline_tpose_pose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tpose, tpose)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_tpose_tpose'

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -577,6 +577,8 @@ Shortestline_pose_tpose(PG_FUNCTION_ARGS)
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   GSERIALIZED *result = shortestline_tpose_pose(temp, pose);
   PG_FREE_IF_COPY(temp, 1);
+  if (! result)
+    PG_RETURN_NULL();
   PG_RETURN_GSERIALIZED_P(result);
 }
 
@@ -584,7 +586,7 @@ PGDLLEXPORT Datum Shortestline_tpose_pose(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Shortestline_tpose_pose);
 /**
  * @ingroup mobilitydb_pose_dist
- * @brief Return the line connecting the nearest approach point between a 
+ * @brief Return the line connecting the nearest approach point between a
  * temporal pose and a pose
  * @sqlfn shortestLine()
  */
@@ -595,6 +597,8 @@ Shortestline_tpose_pose(PG_FUNCTION_ARGS)
   Pose *pose = PG_GETARG_POSE_P(1);
   GSERIALIZED *result = shortestline_tpose_pose(temp, pose);
   PG_FREE_IF_COPY(temp, 0);
+  if (! result)
+    PG_RETURN_NULL();
   PG_RETURN_GSERIALIZED_P(result);
 }
 


### PR DESCRIPTION
shortestLine(pose, tpose) and shortestLine(tpose, pose) bind the wrappers Shortestline_pose_tpose and Shortestline_tpose_pose, which call the MEOS function shortestline_tpose_pose, and that function records both wrappers in its @csqlfn tag. Each wrapper returns NULL where the kernel answers no line, as its siblings do. The kernel takes the point of the pose with pose_to_point, the function the geometry(pose) cast binds, so both signatures answer the line 113_tpose_distance expects of them.