### PR TITLE
State a point cloud schema in SQL rather than as an XML document

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -80,6 +80,9 @@ jobs:
           ./allocator_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o bool_test bool_test.c -L/usr/local/lib -lmeos
           ./bool_test
+          # SIBLING-FROM bool_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o pcschema_dims_test pcschema_dims_test.c -L/usr/local/lib -lmeos
+          ./pcschema_dims_test
           # The tcbuffer test program is generated from the installed headers
           # (gen_smoketest.py introspects meos_cbuffer.h) so it tracks the current
           # API. Regenerate and compile it here; the CBUFFER family is built and

--- a/doc/contributing/tpointcloud_schema_design_notes.md
+++ b/doc/contributing/tpointcloud_schema_design_notes.md
@@ -1,0 +1,146 @@
+<!--
+  MobilityDB — Declaring a Point Cloud Schema in SQL: Design Notes
+  Copyright(c) MobilityDB Contributors
+
+  This documentation is licensed under a Creative Commons Attribution-Share
+  Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
+-->
+
+# Declaring a Point Cloud Schema in SQL — Design Notes
+
+A `pcpoint` and a `pcpatch` carry a `pcid` and nothing else about their own layout: what dimensions they hold, how each is stored, and what a stored integer means as a coordinate all live in a schema resolved by that `pcid`. Today the only way to state a schema is a pgPointCloud XML document, and the only constructor that reads one is `pc_schema_from_xml`. These notes record a SQL-native way to state the same thing, why the columns are the ones below, and what the change costs.
+
+> **Audience**: a contributor or binding author working at the MEOS C level.
+> This is design rationale, not user documentation.
+
+---
+
+## What a schema states, and what it derives
+
+`PCDIMENSION` (`pointcloud-pg/lib/pc_api.h:64-75`) carries nine fields and `PCSCHEMA` (`:77-90`) eleven. Only some are stated; the rest are computed. `pc_schema.c:180-190` is explicit:
+
+```c
+pcs->dims[i]->byteoffset = byteoffset;
+pcs->dims[i]->size = pc_interpretation_size(pcs->dims[i]->interpretation);
+byteoffset += pcs->dims[i]->size;
+```
+
+⇒ `size` follows from `interpretation`, `byteoffset` from the sizes of the dimensions before it, and `pcs->size` from their total. `ndims` is a count, and `xdim` / `ydim` / `zdim` / `mdim` are resolved from the names by `pc_schema_check_xyzm`. **A user who typed any of those could only contradict the engine**, so none of them is a column.
+
+What remains is what a schema genuinely states:
+
+| stated per schema | stated per dimension |
+|---|---|
+| `pcid`, `srid`, `compression`, `description` | `position`, `name`, `interpretation`, `scale`, `offset`, `active`, `description` |
+
+## The tables
+
+```sql
+CREATE TABLE pointcloud_schemas (
+  pcid         integer PRIMARY KEY CHECK (pcid > 0),
+  srid         integer NOT NULL,
+  compression  text    NOT NULL DEFAULT 'none'
+                       CHECK (compression IN ('none','dimensional','laz')),
+  description  text
+);
+
+CREATE TABLE pointcloud_dimensions (
+  pcid            integer NOT NULL REFERENCES pointcloud_schemas(pcid) ON DELETE CASCADE,
+  position        integer NOT NULL CHECK (position >= 1),
+  name            text    NOT NULL,
+  interpretation  text    NOT NULL
+                          CHECK (interpretation IN ('int8_t','uint8_t','int16_t','uint16_t',
+                                                    'int32_t','uint32_t','int64_t','uint64_t',
+                                                    'double','float')),
+  scale           double precision NOT NULL DEFAULT 1,
+  "offset"        double precision NOT NULL DEFAULT 0,
+  active          boolean NOT NULL DEFAULT true,
+  description     text,
+  PRIMARY KEY (pcid, position),
+  UNIQUE (pcid, name)
+);
+```
+
+**`position` is a column and not an insertion order.** A schema whose dimension order came from the order rows happened to be inserted would depend on something SQL does not promise, and a reload, a `COPY`, or a parallel insert would silently reorder the layout. `PRIMARY KEY (pcid, position)` states the order, and makes a duplicate or a gap a constraint violation rather than a wrong byte offset.
+
+**`UNIQUE (pcid, name)`** is what makes `pc_schema_check_xyzm` unambiguous: the X, Y, Z and M dimensions are found by name, so two dimensions sharing one name would leave the choice to array order.
+
+The domains are libpc's own. The interpretation names are the ten of `pc_schema.c:21-22`. `unknown`, the eleventh, sits **outside** the domain: it is what the parser answers for a value it does not recognise, not a storage a schema states. The compression names are those of `pc_compression_string` (`pc_schema.c:84-93`).
+
+## The example of the manual, stated in SQL
+
+`doc/temporal_pointcloud.xml` §19.1.1 registers a minimal 3D schema. The same schema, with every column of both tables populated:
+
+```sql
+INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
+  (1, 4326, 'none', 'Minimal 3D schema, unit-scale int32 dimensions');
+
+INSERT INTO pointcloud_dimensions
+    (pcid, position, name, interpretation, scale, "offset", active, description) VALUES
+  (1, 1, 'X', 'int32_t', 1, 0, true, 'Easting'),
+  (1, 2, 'Y', 'int32_t', 1, 0, true, 'Northing'),
+  (1, 3, 'Z', 'int32_t', 1, 0, true, 'Elevation');
+```
+
+The sizes (4 bytes each) and the byte offsets (0, 4, 8) appear nowhere, being what the engine computes from `int32_t`.
+
+A schema whose dimensions differ from one another, to show the form is not limited to the uniform case:
+
+```sql
+INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
+  (2, 4326, 'dimensional', 'Scanner track: scaled coordinates plus intensity');
+
+INSERT INTO pointcloud_dimensions
+    (pcid, position, name, interpretation, scale, "offset", active, description) VALUES
+  (2, 1, 'X',         'int32_t',  0.01, 0, true,  'Easting, cm precision'),
+  (2, 2, 'Y',         'int32_t',  0.01, 0, true,  'Northing, cm precision'),
+  (2, 3, 'Z',         'int32_t',  0.01, 0, true,  'Elevation, cm precision'),
+  (2, 4, 'Intensity', 'uint16_t', 1,    0, true,  'Return intensity'),
+  (2, 5, 'Reserved',  'uint8_t',  1,    0, false, 'Declared, not populated');
+```
+
+## What MEOS gains
+
+One entry, which every binding then reaches through its own catalog:
+
+```c
+extern bool meos_pc_schema_register_dims(uint32_t pcid, int32_t srid,
+  const char *compression, const PCDimensionSpec *dims, int ndims);
+```
+
+where `PCDimensionSpec` names exactly the seven stated fields of a dimension. The entry allocates the `PCSCHEMA`, fills each dimension, and calls `pc_schema_check_xyzm`, leaving `size`, `byteoffset` and `ndims` to the engine.
+
+⭐ **THE SCHEMA IS BUILT THROUGH libpc'S OWN CONSTRUCTOR, so the entry couples to no layout.**
+`pc_api.h` publishes `pc_schema_from_xml`, `pc_schema_clone`, `pc_schema_set_dimension`,
+`pc_schema_check_xyzm`, `pc_schema_free` and the accessors, while the three pieces a non-XML
+statement also needs carry internal linkage in `pc_schema.c`: `pc_schema_new`, which allocates the
+schema, its dimension array and its name hash table and is what `pc_schema_from_xml` and
+`pc_schema_clone` themselves build every schema through, and the `pc_interpretation_number` /
+`pc_compression_number` name converters. Giving those three external linkage — a `/* MEOS */`-marked
+change to the vendored tree — is what makes the entry a caller of libpc rather than a second
+implementation of it. ⇒ the fields the engine derives are never assigned here:
+`pc_schema_set_dimension` inserts the name in the hash table AND recomputes every `size`,
+`byteoffset` and the width of a point, and `pc_schema_check_xyzm` resolves x/y/z/m from the names.
+
+⭐ **THE ACCEPTANCE TEST IS `meos/test/pcschema_dims_test.c`**: it states the §19.1.1 schema as rows
+and parses the same document with `pc_schema_from_xml`, then requires the two to agree field by
+field, the derived fields included, and the name hash to answer. It keeps the two paths honest as
+libpc moves.
+
+⛔ **`active` IS THE ONE FIELD WHERE A DOCUMENT AND A ROW DISAGREE, and the divergence is
+deliberate.** `pc_schema.c` assigns `d->active` only where the document carries `<pc:active>`, so a
+document omitting it — §19.1.1 included — yields **0**, a schema whose every dimension is declared
+inactive. `active boolean NOT NULL DEFAULT true` is the answer a user means, so a row and a document
+that both STATE the field agree, while a row and a document that omits it do not. A comparison of
+the two paths therefore states `active` on both sides, or it compares a statement against an absence.
+
+## What does not change
+
+- **`pointcloud_formats` is pgPointCloud's**, created by that extension and read by `schema_cache.c:107` through a heap scan that errors when the relation is absent. Nothing here modifies it, and a database already registering schemas that way keeps working.
+- **The XML path stays.** A WKB blob may carry an embedded schema document for a `pcid` the backend has not seen, which `meos_pc_parse_xml_fn` handles; data written by other pgPointCloud tools stays readable.
+- ⇒ the two are alternative ways to state the same schema, and the SQL one is what a binding without a PostgreSQL catalog can offer.
+- **A file carrying the same fact is refused.** A CSV or XML file read from a path resembles `meos_set_ways_csv` and `meos_set_spatial_ref_sys_csv` closely enough to look canonical, which is what makes it a trap: the two tables already state the schema, so a file-based lookup is a second mechanism for one fact, and two mechanisms for one fact is the defect. It is also the larger build — an embedded blob, a temporary file and an RFC 4180 parser against a single registration call.
+
+## Why this reaches the bindings
+
+A binding outside a PostgreSQL backend — MobilityDuck, MobilitySpark — reaches no catalog at all, so it cannot resolve a `pcid` and cannot construct any value whose bounding box needs the schema. Both are blocked on the same thing, so the entry belongs in MEOS rather than in either of them: each binding then materialises these two tables in its own host and calls the one entry.

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -29,23 +29,19 @@ CREATE EXTENSION mobilitydb CASCADE;
 		<sect2 xml:id="tpointcloud_quickstart_setup">
 			<title>Registrar un esquema</title>
 
