### PR TITLE
Name the wrapper each temporal distance, JSON field and box split tag binds

### DIFF
--- a/meos/src/json/tjsonb_jsonfuncs.c
+++ b/meos/src/json/tjsonb_jsonfuncs.c
@@ -557,7 +557,7 @@ tjsonb_array_length(const Temporal *temp)
  * @param[in] astext True when the output is a temporal text, otherwise is a
  * jsonb
  * @param[in] null_handle States the null value treatment
- * @csqlfn #Tjsonb_object_field()
+ * @csqlfn #Tjson_object_field()
  */
 Temporal *
 tjson_object_field(const Temporal *temp, const text *key, bool astext,

--- a/meos/src/npoint/tnpoint_distance.c
+++ b/meos/src/npoint/tnpoint_distance.c
@@ -69,7 +69,7 @@ datum_npoint_distance(Datum np1, Datum np2)
  * @ingroup meos_npoint_dist
  * @brief Return the temporal distance between a geometry point and a temporal
  * network point
- * @csqlfn #Tdistance_tnpoint_geo()
+ * @csqlfn #Tdistance_tnpoint_geo() #Tdistance_point_tnpoint()
  */
 Temporal *
 tdistance_tnpoint_geo(const Temporal *temp, const GSERIALIZED *gs)

--- a/meos/src/pose/tpose_distance.c
+++ b/meos/src/pose/tpose_distance.c
@@ -53,7 +53,7 @@
  * @brief Return the temporal distance between a geometry and a temporal pose
  * @param[in] temp Temporal pose
  * @param[in] gs Geometry
- * @csqlfn #Tdistance_tpose_geo()
+ * @csqlfn #Tdistance_tpose_geo() #Tdistance_point_tpose()
  */
 Temporal *
 tdistance_tpose_geo(const Temporal *temp, const GSERIALIZED *gs)

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -1565,8 +1565,7 @@ PG_FUNCTION_INFO_V1(Stbox_quad_split);
  * @ingroup mobilitydb_geo_box_transf
  * @brief Return a spatiotemporal box split with respect to its space bounds
  * in four quadrants (2D) or eight octants (3D)
- * @sqlfn stbox_intersection()
- * @sqlop @p *
+ * @sqlfn quadSplit()
  */
 Datum
 Stbox_quad_split(PG_FUNCTION_ARGS)


### PR DESCRIPTION
A @sqlfn or @csqlfn tag names the wrapper and the SQL function that the
function it documents actually binds, so the binding generators derive the
whole SQL surface it serves and drop none of it.

The temporal distance between a geometry point and a temporal network point,
and between a geometry point and a temporal pose, each name the wrapper of
both argument orders: SQL spells the geometry argument point where MEOS spells
it geo, which is why the pair reads as two names rather than one commuted
spelling. The JSON object field extraction names Tjson_object_field, the
wrapper that binds it, where the JSONB extraction of the same shape keeps
Tjsonb_object_field. The quadrant split of a spatiotemporal box answers the
SQL function quadSplit and backs no operator.