### PR TITLE
Aggregate a temporal pose chain

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1836,6 +1836,29 @@
 					</listitem>
 				</itemizedlist>
 			</sect3>
+			<sect3>
+				<title>Agregaciones</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tposechain_tCount"><varname>tCount</varname></link>: Conteo temporal</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_wCount"><varname>wCount</varname></link>: Conteo de ventana</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_extent"><varname>extent</varname></link>: Extensión del cuadro delimitador</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_mergeAgg"><varname>mergeAgg</varname></link>: Fusionar las cadenas de poses temporales agregadas. El nombre <varname>merge</varname> denota la misma agregación</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_appendInstantAgg"><varname>appendInstantAgg</varname></link>: Agregar los instantes agregados en una secuencia. El nombre <varname>appendInstant</varname> denota la misma agregación</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_appendSequenceAgg"><varname>appendSequenceAgg</varname></link>: Agregar las secuencias agregadas en un conjunto de secuencias. El nombre <varname>appendSequence</varname> denota la misma agregación</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
 		</sect2>
 	</sect1>
 

--- a/doc/es/temporal_pose_chains.xml
+++ b/doc/es/temporal_pose_chains.xml
@@ -697,5 +697,98 @@ SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 				</listitem>
 			</itemizedlist>
 		</sect2>
+
+		<sect2 xml:id="tposechain_aggregations">
+			<title>Agregaciones</title>
+			<itemizedlist>
+				<listitem xml:id="tposechain_tCount">
+					<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
+					<para>Conteo temporal</para>
+					<para><varname>tCount(tposechain) → {tintSeq,tintSeqSet}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
+    PoseChain(Pose(Point(1 1), 0.3))@2001-01-03)' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.2))@2001-01-02,
+    PoseChain(Pose(Point(1 1), 0.4))@2001-01-04)' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.3))@2001-01-03,
+    PoseChain(Pose(Point(1 1), 0.5))@2001-01-05)' )
+SELECT tCount(Temp)
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_wCount">
+					<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
+					<para>Conteo de ventana</para>
+					<para><varname>wCount(tposechain, interval) → {tintSeq,tintSeqSet}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
+    PoseChain(Pose(Point(1 1), 0.3))@2001-01-03]' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.2))@2001-01-02,
+    PoseChain(Pose(Point(1 1), 0.4))@2001-01-04]' )
+SELECT wCount(Temp, interval '2 days')
+FROM Temp;
+/* {[1@2001-01-01, 2@2001-01-02, 2@2001-01-05],
+   (1@2001-01-05, 1@2001-01-06]} */
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_extent">
+					<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
+					<para>Extensión del cuadro delimitador</para>
+					<para><varname>extent(tposechain) → stbox</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT extent(temp) FROM ( VALUES
+  (NULL::tposechain),
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain '{PoseChain(Pose(Point(2 2), 0.2))@2001-01-01,
+    PoseChain(Pose(Point(3 3), 0.3))@2001-01-02}')) t(temp);
+-- STBOX XT(((1,1),(3,3)),[2001-01-01, 2001-01-02])
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_mergeAgg">
+					<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
+					<para>Fusionar las cadenas de poses temporales agregadas. El nombre <varname>merge</varname> denota la misma agregación</para>
+					<para><varname>mergeAgg(tposechain) → tposechain</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(mergeAgg(temp)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(temp);
+/* {PoseChain(Pose(POINT(1 1),0.1))@2001-01-01,
+   PoseChain(Pose(POINT(2 2),0.2))@2001-01-02} */
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_appendInstantAgg">
+					<indexterm significance="normal"><primary><varname>appendInstantAgg</varname></primary></indexterm>
+					<para>Agregar los instantes agregados en una secuencia. El nombre <varname>appendInstant</varname> denota la misma agregación</para>
+					<para><varname>appendInstantAgg(tposechain) → tposechain</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendInstantAgg(inst)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(inst);
+/* [PoseChain(Pose(POINT(1 1),0.1))@2001-01-01,
+   PoseChain(Pose(POINT(2 2),0.2))@2001-01-02] */
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_appendSequenceAgg">
+					<indexterm significance="normal"><primary><varname>appendSequenceAgg</varname></primary></indexterm>
+					<para>Agregar las secuencias agregadas en un conjunto de secuencias. El nombre <varname>appendSequence</varname> denota la misma agregación</para>
+					<para><varname>appendSequenceAgg(tposechain) → tposechain</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendSequenceAgg(seq)) FROM (VALUES
+  (tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01]'),
+  (tposechain '[PoseChain(Pose(Point(2 2), 0.2))@2001-01-02]')) t(seq);
+/* {[PoseChain(Pose(POINT(1 1),0.1))@2001-01-01],
+   [PoseChain(Pose(POINT(2 2),0.2))@2001-01-02]} */
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
 	</sect1>
 </chapter>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1839,6 +1839,29 @@
 					</listitem>
 				</itemizedlist>
 			</sect3>