-			<para>Cada valor <varname>pcpoint</varname> y <varname>pcpatch</varname> lleva un <varname>pcid</varname> que se resuelve a través de <varname>pointcloud_formats</varname> en un esquema XML. El esquema declara las dimensiones (X, Y, Z, …), su tipo numérico en disco y la escala por dimensión. Un esquema 3D mínimo con todas las dimensiones almacenadas como <varname>int32</varname> con escala unitaria:</para>
+			<para>Cada valor <varname>pcpoint</varname> y <varname>pcpatch</varname> lleva un <varname>pcid</varname> que se resuelve en un <emphasis>esquema</emphasis>, que declara las dimensiones que contiene el valor (X, Y, Z, …), el tipo numérico con el que se almacena cada una, y su escala y desplazamiento. El esquema se declara en SQL, en dos tablas: <varname>pointcloud_schemas</varname> contiene lo que declara un esquema en conjunto, y <varname>pointcloud_dimensions</varname> una fila por dimensión. Un esquema 3D mínimo, con cada dimensión almacenada como <varname>int32_t</varname> con escala unitaria:</para>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
-INSERT INTO pointcloud_formats (pcid, srid, schema) VALUES (1, 4326, '
-&lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;pc:PointCloudSchema xmlns:pc="http://pointcloud.org/schemas/PC/1.1"&gt;
-  &lt;pc:dimension&gt;&lt;pc:position&gt;1&lt;/pc:position&gt;&lt;pc:size&gt;4&lt;/pc:size&gt;
-    &lt;pc:name&gt;X&lt;/pc:name&gt;&lt;pc:interpretation&gt;int32_t&lt;/pc:interpretation&gt;
-    &lt;pc:scale&gt;1&lt;/pc:scale&gt;&lt;/pc:dimension&gt;
-  &lt;pc:dimension&gt;&lt;pc:position&gt;2&lt;/pc:position&gt;&lt;pc:size&gt;4&lt;/pc:size&gt;
-    &lt;pc:name&gt;Y&lt;/pc:name&gt;&lt;pc:interpretation&gt;int32_t&lt;/pc:interpretation&gt;
-    &lt;pc:scale&gt;1&lt;/pc:scale&gt;&lt;/pc:dimension&gt;
-  &lt;pc:dimension&gt;&lt;pc:position&gt;3&lt;/pc:position&gt;&lt;pc:size&gt;4&lt;/pc:size&gt;
-    &lt;pc:name&gt;Z&lt;/pc:name&gt;&lt;pc:interpretation&gt;int32_t&lt;/pc:interpretation&gt;
-    &lt;pc:scale&gt;1&lt;/pc:scale&gt;&lt;/pc:dimension&gt;
-&lt;/pc:PointCloudSchema&gt;');
+INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
+  (1, 4326, 'none', 'Esquema 3D mínimo');
+
+INSERT INTO pointcloud_dimensions
+    (pcid, position, name, interpretation, scale, "offset", active, description) VALUES
+  (1, 1, 'X', 'int32_t', 1, 0, true, 'Este'),
+  (1, 2, 'Y', 'int32_t', 1, 0, true, 'Norte'),
+  (1, 3, 'Z', 'int32_t', 1, 0, true, 'Elevación');
 </programlisting>
-			<para>Los esquemas son globales a la base de datos; normalmente se registran una sola vez durante la carga inicial de datos. El SRID es por esquema y es heredado por cada valor con ese <varname>pcid</varname>.</para>
+			<para>El tamaño de cada dimensión y su desplazamiento dentro de un punto no aparecen porque se derivan de la interpretación, y las dimensiones X, Y, Z y M tampoco porque se resuelven a partir de los nombres. La columna <varname>position</varname> declara el orden en el que se almacenan las dimensiones, de modo que no depende del orden en el que se insertan las filas. Un esquema es global a la base de datos y suele registrarse una sola vez, al cargar los datos; el SRID es por esquema y lo heredan todos los valores que llevan ese <varname>pcid</varname>.</para>
+			<para>Una base de datos cuyos esquemas ya están registrados en el catálogo <varname>pointcloud_formats</varname> de pgPointCloud, como documento XML, sigue funcionando: ese catálogo se lee para un <varname>pcid</varname> que las dos tablas anteriores no declaren.</para>
 		</sect2>
 
 		<sect2 xml:id="tpointcloud_quickstart_construct">

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -30,23 +30,19 @@ CREATE EXTENSION mobilitydb CASCADE;
 		<sect2 xml:id="tpointcloud_quickstart_setup">
 			<title>Register a schema</title>
 
-			<para>Every <varname>pcpoint</varname> and <varname>pcpatch</varname> value carries a <varname>pcid</varname> that resolves through <varname>pointcloud_formats</varname> to an XML schema. The schema declares the dimensions (X, Y, Z, …), their on-disk numeric type, and per-dimension scale. A minimal 3D schema with all dimensions stored as <varname>int32</varname> at unit scale:</para>
+			<para>Every <varname>pcpoint</varname> and <varname>pcpatch</varname> value carries a <varname>pcid</varname> that resolves to a <emphasis>schema</emphasis>, which states the dimensions the value holds (X, Y, Z, …), the numeric type each is stored as, and its scale and offset. The schema is stated in SQL, in two tables: <varname>pointcloud_schemas</varname> holds what a schema states as a whole, and <varname>pointcloud_dimensions</varname> one row per dimension. A minimal 3D schema, every dimension stored as <varname>int32_t</varname> at unit scale:</para>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
-INSERT INTO pointcloud_formats (pcid, srid, schema) VALUES (1, 4326, '
-&lt;?xml version="1.0" encoding="UTF-8"?&gt;
-&lt;pc:PointCloudSchema xmlns:pc="http://pointcloud.org/schemas/PC/1.1"&gt;
-  &lt;pc:dimension&gt;&lt;pc:position&gt;1&lt;/pc:position&gt;&lt;pc:size&gt;4&lt;/pc:size&gt;
-    &lt;pc:name&gt;X&lt;/pc:name&gt;&lt;pc:interpretation&gt;int32_t&lt;/pc:interpretation&gt;
-    &lt;pc:scale&gt;1&lt;/pc:scale&gt;&lt;/pc:dimension&gt;
-  &lt;pc:dimension&gt;&lt;pc:position&gt;2&lt;/pc:position&gt;&lt;pc:size&gt;4&lt;/pc:size&gt;
-    &lt;pc:name&gt;Y&lt;/pc:name&gt;&lt;pc:interpretation&gt;int32_t&lt;/pc:interpretation&gt;
-    &lt;pc:scale&gt;1&lt;/pc:scale&gt;&lt;/pc:dimension&gt;
-  &lt;pc:dimension&gt;&lt;pc:position&gt;3&lt;/pc:position&gt;&lt;pc:size&gt;4&lt;/pc:size&gt;
-    &lt;pc:name&gt;Z&lt;/pc:name&gt;&lt;pc:interpretation&gt;int32_t&lt;/pc:interpretation&gt;
-    &lt;pc:scale&gt;1&lt;/pc:scale&gt;&lt;/pc:dimension&gt;
-&lt;/pc:PointCloudSchema&gt;');
+INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
+  (1, 4326, 'none', 'Minimal 3D schema');
+
+INSERT INTO pointcloud_dimensions
+    (pcid, position, name, interpretation, scale, "offset", active, description) VALUES
+  (1, 1, 'X', 'int32_t', 1, 0, true, 'Easting'),
+  (1, 2, 'Y', 'int32_t', 1, 0, true, 'Northing'),
+  (1, 3, 'Z', 'int32_t', 1, 0, true, 'Elevation');
 </programlisting>
-			<para>Schemas are global to the database; you usually register them once at fixture-load time. SRID is per-schema and inherited by every value with that <varname>pcid</varname>.</para>
+			<para>The size of each dimension and its offset within a point are absent because they follow from the interpretation, and the X, Y, Z and M dimensions are absent because they resolve from the names. The <varname>position</varname> column states the order the dimensions are stored in, so it does not depend on the order the rows are inserted in. A schema is global to the database and usually registered once, at fixture-load time; the SRID is per schema and is inherited by every value carrying that <varname>pcid</varname>.</para>
+			<para>A database whose schemas are already registered in the <varname>pointcloud_formats</varname> catalog of pgPointCloud, as an XML document, keeps working: that catalog is read for a <varname>pcid</varname> that the two tables above do not state.</para>
 		</sect2>
 
 		<sect2 xml:id="tpointcloud_quickstart_construct">

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -466,6 +466,15 @@ if(MEOS)
     install(
       FILES "${CMAKE_SOURCE_DIR}/meos/include/pointcloud/pgsql_compat.h"
       DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/pointcloud")
+    # pgsql_compat.h includes pc_api.h, which states PCSCHEMA and PCDIMENSION,
+    # the structures the public point-cloud surface answers with. The three
+    # travel beside it so that the surface compiles from the install prefix
+    # alone, each reaching the next as a quoted include of the same directory.
+    install(
+      FILES "${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/pc_api.h"
+            "${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/hashtable.h"
+            "${CMAKE_SOURCE_DIR}/pointcloud-pg/lib/pc_config.h"
+      DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/pointcloud")
   endif()
   if(RASTER)
     install(

--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -187,8 +187,30 @@ extern TPCBox *pcpoint_to_tpcbox(const Pcpoint *pt, PCSCHEMA *schema);
  * @c pointcloud_formats).  In standalone-MEOS programs, the application
  * registers schemas explicitly before calling schema-aware helpers. */
 
+/**
+ * @brief One dimension of a point cloud schema, as it is stated
+ *
+ * The fields are the ones a schema states; @p size and @p byteoffset are
+ * absent because the engine computes them from @p interpretation and from
+ * the dimensions before this one.
+ */
+typedef struct
+{
+  const char *name;           /**< Dimension name, unique within the schema */
+  const char *description;    /**< Dimension description, may be @p NULL */
+  int32_t position;           /**< Position within the schema, from 1 */
+  const char *interpretation; /**< Name of the numeric type stored */
+  double scale;               /**< Factor a stored value is multiplied by */
+  double offset;              /**< Value added to a scaled stored value */
+  bool active;                /**< True when the dimension holds values */
+} PCDimensionSpec;
+
 extern PCSCHEMA *meos_pc_schema(uint32_t pcid);
 extern void meos_pc_schema_register(uint32_t pcid, PCSCHEMA *schema);
+extern PCSCHEMA *meos_pc_schema_from_dims(uint32_t pcid, int32_t srid,
+  const char *compression, const PCDimensionSpec *dims, int ndims);
+extern bool meos_pc_schema_register_dims(uint32_t pcid, int32_t srid,
+  const char *compression, const PCDimensionSpec *dims, int ndims);
 extern void meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
   const char *xml_text);
 extern const char *meos_pc_schema_xml(uint32_t pcid);

--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -20,10 +20,14 @@
 #endif
 /* pgPointcloud */
 #include "pc_api.h"
+#include "pc_api_internal.h"
 /* PostGIS */
 #include <liblwgeom.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_internal.h>
+#include <meos_pointcloud.h>
+#include "temporal/temporal.h"
 #include "pointcloud/meos_schema_hook.h"
 
 /*****************************************************************************
@@ -108,6 +112,140 @@ void
 meos_pc_schema_register(uint32_t pcid, PCSCHEMA *schema)
 {
   meos_pc_schema_register_xml(pcid, schema, NULL);
+}
+
+/**
+ * @brief Return a copy of a string allocated by the point cloud library, so
+ * that freeing the schema releases it
+ */
+static char *
+pcschema_string_copy(const char *str)
+{
+  size_t size = strlen(str) + 1;
+  char *result = pcalloc(size);
+  memcpy(result, str, size);
+  return result;
+}
+
+/**
+ * @ingroup meos_pointcloud_schema_cache
+ * @brief Register the schema that a point cloud identifier names, stated as
+ *   its dimensions
+ * @param[in] pcid Identifier the schema is registered under
+ * @param[in] srid Spatial reference identifier every value of the schema
+ *   carries
+ * @param[in] compression Name of the compression applied to the data,
+ *   @p NULL for none
+ * @param[in] dims Dimensions the schema states, in any order
+ * @param[in] ndims Number of dimensions
+ * @return A newly allocated schema, @p NULL on error
+ * @note The schema is built through the constructor of the point cloud
+ *   library, so the size of a dimension, the offset of a dimension within a
+ *   point and the width of a point are the ones that library computes
+ */
+PCSCHEMA *
+meos_pc_schema_from_dims(uint32_t pcid, int32_t srid,
+  const char *compression, const PCDimensionSpec *dims, int ndims)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_not_null((void *) dims))
+    return NULL;
+  if (ndims < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The point cloud schema of pcid %u must state at least one dimension",
+      pcid);
+    return NULL;
+  }
+
+  int comp = pc_compression_number(compression);
+  PCSCHEMA *schema = pc_schema_new((uint32_t) ndims);
+  schema->pcid = pcid;
+  schema->srid = (uint32_t) srid;
+  schema->compression = (uint32_t) comp;
+
+  for (int i = 0; i < ndims; i++)
+  {
+    const PCDimensionSpec *spec = &dims[i];
+    /* A position is stated from 1 while the schema holds it from 0 */
+    if (spec->position < 1 || spec->position > ndims)
+    {
+      pc_schema_free(schema);
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "The point cloud schema of pcid %u states position %d, which is "
+        "outside the %d dimensions it declares", pcid, spec->position, ndims);
+      return NULL;
+    }
+    if (! spec->name || ! *spec->name)
+    {
+      pc_schema_free(schema);
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "The point cloud schema of pcid %u states a dimension with no name "
+        "at position %d", pcid, spec->position);
+      return NULL;
+    }
+    int interp = pc_interpretation_number(spec->interpretation);
+    if (interp == PC_UNKNOWN)
+    {
+      pc_schema_free(schema);
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "The point cloud schema of pcid %u states the unknown interpretation "
+        "\"%s\" for dimension \"%s\"", pcid,
+        spec->interpretation ? spec->interpretation : "", spec->name);
+      return NULL;
+    }
+    if (schema->dims[spec->position - 1])
+    {
+      pc_schema_free(schema);
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "The point cloud schema of pcid %u states position %d twice",
+        pcid, spec->position);
+      return NULL;
+    }
+
+    PCDIMENSION *dim = pcalloc(sizeof(PCDIMENSION));
+    dim->position = (uint32_t) spec->position - 1;
+    dim->name = pcschema_string_copy(spec->name);
+    dim->description = spec->description ?
+      pcschema_string_copy(spec->description) : NULL;
+    dim->interpretation = (uint32_t) interp;
+    dim->scale = spec->scale;
+    dim->offset = spec->offset;
+    dim->active = spec->active ? 1 : 0;
+    /* Sets the dimension, its name in the hash table of the schema, and the
+     * size and the byte offset of every dimension */
+    pc_schema_set_dimension(schema, dim);
+  }
+
+  /* Resolve the X, Y, Z and M dimensions from the names */
+  pc_schema_check_xyzm(schema);
+  return schema;
+}
+
+/**
+ * @ingroup meos_pointcloud_schema_cache
+ * @brief Register the schema that a point cloud identifier names, stated as
+ *   its dimensions
+ * @param[in] pcid Identifier the schema is registered under
+ * @param[in] srid Spatial reference identifier every value of the schema
+ *   carries
+ * @param[in] compression Name of the compression applied to the data,
+ *   @p NULL for none
+ * @param[in] dims Dimensions the schema states, in any order
+ * @param[in] ndims Number of dimensions
+ * @return True on success, false on error
+ * @csqlfn #Pointcloud_schema_register_dims()
+ */
+bool
+meos_pc_schema_register_dims(uint32_t pcid, int32_t srid,
+  const char *compression, const PCDimensionSpec *dims, int ndims)
+{
+  PCSCHEMA *schema = meos_pc_schema_from_dims(pcid, srid, compression, dims,
+    ndims);
+  if (! schema)
+    return false;
+  meos_pc_schema_register(pcid, schema);
+  return true;
 }
 
 /**

--- a/meos/test/pcschema_dims_test.c
+++ b/meos/test/pcschema_dims_test.c
@@ -1,0 +1,132 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2026, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS
+ * DOCUMENTATION, EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Test that a point cloud schema stated as dimensions is the schema
+ * that the same document states
+ *
+ * A schema stated as rows and the same schema parsed from its XML document
+ * are two statements of one thing, so every field of the result must agree,
+ * including the ones the engine computes: the size of a dimension, the offset
+ * of a dimension within a point, and the width of a point.
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <meos.h>
+#include <meos_pointcloud.h>
+#include <pointcloud/pc_api.h>
+
+/* The schema of section 19.1.1 of the manual, as an XML document states it */
+static const char *SCHEMA_XML =
+  "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+  "<pc:PointCloudSchema xmlns:pc=\"http://pointcloud.org/schemas/PC/1.1\">"
+  "  <pc:dimension><pc:position>1</pc:position><pc:size>4</pc:size>"
+  "    <pc:name>X</pc:name><pc:interpretation>int32_t</pc:interpretation>"
+  "    <pc:scale>1</pc:scale><pc:active>1</pc:active></pc:dimension>"
+  "  <pc:dimension><pc:position>2</pc:position><pc:size>4</pc:size>"
+  "    <pc:name>Y</pc:name><pc:interpretation>int32_t</pc:interpretation>"
+  "    <pc:scale>1</pc:scale><pc:active>1</pc:active></pc:dimension>"
+  "  <pc:dimension><pc:position>3</pc:position><pc:size>4</pc:size>"
+  "    <pc:name>Z</pc:name><pc:interpretation>int32_t</pc:interpretation>"
+  "    <pc:scale>1</pc:scale><pc:active>1</pc:active></pc:dimension>"
+  "</pc:PointCloudSchema>";
+
+static int failures = 0;
+
+static void
+check(bool ok, const char *what)
+{
+  if (! ok)
+  {
+    printf("  FAIL %s\n", what);
+    failures++;
+  }
+}
+
+int
+main(void)
+{
+  meos_initialize();
+
+  /* The same schema, stated as its dimensions */
+  PCDimensionSpec dims[3] = {
+    { "X", NULL, 1, "int32_t", 1, 0, true },
+    { "Y", NULL, 2, "int32_t", 1, 0, true },
+    { "Z", NULL, 3, "int32_t", 1, 0, true }
+  };
+  if (! meos_pc_schema_register_dims(1, 4326, "none", dims, 3))
+  {
+    printf("FAILED: the schema stated as dimensions is not registered\n");
+    return 1;
+  }
+  PCSCHEMA *stated = meos_pc_schema(1);
+  PCSCHEMA *parsed = pc_schema_from_xml(SCHEMA_XML);
+  if (! stated || ! parsed)
+  {
+    printf("FAILED: a schema is missing (stated %p, parsed %p)\n",
+      (void *) stated, (void *) parsed);
+    return 1;
+  }
+
+  printf("The schema stated as dimensions against the same document:\n");
+  check(stated->ndims == parsed->ndims, "ndims");
+  check(stated->size == parsed->size, "size");
+  check(stated->compression == parsed->compression, "compression");
+  check(stated->srid == 4326, "srid");
+  check(stated->pcid == 1, "pcid");
+  for (uint32_t i = 0; i < parsed->ndims; i++)
+  {
+    PCDIMENSION *a = stated->dims[i], *b = parsed->dims[i];
+    check(a && b, "dimension present");
+    if (! a || ! b)
+      continue;
+    check(strcmp(a->name, b->name) == 0, "dimension name");
+    check(a->position == b->position, "dimension position");
+    check(a->size == b->size, "dimension size");
+    check(a->byteoffset == b->byteoffset, "dimension byteoffset");
+    check(a->interpretation == b->interpretation, "dimension interpretation");
+    check(a->scale == b->scale, "dimension scale");
+    check(a->offset == b->offset, "dimension offset");
+    check(a->active == b->active, "dimension active");
+  }
+  /* The X, Y and Z dimensions are resolved from the names */
+  check(stated->xdim && strcmp(stated->xdim->name, "X") == 0, "xdim");
+  check(stated->ydim && strcmp(stated->ydim->name, "Y") == 0, "ydim");
+  check(stated->zdim && strcmp(stated->zdim->name, "Z") == 0, "zdim");
+  /* The name hash table answers, as a schema built from a document does */
+  check(pc_schema_get_dimension_by_name(stated, "Y") == stated->dims[1],
+    "dimension by name");
+
+  printf("%s: %d field(s) disagree\n", failures ? "FAILED" : "PASSED",
+    failures);
+  meos_finalize();
+  return failures ? 1 : 0;
+}

