### PR TITLE
Answer a point cloud box predicate from the shared bounding box code

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3353,7 +3353,7 @@
 						<para><link linkend="tpcbox_overlaps"><varname>&amp;&amp;</varname></link>: Devuelve true si dos tpcboxes se solapan</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpcbox_same"><varname>~=</varname></link>: Devuelve true si dos tpcboxes son exactamente iguales</para>
+						<para><link linkend="tpcbox_same"><varname>~=</varname></link>: Devuelve true si dos tpcboxes son iguales en las dimensiones que comparten</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcbox_adjacent"><varname>-|-</varname></link>: Devuelve true si dos tpcboxes son adyacentes (comparten un límite)</para>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -266,7 +266,7 @@ SELECT numValues(set(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 	</sect1>	<sect1 xml:id="tpcbox">
 		<title>Caja Delimitadora <varname>tpcbox</varname></title>
 
-		<para>El tipo <varname>tpcbox</varname> es la caja delimitadora espaciotemporal para los tipos de nube de puntos temporal. Refleja la estructura de <varname>stbox</varname> (véase <xref linkend="box_types" />), mismos ejes X/Y/Z/T, mismos bits de indicador para las dimensiones presentes, y añade un único campo: el <varname>pcid</varname>. Dos valores <varname>tpcbox</varname> con distintos valores de <varname>pcid</varname> nunca se consideran solapados, contenidos, iguales o adyacentes entre sí, independientemente de su extensión geométrica o temporal.</para>
+		<para>El tipo <varname>tpcbox</varname> es la caja delimitadora espaciotemporal para los tipos de nube de puntos temporal. Refleja la estructura de <varname>stbox</varname> (véase <xref linkend="box_types" />), mismos ejes X/Y/Z/T, mismos bits de indicador para las dimensiones presentes, y añade un único campo: el <varname>pcid</varname>. Dos valores <varname>tpcbox</varname> con distintos valores de <varname>pcid</varname> describen esquemas distintos, y una operación entre ellos genera un error en lugar de comparar su extensión geométrica o temporal.</para>
 
 		<para>Propagar el <varname>pcid</varname> a través de la aritmética de cajas delimitadoras garantiza que la poda por caja delimitadora nunca descarte una fila cuyo esquema difiera del esquema de la consulta, y nunca devuelva un resultado entre esquemas incompatibles.</para>
 
@@ -469,13 +469,14 @@ SELECT tpcbox(2, 2, 8, 8, 1, 0) &lt;@ tpcbox(0, 0, 10, 10, 1, 0);
 					<para><varname>tpcbox &amp;&amp; tpcbox → boolean</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(3, 3, 10, 10, 1, 0);  -- t
-SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);  -- f (pcid mismatch)
+SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);
+-- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 </programlisting>
 				</listitem>
 
 				<listitem xml:id="tpcbox_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
-					<para>Devuelve true si dos tpcboxes son exactamente iguales</para>
+					<para>Devuelve true si dos tpcboxes son iguales en las dimensiones que comparten</para>
 					<para><varname>tpcbox ~= tpcbox → boolean</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 2, 2) ~= tpcbox(0, 0, 2, 2);

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3362,7 +3362,7 @@
 						<para><link linkend="tpcbox_overlaps"><varname>&amp;&amp;</varname></link>: Return true if two tpcboxes overlap</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpcbox_same"><varname>~=</varname></link>: Return true if two tpcboxes are exactly equal</para>
+						<para><link linkend="tpcbox_same"><varname>~=</varname></link>: Return true if two tpcboxes are equal in the dimensions they share</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcbox_adjacent"><varname>-|-</varname></link>: Return true if two tpcboxes are adjacent (share a boundary)</para>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -270,7 +270,7 @@ SELECT numValues(set(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 	<sect1 xml:id="tpcbox">
 		<title>Bounding Box <varname>tpcbox</varname></title>
 
