### PR TITLE
Answer the distance of a spatial set as its bounding box answers

### DIFF
--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -137,6 +137,8 @@ extern bool geo_set_stbox(const GSERIALIZED *gs, STBox *result);
 extern void geoarr_set_stbox(const Datum *values, int count, STBox *result);
 extern bool spatial_set_stbox(Datum d, MeosType basetype, STBox *result);
 extern void spatialset_set_stbox(const Set *set, STBox *result);
+extern Datum distance_spatialset_value(const Set *s, Datum value);
+extern Datum distance_spatialset_spatialset(const Set *s1, const Set *s2);
 extern void stbox_set_box3d(const STBox *box, BOX3D *result);
 extern void stbox_set_gbox(const STBox *box, GBOX *result);
 extern void tstzset_set_stbox(const Set *s, STBox *result);

--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -36,11 +36,13 @@
 
 /* C */
 #include <assert.h>
+#include <float.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <varatt.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_geo.h>
 #include <meos_internal.h>
 #include <meos_internal_geo.h>
 #include "temporal/set.h"
@@ -410,6 +412,47 @@ spatialset_set_stbox(const Set *s, STBox *result)
   memcpy(result, SET_BBOX_PTR(s), sizeof(STBox));
   return;
 }
+
+/**
+ * @ingroup meos_internal_setspan_dist
+ * @brief Return the distance between a spatial set and a value
+ * @param[in] s Spatial set
+ * @param[in] value Value
+ * @details A set answers the distance of the extent that bounds it, which for
+ * a spatial set is its spatiotemporal box where for a span set it is its
+ * bounding span: the gaps between the elements are not boundaries of the set.
+ * @return On error return @p DBL_MAX
+ */
+Datum
+distance_spatialset_value(const Set *s, Datum value)
+{
+  assert(s); assert(spatialset_type(s->settype));
+  STBox box1, box2;
+  spatialset_set_stbox(s, &box1);
+  if (! spatial_set_stbox(value, s->basetype, &box2))
+    return Float8GetDatum(DBL_MAX);
+  return Float8GetDatum(nad_stbox_stbox(&box1, &box2));
+}
+
+/**
+ * @ingroup meos_internal_setspan_dist
+ * @brief Return the distance between two spatial sets
+ * @param[in] s1,s2 Spatial sets
+ * @details Each set answers for the extent that bounds it, as above.
+ * @return On error return @p DBL_MAX
+ */
+Datum
+distance_spatialset_spatialset(const Set *s1, const Set *s2)
+{
+  assert(s1); assert(s2); assert(s1->settype == s2->settype);
+  assert(spatialset_type(s1->settype));
+  STBox box1, box2;
+  spatialset_set_stbox(s1, &box1);
+  spatialset_set_stbox(s2, &box2);
+  return Float8GetDatum(nad_stbox_stbox(&box1, &box2));
+}
+
+/*****************************************************************************/
 
 /**
  * @ingroup meos_geo_box_conversion

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -42,6 +42,7 @@
 #include "temporal/set.h"
 #include "temporal/temporal.h"
 #include "temporal/type_util.h"
+#include <meos_internal_geo.h>
 
 /*****************************************************************************
  * Generic operations
@@ -654,6 +655,10 @@ Datum
 distance_set_value(const Set *s, Datum value)
 {
   assert(s);
+  /* A spatial set bounds its elements with a spatiotemporal box and has no
+   * span, so the subclass answers for that extent */
+  if (spatialset_type(s->settype))
+    return distance_spatialset_value(s, value);
   Span s1;
   set_set_span(s, &s1);
   return distance_span_value(&s1, value);
