### PR TITLE
Keep the inclusivity of a bound when a GiST node key is expanded

### DIFF
--- a/mobilitydb/src/geo/tspatial_gist.c
+++ b/mobilitydb/src/geo/tspatial_gist.c
@@ -149,12 +149,8 @@ stbox_adjust(void *bbox1, void *bbox2)
   box1->ymax = FLOAT8_MAX(box1->ymax, box2->ymax);
   box1->zmin = FLOAT8_MIN(box1->zmin, box2->zmin);
   box1->zmax = FLOAT8_MAX(box1->zmax, box2->zmax);
-  TimestampTz tmin = Min(DatumGetTimestampTz(box1->period.lower),
-    DatumGetTimestampTz(box2->period.lower));
-  TimestampTz tmax = Max(DatumGetTimestampTz(box1->period.upper),
-    DatumGetTimestampTz(box2->period.upper));
-  box1->period.lower = TimestampTzGetDatum(tmin);
-  box1->period.upper = TimestampTzGetDatum(tmax);
+  if (MEOS_FLAGS_GET_T(box1->flags))
+    span_expand(&box2->period, &box1->period);
   return;
 }
 
@@ -368,9 +364,11 @@ Stbox_gist_same(PG_FUNCTION_ARGS)
     *result = (FLOAT8_EQ(b1->xmin, b2->xmin) && FLOAT8_EQ(b1->ymin, b2->ymin) &&
       FLOAT8_EQ(b1->zmin, b2->zmin) && FLOAT8_EQ(b1->xmax, b2->xmax) &&
       FLOAT8_EQ(b1->ymax, b2->ymax) && FLOAT8_EQ(b1->zmax, b2->zmax) &&
-      /* Equality test does not require to use DatumGetTimestampTz */
-      (b1->period.lower == b2->period.lower) &&
-      (b1->period.upper == b2->period.upper));
+      /* The period is compared as a span, so that two keys ending on the same
+       * instant with a different inclusivity are NOT reported as the same */
+      MEOS_FLAGS_GET_T(b1->flags) == MEOS_FLAGS_GET_T(b2->flags) &&
+      (! MEOS_FLAGS_GET_T(b1->flags) ||
+        span_eq(&b1->period, &b2->period)));
   else
     *result = (b1 == NULL && b2 == NULL);
   PG_RETURN_POINTER(result);

--- a/mobilitydb/src/pointcloud/tpcbox_gist.c
+++ b/mobilitydb/src/pointcloud/tpcbox_gist.c
@@ -114,12 +114,8 @@ tpcbox_adjust(void *bbox1, void *bbox2)
   box1->ymax = FLOAT8_MAX(box1->ymax, box2->ymax);
   box1->zmin = FLOAT8_MIN(box1->zmin, box2->zmin);
   box1->zmax = FLOAT8_MAX(box1->zmax, box2->zmax);
-  TimestampTz tmin = Min(DatumGetTimestampTz(box1->period.lower),
-    DatumGetTimestampTz(box2->period.lower));
-  TimestampTz tmax = Max(DatumGetTimestampTz(box1->period.upper),
-    DatumGetTimestampTz(box2->period.upper));
-  box1->period.lower = TimestampTzGetDatum(tmin);
-  box1->period.upper = TimestampTzGetDatum(tmax);
+  if (MEOS_FLAGS_GET_T(box1->flags))
+    span_expand(&box2->period, &box1->period);
 }
 
 PGDLLEXPORT Datum Tpcbox_gist_union(PG_FUNCTION_ARGS);
@@ -253,8 +249,11 @@ Tpcbox_gist_same(PG_FUNCTION_ARGS)
       FLOAT8_EQ(b1->xmin, b2->xmin) && FLOAT8_EQ(b1->ymin, b2->ymin) &&
       FLOAT8_EQ(b1->zmin, b2->zmin) && FLOAT8_EQ(b1->xmax, b2->xmax) &&
       FLOAT8_EQ(b1->ymax, b2->ymax) && FLOAT8_EQ(b1->zmax, b2->zmax) &&
-      (b1->period.lower == b2->period.lower) &&
-      (b1->period.upper == b2->period.upper));
+      /* The period is compared as a span, so that two keys ending on the same
+       * instant with a different inclusivity are NOT reported as the same */
+      MEOS_FLAGS_GET_T(b1->flags) == MEOS_FLAGS_GET_T(b2->flags) &&
+      (! MEOS_FLAGS_GET_T(b1->flags) ||
+        span_eq(&b1->period, &b2->period)));
   else
     *result = (b1 == NULL && b2 == NULL);
   PG_RETURN_POINTER(result);

