### PR TITLE
Leave the slots of a new array as the growth path already leaves them

### DIFF
--- a/meos/src/temporal/meos_array.c
+++ b/meos/src/temporal/meos_array.c
@@ -111,7 +111,13 @@ meos_array_create(int elem_size)
      * (e.g. the int ids collected in temporal_rtree.c node_search). */
     array->elem_size = (size_t) elem_size;
   }
-  array->elems = palloc0(array->elem_size * array->capacity);
+  /* The slots are not zeroed: #meos_array_add writes a slot in full before
+   * it raises the count, #meos_array_get refuses an index at or above the
+   * count, and the growth path repallocs without zeroing, so a slot beyond
+   * the count is already uninitialised once the array has grown once. Zeroing
+   * the initial buffer writes bytes no reader ever observes, and the buffer is
+   * MEOS_ARRAY_INITIAL_SIZE slots wide whatever the caller goes on to store */
+  array->elems = palloc(array->elem_size * array->capacity);
   return array;
 }
 


### PR DESCRIPTION
A new array zeroes its whole initial buffer, `MEOS_ARRAY_INITIAL_SIZE` slots
wide whatever the caller goes on to store. An array of edges therefore reserves
and clears 34816 bytes to hold the four a square carries, and a spatial
relationship builds one for each operand.

No reader observes those bytes:

- `meos_array_add` writes a slot in full before the count rises to include it,
  and never reads it first;
- `meos_array_get` refuses an index at or above the count;
- the one caller that walks the storage directly bounds itself by a count the
  same accessor produced.

The growth path settles it: it repallocs without zeroing, so every slot beyond
the count is already uninitialised once an array has doubled once. Clearing
them at the outset holds an invariant the array does not otherwise keep.