### PR TITLE
Hold the child slots of an SPTree node only once it has a child

### DIFF
--- a/meos/include/temporal/temporal_sptree.h
+++ b/meos/include/temporal/temporal_sptree.h
@@ -58,7 +58,8 @@
 typedef struct SPNode
 {
   int64 id;                   /**< Identifier of the box stored at this node */
-  struct SPNode **children;   /**< Array of @p nchild child pointers */
+  struct SPNode **children;   /**< Array of @p nchild child pointers, held
+                                   only once the node gains a child */
   char centroid[];            /**< The bounding box of this node */
 } SPNode;
 

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -560,15 +560,32 @@ sptree_create_tpcbox(SPTreeKind kind)
 
 /**
  * @brief Return a new node holding a bounding box
+ * @details The node holds no child slots. A node acquires them when a descent
+ * first passes through it, so a node that never gains a child never holds one.
  */
 static SPNode *
 spnode_make(const SPTree *sptree, const void *box, int64 id)
 {
   SPNode *node = palloc0(sizeof(SPNode) + sptree->boxsize);
   node->id = id;
-  node->children = palloc0((size_t) sptree->nchild * sizeof(SPNode *));
   memcpy(node->centroid, box, sptree->boxsize);
   return node;
+}
+
+/**
+ * @brief Return the child slots of a node, creating them on first use
+ * @details The slots a node holds are as many as the quadrants of the space it
+ * partitions, which for an STBox is 64 at 6 dimensions and 256 at 8, while the
+ * nodes a tree ends in hold none of them. Reading the slots of a node that has
+ * no child therefore spends the whole array on nothing, so the array is
+ * created by the descent that places the first child rather than by the node.
+ */
+static SPNode **
+spnode_children(const SPTree *sptree, SPNode *node)
+{
+  if (! node->children)
+    node->children = palloc0((size_t) sptree->nchild * sizeof(SPNode *));
+  return node->children;
 }
 
 /**
@@ -671,8 +688,9 @@ sptree_insert(SPTree *sptree, void *box, int64 id)
   int level = 0;
   while (*slot != NULL)
   {
-    slot = &(*slot)->children[spnode_child(sptree, (*slot)->centroid, box,
-      level)];
+    SPNode *cur = *slot;
+    slot = &spnode_children(sptree, cur)[spnode_child(sptree, cur->centroid,
+      box, level)];
     level++;
   }
   *slot = spnode_make(sptree, box, id);
@@ -874,11 +892,12 @@ spnode_build(SPBuild *build, int from, int count, int level)
   {
     int *counts = palloc((size_t) sptree->nchild * sizeof(int));
     spitems_bucket(build, from, rest, node->centroid, level, counts);
+    SPNode **children = spnode_children(sptree, node);
     int offset = 0;
     for (int c = 0; c < sptree->nchild; c++)
     {
       if (counts[c] > 0)
-        node->children[c] = spnode_build(build, from + offset, counts[c],
+        children[c] = spnode_build(build, from + offset, counts[c],
           level + 1);
       offset += counts[c];
     }
@@ -990,7 +1009,8 @@ spnode_search(const SPTree *sptree, const SPNode *node, const void *nodebox,
     int64 id = node->id;
     meos_array_add(result, &id);
   }
-  for (int quadrant = 0; quadrant < sptree->nchild; quadrant++)
+  for (int quadrant = 0; node->children && quadrant < sptree->nchild;
+    quadrant++)
   {
     const SPNode *child = node->children[quadrant];
     if (! child)
@@ -1109,7 +1129,8 @@ spnode_join(const SPTree *sptree1, const SPNode *node1, const SPTree *sptree2,
     meos_array_add(result, &id1);
     meos_array_add(result, &id2);
   }
-  for (int quadrant = 0; quadrant < sptree1->nchild; quadrant++)
+  for (int quadrant = 0; node1->children && quadrant < sptree1->nchild;
+    quadrant++)
   {
     const SPNode *child = node1->children[quadrant];
     if (child)
@@ -1362,19 +1383,22 @@ spnode_free(const SPTree *sptree, SPNode *node)
   while (top > 0)
   {
     SPNode *cur = stack[--top];
-    for (int i = 0; i < sptree->nchild; i++)
+    if (cur->children)
     {
-      SPNode *child = cur->children[i];
-      if (! child)
-        continue;
-      if (top == cap)
+      for (int i = 0; i < sptree->nchild; i++)
       {
-        cap *= 2;
-        stack = repalloc(stack, cap * sizeof(SPNode *));
+        SPNode *child = cur->children[i];
+        if (! child)
+          continue;
+        if (top == cap)
+        {
+          cap *= 2;
+          stack = repalloc(stack, cap * sizeof(SPNode *));
+        }
+        stack[top++] = child;
       }
-      stack[top++] = child;
+      pfree(cur->children);
     }
-    pfree(cur->children);
     pfree(cur);
   }
   pfree(stack);
@@ -1418,11 +1442,12 @@ spnode_stats(const SPTree *sptree, const SPNode *node, int level, int *entries,
   {
     SPNodeLevel cur = stack[--top];
     (*entries)++;
-    *bytes += (int64) (sizeof(SPNode) + sptree->boxsize +
-      (size_t) sptree->nchild * sizeof(SPNode *));
+    *bytes += (int64) (sizeof(SPNode) + sptree->boxsize);
+    if (cur.node->children)
+      *bytes += (int64) ((size_t) sptree->nchild * sizeof(SPNode *));
     if (cur.level > *height)
       *height = cur.level;
-    for (int i = 0; i < sptree->nchild; i++)
+    for (int i = 0; cur.node->children && i < sptree->nchild; i++)
     {
       const SPNode *child = cur.node->children[i];
       if (! child)
@@ -1742,7 +1767,8 @@ sptree_nn_cursor_next(SPNNCursor *cursor, int64 *id_out, double *dist_out)
     sptree_box_nodebox(sptree, node->centroid, centroidbox);
     emit.dist = sptree_nodebox_distance(sptree, cursor->query, centroidbox);
     spnn_heap_push(cursor, &emit);
-    for (int quadrant = 0; quadrant < sptree->nchild; quadrant++)
+    for (int quadrant = 0; node->children && quadrant < sptree->nchild;
+      quadrant++)
     {
       const SPNode *child = node->children[quadrant];
       if (! child)

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -47,6 +47,7 @@
  * @endcode
  */
 
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -978,6 +979,65 @@ test_selective_stbox(SPTreeKind kind, const char *kindname)
   sptree_free(sptree);
 }
 
