### PR TITLE
Read a transform error text from the context that raises it

### DIFF
--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -555,8 +555,18 @@ point_transf_pj(GSERIALIZED *gs, int32_t srid_to, const LWPROJ *pj)
   int pj_errno_val = proj_errno_reset(pj->pj);
   if (pj_errno_val)
   {
+    /* The error text comes from the context the transformation is created in.
+     * proj_errno_string reads a global that another thread may be writing,
+     * which PROJ states as the reason it replaces the function; MEOS answers
+     * from several threads at once, so the text is read from the context */
+#if POSTGIS_PROJ_VERSION >= 80
+    const char *pj_errno_str = proj_context_errno_string(proj_get_context(),
+      pj_errno_val);
+#else
+    const char *pj_errno_str = proj_errno_string(pj_errno_val);
+#endif /* POSTGIS_PROJ_VERSION >= 80 */
     meos_error(ERROR, MEOS_ERR_INVALID_ARG,
-      "Transform: %s (%d)", proj_errno_string(pj_errno_val), pj_errno_val);
+      "Transform: %s (%d)", pj_errno_str, pj_errno_val);
     return false;
   }
   pa_double[0] = (t.xyzt).x;

--- a/postgis/liblwgeom/lwgeom_transform.c
+++ b/postgis/liblwgeom/lwgeom_transform.c
@@ -38,6 +38,21 @@
  * pulling a MEOS header into vendored liblwgeom. */
 extern PJ_CONTEXT *proj_get_context(void);
 
+/* MEOS */
+/* proj_errno_string reads a global error state, which PROJ documents as the
+ * reason proj_context_errno_string replaces it from 8.0.0 on: the text a
+ * failing transform reports can otherwise come from another thread. The
+ * context is the one the transformation is created in, as above. */
+static const char *
+proj_errno_str(int err)
+{
+#if POSTGIS_PROJ_VERSION >= 80
+  return proj_context_errno_string(proj_get_context(), err);
+#else
+  return proj_errno_string(err);
+#endif /* POSTGIS_PROJ_VERSION >= 80 */
+}
+
 /** convert decimal degrees to radians */
 static void
 to_rad(POINT4D *pt)
@@ -271,7 +286,8 @@ ptarray_transform(POINTARRAY *pa, LWPROJ *pj)
 		int pj_errno_val = proj_errno_reset(pj->pj);
 		if (pj_errno_val)
 		{
-			lwerror("transform: %s (%d)", proj_errno_string(pj_errno_val), pj_errno_val);
+			lwerror("transform: %s (%d)",
+				proj_errno_str(pj_errno_val) /* MEOS */, pj_errno_val);
 			return LW_FAILURE;
 		}
 		pa_double[0] = (t.xyzt).x;
@@ -314,7 +330,8 @@ ptarray_transform(POINTARRAY *pa, LWPROJ *pj)
 		int pj_errno_val = proj_errno_reset(pj->pj);
 		if (pj_errno_val)
 		{
-			lwerror("transform: %s (%d)", proj_errno_string(pj_errno_val), pj_errno_val);
+			lwerror("transform: %s (%d)",
+				proj_errno_str(pj_errno_val) /* MEOS */, pj_errno_val);
 			return LW_FAILURE;
 		}
 	}


### PR DESCRIPTION
proj_errno_string reads a global error state, which PROJ documents as the reason proj_context_errno_string replaces it from 8.0.0 on: "This function is potentially thread-unsafe". MEOS answers from several threads at once, holding its PROJ context and the rest of its caches in thread-local storage, so a second thread transforming at the same moment can supply the text a failing transform reports. point_transf_pj and the two transform helpers of the vendored liblwgeom read the text from the context proj_get_context answers with, which is the context the transformation itself is created in and the one the eight other PROJ calls of that file already pass, and the global reader stays for a PROJ older than 8.0.0. The vendored hunk carries the /* MEOS */ marker its siblings carry, and the comment above proj_get_context in that file already records why a shared context is unsafe. nm -uD over the built library reports proj_context_errno_string and no reference to proj_errno_string. No fixture asserts a transform error message, and none is added: asserting the text PROJ produces would pin the suite to a PROJ release, which the same measurements show varies between 9.4.0 and 9.5.1.