### PR TITLE
Name the comparison entry a base-direction wrapper calls

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -1353,6 +1353,18 @@ extern int ever_le_base_temporal(Datum value, const Temporal *temp);
 extern int ever_le_temporal_base(const Temporal *temp, Datum value);
 extern int ever_lt_base_temporal(Datum value, const Temporal *temp);
 extern int ever_lt_temporal_base(const Temporal *temp, Datum value);
+extern Temporal *teq_base_temporal(Datum value, const Temporal *temp);
+extern Temporal *teq_temporal_base(const Temporal *temp, Datum value);
+extern Temporal *tne_base_temporal(Datum value, const Temporal *temp);
+extern Temporal *tne_temporal_base(const Temporal *temp, Datum value);
+extern Temporal *tlt_base_temporal(Datum value, const Temporal *temp);
+extern Temporal *tlt_temporal_base(const Temporal *temp, Datum value);
+extern Temporal *tle_base_temporal(Datum value, const Temporal *temp);
+extern Temporal *tle_temporal_base(const Temporal *temp, Datum value);
+extern Temporal *tgt_base_temporal(Datum value, const Temporal *temp);
+extern Temporal *tgt_temporal_base(const Temporal *temp, Datum value);
+extern Temporal *tge_base_temporal(Datum value, const Temporal *temp);
+extern Temporal *tge_temporal_base(const Temporal *temp, Datum value);
 
 /*****************************************************************************/
 

