### PR TITLE
Answer a failed coordinate transformation with an error

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2649,7 +2649,14 @@ geo_transform(const GSERIALIZED *gs, int32_t srid_to)
   /* now we have a geometry, and input/output PJ structs. */
   GSERIALIZED *gs1 = geo_copy(gs);
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs1);
-  lwgeom_transform(lwgeom, pj);
+  if (lwgeom_transform(lwgeom, pj) == LW_FAILURE)
+  {
+    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
+      "Coordinate transformation failed");
+    lwgeom_free(lwgeom);
+    pfree(gs1);
+    return NULL;
+  }
   lwgeom->srid = srid_to;
 
   /* Re-compute bbox if input had one (COMPUTE_BBOX TAINTING) */


### PR DESCRIPTION
geo_transform reads the result of lwgeom_transform and declines when PROJ cannot perform the transformation, as its sibling geo_transform_pipeline already does. Discarding that result stamps the target SRID on a geometry whose coordinates never move, so SRID=4326;Point(6 51) transformed to EPSG:22300, for which PROJ answers no inverse operation, comes back as SRID=22300;Point(6 51): the original coordinates relabelled as the target system.