### PR TITLE
Admit only an ordered base type to an ordered temporal comparison

### DIFF
--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -293,6 +293,8 @@ extern bool talphanum_type(MeosType type);
 extern bool talpha_type(MeosType type);
 extern bool tnumber_type(MeosType type);
 extern bool ensure_tnumber_type(MeosType type);
+extern bool torder_type(MeosType type);
+extern bool ensure_torder_type(MeosType type);
 extern bool ensure_tnumber_basetype(MeosType type);
 extern bool tnumber_spantype(MeosType type);
 extern bool spatial_basetype(MeosType type);

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -1302,6 +1302,35 @@ ensure_tnumber_basetype(MeosType type)
   return false;
 }
 
+/**
+ * @brief Return true if the type is a temporal type whose base type carries an
+ * order
+ * @details The temporal numbers and `ttext`. `tbool` and `tjsonb` are excluded:
+ * PostgreSQL orders both so that they can be B-tree indexed, and an index
+ * artifact is not a meaning to expose — the minimum of a temporal JSONB value
+ * over time answers nothing. The spatial types are excluded for the same
+ * reason.
+ */
+bool
+torder_type(MeosType type)
+{
+  return (type == T_TINT || type == T_TBIGINT || type == T_TFLOAT ||
+    type == T_TTEXT);
+}
+
+/**
+ * @brief Ensure that a type is a temporal type whose base type carries an order
+ */
+bool
+ensure_torder_type(MeosType type)
+{
+  if (torder_type(type))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+    "The temporal value must be of a type whose base type carries an order");
+  return false;
+}
+
 
 /**
  * @brief Return true if the type is a span number type

--- a/meos/src/temporal/temporal_compops_meos.c
+++ b/meos/src/temporal/temporal_compops_meos.c
@@ -2036,7 +2036,8 @@ Temporal *
 tlt_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_temporal_temporal(temp1, temp2))
+  if (! ensure_valid_temporal_temporal(temp1, temp2) ||
+      ! ensure_torder_type(temp1->temptype))
     return NULL;
   return tcomp_temporal_temporal(temp1, temp2, &datum2_lt);
 }
@@ -2155,7 +2156,8 @@ Temporal *
 tle_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_temporal_temporal(temp1, temp2))
+  if (! ensure_valid_temporal_temporal(temp1, temp2) ||
+      ! ensure_torder_type(temp1->temptype))
     return NULL;
   return tcomp_temporal_temporal(temp1, temp2, &datum2_le);
 }
@@ -2268,7 +2270,8 @@ Temporal *
 tgt_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_temporal_temporal(temp1, temp2))
+  if (! ensure_valid_temporal_temporal(temp1, temp2) ||
+      ! ensure_torder_type(temp1->temptype))
     return NULL;
   return tcomp_temporal_temporal(temp1, temp2, &datum2_gt);
 }
@@ -2387,7 +2390,8 @@ Temporal *
 tge_temporal_temporal(const Temporal *temp1, const Temporal *temp2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_temporal_temporal(temp1, temp2))
+  if (! ensure_valid_temporal_temporal(temp1, temp2) ||
+      ! ensure_torder_type(temp1->temptype))
     return NULL;
   return tcomp_temporal_temporal(temp1, temp2, &datum2_ge);
 }

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -202,6 +202,30 @@ int main(void)
   assert(meos_errno() == 0);
   printf("geo_transform(4326 -> 3857): %s\n", geo_as_ewkt(webmerc, 2));
 
+  /* An ordered comparison admits only a temporal type whose base type carries
+   * an order. A geometry has a B-tree order so that it can be indexed, which is
+   * not a meaning to compare over time, so the call declines */
+  meos_errno_reset();
+  Temporal *tpt1 = tgeompoint_in("[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]");
+  Temporal *tpt2 = tgeompoint_in("[Point(2 2)@2000-01-01, Point(3 3)@2000-01-02]");
+  assert(tpt1 != NULL && tpt2 != NULL && meos_errno() == 0);
+  Temporal *unordered = tlt_temporal_temporal(tpt1, tpt2);
+  printf("tlt_temporal_temporal(tgeompoint, tgeompoint): %s, errno %d\n",
+    unordered ? "answered" : "declined", meos_errno());
+  assert(unordered == NULL);
+  assert(meos_errno() != 0);
+
+  /* The same comparison over a temporal integer answers, so the decline above
+   * discriminates */
+  meos_errno_reset();
+  Temporal *ordered = tlt_temporal_temporal(num, num);
+  assert(ordered != NULL);
+  assert(meos_errno() == 0);
+  printf("tlt_temporal_temporal(tint, tint): answered, errno %d\n",
+    meos_errno());
+  free(ordered);
+  free(tpt1); free(tpt2);
+
   meos_errno_reset();
 
   free(wgs84); free(webmerc);

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -27,7 +27,7 @@
 > `reference: true` subtype is excluded, matching emit mode, which skips it — that
 > file stays hand-owned under `--validate`. Then `--classes` (the manifest's
 > `classes:` block matches the live catalog
-> class predicates — **17** classes, the temporal ones plus the value-domain `set`,
+> class predicates — **18** classes, the temporal ones plus the value-domain `set`,
 > `span`, `spanset` and their catalog sub-predicates), and `--gaps` (per behaviour
 > axis, which members of its class the rendered SQL does not yet name — a backlog
 > report, not a gate; it scores all **21** axes, a value-domain axis against the
@@ -67,6 +67,13 @@ Temporal<T>              temporal_type      = ALL temporal types            (cat
 
 - `tcbuffer`/`tnpoint`/`tpose`/`tposechain`/`trgeometry` inherit `Temporal<T>` +
   `TSpatial<T>` but **not** the `TGeo<T>`/`TPoint<T>`-only surface.
+- ⭐ **`torder_type` = tint, tbigint, tfloat, ttext — a CROSS-CUTTING class, not a node of the
+  tree above.** It is the whole of `TNumber<T>` plus `TText`, i.e. the temporal types whose base
+  type carries an ORDER, and it is what `#<`/`#<=`/`#>`/`#>=`, `minValue`/`maxValue`,
+  `atMin`/`atMax`/`minusMin`/`minusMax` and `minInstant`/`maxInstant` are declared for — twelve
+  surfaces, the same four members throughout. ⛔ `tbool` and `tjsonb` are OUT although they sit in
+  `talpha_type`, and every spatial member is OUT: PostgreSQL orders those so they can be B-tree
+  indexed, and an index artifact is not a meaning to expose over time.
 - ⭐ **`TSpatial<T>` MEMBERSHIP MEANS THE VALUES CARRY AN SRID — IT OBLIGES NO SRS SURFACE
   AND NO PARTICULAR BOX.** The box is `type_bboxtype` (§10): every member bounds itself with
   an `STBox` except `tpcpoint`/`tpcpatch`, which bound themselves with a `TPCBox`. The SRS

--- a/tools/codegen/inherited/manifest.d/classes.yaml
+++ b/tools/codegen/inherited/manifest.d/classes.yaml
@@ -38,6 +38,9 @@ classes:
   tnumber:
     predicate: tnumber_type
     members: [tfloat, tint, tbigint]
+  torder:
+    predicate: torder_type
+    members: [tint, tbigint, tfloat, ttext]
   tspatial:
     predicate: tspatial_type
     members: [tgeompoint, tgeogpoint, tnpoint, tpose, tposechain, tcbuffer, tgeometry, tgeography, trgeometry, th3index, tquadbin, tpcpoint, tpcpatch]


### PR DESCRIPTION
The catalog registers torder_type, the temporal types whose base type carries an
order: tint, tbigint, tfloat and ttext. Those four are exactly the ones SQL
declares #<, #<=, #> and #>= for, and exactly the ones carrying minValue,
maxValue, atMin, atMax, minusMin, minusMax, minInstant and maxInstant, so the
class is closed across twelve surfaces. tbool and tjsonb stay out, as do the
spatial types: PostgreSQL orders them so they can be B-tree indexed, and an
index artifact is not a meaning to expose over time.

tlt, tle, tgt and tge over two temporal values ensure that class, so a caller
asking which of two temporal geometries is the lesser is answered with an error
rather than with the B-tree order of a geometry. The SQL surface never reaches
that case, declaring the four operators for the ordered types alone; a MEOS or
binding caller does, and had no guard. The class is declared to the inherited
generator too, which reads the predicate out of the catalog and confirms its
four members.

error_test asserts the decline and, on a temporal integer, the answer, so the
guard is shown to discriminate rather than to refuse everything.