--- a/mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
+++ b/mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
@@ -1,0 +1,120 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+
+/**
+ * @file
+ * @brief Tables stating the schema that a point cloud identifier names
+ *
+ * A pcpoint and a pcpatch carry a pcid and nothing else about their own
+ * layout: the dimensions they hold, how each is stored, and what a stored
+ * integer means as a coordinate are stated by the schema that pcid names.
+ * The two tables state it in SQL, so registering a schema needs no XML
+ * document.
+ *
+ * The size of a dimension, the offset of a dimension within a point and the
+ * width of a point are absent because the engine computes them from the
+ * interpretation and from the dimensions before each one, and the X, Y, Z
+ * and M dimensions are absent because they resolve from the names. A row
+ * stating any of them could only contradict the engine.
+ */
+
+CREATE TABLE pointcloud_schemas (
+  pcid         integer PRIMARY KEY CHECK (pcid > 0),
+  srid         integer NOT NULL,
+  compression  text    NOT NULL DEFAULT 'none'
+                       CHECK (compression IN ('none','dimensional','laz')),
+  description  text
+);
+
+/*
+ * The position a dimension holds is a column rather than the order the rows
+ * happen to arrive in: a reload, a COPY or a parallel insert would otherwise
+ * reorder the layout of a point. Stating it makes a duplicate or a gap a
+ * constraint violation rather than a wrong byte offset, and the unique name
+ * is what lets the X, Y, Z and M dimensions resolve unambiguously.
+ */
+CREATE TABLE pointcloud_dimensions (
+  pcid            integer NOT NULL REFERENCES pointcloud_schemas(pcid)
+                          ON DELETE CASCADE,
+  position        integer NOT NULL CHECK (position >= 1),
+  name            text    NOT NULL,
+  interpretation  text    NOT NULL
+                          CHECK (interpretation IN ('int8_t','uint8_t',
+                                 'int16_t','uint16_t','int32_t','uint32_t',
+                                 'int64_t','uint64_t','double','float')),
+  scale           double precision NOT NULL DEFAULT 1,
+  "offset"        double precision NOT NULL DEFAULT 0,
+  active          boolean NOT NULL DEFAULT true,
+  description     text,
+  PRIMARY KEY (pcid, position),
+  UNIQUE (pcid, name)
+);
+
+COMMENT ON TABLE  pointcloud_schemas IS
+  'Schema that a point cloud identifier names, stated in SQL. One row per '
+  'schema; the dimensions it holds are the rows of pointcloud_dimensions.';
+COMMENT ON COLUMN pointcloud_schemas.pcid IS
+  'Identifier a pcpoint or a pcpatch carries to name this schema.';
+COMMENT ON COLUMN pointcloud_schemas.srid IS
+  'Spatial reference system every value of this schema is expressed in.';
+COMMENT ON COLUMN pointcloud_schemas.compression IS
+  'How a patch of this schema is stored: ''none'', ''dimensional'' or ''laz''.';
+COMMENT ON COLUMN pointcloud_schemas.description IS
+  'Free-form description for human readers.';
+
+COMMENT ON TABLE  pointcloud_dimensions IS
+  'Dimensions of the schema a pcid names, one row each. The size of a '
+  'dimension and its offset within a point are absent because they follow '
+  'from the interpretation and from the dimensions before it.';
+COMMENT ON COLUMN pointcloud_dimensions.pcid IS
+  'Schema this dimension belongs to.';
+COMMENT ON COLUMN pointcloud_dimensions.position IS
+  'Order this dimension is stored in, from 1, stated rather than taken from '
+  'the order the rows arrive in.';
+COMMENT ON COLUMN pointcloud_dimensions.name IS
+  'Dimension name, unique within the schema. The X, Y, Z and M dimensions '
+  'resolve from it.';
+COMMENT ON COLUMN pointcloud_dimensions.interpretation IS
+  'Name of the numeric type a value of this dimension is stored as.';
+COMMENT ON COLUMN pointcloud_dimensions.scale IS
+  'Factor a stored value is multiplied by to give the coordinate.';
+COMMENT ON COLUMN pointcloud_dimensions."offset" IS
+  'Value added to a scaled stored value to give the coordinate.';
+COMMENT ON COLUMN pointcloud_dimensions.active IS
+  'True when the dimension holds values.';
+COMMENT ON COLUMN pointcloud_dimensions.description IS
+  'Free-form description for human readers.';
+
+/* Mark both catalogs as configuration tables so that pg_dump preserves the
+ * schemas a user registers, as the geopose_frames registry does. */
+SELECT pg_catalog.pg_extension_config_dump('pointcloud_schemas', '');
+SELECT pg_catalog.pg_extension_config_dump('pointcloud_dimensions', '');
+
+/*****************************************************************************/

