### PR TITLE
Answer the adjacency of two boxes from an in-memory index

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -366,7 +366,8 @@ typedef enum
   INDEX_OVERBEFORE,    /**< Find stored boxes that do not extend after the query */
   INDEX_AFTER,         /**< Find stored boxes strictly after the query */
   INDEX_OVERAFTER,     /**< Find stored boxes that do not extend before the query */
-  INDEX_SAME           /**< Find stored boxes whose extent equals the query */
+  INDEX_SAME,          /**< Find stored boxes whose extent equals the query */
+  INDEX_ADJACENT       /**< Find stored boxes that share a boundary with the query */
 } IndexSearchOp;
 
 /**

--- a/meos/include/temporal/temporal_rtree.h
+++ b/meos/include/temporal/temporal_rtree.h
@@ -91,6 +91,10 @@ struct RTree
   void (*bbox_expand)(const void *, void *);
   bool (*bbox_contains)(const void *, const void *);
   bool (*bbox_overlaps)(const void *, const void *);
+  /** Whether the two boxes share a boundary and no point, which overlap does
+   * not answer: a span meeting another at an excluded bound overlaps it in
+   * no point at all */
+  bool (*bbox_adjacent)(const void *, const void *);
   /** Position of the first box with respect to the second one, for the
    * operations that order a dimension. NULL for a box type with none */
   bool (*bbox_position)(const void *, const void *, IndexSearchOp);

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -234,7 +234,7 @@ bool
 ensure_index_join_op(IndexSearchOp op)
 {
   if (op == INDEX_OVERLAPS || op == INDEX_CONTAINS || op == INDEX_CONTAINED_BY ||
-      op == INDEX_SAME)
+      op == INDEX_SAME || op == INDEX_ADJACENT)
     return true;
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
     "A join answers the operations that compare extents, not the ones that "

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -249,6 +249,40 @@ bbox_overlaps_span(const void *box1, const void *box2)
 }
 
 /**
+ * @brief Return `true` if the two boxes share a boundary, `false` otherwise
+ * @details Each delegates to the predicate of its box type, adjacency holding
+ * across every dimension the two boxes share and being a different relation
+ * from overlap: two boxes meeting at an excluded bound share a boundary and no
+ * point, and two boxes meeting at an included one share a point and are not
+ * adjacent.
+ */
+static bool
+bbox_adjacent_span(const void *box1, const void *box2)
+{
+  return adjacent_span_span((const Span *) box1, (const Span *) box2);
+}
+
+static bool
+bbox_adjacent_tbox(const void *box1, const void *box2)
+{
+  return adjacent_tbox_tbox((const TBox *) box1, (const TBox *) box2);
+}
+
+static bool
+bbox_adjacent_stbox(const void *box1, const void *box2)
+{
+  return adjacent_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+}
+
+#if POINTCLOUD
+static bool
+bbox_adjacent_tpcbox(const void *box1, const void *box2)
+{
+  return adjacent_tpcbox_tpcbox((const TPCBox *) box1, (const TPCBox *) box2);
+}
+#endif /* POINTCLOUD */
+
+/**
  * @brief Return `true` if the two temporal boxes overlap, `false` otherwise
  * @details The homogeneous boxes stored in an R-tree share the same value span
  * type by construction, so the dimension and type validation of
@@ -936,6 +970,8 @@ leaf_consistent(const RTree *rtree, const void *key, const void *query,
     case INDEX_SAME:
       /* Two extents are equal exactly when each contains the other */
       return rtree->bbox_contains(key, query) && rtree->bbox_contains(query, key);
+    case INDEX_ADJACENT:
+      return rtree->bbox_adjacent(key, query);
     default:
       /* An entry satisfies a position operation as the box type answers it */
       return rtree->bbox_position ?
