### PR TITLE
Say which argument the traversed area answers for

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2458,7 +2458,7 @@
 			<title>Área recorrida</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="trgeometry_traversedArea_func"><varname>traversedArea</varname></link>: Devuelve la unión de los polígonos materializados a lo largo del dominio temporal de la trgeometry</para>
+					<para><link linkend="trgeometry_traversedArea_func"><varname>traversedArea</varname></link>: Devuelve el área atravesada por la geometría rígida temporal</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -771,7 +771,7 @@ FROM test;
 			<listitem xml:id="tcbuffer_traversedArea">
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
 				<para>Devuelve el área atravesada por el búfer circular temporal</para>
-				<para><varname>traversedArea(tcbuffer) → geometry</varname></para>
+				<para><varname>traversedArea(tcbuffer, unary_union=false) → geometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02]'));

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -297,19 +297,22 @@ SELECT ST_AsText(geom(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0)
 	<sect1 xml:id="trgeometry_traversed_area">
 		<title>Área recorrida</title>
 
-		<para>La función <varname>traversedArea</varname> devuelve la unión de cada geometría materializada sobre el dominio temporal de la trgeometry: la huella espacial del cuerpo en movimiento.</para>
+		<para>La función <varname>traversedArea</varname> devuelve la región que el cuerpo en movimiento cubre sobre el dominio temporal de la trgeometry: las colocaciones que toma, o la unión de ellas cuando se le pide.</para>
 
 		<itemizedlist>
 			<listitem xml:id="trgeometry_traversedArea_func">
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
-				<para>Devuelve la unión de los polígonos materializados a lo largo del dominio temporal de la trgeometry</para>
-				<para><varname>traversedArea(trgeometry [, unary_union boolean = true]) → geometry</varname></para>
+				<para>Devuelve el área atravesada por la geometría rígida temporal</para>
+				<para><varname>traversedArea(trgeometry, unary_union=false) → geometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
--- POLYGON((0 0, 11 0, 11 1, 0 1, 0 0))
+-- MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)),((10 0,11 0,11 1,10 1,10 0)))
+SELECT ST_AsText(traversedArea(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', true));
+-- POLYGON((0 0,0 1,11 1,11 0,0 0))
 </programlisting>
-				<para>Con <varname>unary_union = false</varname> la función devuelve una GeometryCollection de los polígonos materializados por instante sin disolverlos, lo que resulta útil cuando quien llama desea hacer su propio posprocesamiento.</para>
+				<para>El argumento es falso salvo que se indique, y la función responde entonces las colocaciones mismas reunidas en una geometría, un multipolígono para un cuerpo que es un polígono, que es lo que quiere quien llama y hace su propio posprocesamiento. Con <varname>unary_union = true</varname> se disuelven en la región que cubren.</para>
 				<para><emphasis>Advertencia de muestreo:</emphasis> la implementación muestrea en los instantes de entrada, de modo que los segmentos de traslación pura son exactos, pero la cinta barrida entre dos instantes donde ocurre una rotación se aproxima mediante la envolvente convexa de los dos polígonos extremos. Sobremuestrear la <varname>tpose</varname> antes de construir la <varname>trgeometry</varname> ajusta la aproximación.</para>
 			</listitem>
 		</itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2467,7 +2467,7 @@
 			<title>Traversed Area</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="trgeometry_traversedArea_func"><varname>traversedArea</varname></link>: Return the union of the materialised polygons across the trgeometry's time domain</para>
+					<para><link linkend="trgeometry_traversedArea_func"><varname>traversedArea</varname></link>: Return the area traversed by the temporal rigid geometry</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -297,19 +297,22 @@ SELECT ST_AsText(geom(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0)
 	<sect1 xml:id="trgeometry_traversed_area">
 		<title>Traversed Area</title>
 
-		<para>The <varname>traversedArea</varname> function returns the union of every materialised geometry over the trgeometry's time domain, the spatial footprint of the moving body.</para>
+		<para>The <varname>traversedArea</varname> function returns the region the moving body covers over the trgeometry's time domain: the placements it takes, or the union of them when the function is asked for it.</para>
 
 		<itemizedlist>
 			<listitem xml:id="trgeometry_traversedArea_func">
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
-				<para>Return the union of the materialised polygons across the trgeometry's time domain</para>
-				<para><varname>traversedArea(trgeometry [, unary_union boolean = true]) → geometry</varname></para>
+				<para>Return the area traversed by the temporal rigid geometry</para>
+				<para><varname>traversedArea(trgeometry, unary_union=false) → geometry</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
--- POLYGON((0 0, 11 0, 11 1, 0 1, 0 0))
+-- MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)),((10 0,11 0,11 1,10 1,10 0)))
+SELECT ST_AsText(traversedArea(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', true));
+-- POLYGON((0 0,0 1,11 1,11 0,0 0))
 </programlisting>
-				<para>With <varname>unary_union = false</varname> the function returns a GeometryCollection of the per-instant materialised polygons without dissolving them, useful when the caller wants to do its own post-processing.</para>
+				<para>The argument is false unless it is given, and the function then answers the placements themselves gathered into one geometry, a multipolygon for a body that is a polygon, which is what a caller that does its own post-processing wants. With <varname>unary_union = true</varname> they are dissolved into the region they cover.</para>
 				<para><emphasis>Sampling caveat:</emphasis> the implementation samples at the input instants, so pure-translation segments are exact but the swept ribbon between two instants where a rotation happens is approximated by the convex hull of the two endpoint polygons. Up-sampling the <varname>tpose</varname> before constructing the <varname>trgeometry</varname> tightens the approximation.</para>
 			</listitem>
 		</itemizedlist>


### PR DESCRIPTION
Every one of the four traversedArea functions is declared with the union argument false unless it is given -- the circular buffer, the two temporal geos and the rigid geometry alike. The rigid geometry entry says the opposite, writes the argument in a notation no other entry uses, and prints under its worked example the answer the other argument gives.

Over the trgeometry that entry itself uses, the call as written answers MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)),((10 0,11 0,11 1,10 1,10 0))), the two placements, while the call with the argument true answers the corridor POLYGON((0 0,0 1,11 1,11 0,0 0)) the entry prints. The entry shows both calls, each with the answer it gives, read from the shipped function.

The entry also names a GeometryCollection for the undissolved form, where a body that is a polygon answers a multipolygon, and its one-liner describes the union alone. The circular buffer entry next door names the area traversed, which is what both forms answer, so the rigid geometry entry says the same and the reference index carries it.

The Spanish circular buffer entry, alone among the four, omits the argument altogether, so it gains it.
