### PR TITLE
Read the union of a geometry's surfaces from their boundaries

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -140,6 +140,7 @@ angle_normalize(double a)
 /*****************************************************************************/
 
 extern LWGEOM *meos_oriented_envelope(const LWGEOM *geom);
+extern LWGEOM *meos_areal_union(const LWGEOM *geom);
 extern bool meos_is_simple(const LWGEOM *geom, bool *result);
 extern bool meos_relate(const LWGEOM *g1, const LWGEOM *g2, char result[10]);
 extern bool meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2,

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -4555,6 +4555,107 @@ buffer_union_components(LWGEOM **buffers, uint32_t count, int32_t srid)
   return lwcollection_as_lwgeom(result);
 }
 
+/**
+ * @brief Return the union of the areal components of a geometry
+ * @details The components are dissolved into the surfaces they cover: a pair
+ * whose interiors meet becomes one surface, and a pair that only touches stays
+ * apart, which is what a multisurface asks of its components. The answer
+ * covers the same region the geometry does, read as the fewest surfaces it
+ * takes. It is the dissolve the buffer of a geometry of several components
+ * already performs, answered for a geometry a caller brings
+ * @param[in] geom Geometry
+ * @return The union, or @p NULL when the geometry carries something that is
+ * not a surface, or when the boundary overlay does not cover the topology of
+ * one of the pairs -- a caller that has another way to answer may take it
+ */
+LWGEOM *
+meos_areal_union(const LWGEOM *geom)
+{
+  assert(geom);
+  if (lwgeom_is_empty(geom))
+    return NULL;
+
+  /* One surface is its own union */
+  uint8_t type = geom->type;
+  if (type == POLYGONTYPE || type == CURVEPOLYTYPE || type == TRIANGLETYPE)
+    return lwgeom_clone_deep(geom);
+  if (type != MULTIPOLYGONTYPE && type != MULTISURFACETYPE &&
+      type != COLLECTIONTYPE)
+    return NULL;
+
+  const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
+  if (coll->ngeoms == 0)
+    return NULL;
+  /* A point or a line has no area to dissolve, and a geometry carrying one is
+   * not what this answers */
+  for (uint32_t i = 0; i < coll->ngeoms; i++)
+  {
+    uint8_t comp = coll->geoms[i]->type;
+    if (comp != POLYGONTYPE && comp != CURVEPOLYTYPE && comp != TRIANGLETYPE)
+      return NULL;
+  }
+  if (coll->ngeoms == 1)
+    return lwgeom_clone_deep(coll->geoms[0]);
+
+  /* #buffer_union_components() owns the geometries it is given */
+  LWGEOM **surfaces = palloc(sizeof(LWGEOM *) * coll->ngeoms);
+  for (uint32_t i = 0; i < coll->ngeoms; i++)
+    surfaces[i] = lwgeom_clone_deep(coll->geoms[i]);
+  LWGEOM *result = buffer_union_components(surfaces, coll->ngeoms,
+    lwgeom_get_srid(geom));
+  pfree(surfaces);
+  if (! result)
+    return NULL;
+
+  /* The collection carries the type its members do: a multisurface is what a
+   * curved surface asks for, while a set of polygons is a multipolygon.
+   * ⛔ The test is the TYPE, not #lwgeom_is_collection(), which answers true
+   * for a CURVEPOLYGON and a COMPOUNDCURVE as well -- their rings and pieces
+   * are sub-geometries -- so reading THEIR members as surfaces turns a curve
+   * polygon into a multisurface holding its own boundary ring */
+  if (result->type == MULTIPOLYGONTYPE || result->type == MULTISURFACETYPE ||
+      result->type == COLLECTIONTYPE)
+  {
+    LWCOLLECTION *res_coll = (LWCOLLECTION *) result;
+    uint8_t collected = MULTIPOLYGONTYPE;
+    for (uint32_t i = 0; i < res_coll->ngeoms; i++)
+    {
+      uint8_t comp = res_coll->geoms[i]->type;
+      if (comp == POLYGONTYPE)
+        continue;
+      if (comp != CURVEPOLYTYPE && comp != TRIANGLETYPE)
+      {
+        /* A member that is not a surface is not an answer this gives */
+        lwgeom_free(result);
+        return NULL;
+      }
+      collected = MULTISURFACETYPE;
+    }
+    res_coll->type = collected;
+  }
+  else if (result->type != POLYGONTYPE && result->type != CURVEPOLYTYPE &&
+    result->type != TRIANGLETYPE)
+  {
+    lwgeom_free(result);
+    return NULL;
+  }
+
+  /* The boundary is welded out of pieces, so a surface comes back as a curve
+   * polygon even where every piece of it is a segment. A caller that gave
+   * polygons is answered with polygons: the conversion reads the pieces of a
+   * ring that carries no arc into one point array and loses nothing */
+  if (! lwgeom_has_arc(result))
+  {
+    LWGEOM *straight = lwgeom_stroke(result, 0);
+    if (straight)
+    {
+      lwgeom_free(result);
+      result = straight;
+    }
+  }
+  return result;
+}
+
 /*****************************************************************************
  * Buffer - POINT
  *****************************************************************************/

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2209,13 +2209,24 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
     return NULL;
 
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs) ;
-  LWGEOM *lwresult = lwgeom_unaryunion_prec(lwgeom, prec);
-  /* MEOS: PostGIS function #lwgeom_unaryunion_prec only propagates the SRID
-   * and the Z flag. The GEODETIC flag must be set BEFORE serialization, since
-   * the bounding box of a geodetic value is computed on the unit sphere and
-   * occupies 6 floats, while the one of a planar value occupies 2 * ndims
-   * floats */
-  lwgeom_set_geodetic(lwresult, FLAGS_GET_GEODETIC(lwgeom->flags));
+  /* The dissolve of a geometry whose components are surfaces is read from
+   * their boundaries, which keeps a circular arc on its own circle where a
+   * linearization would put the chain of segments approximating it in its
+   * place. A precision model is not something it answers for, and neither is a
+   * geometry carrying a component that is not a surface */
+  LWGEOM *lwresult = (prec < 0) ? meos_areal_union(lwgeom) : NULL;
+  if (! lwresult)
+  {
+    lwresult = lwgeom_unaryunion_prec(lwgeom, prec);
+    /* MEOS: PostGIS function #lwgeom_unaryunion_prec only propagates the SRID
+     * and the Z flag. The GEODETIC flag must be set BEFORE serialization,
+     * since the bounding box of a geodetic value is computed on the unit
+     * sphere and occupies 6 floats, while the one of a planar value occupies
+     * 2 * ndims floats. The answer read from the boundaries needs none of
+     * this: it is built with the flags it carries, and a geodetic geometry
+     * does not reach here */
+    lwgeom_set_geodetic(lwresult, FLAGS_GET_GEODETIC(lwgeom->flags));
+  }
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(lwgeom); lwgeom_free(lwresult);
   return result;