+
+/*****************************************************************************
+ * What a tree reports it holds
+ *
+ * A node partitions the space into as many child slots as the space has
+ * quadrants, and the nodes a tree ends in hold none of them. The size a tree
+ * reports therefore charges the slots to the nodes that hold them, which is
+ * asserted here without naming a byte count. The first entry of a tree costs
+ * the node it makes; the second costs a node AND the slots the root acquires
+ * to hold it. So the step from one entry to two exceeds the step from none to
+ * one, and comparing the two steps cancels whatever fixed size a tree carries
+ * before it holds anything.
+ *****************************************************************************/
+
+static void
+test_reported_size(SPTreeKind kind, const char *kindname)
+{
+  char name[128];
+
+  /* A tree holding nothing */
+  SPTree *none = sptree_create_stbox(kind);
+  MeosArray *result = meos_array_create(sizeof(int64));
+  STBox *query = random_stbox(200, 50);
+  int count = sptree_search(none, INDEX_OVERLAPS, query, result);
+  snprintf(name, sizeof(name), "%s empty answers 0, not the error sentinel",
+    kindname);
+  check(name, count == 0 && count != INT_MAX);
+  snprintf(name, sizeof(name), "%s empty holds no entry", kindname);
+  check(name, sptree_num_entries(none) == 0);
+
+  /* A tree of one entry: its only node never gains a child */
+  SPTree *one = sptree_create_stbox(kind);
+  STBox *a = random_stbox(200, 50);
+  sptree_insert(one, a, 0);
+  snprintf(name, sizeof(name), "%s one entry holds one", kindname);
+  check(name, sptree_num_entries(one) == 1);
+  snprintf(name, sizeof(name), "%s one entry reaches level 1", kindname);
+  check(name, sptree_height(one) == 1);
+  int64 size0 = sptree_mem_size(none);
+  int64 size1 = sptree_mem_size(one);
+
+  /* A second entry makes a node and gives the root its slots */
+  SPTree *two = sptree_create_stbox(kind);
+  sptree_insert(two, a, 0);
+  STBox *b = random_stbox(200, 50);
+  sptree_insert(two, b, 1);
+  int64 size2 = sptree_mem_size(two);
+  snprintf(name, sizeof(name), "%s two entries hold two", kindname);
+  check(name, sptree_num_entries(two) == 2);
+  snprintf(name, sizeof(name),
+    "%s the slots are charged to the node holding them", kindname);
+  check(name, size1 > size0 && (size2 - size1) > (size1 - size0));
+
+  free(query); free(a); free(b);
+  meos_array_destroy(result);
+  sptree_free(none); sptree_free(one); sptree_free(two);
+  return;
+}
+
 int
 main(void)
 {
@@ -1008,6 +1068,8 @@ main(void)
   test_nn_floatspan();
   test_nn_tbox();
   test_nn_stbox();
+  test_reported_size(SPTREE_QUADTREE, "quad-tree");
+  test_reported_size(SPTREE_KDTREE, "k-d tree");
 
   meos_finalize();
 


### PR DESCRIPTION
A node partitions the space into as many slots as the space has quadrants, which for an STBox is 64 at 6 dimensions and 256 at 8, and every node held that array from the moment it was made. The nodes a tree ends in hold no child at all, so about half of the arrays a tree carries stand empty: a quad-tree over 1000000 stbox entries spends 512 of the 640 bytes it holds per entry on child pointers. The array is now created by the descent that places the first child under a node, both when the tree grows an entry at a time and when it is built from a whole entry set, and a node that never gains a child never holds one. The walks that read the slots treat a node without them as a node without children, the freeing walk releases them where they exist, and the bytes an index reports count the array only for the nodes that hold one. The tree built is the one master builds: over 1000000 entries the heights are 26 grown and 21 built on both, and over 100000 they are 22 and 17. What changes is what it costs to hold. The quad-tree measures 640.0 bytes an entry against 387.6 grown and 370.0 built, so an index over a million entries holds 370 MB where it held 640 MB, and the k-d tree measures 144.0 against 135.5 and 133.2. The time follows the memory rather than leading it: interleaved over four rounds at a million entries the build reads 2.060/2.078/2.126/2.175 s against 1.938/2.000/1.901/2.002 s grown, and 1.800/1.680/1.704/1.663 s against 1.436/1.438/1.436/1.474 s loaded. The size a tree reports is asserted by meos/test/sptree_test.c without naming a byte count, since the first entry costs the node it makes while the second costs a node and the slots the root acquires to hold it: the step from one entry to two exceeds the step from none to one. Both tree kinds fail that assertion before this change and pass after it. 
