### PR TITLE
Drop the hole of a closed line contracted through itself

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -4821,9 +4821,32 @@ meos_buffer_line_offset(const LWLINE *line, double radius,
     buffer_curvepoly_add_ring(result, outer);
     LWCOMPOUND *inner = buffer_ring(ring, radius, ! outward, join_style,
       mitre_limit, srid);
+    /* Contracting a ring by more than it encloses carries the contraction
+     * through itself, and it comes back out inverted at the distance it
+     * overshot by. That curve is nearer the line than the buffer distance, so
+     * it bounds nothing and the hole it would stand for is gone rather than
+     * uncovered. The point it holds is what says which of the two it is: an
+     * interior point of a true hole lies further from the line than the
+     * distance, and an interior point of the inverted curve lies nearer */
+    bool inverted = false;
+    if (inner)
+    {
+      double hx, hy;
+      MeosArray *ledges = geom_extract_edges((const LWGEOM *) line);
+      if (ledges && buffer_ring_representative_point(inner, srid, &hx, &hy) &&
+          buffer_point_edges_distance(hx, hy, ledges) <
+            radius - MEOS_GEOM_TOLERANCE)
+      {
+        lwgeom_free(lwcompound_as_lwgeom(inner));
+        inner = NULL;
+        inverted = true;
+      }
+      if (ledges)
+        meos_array_destroy(ledges);
+    }
     if (inner)
       buffer_curvepoly_add_ring(result, inner);
-    else if (! geom_ring_is_convex(ring))
+    else if (! inverted && ! geom_ring_is_convex(ring))
     {
       /* The hole is uncovered rather than absent: contracting a ring that is
        * not convex may leave several holes, which the boundary overlay has to


### PR DESCRIPTION
The buffer of a closed line is the band of twice the distance centred on it,
whose outer boundary bounds the surface and whose inner one is its hole. The
line encloses that hole only while it stays wider than the distance, and
contracting it by more carries the contraction through itself, so it comes back
out inverted at the distance it overshot by. That curve lies nearer the line
than the buffer distance, so it bounds nothing, and the hole it stands for is
gone rather than uncovered.

The point the curve holds is what tells the two apart: an interior point of a
true hole lies further from the line than the distance, and an interior point of
the inverted curve lies nearer. A ring failing that test is dropped, and a ring
dropped for that reason does not send a line that is not convex to the boundary
overlay, since its hole is absent rather than unnamed.

A square ring of side 8 encloses a hole up to a distance of 4. The area of its
buffer reads 302.539754 at 5, 369.097246 at 6, 441.937918 at 7 and 521.061770 at
8, against a square of side 8 + 2r with rounded corners of 302.539816,
369.097336, 441.938040 and 521.061930. The ring the buffer carries in place of
its closed hole is a square of side 2r - 8, which reaches the line itself at a
distance of 8, where the buffer stops covering the line it is taken of.

Over the buffer assertions of the GEOS test suite at distances 1, 5 and 50, the
answers that cover their own input read 84 of 102 against 73, the answers that
do not read 3 against 14, and the geometries the buffer declines stay at 15.

The first commit carries the degenerate-offset fix this one builds on.