### PR TITLE
Cluster the geometries that share a point without GEOS

### DIFF
--- a/meos/include/geo/geo_cluster.h
+++ b/meos/include/geo/geo_cluster.h
@@ -47,6 +47,10 @@ extern bool geo_combine_clusters(UNIONFIND *uf, LWGEOM **geoms,
   uint32_t ngeoms, LWGEOM ***clusters, uint32_t *nclusters);
 extern bool geo_cluster_within_distance(LWGEOM **geoms, uint32_t ngeoms,
   double tolerance, LWGEOM ***clusters, uint32_t *nclusters);
+extern bool geo_union_intersecting(LWGEOM **geoms, uint32_t ngeoms,
+  UNIONFIND *uf);
+extern bool geo_cluster_intersecting_geoms(LWGEOM **geoms, uint32_t ngeoms,
+  LWGEOM ***clusters, uint32_t *nclusters);
 
 /*****************************************************************************/
 

--- a/meos/src/geo/geo_cluster.c
+++ b/meos/src/geo/geo_cluster.c
@@ -58,6 +58,7 @@
 /* MEOS */
 #include "meos.h"
 #include "geo/geo_cluster.h"
+#include "geo/geo_funcs.h"
 
 /*****************************************************************************/
 
@@ -215,6 +216,87 @@ cluster_union_core(LWGEOM **geoms, uint32_t ngeoms, UNIONFIND *uf, double eps,
     }
   }
   pfree(neighbors); pfree(is_core);
+  return result;
+}
+
+/*****************************************************************************/
+
+/**
+ * @brief Merge the geometries of an array into clusters of geometries that
+ * share a point with one another
+ * @param[in] geoms Geometries
+ * @param[in] ngeoms Number of geometries
+ * @param[in,out] uf Union-find the clusters are merged into
+ * @return False where a pair falls outside what the native engine covers,
+ * which leaves the caller to answer it another way
+ * @details Two geometries whose bounding boxes stand apart share no point, so
+ * the boxes decide which pairs are worth asking about, exactly as they decide
+ * which pairs are worth measuring for the clusterings by distance. Sharing a
+ * point is symmetric, so each pair is asked about once
+ * @note The clustering of PostGIS function @p ST_ClusterIntersecting, without
+ * GEOS
+ */
+bool
+geo_union_intersecting(LWGEOM **geoms, uint32_t ngeoms, UNIONFIND *uf)
+{
+  assert(geoms); assert(uf);
+  GBOX *boxes = cluster_boxes(geoms, ngeoms);
+  if (! boxes)
+    return false;
+  bool result = true;
+  for (uint32_t p = 0; p < ngeoms && result; p++)
+  {
+    if (lwgeom_is_empty(geoms[p]))
+      continue;
+    for (uint32_t q = p + 1; q < ngeoms; q++)
+    {
+      if (lwgeom_is_empty(geoms[q]))
+        continue;
+      /* Already the same cluster, and sharing a point does not change it */
+      if (UF_find(uf, p) == UF_find(uf, q))
+        continue;
+      if (! cluster_boxes_within(&boxes[p], &boxes[q], 0.0))
+        continue;
+      bool meet;
+      if (! meos_spatialrel(geoms[p], geoms[q], INTERSECTS, &meet))
+      {
+        result = false;
+        break;
+      }
+      if (meet)
+        UF_union(uf, p, q);
+    }
+  }
+  pfree(boxes);
+  return result;
+}
+
+/*****************************************************************************/
+
+/**
+ * @brief Merge the geometries of an array into clusters of geometries that
+ * share a point with one another, and assemble each cluster
+ * @param[in] geoms Geometries
+ * @param[in] ngeoms Number of geometries
+ * @param[out] clusters Clusters
+ * @param[out] nclusters Number of clusters
+ * @return False where a pair falls outside what the native engine covers
+ * @note The clustering of PostGIS function @p ST_ClusterIntersecting, without
+ * GEOS
+ */
+bool
+geo_cluster_intersecting_geoms(LWGEOM **geoms, uint32_t ngeoms,
+  LWGEOM ***clusters, uint32_t *nclusters)
+{
+  assert(geoms); assert(clusters); assert(nclusters);
+  UNIONFIND *uf = UF_create(ngeoms);
+  if (! geo_union_intersecting(geoms, ngeoms, uf))
+  {
+    UF_destroy(uf);
+    return false;
+  }
+  bool result = geo_combine_clusters(uf, geoms, ngeoms, clusters, nclusters);
+  UF_destroy(uf);
   return result;
 }
 

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1646,12 +1646,46 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
   if (! ensure_positive(ngeoms))
     return NULL;
 