@@ -960,6 +996,11 @@ inner_consistent(const RTree *rtree, const void *key, const void *query,
     case INDEX_OVERLAPS:
     case INDEX_CONTAINED_BY:
       return rtree->bbox_overlaps(key, query);
+    case INDEX_ADJACENT:
+      /* An entry meeting the query lies in a box that meets it or overlaps it,
+       * the entry being contained by that box */
+      return rtree->bbox_overlaps(key, query) ||
+        rtree->bbox_adjacent(key, query);
     case INDEX_CONTAINS:
     case INDEX_SAME:
       /* A subtree holds an entry equal to the query only when the box bounding
@@ -1029,7 +1070,14 @@ node_join(const RTree *rtree1, const RTreeNode *node1, const void *box1,
   const RTree *rtree2, const RTreeNode *node2, const void *box2,
   IndexSearchOp op, MeosArray *result)
 {
-  if (box1 && box2 && ! rtree1->bbox_overlaps(box1, box2))
+  /* A pair of subtrees holds a qualifying pair only where the two boxes
+   * bounding them meet, which for every operation but adjacency is an overlap.
+   * Two boxes meeting at an excluded bound share a boundary and no point, so
+   * pruning that pair on overlap alone drops the pairs an adjacency join is
+   * looking for -- and it drops them at the node boundaries, where nothing
+   * else in the answer is missing. */
+  if (box1 && box2 && ! rtree1->bbox_overlaps(box1, box2) &&
+      ! (op == INDEX_ADJACENT && rtree1->bbox_adjacent(box1, box2)))
     return;
 
   bool leaf1 = (node1->node_type == RTREE_LEAF);
@@ -1095,6 +1143,7 @@ rtree_create(MeosType bboxtype)
     rtree->bbox_expand = &bbox_expand_span;
     rtree->bbox_contains = &bbox_contains_span;
     rtree->bbox_overlaps = &bbox_overlaps_span;
+    rtree->bbox_adjacent = &bbox_adjacent_span;
     rtree->bbox_position = &bbox_position_span;
   }
   else if (bboxtype == T_TBOX)
@@ -1104,6 +1153,7 @@ rtree_create(MeosType bboxtype)
     rtree->bbox_expand = &bbox_expand_tbox;
     rtree->bbox_contains = &bbox_contains_tbox;
     rtree->bbox_overlaps = &bbox_overlaps_tbox;
+    rtree->bbox_adjacent = &bbox_adjacent_tbox;
     rtree->bbox_position = &bbox_position_tbox;
   }
 #if POINTCLOUD
@@ -1116,6 +1166,7 @@ rtree_create(MeosType bboxtype)
     rtree->bbox_expand = &bbox_expand_tpcbox;
     rtree->bbox_contains = &bbox_contains_tpcbox;
     rtree->bbox_overlaps = &bbox_overlaps_tpcbox;
+    rtree->bbox_adjacent = &bbox_adjacent_tpcbox;
     rtree->bbox_position = &bbox_position_tpcbox;
   }
 #endif
@@ -1128,6 +1179,7 @@ rtree_create(MeosType bboxtype)
     rtree->bbox_expand = &bbox_expand_stbox;
     rtree->bbox_contains = &bbox_contains_stbox;
     rtree->bbox_overlaps = &bbox_overlaps_stbox;
+    rtree->bbox_adjacent = &bbox_adjacent_stbox;
     rtree->bbox_position = &bbox_position_stbox;
   }
   rtree->bboxtype = bboxtype;

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -126,6 +126,11 @@ span_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
     case INDEX_CONTAINS:
     case INDEX_SAME:
       return contain2D(n, q);
+    case INDEX_ADJACENT:
+      /* A span meeting another at an excluded bound shares a boundary with it
+       * and no point of it, so overlap alone would prune the very entries an
+       * adjacency search looks for */
+      return adjacent2D(n, q) || overlap2D(n, q);
     case INDEX_LEFT:      return ! overRight2D(n, q);
     case INDEX_OVERLEFT:  return ! right2D(n, q);
     case INDEX_RIGHT:     return ! overLeft2D(n, q);
@@ -146,6 +151,7 @@ span_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
     case INDEX_CONTAINS:      return contains_span_span(k, q);
     case INDEX_CONTAINED_BY:  return contains_span_span(q, k);
     case INDEX_SAME:          return contains_span_span(k, q) && contains_span_span(q, k);
