### PR TITLE
Read a point against a segment with the test that rejects by bounding box

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -174,17 +174,18 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
       const double y1  = e->y1;
 
       const double dxp = x - x1;
-      const double dyp = y - y1;
 
-      /* Boundary check, which reads the point itself rather than the ray */
-      const double cross = dx * dyp - dy * dxp;
-      if (fabs(cross) < MEOS_GEOM_TOLERANCE)
-      {
-        const double dot = dxp * dx + dyp * dy;
-        if (dot >= -MEOS_GEOM_TOLERANCE &&
-            dot <= (e->length) + MEOS_GEOM_TOLERANCE)
-          return 1;
-      }
+      /* Boundary check, which reads the point itself rather than the ray. The
+       * test is the one #point_on_segment_within makes, taking the tolerance
+       * the edge carries: a cross product is an AREA, so bounding it by a
+       * distance reads a point as lying on a segment far from it once the
+       * coordinates are large, and reads a point as lying off a short segment
+       * it does lie on. A repeated vertex draws an edge of no length, whose
+       * cross and dot products are BOTH zero wherever the point is, and the
+       * bounding-box rejection the shared test opens with is what keeps such
+       * an edge from claiming every point of the plane as its own */
+      if (point_on_segment_within(x, y, x1, y1, e->x2, e->y2, e->tol))
+        return 1;
 
       /* Ray casting */
       if ((y1 > ry) != ((y1 + dy) > ry))

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -211,6 +211,26 @@ int main(void)
     free(self);
   }
 
+  /* A repeated vertex draws an edge of no length, and such an edge lies under
+   * every point of the plane unless the test that reads a point against it
+   * rejects the ones its bounding box cannot hold. The witness is a square
+   * that repeats a vertex and is contained in a larger one: the same square
+   * written without the repetition is the control, and answers alike either
+   * way, so what the pair isolates is the degenerate edge and nothing else */
+  GSERIALIZED *outer = geom_in("POLYGON((0 0,0 2,2 2,2 0,0 0))", -1);
+  GSERIALIZED *plain = geom_in("POLYGON((0 0,0 1,1 1,1 0,0 0))", -1);
+  GSERIALIZED *repeated = geom_in("POLYGON((0 0,0 1,0 1,1 1,1 0,0 0))", -1);
+  assert(outer != NULL); assert(plain != NULL); assert(repeated != NULL);
+  meos_errno_reset();
+  int has_plain = geom_contains(outer, plain);
+  int has_repeated = geom_contains(outer, repeated);
+  printf("geom_contains(outer, plain): %d, geom_contains(outer, repeated): "
+    "%d, errno %d\n", has_plain, has_repeated, meos_errno());
+  assert(has_plain == 1);
+  assert(has_repeated == 1);
+  assert(meos_errno() == 0);
+  free(outer); free(plain); free(repeated);
+
   /* Equality is read from the native DE-9IM matrix, so two circular strings
    * describing the SAME arc through DIFFERENT defining points are equal. The
    * three points lie on the circle of centre (0 0) and radius 5, which they


### PR DESCRIPTION
A repeated vertex draws an edge of no length. The on-segment test written
directly inside `point_in_polygon` reads a point against such an edge through a
cross product and a dot product, and both are identically zero wherever the
point is, so that edge answers that it carries every point of the plane.

Two answers follow from it. A square holding a repeated vertex is not contained
in a square that holds it:

```
SELECT ST_Contains(geometry 'POLYGON((0 0,0 2,2 2,2 0,0 0))',
                   geometry 'POLYGON((0 0,0 1,0 1,1 1,1 0,0 0))');
```

and a geometry collection carrying a component that degenerates in the plane
loses its boundary altogether, because the boundary of the union is read by
asking each component where a portion of it stands, and a degenerate component
answers that it covers both sides of every portion. The collection is then left
with no interior and no boundary, and relates to everything as the empty set.

The same question is already answered by `point_on_segment_within`, which opens
with a bounding-box rejection. A degenerate edge passes that rejection for
nothing but its own point. It also bounds the distance from the point to the
segment by a distance, which the edge carries precomputed, where a cross product
is an area and bounding it by a distance reads a point as lying on a segment far
from it once the coordinates are large.

The matrix of the two squares above is `2FF11F212`, which is what GEOS reads for
that pair. The collection of two faces of a polyhedral surface is `2FF11F212`
likewise. What the two engines still give differently is a zero-area polygon,
which is invalid per the OGC and which GEOS drops from a collection entirely.

`meos/test/geo_test.c` asserts the containment above together with the same
square written without the repetition, which answers alike either way and is
therefore the control that isolates the degenerate edge. No expected output in
the regression suite carries a repeated vertex or a degenerate component.