+			<sect3>
+				<title>Aggregations</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="tposechain_tCount"><varname>tCount</varname></link>: Temporal count</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_wCount"><varname>wCount</varname></link>: Window count</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_extent"><varname>extent</varname></link>: Bounding box extent</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_mergeAgg"><varname>mergeAgg</varname></link>: Merge the aggregated temporal pose chains. The name <varname>merge</varname> denotes the same aggregate</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_appendInstantAgg"><varname>appendInstantAgg</varname></link>: Append the aggregated instants into a sequence. The name <varname>appendInstant</varname> denotes the same aggregate</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="tposechain_appendSequenceAgg"><varname>appendSequenceAgg</varname></link>: Append the aggregated sequences into a sequence set. The name <varname>appendSequence</varname> denotes the same aggregate</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
 		</sect2>
 	</sect1>
 

--- a/doc/temporal_pose_chains.xml
+++ b/doc/temporal_pose_chains.xml
@@ -697,5 +697,98 @@ SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 				</listitem>
 			</itemizedlist>
 		</sect2>
+
+		<sect2 xml:id="tposechain_aggregations">
+			<title>Aggregations</title>
+			<itemizedlist>
+				<listitem xml:id="tposechain_tCount">
+					<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
+					<para>Temporal count</para>
+					<para><varname>tCount(tposechain) &#8594; {tintSeq,tintSeqSet}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
+    PoseChain(Pose(Point(1 1), 0.3))@2001-01-03)' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.2))@2001-01-02,
+    PoseChain(Pose(Point(1 1), 0.4))@2001-01-04)' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.3))@2001-01-03,
+    PoseChain(Pose(Point(1 1), 0.5))@2001-01-05)' )
+SELECT tCount(Temp)
+FROM Temp;
+-- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_wCount">
+					<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
+					<para>Window count</para>
+					<para><varname>wCount(tposechain, interval) &#8594; {tintSeq,tintSeqSet}</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH Temp(temp) AS (
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
+    PoseChain(Pose(Point(1 1), 0.3))@2001-01-03]' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.2))@2001-01-02,
+    PoseChain(Pose(Point(1 1), 0.4))@2001-01-04]' )
+SELECT wCount(Temp, interval '2 days')
+FROM Temp;
+/* {[1@2001-01-01, 2@2001-01-02, 2@2001-01-05],
+   (1@2001-01-05, 1@2001-01-06]} */
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_extent">
+					<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
+					<para>Bounding box extent</para>
+					<para><varname>extent(tposechain) &#8594; stbox</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT extent(temp) FROM ( VALUES
+  (NULL::tposechain),
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain '{PoseChain(Pose(Point(2 2), 0.2))@2001-01-01,
+    PoseChain(Pose(Point(3 3), 0.3))@2001-01-02}')) t(temp);
+-- STBOX XT(((1,1),(3,3)),[2001-01-01, 2001-01-02])
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_mergeAgg">
+					<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
+					<para>Merge the aggregated temporal pose chains. The name <varname>merge</varname> denotes the same aggregate</para>
+					<para><varname>mergeAgg(tposechain) &#8594; tposechain</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(mergeAgg(temp)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(temp);
+/* {PoseChain(Pose(POINT(1 1),0.1))@2001-01-01,
+   PoseChain(Pose(POINT(2 2),0.2))@2001-01-02} */
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_appendInstantAgg">
+					<indexterm significance="normal"><primary><varname>appendInstantAgg</varname></primary></indexterm>
+					<para>Append the aggregated instants into a sequence. The name <varname>appendInstant</varname> denotes the same aggregate</para>
+					<para><varname>appendInstantAgg(tposechain) &#8594; tposechain</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendInstantAgg(inst)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(inst);
+/* [PoseChain(Pose(POINT(1 1),0.1))@2001-01-01,
+   PoseChain(Pose(POINT(2 2),0.2))@2001-01-02] */
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="tposechain_appendSequenceAgg">
+					<indexterm significance="normal"><primary><varname>appendSequenceAgg</varname></primary></indexterm>
+					<para>Append the aggregated sequences into a sequence set. The name <varname>appendSequence</varname> denotes the same aggregate</para>
+					<para><varname>appendSequenceAgg(tposechain) &#8594; tposechain</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(appendSequenceAgg(seq)) FROM (VALUES
+  (tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01]'),
+  (tposechain '[PoseChain(Pose(Point(2 2), 0.2))@2001-01-02]')) t(seq);
+/* {[PoseChain(Pose(POINT(1 1),0.1))@2001-01-01],
+   [PoseChain(Pose(POINT(2 2),0.2))@2001-01-02]} */
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
 	</sect1>
 </chapter>

