### PR TITLE
Name the concatenation by the portable dialect

### DIFF
--- a/doc/es/portable_sql.xml
+++ b/doc/es/portable_sql.xml
@@ -15,7 +15,7 @@
 
 	<para>Este capítulo es la referencia canónica, a nivel de todo el ecosistema, de esa correspondencia. Un motor que no acepte un operador dado puede consultarlo aquí y usar la forma de función en su lugar. Por ejemplo, DuckDB no acepta ningún operador que contenga <literal>#</literal> (reserva <literal>#</literal> para las referencias posicionales de columna), de modo que en MobilityDuck las comparaciones temporales (<literal>#=</literal>, …) se escriben <varname>tEq</varname>, … y las pruebas de posición temporal (<literal>&lt;&lt;#</literal>, <literal>#&gt;&gt;</literal>, <literal>&amp;&lt;#</literal>, <literal>#&amp;&gt;</literal>) se escriben <varname>before</varname>, <varname>after</varname>, <varname>overbefore</varname>, <varname>overafter</varname>, mientras que los operadores que sí acepta pueden usarse directamente.</para>
 
-	<para>Las funciones de relación espacial (<varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>eDwithin</varname>, …) y las funciones de restricción (<varname>atTime</varname>, <varname>atGeometry</varname>, <varname>atValue</varname>, …) son siempre funciones con nombre (no tienen operador). El comparador de ordenación de árbol B es asimismo la función con nombre <varname>cmp(a, b)</varname>, que devuelve <literal>-1</literal>, <literal>0</literal> o <literal>1</literal> y no tiene operador. Cada operador se corresponde con un nombre simple de la manera siguiente; para los operadores aritméticos y de teoría de conjuntos el nombre de la función lleva el prefijo de la familia de tipos del operando (<varname>set</varname>, <varname>span</varname> o <varname>spanset</varname>, y <varname>t</varname> para los números temporales).</para>
+	<para>Las funciones de relación espacial (<varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>eDwithin</varname>, …) y las funciones de restricción (<varname>atTime</varname>, <varname>atGeometry</varname>, <varname>atValue</varname>, …) son siempre funciones con nombre (no tienen operador). El comparador de ordenación de árbol B es asimismo la función con nombre <varname>cmp(a, b)</varname>, que devuelve <literal>-1</literal>, <literal>0</literal> o <literal>1</literal> y no tiene operador. Cada operador se corresponde con un nombre simple de la manera siguiente; para los operadores aritméticos y de teoría de conjuntos el nombre de la función lleva el prefijo de la familia de tipos del operando (<varname>set</varname>, <varname>span</varname> o <varname>spanset</varname>, y <varname>t</varname> para los valores temporales).</para>
 
 	<informaltable frame="all" colsep="1" rowsep="1">
 		<?dblatex table-width="autowidth.column: 1 2 3"?>
@@ -85,6 +85,7 @@
 				<row><entry>Unión (set / span / span set)</entry><entry>+</entry><entry>setUnion / spanUnion / spansetUnion (a, b)</entry></row>
 				<row><entry>Intersección (set / span / span set)</entry><entry>*</entry><entry>setIntersection / spanIntersection / spansetIntersection (a, b)</entry></row>
 				<row><entry>Diferencia (set / span / span set)</entry><entry>-</entry><entry>setMinus / spanMinus / spansetMinus (a, b)</entry></row>
+				<row><entry>Concatenación (set / temporal)</entry><entry>||</entry><entry>setConcat / tConcat (a, b)</entry></row>
 			</tbody>
 		</tgroup>
 	</informaltable>

--- a/doc/portable_sql.xml
+++ b/doc/portable_sql.xml
@@ -15,7 +15,7 @@
 
 	<para>This chapter is the canonical, ecosystem-wide reference for that mapping. An engine that does not accept a given operator can look it up here and use the function form instead. For example, DuckDB does not accept any operator containing <literal>#</literal> (it reserves <literal>#</literal> for positional column references), so on MobilityDuck the temporal comparisons (<literal>#=</literal>, …) are written <varname>tEq</varname>, … and the time-position tests (<literal>&lt;&lt;#</literal>, <literal>#&gt;&gt;</literal>, <literal>&amp;&lt;#</literal>, <literal>#&amp;&gt;</literal>) are written <varname>before</varname>, <varname>after</varname>, <varname>overbefore</varname>, <varname>overafter</varname>, while the operators it does accept may be used directly.</para>
 
