### PR TITLE
Answer the radius of a temporal circular buffer under its own name

### DIFF
--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -1397,7 +1397,7 @@ tcbuffer_points(const Temporal *temp)
 /**
  * @ingroup meos_cbuffer_accessor
  * @brief Return the array of radii of a temporal circular buffer
- * @csqlfn #Tcbuffer_points()
+ * @csqlfn #Tcbuffer_radius()
  */
 Set *
 tcbuffer_radius(const Temporal *temp)

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -244,7 +244,7 @@ PG_FUNCTION_INFO_V1(Tcbuffer_radius);
 /**
  * @ingroup mobilitydb_cbuffer_accessor
  * @brief Return the set of radii of a temporal circular buffer
- * @sqlfn points()
+ * @sqlfn radius()
  */
 Datum
 Tcbuffer_radius(PG_FUNCTION_ARGS)


### PR DESCRIPTION
tcbuffer_radius names #Tcbuffer_radius(), the wrapper that calls it, and that wrapper names radius(), the SQL function 202_tcbuffer.in.sql binds it to. The catalog reads the wrapper from @csqlfn and the SQL name from @sqlfn, so the radius accessor reaches every binding as radius(tcbuffer), and points(tcbuffer) keeps the one accessor it has. The catalog's own parser reads tcbuffer_radius through Tcbuffer_radius to the name radius, with the claimant count unchanged.