### PR TITLE
Name the calls that reach GEOS through the vendored sources

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -97,6 +97,14 @@ jobs:
       - name: Check that every error sentinel is the maximum of the return type
         run: python3 tools/scripts/check_error_sentinels.py
 
+  liblwgeom_geos_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check that no new call reaches GEOS through the vendored library
+        run: python3 tools/scripts/check_liblwgeom_geos.py
+
   binding_io_ownership_check:
     runs-on: ubuntu-latest
     steps:

--- a/tools/scripts/check_liblwgeom_geos.py
+++ b/tools/scripts/check_liblwgeom_geos.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: PostgreSQL
+#
+# BINDING-HEADER-PARSE-OK: CI source guard under tools/scripts/, in the
+# shape of check_error_sentinels.py. It reads postgis/liblwgeom/lwgeom_geos*.c
+# for the entry points the vendored library answers with GEOS and meos/src/**.c
+# for the ones MobilityDB calls; it extracts no API surface and generates
+# nothing.
+#
+# Check that MobilityDB reaches GEOS through no entry point of the vendored
+# geometry library beyond the ones already accepted.
+#
+# Why
+# ---
+# A build configured with -DGEOS=OFF compiles the MEOS sources free of GEOS,
+# and what the resulting library still asks of it comes from the vendored
+# PostGIS geometry library, whose GEOS files it compiles whatever the
+# configuration says. Those files answer several dozen entry points and
+# MobilityDB calls a handful of them. Each call is a place a native answer has
+# to reach before a build can leave the library out, so the set shrinks rather
+# than grows.
+#
+# The set is easy to grow without noticing. A function written for one caller
+# reaches for the nearest liblwgeom entry that does the job, and whether that
+# entry answers with GEOS is invisible at the call site: it reads like any
+# other lwgeom_* call. This check names such a call.
+#
+# Usage:
+#   check_liblwgeom_geos.py                list the calls the baseline lacks
+#   check_liblwgeom_geos.py --rebaseline   record the calls as they stand
+#
+# Exit status is non-zero on a call the baseline does not carry (CI guard).
+
+import os
+import re
+import sys
+
+REPO = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+VENDORED_SOURCES = "postgis"
+MEOS_SOURCES = os.path.join("meos", "src")
+BASELINE = os.path.join("tools", "scripts", "liblwgeom_geos_baseline.txt")
+
+# A definition in the vendored sources, written either with the return type on
+# its own line and the name at the start of the next, or with both on one line.
+# The geometry library uses the first and the raster core uses both.
+DEFINITION = re.compile(
+    r"(?m)^(?:[A-Za-z_][\w ]*\**\n|[A-Za-z_][\w ]*[ *])?((?:lw|rt_)[a-z_0-9]+)\s*\(")
+
+
+def geos_entry_points():
+    """The entry points the vendored sources answer with GEOS.
+
+    A vendored file reaching for GEOS is one naming a GEOS entry point, which
+    is what makes every function it defines a place GEOS is reached through.
+    Reading that from the sources rather than from a list of file names covers
+    the geometry library and the raster core alike, and covers a file that
+    arrives with the next refresh of either.
+    """
+    result = set()
+    for root, _, files in os.walk(os.path.join(REPO, VENDORED_SOURCES)):
+        for name in sorted(files):
+            if not name.endswith(".c"):
+                continue
+            text = open(os.path.join(root, name), encoding="utf-8",
+                        errors="replace").read()
+            if not re.search(r"\bGEOS[A-Za-z_0-9]*\s*\(", text):
+                continue
+            for symbol in DEFINITION.findall(text):
+                result.add(symbol)
+    return result
+
+
+def calls(entry_points):
+    """Where the MEOS sources call one of them, as (file, symbol) pairs."""
+    result = set()
+    for root, _, files in os.walk(os.path.join(REPO, MEOS_SOURCES)):
+        for name in sorted(files):
+            if not name.endswith(".c"):
+                continue
+            path = os.path.join(root, name)
+            relative = os.path.relpath(path, REPO)
+            for line in open(path, encoding="utf-8", errors="replace"):
+                # A comment mentioning an entry point is not a call
+                if line.lstrip().startswith(("*", "/*", "//")):
+                    continue
+                for symbol in re.findall(r"\b((?:lw|rt_)[a-z_0-9]+)\s*\(", line):
+                    if symbol in entry_points:
+                        result.add((relative, symbol))
+    return sorted(result)
+
+
+def read_baseline(path):
+    result = set()
+    if os.path.exists(path):
+        for line in open(path, encoding="utf-8"):
+            if line.strip() and not line.startswith("#"):
+                result.add(line.rstrip("\n"))
+    return result
+
+
+def write_baseline(path, findings, count):
+    with open(path, "w", encoding="utf-8") as handle:
+        handle.write(
+            "# Entry points of the vendored PostGIS geometry library that\n"
+            "# answer with GEOS and that MobilityDB calls, as\n"
+            "# tools/scripts/check_liblwgeom_geos.py reads them. The list only\n"
+            "# shrinks: a call to an entry point it does not carry fails the\n"
+            "# check. Regenerate with --rebaseline once a native answer takes\n"
+            f"# a call over. The library answers {count} entry points in all.\n")
+        for relative, symbol in findings:
+            handle.write(f"{relative}\t{symbol}\n")
+
+
+def main():
+    entry_points = geos_entry_points()
+    if not entry_points:
+        print(f"check-liblwgeom-geos: no entry point read from {VENDORED_SOURCES}. "
+              "That is a statement about the parser rather than about the "
+              "sources", file=sys.stderr)
+        return 2
+    findings = calls(entry_points)
+    path = os.path.join(REPO, BASELINE)
+
+    if "--rebaseline" in sys.argv:
+        write_baseline(path, findings, len(entry_points))
+        print(f"check-liblwgeom-geos: baseline written, {len(findings)} call(s) "
+              f"of {len(entry_points)} entry point(s).")
+        return 0
+
+    baseline = read_baseline(path)
+    keys = {f"{relative}\t{symbol}" for relative, symbol in findings}
+    new = sorted(keys - baseline)
+    if new:
+        print(f"{len(new)} call(s) reaching GEOS through the vendored geometry "
+              "library that the baseline does not carry.\n")
+        for line in new:
+            relative, symbol = line.split("\t")
+            print(f"  {relative}: {symbol}")
+        print("\nEach one is a place a native answer has to reach before a "
+              "build without GEOS can leave the library out. Answer it "
+              "natively, or record it with --rebaseline.")
+        return 1
+
+    # A baselined call that no longer occurs is what the campaign is for, so it
+    # is a notice and the shrink happens with the next --rebaseline.
+    stale = sorted(baseline - keys)
+    if stale:
+        print(f"{len(stale)} baselined call(s) no longer occur. "
+              "Run --rebaseline to shrink the baseline:\n")
+        for line in stale:
+            print("  " + line.replace("\t", ": "))
+
+    print(f"check-liblwgeom-geos: clean ({len(baseline)} baselined of "
+          f"{len(entry_points)} entry point(s)).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/scripts/liblwgeom_geos_baseline.txt
+++ b/tools/scripts/liblwgeom_geos_baseline.txt
@@ -1,0 +1,15 @@
+# Entry points of the vendored PostGIS geometry library that
+# answer with GEOS and that MobilityDB calls, as
+# tools/scripts/check_liblwgeom_geos.py reads them. The list only
+# shrinks: a call to an entry point it does not carry fails the
+# check. Regenerate with --rebaseline once a native answer takes
+# a call over. The library answers 125 entry points in all.
+meos/src/geo/postgis_funcs.c	lwgeom_centroid
+meos/src/geo/postgis_funcs.c	lwgeom_difference_prec
+meos/src/geo/postgis_funcs.c	lwgeom_intersection_prec
+meos/src/geo/postgis_funcs.c	lwgeom_is_simple
+meos/src/geo/postgis_funcs.c	lwgeom_unaryunion_prec
+meos/src/raster/raster_rtcore.c	rt_raster_destroy
+meos/src/raster/raster_rtcore.c	rt_raster_get_band
+meos/src/raster/raster_rtcore.c	rt_raster_get_num_bands
+meos/src/temporal/temporal_modif.c	lwgeom_linemerge_directed


### PR DESCRIPTION
A build configured without GEOS compiles the MEOS sources free of it, and what the resulting library still asks of GEOS comes from the vendored PostGIS sources, whose GEOS-reaching files it compiles whatever the configuration says. Those files answer 125 entry points, in the geometry library and in the raster core, and MobilityDB calls nine of them. Each call is a place a native answer has to reach before a build can leave the library out.

The set is easy to grow without noticing, and that is what the check is for. A function written for one caller reaches for the nearest vendored entry that does the job, and whether that entry answers with GEOS is invisible at the call site: it reads like any other `lwgeom_` or `rt_` call. The check reads the entry points out of the vendored sources rather than holding a list of them, so a file arriving with the next refresh of either tree counts from the moment it lands.

A file is one such answer passes through when it names a GEOS entry point, which makes every function it defines such a place: the unit a linker takes is the object file, so calling any function of it brings its GEOS references along. That is why the raster accessors count, and why a build with the raster family and without GEOS reports the raster core's fourteen references undefined.

The baseline carries the nine, in the shape the error sentinel and MEOS-only file checks already use: it only shrinks, and a call it does not carry fails. Its nine are the nine a linker finds, which is what such a build reports as undefined once the MEOS objects are read apart from the vendored ones.
