### PR TITLE
Require the PROJ version the transform path already calls

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -518,9 +518,18 @@ endif()
 message(STATUS "POSTGIS_GEOS_VERSION: ${POSTGIS_GEOS_VERSION}")
 
 # Proj reprojection library
+# The version is required as a plain check rather than as an argument to
+# find_package: PROJ's own package configuration accepts a requested version
+# only when its major number equals the installed one, so a minimum expressed
+# there would reject every later major release.
 find_package(PROJ REQUIRED)
 include_directories(SYSTEM ${PROJ_INCLUDE_DIRS})
 math(EXPR POSTGIS_PROJ_VERSION "${PROJ_VERSION_MAJOR} * 10 + ${PROJ_VERSION_MINOR}")
+if(POSTGIS_PROJ_VERSION LESS 61)
+  message(FATAL_ERROR "PROJ 6.1 or later is required, ${PROJ_VERSION} found. The "
+    "transform path applies the axis order a visualisation expects through "
+    "proj_normalize_for_visualization(), which PROJ publishes from 6.1.0 on.")
+endif()
 message(STATUS "POSTGIS_PROJ_VERSION: ${POSTGIS_PROJ_VERSION}")
 
 # JSON-C library (used for MF-JSON input/output)

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -793,13 +793,8 @@ meos_version(void)
 char *
 meos_full_version(void)
 {
-  const char *proj_vers;
-#if POSTGIS_PROJ_VERSION < 61
-  proj_vers = pj_get_release();
-#else
   PJ_INFO pji = proj_info();
-  proj_vers = pji.version;
-#endif
+  const char *proj_vers = pji.version;
   /* A build carrying no GEOS reports none */
 #if GEOS
   const char *geos_vers = GEOSversion();


### PR DESCRIPTION
The build states its PROJ floor and refuses below it. The transform path applies the axis order a visualisation expects through proj_normalize_for_visualization(), which PROJ publishes from 6.1.0 on, so 6.1 is the earliest release the sources compile against. The check is a plain comparison on the version the build already computes rather than an argument to find_package, because PROJ's package configuration treats a requested version as compatible only when its major number equals the installed one, so a minimum expressed there rejects every later major release. The version string reads the release from proj_info(); the branch it replaces called pj_get_release(), which PROJ declares in proj_api.h, the header removed in 8.0.0, under a condition the floor above never admits.