### PR TITLE
Answer the equality of two boxes from an in-memory index

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -365,7 +365,8 @@ typedef enum
   INDEX_BEFORE,        /**< Find stored boxes strictly before the query */
   INDEX_OVERBEFORE,    /**< Find stored boxes that do not extend after the query */
   INDEX_AFTER,         /**< Find stored boxes strictly after the query */
-  INDEX_OVERAFTER      /**< Find stored boxes that do not extend before the query */
+  INDEX_OVERAFTER,     /**< Find stored boxes that do not extend before the query */
+  INDEX_SAME           /**< Find stored boxes whose extent equals the query */
 } IndexSearchOp;
 
 /**

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -233,7 +233,8 @@ ensure_same_index_bboxtype(MeosType bboxtype1, MeosType bboxtype2)
 bool
 ensure_index_join_op(IndexSearchOp op)
 {
-  if (op == INDEX_OVERLAPS || op == INDEX_CONTAINS || op == INDEX_CONTAINED_BY)
+  if (op == INDEX_OVERLAPS || op == INDEX_CONTAINS || op == INDEX_CONTAINED_BY ||
+      op == INDEX_SAME)
     return true;
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
     "A join answers the operations that compare extents, not the ones that "

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -933,6 +933,9 @@ leaf_consistent(const RTree *rtree, const void *key, const void *query,
       return rtree->bbox_contains(key, query);
     case INDEX_CONTAINED_BY:
       return rtree->bbox_contains(query, key);
+    case INDEX_SAME:
+      /* Two extents are equal exactly when each contains the other */
+      return rtree->bbox_contains(key, query) && rtree->bbox_contains(query, key);
     default:
       /* An entry satisfies a position operation as the box type answers it */
       return rtree->bbox_position ?
