### PR TITLE
Leave the nearest approach instant and shortest line to a box unwritten

### DIFF
--- a/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
@@ -153,10 +153,6 @@ CREATE FUNCTION nearestApproachInstant(geometry, tcbuffer)
   RETURNS tcbuffer
   AS 'MODULE_PATHNAME', 'NAI_geo_tcbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nearestApproachInstant(stbox, tcbuffer)
-  RETURNS tcbuffer
-  AS 'SELECT @extschema@.nearestApproachInstant(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(cbuffer, tcbuffer)
   RETURNS tcbuffer
   AS 'MODULE_PATHNAME', 'NAI_cbuffer_tcbuffer'
@@ -165,10 +161,6 @@ CREATE FUNCTION nearestApproachInstant(tcbuffer, geometry)
   RETURNS tcbuffer
   AS 'MODULE_PATHNAME', 'NAI_tcbuffer_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nearestApproachInstant(tcbuffer, stbox)
-  RETURNS tcbuffer
-  AS 'SELECT @extschema@.nearestApproachInstant($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(tcbuffer, cbuffer)
   RETURNS tcbuffer
   AS 'MODULE_PATHNAME', 'NAI_tcbuffer_cbuffer'
@@ -251,10 +243,6 @@ CREATE FUNCTION shortestLine(geometry, tcbuffer)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_geo_tcbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION shortestLine(stbox, tcbuffer)
-  RETURNS geometry
-  AS 'SELECT @extschema@.shortestLine(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION shortestLine(cbuffer, tcbuffer)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_cbuffer_tcbuffer'
@@ -263,10 +251,6 @@ CREATE FUNCTION shortestLine(tcbuffer, geometry)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_tcbuffer_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION shortestLine(tcbuffer, stbox)
-  RETURNS geometry
-  AS 'SELECT @extschema@.shortestLine($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tcbuffer, cbuffer)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_tcbuffer_cbuffer'

--- a/mobilitydb/sql/pose/110_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/110_tpose_distance.in.sql
@@ -152,10 +152,6 @@ CREATE FUNCTION nearestApproachInstant(geometry, tpose)
   RETURNS tpose
   AS 'MODULE_PATHNAME', 'NAI_geo_tpose'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nearestApproachInstant(stbox, tpose)
-  RETURNS tpose
-  AS 'SELECT @extschema@.nearestApproachInstant(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(pose, tpose)
   RETURNS tpose
   AS 'MODULE_PATHNAME', 'NAI_pose_tpose'
@@ -164,10 +160,6 @@ CREATE FUNCTION nearestApproachInstant(tpose, geometry)
   RETURNS tpose
   AS 'MODULE_PATHNAME', 'NAI_tpose_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nearestApproachInstant(tpose, stbox)
-  RETURNS tpose
-  AS 'SELECT @extschema@.nearestApproachInstant($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION nearestApproachInstant(tpose, pose)
   RETURNS tpose
   AS 'MODULE_PATHNAME', 'NAI_tpose_pose'
