### PR TITLE
Answer the traversed area only for a type that has an area

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1442,6 +1442,9 @@
 					<para><link linkend="tpose_points"><varname>points</varname></link>: Devuelve los puntos</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="tpose_trajectory"><varname>trajectory</varname></link>: Devuelve la trayectoria</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="tpose_valueAtTimestamp"><varname>valueAtTimestamp</varname></link>: Devuelve el valor en una marca de tiempo</para>
 				</listitem>
 				<listitem>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -718,6 +718,21 @@ SELECT asEWKT(points(tpose 'SRID=5676;{Pose(Point(3 3), 0.3)@2001-01-01,
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="tpose_trajectory">
+				<indexterm significance="normal"><primary><varname>trajectory</varname></primary></indexterm>
+				<para>Devuelve la trayectoria</para>
+				<para><varname>trajectory(tpose) → geometry</varname></para>
+				<para>Una pose tiene una posición y una orientación, pero no una extensión, por lo que la geometría que cubre a lo largo del tiempo es la trayectoria de su posición, como para un punto temporal. Una pose que interpola se desplaza por la línea entre dos posiciones consecutivas; una que no interpola permanece en cada una de ellas y no cubre nada entre ellas.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(trajectory(tpose '[Pose(Point(1 1),0.5)@2000-01-01, 
+  Pose(Point(3 3),0.5)@2000-01-02]'));
+-- LINESTRING(1 1,3 3)
+SELECT ST_AsText(trajectory(tpose 'Interp=Step;[Pose(Point(1 1),0.5)@2000-01-01, 
+  Pose(Point(3 3),0.5)@2000-01-02]'));
+-- MULTIPOINT((1 1),(3 3))
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="tpose_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1444,6 +1444,9 @@
 						<para><link linkend="tpose_points"><varname>points</varname></link>: Return the points</para>
 					</listitem>
 					<listitem>
+						<para><link linkend="tpose_trajectory"><varname>trajectory</varname></link>: Return the trajectory</para>
+					</listitem>
+					<listitem>
 						<para><link linkend="tpose_valueAtTimestamp"><varname>valueAtTimestamp</varname></link>: Return the value at a timestamp</para>
 					</listitem>
 					<listitem>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -725,6 +725,21 @@ SELECT asEWKT(points(tpose 'SRID=5676;{Pose(Point(3 3), 0.3)@2001-01-01,
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="tpose_trajectory">
+				<indexterm significance="normal"><primary><varname>trajectory</varname></primary></indexterm>
+				<para>Return the trajectory</para>
+				<para><varname>trajectory(tpose) → geometry</varname></para>
+				<para>A pose has a position and an orientation but no extent, so the geometry it covers over time is the trajectory of its position, as for a temporal point. A pose that interpolates moves along the line between two consecutive positions; one that does not stands at each of them and covers nothing between them.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(trajectory(tpose '[Pose(Point(1 1),0.5)@2000-01-01, 
+  Pose(Point(3 3),0.5)@2000-01-02]'));
+-- LINESTRING(1 1,3 3)
+SELECT ST_AsText(trajectory(tpose 'Interp=Step;[Pose(Point(1 1),0.5)@2000-01-01, 
+  Pose(Point(3 3),0.5)@2000-01-02]'));
+-- MULTIPOINT((1 1),(3 3))
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="tpose_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>

--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -59,6 +59,8 @@
 
 /* Utility functions */
 
+extern GSERIALIZED *geo_values_collect(const Temporal *temp, bool unary_union);
+
 extern void datum_point4d(Datum value, POINT4D *p);
 extern bool datum_point_eq(Datum point1, Datum point2);
 extern bool datum_point_same(Datum point1, Datum point2);

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1409,22 +1409,20 @@ tgeo_convex_hull(const Temporal *temp)
  *****************************************************************************/
 
 /**
- * @ingroup meos_geo_accessor
- * @brief Return the traversed area of a temporal geo or the trajectory for
- * a temporal point with discrete or step interpolation
- * @param[in] temp Temporal geo
- * @param[in] unary_union True when the PostGIS ST_UnaryUnion function is
- * applied to the result
- * @csqlfn #Tgeo_traversed_area()
+ * @brief Return the distinct values a temporal value takes, gathered into one
+ * geometry
+ * @details A value that does not interpolate holds each of its values for the
+ * whole of its own interval and covers nothing between them, so the set of
+ * values it takes IS the set of points it occupies. That answers the traversed
+ * area of a temporal geometry and the trajectory of a temporal point alike,
+ * which is why both entries read it rather than one borrowing the other
+ * @param[in] temp Temporal value
+ * @param[in] unary_union True to dissolve the values into one geometry
  */
 GSERIALIZED *
-tgeo_traversed_area(const Temporal *temp, bool unary_union)
+geo_values_collect(const Temporal *temp, bool unary_union)
 {
-  /* Ensure the validity of the arguments */
-  VALIDATE_TGEO(temp, NULL);
-  if (! ensure_nonlinear_interp(temp->flags))
-    return NULL;
-
+  assert(temp);
   /* Get the array of pointers to the component values */
   int count;
   Datum *values = temporal_values_p(temp, &count);
@@ -1441,6 +1439,39 @@ tgeo_traversed_area(const Temporal *temp, bool unary_union)
   GSERIALIZED *result = geom_unary_union(res, -1);
   pfree(res); 
   return result;
+}
+
+/**
+ * @ingroup meos_geo_accessor
+ * @brief Return the traversed area of a temporal geo that is not a point
+ * @details The values a temporal geo takes are its placements, and it holds
+ * each for the whole of its own interval, so they are also the area it
+ * traverses. A temporal point has no area and answers #tpoint_trajectory()
+ * instead
+ * @note The geodetic case reaches the same planar dissolve as the planar one,
+ * which is a property of this entry that predates the point split and is not
+ * settled by it
+ * @param[in] temp Temporal geo
+ * @param[in] unary_union True when the PostGIS ST_UnaryUnion function is
+ * applied to the result
+ * @csqlfn #Tgeo_traversed_area()
+ */
+GSERIALIZED *
+tgeo_traversed_area(const Temporal *temp, bool unary_union)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TGEO(temp, NULL);
+  /* A temporal point has no area: #tpoint_trajectory() is what answers it,
+   * and it reads #geo_values_collect() directly rather than through here */
+  if (tpoint_type(temp->temptype))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+      "The temporal value must be a temporal geometry or geography");
+    return NULL;
+  }
+  if (! ensure_nonlinear_interp(temp->flags))
+    return NULL;
+  return geo_values_collect(temp, unary_union);
 }
 
 /**

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -775,9 +775,10 @@ tpoint_trajectory(const Temporal *temp, bool unary_union)
   /* Ensure the validity of the arguments */
   VALIDATE_TPOINT(temp, NULL);
 
-  /* Call the traversed area function for discrete or step interpolation */
+  /* A point that does not interpolate stands at each of its values and covers
+   * nothing between them, so the values it takes are its whole trajectory */
   if (! MEOS_FLAGS_LINEAR_INTERP(temp->flags))
-    return tgeo_traversed_area(temp, unary_union);
+    return geo_values_collect(temp, unary_union);
 
   assert(temptype_subtype(temp->subtype));
   /* The TINSTANT case is taken care by the call to #tgeo_traversed_area */

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -1283,9 +1283,14 @@ trgeometry_traversed_area(const Temporal *temp, bool unary_union)
    * the hull of each consecutive pair, which is the case the traversed area
    * is defined for; a body with a concavity keeps the placements alone, as
    * its hull would close a concavity the body never reaches.
+   * A body that does not interpolate covers nothing between its placements:
+   * it holds each of them for the whole of its own interval and then stands
+   * at the next, so the placements ARE the area it traverses and a hull
+   * spanning two of them answers for ground the body never crosses.
    * Only the united form sweeps; the collection form answers the placements
    * themselves, which #trgeo_placements() gives a caller directly. */
-  if (unary_union && n_geoms > 1 && trgeo_ref_is_convex(trgeo_geom_p(temp)))
+  if (unary_union && n_geoms > 1 && MEOS_FLAGS_LINEAR_INTERP(temp->flags) &&
+      trgeo_ref_is_convex(trgeo_geom_p(temp)))
   {
     GSERIALIZED **swept = palloc(sizeof(GSERIALIZED *) * (n_geoms - 1));
     int n_swept = 0;

--- a/mobilitydb/sql/pose/105_tpose_spatialfuncs.in.sql
+++ b/mobilitydb/sql/pose/105_tpose_spatialfuncs.in.sql
@@ -92,13 +92,13 @@ CREATE FUNCTION minusElevation(tpose, floatspan)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
- * traversedArea, centroid, convexHull
+ * trajectory, centroid, convexHull
  *****************************************************************************/
 
-CREATE FUNCTION traversedArea(tpose, bool DEFAULT FALSE)
+CREATE FUNCTION trajectory(tpose)
   RETURNS geometry
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS
-  $$ SELECT @extschema@.traversedArea($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS 'MODULE_PATHNAME', 'Tpose_trajectory'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION centroid(tpose)
   RETURNS tgeompoint

--- a/mobilitydb/src/pose/tpose_spatialfuncs.c
+++ b/mobilitydb/src/pose/tpose_spatialfuncs.c
@@ -55,7 +55,7 @@ PG_FUNCTION_INFO_V1(Tpose_trajectory);
 /**
  * @ingroup mobilitydb_pose_accessor
  * @brief Return the trajectory of a temporal pose
- * @sqlfn atGeometry()
+ * @sqlfn trajectory()
  */
 inline Datum
 Tpose_trajectory(PG_FUNCTION_ARGS)

--- a/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
+++ b/mobilitydb/test/pose/expected/105_tpose_spatialfuncs.test.out
@@ -265,3 +265,50 @@ SELECT atElevation(
 
 SELECT atElevation(tpose 'Pose(Point(1 1),0.5)@2000-01-01', floatspan '[1, 2]');
 ERROR:  The tpose must have Z dimension
+SELECT ST_AsText(trajectory(tpose '[Pose(Point(1 1),0.5)@2000-01-01,
+  Pose(Point(3 3),0.5)@2000-01-02]'));
+      st_astext      
+---------------------
+ LINESTRING(1 1,3 3)
+(1 row)
+
+SELECT ST_AsText(trajectory(tpose 'Interp=Step;[Pose(Point(1 1),0.5)@2000-01-01,
+  Pose(Point(3 3),0.5)@2000-01-02]'));
+        st_astext        
+-------------------------
+ MULTIPOINT((1 1),(3 3))
+(1 row)
+
+SELECT ST_AsText(trajectory(tpose '{Pose(Point(1 1),0.5)@2000-01-01,
+  Pose(Point(3 3),0.5)@2000-01-02}'));
+        st_astext        
+-------------------------
+ MULTIPOINT((1 1),(3 3))
+(1 row)
+
+SELECT ST_AsText(trajectory(tpose 'Pose(Point(1 1),0.5)@2000-01-01'));
+ st_astext  
+------------
+ POINT(1 1)
+(1 row)
+
+SELECT ST_AsEWKT(trajectory(tpose 'SRID=5676;[Pose(Point(1 1),0)@2000-01-01,
+  Pose(Point(3 3),1)@2000-01-02]'));
+           st_asewkt           
+-------------------------------
+ SRID=5676;LINESTRING(1 1,3 3)
+(1 row)
+
+SELECT ST_AsText(trajectory(tpose '[Pose(Point(1 1 1),1,0,0,0)@2000-01-01,
+  Pose(Point(3 3 3),1,0,0,0)@2000-01-02]'));
+         st_astext          
+----------------------------
+ LINESTRING Z (1 1 1,3 3 3)
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE trajectory(temp) IS NOT NULL;
+ count 
+-------
+   100
+(1 row)
+

--- a/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
+++ b/mobilitydb/test/pose/queries/105_tpose_spatialfuncs.test.sql
@@ -181,3 +181,24 @@ SELECT atElevation(
 SELECT atElevation(tpose 'Pose(Point(1 1),0.5)@2000-01-01', floatspan '[1, 2]');
 
 -------------------------------------------------------------------------------
+-- trajectory
+
+-- A pose that interpolates moves along the line between its positions
+SELECT ST_AsText(trajectory(tpose '[Pose(Point(1 1),0.5)@2000-01-01,
+  Pose(Point(3 3),0.5)@2000-01-02]'));
+-- One that does not stands at each of them and covers nothing between
+SELECT ST_AsText(trajectory(tpose 'Interp=Step;[Pose(Point(1 1),0.5)@2000-01-01,
+  Pose(Point(3 3),0.5)@2000-01-02]'));
+SELECT ST_AsText(trajectory(tpose '{Pose(Point(1 1),0.5)@2000-01-01,
+  Pose(Point(3 3),0.5)@2000-01-02}'));
+SELECT ST_AsText(trajectory(tpose 'Pose(Point(1 1),0.5)@2000-01-01'));
+-- The orientation is not part of the trajectory, the SRID is carried
+SELECT ST_AsEWKT(trajectory(tpose 'SRID=5676;[Pose(Point(1 1),0)@2000-01-01,
+  Pose(Point(3 3),1)@2000-01-02]'));
+-- A 3D pose has a 3D trajectory
+SELECT ST_AsText(trajectory(tpose '[Pose(Point(1 1 1),1,0,0,0)@2000-01-01,
+  Pose(Point(3 3 3),1,0,0,0)@2000-01-02]'));
+
+SELECT COUNT(*) FROM tbl_tpose2d WHERE trajectory(temp) IS NOT NULL;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/expected/164_trgeo_spatialfuncs.test.out
+++ b/mobilitydb/test/rgeo/expected/164_trgeo_spatialfuncs.test.out
@@ -12,6 +12,13 @@ SELECT ST_AsText(round(traversedArea(
  POLYGON((0 0,0 1,3 1,3 0,0 0))
 (1 row)
 
+SELECT ST_AsText(round(traversedArea(
+  trgeometry 'Interp=Step;Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2026-01-01, Pose(Point(2 0),0)@2026-01-02]', TRUE), 6));
+                           st_astext                           
+---------------------------------------------------------------
+ MULTIPOLYGON(((0 1,1 1,1 0,0 0,0 1)),((2 1,3 1,3 0,2 0,2 1)))
+(1 row)
+
 SELECT asText(round(centroid(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2026-01-01, Pose(Point(2 0),0)@2026-01-02]'), 6));
                                                  astext                                                 

--- a/mobilitydb/test/rgeo/queries/164_trgeo_spatialfuncs.test.sql
+++ b/mobilitydb/test/rgeo/queries/164_trgeo_spatialfuncs.test.sql
@@ -41,6 +41,12 @@ SELECT ST_AsText(round(traversedArea(
 SELECT ST_AsText(round(traversedArea(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2026-01-01, Pose(Point(2 0),0)@2026-01-02]', TRUE), 6));
 
+-- A body that does not interpolate stands at each of its placements and covers
+-- nothing between them, so the united form answers the placements themselves
+-- and not the corridor between them.
+SELECT ST_AsText(round(traversedArea(
+  trgeometry 'Interp=Step;Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2026-01-01, Pose(Point(2 0),0)@2026-01-02]', TRUE), 6));
+
 -- centroid: trajectory of the polygon centroid under rigid-body motion.
 SELECT asText(round(centroid(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2026-01-01, Pose(Point(2 0),0)@2026-01-02]'), 6));


### PR DESCRIPTION
Three types reach the traversed area without one to answer for.

A temporal pose has no extent, and traversedArea(tpose) casts it through tgeompoint to tgeometry: the second cast asks for a linearly interpolated tgeometry, which no tgeometry may be, so every pose that interpolates -- the default -- ends in an error, and one that does not answers a multipoint. The trajectory is what a pose has, tpose_trajectory already computes it and its wrapper is already compiled, so the entry names that instead and the wrapper's tag names the function it is bound to.

A temporal point reaches tgeo_traversed_area from two directions: the entry accepts it, and tpoint_trajectory calls the entry to gather the values a point takes when it does not interpolate. The gathering is what both want, so it becomes geo_values_collect and each entry reads it; the area entry then answers only for a type that has an area. Every internal caller already dispatches on tpoint_type, so each of them keeps the answer it has.

A body that does not interpolate covers nothing between its placements, yet the sweep is gated on the union alone: a square standing at two places answers the corridor between them. The sweep asks for linear interpolation too, as the circular buffer already does, so the united form of such a body answers its placements.

The pose suite covers trajectory(tpose) over linear, step, discrete, instant, 3D and SRID-carrying values and over the table fixture; the rgeo suite covers the united traversed area of a body that does not interpolate. Both manuals carry the trajectory(tpose) entry and their reference appendixes are regenerated from the chapters.