@@ -958,6 +961,9 @@ inner_consistent(const RTree *rtree, const void *key, const void *query,
     case INDEX_CONTAINED_BY:
       return rtree->bbox_overlaps(key, query);
     case INDEX_CONTAINS:
+    case INDEX_SAME:
+      /* A subtree holds an entry equal to the query only when the box bounding
+       * the subtree contains the query, an entry being contained by it */
       return rtree->bbox_contains(key, query);
     default:
       /* The subtree can hold an entry on one side of the query only when the

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -124,6 +124,7 @@ span_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
   switch (op)
   {
     case INDEX_CONTAINS:
+    case INDEX_SAME:
       return contain2D(n, q);
     case INDEX_LEFT:      return ! overRight2D(n, q);
     case INDEX_OVERLEFT:  return ! right2D(n, q);
@@ -144,6 +145,7 @@ span_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
   {
     case INDEX_CONTAINS:      return contains_span_span(k, q);
     case INDEX_CONTAINED_BY:  return contains_span_span(q, k);
+    case INDEX_SAME:          return contains_span_span(k, q) && contains_span_span(q, k);
     case INDEX_OVERLAPS:      return overlaps_span_span(k, q);
     case INDEX_LEFT:          return left_span_span(k, q);
     case INDEX_OVERLEFT:      return overleft_span_span(k, q);
@@ -196,6 +198,7 @@ tbox_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
   switch (op)
   {
     case INDEX_CONTAINS:
+    case INDEX_SAME:
       return contain4D(n, q);
     case INDEX_LEFT:       return ! overRight4D(n, q);
     case INDEX_OVERLEFT:   return ! right4D(n, q);
@@ -220,6 +223,7 @@ tbox_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
   {
     case INDEX_CONTAINS:      return contains_tbox_tbox(k, q);
     case INDEX_CONTAINED_BY:  return contains_tbox_tbox(q, k);
+    case INDEX_SAME:          return contains_tbox_tbox(k, q) && contains_tbox_tbox(q, k);
     case INDEX_OVERLAPS:      return overlaps_tbox_tbox(k, q);
     case INDEX_LEFT:          return left_tbox_tbox(k, q);
     case INDEX_OVERLEFT:      return overleft_tbox_tbox(k, q);
@@ -282,6 +286,7 @@ stbox_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
   switch (op)
   {
     case INDEX_CONTAINS:
+    case INDEX_SAME:
       return contain8D(n, q);
     case INDEX_OVERLAPS:
     case INDEX_CONTAINED_BY:
@@ -318,6 +323,7 @@ stbox_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
   {
     case INDEX_CONTAINS:      return contains_stbox_stbox(k, q);
     case INDEX_CONTAINED_BY:  return contains_stbox_stbox(q, k);
+    case INDEX_SAME:          return contains_stbox_stbox(k, q) && contains_stbox_stbox(q, k);
     case INDEX_OVERLAPS:      return overlaps_stbox_stbox(k, q);
     case INDEX_LEFT:          return left_stbox_stbox(k, q);
     case INDEX_OVERLEFT:      return overleft_stbox_stbox(k, q);

--- a/meos/test/index_position_test.c
+++ b/meos/test/index_position_test.c
@@ -31,7 +31,8 @@
  * @file
  * @brief A program that tests the position search operations of the in-memory
  * indexes, i.e., the operations that order a dimension, against the exact
- * answer and across both index structures.
+ * answer and across both index structures, together with the equality
+ * operation, which orders no dimension but is pruned the way containment is.
  *
  * An index answers a position operation by two different tests: an entry is
  * accepted by the operator of the box type, and a subtree is descended when it
@@ -213,6 +214,47 @@ main(void)
       printf("index position: %-10s matched %d entries over the query set, "
         "fewer than the %d the comparison needs to be meaningful\n",
         OPS[o].name, hits, MIN_HITS);
+      failures++;
+    }
+  }
+
+  /* The equality operation, whose query must be an entry to match anything.
+   * It is answered by the same descent as containment -- a subtree holds a box
+   * equal to the query only when the region bounding it contains the query --
+   * so the pruning is the part worth asserting, and the entries themselves are
+   * the query set that makes the comparison non-vacuous. */
+  {
+    int checked = 0, hits = 0;
+    for (int q = 0; q < NUM_QUERIES; q++)
+    {
+      const STBox *query = &boxes[(q * 37) % NUM_BOXES];
+      int want = 0;
+      for (int i = 0; i < NUM_BOXES; i++)
+        if (same_stbox_stbox(&boxes[i], query))
+          want++;
+
+      MeosArray *got_rt = meos_array_create(sizeof(int64));
+      MeosArray *got_quad = meos_array_create(sizeof(int64));
+      MeosArray *got_kd = meos_array_create(sizeof(int64));
+      int n_rt = rtree_search(rt, INDEX_SAME, query, got_rt);
+      int n_quad = sptree_search(quad, INDEX_SAME, query, got_quad);
+      int n_kd = sptree_search(kd, INDEX_SAME, query, got_kd);
+      if (n_rt != want || n_quad != want || n_kd != want)
+      {
+        printf("index same: query %d expected %d, R-tree %d, quad-tree %d, "
+          "k-d tree %d\n", q, want, n_rt, n_quad, n_kd);
+        failures++;
+      }
+      hits += want;
+      checked++;
+      meos_array_destroy(got_rt);
+      meos_array_destroy(got_quad);
+      meos_array_destroy(got_kd);
+    }
+    if (hits < checked)
+    {
+      printf("index same: matched %d entries over %d queries, fewer than the "
+        "one per query the comparison needs to be meaningful\n", hits, checked);
       failures++;
     }
   }


### PR DESCRIPTION
The PostgreSQL operator classes of every box type index the equality of two extents, the operator spelled ~=, and both in-memory indexes answered every other operation those classes index but that one. A query for the entries whose box equals a given one therefore read every entry of the index. The operation is added to the enumeration the two indexes share, at its end so that no operation already there is renumbered and a binding built against an older header keeps reading the operations it knows. An entry satisfies it when each of the two extents contains the other, which is what equality of extents is and what the containment the index already tests composes into, so no box type gains a predicate and the point cloud box inherits it through the spatiotemporal box it projects onto. A subtree is descended exactly as containment descends it: a subtree holds a box equal to the query only when the region bounding the subtree contains the query, every entry being contained by that region. The pruning is therefore the containment rule rather than a rule of its own. A join answers it too. The guard that admits an operation into a join reads that a join answers the operations comparing extents rather than those ordering a dimension, and equality compares extents; two equal boxes overlap, which is what a join prunes a pair of nodes by. meos/test/index_position_test.c compares the three structures against a brute-force answer over queries taken from the entries, since a query equal to no entry makes the comparison vacuous. 
