### PR TITLE
Document the temporal spatial relationships of a pose and a network point

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1540,7 +1540,7 @@
 					<para><link linkend="tpose_espatialrels"><varname>eContains</varname>, <varname>eDisjoint</varname>, <varname>eIntersects</varname></link>: Relaciones alguna vez y siempre</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tpose_tspatialrels"><varname>tContains</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname></link>: Relaciones espaciotemporales</para>
+					<para><link linkend="tpose_tspatialrels"><varname>tContains</varname>, <varname>tCovers</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname>, <varname>tIntersects</varname>, <varname>tTouches</varname></link>: Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Una pose temporal las responde en la posición que ocupa, de modo que un valor con interpolación lineal se responde a lo largo de su trayectoria y no solo en sus instantes. La pose temporal declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos poses temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2087,7 +2087,7 @@
 					<para><link linkend="tnpoint_espatialrels"><varname>eContains</varname>, <varname>eDisjoint</varname>, <varname>eIntersects</varname></link>: Relaciones alguna vez y siempre</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tnpoint_tspatialrels"><varname>tContains</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname></link>: Relaciones espaciotemporales</para>
+					<para><link linkend="tnpoint_tspatialrels"><varname>tContains</varname>, <varname>tCovers</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname>, <varname>tIntersects</varname>, <varname>tTouches</varname></link>: Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Un punto de red temporal las responde en la posición a la que se resuelven su ruta y su fracción. El punto de red temporal declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos puntos de red temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -886,10 +886,7 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-03, NPoint(1, 0.3)@2001-01-05]' #&gt;&gt
 	<sect1 xml:id="tnpoint_spatial_rels">
 		<title>Relaciones espaciales</title>
 		<para>
-			Las relaciones topológicas y de distancia descritas en <xref linkend="tgeo_spatial_rel"/>, como <varname>eIntersects</varname>, <varname>aDwithin</varname> o <varname>tContains</varname>, se definen en el espacio geográfico, mientras que los puntos de la red temporal se definen en el espacio de la red. Cada una de estas relaciones también acepta directamente un argumento <varname>tnpoint</varname>: internamente, cada operando de punto de red se convierte en un punto geométrico temporal mediante la conversión estándar <varname>tnpoint::tgeompoint</varname> (el punto resuelto a lo largo de su ruta) y luego en <varname>tgeometry</varname>, y la relación <varname>tgeometry</varname> correspondiente calcula el resultado, exactamente como si la conversión se hubiera escrito manualmente.
-		</para>
-		<para>
-			Dado que el objetivo de la delegación, <varname>tgeometry</varname>, solo admite interpolación escalonada, un argumento <varname>tnpoint</varname> de secuencia con varios instantes debe usar interpolación escalonada (<varname>Interp=Step;...</varname>); una secuencia con la interpolación lineal predeterminada produce un error en la conversión implícita, la misma restricción ya vigente al convertir un <varname>tgeompoint</varname>/<varname>tgeogpoint</varname> lineal en <varname>tgeometry</varname>/<varname>tgeography</varname>. Un único instante no tiene interpolación y no se ve afectado.
+			Las relaciones topológicas y de distancia descritas en <xref linkend="tgeo_spatial_rel"/>, como <varname>eIntersects</varname>, <varname>aDwithin</varname> o <varname>tContains</varname>, se definen en el espacio geográfico, mientras que los puntos de la red temporal se definen en el espacio de la red. Cada una de estas relaciones también acepta directamente un argumento <varname>tnpoint</varname>: cada operando de punto de red se convierte en un punto geométrico temporal mediante la conversión estándar <varname>tnpoint::tgeompoint</varname> (el punto resuelto a lo largo de su ruta) y la relación correspondiente del punto geométrico temporal calcula el resultado, exactamente como si la conversión se hubiera escrito manualmente. Una secuencia conserva la interpolación que lleva, de modo que una con la interpolación lineal predeterminada se responde a lo largo de su ruta y no solo en sus instantes.
 		</para>
 
 		<itemizedlist>