-		<para>The <varname>tpcbox</varname> type is the spatiotemporal bounding box for the temporal point-cloud types. It mirrors the structure of <varname>stbox</varname> (see <xref linkend="box_types" />), same X/Y/Z/T axes, same flag bits for which dimensions are present, and adds a single field: the <varname>pcid</varname>. Two <varname>tpcbox</varname> values with different <varname>pcid</varname> values are never considered to overlap, contain, equal, or be adjacent to each other, regardless of their geometric or temporal extent.</para>
+		<para>The <varname>tpcbox</varname> type is the spatiotemporal bounding box for the temporal point-cloud types. It mirrors the structure of <varname>stbox</varname> (see <xref linkend="box_types" />), same X/Y/Z/T axes, same flag bits for which dimensions are present, and adds a single field: the <varname>pcid</varname>. Two <varname>tpcbox</varname> values with different <varname>pcid</varname> values describe different schemas, and an operation between them raises an error instead of comparing their geometric or temporal extent.</para>
 
 		<para>Carrying the <varname>pcid</varname> through bounding-box arithmetic guarantees that bounding-box pruning never drops a row whose schema differs from the query's schema, and never returns a hit across mismatched schemas.</para>
 
@@ -473,13 +473,14 @@ SELECT tpcbox(2, 2, 8, 8, 1, 0) &lt;@ tpcbox(0, 0, 10, 10, 1, 0);
 					<para><varname>tpcbox &amp;&amp; tpcbox → boolean</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(3, 3, 10, 10, 1, 0);  -- t
-SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);  -- f (pcid mismatch)
+SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);
+-- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 </programlisting>
 				</listitem>
 
 				<listitem xml:id="tpcbox_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
-					<para>Return true if two tpcboxes are exactly equal</para>
+					<para>Return true if two tpcboxes are equal in the dimensions they share</para>
 					<para><varname>tpcbox ~= tpcbox → boolean</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 2, 2) ~= tpcbox(0, 0, 2, 2);

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -58,6 +58,7 @@
 #include <utils/timestamp.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_geo.h>
 #include <meos_internal.h>
 #include <meos_pointcloud.h>
 #include <pgtypes.h>
@@ -896,23 +897,8 @@ intersection_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
  *****************************************************************************/
 
 /**
- * @brief Shared dimension check: returns the effective (hasx, hasz, hast)
- * triple for comparing @p box1 vs @p box2 — predicates only make sense on
- * dimensions both boxes carry.
- */
-static inline void
-tpcbox_shared_dims(const TPCBox *box1, const TPCBox *box2,
-  bool *hasx, bool *hasz, bool *hast)
-{
-  *hasx = MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags);
-  *hasz = MEOS_FLAGS_GET_Z(box1->flags) && MEOS_FLAGS_GET_Z(box2->flags);
-  *hast = MEOS_FLAGS_GET_T(box1->flags) && MEOS_FLAGS_GET_T(box2->flags);
-}
-
-/**
  * @ingroup meos_pointcloud_box_topo
  * @brief Return @p true if the first TPCBox contains the second
- * @details Mismatched pcid yields @p false.
  * @csqlfn #Contains_tpcbox_tpcbox()
  */
 bool
@@ -920,25 +906,9 @@ contains_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpcbox_tpcbox(box1, box2))
-    return NULL;
+    return false;
 
-  bool hasx, hasz, hast;
-  tpcbox_shared_dims(box1, box2, &hasx, &hasz, &hast);
-  /* box2 must have at least the dimensions box1 requires */
-  if (MEOS_FLAGS_GET_X(box1->flags) && ! MEOS_FLAGS_GET_X(box2->flags))
-    return false;
-  if (MEOS_FLAGS_GET_T(box1->flags) && ! MEOS_FLAGS_GET_T(box2->flags))
-    return false;
-  if (hasx)
-  {
-    if (box2->xmin < box1->xmin || box2->xmax > box1->xmax) return false;
-    if (box2->ymin < box1->ymin || box2->ymax > box1->ymax) return false;
-    if (hasz && (box2->zmin < box1->zmin || box2->zmax > box1->zmax))
-      return false;
-  }
-  if (hast && ! contains_span_span(&box1->period, &box2->period))
-    return false;
-  return true;
+  return contains_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -949,13 +919,16 @@ contains_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 bool
 contained_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
-  return contains_tpcbox_tpcbox(box2, box1);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tpcbox_tpcbox(box1, box2))
+    return false;
+
+  return contained_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
  * @ingroup meos_pointcloud_box_topo
  * @brief Return @p true if two TPCBox values overlap
- * @details Mismatched pcid yields @p false.
  * @csqlfn #Overlaps_tpcbox_tpcbox()
  */
 bool
