### PR TITLE
Name the spatiotemporal box among the nearest approach operands

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -817,7 +817,7 @@ SELECT round(ST_Area(convexHull(tcbuffer
 			<listitem xml:id="tcbuffer_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Devuelve la distancia más cercana</para>
-				<para><varname>{geo,cbuffer,tcbuffer} |=| {geo,cbuffer,tcbuffer} → float</varname></para>
+				<para><varname>{geo,cbuffer,tcbuffer,stbox} |=| {geo,cbuffer,tcbuffer,stbox} → float</varname></para>
 				<para>El operador <varname>|=|</varname> se puede utilizar para realizar búsquedas del vecino más cercano utilizando un índice GiST o SP-GiST (ver <xref linkend="ttype_indexing"/>).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -726,7 +726,7 @@ SELECT minusGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01
 			<listitem xml:id="tnpoint_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Devuelve la distancia más cercana</para>
-				<para><varname>{geo,npoint,tnpoint} |=| {geo,npoint,tnpoint} → float</varname></para>
+				<para><varname>{geo,npoint,tnpoint,stbox} |=| {geo,npoint,tnpoint,stbox} → float</varname></para>
 				<para>El operador <varname>|=|</varname> se puede utilizar para realizar búsquedas más cercanas utilizando un índice GiST o SP-GIST (ver <xref linkend="ttype_indexing" />).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-02]' |=|

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -1045,7 +1045,7 @@ SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-03,
 			<listitem xml:id="tpose_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Devuelve la distancia más pequeña alguna vez</para>
-				<para><varname>{geo,pose,tpose} |=| {geo,pose,tpose} → float</varname></para>
+				<para><varname>{geo,pose,tpose,stbox} |=| {geo,pose,tpose,stbox} → float</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(2 2), 0.3)@2001-01-01, Pose(Point(2 2), 0.7)@2001-01-02]' |=|
   geometry 'Linestring(50 50,55 55)';

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -180,7 +180,7 @@ SELECT expandSpace(tgeompoint 'Point(0 0)@2001-01-01', 2);
 			<listitem xml:id="tgeo_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Devuelve la distancia más pequeña que haya existido &Z_support; &geography_support;</para>
-				<para><varname>{geo,tgeo} |=| {geo,tgeo} → float</varname></para>
+				<para><varname>{geo,tgeo,stbox} |=| {geo,tgeo,stbox} → float</varname></para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tgeompoint '[Point(0 0)@2001-01-02, Point(1 1)@2001-01-04, Point(0 0)@2001-01-06)'
   |=| geometry 'Linestring(2 2,2 1,3 1)';

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -818,7 +818,7 @@ SELECT round(ST_Area(convexHull(tcbuffer
 			<listitem xml:id="tcbuffer_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Return the smallest distance ever</para>
-				<para><varname>{geo,cbuffer,tcbuffer} |=| {geo,cbuffer,tcbuffer} → float</varname></para>
+				<para><varname>{geo,cbuffer,tcbuffer,stbox} |=| {geo,cbuffer,tcbuffer,stbox} → float</varname></para>
 				<para>The operator <varname>|=|</varname> that can be used for doing nearest neightbor searches using a GiST or an SP-GiST index (see <xref linkend="ttype_indexing"/>).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -727,7 +727,7 @@ SELECT minusGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01
 			<listitem xml:id="tnpoint_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Return the smallest distance ever</para>
-				<para><varname>{geo,npoint,tnpoint} |=| {geo,npoint,tnpoint} → float</varname></para>
+				<para><varname>{geo,npoint,tnpoint,stbox} |=| {geo,npoint,tnpoint,stbox} → float</varname></para>
 				<para>The operator <varname>|=|</varname> can be used for doing nearest neightbor searches using a GiST or an SP-GiST index (see <xref linkend="ttype_indexing"/>).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-02]' |=|

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1054,7 +1054,7 @@ SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-03,
 			<listitem xml:id="tpose_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Return the smallest distance ever</para>
-				<para><varname>{geo,pose,tpose} |=| {geo,pose,tpose} → float</varname></para>
+				<para><varname>{geo,pose,tpose,stbox} |=| {geo,pose,tpose,stbox} → float</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(2 2), 0.3)@2001-01-01, Pose(Point(2 2), 0.7)@2001-01-02]' |=|
   geometry 'Linestring(50 50,55 55)';

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -179,7 +179,7 @@ SELECT expandSpace(tgeompoint 'Point(0 0)@2001-01-01', 2);
 			<listitem xml:id="tgeo_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Return the smallest distance ever &Z_support; &geography_support;</para>
-				<para><varname>{geo,tgeo} |=| {geo,tgeo} → float</varname></para>
+				<para><varname>{geo,tgeo,stbox} |=| {geo,tgeo,stbox} → float</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[Point(0 0)@2001-01-02, Point(1 1)@2001-01-04, Point(0 0)@2001-01-06)'
   |=| geometry 'Linestring(2 2,2 1,3 1)';


### PR DESCRIPTION
Every spatial family declares nearestApproachDistance over a spatiotemporal box: the operand sets of the six distance files each hold stbox, and the |=| operator it backs is what a GiST or SP-GiST opclass carries as a FOR ORDER BY member, which is the query form a nearest-neighbour scan orders by. The manual names it for temporal rigid geometries alone, writing {geometry,trgeometry,stbox}, so the entry of the four other families reads as though a box is no operand at all. Each entry names stbox beside the geometry and the temporal type it already names, in both manuals, giving {geo,tgeo,stbox}, {geo,cbuffer,tcbuffer,stbox}, {geo,npoint,tnpoint,stbox} and {geo,pose,tpose,stbox}. The reference appendix regenerates from the chapters and both manuals parse.