-	<para>The spatial-relationship functions (<varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>eDwithin</varname>, …) and the restriction functions (<varname>atTime</varname>, <varname>atGeometry</varname>, <varname>atValue</varname>, …) are only ever named functions (they have no operator). The B-tree ordering comparator is likewise the named function <varname>cmp(a, b)</varname>, which returns <literal>-1</literal>, <literal>0</literal> or <literal>1</literal> and has no operator. Every operator maps to a bare name as follows; for the arithmetic and set-theoretic operators the function name carries the operand's type-family prefix (<varname>set</varname>, <varname>span</varname> or <varname>spanset</varname>, and <varname>t</varname> for temporal numbers).</para>
+	<para>The spatial-relationship functions (<varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>eDwithin</varname>, …) and the restriction functions (<varname>atTime</varname>, <varname>atGeometry</varname>, <varname>atValue</varname>, …) are only ever named functions (they have no operator). The B-tree ordering comparator is likewise the named function <varname>cmp(a, b)</varname>, which returns <literal>-1</literal>, <literal>0</literal> or <literal>1</literal> and has no operator. Every operator maps to a bare name as follows; for the arithmetic and set-theoretic operators the function name carries the operand's type-family prefix (<varname>set</varname>, <varname>span</varname> or <varname>spanset</varname>, and <varname>t</varname> for temporal values).</para>
 
 	<informaltable frame="all" colsep="1" rowsep="1">
 		<?dblatex table-width="autowidth.column: 1 2 3"?>
@@ -85,6 +85,7 @@
 				<row><entry>Union (set / span / span set)</entry><entry>+</entry><entry>setUnion / spanUnion / spansetUnion (a, b)</entry></row>
 				<row><entry>Intersection (set / span / span set)</entry><entry>*</entry><entry>setIntersection / spanIntersection / spansetIntersection (a, b)</entry></row>
 				<row><entry>Difference (set / span / span set)</entry><entry>-</entry><entry>setMinus / spanMinus / spansetMinus (a, b)</entry></row>
+				<row><entry>Concatenation (set / temporal)</entry><entry>||</entry><entry>setConcat / tConcat (a, b)</entry></row>
 			</tbody>
 		</tgroup>
 	</informaltable>

--- a/mobilitydb/sql/json/451_jsonbset_jsonfuncs.in.sql
+++ b/mobilitydb/sql/json/451_jsonbset_jsonfuncs.in.sql
@@ -156,21 +156,21 @@ CREATE FUNCTION textset(jsonbset, text,
 
 /*****************************************************************************/
 
-CREATE FUNCTION jsonbsetConcat(jsonb, jsonbset)
+CREATE FUNCTION setConcat(jsonb, jsonbset)
   RETURNS jsonbset
   AS 'MODULE_PATHNAME', 'Concat_jsonb_jsonbset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION jsonbsetConcat(jsonbset, jsonb)
+CREATE FUNCTION setConcat(jsonbset, jsonb)
   RETURNS jsonbset
   AS 'MODULE_PATHNAME', 'Concat_jsonbset_jsonb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR || (
-  PROCEDURE = jsonbsetConcat,
+  PROCEDURE = setConcat,
   LEFTARG   = jsonb, RIGHTARG = jsonbset
 );
 CREATE OPERATOR || (
-  PROCEDURE = jsonbsetConcat,
+  PROCEDURE = setConcat,
   LEFTARG   = jsonbset, RIGHTARG = jsonb
 );
 

--- a/mobilitydb/sql/json/454_tjsonb_jsonfuncs.in.sql
+++ b/mobilitydb/sql/json/454_tjsonb_jsonfuncs.in.sql
@@ -202,29 +202,29 @@ CREATE FUNCTION ttext(tjsonb, text, null_handle text DEFAULT 'raise_exception')
 
 /*****************************************************************************/
 
-CREATE FUNCTION tjsonbConcat(jsonb, tjsonb)
+CREATE FUNCTION tConcat(jsonb, tjsonb)
   RETURNS tjsonb
   AS 'MODULE_PATHNAME', 'Concat_jsonb_tjsonb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tjsonbConcat(tjsonb, jsonb)
+CREATE FUNCTION tConcat(tjsonb, jsonb)
   RETURNS tjsonb
   AS 'MODULE_PATHNAME', 'Concat_tjsonb_jsonb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tjsonbConcat(tjsonb, tjsonb)
+CREATE FUNCTION tConcat(tjsonb, tjsonb)
   RETURNS tjsonb
   AS 'MODULE_PATHNAME', 'Concat_tjsonb_tjsonb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR || (
-  PROCEDURE = tjsonbConcat,
+  PROCEDURE = tConcat,
   LEFTARG   = jsonb, RIGHTARG = tjsonb
 );
 CREATE OPERATOR || (
-  PROCEDURE = tjsonbConcat,
+  PROCEDURE = tConcat,
   LEFTARG   = tjsonb, RIGHTARG = jsonb
 );
 CREATE OPERATOR || (
-  PROCEDURE = tjsonbConcat,
+  PROCEDURE = tConcat,
   LEFTARG   = tjsonb, RIGHTARG = tjsonb
 );
 

