### PR TITLE
Name every wrapper a MEOS function backs in its @csqlfn tag

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -54,6 +54,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Check @csqlfn derivation links
         run: python3 tools/scripts/check_csqlfn.py --gaps
+      - name: Check every wrapper a @csqlfn tag backs is named
+        run: python3 tools/scripts/check_csqlfn.py --complete
 
   spatialrel_orthogonality_check:
     runs-on: ubuntu-latest

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -1006,7 +1006,7 @@ datum_cbuffer_distance(Datum cb1, Datum cb2)
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between a circular buffer and a geometry
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_cbuffer_geo()
+ * @csqlfn #Distance_cbuffer_geo() #Distance_geo_cbuffer()
  */
 double
 distance_cbuffer_geo(const Cbuffer *cb, const GSERIALIZED *gs)
@@ -1025,7 +1025,7 @@ distance_cbuffer_geo(const Cbuffer *cb, const GSERIALIZED *gs)
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between a circular buffer and a spatiotemporal box
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_cbuffer_stbox()
+ * @csqlfn #Distance_cbuffer_stbox() #Distance_stbox_cbuffer()
  */
 double
 distance_cbuffer_stbox(const Cbuffer *cb, const STBox *box)

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -88,7 +88,7 @@ tcbuffer_cbuffer_distance_turnpt(Datum start, Datum end, Datum value,
  * @ingroup meos_cbuffer_dist
  * @brief Return the temporal distance between a temporal circular buffer and
  * a circular buffer
- * @csqlfn #Tdistance_tcbuffer_cbuffer()
+ * @csqlfn #Tdistance_tcbuffer_cbuffer() #Tdistance_cbuffer_tcbuffer()
  */
 Temporal *
 tdistance_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
@@ -463,7 +463,7 @@ tdistance_tcbuffer_geo_analytic(const Temporal *temp, const DistGeom *g)
  * with no exact edge decomposition (a TIN or a polyhedral surface) falls
  * back to the bounding-circle approximation, mirroring the other analytic
  * distance kernels of this file.
- * @csqlfn #Tdistance_tcbuffer_geo()
+ * @csqlfn #Tdistance_tcbuffer_geo() #Tdistance_geo_tcbuffer()
  */
 Temporal *
 tdistance_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2268,7 +2268,7 @@ mindistance_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  * geometry and a temporal circular buffer
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
- * @csqlfn #Shortestline_tcbuffer_geo()
+ * @csqlfn #Shortestline_tcbuffer_geo() #Shortestline_geo_tcbuffer()
  */
 GSERIALIZED *
 shortestline_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2294,7 +2294,7 @@ shortestline_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * circular buffer and a temporal circular buffer
  * @param[in] temp Temporal circular buffer
  * @param[in] cb Circular buffer
- * @csqlfn #Shortestline_tcbuffer_cbuffer()
+ * @csqlfn #Shortestline_tcbuffer_cbuffer() #Shortestline_cbuffer_tcbuffer()
  */
 GSERIALIZED *
 shortestline_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -2776,7 +2776,7 @@ tdwithin_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp, double dist)
  * @param[in] temp Temporal circular buffer
  * @param[in] cb Circular buffer
  * @param[in] dist Distance
