### PR TITLE
Give the span set width functions the wrapper reference the catalog reads

### DIFF
--- a/meos/src/temporal/spanset_meos.c
+++ b/meos/src/temporal/spanset_meos.c
@@ -516,7 +516,7 @@ datespanset_upper(const SpanSet *ss)
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
  * @return On error return INT_MAX
- * @csqlfn #Numspanset_width(()
+ * @csqlfn #Numspanset_width()
  */
 int
 intspanset_width(const SpanSet *ss, bool boundspan)
@@ -532,7 +532,7 @@ intspanset_width(const SpanSet *ss, bool boundspan)
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
  * @return On error return INT64_MAX
- * @csqlfn #Numspanset_width(()
+ * @csqlfn #Numspanset_width()
  */
 int64
 bigintspanset_width(const SpanSet *ss, bool boundspan)
@@ -548,7 +548,7 @@ bigintspanset_width(const SpanSet *ss, bool boundspan)
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
  * @return On error return @p DBL_MAX
- * @csqlfn #Numspanset_width(()
+ * @csqlfn #Numspanset_width()
  */
 double
 floatspanset_width(const SpanSet *ss, bool boundspan)


### PR DESCRIPTION
The @csqlfn tag of intspanset_width, bigintspanset_width and floatspanset_width names #Numspanset_width(), the wrapper the three width() signatures of 007_spanset.in.sql bind. A reference reads as #Name(), so the catalog takes the three span set widths into the SQL surface it derives, each carrying the span set type its VALIDATE macro states.