@@ -963,38 +936,30 @@ overlaps_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpcbox_tpcbox(box1, box2))
-    return NULL;
-
-  bool hasx, hasz, hast;
-  tpcbox_shared_dims(box1, box2, &hasx, &hasz, &hast);
-  if (hasx)
-  {
-    if (box1->xmax < box2->xmin || box2->xmax < box1->xmin) return false;
-    if (box1->ymax < box2->ymin || box2->ymax < box1->ymin) return false;
-    if (hasz && (box1->zmax < box2->zmin || box2->zmax < box1->zmin))
-      return false;
-  }
-  if (hast && ! overlaps_span_span(&box1->period, &box2->period))
     return false;
-  return true;
+
+  return overlaps_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
  * @ingroup meos_pointcloud_box_topo
- * @brief Return @p true if two TPCBox values are exactly equal
- * @details Equivalent to @c tpcbox_eq.  Mismatched pcid yields @p false.
+ * @brief Return @p true if two TPCBox values are equal in the common
+ * dimensions
  * @csqlfn #Same_tpcbox_tpcbox()
  */
 bool
 same_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
-  return tpcbox_eq(box1, box2);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tpcbox_tpcbox(box1, box2))
+    return false;
+
+  return same_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
  * @ingroup meos_pointcloud_box_topo
  * @brief Return @p true if two TPCBox values touch but do not overlap
- * @details Mismatched pcid yields @p false.
  * @csqlfn #Adjacent_tpcbox_tpcbox()
  */
 bool
@@ -1002,30 +967,9 @@ adjacent_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpcbox_tpcbox(box1, box2))
-    return NULL;
+    return false;
 
-  /* Adjacent = their intersection is empty (no interior overlap) AND
-   * their expansion-union shares a boundary. Simplest correct
-   * implementation: touch on at least one face of a shared dimension
-   * and do not overlap on any other. Use the Span adjacency helper for
-   * the time dimension; hand-coded for spatial. */
-  TPCBox inter;
-  if (inter_tpcbox_tpcbox(box1, box2, &inter))
-    return false; /* overlaps strictly → not adjacent */
-  bool hasx, hasz, hast;
-  tpcbox_shared_dims(box1, box2, &hasx, &hasz, &hast);
-  if (hasx)
-  {
-    if (box1->xmax == box2->xmin || box2->xmax == box1->xmin ||
-        box1->ymax == box2->ymin || box2->ymax == box1->ymin)
-      return true;
-    if (hasz &&
-        (box1->zmax == box2->zmin || box2->zmax == box1->zmin))
-      return true;
-  }
-  if (hast && adjacent_span_span(&box1->period, &box2->period))
-    return true;
-  return false;
+  return adjacent_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /*****************************************************************************
@@ -1144,7 +1088,7 @@ bool tpcbox_ge(const TPCBox *box1, const TPCBox *box2)
 /**
  * @ingroup meos_pointcloud_box_pos
  * @brief Return @p true if box1 is strictly left of box2 (X-axis).
- * @details Returns @p false on pcid mismatch or if either box lacks XY.
+ * @details Returns @p false if either box lacks the X dimension.
  * @csqlfn #Left_tpcbox_tpcbox()
  */
 bool
@@ -1155,7 +1099,8 @@ left_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-  return (box1->xmax < box2->xmin);
+
+  return left_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1171,7 +1116,8 @@ overleft_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-  return (box1->xmax <= box2->xmax);
+
+  return overleft_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1187,7 +1133,8 @@ right_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-  return (box1->xmin > box2->xmax);
+
+  return right_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1203,7 +1150,8 @@ overright_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-  return (box1->xmin >= box2->xmin);
+
+  return overright_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /* Y axis */
@@ -1221,7 +1169,8 @@ below_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-  return (box1->ymax < box2->ymin);
+
+  return below_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1237,7 +1186,8 @@ overbelow_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-  return (box1->ymax <= box2->ymax);
+
+  return overbelow_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1253,7 +1203,8 @@ above_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-  return (box1->ymin > box2->ymax);
+
+  return above_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1269,7 +1220,8 @@ overabove_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-  return (box1->ymin >= box2->ymin);
+
+  return overabove_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /* Z axis — front/back only meaningful when both boxes have Z */
@@ -1288,7 +1240,8 @@ front_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_Z(T_TPCBOX, box1->flags) ||
       ! ensure_has_Z(T_TPCBOX, box2->flags))
     return false;
