### PR TITLE
Name the wrapper each of six MEOS functions is reached through

### DIFF
--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -1516,7 +1516,7 @@ tdisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
  * buffer and a circular buffer are disjoint
  * @param[in] temp Temporal circular buffer
  * @param[in] cb Circular buffer
- * @csqlfn #Tdisjoint_tcbuffer_geo()
+ * @csqlfn #Tdisjoint_cbuffer_tcbuffer()
  */
 Temporal *
 tdisjoint_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
@@ -1530,7 +1530,7 @@ tdisjoint_cbuffer_tcbuffer(const Cbuffer *cb, const Temporal *temp)
  * buffer and a circular buffer are disjoint
  * @param[in] temp Temporal circular buffer
  * @param[in] cb Circular buffer
- * @csqlfn #Tdisjoint_tcbuffer_geo()
+ * @csqlfn #Tdisjoint_tcbuffer_cbuffer()
  */
 Temporal *
 tdisjoint_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
@@ -2703,7 +2703,7 @@ ttouches_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb)
  * @brief Return a temporal Boolean that states whether a temporal circular
  * buffer touches another one
  * @param[in] temp1,temp2 Temporal circular buffer
- * @csqlfn #Ttouches_tcbuffer_geo()
+ * @csqlfn #Ttouches_tcbuffer_tcbuffer()
  */
 Temporal *
 ttouches_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)

--- a/meos/src/json/tjsonb_jsonfuncs.c
+++ b/meos/src/json/tjsonb_jsonfuncs.c
@@ -505,7 +505,7 @@ datum_text_to_jsonb(Datum txt)
  * @ingroup meos_json_json
  * @brief Return the length of a temporal JSON array
  * @param[in] temp Temporal JSON value
- * @csqlfn #Tjsonb_array_length()
+ * @csqlfn #Tjson_array_length()
  */
 Temporal *
 tjson_array_length(const Temporal *temp)
@@ -619,7 +619,7 @@ tjsonb_object_field(const Temporal *temp, const text *key, bool astext,
  * @param[in] temp Temporal JSONB
  * @param[in] jb JSONB
  * @param[in] invert True if the arguments must be inverted
- * @csqlfn #Concat_tjsonb_tjsonb()
+ * @csqlfn #Concat_tjsonb_jsonb() #Concat_jsonb_tjsonb()
  */
 Temporal *
 concat_tjsonb_jsonb(const Temporal *temp, const Jsonb *jb, bool invert)

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -372,7 +372,7 @@ numspan_timestamptz_to_tbox(const Span *s, TimestampTz t)
  * @brief Return a temporal box from a number span and a timestamptz span
  * @param[in] s Value span
  * @param[in] p Time span
- * @csqlfn #Numspan_timestamptz_to_tbox()
+ * @csqlfn #Numspan_tstzspan_to_tbox()
  */
 TBox *
 numspan_tstzspan_to_tbox(const Span *s, const Span *p)


### PR DESCRIPTION
Each of these carries the tag of a neighbouring function, so the catalog gives it that neighbour's SQL name and leaves its own signature with no function behind it. Every wrapper named here calls the function it sits on, and every wrapper vacated keeps the one function that calls it. tdisjoint_cbuffer_tcbuffer and tdisjoint_tcbuffer_cbuffer reach tDisjoint() through their own wrappers rather than through the geometry one, and ttouches_tcbuffer_tcbuffer reaches tTouches() the same way; numspan_tstzspan_to_tbox names the span-set conversion rather than the timestamp one, tjson_array_length the JSON wrapper rather than the JSONB one, and concat_tjsonb_jsonb the two wrappers of its own argument orders rather than the two-temporal one. The catalog's own parser reads six functions changing wrapper and none losing one, resolving to tDisjoint, tTouches, tbox, tjsonArrayLength and tjsonbConcat, with the claimant count unchanged and no wrapper shared.