+    case INDEX_ADJACENT:      return adjacent_span_span(k, q);
     case INDEX_OVERLAPS:      return overlaps_span_span(k, q);
     case INDEX_LEFT:          return left_span_span(k, q);
     case INDEX_OVERLEFT:      return overleft_span_span(k, q);
@@ -209,7 +215,9 @@ tbox_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
     case INDEX_AFTER:      return ! overBefore4D(n, q);
     case INDEX_OVERAFTER:  return ! before4D(n, q);
     default:
-      /* INDEX_OVERLAPS and INDEX_CONTAINED_BY prune on overlap */
+      /* INDEX_OVERLAPS, INDEX_CONTAINED_BY and INDEX_ADJACENT prune on
+       * overlap, the region being compared on its bounds rather than on the
+       * spans holding them, so a region meeting the query overlaps it here */
       return overlap4D(n, q);
   }
 }
@@ -224,6 +232,7 @@ tbox_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
     case INDEX_CONTAINS:      return contains_tbox_tbox(k, q);
     case INDEX_CONTAINED_BY:  return contains_tbox_tbox(q, k);
     case INDEX_SAME:          return contains_tbox_tbox(k, q) && contains_tbox_tbox(q, k);
+    case INDEX_ADJACENT:      return adjacent_tbox_tbox(k, q);
     case INDEX_OVERLAPS:      return overlaps_tbox_tbox(k, q);
     case INDEX_LEFT:          return left_tbox_tbox(k, q);
     case INDEX_OVERLEFT:      return overleft_tbox_tbox(k, q);
@@ -290,6 +299,9 @@ stbox_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
       return contain8D(n, q);
     case INDEX_OVERLAPS:
     case INDEX_CONTAINED_BY:
