### PR TITLE
Name the relation each span region predicate answers

### DIFF
--- a/meos/src/temporal/span_spgist.c
+++ b/meos/src/temporal/span_spgist.c
@@ -279,7 +279,7 @@ left2D(const SpanNode *nodebox, const Span *query)
 }
 
 /**
- * @brief Can any span from nodebox does not extend to the right of the query?
+ * @brief Can any span from nodebox stop short of the right of the query?
  */
 bool
 overLeft2D(const SpanNode *nodebox, const Span *query)
@@ -288,7 +288,7 @@ overLeft2D(const SpanNode *nodebox, const Span *query)
 }
 
 /**
- * @brief Can any span from nodebox be right the query?
+ * @brief Can any span from nodebox be to the right of the query?
  */
 bool
 right2D(const SpanNode *nodebox, const Span *query)
@@ -297,7 +297,7 @@ right2D(const SpanNode *nodebox, const Span *query)
 }
 
 /**
- * @brief Can any span from nodebox does not extend to the left of the query?
+ * @brief Can any span from nodebox stop short of the left of the query?
  */
 bool
 overRight2D(const SpanNode *nodebox, const Span *query)
@@ -306,7 +306,7 @@ overRight2D(const SpanNode *nodebox, const Span *query)
 }
 
 /**
- * @brief Can any span from nodebox be to the left of the query?
+ * @brief Can any span from nodebox share a boundary with the query?
  */
 bool
 adjacent2D(const SpanNode *nodebox, const Span *query)


### PR DESCRIPTION
The predicates that ask what a node region can still hold carry a one-line brief apiece, and four of the seven named something other than what they answer. adjacent2D carried the brief of left2D and so said it answered the spans lying to the left of the query, where it answers the spans sharing a boundary with it, which is the relation the operator class reads it for. right2D read as being right the query, and the two operations that ask whether a span stops short of a side of the query read as whether it does not extend to that side, a sentence the question they open does not admit. Each now names its own relation. 
