### PR TITLE
Report an index distance that cannot exceed the operator's own

### DIFF
--- a/meos/include/geo/stbox_index.h
+++ b/meos/include/geo/stbox_index.h
@@ -100,6 +100,8 @@ extern bool before8D(const STboxNode *nodebox, const STBox *query);
 extern bool overBefore8D(const STboxNode *nodebox, const STBox *query);
 extern bool after8D(const STboxNode *nodebox, const STBox *query);
 extern bool overAfter8D(const STboxNode *nodebox, const STBox *query);
+extern double stbox_index_distance_bound(double dist, const STBox *box1,
+  const STBox *box2);
 extern double distance_stbox_nodebox(const STBox *query,
   const STboxNode *nodebox);
 extern void tspatial_spgist_get_stbox(Datum value, MeosType type,

--- a/meos/src/geo/tspatial_spgist.c
+++ b/meos/src/geo/tspatial_spgist.c
@@ -614,6 +614,44 @@ overAfter8D(const STboxNode *nodebox, const STBox *query)
 }
 
 /**
+ * @brief Return a distance an index may report for a pair, lowered so that it
+ * cannot exceed the distance the ordering operator computes for that pair
+ * @details A kNN index distance is a LOWER BOUND: PostgreSQL orders the scan by
+ * it and, where the entry carries a bounding box rather than the value, rechecks
+ * the ordering operator and re-sorts. It refuses a recomputed distance below the
+ * one the index reported. Index and operator reach the same quantity by
+ * different arithmetic — box coordinates here, geometry there — so for an entry
+ * whose box IS its value, a single instant say, the two agree to within their
+ * rounding and the index can land one unit in the last place above.
+ * The margin is eight units in the last place of the larger of the distance and
+ * the coordinate magnitude, which covers the four roundings each side
+ * accumulates over the axis differences, their squares, the sum and the square
+ * root. ⛔ It scales with the COORDINATE magnitude, not with the distance alone:
+ * a gap of a metre between coordinates of 1e7 carries the rounding of 1e7, and
+ * an absolute margin would be inert there and enormous near the origin.
+ * @param[in] dist Distance the index computes
+ * @param[in] box1,box2 Boxes the distance is computed from
+ */
+double
+stbox_index_distance_bound(double dist, const STBox *box1, const STBox *box2)
+{
+  if (! (dist > 0.0) || dist == DBL_MAX)
+    return dist;
+  double scale = dist;
+  const STBox *boxes[2] = { box1, box2 };
+  for (int i = 0; i < 2; i++)
+  {
+    if (! boxes[i])
+      continue;
+    scale = fmax(scale, fmax(fabs(boxes[i]->xmin), fabs(boxes[i]->xmax)));
+    scale = fmax(scale, fmax(fabs(boxes[i]->ymin), fabs(boxes[i]->ymax)));
+    if (MEOS_FLAGS_GET_Z(boxes[i]->flags))
+      scale = fmax(scale, fmax(fabs(boxes[i]->zmin), fabs(boxes[i]->zmax)));
+  }
+  return fmax(dist - 8 * DBL_EPSILON * scale, 0.0);
+}
+
+/**
  * @brief Return the lower bound for the distance between a query and a nodebox
  * @note The temporal dimension is only taken into account for returning
  * +infinity (which will be translated into NULL) if the boxes do not
@@ -661,7 +699,10 @@ distance_stbox_nodebox(const STBox *query, const STboxNode *nodebox)
       dz = 0;
   }
 
-  return hasz ? hypot3d(dx, dy, dz) : hypot(dx, dy);
+  /* A nodebox is a bound, never a value, so the reported distance is lowered
+   * to stay under the one the ordering operator computes */
+  double dist = hasz ? hypot3d(dx, dy, dz) : hypot(dx, dy);
+  return stbox_index_distance_bound(dist, query, &nodebox->left);
 }
 
 /**

--- a/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
@@ -186,8 +186,8 @@ CREATE FUNCTION nearestApproachDistance(geometry, tcbuffer)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(stbox, tcbuffer)
   RETURNS float
-  AS 'SELECT @extschema@.nearestApproachDistance(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAD_stbox_tcbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(cbuffer, tcbuffer)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_cbuffer_tcbuffer'
@@ -198,8 +198,8 @@ CREATE FUNCTION nearestApproachDistance(tcbuffer, geometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tcbuffer, stbox)
   RETURNS float
-  AS 'SELECT @extschema@.nearestApproachDistance($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAD_tcbuffer_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tcbuffer, cbuffer)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_tcbuffer_cbuffer'

--- a/mobilitydb/sql/pose/110_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/110_tpose_distance.in.sql
@@ -185,8 +185,8 @@ CREATE FUNCTION nearestApproachDistance(geometry, tpose)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(stbox, tpose)
   RETURNS float
-  AS 'SELECT @extschema@.nearestApproachDistance(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAD_stbox_tpose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(pose, tpose)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_pose_tpose'
@@ -197,8 +197,8 @@ CREATE FUNCTION nearestApproachDistance(tpose, geometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tpose, stbox)
   RETURNS float
-  AS 'SELECT @extschema@.nearestApproachDistance($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'NAD_tpose_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(tpose, pose)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_tpose_pose'

--- a/mobilitydb/src/geo/tspatial_gist.c
+++ b/mobilitydb/src/geo/tspatial_gist.c
@@ -414,6 +414,13 @@ stbox_gist_distance(FunctionCallInfo fcinfo, bool boxcolumn)
   if (distance < 0)
     PG_RETURN_FLOAT8(DBL_MAX);
 
+  /* An inner entry, and a leaf entry the executor rechecks, carry a bounding
+   * box rather than the value, so what they report is lowered to stay under
+   * the distance the ordering operator computes. The exact leaf of a column of
+   * boxes reports the operator's own answer and keeps it */
+  if (! GIST_LEAF(entry) || *recheck)
+    distance = stbox_index_distance_bound(distance, key, &query);
+
   PG_RETURN_FLOAT8(distance);
 }
 

