### PR TITLE
Name the PROJ context accessor outside PROJ's own namespace

### DIFF
--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -99,7 +99,7 @@
  * Internal function accessing the PROJ library
  *****************************************************************************/
 
-extern PJ_CONTEXT *proj_get_context(void);
+extern PJ_CONTEXT *meos_proj_get_context(void);
 
 /*****************************************************************************
  * Internal function accessing the GEOS library

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -560,7 +560,7 @@ point_transf_pj(GSERIALIZED *gs, int32_t srid_to, const LWPROJ *pj)
      * which PROJ states as the reason it replaces the function; MEOS answers
      * from several threads at once, so the text is read from the context */
 #if POSTGIS_PROJ_VERSION >= 80
-    const char *pj_errno_str = proj_context_errno_string(proj_get_context(),
+    const char *pj_errno_str = proj_context_errno_string(meos_proj_get_context(),
       pj_errno_val);
 #else
     const char *pj_errno_str = proj_errno_string(pj_errno_val);

--- a/meos/src/temporal/meos.c
+++ b/meos/src/temporal/meos.c
@@ -186,10 +186,13 @@ proj_finalize(void)
 #endif /* MEOS */
 
 /**
- * @brief Get the random generator used by temporal aggregation
+ * @brief Return the per-thread PROJ context
+ * @note Named with the @p meos_ prefix
+ * because PROJ owns the @p proj_ one, where it publishes 26 @p proj_get_* entry points; the
+ * sibling @p geos_get_context needs no such qualification, GEOS using @p GEOS instead.
  */
 PJ_CONTEXT *
-proj_get_context(void)
+meos_proj_get_context(void)
 {
   if (! MEOS_PJ_CONTEXT)
     proj_initialize();

--- a/postgis/liblwgeom/lwgeom_transform.c
+++ b/postgis/liblwgeom/lwgeom_transform.c
@@ -31,12 +31,12 @@
 /* MEOS */
 /* PROJ documents PJ_CONTEXT as not thread-safe: concurrent calls sharing the
  * global PJ_DEFAULT_CTX race on its proj.db/SQLite handle and cache. MEOS gives
- * each thread its own context via proj_get_context() (declared in
+ * each thread its own context via meos_proj_get_context() (declared in
  * meos_internal_geo.h, defined in meos/src/temporal/meos.c); the transform
  * helpers below use it instead of PJ_DEFAULT_CTX so MEOS is safe in
  * multi-threaded hosts (JVM/Spark/Flink). Forward-declared here to avoid
  * pulling a MEOS header into vendored liblwgeom. */
-extern PJ_CONTEXT *proj_get_context(void);
+extern PJ_CONTEXT *meos_proj_get_context(void);
 
 /* MEOS */
 /* proj_errno_string reads a global error state, which PROJ documents as the
@@ -47,7 +47,7 @@ static const char *
 proj_errno_str(int err)
 {
 #if POSTGIS_PROJ_VERSION >= 80
-  return proj_context_errno_string(proj_get_context(), err);
+  return proj_context_errno_string(meos_proj_get_context(), err);
 #else
   return proj_errno_string(err);
 #endif /* POSTGIS_PROJ_VERSION >= 80 */
@@ -81,7 +81,7 @@ lwproj_from_str(const char* str_in, const char* str_out)
 	if (! (str_in && str_out))
 		return NULL;
 
-	PJ* pj = proj_create_crs_to_crs(proj_get_context() /* MEOS */, str_in, str_out, NULL);
+	PJ* pj = proj_create_crs_to_crs(meos_proj_get_context() /* MEOS */, str_in, str_out, NULL);
 	if (!pj)
 		return NULL;
 
@@ -90,7 +90,7 @@ lwproj_from_str(const char* str_in, const char* str_out)
 	/* that info in the cache */
 	if (strcmp(str_in, str_out) == 0)
 	{
-		PJ *pj_source_crs = proj_get_source_crs(proj_get_context() /* MEOS */, pj);
+		PJ *pj_source_crs = proj_get_source_crs(meos_proj_get_context() /* MEOS */, pj);
 		PJ *pj_ellps;
 		PJ_TYPE pj_type = proj_get_type(pj_source_crs);
 		if (pj_type == PJ_TYPE_UNKNOWN)
@@ -101,7 +101,7 @@ lwproj_from_str(const char* str_in, const char* str_out)
 		}
 		source_is_latlong = (pj_type == PJ_TYPE_GEOGRAPHIC_2D_CRS) || (pj_type == PJ_TYPE_GEOGRAPHIC_3D_CRS);
 
-		pj_ellps = proj_get_ellipsoid(proj_get_context() /* MEOS */, pj_source_crs);
+		pj_ellps = proj_get_ellipsoid(meos_proj_get_context() /* MEOS */, pj_source_crs);
 		proj_destroy(pj_source_crs);
 		if (!pj_ellps)
 		{
@@ -109,7 +109,7 @@ lwproj_from_str(const char* str_in, const char* str_out)
 			lwerror("%s: unable to access source crs ellipsoid", __func__);
 			return NULL;
 		}
-		if (!proj_ellipsoid_get_parameters(proj_get_context() /* MEOS */,
+		if (!proj_ellipsoid_get_parameters(meos_proj_get_context() /* MEOS */,
 						   pj_ellps,
 						   &semi_major_metre,
 						   &semi_minor_metre,
@@ -125,7 +125,7 @@ lwproj_from_str(const char* str_in, const char* str_out)
 	}
 
 	/* Add in an axis swap if necessary */
-	PJ* pj_norm = proj_normalize_for_visualization(proj_get_context() /* MEOS */, pj);
+	PJ* pj_norm = proj_normalize_for_visualization(meos_proj_get_context() /* MEOS */, pj);
 	/* Swap failed for some reason? Fall back to coordinate operation */
 	if (!pj_norm)
 		pj_norm = pj;
@@ -150,7 +150,7 @@ lwproj_from_str_pipeline(const char* str_pipeline, bool is_forward)
 	if (!str_pipeline)
 		return NULL;
 
-	PJ* pj = proj_create(proj_get_context() /* MEOS */, str_pipeline);
+	PJ* pj = proj_create(meos_proj_get_context() /* MEOS */, str_pipeline);
 	if (!pj)
 		return NULL;
 
@@ -159,7 +159,7 @@ lwproj_from_str_pipeline(const char* str_pipeline, bool is_forward)
 		return NULL;
 
 	/* Add in an axis swap if necessary */
-	PJ* pj_norm = proj_normalize_for_visualization(proj_get_context() /* MEOS */, pj);
+	PJ* pj_norm = proj_normalize_for_visualization(meos_proj_get_context() /* MEOS */, pj);
 	if (!pj_norm)
 		pj_norm = pj;
 	/* Swap is not a copy of input? Clean up input */
@@ -184,7 +184,7 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 	LWPROJ *lp = lwproj_from_str(instr, outstr);
 	if (!lp)
 	{
-		PJ *pj_in = proj_create(proj_get_context() /* MEOS */, instr);
+		PJ *pj_in = proj_create(meos_proj_get_context() /* MEOS */, instr);
 		if (!pj_in)
 		{
 			proj_errno_reset(NULL);
@@ -192,7 +192,7 @@ lwgeom_transform_from_str(LWGEOM *geom, const char* instr, const char* outstr)
 		}
 		proj_destroy(pj_in);
 
-		PJ *pj_out = proj_create(proj_get_context() /* MEOS */, outstr);
+		PJ *pj_out = proj_create(meos_proj_get_context() /* MEOS */, outstr);
 		if (!pj_out)
 		{
 			proj_errno_reset(NULL);
@@ -214,7 +214,7 @@ lwgeom_transform_pipeline(LWGEOM *geom, const char* pipelinestr, bool is_forward
 	LWPROJ *lp = lwproj_from_str_pipeline(pipelinestr, is_forward);
 	if (!lp)
 	{
-		PJ *pj_in = proj_create(proj_get_context() /* MEOS */, pipelinestr);
+		PJ *pj_in = proj_create(meos_proj_get_context() /* MEOS */, pipelinestr);
 		if (!pj_in)
 		{
 			proj_errno_reset(NULL);


### PR DESCRIPTION
The per-thread PROJ context accessor is called meos_proj_get_context, which keeps it out of the proj_ namespace that PROJ populates with 26 proj_get_* entry points and would collide with the day one of those names matches. The rename covers the declaration in meos_internal_geo.h, the definition in meos/src/temporal/meos.c, the caller in tspatial_srid.c and the vendored liblwgeom caller, whose forward declaration exists to keep a MEOS header out of liblwgeom and carries its MEOS marker. The accessor's comment describes the PROJ context it returns rather than the random generator of the pg_prng getter beside it. The sibling geos_get_context keeps its name, GEOS publishing GEOS-prefixed entry points and nothing lowercase.