+    case INDEX_ADJACENT:
+      /* The region is compared on its bounds rather than on the spans holding
+       * them, so a region meeting the query is a region overlapping it here */
       return overlap8D(n, q);
     /* A region can hold a box on one side of the query only when the region
      * itself reaches that side, which is the negation of the opposite
@@ -324,6 +336,7 @@ stbox_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
     case INDEX_CONTAINS:      return contains_stbox_stbox(k, q);
     case INDEX_CONTAINED_BY:  return contains_stbox_stbox(q, k);
     case INDEX_SAME:          return contains_stbox_stbox(k, q) && contains_stbox_stbox(q, k);
+    case INDEX_ADJACENT:      return adjacent_stbox_stbox(k, q);
     case INDEX_OVERLAPS:      return overlaps_stbox_stbox(k, q);
     case INDEX_LEFT:          return left_stbox_stbox(k, q);
     case INDEX_OVERLEFT:      return overleft_stbox_stbox(k, q);

--- a/meos/test/index_position_test.c
+++ b/meos/test/index_position_test.c
@@ -259,6 +259,85 @@ main(void)
     }
   }
 
+  /* Adjacency, on the entry set that separates it from overlap. Two spans
+   * meeting at an excluded bound share a boundary and no point, so they are
+   * adjacent and do NOT overlap, and a descent pruning on overlap alone drops
+   * exactly them -- at the node boundaries, where nothing else in the answer
+   * is missing. The fixture is therefore a chain of half-open spans rather
+   * than the boxes above, and the join is included, a join pruning a pair of
+   * subtrees by the same rule. */
+  {
+    const int NADJ = 512;
+    Span *chain = malloc(sizeof(Span) * NADJ);
+    int64 *chain_ids = malloc(sizeof(int64) * NADJ);
+    char buf[64];
+    for (int i = 0; i < NADJ; i++)
+    {
+      snprintf(buf, sizeof(buf), "[%d,%d)", i * 10, (i + 1) * 10);
+      Span *sp = intspan_in(buf);
+      chain[i] = *sp;
+      free(sp);
+      chain_ids[i] = i;
+    }
+    const Span *query = &chain[NADJ / 2];
+    int want = 0;
+    for (int i = 0; i < NADJ; i++)
+      if (adjacent_span_span(&chain[i], query))
+        want++;
+    if (want < 2)
+    {
+      printf("index adjacent: the query meets %d entries, too few for the "
+        "comparison to be meaningful\n", want);
+      failures++;
+    }
+
+    RTree *art = rtree_create_intspan();
+    SPTree *aquad = sptree_create_intspan(SPTREE_QUADTREE);
+    SPTree *akd = sptree_create_intspan(SPTREE_KDTREE);
+    for (int i = 0; i < NADJ; i++)
+    {
+      rtree_insert(art, &chain[i], chain_ids[i]);
+      sptree_insert(aquad, &chain[i], chain_ids[i]);
+      sptree_insert(akd, &chain[i], chain_ids[i]);
+    }
+    MeosArray *g1 = meos_array_create(sizeof(int64));
+    MeosArray *g2 = meos_array_create(sizeof(int64));
+    MeosArray *g3 = meos_array_create(sizeof(int64));
+    int n1 = rtree_search(art, INDEX_ADJACENT, query, g1);
+    int n2 = sptree_search(aquad, INDEX_ADJACENT, query, g2);
+    int n3 = sptree_search(akd, INDEX_ADJACENT, query, g3);
+    if (n1 != want || n2 != want || n3 != want)
+    {
+      printf("index adjacent: expected %d, R-tree %d, quad-tree %d, "
+        "k-d tree %d\n", want, n1, n2, n3);
+      failures++;
+    }
+
+    int want_pairs = 0;
+    for (int i = 0; i < NADJ; i++)
+      for (int j = 0; j < NADJ; j++)
+        if (adjacent_span_span(&chain[i], &chain[j]))
+          want_pairs++;
+    RTree *art2 = rtree_create_intspan();
+    for (int i = 0; i < NADJ; i++)
+      rtree_insert(art2, &chain[i], chain_ids[i]);
+    MeosArray *pairs = meos_array_create(sizeof(int64));
+    rtree_join(art, art2, INDEX_ADJACENT, pairs);
+    int got_pairs = meos_array_count(pairs) / 2;
+    if (got_pairs != want_pairs)
+    {
+      printf("index adjacent join: expected %d pairs, got %d\n", want_pairs,
+        got_pairs);
+      failures++;
+    }
+
+    meos_array_destroy(g1); meos_array_destroy(g2); meos_array_destroy(g3);
+    meos_array_destroy(pairs);
+    rtree_free(art); rtree_free(art2);
+    sptree_free(aquad); sptree_free(akd);
+    free(chain); free(chain_ids);
+  }
+
   rtree_free(rt);
   sptree_free(quad);
   sptree_free(kd);


### PR DESCRIPTION
The PostgreSQL operator classes of every box type index the adjacency of two extents, the operator spelled -|-, and neither in-memory index answered it, so a query for the entries meeting a given box read every entry of the index. Adjacency is not a weaker overlap, and reading it as one is what a descent gets wrong. Two spans meeting at an excluded bound share a boundary and no point at all, so they are adjacent and do not overlap; two meeting at an included one share a point, so they overlap and are not adjacent. The two relations are disjoint, and a subtree is therefore descended when the box bounding it either overlaps the query or meets it, an entry meeting the query being contained by a box that does one or the other. Where a region is compared on the bounds themselves rather than on the spans carrying them, that test already answers for a shared boundary and the operation prunes as overlap does: the temporal and the spatiotemporal regions compare bounds, while a span region is compared through the span it spans and takes the adjacency test beside its overlap. These are the rules the SP-GiST operator classes of the same three families apply, read from them rather than restated. A join prunes a pair of subtrees by that rule too, and until it did, the pairs it dropped were the ones at the node boundaries and nowhere else: 994 of the 1022 adjacent pairs of a chain of half-open spans, the whole of the shortfall sitting at every thirty-second entry, which is where the pruning happens. A dropped pair leaves no other trace, an operation admitted to an index being sound only where the operation implies the test the descent prunes by. meos/test/index_position_test.c compares the three structures and the join against a brute-force answer over a chain of half-open spans, an entry set on which a descent reading adjacency as overlap answers nothing at all. 