--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -847,7 +847,10 @@ Stbox_spgist_leaf_consistent(PG_FUNCTION_ARGS)
       Datum value = scankey->sk_argument;
       MeosType type = oid_meostype(scankey->sk_subtype);
       tspatial_spgist_get_stbox(value, type, &box);
-      distances[i] = nad_stbox_stbox(&box, key);
+      /* A leaf key is a bounding box the executor rechecks, so what it
+       * reports is lowered to stay under the operator's own distance */
+      distances[i] = stbox_index_distance_bound(nad_stbox_stbox(&box, key),
+        &box, key);
     }
   }
 

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -739,6 +739,30 @@ SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01
  7.800000
 (1 row)
 
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX XT(((10,-1),(12,1)),[2000-01-01, 2000-01-03])')::numeric, 6);
+  round   
+----------
+ 7.500000
+(1 row)
+
+SELECT round(nearestApproachDistance(stbox 'STBOX XT(((10,-1),(12,1)),[2000-01-01, 2000-01-03])', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]')::numeric, 6);
+  round   
+----------
+ 7.500000
+(1 row)
+
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX X((10,-1),(12,1))')::numeric, 6);
+  round   
+----------
+ 5.500000
+(1 row)
+
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX XT(((10,-1),(12,1)),[2000-02-01, 2000-02-02])')::numeric, 6);
+ round 
+-------
+      
+(1 row)
+
 SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(0 0), 1)@2000-01-01, Cbuffer(Point(10 0), 1)@2000-01-02]', cbuffer 'Cbuffer(Point(5 6), 2)'));
       st_astext      
 ---------------------

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -315,6 +315,14 @@ SELECT nearestApproachDistance(tcbuffer 'Cbuffer(Point(0 0), 0.5)@2000-01-01', c
 -- A buffer beside the path: the distance is the centre distance less both radii
 SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)')::numeric, 6);
 
