### PR TITLE
Cite the cell index specifications the coordinates come from

### DIFF
--- a/meos/src/h3/th3index_boxops.c
+++ b/meos/src/h3/th3index_boxops.c
@@ -31,8 +31,14 @@
  * @file
  * @brief Bounding box functions for temporal H3 cell indices.
  *
- * H3 cells are geographic hexagons on the WGS84 sphere — always geodetic,
- * always lat/lon. The bounding box of a th3index value is therefore a
+ * An H3 cell is a hexagon of the grid the H3 specification builds on the
+ * planar faces of a sphere-circumscribed icosahedron and projects back onto
+ * the sphere, whose coordinate reference system is spherical coordinates with
+ * the WGS84/EPSG:4326 authalic radius — a sphere, not the WGS84 ellipsoid, so
+ * SRID 4326 names the coordinates this tree emits rather than the model H3
+ * measures on (https://h3geo.org/docs/core-library/overview/). The cells are
+ * therefore always geodetic and always lat/lon, and the bounding box of a
+ * th3index value is a
  * geodetic STBox (X/Y set, GEODETIC flag set, no Z, T set from the time
  * span), matching the pattern of tgeogpoint and tcbuffer.
  *

--- a/meos/src/h3/th3index_ops.c
+++ b/meos/src/h3/th3index_ops.c
@@ -40,7 +40,9 @@
  *
  * An h3 cell is geodetic, so the descriptor emits a tgeogpoint centroid and,
  * through it, a tgeography boundary. The static adapter behind the centroid
- * builds an SRID-4326 point; geography and geometry are distinguished at the
+ * builds an SRID-4326 point, the coordinates the H3 specification carries on a
+ * sphere of the WGS84/EPSG:4326 authalic radius
+ * (https://h3geo.org/docs/core-library/overview/); geography and geometry are distinguished at the
  * lifting layer by `point_temptype`, exactly as the typed th3index conversions
  * distinguish them by their `restype`.
  */

--- a/meos/src/quadbin/tquadbin_ops.c
+++ b/meos/src/quadbin/tquadbin_ops.c
@@ -34,9 +34,14 @@
  * cell-index machinery (meos/src/temporal/tcellindex.c).
  *
  * A quadbin cell is a uint64 carried in a Datum with the int8/bigint
- * convention (Int64GetDatum / DatumGetInt64). The cell centroid is emitted as
- * a planar tgeompoint in the cell's lon/lat (SRID 4326); a Web-Mercator
- * (SRID 3857) emission would set point_srid = 3857 and reproject here.
+ * convention (Int64GetDatum / DatumGetInt64), holding the Bing Maps Tile
+ * System (quadkey) cell of a map uniformly subdivided in the MERCATOR
+ * projection into four squares at each resolution from 0 to 26
+ * (https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/key-concepts/spatial-indexes).
+ * The cell is defined on that projection, and its centroid is emitted as a
+ * planar tgeompoint converted to lon/lat (SRID 4326); a Web-Mercator
+ * (SRID 3857) emission, which is the cell's own system, would set
+ * point_srid = 3857 and skip that conversion.
  */
 
 #include "quadbin/quadbin.h"


### PR DESCRIPTION
An H3 cell belongs to a grid the specification builds on the planar faces of a
sphere-circumscribed icosahedron and projects back onto the sphere, whose
coordinate reference system is spherical coordinates with the WGS84/EPSG:4326
authalic radius. That sphere is not the WGS84 ellipsoid, so SRID 4326 names the
coordinates this tree emits rather than the model the specification measures
on, and the two files carrying that emission say so and link the specification.

A quadbin cell is the Bing Maps Tile System cell of a map uniformly subdivided
in the Mercator projection into four squares at each resolution from 0 to 26,
so the cell is defined on that projection and the lon/lat centroid is a
conversion from it, which is what a Web-Mercator emission skips.