--- a/meos/src/temporal/temporal_compops.c
+++ b/meos/src/temporal/temporal_compops.c
@@ -722,6 +722,154 @@ tcomp_temporal_temporal(const Temporal *temp1, const Temporal *temp2,
 }
 
 /*****************************************************************************
+ * Temporal comparisons of a temporal value and a base value
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal equality of a base value and a temporal value
+ * @param[in] value Value
+ * @param[in] temp Temporal value
+ */
+Temporal *
+teq_base_temporal(Datum value, const Temporal *temp)
+{
+  return tcomp_base_temporal(value, temp, &datum2_eq);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal equality of a temporal value and a base value
+ * @param[in] temp Temporal value
+ * @param[in] value Value
+ */
+Temporal *
+teq_temporal_base(const Temporal *temp, Datum value)
+{
+  return tcomp_temporal_base(temp, value, &datum2_eq);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal difference of a base value and a temporal value
+ * @param[in] value Value
+ * @param[in] temp Temporal value
+ */
+Temporal *
+tne_base_temporal(Datum value, const Temporal *temp)
+{
+  return tcomp_base_temporal(value, temp, &datum2_ne);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal difference of a temporal value and a base value
+ * @param[in] temp Temporal value
+ * @param[in] value Value
+ */
+Temporal *
+tne_temporal_base(const Temporal *temp, Datum value)
+{
+  return tcomp_temporal_base(temp, value, &datum2_ne);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal less than of a base value and a temporal value
+ * @param[in] value Value
+ * @param[in] temp Temporal value
+ */
+Temporal *
+tlt_base_temporal(Datum value, const Temporal *temp)
+{
+  return tcomp_base_temporal(value, temp, &datum2_lt);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal less than of a temporal value and a base value
+ * @param[in] temp Temporal value
+ * @param[in] value Value
+ */
+Temporal *
+tlt_temporal_base(const Temporal *temp, Datum value)
+{
+  return tcomp_temporal_base(temp, value, &datum2_lt);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal less than or equal to of a base value and a temporal value
+ * @param[in] value Value
+ * @param[in] temp Temporal value
+ */
+Temporal *
+tle_base_temporal(Datum value, const Temporal *temp)
+{
+  return tcomp_base_temporal(value, temp, &datum2_le);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal less than or equal to of a temporal value and a base value
+ * @param[in] temp Temporal value
+ * @param[in] value Value
+ */
+Temporal *
+tle_temporal_base(const Temporal *temp, Datum value)
+{
+  return tcomp_temporal_base(temp, value, &datum2_le);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal greater than of a base value and a temporal value
+ * @param[in] value Value
+ * @param[in] temp Temporal value
+ */
+Temporal *
+tgt_base_temporal(Datum value, const Temporal *temp)
+{
+  return tcomp_base_temporal(value, temp, &datum2_gt);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal greater than of a temporal value and a base value
+ * @param[in] temp Temporal value
+ * @param[in] value Value
+ */
+Temporal *
+tgt_temporal_base(const Temporal *temp, Datum value)
+{
+  return tcomp_temporal_base(temp, value, &datum2_gt);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal greater than or equal to of a base value and a temporal value
+ * @param[in] value Value
+ * @param[in] temp Temporal value
+ */
+Temporal *
+tge_base_temporal(Datum value, const Temporal *temp)
+{
+  return tcomp_base_temporal(value, temp, &datum2_ge);
+}
+
+/**
+ * @ingroup meos_internal_temporal_comp_temp
+ * @brief Return the temporal greater than or equal to of a temporal value and a base value
+ * @param[in] temp Temporal value
+ * @param[in] value Value
+ */
+Temporal *
+tge_temporal_base(const Temporal *temp, Datum value)
+{
+  return tcomp_temporal_base(temp, value, &datum2_ge);
+}
+
+/*****************************************************************************
  * Temporal comparisons
  *****************************************************************************/
 

--- a/mobilitydb/pg_include/pg_temporal/temporal.h
+++ b/mobilitydb/pg_include/pg_temporal/temporal.h
@@ -215,7 +215,7 @@ extern Datum Tcomp_temporal_temporal(FunctionCallInfo fcinfo,
   Temporal * (*func)(const Temporal *, const Temporal *));
 
 extern Datum Tcomp_temporal_base(FunctionCallInfo fcinfo,
-  Datum (*func)(Datum, Datum, MeosType));
+  Temporal * (*func)(const Temporal *, Datum));
 
 /* Indexing functions */
 

--- a/mobilitydb/src/temporal/temporal_compops.c
+++ b/mobilitydb/src/temporal/temporal_compops.c
@@ -648,12 +648,12 @@ Always_ge_temporal_temporal(PG_FUNCTION_ARGS)
  */
 static Datum
 Tcomp_base_temporal(FunctionCallInfo fcinfo,
-  Datum (*func)(Datum, Datum, MeosType))
+  Temporal * (*func)(Datum, const Temporal *))
 {
   Datum value = PG_GETARG_ANYDATUM(0);
   Temporal *temp = PG_GETARG_TEMPORAL_P(1);
   MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 0));
-  Temporal *result = tcomp_base_temporal(value, temp, func);
+  Temporal *result = func(value, temp);
   assert(result);
   DATUM_FREE_IF_COPY(value, basetype, 0);
   PG_FREE_IF_COPY(temp, 1);
@@ -665,12 +665,12 @@ Tcomp_base_temporal(FunctionCallInfo fcinfo,
  */
 Datum
 Tcomp_temporal_base(FunctionCallInfo fcinfo,
-  Datum (*func)(Datum, Datum, MeosType))
+  Temporal * (*func)(const Temporal *, Datum))
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   Datum value = PG_GETARG_ANYDATUM(1);
   MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
-  Temporal *result = tcomp_temporal_base(temp, value, func);
+  Temporal *result = func(temp, value);
   assert(result);
   PG_FREE_IF_COPY(temp, 0);
   DATUM_FREE_IF_COPY(value, basetype, 1);
@@ -708,7 +708,7 @@ PG_FUNCTION_INFO_V1(Teq_base_temporal);
 inline Datum
 Teq_base_temporal(PG_FUNCTION_ARGS)
 {
-  return Tcomp_base_temporal(fcinfo, &datum2_eq);
+  return Tcomp_base_temporal(fcinfo, &teq_base_temporal);
 }
 
 PGDLLEXPORT Datum Tne_base_temporal(PG_FUNCTION_ARGS);
@@ -723,7 +723,7 @@ PG_FUNCTION_INFO_V1(Tne_base_temporal);
 inline Datum
 Tne_base_temporal(PG_FUNCTION_ARGS)
 {
-  return Tcomp_base_temporal(fcinfo, &datum2_ne);
+  return Tcomp_base_temporal(fcinfo, &tne_base_temporal);
 }
 
 PGDLLEXPORT Datum Tlt_base_temporal(PG_FUNCTION_ARGS);
@@ -738,7 +738,7 @@ PG_FUNCTION_INFO_V1(Tlt_base_temporal);
 inline Datum
 Tlt_base_temporal(PG_FUNCTION_ARGS)
 {
-  return Tcomp_base_temporal(fcinfo, &datum2_lt);
+  return Tcomp_base_temporal(fcinfo, &tlt_base_temporal);
 }
 
 PGDLLEXPORT Datum Tle_base_temporal(PG_FUNCTION_ARGS);
@@ -753,7 +753,7 @@ PG_FUNCTION_INFO_V1(Tle_base_temporal);
 inline Datum
 Tle_base_temporal(PG_FUNCTION_ARGS)
 {
-  return Tcomp_base_temporal(fcinfo, &datum2_le);
+  return Tcomp_base_temporal(fcinfo, &tle_base_temporal);
 }
 
 PGDLLEXPORT Datum Tgt_base_temporal(PG_FUNCTION_ARGS);
@@ -768,7 +768,7 @@ PG_FUNCTION_INFO_V1(Tgt_base_temporal);
 inline Datum
 Tgt_base_temporal(PG_FUNCTION_ARGS)
 {
-  return Tcomp_base_temporal(fcinfo, &datum2_gt);
+  return Tcomp_base_temporal(fcinfo, &tgt_base_temporal);
 }
 
 PGDLLEXPORT Datum Tge_base_temporal(PG_FUNCTION_ARGS);
@@ -783,7 +783,7 @@ PG_FUNCTION_INFO_V1(Tge_base_temporal);
 inline Datum
 Tge_base_temporal(PG_FUNCTION_ARGS)
 {
-  return Tcomp_base_temporal(fcinfo, &datum2_ge);
+  return Tcomp_base_temporal(fcinfo, &tge_base_temporal);
 }
 
 /*****************************************************************************/
@@ -800,7 +800,7 @@ PG_FUNCTION_INFO_V1(Teq_temporal_base);
 inline Datum
 Teq_temporal_base(PG_FUNCTION_ARGS)
 {
-  return Tcomp_temporal_base(fcinfo, &datum2_eq);
+  return Tcomp_temporal_base(fcinfo, &teq_temporal_base);
 }
 
 PGDLLEXPORT Datum Tne_temporal_base(PG_FUNCTION_ARGS);
@@ -815,7 +815,7 @@ PG_FUNCTION_INFO_V1(Tne_temporal_base);
 inline Datum
 Tne_temporal_base(PG_FUNCTION_ARGS)
 {
-  return Tcomp_temporal_base(fcinfo, &datum2_ne);
+  return Tcomp_temporal_base(fcinfo, &tne_temporal_base);
 }
 
 PGDLLEXPORT Datum Tlt_temporal_base(PG_FUNCTION_ARGS);
@@ -830,7 +830,7 @@ PG_FUNCTION_INFO_V1(Tlt_temporal_base);
 inline Datum
 Tlt_temporal_base(PG_FUNCTION_ARGS)
 {
-  return Tcomp_temporal_base(fcinfo, &datum2_lt);
+  return Tcomp_temporal_base(fcinfo, &tlt_temporal_base);
 }
 
 PGDLLEXPORT Datum Tle_temporal_base(PG_FUNCTION_ARGS);
@@ -845,7 +845,7 @@ PG_FUNCTION_INFO_V1(Tle_temporal_base);
 inline Datum
 Tle_temporal_base(PG_FUNCTION_ARGS)
 {
-  return Tcomp_temporal_base(fcinfo, &datum2_le);
+  return Tcomp_temporal_base(fcinfo, &tle_temporal_base);
 }
 
 PGDLLEXPORT Datum Tgt_temporal_base(PG_FUNCTION_ARGS);
@@ -860,7 +860,7 @@ PG_FUNCTION_INFO_V1(Tgt_temporal_base);
 inline Datum
 Tgt_temporal_base(PG_FUNCTION_ARGS)
 {
-  return Tcomp_temporal_base(fcinfo, &datum2_gt);
+  return Tcomp_temporal_base(fcinfo, &tgt_temporal_base);
 }
 
 PGDLLEXPORT Datum Tge_temporal_base(PG_FUNCTION_ARGS);
@@ -875,7 +875,7 @@ PG_FUNCTION_INFO_V1(Tge_temporal_base);
 inline Datum
 Tge_temporal_base(PG_FUNCTION_ARGS)
 {
-  return Tcomp_temporal_base(fcinfo, &datum2_ge);
+  return Tcomp_temporal_base(fcinfo, &tge_temporal_base);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
The temporal-valued comparison of a temporal value and a base value reaches the kernel through `t{eq,ne,lt,le,gt,ge}_base_temporal` and their `temporal_base` twins, the shape the ever/always family carries in its twenty-four `ever_`/`always_` counterparts. `Tcomp_base_temporal` and `Tcomp_temporal_base` take one of them rather than a `datum2_` comparator, so the whole PostgreSQL layer names comparison entries and holds no lifting comparator of its own.