--- a/mobilitydb/sql/pointcloud/CMakeLists.txt
+++ b/mobilitydb/sql/pointcloud/CMakeLists.txt
@@ -1,4 +1,5 @@
 SET(LOCAL_FILES
+  399_pointcloud_schemas
   400_pcset
   410_tpcbox
   420_tpcpoint

--- a/mobilitydb/src/pointcloud/schema_cache.c
+++ b/mobilitydb/src/pointcloud/schema_cache.c
@@ -188,9 +188,124 @@ mobilitydb_pc_parse_xml(uint32_t pcid, const char *xml)
   return schema;
 }
 
+/**
+ * @brief Return the install namespace of the mobilitydb extension, or
+ *   @c InvalidOid where it cannot be determined
+ */
+static Oid
+mobilitydb_schema_namespace_oid(void)
+{
+  Oid ext_oid = get_extension_oid("mobilitydb", /* missing_ok */ true);
+  if (ext_oid == InvalidOid)
+    return InvalidOid;
+  return get_extension_schema(ext_oid);
+}
+
+/**
+ * @brief Build the schema that @p pcid names from the rows stating it
+ * @details Reads @c pointcloud_schemas and @c pointcloud_dimensions by direct
+ *   heap scan, the way the XML path reads @c pointcloud_formats. The schema is
+ *   built in @c TopMemoryContext so that it outlives the current query, as the
+ *   MEOS cache holds the pointer for the lifetime of the backend.
+ * @param[in] pcid Identifier the rows state the schema of
+ * @return The schema, or @c NULL where no row states it, which is what sends
+ *   the caller to the XML path
+ */
+static PCSCHEMA *
+fetch_schema_dims(uint32_t pcid)
+{
+  Oid nsp_oid = mobilitydb_schema_namespace_oid();
+  if (nsp_oid == InvalidOid)
+    return NULL;
+  Oid rel_oid = get_relname_relid("pointcloud_schemas", nsp_oid);
+  Oid dim_oid = get_relname_relid("pointcloud_dimensions", nsp_oid);
+  if (rel_oid == InvalidOid || dim_oid == InvalidOid)
+    return NULL;
+
+  /* Column layout: (pcid int4, srid int4, compression text, description text) */
+  Relation rel = table_open(rel_oid, AccessShareLock);
+  TupleDesc tup_desc = RelationGetDescr(rel);
+  ScanKeyData key[1];
+  ScanKeyInit(&key[0], 1, BTEqualStrategyNumber, F_INT4EQ,
+    Int32GetDatum((int32) pcid));
+  SysScanDesc scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+
+  bool found = false, isnull;
+  int32 srid = 0;
+  char *compression = NULL;
+  HeapTuple tuple = systable_getnext(scan);
+  if (HeapTupleIsValid(tuple))
+  {
+    found = true;
+    Datum datum = heap_getattr(tuple, 2, tup_desc, &isnull);
+    if (! isnull)
+      srid = DatumGetInt32(datum);
+    datum = heap_getattr(tuple, 3, tup_desc, &isnull);
+    if (! isnull)
+      compression = text_to_cstring(DatumGetTextPP(datum));
+  }
+  systable_endscan(scan);
+  table_close(rel, AccessShareLock);
+  if (! found)
+    return NULL;
+
+  /* Column layout: (pcid int4, position int4, name text, interpretation text,
+   * scale float8, offset float8, active bool, description text) */
+  rel = table_open(dim_oid, AccessShareLock);
+  tup_desc = RelationGetDescr(rel);
+  ScanKeyInit(&key[0], 1, BTEqualStrategyNumber, F_INT4EQ,
+    Int32GetDatum((int32) pcid));
+  scan = systable_beginscan(rel, InvalidOid, false, NULL, 1, key);
+
+  int ndims = 0, capacity = 8;
+  PCDimensionSpec *dims = palloc0(sizeof(PCDimensionSpec) * capacity);
+  while (HeapTupleIsValid(tuple = systable_getnext(scan)))
+  {
+    if (ndims == capacity)
+    {
+      capacity *= 2;
+      dims = repalloc(dims, sizeof(PCDimensionSpec) * capacity);
+    }
+    PCDimensionSpec *spec = &dims[ndims++];
+    Datum datum = heap_getattr(tuple, 2, tup_desc, &isnull);
+    spec->position = isnull ? 0 : DatumGetInt32(datum);
+    datum = heap_getattr(tuple, 3, tup_desc, &isnull);
+    spec->name = isnull ? NULL : text_to_cstring(DatumGetTextPP(datum));
+    datum = heap_getattr(tuple, 4, tup_desc, &isnull);
+    spec->interpretation = isnull ? NULL :
+      text_to_cstring(DatumGetTextPP(datum));
+    datum = heap_getattr(tuple, 5, tup_desc, &isnull);
+    spec->scale = isnull ? 1.0 : DatumGetFloat8(datum);
+    datum = heap_getattr(tuple, 6, tup_desc, &isnull);
+    spec->offset = isnull ? 0.0 : DatumGetFloat8(datum);
+    datum = heap_getattr(tuple, 7, tup_desc, &isnull);
+    spec->active = isnull ? true : DatumGetBool(datum);
+    datum = heap_getattr(tuple, 8, tup_desc, &isnull);
+    spec->description = isnull ? NULL : text_to_cstring(DatumGetTextPP(datum));
+  }
+  systable_endscan(scan);
+  table_close(rel, AccessShareLock);
+
+  if (ndims == 0)
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+      errmsg("The point cloud schema of pcid %u states no dimension", pcid)));
+
+  MemoryContext old_ctx = MemoryContextSwitchTo(TopMemoryContext);
+  PCSCHEMA *result = meos_pc_schema_from_dims(pcid, srid, compression, dims,
+    ndims);
+  MemoryContextSwitchTo(old_ctx);
+  return result;
+}
+
 PCSCHEMA *
 mobilitydb_pc_schema(uint32_t pcid)
 {
+  /* The rows state the schema without an XML document, and the path below
+   * errors where pgpointcloud is not installed, so they are read first */
+  PCSCHEMA *stated = fetch_schema_dims(pcid);
+  if (stated)
+    return stated;
+
   int32 srid;
   char *xml = fetch_schema_row(pcid, &srid);
   if (xml == NULL)

--- a/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
+++ b/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
@@ -1,0 +1,44 @@
+INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
+  (90, 4326, 'none', 'Three doubles');
+INSERT 0 1
+INSERT INTO pointcloud_dimensions
+    (pcid, position, name, interpretation, scale, "offset", active, description)
+  VALUES
+  (90, 1, 'X', 'double', 1, 0, true, 'Easting'),
+  (90, 2, 'Y', 'double', 1, 0, true, 'Northing'),
+  (90, 3, 'Z', 'double', 1, 0, true, 'Elevation');
+INSERT 0 3
+SELECT asMFJSON(tpcpoint '230000005A000000000000000000F03F00000000000000400000000000000840000000@2024-01-01');
+                                                                                asmfjson                                                                                
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingPCPoint","crs":{"type":"Name","properties":{"name":"EPSG:4326"}},"coordinates":[[1,2,3]],"datetimes":["2024-01-01T00:00:00-08"],"interpolation":"None"}
+(1 row)
+
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (90, 1, 'W', 'double');
+ERROR:  duplicate key value violates unique constraint "pointcloud_dimensions_pkey"
+DETAIL:  Key (pcid, "position")=(90, 1) already exists.
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (90, 4, 'X', 'double');
+ERROR:  duplicate key value violates unique constraint "pointcloud_dimensions_pcid_name_key"
+DETAIL:  Key (pcid, name)=(90, X) already exists.
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (90, 4, 'W', 'float128');
+ERROR:  new row for relation "pointcloud_dimensions" violates check constraint "pointcloud_dimensions_interpretation_check"
+DETAIL:  Failing row contains (90, 4, W, float128, 1, 0, t, null).
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (90, 0, 'W', 'double');
+ERROR:  new row for relation "pointcloud_dimensions" violates check constraint "pointcloud_dimensions_position_check"
+DETAIL:  Failing row contains (90, 0, W, double, 1, 0, t, null).
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (91, 1, 'X', 'double');
+ERROR:  insert or update on table "pointcloud_dimensions" violates foreign key constraint "pointcloud_dimensions_pcid_fkey"
+DETAIL:  Key (pcid)=(91) is not present in table "pointcloud_schemas".
+DELETE FROM pointcloud_schemas WHERE pcid = 90;
+DELETE 1
+SELECT count(*) FROM pointcloud_dimensions WHERE pcid = 90;
+ count 
+-------
+     0
+(1 row)
+

--- a/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
+++ b/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
@@ -1,0 +1,62 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- MobilityDB includes portions of PostGIS version 3 source code released
+-- under the GNU General Public License (GPLv2 or later).
+-- Copyright (c) 2001-2025, PostGIS contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- A point cloud schema stated in SQL
+-------------------------------------------------------------------------------
+
+-- The schema a pcid names is stated as rows and holds no XML document. The
+-- three dimensions are doubles, which is what the value below carries.
+INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
+  (90, 4326, 'none', 'Three doubles');
+INSERT INTO pointcloud_dimensions
+    (pcid, position, name, interpretation, scale, "offset", active, description)
+  VALUES
+  (90, 1, 'X', 'double', 1, 0, true, 'Easting'),
+  (90, 2, 'Y', 'double', 1, 0, true, 'Northing'),
+  (90, 3, 'Z', 'double', 1, 0, true, 'Elevation');
+
+-- The coordinates a value decodes to are the ones the schema states. The text
+-- form of a value is its stored bytes and reads the same under any schema, so
+-- the rendered coordinates are what states that the schema resolved.
+SELECT asMFJSON(tpcpoint '230000005A000000000000000000F03F00000000000000400000000000000840000000@2024-01-01');
+
+-- A position is stated once within a schema
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (90, 1, 'W', 'double');
+
+-- A name is stated once within a schema
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (90, 4, 'X', 'double');
+
+-- An interpretation is one of those the library states
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (90, 4, 'W', 'float128');
+
+-- A position is stated from one
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (90, 0, 'W', 'double');
+
+-- A dimension belongs to a schema that is stated
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (91, 1, 'X', 'double');
+
+-- The dimensions of a schema go when the schema goes
+DELETE FROM pointcloud_schemas WHERE pcid = 90;
+SELECT count(*) FROM pointcloud_dimensions WHERE pcid = 90;
+
+-------------------------------------------------------------------------------

--- a/pointcloud-pg/lib/pc_api.h
+++ b/pointcloud-pg/lib/pc_api.h
@@ -251,6 +251,12 @@ const char *pc_compression_name(int num);
 
 /** Release the memory in a schema structure */
 void pc_schema_free(PCSCHEMA *pcs);
+/** Build an empty schema structure of @p ndims dimensions */
+PCSCHEMA *pc_schema_new(uint32_t ndims); /* MEOS */
+/** Convert a dimension interpretation name to its number */
+int pc_interpretation_number(const char *str); /* MEOS */
+/** Convert a compression name to its number */
+int pc_compression_number(const char *str); /* MEOS */
 /** Build a schema structure from the XML serialisation */
 PCSCHEMA *pc_schema_from_xml(const char *xmlstr);
 /** Print out JSON readable format of schema */

--- a/pointcloud-pg/lib/pc_schema.c
+++ b/pointcloud-pg/lib/pc_schema.c
@@ -40,7 +40,7 @@ const char *pc_interpretation_string(uint32_t interp)
 }
 
 /** Convert XML string token to type interpretation number */
