### PR TITLE
Bound the distance from a point to a segment by a distance

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -43,6 +43,7 @@
 #define __GEO_FUNCS_H__
 
 /* C */
+#include <float.h>
 #include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
@@ -94,6 +95,8 @@ typedef struct
   double x1, y1, x2, y2;         /**< Coordinates of the start/end 2D points */
   double xmin, ymin, xmax, ymax; /**< Precomputed bounding box of the edge */
   double dx, dy, length;         /**< Precomputed dx, dy, and length */
+  double tol;                    /**< Precomputed #coordinate_tolerance of the
+                                      edge, which its own coordinates fix */
   double cx, cy, radius;         /**< Arc center and radius (an arc only) */
   double theta0, theta1;         /**< Arc start/end angles (an arc only) */
   bool ccw;                      /**< Arc traversed counterclockwise */
@@ -523,40 +526,98 @@ arcarc_intersect(const Edge *e1, const Edge *e2)
  *****************************************************************************/
 
 /**
- * @brief Return true if a point is located on a segment
+ * @brief Return the distance within which two coordinates of this size are the
+ * same point
+ * @details The points a native implementation classifies are CONSTRUCTED: the
+ * midpoint of an edge, the point at a parameter along it, the intersection of
+ * two edges. None of them lands exactly where it should, and the distance it
+ * misses by is not a property of the geometry but of the arithmetic -- a few
+ * units in the last place of the largest coordinate involved. A tolerance
+ * meant to absorb that error is therefore that rounding unit, plus the
+ * absolute distance below which the implementation calls two points equal.
+ */
+static inline double
+coordinate_tolerance(double c1, double c2)
+{
+  return MEOS_GEOM_TOLERANCE + 4.0 * DBL_EPSILON * fmax(fabs(c1), fabs(c2));
+}
+
+/**
+ * @brief Set the tolerance the coordinates of an edge call for
+ * @note Read from the bounding box, so an arc is covered by the extent it
+ * occupies rather than by its two endpoints. Call once the box is set.
+ */
+static inline void
+edge_set_tolerance(Edge *e)
+{
+  e->tol = fmax(coordinate_tolerance(e->xmin, e->xmax),
+    coordinate_tolerance(e->ymin, e->ymax));
+}
+
+/**
+ * @brief Return true if a point lies within a given distance of a segment
+ * @details The tolerance is a DISTANCE. The cross and dot products below are
+ * areas, so each is compared against that distance multiplied by the size of
+ * the segment, which is what makes the test read as "the point lies within the
+ * tolerance of the segment" at every scale.
+ * @note Comparing an area against a distance is what this replaces, and it
+ * fails in both directions: dividing through, the effective perpendicular
+ * band was the tolerance divided by the length of the segment, so it closed
+ * below the representable distance where coordinates are large and opened to
+ * swallow the whole figure where the segment is short. A polygon then failed
+ * to cover itself -- 360 of the 931 h3 cells of the tbl_th3index fixture, and
+ * every one of them at a resolution finer than about 0.03 degrees.
+ * @param[in] px,py Point
+ * @param[in] x1,y1,x2,y2 Endpoints of the segment
+ * @param[in] tol Distance within which the point counts as lying on it, which
+ * an #Edge carries precomputed in its @p tol member
  */
 static inline bool
