### PR TITLE
State every GeoPose frame a document names in the frame registry

### DIFF
--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -1464,14 +1464,18 @@ SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
 		<sect2 xml:id="pose_geopose_frames">
 			<title>Registro de metadatos de marcos</title>
 			<para>El estándar OGC GeoPose v1.0 distingue el <emphasis>marco exterior</emphasis> (la referencia global, por ejemplo, WGS-84 geográfico o ECEF) del <emphasis>marco interior</emphasis> (el marco del cuerpo cuya orientación es el cuaternión de la pose). Las clases de conformidad Basic exigen WGS-84 geográfico como marco exterior y un marco interior implícito de ejes de cuerpo dextrógiros; la clase Advanced nombra su marco exterior de forma explícita y sitúa la pose en el origen de ese marco.</para>
-			<para>En MobilityDB, el tipo <varname>pose</varname> codifica el marco exterior de forma implícita mediante su SRID y utiliza el marco interior convencional de ejes de cuerpo dextrógiros. La tabla <varname>geopose_frames</varname> registra esta correspondencia en un catálogo paralelo a la tabla <varname>pointcloud_formats</varname> de pgPointCloud. Las pilas de marcos de la clase Advanced no están admitidas.</para>
+			<para>En MobilityDB, el tipo <varname>pose</varname> codifica el marco exterior de forma implícita mediante su SRID y utiliza el marco interior convencional de ejes de cuerpo dextrógiros. La tabla <varname>geopose_frames</varname> registra esta correspondencia y declara todos los identificadores de marco que un documento puede nombrar: una serie de secuencia compuesta nombra <varname>LTP-ENU</varname> y <varname>RotateTranslate</varname>, y una cadena nombra esos mismos dos marcos como <varname>/Extrinsic/LTP-ENU</varname> e <varname>/Intrinsic/Translate-Rotate</varname>, todos bajo la autoridad <varname>/geopose/1.0</varname>. Las pilas de marcos de la clase Advanced no están admitidas.</para>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT frame_id, authority, code, name, is_geographic
 FROM geopose_frames ORDER BY frame_id;