--- a/mobilitydb/src/temporal/tnumber_gist.c
+++ b/mobilitydb/src/temporal/tnumber_gist.c
@@ -156,18 +156,10 @@ tbox_adjust(void *bbox1, void *bbox2)
 {
   TBox *box1 = (TBox *) bbox1;
   TBox *box2 = (TBox *) bbox2;
-  double xmin = FLOAT8_MIN(DatumGetFloat8(box1->span.lower),
-    DatumGetFloat8(box2->span.lower));
-  double xmax = FLOAT8_MAX(DatumGetFloat8(box1->span.upper),
-    DatumGetFloat8(box2->span.upper));
-  box1->span.lower = Float8GetDatum(xmin);
-  box1->span.upper = Float8GetDatum(xmax);
-  TimestampTz tmin = Min(DatumGetTimestampTz(box1->period.lower),
-    DatumGetTimestampTz(box2->period.lower));
-  TimestampTz tmax = Max(DatumGetTimestampTz(box1->period.upper),
-    DatumGetTimestampTz(box2->period.upper));
-  box1->period.lower = TimestampTzGetDatum(tmin);
-  box1->period.upper = TimestampTzGetDatum(tmax);
+  if (MEOS_FLAGS_GET_X(box1->flags))
+    span_expand(&box2->span, &box1->span);
+  if (MEOS_FLAGS_GET_T(box1->flags))
+    span_expand(&box2->period, &box1->period);
   return;
 }
 
@@ -1000,13 +992,12 @@ Tbox_gist_same(PG_FUNCTION_ARGS)
   TBox *b2 = PG_GETARG_TBOX_P(1);
   bool *result = (bool *) PG_GETARG_POINTER(2);
   if (b1 && b2)
-    *result = FLOAT8_EQ(DatumGetFloat8(b1->span.lower),
-        DatumGetFloat8(b2->span.lower)) &&
-      FLOAT8_EQ(DatumGetFloat8(b1->span.upper),
-        DatumGetFloat8(b2->span.upper)) &&
-      /* Equality test does not require to use DatumGetTimestampTz */
-      (b1->period.lower == b2->period.lower) &&
-      (b1->period.upper == b2->period.upper);
+    /* Each span is compared as a span, so that two keys ending on the same
+     * bound with a different inclusivity are NOT reported as the same */
+    *result = MEOS_FLAGS_GET_X(b1->flags) == MEOS_FLAGS_GET_X(b2->flags) &&
+      MEOS_FLAGS_GET_T(b1->flags) == MEOS_FLAGS_GET_T(b2->flags) &&
+      (! MEOS_FLAGS_GET_X(b1->flags) || span_eq(&b1->span, &b2->span)) &&
+      (! MEOS_FLAGS_GET_T(b1->flags) || span_eq(&b1->period, &b2->period));
   else
     *result = (! b1 && ! b2);
   PG_RETURN_POINTER(result);

--- a/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
+++ b/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
@@ -1017,3 +1017,48 @@ RESET enable_seqscan;
 RESET
 DROP TABLE tbl_tgeompoint_allthesame;
 DROP TABLE
+CREATE FUNCTION gist_bound_inc_disagreements() RETURNS bigint AS $$
+DECLARE n int; s bigint; i bigint; bad bigint := 0;
+BEGIN
+  FOREACH n IN ARRAY ARRAY[200, 300, 400, 800, 1200] LOOP
+    DROP TABLE IF EXISTS tbl_gist_bound_inc;
+    EXECUTE format($f$CREATE TABLE tbl_gist_bound_inc AS
+      SELECT i AS k, tgeompoint(format('[Point(%%s %%s)@%%s, Point(%%s %%s)@%%s)',
+        i %% 97, (i * 7) %% 89,
+        timestamptz '2001-01-01' + (i || ' minutes')::interval,
+        (i + 1) %% 97, (i * 7 + 3) %% 89,
+        timestamptz '2001-01-01' + ((i + 300) || ' minutes')::interval)) AS temp
+      FROM generate_series(1, %s) AS i$f$, n);
+    INSERT INTO tbl_gist_bound_inc
+    SELECT 0, tgeompoint(format('Point(50 50)@%s',
+      (SELECT max(endTimestamp(temp)) FROM tbl_gist_bound_inc)));
+    CREATE INDEX tbl_gist_bound_inc_rtree_idx
+      ON tbl_gist_bound_inc USING gist(temp);
+    ANALYZE tbl_gist_bound_inc;
+    SET LOCAL enable_seqscan = on;
+    SET LOCAL enable_bitmapscan = off;
+    SET LOCAL enable_indexscan = off;
+    SELECT COUNT(*) INTO s FROM tbl_gist_bound_inc
+    WHERE temp #&> (SELECT temp FROM tbl_gist_bound_inc WHERE k = 0);
+    SET LOCAL enable_seqscan = off;
+    SET LOCAL enable_bitmapscan = on;
+    SET LOCAL enable_indexscan = on;
+    SELECT COUNT(*) INTO i FROM tbl_gist_bound_inc
+    WHERE temp #&> (SELECT temp FROM tbl_gist_bound_inc WHERE k = 0);
+    IF s <> i THEN bad := bad + 1; END IF;
+  END LOOP;
+  RETURN bad;
+END;
+$$ LANGUAGE plpgsql;
+CREATE FUNCTION
+SELECT gist_bound_inc_disagreements() AS sizes_where_the_index_disagrees;
+NOTICE:  table "tbl_gist_bound_inc" does not exist, skipping
+ sizes_where_the_index_disagrees 
+---------------------------------
+                               0
+(1 row)
+
+DROP FUNCTION gist_bound_inc_disagreements();
+DROP FUNCTION
+DROP TABLE tbl_gist_bound_inc;
+DROP TABLE