-point_on_segment(double px, double py, double x1, double y1, double x2,
-  double y2)
+point_on_segment_within(double px, double py, double x1, double y1, double x2,
+  double y2, double tol)
 {
+  /* Fast bounding-box rejection, which is where all but a few calls end */
+  if ((px < fmin(x1, x2) - tol) || (px > fmax(x1, x2) + tol) ||
+      (py < fmin(y1, y2) - tol) || (py > fmax(y1, y2) + tol))
+    return false;
+
   /* Vectors AP and AB */
   double apx = px - x1;
   double apy = py - y1;
   double abx = x2 - x1;
   double aby = y2 - y1;
 
-  /* Fast bounding-box rejection */
-  if ((px < fmin(x1, x2) - MEOS_GEOM_TOLERANCE) ||
-      (px > fmax(x1, x2) + MEOS_GEOM_TOLERANCE) ||
-      (py < fmin(y1, y2) - MEOS_GEOM_TOLERANCE) ||
-      (py > fmax(y1, y2) + MEOS_GEOM_TOLERANCE))
-    return false;
+  /* The tolerance as the area it bounds over a segment of this size */
+  double areatol = tol * (fabs(abx) + fabs(aby));
 
   /* Collinearity check via cross product */
   double cross = apx * aby - apy * abx;
-  if (fabs(cross) > MEOS_GEOM_TOLERANCE)
+  if (fabs(cross) > areatol)
     return false;
 
   /* Projection check via dot product */
   double dot = apx * abx + apy * aby;
-  if (dot < -MEOS_GEOM_TOLERANCE)
+  if (dot < -areatol)
     return false;
 
   /* Check if P lies between A and B */
   double ab2 = abx * abx + aby * aby;
-  if (dot > ab2 + MEOS_GEOM_TOLERANCE)
+  if (dot > ab2 + areatol)
     return false;
   return true;
+}
+
+/**
+ * @brief Return true if a point is located on a segment
+ * @details For a caller holding an #Edge, #point_on_segment_within takes the
+ * tolerance the edge already carries instead of deriving it again.
+ */
+static inline bool
+point_on_segment(double px, double py, double x1, double y1, double x2,
+  double y2)
+{
+  return point_on_segment_within(px, py, x1, y1, x2, y2,
+    fmax(coordinate_tolerance(x1, x2), coordinate_tolerance(y1, y2)));
 }
 
 #endif /* __GEO_FUNCS_H__ */

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -78,6 +78,7 @@ emit_ring_edges(const POINTARRAY *pa, MeosArray *edges, EdgeType etype)
     e.dx = e.x2 - e.x1; e.dy = e.y2 - e.y1;
     e.length = e.dx * e.dx + e.dy * e.dy;
     e.etype = etype;
+    edge_set_tolerance(&e);
     meos_array_add(edges, &e);
   }
   return;
@@ -101,6 +102,7 @@ extract_point(const LWPOINT *pt, MeosArray *edges)
   e.y1 = e.y2 = e.ymin = e.ymax = p.y;
   e.dx = e.dy = e.length = 0;
   e.etype = EDGE_POINT;
+  edge_set_tolerance(&e);
   meos_array_add(edges, &e);
   return;
 }
@@ -222,6 +224,7 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
       e.dx = e.dy = e.length = 0;
       e.etype = arc_etype;
       arc_set_bbox(&e);
+      edge_set_tolerance(&e);
       meos_array_add(edges, &e);
     }
     return;
@@ -241,6 +244,7 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
       e.dx = e.x2 - e.x1; e.dy = e.y2 - e.y1;
       e.length = e.dx * e.dx + e.dy * e.dy;
       e.etype = line_etype;
+      edge_set_tolerance(&e);
       meos_array_add(edges, &e);
     }
     return;
@@ -263,6 +267,7 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
   e.dx = e.dy = e.length = 0;
   e.etype = arc_etype;
   arc_set_bbox(&e);
+  edge_set_tolerance(&e);
   meos_array_add(edges, &e);
   return;
 }