--- 1 | EPSG | 4326 | WGS-84 geographic (lat/lon/h)                | t
--- 2 | EPSG | 4978 | WGS-84 ECEF (Earth-Centred Earth-Fixed)      | f
--- 3 | OGC  | LTP  | Local Tangent Plane (East-North-Up)          | f
--- 4 | OGC  | BODY | Right-handed body axes (default inner frame) | f
+-- 1 | EPSG         | 4326                        | WGS-84 geographic (lat/lon/h)                      | t
+-- 2 | EPSG         | 4978                        | WGS-84 ECEF (Earth-Centred Earth-Fixed)            | f
+-- 3 | OGC          | LTP                         | Local Tangent Plane (East-North-Up)                | f
+-- 4 | OGC          | BODY                        | Right-handed body axes (default inner frame)       | f
+-- 5 | /geopose/1.0 | LTP-ENU                     | GeoPose outer frame of a Composite Sequence Series | f
+-- 6 | /geopose/1.0 | RotateTranslate             | GeoPose inner frame of a Composite Sequence Series | f
+-- 7 | /geopose/1.0 | /Extrinsic/LTP-ENU          | GeoPose outer frame of a Chain                     | f
+-- 8 | /geopose/1.0 | /Intrinsic/Translate-Rotate | GeoPose inner frame of a Chain                     | f
 </programlisting>
 			<para>Tres funciones auxiliares SQL proporcionan una interfaz de consulta estable que es independiente de la disposición de la tabla:</para>
 			<itemizedlist>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1482,14 +1482,18 @@ SELECT round(pitch(tpose 'Pose(Point(0 0 0),1,0,0,0)@2001-01-01'), 6);
 		<sect2 xml:id="pose_geopose_frames">
 			<title>Frame Metadata Registry</title>
 			<para>The OGC GeoPose v1.0 standard distinguishes the <emphasis>outer frame</emphasis> (the global reference, e.g., WGS-84 geographic or ECEF) from the <emphasis>inner frame</emphasis> (the body frame whose orientation is the pose's quaternion). The Basic conformance classes mandate WGS-84 geographic as the outer frame and an implicit right-handed body-axes inner frame; the Advanced class names its outer frame explicitly and places the pose at that frame's origin.</para>
-			<para>In MobilityDB the <varname>pose</varname> type encodes the outer frame implicitly via its SRID and uses the conventional right-handed body-axes inner frame. The <varname>geopose_frames</varname> table records this mapping in a registry parallel to pgPointCloud's <varname>pointcloud_formats</varname>. Advanced-class frame stacks are not supported.</para>
+			<para>In MobilityDB the <varname>pose</varname> type encodes the outer frame implicitly via its SRID and uses the conventional right-handed body-axes inner frame. The <varname>geopose_frames</varname> table records this mapping, and states every frame identifier a document can name: a Composite Sequence Series names <varname>LTP-ENU</varname> and <varname>RotateTranslate</varname>, and a Chain names the same two frames as <varname>/Extrinsic/LTP-ENU</varname> and <varname>/Intrinsic/Translate-Rotate</varname>, all under the <varname>/geopose/1.0</varname> authority. Advanced-class frame stacks are not supported.</para>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT frame_id, authority, code, name, is_geographic
 FROM geopose_frames ORDER BY frame_id;
--- 1 | EPSG | 4326 | WGS-84 geographic (lat/lon/h)                | t
--- 2 | EPSG | 4978 | WGS-84 ECEF (Earth-Centred Earth-Fixed)      | f
--- 3 | OGC  | LTP  | Local Tangent Plane (East-North-Up)          | f
--- 4 | OGC  | BODY | Right-handed body axes (default inner frame) | f
+-- 1 | EPSG         | 4326                        | WGS-84 geographic (lat/lon/h)                      | t
+-- 2 | EPSG         | 4978                        | WGS-84 ECEF (Earth-Centred Earth-Fixed)            | f
+-- 3 | OGC          | LTP                         | Local Tangent Plane (East-North-Up)                | f
+-- 4 | OGC          | BODY                        | Right-handed body axes (default inner frame)       | f
+-- 5 | /geopose/1.0 | LTP-ENU                     | GeoPose outer frame of a Composite Sequence Series | f
+-- 6 | /geopose/1.0 | RotateTranslate             | GeoPose inner frame of a Composite Sequence Series | f
+-- 7 | /geopose/1.0 | /Extrinsic/LTP-ENU          | GeoPose outer frame of a Chain                     | f
+-- 8 | /geopose/1.0 | /Intrinsic/Translate-Rotate | GeoPose inner frame of a Chain                     | f
 </programlisting>
 			<para>Three SQL helpers provide a stable lookup interface that is independent of the table layout:</para>
 			<itemizedlist>

--- a/mobilitydb/sql/pose/120_geopose_frames.in.sql
+++ b/mobilitydb/sql/pose/120_geopose_frames.in.sql
@@ -43,13 +43,14 @@
  * frames so that a future Advanced-class lift only needs to extend it,
  * not re-design it.
  *
- * The shape mirrors pgPointCloud's `pointcloud_formats(pcid, …, schema)`
- * registry: a small primary-key-indexed catalog of named formats, with a
- * description column that's free-form for human readers.
+ * The shape is the one `pointcloud_schemas` carries: a small
+ * primary-key-indexed catalog stated in SQL, marked as a configuration table
+ * so that pg_dump preserves the rows a user registers, with a description
+ * column that is free-form for human readers.
  */
 
 CREATE TABLE geopose_frames (
-  frame_id      integer PRIMARY KEY,
+  frame_id      integer PRIMARY KEY CHECK (frame_id > 0),
   authority     text NOT NULL,
   code          text,
   name          text NOT NULL,
@@ -63,7 +64,10 @@ COMMENT ON TABLE  geopose_frames IS
   'the Pose type encodes the outer frame implicitly via SRID and uses '
   'a conventional right-handed body-axes inner frame.';
 COMMENT ON COLUMN geopose_frames.frame_id   IS 'Stable integer key for cross-references.';
-COMMENT ON COLUMN geopose_frames.authority  IS 'Naming authority: ''EPSG'', ''OGC'', ''CUSTOM''.';
+COMMENT ON COLUMN geopose_frames.authority  IS
+  'Naming authority: ''EPSG'' or ''OGC'' for a frame those bodies name, '
+  '''/geopose/1.0'' for one the standard names in a document, and '
+  '''CUSTOM'' for one a user registers.';
 COMMENT ON COLUMN geopose_frames.code       IS 'Authority-specific code (e.g., ''4326'').';
 COMMENT ON COLUMN geopose_frames.name       IS 'Human-readable frame name.';
 COMMENT ON COLUMN geopose_frames.srid       IS 'PostGIS SRID, or NULL if the frame is parametric (e.g., LTP at runtime).';
@@ -81,7 +85,11 @@ INSERT INTO geopose_frames(frame_id, authority, code, name, srid, is_geographic,
   (5, '/geopose/1.0', 'LTP-ENU', 'GeoPose outer frame of a Composite Sequence Series', NULL, false,
      'Authority and id emitted as the outerFrame of a Series. Parameterised by the tangent point of the first pose as ''longitude=<degrees>&latitude=<degrees>&height=<metres>''.'),
   (6, '/geopose/1.0', 'RotateTranslate', 'GeoPose inner frame of a Composite Sequence Series', NULL, false,
-     'Authority and id emitted for each inner frame of a Series. Parameterised as ''translation=[e, n, u]&rotation=[w, x, y, z]'', the translation in metres in the outer frame and the rotation taking body axes to the outer frame.');
+     'Authority and id emitted for each inner frame of a Series. Parameterised as ''translation=[e, n, u]&rotation=[w, x, y, z]'', the translation in metres in the outer frame and the rotation taking body axes to the outer frame.'),
+  (7, '/geopose/1.0', '/Extrinsic/LTP-ENU', 'GeoPose outer frame of a Chain', NULL, false,
+     'The frame a Chain document names where a Series names ''LTP-ENU''. Same frame, same authority, the name its own class uses; a Chain is read accepting either.'),
+  (8, '/geopose/1.0', '/Intrinsic/Translate-Rotate', 'GeoPose inner frame of a Chain', NULL, false,
+     'The frame a Chain document names where a Series names ''RotateTranslate''. Same frame, same authority, the name its own class uses; a Chain is read accepting either.');
 
 /* Helper SQL functions to query the registry without exposing the schema. */
 

--- a/mobilitydb/test/pose/expected/103_pose_geopose.test.out
+++ b/mobilitydb/test/pose/expected/103_pose_geopose.test.out
@@ -415,13 +415,43 @@ FROM j;
  /geopose/1.0 | RotateTranslate | translation=[0, 0, 0]
 (1 row)
 
+WITH emitted(authority, code) AS (
+  SELECT d->'outerFrame'->>'authority', d->'outerFrame'->>'id' FROM (SELECT
+    asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+      Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb) t(d)
+  UNION
+  SELECT d->'innerFrameSeries'->0->>'authority',
+         d->'innerFrameSeries'->0->>'id' FROM (SELECT
+    asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+      Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb) t(d)
+  UNION
+  SELECT c->>'authority', c->>'id' FROM (SELECT asGeoPose(tposechain
+    'SRID=4326;PoseChain(GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+    Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00',
+    6)::jsonb) t(d),
+    LATERAL (SELECT d->'outerFrame' UNION ALL
+             SELECT jsonb_array_elements(d->'frameChain')) u(c))
+SELECT e.authority, e.code, f.frame_id IS NOT NULL AS registered
+FROM emitted e LEFT JOIN geopose_frames f
+  ON f.authority = e.authority AND f.code = e.code
+WHERE e.authority IS NOT NULL ORDER BY e.code;
+  authority   |            code             | registered 
+--------------+-----------------------------+------------
+ /geopose/1.0 | /Extrinsic/LTP-ENU          | t
+ /geopose/1.0 | /Intrinsic/Translate-Rotate | t
+ /geopose/1.0 | LTP-ENU                     | t
+ /geopose/1.0 | RotateTranslate             | t
+(4 rows)
+
 SELECT authority, code FROM geopose_frames WHERE authority = '/geopose/1.0'
 ORDER BY code;
-  authority   |      code       
---------------+-----------------
+  authority   |            code             
+--------------+-----------------------------
+ /geopose/1.0 | /Extrinsic/LTP-ENU
+ /geopose/1.0 | /Intrinsic/Translate-Rotate
  /geopose/1.0 | LTP-ENU
  /geopose/1.0 | RotateTranslate
-(2 rows)
+(4 rows)
 
 SELECT asText(round(tposeFromGeoPose(asGeoPose(
   tpose 'Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01', 0, 15)), 6));

--- a/mobilitydb/test/pose/expected/107_geopose_frames.test.out
+++ b/mobilitydb/test/pose/expected/107_geopose_frames.test.out
@@ -1,7 +1,7 @@
 SELECT count(*) FROM geopose_frames;
  count 
 -------
-     6
+     8
 (1 row)
 
 SELECT geoPoseFrameSRID(1), geoPoseFrameIsGeographic(1);
@@ -44,6 +44,9 @@ DELETE 1
 SELECT count(*) FROM geopose_frames;
  count 
 -------
-     6
+     8
 (1 row)
 
+INSERT INTO geopose_frames(frame_id, authority, name) VALUES (0, 'CUSTOM', 'Zero');
+ERROR:  new row for relation "geopose_frames" violates check constraint "geopose_frames_frame_id_check"
+DETAIL:  Failing row contains (0, CUSTOM, null, Zero, null, f, null).

--- a/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
+++ b/mobilitydb/test/pose/queries/103_pose_geopose.test.sql
@@ -367,7 +367,31 @@ SELECT d->'innerFrameSeries'->0->>'authority', d->'innerFrameSeries'->0->>'id',
   split_part(d->'innerFrameSeries'->0->>'parameters', '&', 1)
 FROM j;
 
--- The registry documents the authority and id pairs the encoder emits.
+-- The registry states every authority and id pair an encoder emits. Read the
+-- pairs out of documents the encoders actually write rather than out of a
+-- literal, so a frame the registry never heard of fails here.
+WITH emitted(authority, code) AS (
+  SELECT d->'outerFrame'->>'authority', d->'outerFrame'->>'id' FROM (SELECT
+    asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+      Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb) t(d)
+  UNION
+  SELECT d->'innerFrameSeries'->0->>'authority',
+         d->'innerFrameSeries'->0->>'id' FROM (SELECT
+    asGeoPose(tpose '[Geodpose(Point(8 47 1500), 1, 0, 0, 0)@2026-01-01,
+      Geodpose(Point(9 48 1600), 1, 0, 0, 0)@2026-01-02]', 0, 6)::jsonb) t(d)
+  UNION
+  SELECT c->>'authority', c->>'id' FROM (SELECT asGeoPose(tposechain
+    'SRID=4326;PoseChain(GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),
+    Pose(Point Z(2 0 0), 1, 0, 0, 0))@2021-04-28 05:36:10.083+00',
+    6)::jsonb) t(d),
+    LATERAL (SELECT d->'outerFrame' UNION ALL
+             SELECT jsonb_array_elements(d->'frameChain')) u(c))
+SELECT e.authority, e.code, f.frame_id IS NOT NULL AS registered
+FROM emitted e LEFT JOIN geopose_frames f
+  ON f.authority = e.authority AND f.code = e.code
+WHERE e.authority IS NOT NULL ORDER BY e.code;
+
+-- The registry states the pairs, and nothing it does not.
 SELECT authority, code FROM geopose_frames WHERE authority = '/geopose/1.0'
 ORDER BY code;
 

--- a/mobilitydb/test/pose/queries/107_geopose_frames.test.sql
+++ b/mobilitydb/test/pose/queries/107_geopose_frames.test.sql
@@ -35,3 +35,7 @@ SELECT geoPoseFrameSRID(1000), geoPoseFrameName(1000);
 -- Cleanup the user-added row so the test doesn't leave state behind.
 DELETE FROM geopose_frames WHERE frame_id = 1000;
 SELECT count(*) FROM geopose_frames;
+
+-- A frame is stated from one. (103_pose_geopose asserts that the registry
+-- states every authority and id pair the encoder emits.)
+INSERT INTO geopose_frames(frame_id, authority, name) VALUES (0, 'CUSTOM', 'Zero');


### PR DESCRIPTION
The geopose_frames registry states every authority and id pair an encoder writes. A Chain document names its two frames /Extrinsic/LTP-ENU and /Intrinsic/Translate-Rotate where a Composite Sequence Series names the bare pair LTP-ENU and RotateTranslate, and all four carry a row under the /geopose/1.0 authority that pose_geopose.c defines. The authority column states EPSG or OGC for a frame those bodies name, /geopose/1.0 for one the standard names in a document, and CUSTOM for one a user registers, which is what the seeded rows carry, and a frame is stated from one. 103_pose_geopose reads the pairs out of documents the encoders write, a Series through asGeoPose(tpose) and a Chain through asGeoPose(tposechain), and joins them against the registry, so a frame the registry does not state reads registered=f: against a registry holding only the Series pair that same join reads f for both Chain frames, which is what makes the assertion discriminate rather than compare the registry with itself. Both manuals list every registered frame, harvested from the query they show, and name the two identifiers a Chain uses.