--- a/mobilitydb/sql/posechain/561_tposechain_aggfuncs.in.sql
+++ b/mobilitydb/sql/posechain/561_tposechain_aggfuncs.in.sql
@@ -1,0 +1,209 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Aggregate functions for temporal pose chains
+ */
+
+-- The function is not strict
+CREATE FUNCTION tcount_transfn(internal, tposechain)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_tcount_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE tCount(tposechain) (
+  SFUNC = tcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tcount_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+CREATE FUNCTION tspatial_extent_transfn(stbox, tposechain)
+  RETURNS stbox
+  AS 'MODULE_PATHNAME', 'Tspatial_extent_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+CREATE AGGREGATE extent(tposechain) (
+  SFUNC = tspatial_extent_transfn,
+  STYPE = stbox,
+  COMBINEFUNC = stbox_extent_combinefn,
+  PARALLEL = safe
+);
+
+-- The function is not strict
+CREATE FUNCTION wcount_transfn(internal, tposechain, interval)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_wcount_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE wCount(tposechain, interval) (
+  SFUNC = wcount_transfn,
+  STYPE = internal,
+  COMBINEFUNC = tint_tsum_combinefn,
+  FINALFUNC = tint_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = SAFE
+);
+
+/*****************************************************************************/
+
+-- The function is not strict
+CREATE FUNCTION temporal_merge_transfn(internal, tposechain)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Temporal_merge_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION tposechain_tagg_finalfn(internal)
+  RETURNS tposechain
+  AS 'MODULE_PATHNAME', 'Temporal_tagg_finalfn'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/* Function deprecated in 1.4
+   Some bindings require Agg suffix to disambiguate from the scalar function */
+CREATE AGGREGATE merge(tposechain) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tposechain_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+CREATE AGGREGATE mergeAgg(tposechain) (
+  SFUNC = temporal_merge_transfn,
+  STYPE = internal,
+  COMBINEFUNC = temporal_merge_combinefn,
+  FINALFUNC = tposechain_tagg_finalfn,
+  SERIALFUNC = taggstate_serialize,
+  DESERIALFUNC = taggstate_deserialize,
+  PARALLEL = safe
+);
+
+/*****************************************************************************
+ * Append tinstant aggregate functions
+ *****************************************************************************/
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_app_tinst_transfn(tposechain, tposechain)
+  RETURNS tposechain
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_app_tinst_transfn(tposechain, tposechain,
+    interp text DEFAULT NULL)
+  RETURNS tposechain
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_app_tinst_transfn(tposechain, tposechain,
+    interp text DEFAULT NULL, maxdist float DEFAULT NULL, 
+    maxt interval DEFAULT NULL)
+  RETURNS tposechain
+  AS 'MODULE_PATHNAME', 'Temporal_app_tinst_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION temporal_append_finalfn(tposechain)
+  RETURNS tposechain
+  AS 'MODULE_PATHNAME', 'Temporal_append_finalfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+/* Function deprecated in 1.4
+   Some bindings require Agg suffix to disambiguate from the scalar function */
+CREATE AGGREGATE appendInstant(tposechain) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tposechain,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+CREATE AGGREGATE appendInstantAgg(tposechain) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tposechain,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+/* Function deprecated in 1.4
+   Some bindings require Agg suffix to disambiguate from the scalar function */
+CREATE AGGREGATE appendInstant(tposechain, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tposechain,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+CREATE AGGREGATE appendInstantAgg(tposechain, text) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tposechain,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+/* Function deprecated in 1.4
+   Some bindings require Agg suffix to disambiguate from the scalar function */
+CREATE AGGREGATE appendInstant(tposechain, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tposechain,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+CREATE AGGREGATE appendInstantAgg(tposechain, text, float, interval) (
+  SFUNC = temporal_app_tinst_transfn,
+  STYPE = tposechain,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+/*****************************************************************************/
+
+-- The function is not STRICT
+CREATE FUNCTION temporal_app_tseq_transfn(tposechain, tposechain)
+  RETURNS tposechain
+  AS 'MODULE_PATHNAME', 'Temporal_app_tseq_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+/* Function deprecated in 1.4
+   Some bindings require Agg suffix to disambiguate from the scalar function */
+CREATE AGGREGATE appendSequence(tposechain) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tposechain,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+CREATE AGGREGATE appendSequenceAgg(tposechain) (
+  SFUNC = temporal_app_tseq_transfn,
+  STYPE = tposechain,
+  FINALFUNC = temporal_append_finalfn,
+  PARALLEL = safe
+);
+
+/*****************************************************************************/

--- a/mobilitydb/sql/posechain/CMakeLists.txt
+++ b/mobilitydb/sql/posechain/CMakeLists.txt
@@ -4,6 +4,7 @@ SET(LOCAL_FILES
   552_tposechain
   553_tposechain_spatialfuncs
   554_tposechain_compops
+  561_tposechain_aggfuncs
   558_tposechain_topops
   559_tposechain_posops
   )

--- a/mobilitydb/test/posechain/expected/561_tposechain_aggfuncs.test.out
+++ b/mobilitydb/test/posechain/expected/561_tposechain_aggfuncs.test.out
@@ -1,0 +1,96 @@
+SELECT extent(temp) FROM ( VALUES
+  (NULL::tposechain),
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain '{PoseChain(Pose(Point(2 2), 0.2))@2001-01-01, PoseChain(Pose(Point(3 3), 0.3))@2001-01-02}')) t(temp);
+                                        extent                                        
+--------------------------------------------------------------------------------------
+ STBOX XT(((1,1),(3,3)),[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST])
+(1 row)
+
+SELECT extent(temp) FROM ( VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (NULL)) t(temp);
+                                        extent                                        
+--------------------------------------------------------------------------------------
+ STBOX XT(((1,1),(1,1)),[Mon Jan 01 00:00:00 2001 PST, Mon Jan 01 00:00:00 2001 PST])
+(1 row)
+
+SELECT extent(temp) FROM ( VALUES (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01')) t(temp);
+                                        extent                                        
+--------------------------------------------------------------------------------------
+ STBOX XT(((1,1),(1,1)),[Mon Jan 01 00:00:00 2001 PST, Mon Jan 01 00:00:00 2001 PST])
+(1 row)
+
+SELECT extent(temp) FROM ( VALUES (NULL::tposechain)) t(temp);
+ extent 
+--------
+ 
+(1 row)
+
+WITH Temp(temp) AS (
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(1 1), 0.3))@2001-01-03)' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.2))@2001-01-02, PoseChain(Pose(Point(1 1), 0.4))@2001-01-04)' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.3))@2001-01-03, PoseChain(Pose(Point(1 1), 0.5))@2001-01-05)' )
+SELECT tCount(Temp) FROM Temp;
+                                                               tcount                                                               
+------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Mon Jan 01 00:00:00 2001 PST, 2@Tue Jan 02 00:00:00 2001 PST, 1@Thu Jan 04 00:00:00 2001 PST, 1@Fri Jan 05 00:00:00 2001 PST)}
+(1 row)
+
+WITH Temp(temp) AS (
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(1 1), 0.3))@2001-01-03]' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.2))@2001-01-02, PoseChain(Pose(Point(1 1), 0.4))@2001-01-04]' )
+SELECT wCount(Temp, interval '2 days') FROM Temp;
+                                                                                wcount                                                                                
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[1@Mon Jan 01 00:00:00 2001 PST, 2@Tue Jan 02 00:00:00 2001 PST, 2@Fri Jan 05 00:00:00 2001 PST], (1@Fri Jan 05 00:00:00 2001 PST, 1@Sat Jan 06 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(merge(temp)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(temp);
+                                                            astext                                                            
+------------------------------------------------------------------------------------------------------------------------------
+ {PoseChain(Pose(POINT(1 1),0.1))@Mon Jan 01 00:00:00 2001 PST, PoseChain(Pose(POINT(2 2),0.2))@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+SELECT asText(mergeAgg(temp)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(temp);
+                                                            astext                                                            
+------------------------------------------------------------------------------------------------------------------------------
+ {PoseChain(Pose(POINT(1 1),0.1))@Mon Jan 01 00:00:00 2001 PST, PoseChain(Pose(POINT(2 2),0.2))@Tue Jan 02 00:00:00 2001 PST}
+(1 row)
+
+SELECT asText(appendInstant(inst)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(inst);
+                                                            astext                                                            
+------------------------------------------------------------------------------------------------------------------------------
+ [PoseChain(Pose(POINT(1 1),0.1))@Mon Jan 01 00:00:00 2001 PST, PoseChain(Pose(POINT(2 2),0.2))@Tue Jan 02 00:00:00 2001 PST]
+(1 row)
+
+SELECT asText(appendInstantAgg(inst)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(inst);
+                                                            astext                                                            
+------------------------------------------------------------------------------------------------------------------------------
+ [PoseChain(Pose(POINT(1 1),0.1))@Mon Jan 01 00:00:00 2001 PST, PoseChain(Pose(POINT(2 2),0.2))@Tue Jan 02 00:00:00 2001 PST]
+(1 row)
+
+SELECT asText(appendSequence(seq)) FROM (VALUES
+  (tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01]'),
+  (tposechain '[PoseChain(Pose(Point(2 2), 0.2))@2001-01-02]')) t(seq);
+                                                              astext                                                              
+----------------------------------------------------------------------------------------------------------------------------------
+ {[PoseChain(Pose(POINT(1 1),0.1))@Mon Jan 01 00:00:00 2001 PST], [PoseChain(Pose(POINT(2 2),0.2))@Tue Jan 02 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(appendSequenceAgg(seq)) FROM (VALUES
+  (tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01]'),
+  (tposechain '[PoseChain(Pose(Point(2 2), 0.2))@2001-01-02]')) t(seq);
+                                                              astext                                                              
+----------------------------------------------------------------------------------------------------------------------------------
+ {[PoseChain(Pose(POINT(1 1),0.1))@Mon Jan 01 00:00:00 2001 PST], [PoseChain(Pose(POINT(2 2),0.2))@Tue Jan 02 00:00:00 2001 PST]}
+(1 row)
+

--- a/mobilitydb/test/posechain/queries/561_tposechain_aggfuncs.test.sql
+++ b/mobilitydb/test/posechain/queries/561_tposechain_aggfuncs.test.sql
@@ -1,0 +1,85 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Aggregate functions for temporal pose chains
+-------------------------------------------------------------------------------
+
+-- extent(tposechain): mixed temporal subtypes folded together, NULLs filtered
+SELECT extent(temp) FROM ( VALUES
+  (NULL::tposechain),
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain '{PoseChain(Pose(Point(2 2), 0.2))@2001-01-01, PoseChain(Pose(Point(3 3), 0.3))@2001-01-02}')) t(temp);
+SELECT extent(temp) FROM ( VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (NULL)) t(temp);
+
+-- extent(tposechain): single row and all-NULL degenerate cases
+SELECT extent(temp) FROM ( VALUES (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01')) t(temp);
+SELECT extent(temp) FROM ( VALUES (NULL::tposechain)) t(temp);
+
+-------------------------------------------------------------------------------
+
+WITH Temp(temp) AS (
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(1 1), 0.3))@2001-01-03)' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.2))@2001-01-02, PoseChain(Pose(Point(1 1), 0.4))@2001-01-04)' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.3))@2001-01-03, PoseChain(Pose(Point(1 1), 0.5))@2001-01-05)' )
+SELECT tCount(Temp) FROM Temp;
+
+WITH Temp(temp) AS (
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(1 1), 0.3))@2001-01-03]' UNION
+  SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.2))@2001-01-02, PoseChain(Pose(Point(1 1), 0.4))@2001-01-04]' )
+SELECT wCount(Temp, interval '2 days') FROM Temp;
+
+-------------------------------------------------------------------------------
+
+SELECT asText(merge(temp)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(temp);
+SELECT asText(mergeAgg(temp)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(temp);
+
+-------------------------------------------------------------------------------
+
+SELECT asText(appendInstant(inst)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(inst);
+SELECT asText(appendInstantAgg(inst)) FROM (VALUES
+  (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
+  (tposechain 'PoseChain(Pose(Point(2 2), 0.2))@2001-01-02')) t(inst);
+
+SELECT asText(appendSequence(seq)) FROM (VALUES
+  (tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01]'),
+  (tposechain '[PoseChain(Pose(Point(2 2), 0.2))@2001-01-02]')) t(seq);
+SELECT asText(appendSequenceAgg(seq)) FROM (VALUES
+  (tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01]'),
+  (tposechain '[PoseChain(Pose(Point(2 2), 0.2))@2001-01-02]')) t(seq);
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -546,9 +546,9 @@ Reading the table:
   `subtypes:` `files:` track (§3): cbuffer, npoint, pose, rgeo (`[compops, topops,
   posops, indexes]`) and h3, quadbin (`[compops, posops, topops, spatialrels, gist,
   spgist]`).
-- **`aggfuncs` is generated for cbuffer, npoint, pose, rgeo, h3, quadbin** via the
-  whole-file `aggregate_families` axis (§4b), not the `subtypes:` track (`--gaps`:
-  `aggregate_families` 18/18, full coverage).
+- **`aggfuncs` is generated for cbuffer, npoint, pose, posechain, rgeo, h3, quadbin**
+  via the whole-file `aggregate_families` axis (§4b), not the `subtypes:` track
+  (`--gaps`: `aggregate_families` 19/19, full coverage).
 - **`tempsp.rels` is generated for cbuffer, npoint, pose, rgeo, h3, quadbin** via
   `tempspatialrel_families` (§3/§5) — native for cbuffer, cast-delegated for the
   other five (`--gaps`: `tempspatialrel_families` 10/10, full `tspatial`-class
@@ -614,12 +614,12 @@ its last edit:
   B-tree / hash` for the canonical banner, `boolean`/`integer` for `bool`/`int4`,
   eq-first ordering, a one-line operator head, wider opclass spacing). Adding the
   divider gives each behaviour one owner and no transcription.
-- `aggregate_families`, **18/19**: `tposechain`. `tempspatialrel_families`,
-  **10/13**: `tposechain`, `tpcpoint`, `tpcpatch`.
-  ⛔ These two project onto a file the family does NOT have — `tpose` carries
-  `111_tpose_aggfuncs.in.sql` and `114_tpose_tempspatialrels.in.sql`, posechain
-  carries neither — so closing them ADDS SURFACE. That is a functional decision
-  for the owner, not a governance one.
+- `aggregate_families` is **19/19**: `561_tposechain_aggfuncs.in.sql` carries the
+  surface its siblings carry, every statement binding a generic transition or final
+  function, so the family needs no kernel of its own.
+  `tempspatialrel_families`, **10/13**: `tposechain`, `tpcpoint`, `tpcpatch`.
+  ⛔ That one projects onto a file the family does NOT have, so closing it ADDS
+  SURFACE. That is a functional decision for the owner, not a governance one.
 - `distance_families`, **10/15** of the value-domain types: `posechainset`,
   `h3indexset`, `quadbinset`, `pcpointset`, `pcpatchset`. `posechainset` is
   deliberate and `setfamilies.yaml` says so in place — a pose chain has no

--- a/tools/codegen/inherited/manifest.d/aggregate_families.yaml
+++ b/tools/codegen/inherited/manifest.d/aggregate_families.yaml
@@ -365,6 +365,43 @@ aggregate_families:
   - fns:
     - {sig: "temporal_app_tseq_transfn(tpose, tpose)", ret: "tpose", sym: "Temporal_app_tseq_transfn", strict: false, pre: "-- The function is not STRICT\n"}
   - lit: "\n/* Function deprecated in 1.4\n   Some bindings require Agg suffix to disambiguate from the scalar function */\nCREATE AGGREGATE appendSequence(tpose) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tpose,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendSequenceAgg(tpose) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tpose,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/*****************************************************************************/\n"
+
+- family: posechain
+  file: mobilitydb/sql/posechain/561_tposechain_aggfuncs.in.sql
+  reference: true
+  begin: "@brief Aggregate functions for temporal pose chains"
+  whole_file: true
+  blocks:
+  - lit: "/**\n * @file\n * @brief Aggregate functions for temporal pose chains\n */\n\n"
+  - fns:
+    - {sig: "tcount_transfn(internal, tposechain)", ret: "internal", sym: "Temporal_tcount_transfn", strict: false, pre: "-- The function is not strict\n"}
+  - lit: "\nCREATE AGGREGATE tCount(tposechain) (\n  SFUNC = tcount_transfn,\n  STYPE = internal,\n  COMBINEFUNC = tcount_combinefn,\n  FINALFUNC = tint_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = SAFE\n);\n\n"
+  - fns:
+    - {sig: "tspatial_extent_transfn(stbox, tposechain)", ret: "stbox", sym: "Tspatial_extent_transfn", strict: false}
+  - lit: "CREATE AGGREGATE extent(tposechain) (\n  SFUNC = tspatial_extent_transfn,\n  STYPE = stbox,\n  COMBINEFUNC = stbox_extent_combinefn,\n  PARALLEL = safe\n);\n\n"
+  - fns:
+    - {sig: "wcount_transfn(internal, tposechain, interval)", ret: "internal", sym: "Temporal_wcount_transfn", strict: false, pre: "-- The function is not strict\n"}
+  - lit: "\nCREATE AGGREGATE wCount(tposechain, interval) (\n  SFUNC = wcount_transfn,\n  STYPE = internal,\n  COMBINEFUNC = tint_tsum_combinefn,\n  FINALFUNC = tint_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = SAFE\n);\n\n/*****************************************************************************/\n\n"
+  - fns:
+    - {sig: "temporal_merge_transfn(internal, tposechain)", ret: "internal", sym: "Temporal_merge_transfn", strict: false, pre: "-- The function is not strict\n"}
+    - {sig: "tposechain_tagg_finalfn(internal)", ret: "tposechain", sym: "Temporal_tagg_finalfn"}
+  - lit: "\n/* Function deprecated in 1.4\n   Some bindings require Agg suffix to disambiguate from the scalar function */\nCREATE AGGREGATE merge(tposechain) (\n  SFUNC = temporal_merge_transfn,\n  STYPE = internal,\n  COMBINEFUNC = temporal_merge_combinefn,\n  FINALFUNC = tposechain_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = safe\n);\nCREATE AGGREGATE mergeAgg(tposechain) (\n  SFUNC = temporal_merge_transfn,\n  STYPE = internal,\n  COMBINEFUNC = temporal_merge_combinefn,\n  FINALFUNC = tposechain_tagg_finalfn,\n  SERIALFUNC = taggstate_serialize,\n  DESERIALFUNC = taggstate_deserialize,\n  PARALLEL = safe\n);\n\n/*****************************************************************************\n * Append tinstant aggregate functions\n *****************************************************************************/\n\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(tposechain, tposechain)", ret: "tposechain", sym: "Temporal_app_tinst_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(tposechain, tposechain,\n    interp text DEFAULT NULL)", ret: "tposechain", sym: "Temporal_app_tinst_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_app_tinst_transfn(tposechain, tposechain,\n    interp text DEFAULT NULL, maxdist float DEFAULT NULL, \n    maxt interval DEFAULT NULL)", ret: "tposechain", sym: "Temporal_app_tinst_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\n"
+  - fns:
+    - {sig: "temporal_append_finalfn(tposechain)", ret: "tposechain", sym: "Temporal_append_finalfn", strict: false}
+  - lit: "\n/* Function deprecated in 1.4\n   Some bindings require Agg suffix to disambiguate from the scalar function */\nCREATE AGGREGATE appendInstant(tposechain) (\n  SFUNC = temporal_app_tinst_transfn,\n  STYPE = tposechain,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendInstantAgg(tposechain) (\n  SFUNC = temporal_app_tinst_transfn,\n  STYPE = tposechain,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/* Function deprecated in 1.4\n   Some bindings require Agg suffix to disambiguate from the scalar function */\nCREATE AGGREGATE appendInstant(tposechain, text) (\n  SFUNC = temporal_app_tinst_transfn,\n  STYPE = tposechain,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendInstantAgg(tposechain, text) (\n  SFUNC = temporal_app_tinst_transfn,\n  STYPE = tposechain,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/* Function deprecated in 1.4\n   Some bindings require Agg suffix to disambiguate from the scalar function */\nCREATE AGGREGATE appendInstant(tposechain, text, float, interval) (\n  SFUNC = temporal_app_tinst_transfn,\n  STYPE = tposechain,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendInstantAgg(tposechain, text, float, interval) (\n  SFUNC = temporal_app_tinst_transfn,\n  STYPE = tposechain,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/*****************************************************************************/\n\n"
+  - fns:
+    - {sig: "temporal_app_tseq_transfn(tposechain, tposechain)", ret: "tposechain", sym: "Temporal_app_tseq_transfn", strict: false, pre: "-- The function is not STRICT\n"}
+  - lit: "\n/* Function deprecated in 1.4\n   Some bindings require Agg suffix to disambiguate from the scalar function */\nCREATE AGGREGATE appendSequence(tposechain) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tposechain,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\nCREATE AGGREGATE appendSequenceAgg(tposechain) (\n  SFUNC = temporal_app_tseq_transfn,\n  STYPE = tposechain,\n  FINALFUNC = temporal_append_finalfn,\n  PARALLEL = safe\n);\n\n/*****************************************************************************/\n"
+
 - family: rgeo
   file: mobilitydb/sql/rgeo/168_trgeo_aggfuncs.in.sql
   reference: true


### PR DESCRIPTION
`561_tposechain_aggfuncs` declares the aggregate surface every sibling family carries: `tCount`, `wCount`, `extent`, `merge` and `mergeAgg`, `appendInstant` and `appendInstantAgg` over their three argument forms, and `appendSequence` and `appendSequenceAgg`. Each binds the generic transition and final functions the other families bind, so the family inherits the surface without a kernel of its own; `extent` reaches it because `tposechain` is a member of `tspatial_type`.

The manifest governs the file, taking the aggregate axis to nineteen families of nineteen, and both manuals document the surface with its reference entries.
