### PR TITLE
Classify a point cloud set as the spatial set it is

### DIFF
--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -407,7 +407,9 @@ spatialarr_as_ewkt(const Datum *spatialarr, MeosType elemtype, int count,
 void
 spatialset_set_stbox(const Set *s, STBox *result)
 {
-  assert(s); assert(result);
+  /* A spatial set carries an SRID; the box it is asked for here is the
+   * separate property the catalog answers, which a point cloud set lacks */
+  assert(s); assert(result); assert(type_bboxtype(s->settype) == T_STBOX);
   memset(result, 0, sizeof(STBox));
   memcpy(result, SET_BBOX_PTR(s), sizeof(STBox));
   return;
@@ -426,7 +428,7 @@ spatialset_set_stbox(const Set *s, STBox *result)
 Datum
 distance_spatialset_value(const Set *s, Datum value)
 {
-  assert(s); assert(spatialset_type(s->settype));
+  assert(s); assert(type_bboxtype(s->settype) == T_STBOX);
   STBox box1, box2;
   spatialset_set_stbox(s, &box1);
   if (! spatial_set_stbox(value, s->basetype, &box2))
@@ -445,7 +447,7 @@ Datum
 distance_spatialset_spatialset(const Set *s1, const Set *s2)
 {
   assert(s1); assert(s2); assert(s1->settype == s2->settype);
-  assert(spatialset_type(s1->settype));
+  assert(type_bboxtype(s1->settype) == T_STBOX);
   STBox box1, box2;
   spatialset_set_stbox(s1, &box1);
   spatialset_set_stbox(s2, &box2);

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -924,7 +924,12 @@ ensure_geoset_type(MeosType type)
 #endif /* MEOS */
 
 /**
- * @brief Return true if the type is a geo set type
+ * @brief Return true if the type is a spatial set type
+ * @details A set is spatial when its elements carry an SRID, which is what the
+ * operations reading this predicate need: the same-SRID test between two sets
+ * and the writing of an SRID into the extended binary form. Carrying a bounding
+ * box is a separate property that @p type_bboxtype answers, and a point cloud
+ * set has the first without the second.
  */
 bool
 spatialset_type(MeosType type)
@@ -932,7 +937,11 @@ spatialset_type(MeosType type)
   return (type == T_GEOMSET || type == T_GEOGSET || type == T_NPOINTSET ||
     type == T_POSESET || type == T_POSECHAINSET || type == T_CBUFFERSET ||
     type == T_H3INDEXSET ||
-    type == T_QUADBINSET);
+    type == T_QUADBINSET
+#if POINTCLOUD
+    || type == T_PCPOINTSET || type == T_PCPATCHSET
+#endif
+    );
 }
 
 #if MEOS

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -655,9 +655,9 @@ Datum
 distance_set_value(const Set *s, Datum value)
 {
   assert(s);
-  /* A spatial set bounds its elements with a spatiotemporal box and has no
-   * span, so the subclass answers for that extent */
-  if (spatialset_type(s->settype))
+  /* A set bounding its elements with a spatiotemporal box has no span, so the
+   * subclass answers for that extent */
+  if (type_bboxtype(s->settype) == T_STBOX)
     return distance_spatialset_value(s, value);
   Span s1;
   set_set_span(s, &s1);
@@ -676,7 +676,7 @@ Datum
 distance_set_set(const Set *s1, const Set *s2)
 {
   assert(s1); assert(s2); assert(s1->settype == s2->settype);
-  if (spatialset_type(s1->settype))
+  if (type_bboxtype(s1->settype) == T_STBOX)
     return distance_spatialset_spatialset(s1, s2);
   Span sp1, sp2;
   set_set_span(s1, &sp1);

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -2271,16 +2271,21 @@ set_flags_from_wkb_state(meos_wkb_parse_state *s, uint8_t wkb_flags)
   s->has_srid = false;
   if (wkb_flags & MEOS_WKB_ORDERED)
     s->ordered = true;
-  /* Get the flags */
+  /* The Z and geodetic bits state what a base type derives from its own flags */
   if (spatial_basetype(s->basetype))
   {
     if (wkb_flags & MEOS_WKB_ZFLAG)
       s->hasz = true;
     if (wkb_flags & MEOS_WKB_GEODETICFLAG)
       s->geodetic = true;
-    if (wkb_flags & MEOS_WKB_SRIDFLAG)
-      s->has_srid = true;
   }
+  /* The SRID bit states whether the writer put an SRID on the wire, which the
+   * form is self-describing about: a set of a base type deriving no flags of
+   * its own still carries one when its elements have an SRID. Deciding it here
+   * from anything but the bit desynchronises the reader from
+   * #set_flags_to_wkb_buf and the count is then read from the SRID's bytes. */
+  if (wkb_flags & MEOS_WKB_SRIDFLAG)
+    s->has_srid = true;
   return;
 }
 

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -2526,16 +2526,21 @@ set_flags_to_wkb_buf(const Set *set, uint8_t *buf, uint8_t variant)
 {
   /* Set the flags */
   uint8_t wkb_flags = MEOS_WKB_ORDERED;
+  /* The Z and geodetic bits state what a base type derives from its own flags */
   if (spatial_basetype(set->basetype))
   {
     if (MEOS_FLAGS_GET_Z(set->flags))
       wkb_flags |= MEOS_WKB_ZFLAG;
     if (MEOS_FLAGS_GET_GEODETIC(set->flags))
       wkb_flags |= MEOS_WKB_GEODETICFLAG;
-    if (spatialset_type(set->settype) &&
-        spatial_wkb_needs_srid(spatialset_srid(set), variant))
-      wkb_flags |= MEOS_WKB_SRIDFLAG;
   }
+  /* The SRID bit states what the two sites writing the SRID itself decide,
+   * #set_to_wkb_size and #set_to_wkb_buf, so the three read one predicate: a
+   * set whose elements carry an SRID, which a set of a base type deriving no
+   * flags of its own may still be */
+  if (spatialset_type(set->settype) &&
+      spatial_wkb_needs_srid(spatialset_srid(set), variant))
+    wkb_flags |= MEOS_WKB_SRIDFLAG;
   /* Write the flags */
   return uint8_to_wkb_buf(wkb_flags, buf, variant);
 }

--- a/mobilitydb/src/geo/tspatial_analyze.c
+++ b/mobilitydb/src/geo/tspatial_analyze.c
@@ -605,12 +605,15 @@ gserialized_compute_stats(VacAttrStats *stats, AnalyzeAttrFetchFunc fetchfunc,
      * a temporal point while the original function gets a geometry.
      */
     MeosType type = oid_meostype(stats->attrtypid);
-    assert(spatialset_type(type) || tspatial_type(type)
+    /* The set branch reads a bounding box the set stores, which is the
+     * property the catalog answers and not the spatiality of its elements */
+    assert((set_type(type) && type_bboxtype(type) == T_STBOX) ||
+      tspatial_type(type)
 #if POINTCLOUD
       || tpointcloud_temptype(type)
 #endif
       );
-    if (spatialset_type(type))
+    if (set_type(type))
     {
       /* Get bounding box from spatial set */
       Set *set = DatumGetSetP(datum);
@@ -1188,7 +1191,7 @@ Spatialset_analyze(PG_FUNCTION_ARGS)
   VacAttrStats *stats = (VacAttrStats *) PG_GETARG_POINTER(0);
 
   /* Ensure type has a STBox as a bounding box */
-  assert(spatialset_type(oid_meostype(stats->attrtypid)));
+  assert(type_bboxtype(oid_meostype(stats->attrtypid)) == T_STBOX);
 
   /*
    * Call the standard typanalyze function. It may fail to find needed

--- a/mobilitydb/test/pointcloud/expected/400_pcpoint_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/400_pcpoint_tbl.test.out
@@ -110,3 +110,34 @@ WHERE s IS NOT NULL AND pcpatchsetFromHexWKB(asHexEWKB(s)) <> s;
      0
 (1 row)
 
+SELECT COUNT(*) FROM tbl_pcpointset
+WHERE s IS NOT NULL AND asEWKB(s) = asBinary(s);
+ count 
+-------
+    75
+(1 row)
+
+SELECT COUNT(*) FROM tbl_pcpatchset
+WHERE s IS NOT NULL AND asEWKB(s) = asBinary(s);
+ count 
+-------
+    75
+(1 row)
+
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 3, 4326, schema FROM pointcloud_formats WHERE pcid = 1;
+INSERT 0 1
+WITH t AS (SELECT set(ARRAY[pcpoint(3, 1.0, 1.0, 1.0),
+  pcpoint(3, 2.0, 2.0, 2.0)]) AS s)
+SELECT asEWKB(s) <> asBinary(s) AS differ,
+  octet_length(asEWKB(s)) - octet_length(asBinary(s)) AS extra_bytes,
+  pcpointsetFromBinary(asEWKB(s)) = s AS ewkb_roundtrips,
+  pcpointsetFromBinary(asBinary(s)) = s AS wkb_roundtrips
+FROM t;
+ differ | extra_bytes | ewkb_roundtrips | wkb_roundtrips 
+--------+-------------+-----------------+----------------
+ t      |           4 | t               | t
+(1 row)
+
+DELETE FROM pointcloud_formats WHERE pcid = 3;
+DELETE 1

--- a/mobilitydb/test/pointcloud/queries/400_pcpoint_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/400_pcpoint_tbl.test.sql
@@ -85,4 +85,29 @@ WHERE s IS NOT NULL AND pcpatchsetFromHexWKB(asHexWKB(s)) <> s;
 SELECT COUNT(*) FROM tbl_pcpatchset
 WHERE s IS NOT NULL AND pcpatchsetFromHexWKB(asHexEWKB(s)) <> s;
 
+-- The extended form carries the SRID the plain one omits, and a round trip
+-- holds either way, so only a comparison of the two forms sees it. The fixture
+-- registers its only schema with SRID 0, where the two forms agree by
+-- definition, so a schema carrying an SRID is what makes the question
+-- answerable.
+SELECT COUNT(*) FROM tbl_pcpointset
+WHERE s IS NOT NULL AND asEWKB(s) = asBinary(s);
+SELECT COUNT(*) FROM tbl_pcpatchset
+WHERE s IS NOT NULL AND asEWKB(s) = asBinary(s);
+
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 3, 4326, schema FROM pointcloud_formats WHERE pcid = 1;
+
+-- Of a schema carrying an SRID: the extended form is the four bytes of the
+-- SRID longer, differs from the plain one, and both still round-trip.
+WITH t AS (SELECT set(ARRAY[pcpoint(3, 1.0, 1.0, 1.0),
+  pcpoint(3, 2.0, 2.0, 2.0)]) AS s)
+SELECT asEWKB(s) <> asBinary(s) AS differ,
+  octet_length(asEWKB(s)) - octet_length(asBinary(s)) AS extra_bytes,
+  pcpointsetFromBinary(asEWKB(s)) = s AS ewkb_roundtrips,
+  pcpointsetFromBinary(asBinary(s)) = s AS wkb_roundtrips
+FROM t;
+
+DELETE FROM pointcloud_formats WHERE pcid = 3;
+
 -------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -652,22 +652,27 @@ axes are cited by `manifest.d/<axis>.yaml` filename, not by line number.
 | `Span<T>` (**5**) | intspan, bigintspan, floatspan, datespan, tstzspan | `MEOS_SPANTYPE_CATALOG` :287-295 · `span_type()` :982-987 |
 | `SpanSet<T>` (**5**) | intspanset, bigintspanset, floatspanset, datespanset, tstzspanset | `MEOS_SPANSETTYPE_CATALOG` :301-309 · `spanset_type()` :1080-1085 |
 
-Sub-predicates, all live at master `74c28447cf`: `spatialset_type()` :912 =
-geomset, geogset, npointset, poseset, posechainset, cbufferset, h3indexset,
-quadbinset (**8**). `numset_type()` :818 · `timeset_type()` :845 ·
-`geoset_type()` :889 · `alphanumset_type()` :877 · `pointcloudset_type()` :955 =
-pcpointset, pcpatchset.
+Sub-predicates: `spatialset_type()` = geomset, geogset, npointset, poseset,
+posechainset, cbufferset, h3indexset, quadbinset, pcpointset, pcpatchset
+(**10**). `numset_type()` · `timeset_type()` · `geoset_type()` ·
+`alphanumset_type()` · `pointcloudset_type()` = pcpointset, pcpatchset, which
+names the two sets whose dimensions need the schema, not a class outside the
+spatial one.
 
-⛔ **`spatialset_type()` NAMES SPATIALITY AND CURRENTLY ENCODES BBOX-CARRYING, AND
-THE TWO COME APART.** `set_bbox_size()` (`set.c`) returns `0` for a pointcloud set,
-which is why `pointcloudset_type()` holds them instead — yet the pointcloud family
-publishes `SRID(pcpoint)`, `SRID(pcpatch)`, `SRID(tpcpoint)` and `SRID(tpcbox)`, and
-`SRID(tpcpoint)` binds the GENERIC `Tspatial_srid`, which the committed pointcloud
-expected output records answering and agreeing with `pointcloud_formats`. A type
-carrying an SRID is spatial, so the exclusion charges a BBOX property to a
-SPATIALITY predicate, and 14 dispatch sites carry a second `|| pointcloud_*` clause
-as a result. The three properties the predicate conflates — carries an SRID, has
-schema-derivable flags, stores a bbox — each need their own predicate.
+⭐ **`spatialset_type()` NAMES SPATIALITY, AND THE BBOX QUESTION IS ANSWERED
+ELSEWHERE.** The two came apart at the pointcloud family: `set_bbox_size()`
+(`set.c`) returns `0` for a pointcloud set, while the family publishes
+`SRID(pcpoint)`, `SRID(pcpatch)`, `SRID(tpcpoint)` and `SRID(tpcbox)`, and
+`SRID(tpcpoint)` binds the GENERIC `Tspatial_srid`. A type carrying an SRID is
+spatial, so a site meaning *stores a box* now reads `type_bboxtype(t) == T_STBOX`
+and the spatial predicate answers only about spatiality. Three properties were
+conflated — carries an SRID, has schema-derivable flags, stores a bbox — and each
+has its own predicate now.
+⛔ The SRID is what a set's EXTENDED binary form writes, so all four sites deciding
+it read one predicate: `set_to_wkb_size`, `set_to_wkb_buf`, `set_flags_to_wkb_buf`
+and, on the reading side, `set_flags_from_wkb_state`, which honours the wire's own
+SRID bit. A reader re-deriving that decision from a base-type predicate reads the
+element count out of the SRID's bytes.
 
 ⭐ **THE CELL SETS ARE NOT THE SAME CASE.** `h3indexset`/`quadbinset` sit in
 `spatialset_type()` and declare no `SRID`/`setSRID`/`transform`, and that is
@@ -682,7 +687,7 @@ inherited from the `ways` network table.
 
 ### 9.1b `SpatialSet<T>` — the subclass surface, derived from `Spatial<T>`
 
-`SpatialSet<T>` = `spatialset_type()` (**8** members). Its surface is the set-lift
+`SpatialSet<T>` = `spatialset_type()` (**10** members). Its surface is the set-lift
 of what a spatial BASE type carries BECAUSE it is spatial — the operations left
 after removing what every value type has (comparisons, `hash`, the set operations,
 ever/always, `asText`/`asBinary`/`asHexWKB`). Counted from the `CREATE FUNCTION`
@@ -813,7 +818,7 @@ flags the per-surface set axes implement as deployment gates.
 | `ordered` | the base has a SEMANTIC total order (int, bigint, float, text, date, timestamptz) — **this flag is what decides whether position operators are emitted at all**; the 10 unordered bases get none |
 | `posops_spelling` | `value` = `<< >> &< &>` (numbers + text) · `time` = `<<# #>> &<# #&>` (date + timestamptz); omitted when not ordered |
 | `metric` | `<->` / `setDistance` is deployed (all ordered bases except text, plus geomset/geogset/npointset/poseset/cbufferset) — the gate of `manifest.d/distance_families.yaml` |
-| `spatial` | the set is `spatialset_type()` (:909-914) — carries a bounding box and the SRS section (§9.3); pcpointset/pcpatchset are `pointcloudset_type()`, not spatial |
+| `spatial` | the set STORES A BOUNDING BOX and carries the SRS section (§9.3). ⛔ NOT `spatialset_type()`, which answers whether the elements carry an SRID: pcpointset/pcpatchset are spatial sets that store no box, so they are `false` here |
 
 Known deployed irregularity the axis does not model: jsonbset has the `<<`/`>>`
 pair (`json/450_jsonbset.in.sql:378-393`, `Left_set_set`/`Right_set_set`)

--- a/tools/codegen/inherited/manifest.d/classes.yaml
+++ b/tools/codegen/inherited/manifest.d/classes.yaml
@@ -19,7 +19,7 @@ classes:
     members: [geomset, geogset]
   spatialset:
     predicate: spatialset_type
-    members: [geomset, geogset, npointset, poseset, posechainset, cbufferset, h3indexset, quadbinset]
+    members: [geomset, geogset, npointset, poseset, posechainset, cbufferset, h3indexset, quadbinset, pcpointset, pcpatchset]
   alphanumset:
     predicate: alphanumset_type
     members: [dateset, floatset, intset, bigintset, textset, tstzset, jsonbset]

--- a/tools/codegen/inherited/manifest.d/setfamilies.yaml
+++ b/tools/codegen/inherited/manifest.d/setfamilies.yaml
@@ -22,8 +22,9 @@
 #                     time  = <<# #>> &<# #&>  (date + timestamptz)
 #                     omitted when not ordered
 #   metric            true where `<->` / setDistance is deployed today
-#   spatial           true where the set carries a bounding box —
-#                     spatialset_type() (meos_catalog.c:909-914)
+#   spatial           true where the set carries a bounding box. This is NOT
+#                     spatialset_type(), which answers whether the elements
+#                     carry an SRID — a set is spatial without holding a box.
 setfamilies:
   - {set: intset,     base: integer,     ordered: true,  posops_spelling: value, metric: true,  spatial: false}
   - {set: bigintset,  base: bigint,      ordered: true,  posops_spelling: value, metric: true,  spatial: false}
@@ -45,7 +46,8 @@ setfamilies:
   - {set: jsonbset,   base: jsonb,       ordered: false,                         metric: false, spatial: false}
   - {set: h3indexset, base: h3index,     ordered: false,                         metric: false, spatial: true}
   - {set: quadbinset, base: quadbin,     ordered: false,                         metric: false, spatial: true}
-  # pointcloud sets are NOT spatialset_type(): they carry no bounding box —
-  # pointcloudset_type() (meos_catalog.c:950-954) is the separate predicate.
+  # pointcloud sets ARE spatialset_type() — their elements carry an SRID — and
+  # carry no bounding box, which is what this column states: the dimensions of
+  # a pcpoint need the schema XML keyed by pcid, which MEOS cannot read.
   - {set: pcpointset, base: pcpoint,     ordered: false,                         metric: false, spatial: false}
   - {set: pcpatchset, base: pcpatch,     ordered: false,                         metric: false, spatial: false}


### PR DESCRIPTION
A set is spatial when its elements carry an SRID, and a point cloud set carries
one: the schema its identifier names holds it, which is how the SRID of a point
cloud value, of its temporal form and of its box already answer. The predicate
therefore holds the two point cloud set types, so a pair of them is tested for
a common SRID as any other pair of spatial sets is, and the extended binary
form of one writes the SRID it carries where it wrote none and returned what
the plain form returns.

Carrying a bounding box is the separate property the catalog answers, and a
point cloud set has the SRID without the box, so the reading of the box of a
spatial set, and the distance that reaches it, ask the catalog for the box
rather than asking whether the set is spatial.

The tests read the extended form against the plain one, which the round trips
beside them hold equal whether or not an SRID is written.