@@ -914,20 +911,40 @@ SELECT eIntersects(
 
 			<listitem xml:id="tnpoint_tspatialrels">
 				<indexterm significance="normal"><primary><varname>tContains</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tCovers</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
-				<para>Relaciones espaciotemporales</para>
+				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
+				<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Un punto de red temporal las responde en la posición a la que se resuelven su ruta y su fracción. El punto de red temporal declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos puntos de red temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
+				<para><varname>tContains(geometry,tnpoint) → tbool</varname></para>
+				<para><varname>tCovers(geometry,tnpoint) → tbool</varname></para>
+				<para><varname>tDisjoint({geometry,tnpoint},{geometry,tnpoint}) → tbool</varname></para>
+				<para><varname>tDwithin({geometry,tnpoint},{geometry,tnpoint},float) → tbool</varname></para>
+				<para><varname>tIntersects({geometry,tnpoint},{geometry,tnpoint}) → tbool</varname></para>
+				<para><varname>tTouches(geometry,tnpoint) → tbool</varname></para>
+				<para><varname>tTouches(tnpoint,geometry) → tbool</varname></para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
-  tnpoint 'Interp=Step;[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
--- [f@2001-01-01, f@2001-01-03]
+  tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
+-- {[f@2001-01-01, f@2001-01-03]}
+SELECT tCovers(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
+  tnpoint 'Npoint(1, 0.1)@2001-01-01');
+-- f@2001-01-01
 SELECT tDisjoint(geometry(npoint 'NPoint(2, 0.0)'),
-  tnpoint 'Interp=Step;[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
--- [t@2001-01-01, t@2001-01-03]
-SELECT tDwithin(
-  tnpoint 'Interp=Step;[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]',
-  tnpoint 'Interp=Step;[Npoint(1, 0.5)@2001-01-01, Npoint(1, 0.3)@2001-01-03]', 1);
--- [f@2001-01-01, f@2001-01-03]
+  tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
+-- {[t@2001-01-01, t@2001-01-03]}
+SELECT tTouches(tnpoint 'Npoint(1, 0.1)@2001-01-01',
+  geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))');
+-- f@2001-01-01
+SELECT tIntersects(tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]',
+  tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.1)@2001-01-03]');
+-- {[f@2001-01-01, t@2001-01-02], (f@2001-01-02, f@2001-01-03]}
+SELECT tDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]',
+  tnpoint '[Npoint(1, 0.5)@2001-01-01, Npoint(1, 0.3)@2001-01-03]', 1);
+/* {[f@2001-01-01, t@2001-01-01 22:19:04.400634+00,
+  t@2001-01-02 01:40:55.599365+00], (f@2001-01-02 01:40:55.599365+00,
+  f@2001-01-03]} */
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -1118,7 +1118,7 @@ SELECT round(tpose '[Pose(Point(1 1), 0.3)@2001-01-01,
 	<sect1 xml:id="tpose_spatial_rels">
 		<title>Relaciones espaciales</title>
 		<para>
-			Las relaciones topológicas y de distancia descritas en la <xref linkend="tgeo_spatial_rel"/> tales como <varname>eIntersects</varname>, <varname>aDwithin</varname> o <varname>tContains</varname> solo consideran la ubicación de las geometrías, no su orientación. Para poder aplicar estas relaciones espaciales a las poses temporales, se deben transformar a puntos geométricos temporales. Esto se puede realizar fácilmente utilizando las funciones <varname>geometry</varname> y <varname>tgeompoint</varname> o utilizando un casting explícito <varname>::</varname> como se muestra en los ejemplos a continuación.
+			Las relaciones topológicas y de distancia descritas en la <xref linkend="tgeo_spatial_rel"/> tales como <varname>eIntersects</varname>, <varname>aDwithin</varname> o <varname>tContains</varname> solo consideran la ubicación de un valor, no su orientación. Una pose temporal las acepta directamente y las responde en la posición que ocupa su pose, que es el punto que nombra el destino de conversión <varname>tgeompoint</varname>. Las funciones <varname>geometry</varname> y <varname>tgeompoint</varname> y los castings explícitos <varname>::</varname> correspondientes siguen disponibles cuando lo que se quiere es la geometría misma.
 		</para>
 
 		<itemizedlist>
@@ -1143,21 +1143,40 @@ SELECT eIntersects(
 
 			<listitem xml:id="tpose_tspatialrels">
 				<indexterm significance="normal"><primary><varname>tContains</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tCovers</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
-				<para>Relaciones espaciotemporales</para>
+				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
+				<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Una pose temporal las responde en la posición que ocupa, de modo que un valor con interpolación lineal se responde a lo largo de su trayectoria y no solo en sus instantes. La pose temporal declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos poses temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
+				<para><varname>tContains(geometry,tpose) → tbool</varname></para>
+				<para><varname>tCovers(geometry,tpose) → tbool</varname></para>
+				<para><varname>tDisjoint({geometry,tpose},{geometry,tpose}) → tbool</varname></para>
+				<para><varname>tDwithin({geometry,tpose},{geometry,tpose},float) → tbool</varname></para>
+				<para><varname>tIntersects({geometry,tpose},{geometry,tpose}) → tbool</varname></para>
+				<para><varname>tTouches(geometry,tpose) → tbool</varname></para>
+				<para><varname>tTouches(tpose,geometry) → tbool</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tContains(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
-  tgeompoint(tpose '[Pose(Point(1 1),0.1)@2001-01-01, Pose(Point(1 1),0.3)@2001-01-03)'));
--- {[t@2001-01-01, t@2001-01-03)}
-SELECT tDisjoint(geometry(pose 'Pose(Point(2 2), 0.0)'),
-  tgeompoint(tpose '[Pose(Point(1 1),0.1)@2001-01-01, Pose(Point(1 1),0.3)@2001-01-03)'));
--- [t@2001-01-01, t@2001-01-03)
-SELECT tDwithin(
- tpose '[Pose(Point(1 1),0.3)@2001-01-01,Pose(Point(1 1),0.5)@2001-01-03)'::tgeompoint, 
- tpose '[Pose(Point(1 1),0.5)@2001-01-01,Pose(Point(3 3),0.3)@2001-01-03)'::tgeompoint,1);
-/* {[t@2001-01-01 00:00:00+01, t@2001-01-01 16:58:14.025894+01],
-  (f@2001-01-01 16:58:14.025894+01, f@2001-01-03 00:00:00+01)} */
+SELECT tIntersects(tpose '[Pose(Point(1 1), 0.1)@2001-01-01,
+  Pose(Point(3 3), 0.1)@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+-- {[t@2001-01-01, t@2001-01-02], (f@2001-01-02, f@2001-01-03]}
+SELECT tDisjoint(tpose '[Pose(Point(1 1), 0.1)@2001-01-01,
+  Pose(Point(3 3), 0.1)@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+-- {[f@2001-01-01, f@2001-01-02], (t@2001-01-02, t@2001-01-03]}
+SELECT tContains(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))',
+  tpose 'Pose(Point(0 0), 0.1)@2001-01-01');
+-- f@2001-01-01
+SELECT tCovers(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))',
+  tpose 'Pose(Point(0 0), 0.1)@2001-01-01');
+-- t@2001-01-01
+SELECT tTouches(tpose 'Pose(Point(0 0), 0.1)@2001-01-01',
+  geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+-- t@2001-01-01
+SELECT tDwithin(tpose '[Pose(Point(1 1),0.3)@2001-01-01,
+  Pose(Point(1 1),0.5)@2001-01-03)', tpose '[Pose(Point(1 1),0.5)@2001-01-01,
+  Pose(Point(3 3),0.3)@2001-01-03)', 1);
+/* {[t@2001-01-01, t@2001-01-01 16:58:14.025894+00],
+  (f@2001-01-01 16:58:14.025894+00, f@2001-01-03)} */
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1542,7 +1542,7 @@
 						<para><link linkend="tpose_espatialrels"><varname>eContains</varname>, <varname>eDisjoint</varname>, <varname>eIntersects</varname></link>: Ever and always relationships</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpose_tspatialrels"><varname>tContains</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname></link>: Spatiotemporal relationships</para>
+						<para><link linkend="tpose_tspatialrels"><varname>tContains</varname>, <varname>tCovers</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname>, <varname>tIntersects</varname>, <varname>tTouches</varname></link>: The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal pose answers them at the position it occupies, so a value with linear interpolation is answered along its trajectory rather than at its instants alone. The temporal pose declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two temporal poses, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2092,7 +2092,7 @@
 						<para><link linkend="tnpoint_espatialrels"><varname>eContains</varname>, <varname>eDisjoint</varname>, <varname>eIntersects</varname></link>: Ever and always spatial relationships</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tnpoint_tspatialrels"><varname>tContains</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname></link>: Spatiotemporal relationships</para>
+						<para><link linkend="tnpoint_tspatialrels"><varname>tContains</varname>, <varname>tCovers</varname>, <varname>tDisjoint</varname>, <varname>tDwithin</varname>, <varname>tIntersects</varname>, <varname>tTouches</varname></link>: The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal network point answers them at the position its route and fraction resolve to. The temporal network point declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two temporal network points, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -887,10 +887,7 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-03, NPoint(1, 0.3)@2001-01-05]' #&gt;&gt
 	<sect1 xml:id="tnpoint_spatial_rels">
 		<title>Spatial Relationships</title>
 		<para>