-  return (box1->zmax < box2->zmin);
+
+  return front_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1304,7 +1257,8 @@ overfront_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_Z(T_TPCBOX, box1->flags) ||
       ! ensure_has_Z(T_TPCBOX, box2->flags))
     return false;
-  return (box1->zmax <= box2->zmax);
+
+  return overfront_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1320,7 +1274,8 @@ back_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_Z(T_TPCBOX, box1->flags) ||
       ! ensure_has_Z(T_TPCBOX, box2->flags))
     return false;
-  return (box1->zmin > box2->zmax);
+
+  return back_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1336,7 +1291,8 @@ overback_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_Z(T_TPCBOX, box1->flags) ||
       ! ensure_has_Z(T_TPCBOX, box2->flags))
     return false;
-  return (box1->zmin >= box2->zmin);
+
+  return overback_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /* Time axis — before/after only meaningful when both boxes have T */
@@ -1355,8 +1311,8 @@ before_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
-  return (DatumGetTimestampTz(box1->period.upper) <
-          DatumGetTimestampTz(box2->period.lower));
+
+  return before_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1372,8 +1328,8 @@ overbefore_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
-  return (DatumGetTimestampTz(box1->period.upper) <=
-          DatumGetTimestampTz(box2->period.upper));
+
+  return overbefore_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1389,8 +1345,8 @@ after_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
-  return (DatumGetTimestampTz(box1->period.lower) >
-          DatumGetTimestampTz(box2->period.upper));
+
+  return after_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1406,8 +1362,8 @@ overafter_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
-  return (DatumGetTimestampTz(box1->period.lower) >=
-          DatumGetTimestampTz(box2->period.lower));
+
+  return overafter_stbox_stbox((const STBox *) box1, (const STBox *) box2);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -197,13 +197,13 @@ SELECT same(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(0, 0, 5, 5, 1, 0));
 SELECT tpcbox(0, 0, 5, 5, 1, 0)  -|- tpcbox(5, 0, 10, 5, 1, 0);
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT adjacent(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(5, 0, 10, 5, 1, 0));
  adjacent 
 ----------
- f
+ t
 (1 row)
 
 SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 8, 8, 2, 0);
@@ -211,11 +211,7 @@ ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(0, 0, 5, 5, 2, 0);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 2, 0);
- ?column? 
-----------
- f
-(1 row)
-
+ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 SELECT tpcbox(0, 0, 5, 5, 1, 0) =  tpcbox(0, 0, 5, 5, 1, 0);
  ?column? 
 ----------

--- a/mobilitydb/test/pointcloud/expected/436_tpc_topops.test.out
+++ b/mobilitydb/test/pointcloud/expected/436_tpc_topops.test.out
@@ -61,7 +61,7 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::t
 SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) -|- (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));

--- a/mobilitydb/test/pointcloud/expected/436_tpc_topops_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/436_tpc_topops_tbl.test.out
@@ -25,7 +25,7 @@ SELECT bool_and(temp ~= temp) FROM tbl_tpcpoint;
 SELECT bool_and(NOT (temp -|- temp)) FROM tbl_tpcpoint;
  bool_and 
 ----------
- t
+ f
 (1 row)
 
 SELECT bool_and(temp && temp) FROM tbl_tpcpatch;
@@ -55,7 +55,7 @@ SELECT bool_and(temp ~= temp) FROM tbl_tpcpatch;
 SELECT bool_and(NOT (temp -|- temp)) FROM tbl_tpcpatch;
  bool_and 
 ----------
- t
+ f
 (1 row)
 
 SELECT bool_and(tpcbox_zt(-200, -200, -200, 200, 200, 200,


### PR DESCRIPTION
Each of the twenty-one topological and position predicates over two point cloud
boxes gates the schema and the SRID through ensure_valid_tpcbox_tpcbox, then
answers from the spatiotemporal box predicate of the same name, reading each
operand through an STBox pointer as the fourteen accessors of this file already
do. The schema identifier is the one thing a point cloud box carries that a
spatiotemporal box does not, and it is settled before any geometry is compared;
every field a spatiotemporal box predicate reads sits at the offset the static
assertions of meos_pointcloud.h hold it to.

The predicates answer what every bounding box type answers. Adjacency holds
where the boxes meet in every dimension they share and touch in one of them,
rather than wherever a single face coincides, and ~= compares the shared
dimensions where = compares identity. The manual says so in both languages:
two boxes of different schemas raise an error rather than compare their extent,
and ~= is equality in the dimensions the two boxes share.