### PR TITLE
Keep every piece of a buffer ring at projected coordinates

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -265,14 +265,53 @@ buffer_make_arc(int32_t srid, double cx, double cy, double radius,
 /**
  * @brief Add a straight segment to a compound curve
  */
+/* Defined with the ring walk that shares its question of node identity */
+static bool buffer_points_equal(POINT2D p1, POINT2D p2);
+
+/**
+ * @brief Write a piece's start as the point the curve already ends at
+ * @details The walk decides that two pieces meet by #buffer_points_equal, at
+ * the tolerance the buffer places a node to, and #lwcompound_add_lwgeom
+ * decides it AGAIN by liblwgeom's own `FP_EQUALS` -- an ABSOLUTE 1e-12 on a
+ * coordinate, a thousand times finer than the last bit of a projected 6.4e6.
+ * Two computations of one node therefore join for the walk and not for the
+ * compound, which REFUSES the component; the refusal is a return value the
+ * callers drop, so the piece leaves the ring without a word and the boundary
+ * closes across the gap it left. Writing the shared node ONCE -- the
+ * coordinates the curve already carries -- makes the two agree by
+ * construction, which is what one node means
+ */
+static void
+buffer_snap_to_curve_end(const LWCOMPOUND *curve, POINT2D *point)
+{
+  assert(curve); assert(point);
+  if (curve->ngeoms == 0)
+    return;
+  /* A compound carries lines and circular strings, which hold their points
+   * the same way, and this reads only the last of them */
+  const LWLINE *prev = (const LWLINE *) curve->geoms[curve->ngeoms - 1];
+  if (! prev || ! prev->points || prev->points->npoints == 0)
+    return;
+  POINT4D last;
+  getPoint4d_p(prev->points, prev->points->npoints - 1, &last);
+  POINT2D end;
+  end.x = last.x;
+  end.y = last.y;
+  if (buffer_points_equal(end, *point))
+    *point = end;
+  return;
+}
+
 static void
 buffer_add_segment(LWCOMPOUND *curve, int32_t srid, POINT2D p1, POINT2D p2)
 {
   assert(curve);
+  buffer_snap_to_curve_end(curve, &p1);
   if (hypot(p2.x - p1.x, p2.y - p1.y) <= MEOS_GEOM_TOLERANCE)
     return;
   LWLINE *line = buffer_make_segment(srid, p1, p2);
-  lwcompound_add_lwgeom(curve, lwline_as_lwgeom(line));
+  if (lwcompound_add_lwgeom(curve, lwline_as_lwgeom(line)) != LW_SUCCESS)
+    lwline_free(line);
 }
 
 /**
@@ -296,15 +335,25 @@ buffer_add_arc(LWCOMPOUND *curve, int32_t srid, double cx, double cy,
   if (count < 1)
     count = 1;
   double delta = sweep / (double) count;
+  POINT2D first;
+  const POINT2D *snapped = start;
+  if (start)
+  {
+    first = *start;
+    buffer_snap_to_curve_end(curve, &first);
+    snapped = &first;
+  }
   for (int i = 0; i < count; i++)
   {
     double a0 = ccw ? start_angle + delta * i : start_angle - delta * i;
     double a1 = ccw ? start_angle + delta * (i + 1) : 
       start_angle - delta * (i + 1);
     LWCIRCSTRING *arc = buffer_make_arc(srid, cx, cy, radius, a0, a1, ccw,
-      i == 0 ? start : NULL, i == count - 1 ? end : NULL);
-    if (arc)
-      lwcompound_add_lwgeom(curve, lwcircstring_as_lwgeom(arc));
+      i == 0 ? snapped : NULL, i == count - 1 ? end : NULL);
+    if (arc &&
+        lwcompound_add_lwgeom(curve, lwcircstring_as_lwgeom(arc)) !=
+          LW_SUCCESS)
+      lwcircstring_free(arc);
   }
 }
 
@@ -1788,33 +1837,25 @@ buffer_piece_contains_point(const BufferPiece *piece, POINT2D *point)
 {
   assert(piece); assert(point);
   if (piece->type == BUFFER_SEGMENT)
-  {
-    double dx = piece->x2 - piece->x1;
-    double dy = piece->y2 - piece->y1;
-    double px = point->x - piece->x1;
-    double py = point->y - piece->y1;
-    /* Collinearity test */
-    double cross = buffer_cross(dx, dy, px, py);
-    double scale = fmax(1.0, hypot(dx, dy) * hypot(px, py));
-    if (fabs(cross) > MEOS_GEOM_TOLERANCE * scale)
-      return false;
-    /* Bounding-box test */
-    if (point->x < fmin(piece->x1, piece->x2) - MEOS_GEOM_TOLERANCE ||
-        point->x > fmax(piece->x1, piece->x2) + MEOS_GEOM_TOLERANCE ||
-        point->y < fmin(piece->y1, piece->y2) - MEOS_GEOM_TOLERANCE ||
-        point->y > fmax(piece->y1, piece->y2) + MEOS_GEOM_TOLERANCE)
-      return false;
-    return true;
-  }
+    /* The node the splitter asks about was placed by the arithmetic of the
+     * boundary that produced it, so it lies off the piece by the rounding of
+     * ITS OWN COORDINATES rather than by the size of the piece. Bounding the
+     * collinearity by the piece's local lengths asks a node at a projected
+     * 6.4e6 to be collinear to 1e-12 of a metre, which is a thousand times
+     * finer than the last bit of the coordinates it is built from */
+    return point_on_segment(point->x, point->y, piece->x1, piece->y1,
+      piece->x2, piece->y2);
 
   if (piece->type == BUFFER_ARC)
   {
     double dx = point->x - piece->cx;
     double dy = point->y - piece->cy;
     double distance = hypot(dx, dy);
-    /* First check that the point is on the supporting circle */
+    /* The radial distance is read from the coordinates of the point and of
+     * the centre, so it carries their rounding and not the arc's radius */
     if (fabs(distance - piece->radius) >
-        MEOS_GEOM_TOLERANCE * fmax(1.0, piece->radius))
+        fmax(coordinate_tolerance(point->x, piece->cx),
+          coordinate_tolerance(point->y, piece->cy)))
       return false;
     /* Then check that its angle lies within the finite arc */
     return buffer_point_on_arc(piece, point->x, point->y);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -275,12 +275,11 @@ int main(void)
    * root belongs to the rounding those coordinates carry instead, so the
    * scaled form bounds a node by 0.318 metres at a projected 6.4e6 and reads
    * two crossings a centimetre apart as one. The witness is a rectangle with