--- a/mobilitydb/sql/temporal/001_set.in.sql
+++ b/mobilitydb/sql/temporal/001_set.in.sql
@@ -722,21 +722,21 @@ CREATE FUNCTION unnest(tstzset)
  * Temporal text concatenation
  *****************************************************************************/
 
-CREATE FUNCTION textset_cat(text, textset)
+CREATE FUNCTION setConcat(text, textset)
   RETURNS textset
   AS 'MODULE_PATHNAME', 'Textcat_text_textset'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION textset_cat(textset, text)
+CREATE FUNCTION setConcat(textset, text)
   RETURNS textset
   AS 'MODULE_PATHNAME', 'Textcat_textset_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR || (
-  PROCEDURE = textset_cat,
+  PROCEDURE = setConcat,
   LEFTARG = text, RIGHTARG = textset
 );
 CREATE OPERATOR || (
-  PROCEDURE = textset_cat,
+  PROCEDURE = setConcat,
   LEFTARG = textset, RIGHTARG = text
 );
 

--- a/mobilitydb/sql/temporal/029_ttext_textfuncs.in.sql
+++ b/mobilitydb/sql/temporal/029_ttext_textfuncs.in.sql
@@ -36,29 +36,29 @@
  * Temporal text concatenation
  *****************************************************************************/
 
-CREATE FUNCTION ttext_cat(text, ttext)
+CREATE FUNCTION tConcat(text, ttext)
   RETURNS ttext
   AS 'MODULE_PATHNAME', 'Textcat_text_ttext'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION ttext_cat(ttext, text)
+CREATE FUNCTION tConcat(ttext, text)
   RETURNS ttext
   AS 'MODULE_PATHNAME', 'Textcat_ttext_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION ttext_cat(ttext, ttext)
+CREATE FUNCTION tConcat(ttext, ttext)
   RETURNS ttext
   AS 'MODULE_PATHNAME', 'Textcat_ttext_ttext'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR || (
-  PROCEDURE = ttext_cat,
+  PROCEDURE = tConcat,
   LEFTARG = text, RIGHTARG = ttext
 );
 CREATE OPERATOR || (
-  PROCEDURE = ttext_cat,
+  PROCEDURE = tConcat,
   LEFTARG = ttext, RIGHTARG = text
 );
 CREATE OPERATOR || (
-  PROCEDURE = ttext_cat,
+  PROCEDURE = tConcat,
   LEFTARG = ttext, RIGHTARG = ttext
 );
 

--- a/mobilitydb/src/json/jsonbset_jsonfuncs.c
+++ b/mobilitydb/src/json/jsonbset_jsonfuncs.c
@@ -177,7 +177,7 @@ PG_FUNCTION_INFO_V1(Concat_jsonb_jsonbset);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Concat a JSONB value with a JSONB set
- * @sqlfn jsonbsetConcat()
+ * @sqlfn setConcat()
  * @sqlop @p ||
  */
 Datum
@@ -199,7 +199,7 @@ PG_FUNCTION_INFO_V1(Concat_jsonbset_jsonb);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Concat a JSONB set with a JSONB value
- * @sqlfn jsonbsetConcat()
+ * @sqlfn setConcat()
  * @sqlop @p ||
  */
 Datum

--- a/mobilitydb/src/json/tjsonb_jsonfuncs.c
+++ b/mobilitydb/src/json/tjsonb_jsonfuncs.c
@@ -338,7 +338,7 @@ PG_FUNCTION_INFO_V1(Concat_jsonb_tjsonb);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Concat a JSONB value with a temporal JSONB
- * @sqlfn tjsonbConcat()
+ * @sqlfn tConcat()
  * @sqlop @p ||
  */
 Datum
@@ -360,7 +360,7 @@ PG_FUNCTION_INFO_V1(Concat_tjsonb_jsonb);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Concat a temporal JSONB with a JSONB value
- * @sqlfn tjsonbConcat()
+ * @sqlfn tConcat()
  * @sqlop @p ||
  */
 Datum
@@ -382,7 +382,7 @@ PG_FUNCTION_INFO_V1(Concat_tjsonb_tjsonb);
 /**
  * @ingroup mobilitydb_json_json
  * @brief Concat two temporal JSONB values
- * @sqlfn tjsonbConcat()
+ * @sqlfn tConcat()
  * @sqlop @p ||
  */
 Datum

--- a/mobilitydb/src/temporal/set.c
+++ b/mobilitydb/src/temporal/set.c
@@ -692,7 +692,7 @@ PG_FUNCTION_INFO_V1(Textcat_text_textset);
 /**
  * @ingroup mobilitydb_setspan_transf
  * @brief Return a text value concatenated with a text set
- * @sqlfn textset_cat()
+ * @sqlfn setConcat()
  * @sqlop @p ||
  */
 Datum
