### PR TITLE
Say how each geometry function reads a circular arc

### DIFF
--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -48,12 +48,14 @@
 				<indexterm significance="normal"><primary><varname>OrientedEnvelope</varname></primary></indexterm>
 				<para>Devuelve el rectángulo de área mínima que encierra una geometría</para>
 				<para><varname>OrientedEnvelope(geometry) → geometry</varname></para>
-				<para>El rectángulo se orienta en el ángulo que lo hace más pequeño, que en general no es el ángulo de los ejes. Se devuelve como una línea cuando la geometría está contenida en una y como un punto cuando la geometría es uno. Una geometría que lleva un arco circular la responde GEOS, que lee el arco como la cadena de segmentos que lo aproxima.</para>
+				<para>El rectángulo se orienta en el ángulo que lo hace más pequeño, que en general no es el ángulo de los ejes. Se devuelve como una línea cuando la geometría está contenida en una y como un punto cuando la geometría es uno. Una geometría que lleva un arco circular se responde sobre el arco mismo: el rectángulo se coloca contra el círculo en el que se encuentra el arco y no contra la cadena de segmentos que lo aproxima.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
 -- POLYGON((0 0,3 4,-1 7,-4 3,0 0))
 SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
 -- LINESTRING(0 0,10 0)
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Circularstring(0 0,0.5 0.1,1 0)'), 6));
+-- POLYGON((1 0.1,0 0.1,0 0,1 0,1 0.1))
 </programlisting>
 			</listitem>
 
@@ -61,12 +63,14 @@ SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
 				<indexterm significance="normal"><primary><varname>ConvexHull</varname></primary></indexterm>
 				<para>Devuelve la geometría convexa más pequeña que encierra una geometría</para>
 				<para><varname>ConvexHull(geometry) → geometry</varname></para>
-				<para>El resultado es un polígono en el que cada esquina es un punto de la geometría, una línea cuando la geometría está contenida en una y un punto cuando la geometría es uno. Una geometría que lleva un arco circular la responde GEOS, que lee el arco como la cadena de segmentos que lo aproxima.</para>
+				<para>El resultado es un polígono en el que cada esquina es un punto de la geometría, una línea cuando la geometría está contenida en una y un punto cuando la geometría es uno. Una geometría que lleva un arco circular se responde sobre el arco mismo, por lo que la envolvente está delimitada por el arco y se devuelve como una geometría curva y no como un polígono que la aproxima.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
 -- POLYGON((0 0,0 10,10 10,10 0,0 0))
 SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
 -- POLYGON((0 0,0 10,10 10,10 0,0 0))
+SELECT ST_AsText(round(ConvexHull(geometry 'Circularstring(5 0,0 5,-5 0)'), 6));
+-- CURVEPOLYGON(COMPOUNDCURVE((5 0,-5 0),CIRCULARSTRING(-5 0,0 5,5 0)))
 </programlisting>
 			</listitem>
 
@@ -74,7 +78,7 @@ SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0
 				<indexterm significance="normal"><primary><varname>isSimple</varname></primary></indexterm>
 				<para>Devuelve verdadero si una geometría no tiene ningún punto en el que se cruce o se toque a sí misma</para>
 				<para><varname>isSimple(geometry) → boolean</varname></para>
-				<para>Un punto siempre es simple, un multipunto es simple cuando no repite ningún punto, una línea es simple cuando se encuentra consigo misma solo donde dos de sus segmentos se siguen y, cuando se cierra, en el punto donde se cierra, y una geometría de área es simple cuando cada uno de sus anillos lo es. Además, dos líneas de una multilínea pueden encontrarse en un punto que termina ambas. Una geometría que lleva un arco circular la responde GEOS, ya que tal geometría se encuentra consigo misma a lo largo de un arco y no en un punto.</para>
+				<para>Un punto siempre es simple, un multipunto es simple cuando no repite ningún punto, una línea es simple cuando se encuentra consigo misma solo donde dos de sus segmentos se siguen y, cuando se cierra, en el punto donde se cierra, y una geometría de área es simple cuando cada uno de sus anillos lo es. Además, dos líneas de una multilínea pueden encontrarse en un punto que termina ambas. Una geometría que lleva un arco circular se encuentra consigo misma a lo largo de un arco y no en un punto, lo que la intersección de segmentos en la que esto se basa no lee, por lo que tal geometría se responde sobre la cadena de segmentos que aproxima sus arcos.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isSimple(geometry 'Linestring(0 0,10 10,10 0,0 10)');
 -- false

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -48,12 +48,14 @@
 				<indexterm significance="normal"><primary><varname>OrientedEnvelope</varname></primary></indexterm>
 				<para>Return the rectangle of minimum area enclosing a geometry</para>
 				<para><varname>OrientedEnvelope(geometry) → geometry</varname></para>