+-- A box carrying a period measures the part of the temporal buffer inside it
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX XT(((10,-1),(12,1)),[2000-01-01, 2000-01-03])')::numeric, 6);
+SELECT round(nearestApproachDistance(stbox 'STBOX XT(((10,-1),(12,1)),[2000-01-01, 2000-01-03])', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]')::numeric, 6);
+-- The same box with no period measures the whole temporal buffer
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX X((10,-1),(12,1))')::numeric, 6);
+-- No part of the temporal buffer is inside the period
+SELECT round(nearestApproachDistance(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX XT(((10,-1),(12,1)),[2000-02-01, 2000-02-02])')::numeric, 6);
+
 -- The shortest line against a static circular buffer runs between the two disk
 -- boundaries, so its length is the nearest approach distance of the same pair.
 -- Reading the disc and the traversed area as polygons measures between two

--- a/mobilitydb/test/pose/expected/110_tpose_indexes_tbl.test.out
+++ b/mobilitydb/test/pose/expected/110_tpose_indexes_tbl.test.out
@@ -264,11 +264,11 @@ WITH test AS (
   SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
   FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
- round 
--------
-     0
-     0
-     0
+   round   
+-----------
+ 13.283949
+ 18.005858
+          
 (3 rows)
 
 DROP INDEX tbl_tpose2d_rtree_idx;
@@ -312,11 +312,11 @@ WITH test AS (
   SELECT temp |=| stbox 'SRID=3812;STBOX XT(((0,0),(50,50)),[2001-06-01, 2001-07-01])' AS distance
   FROM tbl_tpose2d ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
- round 
--------
-     0
-     0
-     0
+   round   
+-----------
+ 13.283949
+ 18.005858
+          
 (3 rows)
 
 DROP INDEX tbl_tpose2d_quadtree_idx;

--- a/mobilitydb/test/pose/expected/113_tpose_distance.test.out
+++ b/mobilitydb/test/pose/expected/113_tpose_distance.test.out
@@ -228,6 +228,30 @@ SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose
      0
 (1 row)
 
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX XT(((10,-1),(12,1)),[2000-01-01, 2000-01-03])'), 6);
+ round 
+-------
+     8
+(1 row)
+
+SELECT round(nearestApproachDistance(stbox 'STBOX XT(((10,-1),(12,1)),[2000-01-01, 2000-01-03])', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+ round 
+-------
+     8
+(1 row)
+
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((10,-1),(12,1))'), 6);
+ round 
+-------
+     6
+(1 row)
+
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX XT(((10,-1),(12,1)),[2000-02-01, 2000-02-02])'), 6);
+ round 
+-------
+      
+(1 row)
+
 SELECT round(nearestApproachDistance(
   tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
   tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'), 6);

--- a/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
+++ b/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
@@ -95,6 +95,14 @@ SELECT round(nearestApproachDistance(pose 'Pose(Point(2 0),0)', tpose '[Pose(Poi
 SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'), 6);
 SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'), 6);
 SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'), 6);
+
+-- A box carrying a period measures the part of the temporal pose inside it
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX XT(((10,-1),(12,1)),[2000-01-01, 2000-01-03])'), 6);
+SELECT round(nearestApproachDistance(stbox 'STBOX XT(((10,-1),(12,1)),[2000-01-01, 2000-01-03])', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'), 6);
+-- The same box with no period measures the whole temporal pose
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((10,-1),(12,1))'), 6);
+-- No part of the temporal pose is inside the period
+SELECT round(nearestApproachDistance(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX XT(((10,-1),(12,1)),[2000-02-01, 2000-02-02])'), 6);
 SELECT round(nearestApproachDistance(
   tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
   tpose '[Pose(Point(0 2),0)@2000-01-01, Pose(Point(4 2),0)@2000-01-05]'), 6);


### PR DESCRIPTION
A kNN index distance is a lower bound: PostgreSQL orders the scan by it and, where the entry carries a bounding box rather than the value, rechecks the ordering operator and re-sorts, refusing a recomputed distance below the one the index reported. Index and operator reach the same quantity by different arithmetic, box coordinates against geometry, so for an entry whose box IS its value they agree only to within their rounding: a temporal pose holding a single instant answers 13.28394889316793 through the operator while nad_stbox_stbox answers 13.283948893167931, one unit in the last place above, and an ordered scan reaching that row raises "index returned tuples in wrong order". stbox_index_distance_bound lowers a distance an index reports by eight units in the last place of the larger of the distance and the coordinate magnitude, covering the four roundings each side accumulates over the axis differences, their squares, the sum and the square root; the margin scales with the coordinate magnitude rather than the distance alone, since a gap of a metre between coordinates of 1e7 carries the rounding of 1e7. The GiST distance, the SP-GiST leaf distances and the SP-GiST nodebox distance report through it, while the exact leaf of a column of spatiotemporal boxes keeps the answer the operator itself computes, and the whole suite passes unchanged on that commit alone since nothing reads the bound. The second commit binds the four nearestApproachDistance signatures pairing a box with a tcbuffer or a tpose to their C wrappers, which measure from the part of the value the box period holds, in place of a cast composition that reaches the box as its envelope alone: a disc of radius 0.5 travelling from Point(0 0) to Point(4 0) over four days answers 7.5 to a box over [10,12]x[-1,1] holding its first half and 5.5 to the same box carrying no period. The kNN scans of 110_tpose_indexes_tbl answer 13.283949, 18.005858 and NULL, which is what a sequential scan of that table answers for the same box.