### PR TITLE
Read the SRID a point cloud schema declares from the row that declares it

### DIFF
--- a/mobilitydb/src/pointcloud/schema_cache.c
+++ b/mobilitydb/src/pointcloud/schema_cache.c
@@ -87,13 +87,17 @@ pointcloud_namespace_oid(void)
 }
 
 /**
- * @brief Fetch the XML schema text for a given pcid from
+ * @brief Fetch the XML schema text and the SRID for a given pcid from
  *   @c pointcloud_formats via a direct heap scan.
+ * @details The SRID is a column of that table and appears nowhere in the
+ *   schema XML, so this is the only place it can be read from.
+ * @param[in] pcid pgPointCloud schema identifier
+ * @param[out] srid The SRID the row declares
  * @return palloc'd cstring on hit, NULL on miss.  The memory context
  *   is whatever was current at call time.
  */
 static char *
-fetch_schema_xml(uint32_t pcid)
+fetch_schema_row(uint32_t pcid, int32 *srid)
 {
   Oid nsp_oid = pointcloud_namespace_oid();
   if (nsp_oid == InvalidOid)
@@ -121,10 +125,17 @@ fetch_schema_xml(uint32_t pcid)
     /* indexOK */ false, NULL, 1, key);
 
   char *xml = NULL;
+  /* 0 is what liblwgeom spells SRID_UNKNOWN, whose header this file does not
+   * read, and what a pointcloud_formats row declaring no SRID carries */
+  *srid = 0;
   HeapTuple tuple = systable_getnext(scan);
   if (HeapTupleIsValid(tuple))
   {
     bool isnull;
+    /* srid is the second column (attnum 2) */
+    Datum srid_datum = heap_getattr(tuple, 2, tupDesc, &isnull);
+    if (! isnull)
+      *srid = DatumGetInt32(srid_datum);
     /* schema is the third column (attnum 3) */
     Datum xml_datum = heap_getattr(tuple, 3, tupDesc, &isnull);
     if (! isnull)
@@ -180,7 +191,8 @@ mobilitydb_pc_parse_xml(uint32_t pcid, const char *xml)
 PCSCHEMA *
 mobilitydb_pc_schema(uint32_t pcid)
 {
-  char *xml = fetch_schema_xml(pcid);
+  int32 srid;
+  char *xml = fetch_schema_row(pcid, &srid);
   if (xml == NULL)
     return NULL;
 
@@ -198,8 +210,11 @@ mobilitydb_pc_schema(uint32_t pcid)
       errmsg("Failed to parse pgpointcloud schema XML for pcid=%u", pcid)));
   }
 
-  /* pc_schema_from_xml doesn't populate schema->pcid — wire it up. */
+  /* pc_schema_from_xml populates neither the pcid nor the srid — both are
+   * columns of pointcloud_formats rather than elements of the XML, and the
+   * pgpointcloud loader assigns both after its own fetch. */
   schema->pcid = pcid;
+  schema->srid = (uint32_t) srid;
   /* Register both parsed schema AND XML — the MEOS WKB encoder needs
    * the XML to embed in cross-cluster-portable WKB blobs. */
   meos_pc_schema_register_xml(pcid, schema, xml);

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -530,6 +530,40 @@ SELECT SRID(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::flo
  t
 (1 row)
 
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 4, 4326, schema FROM pointcloud_formats WHERE pcid = 1;
+INSERT 0 1
+SELECT SRID(pcpoint(4, 1.0, 1.0, 1.0));
+ srid 
+------
+ 4326
+(1 row)
+
+SELECT SRID(tpcpoint(pcpoint(4, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz));
+ srid 
+------
+ 4326
+(1 row)
+
+SELECT SRID(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(4, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(4, 2.0, 2.0, 2.0), '2024-01-02'::timestamptz)]));
+ srid 
+------
+ 4326
+(1 row)
+
+SELECT SRID(pcpoint(4, 1.0, 1.0, 1.0)) =
+  (SELECT srid FROM pointcloud_formats WHERE pcid = 4);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT set(ARRAY[pcpoint(1, 1.0, 1.0, 1.0), pcpoint(4, 2.0, 2.0, 2.0)]);
+ERROR:  Set elements have different pcpoint schemas: 1 vs 4
+DELETE FROM pointcloud_formats WHERE pcid = 4;
+DELETE 1
 SELECT count(*) FROM unnest(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]));
  count 
 -------

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -267,6 +267,26 @@ SELECT SRID(tpcpointSeqSet(ARRAY[tpcpointSeq(ARRAY[:inst1, :inst2])]));
 SELECT SRID(:inst1) = (SELECT srid FROM pointcloud_formats WHERE pcid = 1);
 SELECT SRID(tpcpointSeq(ARRAY[:inst1, :inst2])) = SRID(:inst1);
 
+-- The schema of pcid 1 declares SRID 0, so every equality above holds with
+-- both sides zero and none of them can see an SRID that fails to arrive. A
+-- schema declaring one is what makes them answer about the value.
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 4, 4326, schema FROM pointcloud_formats WHERE pcid = 1;
+
+SELECT SRID(pcpoint(4, 1.0, 1.0, 1.0));
+SELECT SRID(tpcpoint(pcpoint(4, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz));
+SELECT SRID(tpcpointSeq(ARRAY[
+  tpcpoint(pcpoint(4, 1.0, 1.0, 1.0), '2024-01-01'::timestamptz),
+  tpcpoint(pcpoint(4, 2.0, 2.0, 2.0), '2024-01-02'::timestamptz)]));
+SELECT SRID(pcpoint(4, 1.0, 1.0, 1.0)) =
+  (SELECT srid FROM pointcloud_formats WHERE pcid = 4);
+-- Values of two schemas do not share a set. The schemas decide it before the
+-- SRIDs do: uniformity of pcid is the stricter requirement, since two schemas
+-- may declare one SRID and still lay their dimensions out differently.
+SELECT set(ARRAY[pcpoint(1, 1.0, 1.0, 1.0), pcpoint(4, 2.0, 2.0, 2.0)]);
+
+DELETE FROM pointcloud_formats WHERE pcid = 4;
+
 -------------------------------------------------------------------------------
 -- Unnest
 -- One row per distinct value, with the span set on which the temporal value


### PR DESCRIPTION
The pgpointcloud schema of a pcid is a row of pointcloud_formats holding
(pcid, srid, schema), where the SRID is a column and appears nowhere in the
schema XML. The MobilityDB resolver read the XML column alone and assigned
the pcid to the parsed schema, so its srid stayed 0 and every reader of it
answered 0: SRID(pcpoint), SRID(pcpatch), SRID(tpcpoint) and SRID(tpcbox)
alike. The resolver now reads the SRID column beside the XML and assigns it
as pgpointcloud's own loader does.

The regression tests compared the SRID of a value against the SRID of the
schema of pcid 1, which the fixture declares as 0, so both sides were zero
and no SRID had to arrive for them to hold. A schema declaring 4326 is
registered alongside, under which the value reports the SRID of its schema
and two schemas of differing SRID refuse to share a set.