### PR TITLE
Reach the geometry engine at the cast target a point names

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1840,7 +1840,7 @@
 				<title>Relaciones espaciales temporales</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tposechain_tspatialrels"><varname>tContains</varname>, <varname>tCovers</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname>, <varname>tIntersects</varname>, <varname>tTouches</varname></link>: Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Una cadena de poses temporal las responde en la posición que ocupa la pose que compone.</para>
+						<para><link linkend="tposechain_tspatialrels"><varname>tContains</varname>, <varname>tCovers</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname>, <varname>tIntersects</varname>, <varname>tTouches</varname></link>: Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Una cadena de poses temporal las responde en la posición que ocupa la pose que compone, de modo que una cadena con interpolación lineal se responde a lo largo de su trayectoria y no solo en sus instantes. La cadena declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos cadenas, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -1269,7 +1269,7 @@ SELECT aDwithin(tpcpointSeq(ARRAY[
 
 		<sect2 xml:id="tpcpoint_tempspatialrels">
 			<title>Relaciones espaciales temporales</title>
-			<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Leen la misma proyección a <varname>tgeompoint</varname> que leen las relaciones ever/always, y están conectadas en los mismos tres órdenes de argumentos. Un tpcpoint lleva la Z que declara su esquema, y <varname>tContains</varname>, <varname>tCovers</varname> y <varname>tTouches</varname> son relaciones planas que rechazan una dimensión Z, de modo que el tipo responde las tres que un valor con Z puede responder.</para>
+			<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Leen la misma proyección a <varname>tgeompoint</varname> que leen las relaciones ever/always, y están conectadas en los mismos tres órdenes de argumentos. Un tpcpoint lleva la Z que declara su esquema, y <varname>tContains</varname>, <varname>tCovers</varname> y <varname>tTouches</varname> son relaciones planas que rechazan una dimensión Z, de modo que el tipo responde las tres que un valor con Z puede responder. Esa proyección lleva la interpolación de su origen, de modo que una secuencia tpcpoint se responde a lo largo de su trayectoria y no solo en sus instantes.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcpoint_tspatialrels">
 					<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>

--- a/doc/es/temporal_pose_chains.xml
+++ b/doc/es/temporal_pose_chains.xml
@@ -715,13 +715,14 @@ SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 					<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
-					<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Una cadena de poses temporal las responde en la posición que ocupa la pose que compone.</para>
+					<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Una cadena de poses temporal las responde en la posición que ocupa la pose que compone, de modo que una cadena con interpolación lineal se responde a lo largo de su trayectoria y no solo en sus instantes. La cadena declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos cadenas, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
 					<para><varname>tContains(geometry,tposechain) → tbool</varname></para>
 					<para><varname>tCovers(geometry,tposechain) → tbool</varname></para>
 					<para><varname>tDisjoint({geometry,tposechain},{geometry,tposechain}) → tbool</varname></para>
 					<para><varname>tDwithin({geometry,tposechain},{geometry,tposechain},float) → tbool</varname></para>
 					<para><varname>tIntersects({geometry,tposechain},{geometry,tposechain}) → tbool</varname></para>
-					<para><varname>tTouches({geometry,tposechain},{geometry,tposechain}) → tbool</varname></para>
+					<para><varname>tTouches(geometry,tposechain) → tbool</varname></para>
+					<para><varname>tTouches(tposechain,geometry) → tbool</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tposechain '{PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
   PoseChain(Pose(Point(3 3), 0.1))@2001-01-03}',

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1843,7 +1843,7 @@
 				<title>Temporal Spatial Relationships</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tposechain_tspatialrels"><varname>tContains</varname>, <varname>tCovers</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname>, <varname>tIntersects</varname>, <varname>tTouches</varname></link>: The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal pose chain answers them at the position its composed pose occupies.</para>
+						<para><link linkend="tposechain_tspatialrels"><varname>tContains</varname>, <varname>tCovers</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname>, <varname>tIntersects</varname>, <varname>tTouches</varname></link>: The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal pose chain answers them at the position its composed pose occupies, so a chain with linear interpolation is answered along its trajectory rather than at its instants alone. The chain declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two chains, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -1274,7 +1274,7 @@ SELECT aDwithin(tpcpointSeq(ARRAY[
 
 		<sect2 xml:id="tpcpoint_tempspatialrels">
 			<title>Temporal Spatial Relationships</title>
-			<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. They read the same <varname>tgeompoint</varname> projection the ever/always relationships read, and are wired in the same three argument orders. A tpcpoint carries the Z its schema declares, and <varname>tContains</varname>, <varname>tCovers</varname> and <varname>tTouches</varname> are planar relationships that refuse a Z dimension, so the type answers the three that a Z-carrying value can.</para>
+			<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. They read the same <varname>tgeompoint</varname> projection the ever/always relationships read, and are wired in the same three argument orders. A tpcpoint carries the Z its schema declares, and <varname>tContains</varname>, <varname>tCovers</varname> and <varname>tTouches</varname> are planar relationships that refuse a Z dimension, so the type answers the three that a Z-carrying value can. That projection carries the interpolation of its source, so a tpcpoint sequence is answered along its trajectory rather than at its instants alone.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcpoint_tspatialrels">
 					<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>

--- a/doc/temporal_pose_chains.xml
+++ b/doc/temporal_pose_chains.xml
@@ -715,13 +715,14 @@ SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 					<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
-					<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal pose chain answers them at the position its composed pose occupies.</para>
+					<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal pose chain answers them at the position its composed pose occupies, so a chain with linear interpolation is answered along its trajectory rather than at its instants alone. The chain declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two chains, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
 					<para><varname>tContains(geometry,tposechain) &#8594; tbool</varname></para>
 					<para><varname>tCovers(geometry,tposechain) &#8594; tbool</varname></para>
 					<para><varname>tDisjoint({geometry,tposechain},{geometry,tposechain}) &#8594; tbool</varname></para>
 					<para><varname>tDwithin({geometry,tposechain},{geometry,tposechain},float) &#8594; tbool</varname></para>
 					<para><varname>tIntersects({geometry,tposechain},{geometry,tposechain}) &#8594; tbool</varname></para>
-					<para><varname>tTouches({geometry,tposechain},{geometry,tposechain}) &#8594; tbool</varname></para>
+					<para><varname>tTouches(geometry,tposechain) &#8594; tbool</varname></para>
+					<para><varname>tTouches(tposechain,geometry) &#8594; tbool</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tposechain '{PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
   PoseChain(Pose(Point(3 3), 0.1))@2001-01-03}',

--- a/mobilitydb/sql/npoint/322_tnpoint_tempspatialrels.in.sql
+++ b/mobilitydb/sql/npoint/322_tnpoint_tempspatialrels.in.sql
@@ -39,85 +39,62 @@
 CREATE FUNCTION tContains(geometry, tnpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
-CREATE FUNCTION tContains(tnpoint, geometry)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tContains(tnpoint, tnpoint)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                          $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains($1, $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tCovers(geometry, tnpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
-CREATE FUNCTION tCovers(tnpoint, geometry)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tCovers(tnpoint, tnpoint)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                        $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers($1, $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tDisjoint(geometry, tnpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tDisjoint(tnpoint, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint, $2) $$;
 CREATE FUNCTION tDisjoint(tnpoint, tnpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                          $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint,
+                          $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tIntersects(geometry, tnpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tIntersects(tnpoint, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint, $2) $$;
 CREATE FUNCTION tIntersects(tnpoint, tnpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                            $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint,
+                            $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tTouches(geometry, tnpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1, $2::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tTouches(tnpoint, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tTouches(tnpoint, tnpoint)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                         $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tgeompoint, $2) $$;
 
 CREATE FUNCTION tDwithin(geometry, tnpoint, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tgeompoint, $3) $$;
 CREATE FUNCTION tDwithin(tnpoint, geometry, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint, $2, $3) $$;
 CREATE FUNCTION tDwithin(tnpoint, tnpoint, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                         $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint,
+                         $2::@extschema@.tgeompoint, $3) $$;
 
 /*****************************************************************************/

--- a/mobilitydb/sql/pointcloud/444_tpcpoint_tempspatialrels.in.sql
+++ b/mobilitydb/sql/pointcloud/444_tpcpoint_tempspatialrels.in.sql
@@ -39,43 +39,43 @@
 CREATE FUNCTION tDisjoint(geometry, tpcpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tDisjoint(tpcpoint, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint, $2) $$;
 CREATE FUNCTION tDisjoint(tpcpoint, tpcpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                          $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint,
+                          $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tIntersects(geometry, tpcpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tIntersects(tpcpoint, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint, $2) $$;
 CREATE FUNCTION tIntersects(tpcpoint, tpcpoint)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                            $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint,
+                            $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tDwithin(geometry, tpcpoint, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tgeompoint, $3) $$;
 CREATE FUNCTION tDwithin(tpcpoint, geometry, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint, $2, $3) $$;
 CREATE FUNCTION tDwithin(tpcpoint, tpcpoint, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                         $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint,
+                         $2::@extschema@.tgeompoint, $3) $$;
 
 /*****************************************************************************/

--- a/mobilitydb/sql/pose/114_tpose_tempspatialrels.in.sql
+++ b/mobilitydb/sql/pose/114_tpose_tempspatialrels.in.sql
@@ -39,85 +39,62 @@
 CREATE FUNCTION tContains(geometry, tpose)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
-CREATE FUNCTION tContains(tpose, geometry)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tContains(tpose, tpose)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                          $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains($1, $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tCovers(geometry, tpose)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
-CREATE FUNCTION tCovers(tpose, geometry)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tCovers(tpose, tpose)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                        $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers($1, $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tDisjoint(geometry, tpose)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tDisjoint(tpose, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint, $2) $$;
 CREATE FUNCTION tDisjoint(tpose, tpose)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                          $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tgeompoint,
+                          $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tIntersects(geometry, tpose)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tIntersects(tpose, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint, $2) $$;
 CREATE FUNCTION tIntersects(tpose, tpose)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                            $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tgeompoint,
+                            $2::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tTouches(geometry, tpose)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1, $2::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tTouches(tpose, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tTouches(tpose, tpose)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                         $2::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tgeompoint, $2) $$;
 
 CREATE FUNCTION tDwithin(geometry, tpose, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tgeompoint, $3) $$;
 CREATE FUNCTION tDwithin(tpose, geometry, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint, $2, $3) $$;
 CREATE FUNCTION tDwithin(tpose, tpose, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint::@extschema@.tgeometry,
-                         $2::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tgeompoint,
+                         $2::@extschema@.tgeompoint, $3) $$;
 
 /*****************************************************************************/

--- a/mobilitydb/sql/posechain/564_tposechain_tempspatialrels.in.sql
+++ b/mobilitydb/sql/posechain/564_tposechain_tempspatialrels.in.sql
@@ -39,85 +39,62 @@
 CREATE FUNCTION tContains(geometry, tposechain)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1, $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
-CREATE FUNCTION tContains(tposechain, geometry)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tContains(tposechain, tposechain)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tContains($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry,
-                          $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tContains($1, $2::@extschema@.tpose::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tCovers(geometry, tposechain)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1, $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
-CREATE FUNCTION tCovers(tposechain, geometry)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tCovers(tposechain, tposechain)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tCovers($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry,
-                        $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tCovers($1, $2::@extschema@.tpose::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tDisjoint(geometry, tposechain)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1, $2::@extschema@.tpose::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tDisjoint(tposechain, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tpose::@extschema@.tgeompoint, $2) $$;
 CREATE FUNCTION tDisjoint(tposechain, tposechain)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry,
-                          $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tDisjoint($1::@extschema@.tpose::@extschema@.tgeompoint,
+                          $2::@extschema@.tpose::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tIntersects(geometry, tposechain)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1, $2::@extschema@.tpose::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tIntersects(tposechain, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
+  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tpose::@extschema@.tgeompoint, $2) $$;
 CREATE FUNCTION tIntersects(tposechain, tposechain)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry,
-                            $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tIntersects($1::@extschema@.tpose::@extschema@.tgeompoint,
+                            $2::@extschema@.tpose::@extschema@.tgeompoint) $$;
 
 CREATE FUNCTION tTouches(geometry, tposechain)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1, $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1, $2::@extschema@.tpose::@extschema@.tgeompoint) $$;
 CREATE FUNCTION tTouches(tposechain, geometry)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry, $2) $$;
-CREATE FUNCTION tTouches(tposechain, tposechain)
-  RETURNS tbool
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry,
-                         $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry) $$;
+  AS $$ SELECT @extschema@.tTouches($1::@extschema@.tpose::@extschema@.tgeompoint, $2) $$;
 
 CREATE FUNCTION tDwithin(geometry, tposechain, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1, $2::@extschema@.tpose::@extschema@.tgeompoint, $3) $$;
 CREATE FUNCTION tDwithin(tposechain, geometry, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry, $2, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tpose::@extschema@.tgeompoint, $2, $3) $$;
 CREATE FUNCTION tDwithin(tposechain, tposechain, dist float)
   RETURNS tbool
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
-  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry,
-                         $2::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry, $3) $$;
+  AS $$ SELECT @extschema@.tDwithin($1::@extschema@.tpose::@extschema@.tgeompoint,
+                         $2::@extschema@.tpose::@extschema@.tgeompoint, $3) $$;
 
 /*****************************************************************************/

--- a/mobilitydb/test/npoint/expected/322_tnpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/npoint/expected/322_tnpoint_tempspatialrels.test.out
@@ -18,17 +18,15 @@ WITH t AS (
 )
 SELECT
   asText(tContains(big_region, seq1)) = asText(tContains(big_region, seq1::tgeompoint::tgeometry)) AS tc_geo_np,
-  asText(tContains(seq1, big_region)) = asText(tContains(seq1::tgeompoint::tgeometry, big_region)) AS tc_np_geo,
-  asText(tContains(seq1, seq2)) = asText(tContains(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tc_np_np,
   asText(tCovers(big_region, seq1)) = asText(tCovers(big_region, seq1::tgeompoint::tgeometry)) AS tcv_geo_np,
   asText(tDisjoint(far_point, seq1)) = asText(tDisjoint(far_point, seq1::tgeompoint::tgeometry)) AS tdj_geo_np,
   asText(tIntersects(seq1, seq2)) = asText(tIntersects(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ti_np_np,
   asText(tTouches(big_region, seq1)) = asText(tTouches(big_region, seq1::tgeompoint::tgeometry)) AS ttc_geo_np,
   asText(tDwithin(seq1, seq2, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry, 1.0)) AS tdw_np_np
 FROM t;
- tc_geo_np | tc_np_geo | tc_np_np | tcv_geo_np | tdj_geo_np | ti_np_np | ttc_geo_np | tdw_np_np 
------------+-----------+----------+------------+------------+----------+------------+-----------
- t         | t         | t        | t          | t          | t        | t          | t
+ tc_geo_np | tcv_geo_np | tdj_geo_np | ti_np_np | ttc_geo_np | tdw_np_np 
+-----------+------------+------------+----------+------------+-----------
+ t         | t          | t          | t        | t          | t
 (1 row)
 
 SELECT tContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
@@ -51,5 +49,43 @@ SELECT tDwithin(
                              tdwithin                             
 ------------------------------------------------------------------
  [f@Mon Jan 01 00:00:00 2001 PST, f@Wed Jan 03 00:00:00 2001 PST]
+(1 row)
+
+WITH t AS (
+  SELECT tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.9)@2001-01-03]' AS lin1,
+         tnpoint '[Npoint(1, 0.9)@2001-01-01, Npoint(1, 0.1)@2001-01-03]' AS lin2,
+         geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))' AS region
+)
+SELECT
+  asText(tIntersects(region, lin1)) AS ti_geo_np,
+  asText(tIntersects(lin1, region)) AS ti_np_geo,
+  asText(tDisjoint(lin1, region)) AS tdj_np_geo,
+  asText(tDwithin(lin1, lin2, 1.0)) AS tdw_np_np
+FROM t;
+                             ti_geo_np                              |                             ti_np_geo                              |                             tdj_np_geo                             |                                                                                        tdw_np_np                                                                                         
+--------------------------------------------------------------------+--------------------------------------------------------------------+--------------------------------------------------------------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Mon Jan 01 00:00:00 2001 PST, f@Wed Jan 03 00:00:00 2001 PST]} | {[f@Mon Jan 01 00:00:00 2001 PST, f@Wed Jan 03 00:00:00 2001 PST]} | {[t@Mon Jan 01 00:00:00 2001 PST, t@Wed Jan 03 00:00:00 2001 PST]} | {[f@Mon Jan 01 00:00:00 2001 PST, t@Mon Jan 01 23:34:43.68921 2001 PST, t@Tue Jan 02 00:25:16.310789 2001 PST], (f@Tue Jan 02 00:25:16.310789 2001 PST, f@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+WITH t AS (
+  SELECT tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.9)@2001-01-03]' AS lin1,
+         geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))' AS region
+)
+SELECT
+  asText(tIntersects(lin1, region)) = asText(tIntersects(lin1::tgeompoint, region)) AS ti_agrees,
+  asText(tDwithin(lin1, region, 1.0)) = asText(tDwithin(lin1::tgeompoint, region, 1.0)) AS tdw_agrees
+FROM t;
+ ti_agrees | tdw_agrees 
+-----------+------------
+ t         | t
+(1 row)
+
+SELECT to_regprocedure('tContains(tnpoint, geometry)') IS NULL AS tcontains_absent,
+       to_regprocedure('tCovers(tnpoint, geometry)') IS NULL AS tcovers_absent,
+       to_regprocedure('tTouches(tnpoint, tnpoint)') IS NULL AS ttouches_absent,
+       to_regprocedure('tContains(geometry, tnpoint)') IS NOT NULL AS tcontains_present;
+ tcontains_absent | tcovers_absent | ttouches_absent | tcontains_present 
+------------------+----------------+-----------------+-------------------
+ t                | t              | t               | t
 (1 row)
 

--- a/mobilitydb/test/npoint/queries/322_tnpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/npoint/queries/322_tnpoint_tempspatialrels.test.sql
@@ -30,17 +30,18 @@
 --
 -- Each function returns a tbool whose value at instant t is the static
 -- spatial relation applied to the network point resolved at t: cast the
--- tnpoint to tgeompoint, then to tgeometry, and delegate to tgeometry's
--- temporal spatial-rel kernel (072_tgeo_tempspatialrels.in.sql). Each block
--- checks that the direct tnpoint overload agrees with the equivalent manual
--- cast chain (::tgeompoint::tgeometry).
+-- tnpoint to tgeompoint and delegate to the temporal spatial-rel kernel the
+-- geo family owns (072_tgeo_tempspatialrels.in.sql). A network point resolves
+-- to a position, so tgeompoint is the cast target its geometry names; the
+-- block below checks that each direct tnpoint overload agrees with the longer
+-- manual chain (::tgeompoint::tgeometry) that reaches the same kernel.
 --
--- The delegate target tgeometry only supports STEP interpolation, so a
--- multi-instant sequence operand below is written 'Interp=Step;...' (a
--- LINEAR tnpoint sequence errors on the ::tgeometry step of the chain, the
--- same documented restriction already exercised for tgeompoint/tgeogpoint
--- in geo/056_tgeo_spatialfuncs.test.sql). Single-instant values have no
--- interpolation and are unaffected.
+-- The family declares the matrix its target declares: tContains and tCovers
+-- take the geometry first only, and tTouches has no direction between two
+-- tnpoints, because a moving point neither contains nor covers a geometry and
+-- two moving points do not touch. The equivalence block below keeps its
+-- sequences 'Interp=Step;...' so the longer chain it compares against, which
+-- reaches tgeometry, can carry them.
 --
 -------------------------------------------------------------------------------
 
@@ -60,8 +61,6 @@ WITH t AS (
 )
 SELECT
   asText(tContains(big_region, seq1)) = asText(tContains(big_region, seq1::tgeompoint::tgeometry)) AS tc_geo_np,
-  asText(tContains(seq1, big_region)) = asText(tContains(seq1::tgeompoint::tgeometry, big_region)) AS tc_np_geo,
-  asText(tContains(seq1, seq2)) = asText(tContains(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tc_np_np,
   asText(tCovers(big_region, seq1)) = asText(tCovers(big_region, seq1::tgeompoint::tgeometry)) AS tcv_geo_np,
   asText(tDisjoint(far_point, seq1)) = asText(tDisjoint(far_point, seq1::tgeompoint::tgeometry)) AS tdj_geo_np,
   asText(tIntersects(seq1, seq2)) = asText(tIntersects(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ti_np_np,
@@ -81,5 +80,40 @@ SELECT tDisjoint(geometry(npoint 'NPoint(2, 0.0)'),
 SELECT tDwithin(
   tnpoint 'Interp=Step;[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]',
   tnpoint 'Interp=Step;[Npoint(1, 0.5)@2001-01-01, Npoint(1, 0.3)@2001-01-03]', 1);
+
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Linear interpolation, which the tgeompoint target carries
+-------------------------------------------------------------------------------
+
+WITH t AS (
+  SELECT tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.9)@2001-01-03]' AS lin1,
+         tnpoint '[Npoint(1, 0.9)@2001-01-01, Npoint(1, 0.1)@2001-01-03]' AS lin2,
+         geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))' AS region
+)
+SELECT
+  asText(tIntersects(region, lin1)) AS ti_geo_np,
+  asText(tIntersects(lin1, region)) AS ti_np_geo,
+  asText(tDisjoint(lin1, region)) AS tdj_np_geo,
+  asText(tDwithin(lin1, lin2, 1.0)) AS tdw_np_np
+FROM t;
+
+-- The answer is the one the network point's own tgeompoint gives
+WITH t AS (
+  SELECT tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.9)@2001-01-03]' AS lin1,
+         geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))' AS region
+)
+SELECT
+  asText(tIntersects(lin1, region)) = asText(tIntersects(lin1::tgeompoint, region)) AS ti_agrees,
+  asText(tDwithin(lin1, region, 1.0)) = asText(tDwithin(lin1::tgeompoint, region, 1.0)) AS tdw_agrees
+FROM t;
+
+-- A moving point neither contains nor covers a geometry, and two of them do
+-- not touch, so those five signatures are not declared
+SELECT to_regprocedure('tContains(tnpoint, geometry)') IS NULL AS tcontains_absent,
+       to_regprocedure('tCovers(tnpoint, geometry)') IS NULL AS tcovers_absent,
+       to_regprocedure('tTouches(tnpoint, tnpoint)') IS NULL AS ttouches_absent,
+       to_regprocedure('tContains(geometry, tnpoint)') IS NOT NULL AS tcontains_present;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/expected/444_tpcpoint_tempspatialrels.test.out
+++ b/mobilitydb/test/pointcloud/expected/444_tpcpoint_tempspatialrels.test.out
@@ -40,3 +40,34 @@ SELECT asText(tDwithin(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), 
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
+SELECT asText(tIntersects(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), '2001-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 0.0]::float[]), '2001-01-02'::timestamptz)]), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+                                                                astext                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Mon Jan 01 00:00:00 2001 PST, t@Mon Jan 01 12:00:00 2001 PST], (f@Mon Jan 01 12:00:00 2001 PST, f@Tue Jan 02 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tIntersects(geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))', tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), '2001-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 0.0]::float[]), '2001-01-02'::timestamptz)])));
+                                                                astext                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Mon Jan 01 00:00:00 2001 PST, t@Mon Jan 01 12:00:00 2001 PST], (f@Mon Jan 01 12:00:00 2001 PST, f@Tue Jan 02 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tDisjoint(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), '2001-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 0.0]::float[]), '2001-01-02'::timestamptz)]), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+                                                                astext                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Mon Jan 01 00:00:00 2001 PST, f@Mon Jan 01 12:00:00 2001 PST], (t@Mon Jan 01 12:00:00 2001 PST, t@Tue Jan 02 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tDwithin(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), '2001-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 0.0]::float[]), '2001-01-02'::timestamptz)]), geometry 'SRID=0;Point(1 1)', 1.0));
+                                                                       astext                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Mon Jan 01 00:00:00 2001 PST, t@Mon Jan 01 08:29:07.012947 2001 PST], (f@Mon Jan 01 08:29:07.012947 2001 PST, f@Tue Jan 02 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tIntersects(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), '2001-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 0.0]::float[]), '2001-01-02'::timestamptz)]), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))')) =
+  asText(tIntersects(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), '2001-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 0.0]::float[]), '2001-01-02'::timestamptz)])::tgeompoint, geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))')) AS ti_agrees;
+ ti_agrees 
+-----------
+ t
+(1 row)
+

--- a/mobilitydb/test/pointcloud/queries/444_tpcpoint_tempspatialrels.test.sql
+++ b/mobilitydb/test/pointcloud/queries/444_tpcpoint_tempspatialrels.test.sql
@@ -16,8 +16,10 @@
 -------------------------------------------------------------------------------
 
 -- Temporal spatial relationships for tpcpoint. Every one of them converts its
--- operands to a temporal geometry and re-delegates, the three predicates its
--- Z-carrying values can answer.
+-- operands to the temporal geometry point the schema-aware projection gives
+-- and re-delegates, the three predicates its Z-carrying values can answer.
+-- That projection promotes step to linear, so tgeompoint — which carries
+-- linear interpolation, unlike tgeometry — is what a sequence can reach.
 
 \set square 'geometry ''SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'''
 \set inside 'tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), ''2001-01-01''::timestamptz)'
@@ -42,5 +44,20 @@ SELECT asText(tDwithin(:inside, geometry 'SRID=0;Point(1 5)', 2.0));
 SELECT asText(tDwithin(:inside, :inside, 0.0));
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- A sequence, whose projection carries linear interpolation
+-------------------------------------------------------------------------------
+
+\set seq 'tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 0.0]::float[]), ''2001-01-01''::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 0.0]::float[]), ''2001-01-02''::timestamptz)])'
+
+SELECT asText(tIntersects(:seq, :square));
+SELECT asText(tIntersects(:square, :seq));
+SELECT asText(tDisjoint(:seq, :square));
+SELECT asText(tDwithin(:seq, geometry 'SRID=0;Point(1 1)', 1.0));
+
+-- The answer is the one the projection itself gives
+SELECT asText(tIntersects(:seq, :square)) =
+  asText(tIntersects(:seq::tgeompoint, :square)) AS ti_agrees;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pose/expected/114_tpose_tempspatialrels.test.out
+++ b/mobilitydb/test/pose/expected/114_tpose_tempspatialrels.test.out
@@ -18,11 +18,7 @@ WITH t AS (
 )
 SELECT
   asText(tContains(region, seq1)) = asText(tContains(region, seq1::tgeompoint::tgeometry)) AS tc_geo_po,
-  asText(tContains(seq1, region)) = asText(tContains(seq1::tgeompoint::tgeometry, region)) AS tc_po_geo,
-  asText(tContains(seq1, seq2)) = asText(tContains(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tc_po_po,
   asText(tCovers(region, seq1)) = asText(tCovers(region, seq1::tgeompoint::tgeometry)) AS tcv_geo_po,
-  asText(tCovers(seq1, region)) = asText(tCovers(seq1::tgeompoint::tgeometry, region)) AS tcv_po_geo,
-  asText(tCovers(seq1, seq2)) = asText(tCovers(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tcv_po_po,
   asText(tDisjoint(far_point, seq1)) = asText(tDisjoint(far_point, seq1::tgeompoint::tgeometry)) AS tdj_geo_po,
   asText(tDisjoint(seq1, far_point)) = asText(tDisjoint(seq1::tgeompoint::tgeometry, far_point)) AS tdj_po_geo,
   asText(tDisjoint(seq1, seq2)) = asText(tDisjoint(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tdj_po_po,
@@ -31,14 +27,13 @@ SELECT
   asText(tIntersects(seq1, seq2)) = asText(tIntersects(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ti_po_po,
   asText(tTouches(region, seq1)) = asText(tTouches(region, seq1::tgeompoint::tgeometry)) AS ttc_geo_po,
   asText(tTouches(seq1, region)) = asText(tTouches(seq1::tgeompoint::tgeometry, region)) AS ttc_po_geo,
-  asText(tTouches(seq1, seq2)) = asText(tTouches(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ttc_po_po,
   asText(tDwithin(region, seq1, 1.0)) = asText(tDwithin(region, seq1::tgeompoint::tgeometry, 1.0)) AS tdw_geo_po,
   asText(tDwithin(seq1, region, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, region, 1.0)) AS tdw_po_geo,
   asText(tDwithin(seq1, seq2, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry, 1.0)) AS tdw_po_po
 FROM t;
- tc_geo_po | tc_po_geo | tc_po_po | tcv_geo_po | tcv_po_geo | tcv_po_po | tdj_geo_po | tdj_po_geo | tdj_po_po | ti_geo_po | ti_po_geo | ti_po_po | ttc_geo_po | ttc_po_geo | ttc_po_po | tdw_geo_po | tdw_po_geo | tdw_po_po 
------------+-----------+----------+------------+------------+-----------+------------+------------+-----------+-----------+-----------+----------+------------+------------+-----------+------------+------------+-----------
- t         | t         | t        | t          | t          | t         | t          | t          | t         | t         | t         | t        | t          | t          | t         | t          | t          | t
+ tc_geo_po | tcv_geo_po | tdj_geo_po | tdj_po_geo | tdj_po_po | ti_geo_po | ti_po_geo | ti_po_po | ttc_geo_po | ttc_po_geo | tdw_geo_po | tdw_po_geo | tdw_po_po 
+-----------+------------+------------+------------+-----------+-----------+-----------+----------+------------+------------+------------+------------+-----------
+ t         | t          | t          | t          | t         | t         | t         | t        | t          | t          | t          | t          | t
 (1 row)
 
 SELECT tContains(geometry 'Polygon((0 0,0 5,5 5,5 0,0 0))',
@@ -61,5 +56,44 @@ SELECT tDwithin(
                              tdwithin                             
 ------------------------------------------------------------------
  [f@Sat Jan 01 00:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+WITH t AS (
+  SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(4 4), 0.4)@2000-01-03]' AS lin1,
+         tpose '[Pose(Point(4 4), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]' AS lin2,
+         geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))' AS region
+)
+SELECT
+  asText(tIntersects(region, lin1)) AS ti_geo_po,
+  asText(tIntersects(lin1, region)) AS ti_po_geo,
+  asText(tDisjoint(lin1, region)) AS tdj_po_geo,
+  asText(tDwithin(lin1, region, 1.0)) AS tdw_po_geo,
+  asText(tDwithin(lin1, lin2, 1.0)) AS tdw_po_po
+FROM t;
+                                                              ti_geo_po                                                               |                                                              ti_po_geo                                                               |                                                              tdj_po_geo                                                              |                                                                     tdw_po_geo                                                                     |                                                                                         tdw_po_po                                                                                         
+--------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------+--------------------------------------------------------------------------------------------------------------------------------------+----------------------------------------------------------------------------------------------------------------------------------------------------+-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 16:00:00 2000 PST], (f@Sat Jan 01 16:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]} | {[t@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 16:00:00 2000 PST], (f@Sat Jan 01 16:00:00 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]} | {[f@Sat Jan 01 00:00:00 2000 PST, f@Sat Jan 01 16:00:00 2000 PST], (t@Sat Jan 01 16:00:00 2000 PST, t@Mon Jan 03 00:00:00 2000 PST]} | {[t@Sat Jan 01 00:00:00 2000 PST, t@Sun Jan 02 03:18:49.350596 2000 PST], (f@Sun Jan 02 03:18:49.350596 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]} | {[f@Sat Jan 01 00:00:00 2000 PST, t@Sat Jan 01 18:20:35.324701 2000 PST, t@Sun Jan 02 05:39:24.675298 2000 PST], (f@Sun Jan 02 05:39:24.675298 2000 PST, f@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+WITH t AS (
+  SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(4 4), 0.4)@2000-01-03]' AS lin1,
+         geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))' AS region
+)
+SELECT
+  asText(tIntersects(lin1, region)) = asText(tIntersects(lin1::tgeompoint, region)) AS ti_agrees,
+  asText(tDwithin(lin1, region, 1.0)) = asText(tDwithin(lin1::tgeompoint, region, 1.0)) AS tdw_agrees
+FROM t;
+ ti_agrees | tdw_agrees 
+-----------+------------
+ t         | t
+(1 row)
+
+SELECT to_regprocedure('tContains(tpose, geometry)') IS NULL AS tcontains_absent,
+       to_regprocedure('tCovers(tpose, geometry)') IS NULL AS tcovers_absent,
+       to_regprocedure('tTouches(tpose, tpose)') IS NULL AS ttouches_absent,
+       to_regprocedure('tContains(geometry, tpose)') IS NOT NULL AS tcontains_present;
+ tcontains_absent | tcovers_absent | ttouches_absent | tcontains_present 
+------------------+----------------+-----------------+-------------------
+ t                | t              | t               | t
 (1 row)
 

--- a/mobilitydb/test/pose/queries/114_tpose_tempspatialrels.test.sql
+++ b/mobilitydb/test/pose/queries/114_tpose_tempspatialrels.test.sql
@@ -30,13 +30,17 @@
 --
 -- Each function returns a tbool whose value at instant t is the static
 -- spatial relation applied to the position the pose holds at t: cast the
--- tpose to tgeompoint, then to tgeometry, and delegate to the temporal
--- spatial-rel kernel of tgeometry (072_tgeo_tempspatialrels.in.sql). Each
--- block checks that the direct tpose overload agrees with the equivalent
--- manual cast chain (::tgeompoint::tgeometry).
+-- tpose to tgeompoint and delegate to the temporal spatial-rel kernel the geo
+-- family owns (072_tgeo_tempspatialrels.in.sql). A pose holds a position, so
+-- tgeompoint is the cast target its geometry names; the block below checks
+-- that each direct tpose overload agrees with the longer manual chain
+-- (::tgeompoint::tgeometry) that reaches the same kernel, which is what makes
+-- the shorter route a pure gain rather than a different answer.
 --
--- The delegate target tgeometry only supports step interpolation, so the
--- sequences below carry step interpolation.
+-- The family declares the matrix its target declares: tContains and tCovers
+-- take the geometry first only, and tTouches has no direction between two
+-- tposes, because a moving point neither contains nor covers a geometry and
+-- two moving points do not touch.
 --
 -------------------------------------------------------------------------------
 
@@ -56,11 +60,7 @@ WITH t AS (
 )
 SELECT
   asText(tContains(region, seq1)) = asText(tContains(region, seq1::tgeompoint::tgeometry)) AS tc_geo_po,
-  asText(tContains(seq1, region)) = asText(tContains(seq1::tgeompoint::tgeometry, region)) AS tc_po_geo,
-  asText(tContains(seq1, seq2)) = asText(tContains(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tc_po_po,
   asText(tCovers(region, seq1)) = asText(tCovers(region, seq1::tgeompoint::tgeometry)) AS tcv_geo_po,
-  asText(tCovers(seq1, region)) = asText(tCovers(seq1::tgeompoint::tgeometry, region)) AS tcv_po_geo,
-  asText(tCovers(seq1, seq2)) = asText(tCovers(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tcv_po_po,
   asText(tDisjoint(far_point, seq1)) = asText(tDisjoint(far_point, seq1::tgeompoint::tgeometry)) AS tdj_geo_po,
   asText(tDisjoint(seq1, far_point)) = asText(tDisjoint(seq1::tgeompoint::tgeometry, far_point)) AS tdj_po_geo,
   asText(tDisjoint(seq1, seq2)) = asText(tDisjoint(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS tdj_po_po,
@@ -69,7 +69,6 @@ SELECT
   asText(tIntersects(seq1, seq2)) = asText(tIntersects(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ti_po_po,
   asText(tTouches(region, seq1)) = asText(tTouches(region, seq1::tgeompoint::tgeometry)) AS ttc_geo_po,
   asText(tTouches(seq1, region)) = asText(tTouches(seq1::tgeompoint::tgeometry, region)) AS ttc_po_geo,
-  asText(tTouches(seq1, seq2)) = asText(tTouches(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry)) AS ttc_po_po,
   asText(tDwithin(region, seq1, 1.0)) = asText(tDwithin(region, seq1::tgeompoint::tgeometry, 1.0)) AS tdw_geo_po,
   asText(tDwithin(seq1, region, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, region, 1.0)) AS tdw_po_geo,
   asText(tDwithin(seq1, seq2, 1.0)) = asText(tDwithin(seq1::tgeompoint::tgeometry, seq2::tgeompoint::tgeometry, 1.0)) AS tdw_po_po
@@ -86,5 +85,41 @@ SELECT tDisjoint(geometry 'Point(50 50)',
 SELECT tDwithin(
   tpose 'Interp=Step;[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(2 2), 0.4)@2000-01-03]',
   tpose 'Interp=Step;[Pose(Point(2 2), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]', 1.0);
+
+-------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- Linear interpolation, which the tgeompoint target carries
+-------------------------------------------------------------------------------
+
+WITH t AS (
+  SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(4 4), 0.4)@2000-01-03]' AS lin1,
+         tpose '[Pose(Point(4 4), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-03]' AS lin2,
+         geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))' AS region
+)
+SELECT
+  asText(tIntersects(region, lin1)) AS ti_geo_po,
+  asText(tIntersects(lin1, region)) AS ti_po_geo,
+  asText(tDisjoint(lin1, region)) AS tdj_po_geo,
+  asText(tDwithin(lin1, region, 1.0)) AS tdw_po_geo,
+  asText(tDwithin(lin1, lin2, 1.0)) AS tdw_po_po
+FROM t;
+
+-- The answer is the one the pose's own tgeompoint gives, turning points and all
+WITH t AS (
+  SELECT tpose '[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(4 4), 0.4)@2000-01-03]' AS lin1,
+         geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))' AS region
+)
+SELECT
+  asText(tIntersects(lin1, region)) = asText(tIntersects(lin1::tgeompoint, region)) AS ti_agrees,
+  asText(tDwithin(lin1, region, 1.0)) = asText(tDwithin(lin1::tgeompoint, region, 1.0)) AS tdw_agrees
+FROM t;
+
+-- A moving point neither contains nor covers a geometry, and two of them do
+-- not touch, so those five signatures are not declared
+SELECT to_regprocedure('tContains(tpose, geometry)') IS NULL AS tcontains_absent,
+       to_regprocedure('tCovers(tpose, geometry)') IS NULL AS tcovers_absent,
+       to_regprocedure('tTouches(tpose, tpose)') IS NULL AS ttouches_absent,
+       to_regprocedure('tContains(geometry, tpose)') IS NOT NULL AS tcontains_present;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/posechain/expected/564_tposechain_tempspatialrels.test.out
+++ b/mobilitydb/test/posechain/expected/564_tposechain_tempspatialrels.test.out
@@ -88,3 +88,43 @@ SELECT asText(tDwithin(tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01',
  f@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
+SELECT asText(tIntersects(tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(3 3), 0.1))@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))'));
+                                                                astext                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Mon Jan 01 00:00:00 2001 PST, t@Tue Jan 02 00:00:00 2001 PST], (f@Tue Jan 02 00:00:00 2001 PST, f@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tIntersects(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))', tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(3 3), 0.1))@2001-01-03]'));
+                                                                astext                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Mon Jan 01 00:00:00 2001 PST, t@Tue Jan 02 00:00:00 2001 PST], (f@Tue Jan 02 00:00:00 2001 PST, f@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tDisjoint(tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(3 3), 0.1))@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))'));
+                                                                astext                                                                
+--------------------------------------------------------------------------------------------------------------------------------------
+ {[f@Mon Jan 01 00:00:00 2001 PST, f@Tue Jan 02 00:00:00 2001 PST], (t@Tue Jan 02 00:00:00 2001 PST, t@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tDwithin(tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(3 3), 0.1))@2001-01-03]', geometry 'Point(1 1)', 1.0));
+                                                                       astext                                                                       
+----------------------------------------------------------------------------------------------------------------------------------------------------
+ {[t@Mon Jan 01 00:00:00 2001 PST, t@Mon Jan 01 16:58:14.025894 2001 PST], (f@Mon Jan 01 16:58:14.025894 2001 PST, f@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(tIntersects(tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(3 3), 0.1))@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))')) =
+  asText(tIntersects(tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(3 3), 0.1))@2001-01-03]'::tpose::tgeompoint, geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))')) AS ti_agrees;
+ ti_agrees 
+-----------
+ t
+(1 row)
+
+SELECT to_regprocedure('tContains(tposechain, geometry)') IS NULL AS tcontains_absent,
+       to_regprocedure('tCovers(tposechain, geometry)') IS NULL AS tcovers_absent,
+       to_regprocedure('tTouches(tposechain, tposechain)') IS NULL AS ttouches_absent,
+       to_regprocedure('tContains(geometry, tposechain)') IS NOT NULL AS tcontains_present;
+ tcontains_absent | tcovers_absent | ttouches_absent | tcontains_present 
+------------------+----------------+-----------------+-------------------
+ t                | t              | t               | t
+(1 row)
+

--- a/mobilitydb/test/posechain/queries/564_tposechain_tempspatialrels.test.sql
+++ b/mobilitydb/test/posechain/queries/564_tposechain_tempspatialrels.test.sql
@@ -16,8 +16,12 @@
 -------------------------------------------------------------------------------
 
 -- Temporal spatial relationships for temporal pose chains. Every one of them
--- converts its operands to a temporal geometry and re-delegates, so a chain
--- answers exactly as the pose it composes to does.
+-- converts its operands to the temporal geometry point the chain composes to
+-- and re-delegates, so a chain answers exactly as that pose does. The family
+-- declares the matrix its target declares: tContains and tCovers take the
+-- geometry first only, and tTouches has no direction between two chains,
+-- because a moving point neither contains nor covers a geometry and two
+-- moving points do not touch.
 
 \set square 'geometry ''Polygon((0 0,0 2,2 2,2 0,0 0))'''
 \set inside 'tposechain ''PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'''
@@ -49,6 +53,7 @@ SELECT asText(tCovers(:square, :corner));
 SELECT asText(tTouches(:corner, :square));
 SELECT asText(tTouches(:square, :corner));
 SELECT asText(tTouches(:inside, :square));
+-- two chains do not touch, so the direction between them is not declared
 
 -------------------------------------------------------------------------------
 -- tDwithin, including the two-chain direction
@@ -58,5 +63,27 @@ SELECT asText(tDwithin(:inside, :square, 0.0));
 SELECT asText(tDwithin(:inside, geometry 'Point(1 5)', 2.0));
 SELECT asText(tDwithin(:inside, tposechain 'PoseChain(Pose(Point(1 2), 0.1))@2001-01-01', 2.0));
 SELECT asText(tDwithin(:inside, tposechain 'PoseChain(Pose(Point(1 9), 0.1))@2001-01-01', 2.0));
+
+-------------------------------------------------------------------------------
+-- Linear interpolation, which the tgeompoint target carries
+-------------------------------------------------------------------------------
+
+\set lin 'tposechain ''[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01, PoseChain(Pose(Point(3 3), 0.1))@2001-01-03]'''
+
+SELECT asText(tIntersects(:lin, :square));
+SELECT asText(tIntersects(:square, :lin));
+SELECT asText(tDisjoint(:lin, :square));
+SELECT asText(tDwithin(:lin, geometry 'Point(1 1)', 1.0));
+
+-- The answer is the one the chain's own pose gives, turning points and all
+SELECT asText(tIntersects(:lin, :square)) =
+  asText(tIntersects(:lin::tpose::tgeompoint, :square)) AS ti_agrees;
+
+-- A moving point neither contains nor covers a geometry, so the direction
+-- taking the chain first is not declared
+SELECT to_regprocedure('tContains(tposechain, geometry)') IS NULL AS tcontains_absent,
+       to_regprocedure('tCovers(tposechain, geometry)') IS NULL AS tcovers_absent,
+       to_regprocedure('tTouches(tposechain, tposechain)') IS NULL AS ttouches_absent,
+       to_regprocedure('tContains(geometry, tposechain)') IS NOT NULL AS tcontains_present;
 
 -------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -551,8 +551,20 @@ Reading the table:
   (`--gaps`: `aggregate_families` 19/19, full coverage).
 - **`tempsp.rels` is generated for cbuffer, npoint, pose, posechain, pointcloud
   (both types), rgeo, h3, quadbin** via `tempspatialrel_families` (§3/§5) — native
-  for cbuffer, cast-delegated for the other eight, every one of them converting to
-  `tgeometry` (`--gaps`: `tempspatialrel_families` 13/13, full coverage).
+  for cbuffer, cast-delegated for the other eight (`--gaps`:
+  `tempspatialrel_families` 13/13, full coverage).
+  ⭐ The cast target follows the value's geometry: an AREA-valued family reaches
+  `tgeometry`, a POINT-valued one reaches `tgeompoint`. It is load-bearing rather
+  than cosmetic — a `tgeompoint` carries linear interpolation and a `tgeometry`
+  cannot, two consecutive geometries sharing neither type nor vertex
+  correspondence — so reaching past a point's own target would refuse every linear
+  value of the family.
+  ⭐ A family declares the matrix of ITS target rather than a fixed six by three:
+  `tpose`, `tposechain` and `tnpoint` declare the 13 cells the `tpoint` entry
+  declares, since a moving point neither contains nor covers a geometry and two
+  moving points do not touch. `tpcpoint` and `tpcpatch` narrow further to
+  `tDisjoint`, `tIntersects` and `tDwithin`, the three a Z-carrying value can
+  answer.
   ⛔ A delegating family declares the predicates its VALUES can answer, not a fixed
   six: `tpcpoint` and `tpcpatch` carry the Z their schema declares and `tContains`,
   `tCovers` and `tTouches` are planar DE-9IM relationships that refuse a Z

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -573,9 +573,17 @@ def _tsr_cast_operand(t: str, pos: int, convert: str) -> str:
     return convert.replace("@N@", f"${pos}")
 
 
+# A cast family whose values are POINTS reaches the geometry engine as a
+# `tgeompoint`, which is the cast target the value's geometry names: a
+# `tgeompoint` carries linear interpolation, a `tgeometry` cannot (two
+# consecutive geometries need not even share a type, so there is nothing to
+# interpolate along). Such a family also declares the matrix ITS target
+# declares — a moving point neither contains nor covers a geometry, and two
+# moving points do not touch — so its `predicates` list the same cells the
+# `tpoint` entry lists.
 def _tsr_cast_body(pred: str, d: dict, fam: dict) -> str:
     """One cast-family CREATE FUNCTION: both operands converted (or passed
-    through raw) and re-delegated to tgeometry's same-named predicate. When
+    through raw) and re-delegated to the target's same-named predicate. When
     BOTH operands need conversion (the own-type x own-type direction), the
     call wraps onto a second line indented to the column of the CREATE
     FUNCTION signature's argument list, matching the historical hand-tuned

--- a/tools/codegen/inherited/manifest.d/tempspatialrel_families.yaml
+++ b/tools/codegen/inherited/manifest.d/tempspatialrel_families.yaml
@@ -13,10 +13,20 @@
 #    kernel of its own; per the cast-only spatial-uniformization rule (geo is
 #    the one place the relationship logic lives — memory
 #    north-star-spatial-cast-only-no-duplication), it converts each of its own
-#    operands to tgeometry via `convert` and re-delegates to tgeometry's
-#    tContains..tDwithin. See generate.py's render_tempspatialrels for the
-#    full mechanism (both impls share the predicate/direction matrix; only the
-#    per-cell CREATE FUNCTION body differs).
+#    operands via `convert` and re-delegates to the target's tContains..tDwithin.
+#    See generate.py's render_tempspatialrels for the full mechanism (both impls
+#    share the predicate/direction matrix; only the per-cell CREATE FUNCTION
+#    body differs).
+#    ⭐ The cast target follows the value's geometry: a family whose values are
+#    AREAS reaches tgeometry, a family whose values are POINTS reaches
+#    tgeompoint. The distinction is load-bearing rather than cosmetic — a
+#    tgeompoint carries linear interpolation and a tgeometry cannot, since two
+#    consecutive geometries need not even share a type, so reaching past a
+#    point's own target would refuse every linear value of the family.
+#    ⭐ A family also declares the matrix of ITS target, not a fixed six by
+#    three: a moving point neither contains nor covers a geometry, and two
+#    moving points do not touch, so the point-like families below declare the
+#    same cells the tpoint entry declares.
 tempspatialrel_families:
   - family:  cbuffer
     impl:    native
@@ -145,12 +155,33 @@ tempspatialrel_families:
   - family:  tpose
     impl:    cast
     file:    mobilitydb/sql/pose/114_tpose_tempspatialrels.in.sql
-    predicates: [tContains, tCovers, tDisjoint, tIntersects, tTouches, tDwithin]
-    directions:
-      - {l: geometry, r: tpose}
-      - {l: tpose,    r: geometry}
-      - {l: tpose,    r: tpose}
-    convert: "@N@::@extschema@.tgeompoint::@extschema@.tgeometry"
+    predicates:
+      - name: tContains
+        directions:
+          - {l: geometry, r: tpose}
+      - name: tCovers
+        directions:
+          - {l: geometry, r: tpose}
+      - name: tDisjoint
+        directions:
+          - {l: geometry, r: tpose}
+          - {l: tpose, r: geometry}
+          - {l: tpose, r: tpose}
+      - name: tIntersects
+        directions:
+          - {l: geometry, r: tpose}
+          - {l: tpose, r: geometry}
+          - {l: tpose, r: tpose}
+      - name: tTouches
+        directions:
+          - {l: geometry, r: tpose}
+          - {l: tpose, r: geometry}
+      - name: tDwithin
+        directions:
+          - {l: geometry, r: tpose}
+          - {l: tpose, r: geometry}
+          - {l: tpose, r: tpose}
+    convert: "@N@::@extschema@.tgeompoint"
     doc: |-
       /**
        * @file
@@ -169,7 +200,7 @@ tempspatialrel_families:
       - {l: geometry, r: tpcpoint}
       - {l: tpcpoint, r: geometry}
       - {l: tpcpoint, r: tpcpoint}
-    convert: "@N@::@extschema@.tgeompoint::@extschema@.tgeometry"
+    convert: "@N@::@extschema@.tgeompoint"
     doc: |-
       /**
        * @file
@@ -197,12 +228,33 @@ tempspatialrel_families:
   - family:  tposechain
     impl:    cast
     file:    mobilitydb/sql/posechain/564_tposechain_tempspatialrels.in.sql
-    predicates: [tContains, tCovers, tDisjoint, tIntersects, tTouches, tDwithin]
-    directions:
-      - {l: geometry,   r: tposechain}
-      - {l: tposechain, r: geometry}
-      - {l: tposechain, r: tposechain}
-    convert: "@N@::@extschema@.tpose::@extschema@.tgeompoint::@extschema@.tgeometry"
+    predicates:
+      - name: tContains
+        directions:
+          - {l: geometry, r: tposechain}
+      - name: tCovers
+        directions:
+          - {l: geometry, r: tposechain}
+      - name: tDisjoint
+        directions:
+          - {l: geometry, r: tposechain}
+          - {l: tposechain, r: geometry}
+          - {l: tposechain, r: tposechain}
+      - name: tIntersects
+        directions:
+          - {l: geometry, r: tposechain}
+          - {l: tposechain, r: geometry}
+          - {l: tposechain, r: tposechain}
+      - name: tTouches
+        directions:
+          - {l: geometry, r: tposechain}
+          - {l: tposechain, r: geometry}
+      - name: tDwithin
+        directions:
+          - {l: geometry, r: tposechain}
+          - {l: tposechain, r: geometry}
+          - {l: tposechain, r: tposechain}
+    convert: "@N@::@extschema@.tpose::@extschema@.tgeompoint"
     doc: |-
       /**
        * @file
@@ -230,12 +282,33 @@ tempspatialrel_families:
   - family:  tnpoint
     impl:    cast
     file:    mobilitydb/sql/npoint/322_tnpoint_tempspatialrels.in.sql
-    predicates: [tContains, tCovers, tDisjoint, tIntersects, tTouches, tDwithin]
-    directions:
-      - {l: geometry, r: tnpoint}
-      - {l: tnpoint,  r: geometry}
-      - {l: tnpoint,  r: tnpoint}
-    convert: "@N@::@extschema@.tgeompoint::@extschema@.tgeometry"
+    predicates:
+      - name: tContains
+        directions:
+          - {l: geometry, r: tnpoint}
+      - name: tCovers
+        directions:
+          - {l: geometry, r: tnpoint}
+      - name: tDisjoint
+        directions:
+          - {l: geometry, r: tnpoint}
+          - {l: tnpoint, r: geometry}
+          - {l: tnpoint, r: tnpoint}
+      - name: tIntersects
+        directions:
+          - {l: geometry, r: tnpoint}
+          - {l: tnpoint, r: geometry}
+          - {l: tnpoint, r: tnpoint}
+      - name: tTouches
+        directions:
+          - {l: geometry, r: tnpoint}
+          - {l: tnpoint, r: geometry}
+      - name: tDwithin
+        directions:
+          - {l: geometry, r: tnpoint}
+          - {l: tnpoint, r: geometry}
+          - {l: tnpoint, r: tnpoint}
+    convert: "@N@::@extschema@.tgeompoint"
     doc: |-
       /**
        * @file


### PR DESCRIPTION
A temporal pose, pose chain, network point and pgpointcloud point all hold a position, so the temporal geometry point is the cast target their geometry names and the one their temporal spatial relationships convert to. Reaching past it to a temporal geometry refuses every value the family carries with linear interpolation, since a temporal geometry carries step interpolation only: two consecutive geometries share neither a type nor a vertex correspondence, so there is nothing to interpolate along. The temporal geometry point carries it, and answers from the same kernel, so a linear value is answered along its trajectory and a step value answers exactly as before. Each family also declares the matrix of its target rather than a fixed six predicates by three directions: a moving point neither contains nor covers a geometry, and two moving points do not touch, so tContains and tCovers take the geometry first only and tTouches has no direction between two values of the family. The pose chain chapter records the two directions tTouches carries in both languages.