-   * a notch narrower than that, whose buffer comes back as a surface of a
-   * seventieth of the area it must have -- and a buffer that answers at all
-   * covers the geometry it is taken of. The SAME shape at the origin, where
-   * the two forms agree, is the control: it answers, and it answers a surface
-   * of 703.14, the rounded 32 by 22 rectangle the notch is too narrow to
-   * reach into */
+   * a notch narrower than that. A buffer is the same shape wherever the
+   * geometry sits, so the two copies below answer the SAME surface: the
+   * rounded 32 by 22 rectangle of area 703.14, the notch being too narrow for
+   * the offset to reach into. The copy at the origin, where every tolerance
+   * is far from its limits, is what the projected one is read against */
   const char *notched[] = {
     "Polygon((0 0,30 0,30 20,15.025 20,15.025 18,14.975 18,14.975 20,"
       "0 20,0 0))",
@@ -295,20 +294,15 @@ int main(void)
     assert(g != NULL);
     meos_errno_reset();
     GSERIALIZED *b = geom_buffer(g, 1.0, "");
-    /* A buffer that is not answered covers nothing and claims nothing */
-    bool covers = b ? geom_relate_pattern(b, g, notched_patt) : true;
     printf("geom_buffer(a notched rectangle %s the origin): answered %d, "
-      "covers %d\n", i ? "away from" : "at", b != NULL, b != NULL && covers);
-    /* At the origin the buffer exists, and wherever it exists it covers */
-    if (i == 0)
-    {
-      assert(b != NULL);
-      assert(meos_errno() == 0);
-    }
+      "errno %d\n", i ? "away from" : "at", b != NULL, meos_errno());
+    assert(b != NULL);
+    assert(meos_errno() == 0);
+    bool covers = geom_relate_pattern(b, g, notched_patt);
+    printf("  it covers the geometry it is taken of: %d\n", covers);
     assert(covers == true);
