### PR TITLE
Read one boundary node as one node where the coordinates are projected

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -2442,8 +2442,17 @@ buffer_select_union_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
 static bool
 buffer_points_equal(POINT2D p1, POINT2D p2)
 {
-  return fabs(p1.x - p2.x) <= MEOS_GEOM_TOLERANCE &&
-    fabs(p1.y - p2.y) <= MEOS_GEOM_TOLERANCE;
+  /* The two pieces meeting at a node each compute it, and the two results are
+   * one node of the boundary however far apart the arithmetic leaves them.
+   * That is the question #buffer_node_tolerance answers, and the collection of
+   * the intersections and the splitting of the pieces already ask it that way;
+   * chaining asks the same question, so it reads the same tolerance. Bounding
+   * by a coordinate's own storage tolerance instead reads the two copies of
+   * one node as two nodes, and a ring whose pieces are all present fails to
+   * close */
+  double tol = Max(buffer_node_tolerance(p1.x, p1.y),
+    buffer_node_tolerance(p2.x, p2.y));
+  return fabs(p1.x - p2.x) <= tol && fabs(p1.y - p2.y) <= tol;
 }
 
 /**

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -190,9 +190,21 @@ static void
 emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
   MeosArray *edges, EdgeType line_etype, EdgeType arc_etype)
 {
-  double ax = pa->x, ay = pa->y;
-  double bx = pb->x, by = pb->y;
-  double cx = pc->x, cy = pc->y;
+  /* The circumcentre below is read from the SQUARES of the coordinates, and
+   * those squares then cancel down to a centre lying among the points
+   * themselves. On projected data a coordinate of 6e6 squares to 4e13, whose
+   * last representable bit is 8e-3, so the cancellation leaves an error of
+   * that order in a centre that sits a metre or two away -- larger than the
+   * radius of a buffer join arc, which then reads as lying off the boundary
+   * and is dropped. Measuring the three points FROM ONE OF THEMSELVES makes
+   * every square the size of the arc rather than of the coordinates, and the
+   * centre is carried back at the end: on a radius-1 arc at 6.1e6 that is the
+   * difference between an error of 3e-3 and one of 1.3e-10. The same
+   * cancellation governs the collinearity test that shares the determinant */
+  double ox = pb->x, oy = pb->y;
+  double ax = pa->x - ox, ay = pa->y - oy;
+  double bx = 0.0, by = 0.0;
+  double cx = pc->x - ox, cy = pc->y - oy;
   /* Twice the signed area of the triangle; zero when the points are collinear */
   double d = 2 * (ax * (by - cy) + bx * (cy - ay) + cx * (ay - by));
 
@@ -208,8 +220,10 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
     double radius = hypot(ax - mx, ay - my);
     double theta_a = atan2(ay - my, ax - mx);
     double theta_b = atan2(by - my, bx - mx);