--- a/mobilitydb/test/rgeo/expected/164_trgeo_spatialfuncs.test.out
+++ b/mobilitydb/test/rgeo/expected/164_trgeo_spatialfuncs.test.out
@@ -16,7 +16,7 @@ SELECT ST_AsText(round(traversedArea(
   trgeometry 'Interp=Step;Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2026-01-01, Pose(Point(2 0),0)@2026-01-02]', TRUE), 6));
                            st_astext                           
 ---------------------------------------------------------------
- MULTIPOLYGON(((0 1,1 1,1 0,0 0,0 1)),((2 1,3 1,3 0,2 0,2 1)))
+ MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)),((2 0,3 0,3 1,2 1,2 0)))
 (1 row)
 
 SELECT asText(round(centroid(


### PR DESCRIPTION
The dissolve of the components of a geometry is the last algorithm MEOS asks GEOS for. The buffer of a geometry of several components already performs it: where two component buffers overlap it reads their boundaries, keeps the pieces that bound the union and welds them into the rings of one surface, holes included. What that answers for a geometry a caller brings is the same question, so the buffer's combiner gains an entry and the union reads it.

The entry answers a geometry whose components are all surfaces, which is the shape the traversed area of a moving body takes and the shape a route or a circular buffer union takes. Anything else -- a component that is a point or a line, or a pair whose topology the boundary overlay does not cover -- answers nothing, and the caller falls back as it does today.

The precision model is the other thing it does not answer for. No caller asks for one: all six in-tree callers pass a negative precision, and the function reaches no SQL surface, so the fallback is what a precision argument reaches if one is ever given.

A boundary welded out of pieces is a curve polygon even where every piece of it is a segment, so a result carrying no arc is read back into the polygon a caller that gave polygons expects. An arc stays on its own circle throughout, where the linearization a GEOS union performs replaces it with the chain of segments approximating it.

Over the hundred rigid geometries of the fixture the answer is the same region, of the same type and in the same number of parts: the greatest symmetric difference between the two answers has an area of 1e-12 and the greatest difference in area is 4e-12. Thirty of them are written differently, starting the ring at another vertex or running it the other way round, and one of those thirty is a row of the suite -- the row this PR adopts, whose exterior runs counter-clockwise from its lowest corner.