-static int pc_interpretation_number(const char *str)
+int pc_interpretation_number(const char *str) /* MEOS */
 {
   if (str[0] == 'i' || str[0] == 'I')
   {
@@ -93,7 +93,7 @@ const char *pc_compression_name(int num)
   }
 }
 
-static int pc_compression_number(const char *str)
+int pc_compression_number(const char *str) /* MEOS */
 {
   if (!str)
     return PC_NONE;
@@ -163,7 +163,7 @@ static void pc_dimension_free(PCDIMENSION *pcd)
   pcfree(pcd);
 }
 
-static PCSCHEMA *pc_schema_new(uint32_t ndims)
+PCSCHEMA *pc_schema_new(uint32_t ndims) /* MEOS */
 {
   PCSCHEMA *pcs = pcalloc(sizeof(PCSCHEMA));
   pcs->dims = pcalloc(sizeof(PCDIMENSION *) * ndims);

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -83,8 +83,15 @@ Temporal<T>              temporal_type      = ALL temporal types            (cat
   | where the SRID lives | families | `SRID` | `setSRID` | `transform` |
   |---|---|---|---|---|
   | stored in the value | tgeo, tcbuffer, tpose, tposechain | ✓ | ✓ | ✓ |
-  | inherited from a table | tnpoint (`ways`), tpcpoint/tpcpatch (`pointcloud_formats`) | ✓ | — | — |
+  | inherited from a table | tnpoint (`ways`), tpcpoint/tpcpatch (`pointcloud_schemas`) | ✓ | — | — |
   | imposed by the specification | th3index, tquadbin | — | — | — |
+
+  ⭐ **The pointcloud table is `pointcloud_schemas`, stated in SQL.** `mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql`
+  states the schema a `pcid` names as rows of `pointcloud_schemas` (which carries the SRID)
+  and `pointcloud_dimensions`, both hand-written and so listed in `coverage_exceptions.txt`,
+  both marked `pg_extension_config_dump` so a registered schema survives a dump — the shape
+  `mobilitydb/sql/pose/120_geopose_frames.in.sql` already carries. The `pointcloud_formats`
+  catalog of pgPointCloud is read after them and stays for data written by other tools.
 
   ⛔ So an absent `setSRID`/`transform` is the PROPERTY of an inherited or imposed reference
   system, never a parity gap: nothing per value can be set or transformed when the value

--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -62,6 +62,7 @@ mobilitydb/sql/npoint/307_tnpoint_boxops.in.sql
 mobilitydb/sql/npoint/310_tnpoint_routeops.in.sql
 mobilitydb/sql/npoint/311_tnpoint_gin.in.sql
 mobilitydb/sql/npoint/312_tnpoint_distance.in.sql
+mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
 mobilitydb/sql/pointcloud/410_tpcbox.in.sql
 mobilitydb/sql/pointcloud/436_tpc_topops.in.sql
 mobilitydb/sql/pointcloud/437_tpc_posops.in.sql


### PR DESCRIPTION
A pcpoint and a pcpatch carry a pcid and nothing else about their own layout, so the dimensions they hold, how each is stored and what a stored integer means as a coordinate are stated by the schema that pcid names. The tables pointcloud_schemas and pointcloud_dimensions state it in SQL, so registering a schema needs no XML document. They state what a schema states and nothing the engine derives: the size of a dimension, the offset of a dimension within a point and the width of a point follow from the interpretations, and the X, Y, Z and M dimensions resolve from the names. The position a dimension holds is a column rather than the order rows arrive in, so a reload, a COPY or a parallel insert cannot reorder the layout of a point, and a duplicate or a gap is a constraint violation rather than a wrong byte offset. Both tables are marked pg_extension_config_dump, so a registered schema survives a dump, as the geopose_frames registry is. meos_pc_schema_from_dims and meos_pc_schema_register_dims take those dimensions as a PCDimensionSpec array and build the PCSCHEMA, so a binding that reaches no PostgreSQL catalog materialises the two tables in its own host and registers through the same entry. A schema that a pcid names is read from the rows before the XML document of pointcloud_formats, which stays for data written by other pgPointCloud tools. A schema built from the rows is equal, field by field including byteoffset, to the same schema parsed from the manual document by pc_schema_from_xml, and the regression test reads the coordinates a value decodes to rather than its text form, which is the stored bytes and reads the same under any schema. doc/contributing/tpointcloud_schema_design_notes.md states the design, and section 19.1.1 of both manuals registers the minimal three-dimensional schema as rows of the two tables. The vendored publish of the pgPointCloud schema constructor and name converters is its own commit.
