### PR TITLE
Answer the buffer at the radius where an offset degenerates

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -2852,6 +2852,7 @@ buffer_classify_rings(const MeosArray *rings, int32_t srid,
 
   /* Initialize the ring information and compute one representative
    * point strictly inside every ring */
+  uint32_t kept = 0;
   for (uint32_t i = 0; i < count; i++)
   {
     const BufferRingInfo *ring_info =
@@ -2861,16 +2862,26 @@ buffer_classify_rings(const MeosArray *rings, int32_t srid,
       pfree(info);
       return false;
     }
-    info[i] = *ring_info;
-    info[i].parent = -1;
-    info[i].depth = 0;
-    info[i].shell = -1;
-    if (! buffer_ring_representative_point(info[i].ring, srid,
-        &info[i].x, &info[i].y))
-    {
-      pfree(info);
-      return false;
-    }
+    info[kept] = *ring_info;
+    info[kept].parent = -1;
+    info[kept].depth = 0;
+    info[kept].shell = -1;
+    /* A ring holding no point at all holds no area, which is what a boundary
+     * pinched to zero width leaves behind: where a hole closes exactly, the
+     * ring that bounded it survives the split with its two sides coincident.
+     * Such a ring contributes no surface and no hole, so it is dropped and
+     * the rest of the classification stands. Refusing it instead loses the
+     * whole buffer over a ring that bounds nothing */
+    if (! buffer_ring_representative_point(info[kept].ring, srid,
+        &info[kept].x, &info[kept].y))
+      continue;
+    kept++;
+  }
+  count = kept;
+  if (count == 0)
+  {
+    pfree(info);
+    return true;
   }
 
   /* First determine all pairwise containment relationships.
@@ -3741,7 +3752,19 @@ buffer_offset_edge(const Edge *edge, double radius, bool left,
       r = -r;
       half = M_PI;
       if (r <= MEOS_GEOM_TOLERANCE)
-        return false;
+      {
+        /* Offsetting into an arc by exactly what it turns on carries every
+         * point of the offset onto the centre, so the offset IS that point.
+         * A point bounds nothing, which is the case above one step further,
+         * and it is emitted as a piece of no length for the same reason: the
+         * ring stays closed and #buffer_ring_resolve drops what bounds
+         * nothing. Refusing it loses a buffer that exists on both sides of
+         * this radius */
+        piece->type = BUFFER_SEGMENT;
+        piece->x1 = piece->x2 = edge->cx;
+        piece->y1 = piece->y2 = edge->cy;
+        return true;
+      }
     }
     piece->type = BUFFER_ARC;
     piece->cx = edge->cx;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -236,6 +236,40 @@ int main(void)
     free(self);
   }
 
+  /* An offset that degenerates at one exact radius: the two offsets of a U
+   * meet with no width left where the radius is half the gap between its arms,
+   * and the inward offset of an arc lands on the centre where the radius
+   * equals the arc's own. Both bound a buffer that exists on either side of
+   * that radius, so the answer has to exist AT it too, and it has to sit
+   * between its neighbours: a buffer grows with its radius, so the critical
+   * one covers the smaller and is covered by the larger. That sandwich is the
+   * oracle -- a buffer that merely answers proves nothing about its shape */
+  const char *degenerate[] = {
+    "Linestring(0 0,2 0,2 2,0 2)",      /* arms 2 apart, critical radius 1 */
+    "Circularstring(20 0,21 1,22 0)"    /* radius 1, critical radius 1 */
+  };
+  char covers_patt[10] = "T*****FF*";
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *g = geom_in(degenerate[i], -1);
+    assert(g != NULL);
+    meos_errno_reset();
+    GSERIALIZED *below = geom_buffer(g, 0.999, "");
+    GSERIALIZED *at = geom_buffer(g, 1.0, "");
+    GSERIALIZED *above = geom_buffer(g, 1.001, "");
+    printf("geom_buffer(%s) below %d at %d above %d, errno %d\n",
+      degenerate[i], below != NULL, at != NULL, above != NULL, meos_errno());
+    assert(below != NULL); assert(at != NULL); assert(above != NULL);
+    assert(meos_errno() == 0);
+    bool grows = geom_relate_pattern(at, below, covers_patt);
+    bool grown = geom_relate_pattern(above, at, covers_patt);
+    printf("  covers(at, below): %d, covers(above, at): %d\n", grows, grown);
+    assert(grows == true);
+    assert(grown == true);
+    free(g); free(below); free(at); free(above);
+    meos_errno_reset();
+  }
+
   /* A repeated vertex draws an edge of no length, and such an edge lies under
    * every point of the plane unless the test that reads a point against it
    * rejects the ones its bounding box cannot hold. The witness is a square


### PR DESCRIPTION
An offset that runs into itself is already read rather than refused: where a
geometry turns tighter than the buffer distance the offsets cross, and the loop
the crossing leaves is dropped because it bounds nothing. Two shapes reach the
exact radius at which that loop has no width at all, and there the buffer is
refused instead.

The inward offset of an arc lands on the centre where the buffer distance equals
the arc's own radius, so the offset is that single point. It is emitted as a
piece of no length, on the same reasoning as the offset that overshoots the
centre: the ring stays closed and the resolve drops what bounds nothing.

The two offsets of a line meet with no width left where the buffer distance is
half the gap between its arms, and the ring that bounded the closing hole
survives the split with its two sides coincident. Such a ring holds no point at
all, so the classification of the rings drops that one and keeps the rest.

These five curved and straight shapes answer at every distance of 1, 0.5, 0.1
and 0.01:

```
Linestring(0 0,2 0,2 2,0 2)
Compoundcurve((0 0,2 0),Circularstring(2 0,3 1,4 0))
Circularstring(0 0,1 1,2 0,3 -1,4 0)
Multicurve((0 0,4 0),Circularstring(20 0,21 1,22 0))
Compoundcurve(Circularstring(0 0,1 1,2 0),Circularstring(2 0,3 1,4 0))
```

The answers are continuous through the critical radius. The area of the buffer
of a linestring whose arms lie 2 apart reads 14.69496318 at 0.999, 14.71238524
at 1 and 14.72775511 at 1.001. A semicircle of radius 1 buffered by 1 covers a
half disc of radius 2 and two caps of radius 1, which is 3*pi: the answer reads
9.42477048 against 9.42477796, the difference being the linearization the area
is measured on.

`meos/test/geo_test.c` asserts both shapes at the critical radius together with
the radii on either side, and that the answer covers the smaller buffer and is
covered by the larger, since a buffer that merely answers says nothing about its
shape.

Over 283 real projected polygons at three distances, and over the buffer
assertions of the GEOS test suite, the counts of answers covering their own
input, answers not covering it, and geometries the buffer declines are the same
on both sides of this commit.