- * @csqlfn #Tdwithin_tcbuffer_cbuffer()
+ * @csqlfn #Tdwithin_tcbuffer_cbuffer() #Tdwithin_cbuffer_tcbuffer()
  */
 Temporal *
 tdwithin_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb, double dist)

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1752,7 +1752,7 @@ tpointsegm_distance_turnpt(Datum start1, Datum end1, Datum start2,
  * geometry/geography
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry/geography
- * @csqlfn #Tdistance_tgeo_geo()
+ * @csqlfn #Tdistance_tgeo_geo() #Tdistance_geo_tgeo()
  */
 Temporal *
 tdistance_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2892,7 +2892,7 @@ geography_shortestline_internal(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
  * temporal geo and a geometry/geography
  * @param[in] temp Temporal value
  * @param[in] gs Geometry/geography
- * @csqlfn #Shortestline_tgeo_geo()
+ * @csqlfn #Shortestline_tgeo_geo() #Shortestline_geo_tgeo()
  */
 GSERIALIZED *
 shortestline_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -2951,7 +2951,7 @@ bearing_point_point(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
  * @param[in] gs Geometry
  * @param[in] invert True when the result should be inverted
  * @return On empty geometry or on error return NULL
- * @csqlfn #Bearing_tpoint_point()
+ * @csqlfn #Bearing_tpoint_point() #Bearing_point_tpoint()
  */
 Temporal *
 bearing_tpoint_point(const Temporal *temp, const GSERIALIZED *gs, bool invert)

--- a/meos/src/json/tjsonb_jsonfuncs.c
+++ b/meos/src/json/tjsonb_jsonfuncs.c
@@ -668,7 +668,7 @@ concat_tjsonb_tjsonb(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Temporal JSONB
  * @param[in] jb JSONB
  * @param[in] invert True if the arguments must be inverted
- * @csqlfn #Contains_tjsonb_jsonb()
+ * @csqlfn #Contains_tjsonb_jsonb() #Contains_jsonb_tjsonb()
  */
 Temporal *
 contains_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb, bool invert)

--- a/meos/src/npoint/tnpoint_compops.c
+++ b/meos/src/npoint/tnpoint_compops.c
@@ -275,7 +275,7 @@ tcomp_tnpoint_npoint(const Temporal *temp, const Npoint *np,
  * network point
  * @param[in] temp Temporal network point
  * @param[in] np Network point
- * @csqlfn #Teq_tnpoint_npoint()
+ * @csqlfn #Teq_tnpoint_npoint() #Teq_npoint_tnpoint()
  */
 Temporal *
 teq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
@@ -289,7 +289,7 @@ teq_tnpoint_npoint(const Temporal *temp, const Npoint *np)
  * network point
  * @param[in] temp Temporal network point
  * @param[in] np Network point
- * @csqlfn #Tne_tnpoint_npoint()
+ * @csqlfn #Tne_tnpoint_npoint() #Tne_npoint_tnpoint()
  */
 Temporal *
 tne_tnpoint_npoint(const Temporal *temp, const Npoint *np)

--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -91,7 +91,7 @@ tdistance_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
  * a network point
  * @param[in] temp Temporal point
  * @param[in] np Network point
- * @csqlfn #Tdistance_tnpoint_npoint()
+ * @csqlfn #Tdistance_tnpoint_npoint() #Tdistance_npoint_tnpoint()
  */
 Temporal *
 tdistance_tnpoint_npoint(const Temporal *temp, const Npoint *np)
@@ -311,7 +311,7 @@ nad_tnpoint_tnpoint(const Temporal *temp1, const Temporal *temp2)
  * geometry and a temporal network point
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
- * @csqlfn #Shortestline_tnpoint_geo()
+ * @csqlfn #Shortestline_tnpoint_geo() #Shortestline_geo_tnpoint()
  */
 GSERIALIZED *
 shortestline_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -332,7 +332,7 @@ shortestline_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
  * network point and a temporal network point
  * @param[in] temp Temporal point
  * @param[in] np Network point
- * @csqlfn #Shortestline_tnpoint_npoint()
+ * @csqlfn #Shortestline_tnpoint_npoint() #Shortestline_npoint_tnpoint()
  */
 GSERIALIZED *
 shortestline_tnpoint_npoint(const Temporal *temp, const Npoint *np)

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -2239,7 +2239,7 @@ datum_pose_distance(Datum pose1, Datum pose2)
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a geometry
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_pose_geo()
+ * @csqlfn #Distance_pose_geo() #Distance_geo_pose()
  */
 double
 distance_pose_geo(const Pose *pose, const GSERIALIZED *gs)
@@ -2258,7 +2258,7 @@ distance_pose_geo(const Pose *pose, const GSERIALIZED *gs)
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a spatiotemporal box
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_pose_stbox()
+ * @csqlfn #Distance_pose_stbox() #Distance_stbox_pose()
  */
 double
 distance_pose_stbox(const Pose *pose, const STBox *box)

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -73,7 +73,7 @@ tdistance_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return the temporal distance between a temporal pose and a pose
  * @param[in] temp Temporal pose
  * @param[in] pose Pose
- * @csqlfn #Tdistance_tpose_pose()
+ * @csqlfn #Tdistance_tpose_pose() #Tdistance_pose_tpose()
  */
 Temporal *
 tdistance_tpose_pose(const Temporal *temp, const Pose *pose)
@@ -291,7 +291,7 @@ nad_tpose_tpose(const Temporal *temp1, const Temporal *temp2)
  * geometry and a temporal pose
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @csqlfn #Shortestline_tpose_geo()
+ * @csqlfn #Shortestline_tpose_geo() #Shortestline_geo_tpose()
  */
 GSERIALIZED *
 shortestline_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2265,7 +2265,7 @@ dist2d_trgeoseqset_trgeoseqset(const TSequenceSet *ss1, const TSequenceSet *ss2,
  * @param[in] temp Temporal
  * @param[in] gs Geometry
  * @sqlop @p <->
- * @csqlfn #Tdistance_trgeometry_geo()
+ * @csqlfn #Tdistance_trgeometry_geo() #Tdistance_geo_trgeometry()
  */
 Temporal *
 tdistance_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2361,7 +2361,7 @@ trgeoseqset_translate_by_tpoint(const TSequenceSet *pss,
  * @brief Return the temporal distance between a temporal rigid geometry and a
  * temporal geometry point
  * @sqlop @p <->
- * @csqlfn #Tdistance_trgeometry_tpoint()
+ * @csqlfn #Tdistance_trgeometry_tpoint() #Tdistance_tpoint_trgeometry()
  */
 Temporal *
 tdistance_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
@@ -2701,7 +2701,7 @@ nad_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
  * @brief Return the line connecting the nearest approach point between a
  * temporal rigid geometry and a geometry
  * @sqlfn shortestLine()
- * @csqlfn #Shortestline_trgeometry_geo()
+ * @csqlfn #Shortestline_trgeometry_geo() #Shortestline_geo_trgeometry()
  */
 GSERIALIZED *
 shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2727,7 +2727,7 @@ shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @brief Return the line connecting the nearest approach point between a
  * temporal rigid geometry and a temporal geometry point
  * @sqlfn shortestLine()
- * @csqlfn #Shortestline_trgeometry_tpoint()
+ * @csqlfn #Shortestline_trgeometry_tpoint() #Shortestline_tpoint_trgeometry()
  */
 GSERIALIZED *
 shortestline_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)

--- a/tools/scripts/check_csqlfn.py
+++ b/tools/scripts/check_csqlfn.py
@@ -80,13 +80,27 @@ def pg_wrappers(dirs):
     return rows
 
 
+# The catalog reads a tag reference as '#(\w+)\s*\(\)', so '#Name ()' with a
+# stray space parses there and must parse here too: a checker stricter than the
+# generator reports a gap the generator does not have.
+CSQLFN_REF = re.compile(r'#(\w+)\s*\(\)')
+
+
 def ingroup_block(lines, i):
-    """Scan one @ingroup block; return (name, has_csqlfn, is_binding_api, end)."""
-    has = False
+    """Scan one @ingroup block; return (name, refs, is_binding_api, internal, end)."""
+    refs = set()
+    internal = False
     j = i
+    tag = False
     while j < len(lines) and lines[j].strip() != '*/':
+        if '@ingroup meos_internal' in lines[j]:
+            internal = True
         if '@csqlfn' in lines[j]:
-            has = True
+            tag = True
+        elif re.search(r'@\w', lines[j]):
+            tag = False
+        if tag:
+            refs |= set(CSQLFN_REF.findall(lines[j]))
         j += 1
     k = j + 1
     name = None
@@ -101,7 +115,7 @@ def ingroup_block(lines, i):
         sig = ' '.join(lines[k:k + 4])
         sig = sig[:sig.find(')') + 1] if ')' in sig else sig
         is_api = 'Datum' not in sig  # skip generic Datum workers (not binding API)
-    return name, has, is_api, j
+    return name, refs, is_api, internal, j
 
 
 # Datum-signature functions are the generic Datum workers (one C function
@@ -109,7 +123,7 @@ def ingroup_block(lines, i):
 # @csqlfn link lives on their typed instantiations in *_meos.c, so they are
 # excluded here and the guard does not flag them.
 def meos_public(dirs):
-    """Map meos_fn -> (file, has_csqlfn) for every binding-API MEOS function."""
+    """Map meos_fn -> (file, refs, internal) for every binding-API MEOS function."""
     out = {}
     for d in dirs:
         for path in sorted(glob.glob(f'{ROOT}/meos/src/{d}/**/*.c', recursive=True)):
@@ -117,12 +131,28 @@ def meos_public(dirs):
             i = 0
             while i < len(lines):
                 if '@ingroup meos_' in lines[i]:
-                    name, has, is_api, end = ingroup_block(lines, i)
+                    name, refs, is_api, internal, end = ingroup_block(lines, i)
                     if name and is_api:
-                        out[name] = (os.path.basename(path), has)
+                        out[name] = (os.path.basename(path), refs, internal)
                     i = end
                 i += 1
     return out
+
+
+def sql_bound():
+    """Wrappers a CREATE FUNCTION binds, and the count of name-bound ones skipped.
+
+    `AS 'MODULE_PATHNAME', 'Wrapper'` names its symbol; the bare
+    `AS 'MODULE_PATHNAME'` form takes the SQL name as the symbol, which no
+    wrapper of this convention carries, so those are counted and reported rather
+    than silently dropped.
+    """
+    names, bare = set(), 0
+    for path in glob.glob(f'{ROOT}/mobilitydb/sql/**/*.in.sql', recursive=True):
+        text = read_text(path)
+        names |= set(re.findall(r"MODULE_PATHNAME'\s*,\s*'(\w+)'", text))
+        bare += len(re.findall(r"AS 'MODULE_PATHNAME'\s*$", text, re.M))
+    return names, bare
 
 
 def cap(fn):
@@ -142,8 +172,8 @@ def resolve(dirs):
         if dg:
             deleg_of[pg] = dg
     auto, review = [], []
-    for fn, (f, has) in meos_public(dirs).items():
-        if has:
+    for fn, (f, refs, _internal) in meos_public(dirs).items():
+        if refs:
             continue
         # A wrapper whose name is the function's own stem binds it, unless the
         # wrapper resolves to a different MEOS function: raquet_read and
@@ -194,6 +224,68 @@ def families():
     return sorted(d for d in os.listdir(src) if os.path.isdir(f'{src}/{d}'))
 
 
+def tokens(wrapper):
+    """The lowercase name parts of a wrapper, for the commuted-order test."""
+    return sorted(wrapper.lower().split('_'))
+
+
+def incomplete(dirs):
+    """Return (commuted, mistagged, dispatch, bare) for the tagged MEOS functions.
+
+    A tag must name EVERY wrapper a CREATE FUNCTION binds to the function, since
+    the catalog gives a function the SQL surface of the wrappers its tag names
+    and drops the rest. The three groups differ in what closing them costs:
+
+    commuted  the omitted wrapper is the tagged one with its arguments the other
+              way round -- one operation, one kernel, and the tag simply misses
+              a name. This is the group the check FAILS on.
+    mistagged the tag names a wrapper that binds a DIFFERENT function. Each one
+              is read on its own: a body-resolved delegate cannot see the
+              restrict-at/minus flag dispatch, so this group holds both real
+              mistags and functions whose tag the resolver cannot follow.
+    dispatch  the omitted wrapper reaches the function through a generic
+              dispatcher or from another family. Naming it states that the
+              function serves that SQL surface, which changes what the bindings
+              generate, so it is a decision rather than a correction.
+    """
+    rows = pg_wrappers(dirs)
+    bound, bare = sql_bound()
+    deleg = {pg: dg for pg, _sf, _so, dg, _how, _f in rows if dg}
+    binds = {}
+    for pg, dg in deleg.items():
+        if pg in bound:
+            binds.setdefault(dg, set()).add(pg)
+    public = sorted(meos_public(dirs).items())
+    # A wrapper another function already claims is nobody else's omission. The
+    # commuted npoint comparisons are the case: Ever_eq_npoint_tnpoint passes
+    # &ever_eq_tnpoint_npoint, so the body resolver reads it as the temporal-first
+    # function's, while the npoint-first function of that argument order exists and
+    # claims it. Naming it twice gives two MEOS functions one SQL signature, which
+    # is the per-wrapper attachment the type scope exists to prevent.
+    claimed = {}
+    for fn, (_f, refs, _internal) in public:
+        for pg in refs:
+            claimed.setdefault(pg, set()).add(fn)
+    commuted, mistagged, dispatch = [], [], []
+    for fn, (f, refs, internal) in public:
+        if not refs or internal:
+            continue
+        missing = sorted(pg for pg in binds.get(fn, set()) - refs
+                         if not claimed.get(pg, set()) - {fn})
+        if not missing:
+            continue
+        wrong = sorted(r for r in refs if deleg.get(r, fn) != fn)
+        if wrong:
+            mistagged.append((fn, f, sorted(refs), missing, wrong))
+            continue
+        for pg in missing:
+            if any(tokens(pg) == tokens(r) for r in refs):
+                commuted.append((fn, f, pg))
+            else:
+                dispatch.append((fn, f, pg))
+    return commuted, mistagged, dispatch, bare
+
+
 def main():
     """Dispatch on the mode argument and report the @csqlfn coverage."""
     mode = sys.argv[1] if len(sys.argv) > 1 else '--gaps'
@@ -202,6 +294,21 @@ def main():
     if mode == '--table':
         for pg, sf, so, dg, _how, _f in sorted(rows):
             print(f'{pg:42s} sqlfn={sf:24s} sqlop={so:10s} -> meos:{dg or "-"}')
+    elif mode == '--complete':
+        commuted, mistagged, dispatch, bare = incomplete(dirs)
+        print(f'@csqlfn tags omitting a COMMUTED wrapper: {len(commuted)}')
+        for fn, f, pg in commuted:
+            print(f'  {f:26s} {fn:40s} += #{pg}()')
+        print(f'\ntag names a wrapper of another function (read each): '
+              f'{len(mistagged)}')
+        for fn, f, refs, missing, wrong in mistagged:
+            print(f'  {f:26s} {fn:40s} tag={refs} of={wrong} omits={missing}')
+        print(f'\nreached through a dispatcher or another family (a decision): '
+              f'{len(dispatch)} over {len({fn for fn, _f, _pg in dispatch})} '
+              f'functions')
+        print(f'\n{bare} bare "AS \'MODULE_PATHNAME\'" bindings carry no wrapper '
+              f'symbol and are outside this check')
+        sys.exit(1 if commuted else 0)
     elif mode == '--fix':
         n = 0
         for fn, pg, f, _how in auto:


### PR DESCRIPTION
The catalog gives a MEOS function the SQL surface of the wrappers its tag names and drops the rest, so a wrapper of the commuted argument order left unnamed is a SQL signature no binding generates. Twenty-four distance, shortest-line, bearing, comparison and containment functions name the wrapper of their other argument order, each of which calls that same function; the catalog's own parser reads 24 functions gaining a wrapper, none losing one, and no wrapper becoming shared. check_csqlfn.py --complete reports what a tagged function omits, in the three groups that differ in what closing them costs: the commuted wrapper, which the check exits non-zero on and which the csqlfn_check job runs; a tag naming a wrapper of another function, which is read one at a time; and a wrapper reaching the function through a dispatcher or another family, which states a surface rather than corrects one. A wrapper another function already claims belongs to that function, so it is nobody else's omission.