-				<para>The rectangle is at the angle that makes it smallest, which is not in general the angle of the axes. It is answered as a line when the geometry is contained in one and as a point when the geometry is one. A geometry carrying a circular arc is answered by GEOS, which reads the arc as the chain of segments approximating it.</para>
+				<para>The rectangle is at the angle that makes it smallest, which is not in general the angle of the axes. It is answered as a line when the geometry is contained in one and as a point when the geometry is one. A geometry carrying a circular arc is answered on the arc itself, the rectangle being placed against the circle the arc lies on rather than against the chain of segments approximating it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
 -- POLYGON((0 0,3 4,-1 7,-4 3,0 0))
 SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
 -- LINESTRING(0 0,10 0)
+SELECT ST_AsText(round(OrientedEnvelope(geometry 'Circularstring(0 0,0.5 0.1,1 0)'), 6));
+-- POLYGON((1 0.1,0 0.1,0 0,1 0,1 0.1))
 </programlisting>
 			</listitem>
 
@@ -61,12 +63,14 @@ SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
 				<indexterm significance="normal"><primary><varname>ConvexHull</varname></primary></indexterm>
 				<para>Return the smallest convex geometry enclosing a geometry</para>
 				<para><varname>ConvexHull(geometry) → geometry</varname></para>
-				<para>The result is a polygon whose every corner is a point of the geometry, a line when the geometry is contained in one, and a point when the geometry is one. A geometry carrying a circular arc is answered by GEOS, which reads the arc as the chain of segments approximating it.</para>
+				<para>The result is a polygon whose every corner is a point of the geometry, a line when the geometry is contained in one, and a point when the geometry is one. A geometry carrying a circular arc is answered on the arc itself, so the hull is bounded by the arc and is returned as a curved geometry rather than as a polygon approximating it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
 -- POLYGON((0 0,0 10,10 10,10 0,0 0))
 SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
 -- POLYGON((0 0,0 10,10 10,10 0,0 0))
+SELECT ST_AsText(round(ConvexHull(geometry 'Circularstring(5 0,0 5,-5 0)'), 6));
+-- CURVEPOLYGON(COMPOUNDCURVE((5 0,-5 0),CIRCULARSTRING(-5 0,0 5,5 0)))
 </programlisting>
 			</listitem>
 
@@ -74,7 +78,7 @@ SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0
 				<indexterm significance="normal"><primary><varname>isSimple</varname></primary></indexterm>
 				<para>Return true if a geometry has no point at which it crosses or touches itself</para>
 				<para><varname>isSimple(geometry) → boolean</varname></para>
-				<para>A point is always simple, a multipoint is simple when it repeats no point, a line is simple when it meets itself only where two of its segments follow one another and, when it closes, at the point where it closes, and an areal geometry is simple when each of its rings is. Two lines of a multiline may additionally meet at a point that ends both. A geometry carrying a circular arc is answered by GEOS, since such a geometry meets itself along an arc rather than at a point.</para>
+				<para>A point is always simple, a multipoint is simple when it repeats no point, a line is simple when it meets itself only where two of its segments follow one another and, when it closes, at the point where it closes, and an areal geometry is simple when each of its rings is. Two lines of a multiline may additionally meet at a point that ends both. A geometry carrying a circular arc meets itself along an arc rather than at a point, which the segment intersection this rests on does not read, so such a geometry is answered on the chain of segments approximating its arcs.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isSimple(geometry 'Linestring(0 0,10 10,10 0,0 10)');
 -- false


### PR DESCRIPTION
The section states, of every function in it, how it reads a geometry bounded by circular arcs, since an answer built from the arcs and an answer built from a polygonal approximation of them are not the same answer. Three of those statements name GEOS, and none of the three is what the function does.

The oriented envelope is placed against the circle an arc lies on. Over Circularstring(0 0,0.5 0.1,1 0) it answers the rectangle of area 0.1, the exact one, where a rectangle placed against the segments approximating the arc measures 0.0999971552: the highest of those segment ends lies below the apex of the arc.

The convex hull is bounded by the arc and comes back curved. Over Circularstring(5 0,0 5,-5 0) it answers CURVEPOLYGON(COMPOUNDCURVE((5 0,-5 0),CIRCULARSTRING(-5 0,0 5,5 0))), carrying the arc itself, where an approximation answers a polygon of sixty-five points.

Whether a geometry is simple is the one of the three that does read an approximation, since a geometry meets itself along an arc rather than at a point and the segment intersection the answer rests on does not read that. It reads the segments through liblwgeom, which is not GEOS either.

Each entry says which of the two it does, and the two that answer the arc carry an example of it. Both manuals carry the same correction, and every figure above is read from the shipped functions.