@@ -3147,7 +3152,8 @@ relate_point_on_boundary(double x, double y, Edge **edges, int nedges)
     switch (e->etype)
     {
       case EDGE_POLYSEG:
-        if (point_on_segment(x, y, e->x1, e->y1, e->x2, e->y2))
+        if (point_on_segment_within(x, y, e->x1, e->y1, e->x2, e->y2,
+              e->tol))
           return true;
         break;
       case EDGE_POLYARC:
@@ -5325,10 +5331,15 @@ relate_area_edge_interior_point(const Edge *e, Edge **edges, int nedges,
     double nx = -ty;
     double ny =  tx;
 
-    /* The tolerance is deliberately small relative to the edge
-     * length. This is only used to obtain an interior witness
-     * point; all actual intersections remain exact. */
+    /* The witness steps off the edge far enough to leave the band within
+     * which #point_on_segment reads a point as lying on that edge, since
+     * #relate_point_in_area answers boundary before it answers interior and a
+     * witness inside the band would be taken for a boundary point and the
+     * interior would be reported empty. Ten times the band leaves the margin,
+     * and the step stays small relative to the edge so the witness cannot
+     * cross to the far side of the geometry. */
     double eps = fmax(MEOS_GEOM_TOLERANCE * 10.0, len * 1e-9);
+    eps = fmax(eps, 10.0 * coordinate_tolerance(px, py));
     double qx = px + eps * nx;
     double qy = py + eps * ny;
     if (relate_point_in_area(qx, qy, edges, nedges) == 0)

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -176,6 +176,41 @@ int main(void)
   free(coll); free(away); free(through); free(tin);
   meos_errno_reset();
 
+  /* A geometry covers itself, whatever its coordinates are and however short
+   * its edges. Both records below answered otherwise: the first is a five
+   * metre feature in a projected CRS, where the engine split its own edges at
+   * points that are not there and answered 2F2F11212; the second is the
+   * boundary of an H3 cell, whose edges are a few hundredths of a degree, where
+   * the interior went missing and it answered FFFF1FFF2 -- a matrix under which
+   * a cell touches itself and contains nothing. Neither is exotic: the two
+   * cover the ranges every projected dataset and every cell index live in */
+  const char *self_wkt[] = {
+    "POLYGON((509005 6617000,509002.5 6617004.3301270185,"
+      "508997.5 6617004.3301270185,508995 6617000,"
+      "508997.5 6616995.6698729815,509002.5 6616995.6698729815,"
+      "509005 6617000))",
+    "POLYGON((110.56363551525037 -23.502418506349507,"
+      "110.56870217314606 -23.532108271018778,"
+      "110.5941357885684 -23.54380157929298,"
+      "110.61448404730675 -23.525811891613976,"
+      "110.60940975095393 -23.49613923666697,"
+      "110.58399482710622 -23.48443916400023,"
+      "110.56363551525037 -23.502418506349507))"
+  };
+  char covers[10] = "T*****FF*";
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *self = geom_in(self_wkt[i], -1);
+    assert(self != NULL);
+    meos_errno_reset();
+    bool self_covers = geom_relate_pattern(self, self, covers);
+    printf("geom_relate_pattern(self %d, self %d, covers): %d, errno %d\n",
+      i, i, self_covers, meos_errno());
+    assert(self_covers == true);
+    assert(meos_errno() == 0);
+    free(self);
+  }
+
   /* Equality is read from the native DE-9IM matrix, so two circular strings
    * describing the SAME arc through DIFFERENT defining points are equal. The
    * three points lie on the circle of centre (0 0) and radius 5, which they


### PR DESCRIPTION
point_on_segment compares a cross product and a dot product, both of which have the dimension of an area, against MEOS_GEOM_TOLERANCE, which is a distance. Dividing through, the perpendicular band such a test applies is that distance divided by the length of the segment, so it closes below the representable distance where coordinates are large and opens wide enough to swallow the figure where the segment is short. Ordinary data reaches both directions, and a geometry fails to cover itself: a five metre feature in a projected CRS answers 2F2F11212, the engine having split its own edges at points that are not there, and the boundary of an H3 cell answers FFFF1FFF2, a matrix under which a cell touches itself and contains nothing.

This makes the tolerance a distance throughout. coordinate_tolerance answers the distance within which two coordinates of a given size are the same point: the absolute tolerance plus the rounding of the largest coordinate involved, which is what the points the engine classifies are actually built to. Each area is compared against that distance multiplied by the size of the segment. An edge carries the tolerance its own bounding box calls for, beside the box and the deltas it already carries, so the rejection that ends all but a few calls reads it rather than deriving it again.

The interior witness is the other half and moves with it. relate_point_in_area answers boundary before it answers interior, so a witness placed inside the band counts as a boundary point and the interior reads empty; the witness therefore steps off by ten times the same tolerance.

Measured over 931 H3 cell boundaries, every one of which is a polygon related to itself: 372 wrong matrices drop to zero. Over 220 synthetic self-pairs spanning coordinates from 1 to 1e9: 150 drop to zero. Over 14904 cross-pairs from the adversarial, areal, trip and geometry corpora, three answers change, each of them from disagreeing with GEOS to agreeing with it, and no other answer moves. Neither factor is fitted: the same corpora give the same answers with the rounding term anywhere from 1 to 1024 units in the last place and the witness margin anywhere from 1.5 to 10000.

Timed against GEOS over the 1444 areal pairs, five interleaved runs each, the median ratio is 0.895 against a median of 0.886 for the code this replaces.

The two witnesses in geo_test are the two shapes of the failure, and each fails its assertion against the code this replaces.
