### PR TITLE
Close a hole that encloses no area rather than offsetting it

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -5402,6 +5402,17 @@ meos_buffer_poly(const LWPOLY *poly, double radius, JoinStyle join_style,
    */
   for (uint32_t i = 1; i < poly->nrings; i++)
   {
+    /* A positive buffer erodes a hole, and what is left of one is non-empty
+     * only where the hole holds a disc of the buffer distance, so a hole
+     * enclosing less area than that disc holds none of it and closes
+     * completely. What this reaches on real data is a ring enclosing NO area
+     * at all, a slit that runs out to a point and back: offsetting one sweeps
+     * a band of the buffer distance about the slit and punches that band out
+     * of the answer, which is a hole the geometry never had. An erosion
+     * widens a hole rather than closing it, so this reads the outward case */
+    if (! inward &&
+        fabs(buffer_ring_area(poly->rings[i])) < M_PI * radius * radius)
+      continue;
     bool hole_left = ! buffer_ring_outward_left(poly->rings[i]);
     if (inward)
       hole_left = ! hole_left;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -306,6 +306,32 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* A ring of a polygon can enclose no area at all -- a slit that runs out to
+   * a point and comes back along itself -- and real survey data carries them.
+   * A hole is what a positive buffer ERODES, and a slit holds no disc of any
+   * radius, so it closes completely and the answer is the buffer of the
+   * rectangle alone: the rounded 32 by 22 of area 703.14. Offsetting the slit
+   * instead sweeps a band of the buffer distance about it and punches that
+   * band out, leaving a hole the geometry never had and 26.9 of the 600 the
+   * rectangle covers outside its own buffer */
+  const char *slit =
+    "Polygon((0 0,30 0,30 20,0 20,0 0),(10 10,20 10,20 12,20 10,10 10))";
+  char slit_patt[10] = "T*****FF*";
+  GSERIALIZED *slit_geo = geom_in(slit, -1);
+  assert(slit_geo != NULL);
+  meos_errno_reset();
+  GSERIALIZED *slit_buf = geom_buffer(slit_geo, 1.0, "");
+  printf("geom_buffer(a rectangle whose hole encloses no area): %d, errno %d\n",
+    slit_buf != NULL, meos_errno());
+  assert(slit_buf != NULL);
+  assert(meos_errno() == 0);
+  bool slit_covers = geom_relate_pattern(slit_buf, slit_geo, slit_patt);
+  printf("  it covers the geometry it is taken of: %d\n", slit_covers);
+  assert(slit_covers == true);
+  assert(meos_errno() == 0);
+  free(slit_geo); free(slit_buf);
+  meos_errno_reset();
+
   /* An offset that degenerates at one exact radius: the two offsets of a U
    * meet with no width left where the radius is half the gap between its arms,
    * and the inward offset of an arc lands on the centre where the radius


### PR DESCRIPTION
A ring of a polygon can enclose no area at all — a slit that runs out to a point and comes back along itself — and real survey data carries them. This 30 by 20 rectangle has one such hole:

```
POLYGON((0 0,30 0,30 20,0 20,0 0),(10 10,20 10,20 12,20 10,10 10))
```

A positive buffer *erodes* a hole, and what is left of one is non-empty only where the hole holds a disc of the buffer distance. A slit holds no disc of any radius, so it closes completely and the answer is the buffer of the rectangle alone: the rounded 32 by 22 rectangle of area 703.14.

Offsetting the slit instead sweeps a band of the buffer distance about it and punches that band out of the answer, which is a hole the geometry never carries:

| | rings | area | against the closed form 703.141593 |
|---|---|---|---|
| offsetting the slit | 2 | 676.2149 | **−3.83%** |
| closing it | 1 | 703.1403 | −0.0002% |

**26.9 of the 600 square units the rectangle covers fall outside its own buffer**, and differencing the input against the answer with every hole of the answer filled leaves 0.000000 — so the spurious hole is the whole of the miss. The reading is identical at the origin and at projected coordinates, so no tolerance is involved.

The test is that the hole encloses less area than the disc it would have to hold, which is the condition under which it cannot survive the erosion. That is a necessary condition and therefore conservative: a hole that does survive has area at least `pi * radius^2` and is never dropped. An erosion widens a hole rather than closing it, so this reads the outward case only.

The file already answers a degenerate ring this way twice — for an offset that lands exactly on the centre it turns about, and for a ring pinched to zero width that holds no representative point.

## Measured

Over 283 real projected polygons at radii 1, 5 and 50, and over the GEOS buffer corpus, every count is identical to master: this closes a wrong answer rather than reaching a new one. `meos/test/geo_test.c` gains the rectangle above, whose buffer covers the geometry it is taken of.