-  int is3d = 0;
-  uint32_t nclusters, i, j;
-  int32_t srid = SRID_UNKNOWN;
-  bool gotsrid = false;
+  uint32_t i;
 
   /* TODO short-circuit for one element? */
+
+#if ! GEOS
+  /* The clustering of liblwgeom reaches GEOS for the index narrowing the pairs
+   * whose intersection it asks about, and for the predicate itself. The
+   * bounding boxes answer the narrowing and the native engine answers the
+   * predicate, so a build carrying no GEOS clusters as well as one that does */
+  LWGEOM **lwgeoms = palloc(ngeoms * sizeof(LWGEOM *));
+  for (i = 0; i < ngeoms; i++)
+    lwgeoms[i] = lwgeom_from_gserialized(geoms[i]);
+  LWGEOM **lw_results;
+  uint32_t nclusters_n;
+  bool ok = geo_cluster_intersecting_geoms(lwgeoms, ngeoms, &lw_results,
+    &nclusters_n);
+  /* The collections take ownership of the geometries they are built from */
+  pfree(lwgeoms);
+  if (! ok)
+  {
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "The clustering of geometries the native engine does not cover is "
+      "answered by the GEOS library, which this build excludes: configure "
+      "with -DGEOS=ON");
+    return NULL;
+  }
+  GSERIALIZED **res_n = palloc(nclusters_n * sizeof(GSERIALIZED *));
+  for (i = 0; i < nclusters_n; i++)
+  {
+    res_n[i] = geo_serialize(lw_results[i]);
+    lwgeom_free(lw_results[i]);
+  }
+  lwfree(lw_results);
+  *count = (int) nclusters_n;
+  return res_n;
+#else
+  int is3d = 0;
+  uint32_t nclusters, j;
+  int32_t srid = SRID_UNKNOWN;
+  bool gotsrid = false;
 
   /* Ok, we really need geos now ;) */
   GEOSContextHandle_t ctx = geos_get_context();
@@ -1705,6 +1739,7 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
   lwfree(geos_results);
   *count = nclusters;
   return result;
+#endif /* ! GEOS */
 }
 
 /**


### PR DESCRIPTION
The clustering of liblwgeom that partitions geometries into the groups whose members meet reaches GEOS for two things: an STRtree narrowing the pairs worth asking about, and the prepared predicate answering whether a pair meets. The merge itself is the union-find of `lwunionfind.c` and a cluster assembles with `lwcollection_construct`, neither of which reaches GEOS. So a build carrying none reports the clustering unsupported, although only those two are missing.

The bounding boxes answer the narrowing, as they already do for the clusterings by distance in the same file: two geometries whose boxes stand apart share no point. The native engine answers the predicate, through the entry that reads it from the edges of the pair rather than from a matrix. Sharing a point is symmetric, so each pair is asked about once, and a pair already in one cluster is not asked about at all.

A pair falling outside what the native engine covers leaves the clustering unanswered rather than wrong, and the build reports it as unsupported.

A build carrying GEOS keeps the liblwgeom path, so the two answers stand side by side. Over 20 geometries mixing polygons, points and line strings, which they partition into eight clusters, the two agree on every cluster.