-			The topological and distance relationships described in <xref linkend="tgeo_spatial_rel"/> such as <varname>eIntersects</varname>, <varname>aDwithin</varname>, or <varname>tContains</varname> are defined over the geographical space while the temporal network points are defined over the network space. Every one of these relationships also accepts a <varname>tnpoint</varname> argument directly: internally, each network-point operand is converted to a temporal geometry point through the standard <varname>tnpoint::tgeompoint</varname> cast (the point resolved along its route) and then to <varname>tgeometry</varname>, and the corresponding <varname>tgeometry</varname> relationship computes the result, exactly as if the cast had been written out by hand.
-		</para>
-		<para>
-			Because the delegate target <varname>tgeometry</varname> only supports step interpolation, a multi-instant <varname>tnpoint</varname> sequence argument must use step interpolation (<varname>Interp=Step;...</varname>); a sequence with the default linear interpolation raises an error on the implicit conversion, the same restriction already in force when casting a linear <varname>tgeompoint</varname>/<varname>tgeogpoint</varname> to <varname>tgeometry</varname>/<varname>tgeography</varname>. A single instant has no interpolation and is unaffected.
+			The topological and distance relationships described in <xref linkend="tgeo_spatial_rel"/> such as <varname>eIntersects</varname>, <varname>aDwithin</varname>, or <varname>tContains</varname> are defined over the geographical space while the temporal network points are defined over the network space. Every one of these relationships also accepts a <varname>tnpoint</varname> argument directly: each network-point operand is converted to a temporal geometry point through the standard <varname>tnpoint::tgeompoint</varname> cast (the point resolved along its route) and the corresponding temporal geometry point relationship computes the result, exactly as if the cast had been written out by hand. A sequence keeps the interpolation it carries, so one with the default linear interpolation is answered along its route rather than at its instants alone.
 		</para>
 
 		<itemizedlist>
