### PR TITLE
Answer the spatial relationship of two geometries from their edges

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1788,51 +1788,6 @@ GEOS2POSTGIS(GEOSGeom geom, char want3d)
 }
 
 /**
- * @brief Transform two @p GSERIALIZED geometries into @p GEOSGeometry and
- * call the GEOS function passed as argument
- */
-static bool
-meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
-  char (*func)(GEOSContextHandle_t ctx, const GEOSGeometry *geos1,
-    const GEOSGeometry *geos2))
-{
-  assert(gs1); assert(gs2); assert(func);
-  GEOSContextHandle_t ctx = geos_get_context();
-
-  GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
-  if (! geos1)
-  {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "First argument geometry could not be converted to GEOS");
-    return false;
-  }
-  GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
-  if (! geos2)
-  {
-    GEOSGeom_destroy_r(ctx, geos1);
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "Second argument geometry could not be converted to GEOS");
-    return false;
-  }
-
-  char result = func(ctx, geos1, geos2);
-
-  GEOSGeom_destroy_r(ctx, geos1); GEOSGeom_destroy_r(ctx, geos2);
-  /* GEOS reports a failure as 2, which is the relationship reporting nothing.
-   * The answer is false, the one every other failure of these functions gives;
-   * an error handler that returns, which is the handler a language binding
-   * installs, would otherwise read a relationship that was never evaluated as
-   * holding */
-  if (result == 2)
-  {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "GEOS returned error");
-    return false;
-  }
-  return (bool) result;
-}
-
-/**
  * @ingroup meos_internal_geo_base_rel
  * @brief Return true if two geometries satisfy a given spatial relationship,
  * where the function called depend on the third argument
@@ -1889,23 +1844,23 @@ geom_spatialrel(const GSERIALIZED *gs1, const GSERIALIZED *gs2, spatialRel rel)
       (gserialized_is_point(gs1) && gserialized_is_poly(gs2))))
     return meos_point_in_polygon(gs1, gs2, TOUCHES);
 
-  /* Call GEOS function */
+  /* The relationship is read from the edges of the two geometries, so a
+   * circular arc is met on its own circle rather than on the chords a
+   * linearization would put in its place */
   assert(rel == INTERSECTS || rel == CONTAINS || rel == TOUCHES ||
     rel == COVERS);
-  switch (rel)
+  LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
+  LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
+  bool result;
+  bool answered = meos_spatialrel(geom1, geom2, rel, &result);
+  lwgeom_free(geom1); lwgeom_free(geom2);
+  if (! answered)
   {
-    case INTERSECTS:
-      return meos_call_geos2(gs1, gs2, &GEOSIntersects_r);
-    case CONTAINS:
-      return meos_call_geos2(gs1, gs2, &GEOSContains_r);
-    case TOUCHES:
-      return meos_call_geos2(gs1, gs2, &GEOSTouches_r);
-    case COVERS:
-      return meos_call_geos2(gs1, gs2, &GEOSCovers_r);
-    default:
-      /* keep compiler quiet */
-      return false;
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "The spatial relationship of the geometries is not supported");
+    return false;
   }
+  return result;
 }
 
 /**

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -240,6 +240,36 @@ int main(void)
   free(arc1); free(arc2); free(arc3); free(part); free(chords);
   meos_errno_reset();
 
+  /* A relationship of a curved geometry is read on the arc itself. The
+   * polygon below is a circle of centre (49.092934300 -78.568502344) and
+   * radius 17.469913928; the segment's ends lie 1.646e-3 and 5.64 INSIDE it,
+   * so the circle contains and covers the segment. A linearization answers
+   * about the chords it puts in the arc's place, and its chord at that angle
+   * dips about 5e-3 in -- three times the clearance the near end has -- so it
+   * places that end outside and answers neither */
+  GSERIALIZED *circle = geom_in(
+    "Curvepolygon(Circularstring("
+    "66.56284822756567 -78.56850234445656,63.22639155760828 -68.29994457883014,"
+    "54.491434593668544 -61.953626864231325,43.69443400570384 -61.95362686423132,"
+    "34.9594770417641 -68.29994457883012,31.62302037180671 -78.56850234445656,"
+    "34.9594770417641 -88.83706011008299,43.69443400570384 -95.1833778246818,"
+    "54.49143459366854 -95.1833778246818,63.22639155760828 -88.83706011008299,"
+    "66.56284822756567 -78.56850234445656))", -1);
+  GSERIALIZED *inside = geom_in(
+    "Linestring(43.28384893138511 -95.04256998228166,"
+    "50.64080603370938 -90.29607546387359)", -1);
+  assert(circle != NULL); assert(inside != NULL);
+  meos_errno_reset();
+  bool arc_contains = geom_contains(circle, inside);
+  bool arc_covers = geom_covers(circle, inside);
+  printf("geom_contains(circle, segment inside it): %d, "
+    "geom_covers: %d, errno %d\n", arc_contains, arc_covers, meos_errno());
+  assert(arc_contains == true);
+  assert(arc_covers == true);
+  assert(meos_errno() == 0);
+  free(circle); free(inside);
+  meos_errno_reset();
+
   /* A malformed box3d returns NULL and sets the error status */
   meos_errno_reset();
   BOX3D *bad_box3d = box3d_in("BOX3D(1 2 3)");

--- a/mobilitydb/test/geo/expected/072_tgeo_tempspatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/072_tgeo_tempspatialrels_tbl.test.out
@@ -19,7 +19,7 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE tContains(t1.temp,
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tContains(g, temp) ?= true <> eContains(g, temp);
  count 
 -------
-   830
+   829
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE tCovers(g, temp) IS NOT NULL;


### PR DESCRIPTION
The four relationships a geometry pair answers -- intersects, contains, touches and covers -- reach GEOS once the bounding boxes and the point-in-polygon short-circuits leave the question open, while the engine that reads them from the edges answers all four and is what the canonical GEOS suite already scores 154 of 154 against. This reads them from the edges. A circular arc is met on its own circle rather than on the chords a linearization puts in its place, and a pair the edge extractor does not read reports MEOS_ERR_FEATURE_NOT_SUPPORTED as the native buffer and equality already do. Disjointness follows, being the complement of intersecting. The helper that carried a geometry pair into GEOS keeps no caller and goes with them.

Over the 16000 geometry and temporal geometry pairs the regression fixture holds, the four ever relationships answer exactly what they answered before, and one temporal answer moves. The geometry of that pair is a circle of centre (49.092934300 -78.568502344) and radius 17.469913928, and the segment it holds at that instant has its ends 1.6e-3 and 5.6 inside it, so the circle contains the segment. The chords of a linearization dip about 5e-3 in, three times the clearance the near end has, and place that end outside; asking the same question of a circle stroked to a tenth of a nanometre answers as this does, matrix 102FF1FF2. That is the single count that moves in 072_tgeo_tempspatialrels_tbl.

The pair is the witness geo_test carries, and it fails its assertion on the code this replaces.