-    if (b)
-      free(b);
-    free(g);
+    assert(meos_errno() == 0);
+    free(b); free(g);
     meos_errno_reset();
   }
 


### PR DESCRIPTION
The boundary of a buffer is welded out of pieces, and two steps of that weld ask the same question — do these two points name one node — with tolerances three orders apart. On projected data they disagree, and a piece is lost at each disagreement.

## The splitter asks it first

A node is offered to every piece it might split, and `buffer_piece_contains_point` decides whether it lies on a segment by bounding the cross product with `MEOS_GEOM_TOLERANCE` times the piece's own lengths, which comes to an offset of `1e-12 * |p|`. One ulp of a projected 6.4e6 coordinate is 1.2e-9 — three orders larger — so a node computed exactly cannot pass its own on-segment test. Measured on one real polygon:

| piece | offset of the node | cross | threshold | on the piece? |
|---|---|---|---|---|
| `(615389.85,6359023.97)->(615390.78,6359024.49)` | 3.7e-11 m | 3.97e-11 | 1.0e-12 | **no** |
| `(615390.65,6359025.07)->(615389.98,6359023.18)` | 2e-12 m | 3.15e-12 | 1.71e-12 | **no** |

The house function `point_on_segment` already bounds that cross product by a distance the coordinates carry, and reading it here is what the shared primitive is for. It widens nothing loosely: over the failing geometry it accepts exactly three nodes the local-length band refuses, at offsets of 3.7e-11, 1.5e-10 and 2.7e-10 metres.

## The compound asks it again

`lwcompound_add_lwgeom` refuses a component whose first point is not `FP_EQUALS` the previous last point — an absolute 1e-12 on a coordinate — and returns `LW_FAILURE`, which the three call sites here drop. A refused piece leaves the ring silently and the boundary closes across the gap. On a 27-vertex protected area **31 of 72 segments go that way**, among them edges of 4.1, 10.4, 12.4, 16.7, 16.9 and 23.5 km, and the answer holds **0.77%** of the area it should.

A tolerance cannot settle this one, since the second asker is PostGIS. This starts the piece at the coordinates the curve already carries, so the two agree by construction, and releases a component that is still refused rather than leaking it.

## Neither half moves anything alone

The splitter fix alone reaches answers the weld then drops. The weld fix alone is invisible: every count over the 283 real projected polygons and over the GEOS buffer corpus is identical to master.

| arm | 283 polygons, cover / do not cover / declined | GEOS corpus |
|---|---|---|
| master | 270 / 0 / 579 | 87 / 0 / 15 |
| splitter alone | 129 / **18** / 136 at r=1 | 89 / **4** / 9 |
| weld alone | identical to master at every radius | identical |
| **both** | **470 / 0 / 379** | **93 / 0 / 9** |

## The witness

The notched rectangle already in `meos/test/geo_test.c` is the witness, at the origin and at `(600000, 6360000)`. A buffer is the same shape wherever the geometry sits, so both copies answer the rounded 32 by 22 rectangle of area 703.14, the notch being too narrow for the offset to reach into. The projected copy is refused without this change and answered with it.