### PR TITLE
Bound a buffer node by the square root of the rounding its coordinates carry

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -1348,10 +1348,17 @@ buffer_components_relation(const LWGEOM *geom1, const LWGEOM *geom2)
 static double
 buffer_node_tolerance(double x, double y)
 {
-  /* The square root of the double epsilon, scaled by the coordinates, and
-   * never below the tolerance an exactly computed node is placed to */
+  /* The square root belongs to the ROUNDING the coordinates carry, not to the
+   * epsilon alone with the coordinates multiplied in afterwards: an
+   * ill-conditioned crossing moves by the square root of the rounding of its
+   * inputs, and that rounding is `DBL_EPSILON * scale`. Taking the root of the
+   * epsilon and scaling the result multiplies two unrelated magnitudes
+   * together, which at a projected 6.4e6 bounds one node by 0.318 metres --
+   * a third of a buffer of radius 1, so that two crossings a centimetre apart
+   * read as one node and the ring closes around the wrong pieces. The two
+   * forms agree at unit coordinates, where the distinction does not arise */
   double scale = Max(fabs(x), fabs(y));
-  double tol = 5.0e-8 * Max(scale, 1.0);
+  double tol = sqrt(4.0 * DBL_EPSILON * Max(scale, 1.0));
   return Max(tol, MEOS_GEOM_TOLERANCE);
 }
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -269,6 +269,49 @@ int main(void)
   free(holed_geo); free(holed_buf);
   meos_errno_reset();
 
+  /* Two computations of one node read as one node when they lie nearer than
+   * the tolerance the buffer allows a node, and that tolerance takes the
+   * square root of the machine epsilon and scales it by the COORDINATES. The
+   * root belongs to the rounding those coordinates carry instead, so the
+   * scaled form bounds a node by 0.318 metres at a projected 6.4e6 and reads
+   * two crossings a centimetre apart as one. The witness is a rectangle with
+   * a notch narrower than that, whose buffer comes back as a surface of a
+   * seventieth of the area it must have -- and a buffer that answers at all
+   * covers the geometry it is taken of. The SAME shape at the origin, where
+   * the two forms agree, is the control: it answers, and it answers a surface
+   * of 703.14, the rounded 32 by 22 rectangle the notch is too narrow to
+   * reach into */
+  const char *notched[] = {
+    "Polygon((0 0,30 0,30 20,15.025 20,15.025 18,14.975 18,14.975 20,"
+      "0 20,0 0))",
+    "Polygon((600000 6360000,600030 6360000,600030 6360020,"
+      "600015.025 6360020,600015.025 6360018,600014.975 6360018,"
+      "600014.975 6360020,600000 6360020,600000 6360000))"
+  };
+  char notched_patt[10] = "T*****FF*";
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *g = geom_in(notched[i], -1);
+    assert(g != NULL);
+    meos_errno_reset();
+    GSERIALIZED *b = geom_buffer(g, 1.0, "");
+    /* A buffer that is not answered covers nothing and claims nothing */
+    bool covers = b ? geom_relate_pattern(b, g, notched_patt) : true;
+    printf("geom_buffer(a notched rectangle %s the origin): answered %d, "
+      "covers %d\n", i ? "away from" : "at", b != NULL, b != NULL && covers);
+    /* At the origin the buffer exists, and wherever it exists it covers */
+    if (i == 0)
+    {
+      assert(b != NULL);
+      assert(meos_errno() == 0);
+    }
+    assert(covers == true);
+    if (b)
+      free(b);
+    free(g);
+    meos_errno_reset();
+  }
+
   /* An offset that degenerates at one exact radius: the two offsets of a U
    * meet with no width left where the radius is half the gap between its arms,
    * and the inward offset of an arc lands on the centre where the radius


### PR DESCRIPTION
`buffer_node_tolerance` answers how far apart two computations of one boundary node may lie. An ill-conditioned crossing moves by the square root of the rounding of its inputs, and that rounding is the last bit of the coordinates, `DBL_EPSILON` times their magnitude. The tolerance takes the square root of the epsilon alone and scales the result by the coordinates afterwards:

```c
double tol = 5.0e-8 * Max(scale, 1.0);
```

which multiplies two unrelated magnitudes together. At a projected 6.4e6 that bounds one node by **0.318 metres** — a third of a buffer of radius 1 — so two genuine crossings a centimetre apart read as one node and the ring closes around the wrong pieces.

This bounds the node by `sqrt(4.0 * DBL_EPSILON * Max(scale, 1.0))` instead. The two forms agree at unit coordinates (3e-8 against 5e-8), so the defect and the fix are both invisible to a small-coordinate corpus.

## The witness

`meos/test/geo_test.c` gains a rectangle with a notch narrower than the tolerance, at the origin and translated to projected coordinates. Its buffer at radius 1 is the rounded 32 by 22 rectangle of area 703.14 — the notch is too narrow for the offset to reach into it. The copy at the origin is the control: it answers, and it answers that surface. Against the scaled tolerance the projected copy answers a surface of a seventieth of that area, which does not cover the geometry it is taken of, so the assertion that a buffer covers its own input fails on it.

## Measured

283 real projected polygons at radii 1, 5 and 50, scored on `ST_Covers(buffer(g, d), g)`:

|  | master | this change |
|---|---|---|
| cover their input | 270 | 270 |
| do NOT cover | 3 | **0** |
| declined | 576 | 579 |

Radii 5 and 50 are identical to master; the whole movement is the three wrong answers at radius 1. The GEOS buffer corpus, whose coordinates are small, is unchanged at 87 cover / 0 do not cover / 15 declined.

Those three geometries decline, which `ST_Buffer` reports as an error rather than as a surface that does not contain its own input.