@@ -250,10 +242,6 @@ CREATE FUNCTION shortestLine(geometry, tpose)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_geo_tpose'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION shortestLine(stbox, tpose)
-  RETURNS geometry
-  AS 'SELECT @extschema@.shortestLine(geometry($1), $2)'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION shortestLine(pose, tpose)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_pose_tpose'
@@ -262,10 +250,6 @@ CREATE FUNCTION shortestLine(tpose, geometry)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_tpose_geo'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION shortestLine(tpose, stbox)
-  RETURNS geometry
-  AS 'SELECT @extschema@.shortestLine($1, geometry($2))'
-  LANGUAGE SQL IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION shortestLine(tpose, pose)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Shortestline_tpose_pose'

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -495,12 +495,6 @@ SELECT asText(nearestApproachInstant(geometry 'Point(2 3)', tcbuffer '[Cbuffer(P
  Cbuffer(POINT(2 0),0.5)@Mon Jan 03 00:00:00 2000 PST
 (1 row)
 
-SELECT asText(nearestApproachInstant(stbox 'STBOX X((5,2),(7,4))', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
-                        astext                        
-------------------------------------------------------
- Cbuffer(POINT(4 0),0.5)@Wed Jan 05 00:00:00 2000 PST
-(1 row)
-
 SELECT asText(nearestApproachInstant(cbuffer 'Cbuffer(Point(4 9), 0.7)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
                         astext                        
 ------------------------------------------------------
@@ -511,12 +505,6 @@ SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01
                         astext                        
 ------------------------------------------------------
  Cbuffer(POINT(2 0),0.5)@Mon Jan 03 00:00:00 2000 PST
-(1 row)
-
-SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX X((5,2),(7,4))'));
-                        astext                        
-------------------------------------------------------
- Cbuffer(POINT(4 0),0.5)@Wed Jan 05 00:00:00 2000 PST
 (1 row)
 
 SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)'));

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -230,10 +230,8 @@ SELECT abs(a - b) < 1e-3 FROM d;
 -- Every overload, against a buffer sweeping from (0 0) to (4 0). Each probe is
 -- placed so that a single instant attains the minimum.
 SELECT asText(nearestApproachInstant(geometry 'Point(2 3)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
-SELECT asText(nearestApproachInstant(stbox 'STBOX X((5,2),(7,4))', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
 SELECT asText(nearestApproachInstant(cbuffer 'Cbuffer(Point(4 9), 0.7)', tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]'));
 SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', geometry 'Point(2 3)'));
-SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', stbox 'STBOX X((5,2),(7,4))'));
 SELECT asText(nearestApproachInstant(tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]', cbuffer 'Cbuffer(Point(4 9), 0.7)'));
 SELECT asText(nearestApproachInstant(
   tcbuffer '[Cbuffer(Point(0 0), 0.5)@2000-01-01, Cbuffer(Point(4 0), 0.5)@2000-01-05]',

--- a/mobilitydb/test/pose/expected/113_tpose_distance.test.out
+++ b/mobilitydb/test/pose/expected/113_tpose_distance.test.out
@@ -154,12 +154,6 @@ SELECT asText(nearestApproachInstant(geometry 'Point(2 0)', tpose '[Pose(Point(0
  Pose(POINT(2 0),0)@Mon Jan 03 00:00:00 2000 PST
 (1 row)
 
-SELECT asText(nearestApproachInstant(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
-                     astext                      
--------------------------------------------------
- Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST
-(1 row)
-
 SELECT asText(nearestApproachInstant(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
                      astext                      
 -------------------------------------------------
@@ -170,12 +164,6 @@ SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose
                      astext                      
 -------------------------------------------------
  Pose(POINT(2 0),0)@Mon Jan 03 00:00:00 2000 PST
-(1 row)
-
-SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'));
-                     astext                      
--------------------------------------------------
- Pose(POINT(1 0),0)@Sun Jan 02 00:00:00 2000 PST
 (1 row)
 
 SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'));
@@ -266,12 +254,6 @@ SELECT ST_AsText(shortestLine(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@
  LINESTRING(2 0,2 0)
 (1 row)
 
-SELECT ST_AsText(shortestLine(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
-      st_astext      
----------------------
- LINESTRING(1 0,1 0)
-(1 row)
-
 SELECT ST_AsText(shortestLine(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
       st_astext      
 ---------------------
@@ -282,12 +264,6 @@ SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(
       st_astext      
 ---------------------
  LINESTRING(2 0,2 0)
-(1 row)
-
-SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'));
-      st_astext      
----------------------
- LINESTRING(1 0,1 0)
 (1 row)
 
 SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'));

--- a/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
+++ b/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
@@ -76,10 +76,8 @@ SELECT round(tDistance(
 -------------------------------------------------------------------------------
 
 SELECT asText(nearestApproachInstant(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
-SELECT asText(nearestApproachInstant(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
 SELECT asText(nearestApproachInstant(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
 SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'));
-SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'));
 SELECT asText(nearestApproachInstant(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'));
 SELECT asText(nearestApproachInstant(
   tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',
@@ -112,10 +110,8 @@ SELECT round(nearestApproachDistance(
 -------------------------------------------------------------------------------
 
 SELECT ST_AsText(shortestLine(geometry 'Point(2 0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
-SELECT ST_AsText(shortestLine(stbox 'STBOX X((1,-1),(3,1))', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
 SELECT ST_AsText(shortestLine(pose 'Pose(Point(2 0),0)', tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]'));
 SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', geometry 'Point(2 0)'));
-SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', stbox 'STBOX X((1,-1),(3,1))'));
 SELECT ST_AsText(shortestLine(tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]', pose 'Pose(Point(2 0),0)'));
 SELECT ST_AsText(shortestLine(
   tpose '[Pose(Point(0 0),0)@2000-01-01, Pose(Point(4 0),0)@2000-01-05]',


### PR DESCRIPTION
A spatiotemporal box reaches a distance function as the query form of the nearest approach operator: every nearestApproachDistance signature taking one backs a |=| operator, which a GiST or SP-GiST opclass carries as a FOR ORDER BY member, and all five spatial families declare that pair. nearestApproachInstant returns an instant and shortestLine a line, so neither orders a scan and neither has that role, which is why the geo, network point and rigid geometry families declare neither over a box: counted on master, those three answer 0 for both while declaring 9, 4 and 2 nearest approach distances over a box. The circular buffer and pose families declare both, each as a LANGUAGE SQL body reading geometry($n), which is stbox_geo, the spatial rectangle of the box carrying no time, so the answer describes the envelope over all time rather than the value over the box period; shortestLine of a temporal pose and a box the pose crosses answers LINESTRING(1 0,1 0), a line of zero length lying on the envelope. Nothing depends on the eight: no CREATE OPERATOR names one, the manual documents none of them since shortestLine appears 65 times in doc and never beside a box, and a LANGUAGE SQL body publishes no MEOS symbol, so no generated binding carries them. Both expected outputs shrink by the removed rows alone, 16 lines and 8, with no answer moved. Each family declares over a box what the reference declares, the distance alone.