@@ -711,7 +711,7 @@ PG_FUNCTION_INFO_V1(Textcat_textset_text);
 /**
  * @ingroup mobilitydb_setspan_transf
  * @brief Return a text set concatenated with a text value
- * @sqlfn textset_cat()
+ * @sqlfn setConcat()
  * @sqlop @p ||
  */
 Datum

--- a/mobilitydb/src/temporal/ttext_funcs.c
+++ b/mobilitydb/src/temporal/ttext_funcs.c
@@ -48,7 +48,7 @@ PG_FUNCTION_INFO_V1(Textcat_text_ttext);
 /**
  * @ingroup mobilitydb_temporal_text
  * @brief Return the concatenation of a text and a temporal text
- * @sqlfn textcat()
+ * @sqlfn tConcat()
  * @sqlop @p ||
  */
 Datum
@@ -66,7 +66,7 @@ PG_FUNCTION_INFO_V1(Textcat_ttext_text);
 /**
  * @ingroup mobilitydb_temporal_text
  * @brief Return the concatenation of a temporal text and a text
- * @sqlfn textcat()
+ * @sqlfn tConcat()
  * @sqlop @p ||
  */
 Datum
@@ -84,7 +84,7 @@ PG_FUNCTION_INFO_V1(Textcat_ttext_ttext);
 /**
  * @ingroup mobilitydb_temporal_text
  * @brief Return the concatenation of the two temporal texts
- * @sqlfn textcat()
+ * @sqlfn tConcat()
  * @sqlop @p ||
  */
 Datum

--- a/tools/codegen/inherited/manifest.d/span_families.yaml
+++ b/tools/codegen/inherited/manifest.d/span_families.yaml
@@ -2262,11 +2262,11 @@ span_families:
   - lit: "\n/******************************************************************************\n * Transform a set to a set of values\n ******************************************************************************/\n\n"
   - {sig: "unnest({vs})", ret: "SETOF {v}", sym: Set_unnest}
   - lit: "\n/*****************************************************************************\n * Temporal text concatenation\n *****************************************************************************/\n\n"
-  - {sig: "textset_cat({v}, {vs})", ret: "{vs}", sym: Textcat_text_textset, only: [text]}
-  - {sig: "textset_cat({vs}, {v})", ret: "{vs}", sym: Textcat_textset_text, only: [text]}
+  - {sig: "setConcat({v}, {vs})", ret: "{vs}", sym: Textcat_text_textset, only: [text]}
+  - {sig: "setConcat({vs}, {v})", ret: "{vs}", sym: Textcat_textset_text, only: [text]}
   - lit: "\n"
-  - {stmt: "CREATE OPERATOR || (\n  PROCEDURE = textset_cat,\n  LEFTARG = {v}, RIGHTARG = {vs}\n);", only: [text]}
-  - {stmt: "CREATE OPERATOR || (\n  PROCEDURE = textset_cat,\n  LEFTARG = {vs}, RIGHTARG = {v}\n);", only: [text]}
+  - {stmt: "CREATE OPERATOR || (\n  PROCEDURE = setConcat,\n  LEFTARG = {v}, RIGHTARG = {vs}\n);", only: [text]}
+  - {stmt: "CREATE OPERATOR || (\n  PROCEDURE = setConcat,\n  LEFTARG = {vs}, RIGHTARG = {v}\n);", only: [text]}
   - lit: "\n"
 
 - family: geoset_transformations

--- a/tools/codegen/portable_aliases/generate.py
+++ b/tools/codegen/portable_aliases/generate.py
@@ -41,8 +41,8 @@ OP_TO_NAME = {
 # portable under its own name -- documented, not a gap.
 ALREADY_NAMED = {
     "@=": "same_rid", "?@": "contained_rid", "@?": "contains_rid",
-    "@@": "overlaps_rid", "&": "tbool_and", "|": "tbool_or",
-    "~": "tbool_not", "||": "tConcat",
+    "@@": "overlaps_rid", "&": "tAnd", "|": "tOr",
+    "~": "tNot", "||": "setConcat / tConcat",
 }
 
 # Coverage-audit buckets: operators that need no portable rename.


### PR DESCRIPTION
The functions backing || carry the portable bare name the dialect gives the
operator: setConcat over a set and tConcat over a temporal value, each
overloaded by argument type the way setUnion and tAdd are, so one name serves
the text and the JSONB families rather than one name per type. The manual's
Portable Named-Function Dialect lists the operator alongside the union,
intersection and difference it sits with, in both languages, and the type-family
prefix it describes reads t for a temporal value, which is what tAnd over a
temporal boolean and tConcat over a temporal text both carry.

The operator coverage tool records the backing name of every symbol it
classifies as already portable, and the three temporal boolean operators answer
tAnd, tOr and tNot, the names their SQL functions and the manual both carry.