@@ -671,6 +676,8 @@ Datum
 distance_set_set(const Set *s1, const Set *s2)
 {
   assert(s1); assert(s2); assert(s1->settype == s2->settype);
+  if (spatialset_type(s1->settype))
+    return distance_spatialset_spatialset(s1, s2);
   Span sp1, sp2;
   set_set_span(s1, &sp1);
   set_set_span(s2, &sp2);

--- a/mobilitydb/test/geo/expected/050_set_tbl.test.out
+++ b/mobilitydb/test/geo/expected/050_set_tbl.test.out
@@ -423,3 +423,39 @@ SELECT asText(setIntersection(geogset '{"Point(1 1)", "Point(2 2)"}', geography 
  {"POINT(1 1)"}
 (1 row)
 
+SELECT round(setDistance(geometry 'Point(1 1)', geomset '{"Point(4 5)", "Point(10 10)"}')::numeric, 6);
+  round   
+----------
+ 5.000000
+(1 row)
+
+SELECT round(setDistance(geomset '{"Point(4 5)", "Point(10 10)"}', geometry 'Point(1 1)')::numeric, 6);
+  round   
+----------
+ 5.000000
+(1 row)
+
+SELECT round(setDistance(geomset '{"Point(1 1)"}', geomset '{"Point(4 5)"}')::numeric, 6);
+  round   
+----------
+ 5.000000
+(1 row)
+
+SELECT round((geometry 'Point(1 1)' <-> geomset '{"Point(4 5)", "Point(10 10)"}')::numeric, 6);
+  round   
+----------
+ 5.000000
+(1 row)
+
+SELECT round(setDistance(geography 'Point(1 1)', geogset '{"Point(1 1)", "Point(2 2)"}')::numeric, 6);
+  round   
+----------
+ 0.000000
+(1 row)
+
+SELECT round(setDistance(geogset '{"Point(1 1)", "Point(2 2)"}', geography 'Point(1 1)')::numeric, 6);
+  round   
+----------
+ 0.000000
+(1 row)
+

--- a/mobilitydb/test/geo/queries/050_set_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/050_set_tbl.test.sql
@@ -181,3 +181,17 @@ SELECT asText(setIntersection(geography 'Point(1 1)', geogset '{"Point(1 1)", "P
 SELECT asText(setIntersection(geogset '{"Point(1 1)", "Point(2 2)"}', geography 'Point(1 1)'));
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Distance
+-------------------------------------------------------------------------------
+
+SELECT round(setDistance(geometry 'Point(1 1)', geomset '{"Point(4 5)", "Point(10 10)"}')::numeric, 6);
+SELECT round(setDistance(geomset '{"Point(4 5)", "Point(10 10)"}', geometry 'Point(1 1)')::numeric, 6);
+SELECT round(setDistance(geomset '{"Point(1 1)"}', geomset '{"Point(4 5)"}')::numeric, 6);
+SELECT round((geometry 'Point(1 1)' <-> geomset '{"Point(4 5)", "Point(10 10)"}')::numeric, 6);
+
+SELECT round(setDistance(geography 'Point(1 1)', geogset '{"Point(1 1)", "Point(2 2)"}')::numeric, 6);
+SELECT round(setDistance(geogset '{"Point(1 1)", "Point(2 2)"}', geography 'Point(1 1)')::numeric, 6);
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/temporal/expected/002_set_ops_tbl.test.out
+++ b/mobilitydb/test/temporal/expected/002_set_ops_tbl.test.out
@@ -442,3 +442,33 @@ SELECT MIN(t1.t <-> t2.t) FROM tbl_tstzset t1, tbl_tstzset t2;
    0
 (1 row)
 
+SELECT setDistance(1, intset '{3, 7}');
+ setdistance 
+-------------
+           2
+(1 row)
+
+SELECT setDistance(intset '{3, 7}', 1);
+ setdistance 
+-------------
+           2
+(1 row)
+
+SELECT setDistance(intset '{3, 7}', intset '{10, 20}');
+ setdistance 
+-------------
+           3
+(1 row)
+
+SELECT round(setDistance(1.0, floatset '{3.5, 7.5}')::numeric, 6);
+  round   
+----------
+ 2.500000
+(1 row)
+
+SELECT setDistance(date '2000-01-01', dateset '{2000-01-05, 2000-01-10}');
+ setdistance 
+-------------
+           4
+(1 row)
+

--- a/mobilitydb/test/temporal/queries/002_set_ops_tbl.test.sql
+++ b/mobilitydb/test/temporal/queries/002_set_ops_tbl.test.sql
@@ -136,3 +136,12 @@ SELECT MIN(t1.t <-> t2.t) FROM tbl_tstzset t1, tbl_timestamptz t2;
 SELECT MIN(t1.t <-> t2.t) FROM tbl_tstzset t1, tbl_tstzset t2;
 
 -------------------------------------------------------------------------------
+
+-- The named portable form of the <-> operator tested above
+SELECT setDistance(1, intset '{3, 7}');
+SELECT setDistance(intset '{3, 7}', 1);
+SELECT setDistance(intset '{3, 7}', intset '{10, 20}');
+SELECT round(setDistance(1.0, floatset '{3.5, 7.5}')::numeric, 6);
+SELECT setDistance(date '2000-01-01', dateset '{2000-01-05, 2000-01-10}');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
A set answers the distance of the extent that bounds it, and a spatial set
bounds its elements with a spatiotemporal box where a span set bounds its spans
with a span, so the subclass answers for that box and the gaps between the
elements are no more boundaries of the set than the holes of a span set are of
it. The distance of a set reads the class of its type and takes the box of a
spatial one, which leaves every numeric, date and timestamp answer as it is.

The tests carry the distance of a geometry and a geography set in the argument
orders the surface declares, and the named form of the operator for the numeric
and date sets the table tests exercise through the operator alone.