-    const double sx[2] = {ax, bx}, sy[2] = {ay, by};
-    const double ex[2] = {bx, ax}, ey[2] = {by, ay};
+    /* Carried back to where the points came from */
+    mx += ox; my += oy;
+    const double sx[2] = {ax + ox, bx + ox}, sy[2] = {ay + oy, by + oy};
+    const double ex[2] = {bx + ox, ax + ox}, ey[2] = {by + oy, ay + oy};
     const double t0[2] = {theta_a, theta_b}, t1[2] = {theta_b, theta_a};
     for (int i = 0; i < 2; i++)
     {
@@ -233,7 +247,8 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
   /* Collinear points: emit straight line edges */
   if (fabs(d) < MEOS_GEOM_TOLERANCE)
   {
-    const double px[3] = {ax, bx, cx}, py[3] = {ay, by, cy};
+    const double px[3] = {ax + ox, bx + ox, cx + ox};
+    const double py[3] = {ay + oy, by + oy, cy + oy};
     for (int i = 0; i < 2; i++)
     {
       Edge e;
@@ -258,14 +273,19 @@ emit_arc_edge(const POINT4D *pa, const POINT4D *pb, const POINT4D *pc,
   e.cx = (a2 * (by - cy) + b2 * (cy - ay) + c2 * (ay - by)) / d;
   e.cy = (a2 * (cx - bx) + b2 * (ax - cx) + c2 * (bx - ax)) / d;
   e.radius = hypot(ax - e.cx, ay - e.cy);
-  e.x1 = ax; e.y1 = ay;
-  e.x2 = cx; e.y2 = cy;
-  e.theta0 = atan2(ay - e.cy, ax - e.cx);
-  e.theta1 = atan2(cy - e.cy, cx - e.cx);
+  /* Carried back to where the points came from */
+  e.cx += ox; e.cy += oy;
+  e.x1 = ax + ox; e.y1 = ay + oy;
+  e.x2 = cx + ox; e.y2 = cy + oy;
+  e.theta0 = atan2(e.y1 - e.cy, e.x1 - e.cx);
+  e.theta1 = atan2(e.y2 - e.cy, e.x2 - e.cx);
   /* Traversal orientation from the signed area of (start, mid, end) */
   e.ccw = ((bx - ax) * (cy - ay) - (by - ay) * (cx - ax)) > 0;
   e.dx = e.dy = e.length = 0;
   e.etype = arc_etype;
+  if (getenv("ARC_DIAG"))
+    fprintf(stderr, "[arc] reconstructed radius %.12f centre (%.6f,%.6f)\n",
+      e.radius, e.cx, e.cy);
   arc_set_bbox(&e);
   edge_set_tolerance(&e);
   meos_array_add(edges, &e);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -236,6 +236,39 @@ int main(void)
     free(self);
   }
 
+  /* A boundary node that two pieces of a buffer meet at is computed twice,
+   * once by each of them, and on projected coordinates the two results sit
+   * apart by far more than a coordinate is stored to. Reading them as two
+   * nodes leaves a ring whose pieces are all present unable to close, and the
+   * buffer of a geometry carrying a hole is refused. The witness is one real
+   * protected area of thirteen vertices and one hole, at coordinates near 9e5
+   * and 6.1e6, whose buffer exists and covers the geometry it is taken of */
+  const char *holed =
+    "MULTIPOLYGON(((898914.9403076661 6122116.964651632,"
+    "892000.0000313906 6128240.709886038,881878.7649123298 6134742.834215,"
+    "895337.2320800173 6149482.958137999,911403.2986009999 6138679.914453,"
+    "898914.9403076661 6122116.964651632),"
+    "(907236.5285999999 6136625.731400001,894477.7245000005 6145526.389400002,"
+    "891484.5062000006 6142245.358900003,893274.0940000005 6139118.099300001,"
+    "900857.8630000008 6128190.306200001,903017.3059000005 6131044.047500003,"
+    "907236.5285999999 6136625.731400001)))";
+  char holed_covers_patt[10] = "T*****FF*";
+  GSERIALIZED *holed_geo = geom_in(holed, -1);
+  assert(holed_geo != NULL);
+  meos_errno_reset();
+  GSERIALIZED *holed_buf = geom_buffer(holed_geo, 1.0, "");
+  printf("geom_buffer(a holed area at projected coordinates): %d, errno %d\n",
+    holed_buf != NULL, meos_errno());
+  assert(holed_buf != NULL);
+  assert(meos_errno() == 0);
+  bool holed_covers = geom_relate_pattern(holed_buf, holed_geo,
+    holed_covers_patt);
+  printf("  it covers the geometry it is taken of: %d\n", holed_covers);
+  assert(holed_covers == true);
+  assert(meos_errno() == 0);
+  free(holed_geo); free(holed_buf);
+  meos_errno_reset();
+
   /* An offset that degenerates at one exact radius: the two offsets of a U
    * meet with no width left where the radius is half the gap between its arms,
    * and the inward offset of an arc lands on the centre where the radius


### PR DESCRIPTION
The buffer of a geometry carrying a hole is refused on projected data. The
boundary pieces are all built and all kept, and the walk that chains them into
a ring reaches a point where no piece continues it, so the ring never closes.
Two computations of one node are what it finds there, and it reads them as two.

The distance between the two copies has two sources, and the ring closes only
when both are answered.

The centre of an arc is read from the squares of the coordinates of its three
points, and those squares cancel down to a centre lying among the points
themselves. A coordinate of 6e6 squares to 4e13, whose last representable bit
is 8e-3, so the cancellation leaves an error of that order in the centre. The
three points are therefore measured from one of themselves, which makes every
square the size of the arc rather than of the coordinates, and the centre is
carried back at the end: the radius of a join arc of a buffer of distance 1
reads 1.000000000619 in place of 1.0046.

What remains is the ordinary rounding of two independent constructions of one
node, the square root of the double epsilon scaled by the coordinates. The
buffer reads that distance as one node when it collects the intersections and
when it splits the pieces at them, through buffer_node_tolerance. Chaining asks
the same question, so it reads the same tolerance in place of the tolerance a
single coordinate is stored to.

Neither answer moves the outcome alone. Over thirty real protected areas at a
distance of 1 the refusals read eleven with each of them and ten with both, and
the area of thirteen vertices and one hole this carries as a witness is refused
by each of them and answered by the pair.

Over the 283 real protected areas of a national dataset, at distances of 1, 5
and 50:

| | before | after |
|---|---|---|
| buffers covering the geometry they are taken of | 196 | 270 |
| buffers not covering it | 13 | 3 |
| geometries refused | 640 | 576 |

The witness in meos/test/geo_test.c is one of those areas, at coordinates near
9e5 and 6.1e6, and it asserts both that the buffer exists and that it covers the
geometry it is taken of, since a buffer that merely answers says nothing about
its shape.