### PR TITLE
Lint the vendored geometry library where its bodies are not stubs

### DIFF
--- a/postgis/liblwgeom/CMakeLists.txt
+++ b/postgis/liblwgeom/CMakeLists.txt
@@ -100,3 +100,15 @@ set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)
 # standard flags. /* MEOS */
 set_source_files_properties(lwin_wkt_parse.c lwin_wkt_lex.c
   PROPERTIES COMPILE_OPTIONS "-w")
+
+# A build carrying no GEOS reports the version of the library it does not have
+# as 0, which is below every version a guard in these files tests for, so the
+# bodies those guards choose are the ones that return at once and the arguments
+# they were given go unread. The files are vendored, so the parameters are not
+# ours to mark, and the suppression is confined to the build that turns the
+# bodies into stubs: with GEOS present the files are linted as the rest of
+# liblwgeom is. /* MEOS */
+if(NOT GEOS)
+  set_source_files_properties(lwgeom_geos.c lwgeom_geos_clean.c
+    PROPERTIES COMPILE_OPTIONS "-w")
+endif()


### PR DESCRIPTION
A build configured without GEOS reports the version of the library it does not carry as zero, and zero is below every version the guards in `lwgeom_geos.c` and `lwgeom_geos_clean.c` test for. The bodies those guards select return at once, so the arguments the functions receive go unread and the compiler reports three unused parameters.

The two files are vendored from PostGIS, so the parameters are not ours to mark, and the flag that silences them is confined to the configuration whose bodies are stubs. A build carrying GEOS compiles both files under the standard flags, as the rest of liblwgeom does, which the generated flags show: it carries only the two entries belonging to the generated parser and lexer, while the build without GEOS carries those two and these.

Both configurations build with no warning at all.