--- a/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
@@ -334,4 +334,52 @@ RESET enable_seqscan;
 
 DROP TABLE tbl_tgeompoint_allthesame;
 
+--------------------------------------------------------------------------------
+-- A node key must keep the inclusivity of the bound it is expanded to, and
+-- two keys that differ only in that inclusivity are not the same key. Every
+-- value below ends on an EXCLUSIVE upper bound and the last one is an instant
+-- sitting exactly on the largest of them, so a key that takes the bound value
+-- while keeping the exclusivity of the entry it starts from excludes that
+-- instant and the scan prunes the page that holds it. Several sizes are built
+-- because which node ends on that bound follows from how the pages split.
+
+CREATE FUNCTION gist_bound_inc_disagreements() RETURNS bigint AS $$
+DECLARE n int; s bigint; i bigint; bad bigint := 0;
+BEGIN
+  FOREACH n IN ARRAY ARRAY[200, 300, 400, 800, 1200] LOOP
+    DROP TABLE IF EXISTS tbl_gist_bound_inc;
+    EXECUTE format($f$CREATE TABLE tbl_gist_bound_inc AS
+      SELECT i AS k, tgeompoint(format('[Point(%%s %%s)@%%s, Point(%%s %%s)@%%s)',
+        i %% 97, (i * 7) %% 89,
+        timestamptz '2001-01-01' + (i || ' minutes')::interval,
+        (i + 1) %% 97, (i * 7 + 3) %% 89,
+        timestamptz '2001-01-01' + ((i + 300) || ' minutes')::interval)) AS temp
+      FROM generate_series(1, %s) AS i$f$, n);
+    INSERT INTO tbl_gist_bound_inc
+    SELECT 0, tgeompoint(format('Point(50 50)@%s',
+      (SELECT max(endTimestamp(temp)) FROM tbl_gist_bound_inc)));
+    CREATE INDEX tbl_gist_bound_inc_rtree_idx
+      ON tbl_gist_bound_inc USING gist(temp);
+    ANALYZE tbl_gist_bound_inc;
+    SET LOCAL enable_seqscan = on;
+    SET LOCAL enable_bitmapscan = off;
+    SET LOCAL enable_indexscan = off;
+    SELECT COUNT(*) INTO s FROM tbl_gist_bound_inc
+    WHERE temp #&> (SELECT temp FROM tbl_gist_bound_inc WHERE k = 0);
+    SET LOCAL enable_seqscan = off;
+    SET LOCAL enable_bitmapscan = on;
+    SET LOCAL enable_indexscan = on;
+    SELECT COUNT(*) INTO i FROM tbl_gist_bound_inc
+    WHERE temp #&> (SELECT temp FROM tbl_gist_bound_inc WHERE k = 0);
+    IF s <> i THEN bad := bad + 1; END IF;
+  END LOOP;
+  RETURN bad;
+END;
+$$ LANGUAGE plpgsql;
+
+SELECT gist_bound_inc_disagreements() AS sizes_where_the_index_disagrees;
+
+DROP FUNCTION gist_bound_inc_disagreements();
+DROP TABLE tbl_gist_bound_inc;
+
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The union of an operator class takes the bounds of the spans a node key covers, so it takes their inclusivity with them. Expanding only the bound values leaves the key carrying the inclusivity of whichever entry it copies: a key expanded to end exactly on the instant of another entry keeps an exclusive upper bound, excludes that instant, and the scan prunes the page holding it, so the index answers with fewer rows than a sequential scan over the same table. The three operator classes expand a span through span_expand(), which is what the bounding box of a spatiotemporal value already does, rather than each of them writing the bounds itself; the temporal box takes its value span the same way, so an integer span is compared as one. A span is expanded only where the key carries that dimension, since a box built from a value that has no time keeps an empty period, which names no span type to compare. The regression case builds values that all end on an exclusive upper bound with one instant sitting exactly on the largest of them, which is enough entries for the index to carry an inner node: the sequential scan and the index agree on it only when the key keeps the bound.