@@ -915,20 +912,40 @@ SELECT eIntersects(
 
 			<listitem xml:id="tnpoint_tspatialrels">
 				<indexterm significance="normal"><primary><varname>tContains</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tCovers</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
-				<para>Spatiotemporal relationships</para>
+				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
+				<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal network point answers them at the position its route and fraction resolve to. The temporal network point declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two temporal network points, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
+				<para><varname>tContains(geometry,tnpoint) &#8594; tbool</varname></para>
+				<para><varname>tCovers(geometry,tnpoint) &#8594; tbool</varname></para>
+				<para><varname>tDisjoint({geometry,tnpoint},{geometry,tnpoint}) &#8594; tbool</varname></para>
+				<para><varname>tDwithin({geometry,tnpoint},{geometry,tnpoint},float) &#8594; tbool</varname></para>
+				<para><varname>tIntersects({geometry,tnpoint},{geometry,tnpoint}) &#8594; tbool</varname></para>
+				<para><varname>tTouches(geometry,tnpoint) &#8594; tbool</varname></para>
+				<para><varname>tTouches(tnpoint,geometry) &#8594; tbool</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
-  tnpoint 'Interp=Step;[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
--- [f@2001-01-01, f@2001-01-03]
+  tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
+-- {[f@2001-01-01, f@2001-01-03]}
+SELECT tCovers(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
+  tnpoint 'Npoint(1, 0.1)@2001-01-01');
+-- f@2001-01-01
 SELECT tDisjoint(geometry(npoint 'NPoint(2, 0.0)'),
-  tnpoint 'Interp=Step;[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
--- [t@2001-01-01, t@2001-01-03]
-SELECT tDwithin(
-  tnpoint 'Interp=Step;[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]',
-  tnpoint 'Interp=Step;[Npoint(1, 0.5)@2001-01-01, Npoint(1, 0.3)@2001-01-03]', 1);
--- [f@2001-01-01, f@2001-01-03]
+  tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
+-- {[t@2001-01-01, t@2001-01-03]}
+SELECT tTouches(tnpoint 'Npoint(1, 0.1)@2001-01-01',
+  geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))');
+-- f@2001-01-01
+SELECT tIntersects(tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]',
+  tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.1)@2001-01-03]');
+-- {[f@2001-01-01, t@2001-01-02], (f@2001-01-02, f@2001-01-03]}
+SELECT tDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]',
+  tnpoint '[Npoint(1, 0.5)@2001-01-01, Npoint(1, 0.3)@2001-01-03]', 1);
+/* {[f@2001-01-01, t@2001-01-01 22:19:04.400634+00,
+  t@2001-01-02 01:40:55.599365+00], (f@2001-01-02 01:40:55.599365+00,
+  f@2001-01-03]} */
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1127,7 +1127,7 @@ SELECT round(tpose '[Pose(Point(1 1), 0.3)@2001-01-01,
 	<sect1 xml:id="tpose_spatial_rels">
 		<title>Spatial Relationships</title>
 		<para>
-			The topological and distance relationships described in <xref linkend="tgeo_spatial_rel"/> such as <varname>eIntersects</varname>, <varname>aDwithin</varname>, or <varname>tContains</varname> only consider the location of the geometries, not their orientation. To be able to apply these spatial relationships to the temporal poses, they must be transformed to temporal geometry points. This can be easily performed using the functions <varname>geometry</varname> and <varname>tgeompoint</varname> or using an explicit casting <varname>::</varname> as shown in the examples below.
+			The topological and distance relationships described in <xref linkend="tgeo_spatial_rel"/> such as <varname>eIntersects</varname>, <varname>aDwithin</varname>, or <varname>tContains</varname> only consider the location of a value, not its orientation. A temporal pose accepts them directly and answers them at the position its pose occupies, which is the point the <varname>tgeompoint</varname> cast target names. The functions <varname>geometry</varname> and <varname>tgeompoint</varname> and the corresponding explicit casts <varname>::</varname> remain available wherever the geometry itself is wanted.
 		</para>
 
 		<itemizedlist>
@@ -1152,21 +1152,40 @@ SELECT eIntersects(
 
 			<listitem xml:id="tpose_tspatialrels">
 				<indexterm significance="normal"><primary><varname>tContains</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tCovers</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
-				<para>Spatiotemporal relationships</para>
+				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
+				<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal pose answers them at the position it occupies, so a value with linear interpolation is answered along its trajectory rather than at its instants alone. The temporal pose declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two temporal poses, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
+				<para><varname>tContains(geometry,tpose) &#8594; tbool</varname></para>
+				<para><varname>tCovers(geometry,tpose) &#8594; tbool</varname></para>
+				<para><varname>tDisjoint({geometry,tpose},{geometry,tpose}) &#8594; tbool</varname></para>
+				<para><varname>tDwithin({geometry,tpose},{geometry,tpose},float) &#8594; tbool</varname></para>
+				<para><varname>tIntersects({geometry,tpose},{geometry,tpose}) &#8594; tbool</varname></para>
+				<para><varname>tTouches(geometry,tpose) &#8594; tbool</varname></para>
+				<para><varname>tTouches(tpose,geometry) &#8594; tbool</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tContains(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
-  tgeompoint(tpose '[Pose(Point(1 1),0.1)@2001-01-01, Pose(Point(1 1),0.3)@2001-01-03)'));
--- {[t@2001-01-01, t@2001-01-03)}
-SELECT tDisjoint(geometry(pose 'Pose(Point(2 2), 0.0)'),
-  tgeompoint(tpose '[Pose(Point(1 1),0.1)@2001-01-01, Pose(Point(1 1),0.3)@2001-01-03)'));
--- [t@2001-01-01, t@2001-01-03)
-SELECT tDwithin(
- tpose '[Pose(Point(1 1),0.3)@2001-01-01,Pose(Point(1 1),0.5)@2001-01-03)'::tgeompoint, 
- tpose '[Pose(Point(1 1),0.5)@2001-01-01,Pose(Point(3 3),0.3)@2001-01-03)'::tgeompoint,1);
-/* {[t@2001-01-01 00:00:00+01, t@2001-01-01 16:58:14.025894+01],
-  (f@2001-01-01 16:58:14.025894+01, f@2001-01-03 00:00:00+01)} */
+SELECT tIntersects(tpose '[Pose(Point(1 1), 0.1)@2001-01-01,
+  Pose(Point(3 3), 0.1)@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+-- {[t@2001-01-01, t@2001-01-02], (f@2001-01-02, f@2001-01-03]}
+SELECT tDisjoint(tpose '[Pose(Point(1 1), 0.1)@2001-01-01,
+  Pose(Point(3 3), 0.1)@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+-- {[f@2001-01-01, f@2001-01-02], (t@2001-01-02, t@2001-01-03]}
+SELECT tContains(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))',
+  tpose 'Pose(Point(0 0), 0.1)@2001-01-01');
+-- f@2001-01-01
+SELECT tCovers(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))',
+  tpose 'Pose(Point(0 0), 0.1)@2001-01-01');
+-- t@2001-01-01
+SELECT tTouches(tpose 'Pose(Point(0 0), 0.1)@2001-01-01',
+  geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+-- t@2001-01-01
+SELECT tDwithin(tpose '[Pose(Point(1 1),0.3)@2001-01-01,
+  Pose(Point(1 1),0.5)@2001-01-03)', tpose '[Pose(Point(1 1),0.5)@2001-01-01,
+  Pose(Point(3 3),0.3)@2001-01-03)', 1);
+/* {[t@2001-01-01, t@2001-01-01 16:58:14.025894+00],
+  (f@2001-01-01 16:58:14.025894+00, f@2001-01-03)} */
 </programlisting>
 			</listitem>
 		</itemizedlist>


### PR DESCRIPTION
A temporal pose and a temporal network point answer the six temporal spatial relationships at the position they occupy, and each chapter states that surface in both manuals: the seven signatures the family declares, where tContains and tCovers take the geometry first only and tTouches has no direction between two values of the family, and a harvested example of each relationship. The network point chapter states the conversion those relationships perform, the point resolved along its route as a temporal geometry point, and that a sequence keeps the interpolation it carries, so one with the default linear interpolation is answered along its route rather than at its instants alone. Every listing is run as written and carries what the server printed, and both reference appendixes are regenerated from the chapters.