### PR TITLE
Split every bounding box operator into a validating and an asserting form

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -954,6 +954,22 @@ extern bool ensure_index_join_op(IndexSearchOp op);
 extern void *bbox_temporal_split_boxes(MeosType bboxtype, size_t boxsize,
   const Temporal *temp, int maxboxes, int *count);
 
+/*****************************************************************************/
+
+/* Bounding box operators for span types */
+
+extern bool span_contains(const Span *s1, const Span *s2);
+extern bool span_contained(const Span *s1, const Span *s2);
+extern bool span_overlaps(const Span *s1, const Span *s2);
+extern bool span_same(const Span *s1, const Span *s2);
+extern bool span_adjacent(const Span *s1, const Span *s2);
+extern bool span_left(const Span *s1, const Span *s2);
+extern bool span_right(const Span *s1, const Span *s2);
+extern bool span_overleft(const Span *s1, const Span *s2);
+extern bool span_overright(const Span *s1, const Span *s2);
+
+/*****************************************************************************/
+
 /* Set functions for set and span types */
 
 extern void bbox_union_span_span(const Span *s1, const Span *s2, Span *result);
@@ -1033,6 +1049,26 @@ extern void tstzspan_set_tbox(const Span *s, TBox *box);
 
 extern TBox *tbox_shift_scale_value(const TBox *box, Datum shift, Datum width, bool hasshift, bool haswidth);
 extern void tbox_expand(const TBox *box1, TBox *box2);
+
+/*****************************************************************************/
+
+/*****************************************************************************/
+
+/* Bounding box operators for temporal box types */
+
+extern bool tbox_contains(const TBox *box1, const TBox *box2);
+extern bool tbox_contained(const TBox *box1, const TBox *box2);
+extern bool tbox_overlaps(const TBox *box1, const TBox *box2);
+extern bool tbox_same(const TBox *box1, const TBox *box2);
+extern bool tbox_adjacent(const TBox *box1, const TBox *box2);
+extern bool tbox_left(const TBox *box1, const TBox *box2);
+extern bool tbox_right(const TBox *box1, const TBox *box2);
+extern bool tbox_overleft(const TBox *box1, const TBox *box2);
+extern bool tbox_overright(const TBox *box1, const TBox *box2);
+extern bool tbox_before(const TBox *box1, const TBox *box2);
+extern bool tbox_after(const TBox *box1, const TBox *box2);
+extern bool tbox_overbefore(const TBox *box1, const TBox *box2);
+extern bool tbox_overafter(const TBox *box1, const TBox *box2);
 
 /*****************************************************************************/
 

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -155,6 +155,34 @@ extern bool stbox_expand_space_set(const STBox *box, double d, STBox *result);
 
 /*****************************************************************************/
 
+/*****************************************************************************/
+
+/* Bounding box operators for spatiotemporal box types */
+
+extern bool stbox_contains(const STBox *box1, const STBox *box2);
+extern bool stbox_contained(const STBox *box1, const STBox *box2);
+extern bool stbox_overlaps(const STBox *box1, const STBox *box2);
+extern bool stbox_same(const STBox *box1, const STBox *box2);
+extern bool stbox_adjacent(const STBox *box1, const STBox *box2);
+extern bool stbox_left(const STBox *box1, const STBox *box2);
+extern bool stbox_right(const STBox *box1, const STBox *box2);
+extern bool stbox_overleft(const STBox *box1, const STBox *box2);
+extern bool stbox_overright(const STBox *box1, const STBox *box2);
+extern bool stbox_below(const STBox *box1, const STBox *box2);
+extern bool stbox_above(const STBox *box1, const STBox *box2);
+extern bool stbox_overbelow(const STBox *box1, const STBox *box2);
+extern bool stbox_overabove(const STBox *box1, const STBox *box2);
+extern bool stbox_front(const STBox *box1, const STBox *box2);
+extern bool stbox_back(const STBox *box1, const STBox *box2);
+extern bool stbox_overfront(const STBox *box1, const STBox *box2);
+extern bool stbox_overback(const STBox *box1, const STBox *box2);
+extern bool stbox_before(const STBox *box1, const STBox *box2);
+extern bool stbox_after(const STBox *box1, const STBox *box2);
+extern bool stbox_overbefore(const STBox *box1, const STBox *box2);
+extern bool stbox_overafter(const STBox *box1, const STBox *box2);
+
+/*****************************************************************************/
+
 /* Set functions for box types */
 
 extern bool inter_stbox_stbox(const STBox *box1, const STBox *box2, STBox *result);

--- a/meos/include/pointcloud/tpcbox.h
+++ b/meos/include/pointcloud/tpcbox.h
@@ -34,6 +34,30 @@
 
 extern bool ensure_valid_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2);
 
+/* Bounding box operators */
+
+extern bool tpcbox_contains(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_contained(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overlaps(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_same(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_adjacent(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_left(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_right(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overleft(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overright(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_below(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_above(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overbelow(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overabove(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_front(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_back(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overfront(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overback(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_before(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_after(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overbefore(const TPCBox *box1, const TPCBox *box2);
+extern bool tpcbox_overafter(const TPCBox *box1, const TPCBox *box2);
+
 /* Input/output functions */
 
 extern TPCBox *tpcbox_parse(const char **str);

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1854,11 +1854,36 @@ topo_stbox_stbox_init(const STBox *box1, const STBox *box2, bool *hasx,
   VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
   if (! ensure_common_dimension(box1->flags, box2->flags))
     return false;
+  /* Both boxes carry X here, so reading the SRID through the validating
+   * accessor would only repeat the test the condition has just made */
   if (MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags) &&
      (! ensure_same_geodetic(box1->flags, box2->flags) ||
-      ! ensure_same_srid(stbox_srid(box1), stbox_srid(box2))))
+      ! ensure_same_srid(box1->srid, box2->srid)))
     return false;
   stbox_stbox_flags(box1, box2, hasx, hasz, hast, geodetic);
+  return true;
+}
+
+/**
+ * @ingroup meos_internal_geo_box_topo
+ * @brief Return true if the first spatiotemporal box contains the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_contains(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  bool hasx, hasz, hast, geodetic;
+  stbox_stbox_flags(box1, box2, &hasx, &hasz, &hast, &geodetic);
+  if (hasx && (box2->xmin < box1->xmin || box2->xmax > box1->xmax ||
+    box2->ymin < box1->ymin || box2->ymax > box1->ymax))
+      return false;
+  if (hasz && (box2->zmin < box1->zmin || box2->zmax > box1->zmax))
+      return false;
+  if (hast && (
+    datum_lt(box2->period.lower, box1->period.lower, T_TIMESTAMPTZ) ||
+    datum_gt(box2->period.upper, box1->period.upper, T_TIMESTAMPTZ)))
+      return false;
   return true;
 }
 
@@ -1875,17 +1900,21 @@ contains_stbox_stbox(const STBox *box1, const STBox *box2)
   bool hasx, hasz, hast, geodetic;
   if (! topo_stbox_stbox_init(box1, box2, &hasx, &hasz, &hast, &geodetic))
     return false;
+  return stbox_contains(box1, box2);
+}
 
-  if (hasx && (box2->xmin < box1->xmin || box2->xmax > box1->xmax ||
-    box2->ymin < box1->ymin || box2->ymax > box1->ymax))
-      return false;
-  if (hasz && (box2->zmin < box1->zmin || box2->zmax > box1->zmax))
-      return false;
-  if (hast && (
-    datum_lt(box2->period.lower, box1->period.lower, T_TIMESTAMPTZ) ||
-    datum_gt(box2->period.upper, box1->period.upper, T_TIMESTAMPTZ)))
-      return false;
-  return true;
+
+/**
+ * @ingroup meos_internal_geo_box_topo
+ * @brief Return true if the first spatiotemporal box is contained in the
+ * second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_contained(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  return stbox_contains(box2, box1);
 }
 
 /**
@@ -1898,7 +1927,34 @@ contains_stbox_stbox(const STBox *box1, const STBox *box2)
 bool
 contained_stbox_stbox(const STBox *box1, const STBox *box2)
 {
-  return contains_stbox_stbox(box2, box1);
+  /* Ensure the validity of the arguments */
+  bool hasx, hasz, hast, geodetic;
+  if (! topo_stbox_stbox_init(box1, box2, &hasx, &hasz, &hast, &geodetic))
+    return false;
+  return stbox_contained(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_topo
+ * @brief Return true if the spatiotemporal boxes overlap
+ */
+bool
+stbox_overlaps(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  bool hasx, hasz, hast, geodetic;
+  stbox_stbox_flags(box1, box2, &hasx, &hasz, &hast, &geodetic);
+  if (hasx && (box1->xmax < box2->xmin || box1->xmin > box2->xmax ||
+    box1->ymax < box2->ymin || box1->ymin > box2->ymax))
+    return false;
+  if (hasz && (box1->zmax < box2->zmin || box1->zmin > box2->zmax))
+    return false;
+  if (hast && (
+    datum_lt(box1->period.upper, box2->period.lower, T_TIMESTAMPTZ) ||
+    datum_gt(box1->period.lower, box2->period.upper, T_TIMESTAMPTZ)))
+    return false;
+  return true;
 }
 
 /**
@@ -1913,15 +1969,29 @@ overlaps_stbox_stbox(const STBox *box1, const STBox *box2)
   bool hasx, hasz, hast, geodetic;
   if (! topo_stbox_stbox_init(box1, box2, &hasx, &hasz, &hast, &geodetic))
     return false;
+  return stbox_overlaps(box1, box2);
+}
 
-  if (hasx && (box1->xmax < box2->xmin || box1->xmin > box2->xmax ||
-    box1->ymax < box2->ymin || box1->ymin > box2->ymax))
+
+/**
+ * @ingroup meos_internal_geo_box_topo
+ * @brief Return true if the spatiotemporal boxes are equal in the common
+ * dimensions
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_same(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  bool hasx, hasz, hast, geodetic;
+  stbox_stbox_flags(box1, box2, &hasx, &hasz, &hast, &geodetic);
+  if (hasx && (box1->xmin != box2->xmin || box1->xmax != box2->xmax ||
+    box1->ymin != box2->ymin || box1->ymax != box2->ymax))
     return false;
-  if (hasz && (box1->zmax < box2->zmin || box1->zmin > box2->zmax))
+  if (hasz && (box1->zmin != box2->zmin || box1->zmax != box2->zmax))
     return false;
-  if (hast && (
-    datum_lt(box1->period.upper, box2->period.lower, T_TIMESTAMPTZ) ||
-    datum_gt(box1->period.lower, box2->period.upper, T_TIMESTAMPTZ)))
+  if (hast && (box1->period.lower != box2->period.lower ||
+               box1->period.upper != box2->period.upper))
     return false;
   return true;
 }
@@ -1940,17 +2010,9 @@ same_stbox_stbox(const STBox *box1, const STBox *box2)
   bool hasx, hasz, hast, geodetic;
   if (! topo_stbox_stbox_init(box1, box2, &hasx, &hasz, &hast, &geodetic))
     return false;
-
-  if (hasx && (box1->xmin != box2->xmin || box1->xmax != box2->xmax ||
-    box1->ymin != box2->ymin || box1->ymax != box2->ymax))
-    return false;
-  if (hasz && (box1->zmin != box2->zmin || box1->zmax != box2->zmax))
-    return false;
-  if (hast && (box1->period.lower != box2->period.lower ||
-               box1->period.upper != box2->period.upper))
-    return false;
-  return true;
+  return stbox_same(box1, box2);
 }
+
 
 /**
  * @brief Return true if two spatial extents meet, that is, if they overlap or
@@ -1971,19 +2033,16 @@ meet_extent_extent(double min1, double max1, double min2, double max2,
 }
 
 /**
- * @ingroup meos_geo_box_topo
+ * @ingroup meos_internal_geo_box_topo
  * @brief Return true if the spatiotemporal boxes are adjacent
  * @param[in] box1,box2 Spatiotemporal boxes
- * @csqlfn #Adjacent_stbox_stbox()
  */
 bool
-adjacent_stbox_stbox(const STBox *box1, const STBox *box2)
+stbox_adjacent(const STBox *box1, const STBox *box2)
 {
-  /* Ensure the validity of the arguments */
+  assert(box1); assert(box2);
   bool hasx, hasz, hast, geodetic;
-  if (! topo_stbox_stbox_init(box1, box2, &hasx, &hasz, &hast, &geodetic))
-    return false;
-
+  stbox_stbox_flags(box1, box2, &hasx, &hasz, &hast, &geodetic);
   /* Boxes are adjacent if they meet in every common dimension and touch in at
    * least one of them. The test is made dimension by dimension so that periods
    * meeting at an excluded bound are kept: they are adjacent although they do
@@ -2003,13 +2062,30 @@ adjacent_stbox_stbox(const STBox *box1, const STBox *box2)
   }
   if (hast)
   {
-    if (adjacent_span_span(&box1->period, &box2->period))
+    if (span_adjacent(&box1->period, &box2->period))
       touch = true;
-    else if (! overlaps_span_span(&box1->period, &box2->period))
+    else if (! span_overlaps(&box1->period, &box2->period))
       return false;
   }
   return touch;
 }
+
+/**
+ * @ingroup meos_geo_box_topo
+ * @brief Return true if the spatiotemporal boxes are adjacent
+ * @param[in] box1,box2 Spatiotemporal boxes
+ * @csqlfn #Adjacent_stbox_stbox()
+ */
+bool
+adjacent_stbox_stbox(const STBox *box1, const STBox *box2)
+{
+  /* Ensure the validity of the arguments */
+  bool hasx, hasz, hast, geodetic;
+  if (! topo_stbox_stbox_init(box1, box2, &hasx, &hasz, &hast, &geodetic))
+    return false;
+  return stbox_adjacent(box1, box2);
+}
+
 
 /*****************************************************************************
  * Position operators
@@ -2024,11 +2100,28 @@ ensure_valid_pos_stbox_stbox_x(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(box1, NULL); VALIDATE_NOT_NULL(box2, NULL);
+  /* Both boxes carry X here, so reading the SRID through the validating
+   * accessor would only repeat the test the condition has just made */
   if (MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags) && (
-       ! ensure_same_srid(stbox_srid(box1), stbox_srid(box2)) ||
+       ! ensure_same_srid(box1->srid, box2->srid) ||
        ! ensure_same_geodetic(box1->flags, box2->flags)))
     return false;
   return true;
+}
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is to the left of the
+ * second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_left(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return (box1->xmax < box2->xmin);
 }
 
 /**
@@ -2046,7 +2139,23 @@ left_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
-  return (box1->xmax < box2->xmin);
+  return stbox_left(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box does not extend to the
+ * right of the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_overleft(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return (box1->xmax <= box2->xmax);
 }
 
 /**
@@ -2064,7 +2173,23 @@ overleft_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
-  return (box1->xmax <= box2->xmax);
+  return stbox_overleft(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is to the right of the
+ * second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_right(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return (box1->xmin > box2->xmax);
 }
 
 /**
@@ -2082,7 +2207,23 @@ right_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
-  return (box1->xmin > box2->xmax);
+  return stbox_right(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box does not extend to the
+ * left of the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_overright(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return (box1->xmin >= box2->xmin);
 }
 
 /**
@@ -2100,7 +2241,22 @@ overright_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
-  return (box1->xmin >= box2->xmin);
+  return stbox_overright(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is below the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_below(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return (box1->ymax < box2->ymin);
 }
 
 /**
@@ -2117,7 +2273,23 @@ below_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
-  return (box1->ymax < box2->ymin);
+  return stbox_below(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box does not extend above the
+ * second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_overbelow(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return (box1->ymax <= box2->ymax);
 }
 
 /**
@@ -2135,7 +2307,22 @@ overbelow_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
-  return (box1->ymax <= box2->ymax);
+  return stbox_overbelow(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is above the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_above(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return (box1->ymin > box2->ymax);
 }
 
 /**
@@ -2152,7 +2339,23 @@ above_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
-  return (box1->ymin > box2->ymax);
+  return stbox_above(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box does not extend below the
+ * second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_overabove(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return (box1->ymin >= box2->ymin);
 }
 
 /**
@@ -2170,7 +2373,23 @@ overabove_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
-  return (box1->ymin >= box2->ymin);
+  return stbox_overabove(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is in front of the
+ * the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_front(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_Z(box1->flags));
+  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  return (box1->zmax < box2->zmin);
 }
 
 /**
@@ -2188,7 +2407,23 @@ front_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_Z(T_STBOX, box1->flags) ||
       ! ensure_has_Z(T_STBOX, box2->flags))
     return false;
-  return (box1->zmax < box2->zmin);
+  return stbox_front(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box does not extend to the
+ * back of the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_overfront(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_Z(box1->flags));
+  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  return (box1->zmax <= box2->zmax);
 }
 
 /**
@@ -2206,7 +2441,23 @@ overfront_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_Z(T_STBOX, box1->flags) ||
       ! ensure_has_Z(T_STBOX, box2->flags))
     return false;
-  return (box1->zmax <= box2->zmax);
+  return stbox_overfront(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is at the back of the
+ * second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_back(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_Z(box1->flags));
+  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  return (box1->zmin > box2->zmax);
 }
 
 /**
@@ -2224,7 +2475,23 @@ back_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_Z(T_STBOX, box1->flags) ||
       ! ensure_has_Z(T_STBOX, box2->flags))
     return false;
-  return (box1->zmin > box2->zmax);
+  return stbox_back(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box does not extend to the
+ * front of the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_overback(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_Z(box1->flags));
+  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  return (box1->zmin >= box2->zmin);
 }
 
 /**
@@ -2242,10 +2509,25 @@ overback_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_Z(T_STBOX, box1->flags) ||
       ! ensure_has_Z(T_STBOX, box2->flags))
     return false;
-  return (box1->zmin >= box2->zmin);
+  return stbox_overback(box1, box2);
 }
 
+
 /*****************************************************************************/
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is before the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_before(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return span_left(&box1->period, &box2->period);
+}
 
 /**
  * @ingroup meos_geo_box_pos
@@ -2261,7 +2543,23 @@ before_stbox_stbox(const STBox *box1, const STBox *box2)
   if (! ensure_has_T(T_STBOX, box1->flags) ||
       ! ensure_has_T(T_STBOX, box2->flags))
     return false;
-  return left_span_span(&box1->period, &box2->period);
+  return stbox_before(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is not after the second
+ * one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_overbefore(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return span_overleft(&box1->period, &box2->period);
 }
 
 /**
@@ -2279,7 +2577,22 @@ overbefore_stbox_stbox(const STBox *box1, const STBox *box2)
   if (! ensure_has_T(T_STBOX, box1->flags) ||
       ! ensure_has_T(T_STBOX, box2->flags))
     return false;
-  return overleft_span_span(&box1->period, &box2->period);
+  return stbox_overbefore(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is after the second one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_after(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return span_right(&box1->period, &box2->period);
 }
 
 /**
@@ -2296,7 +2609,23 @@ after_stbox_stbox(const STBox *box1, const STBox *box2)
   if (! ensure_has_T(T_STBOX, box1->flags) ||
       ! ensure_has_T(T_STBOX, box2->flags))
     return false;
-  return right_span_span(&box1->period, &box2->period);
+  return stbox_after(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_geo_box_pos
+ * @brief Return true if the first spatiotemporal box is not before the second
+ * one
+ * @param[in] box1,box2 Spatiotemporal boxes
+ */
+bool
+stbox_overafter(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return span_overright(&box1->period, &box2->period);
 }
 
 /**
@@ -2314,8 +2643,9 @@ overafter_stbox_stbox(const STBox *box1, const STBox *box2)
   if (! ensure_has_T(T_STBOX, box1->flags) ||
       ! ensure_has_T(T_STBOX, box2->flags))
     return false;
-  return overright_span_span(&box1->period, &box2->period);
+  return stbox_overafter(box1, box2);
 }
+
 
 /*****************************************************************************
  * Set operators

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -60,6 +60,7 @@
 #include <meos.h>
 #include <meos_geo.h>
 #include <meos_internal.h>
+#include <meos_internal_geo.h>
 #include <meos_pointcloud.h>
 #include <pgtypes.h>
 #include "temporal/span.h"
@@ -897,6 +898,17 @@ intersection_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
  *****************************************************************************/
 
 /**
+ * @ingroup meos_internal_pointcloud_box_topo
+ * @brief Return @p true if the first TPCBox contains the second
+ */
+bool
+tpcbox_contains(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  return stbox_contains((const STBox *) box1, (const STBox *) box2);
+}
+
+/**
  * @ingroup meos_pointcloud_box_topo
  * @brief Return @p true if the first TPCBox contains the second
  * @csqlfn #Contains_tpcbox_tpcbox()
@@ -907,8 +919,19 @@ contains_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpcbox_tpcbox(box1, box2))
     return false;
+  return tpcbox_contains(box1, box2);
+}
 
-  return contains_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_topo
+ * @brief Return @p true if the first TPCBox is contained in the second
+ */
+bool
+tpcbox_contained(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  return stbox_contained((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -922,8 +945,19 @@ contained_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpcbox_tpcbox(box1, box2))
     return false;
+  return tpcbox_contained(box1, box2);
+}
 
-  return contained_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_topo
+ * @brief Return @p true if two TPCBox values overlap
+ */
+bool
+tpcbox_overlaps(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  return stbox_overlaps((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -937,8 +971,20 @@ overlaps_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpcbox_tpcbox(box1, box2))
     return false;
+  return tpcbox_overlaps(box1, box2);
+}
 
-  return overlaps_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_topo
+ * @brief Return @p true if two TPCBox values are equal in the common
+ * dimensions
+ */
+bool
+tpcbox_same(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  return stbox_same((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -953,8 +999,19 @@ same_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpcbox_tpcbox(box1, box2))
     return false;
+  return tpcbox_same(box1, box2);
+}
 
-  return same_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_topo
+ * @brief Return @p true if two TPCBox values touch but do not overlap
+ */
+bool
+tpcbox_adjacent(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  return stbox_adjacent((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -968,9 +1025,9 @@ adjacent_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_tpcbox_tpcbox(box1, box2))
     return false;
-
-  return adjacent_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+  return tpcbox_adjacent(box1, box2);
 }
+
 
 /*****************************************************************************
  * Comparison
@@ -1086,6 +1143,20 @@ bool tpcbox_ge(const TPCBox *box1, const TPCBox *box2)
 /* X axis */
 
 /**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 is strictly left of box2 (X-axis).
+ * @details Returns @p false if either box lacks the X dimension.
+ */
+bool
+tpcbox_left(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return stbox_left((const STBox *) box1, (const STBox *) box2);
+}
+
+/**
  * @ingroup meos_pointcloud_box_pos
  * @brief Return @p true if box1 is strictly left of box2 (X-axis).
  * @details Returns @p false if either box lacks the X dimension.
@@ -1099,8 +1170,21 @@ left_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_left(box1, box2);
+}
 
-  return left_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 does not extend to the right of box2.
+ */
+bool
+tpcbox_overleft(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return stbox_overleft((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1116,8 +1200,21 @@ overleft_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_overleft(box1, box2);
+}
 
-  return overleft_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 is strictly right of box2 (X-axis).
+ */
+bool
+tpcbox_right(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return stbox_right((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1133,8 +1230,21 @@ right_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_right(box1, box2);
+}
 
-  return right_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 does not extend to the left of box2.
+ */
+bool
+tpcbox_overright(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return stbox_overright((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1150,11 +1260,24 @@ overright_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-
-  return overright_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+  return tpcbox_overright(box1, box2);
 }
 
+
 /* Y axis */
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 is strictly below box2 (Y-axis).
+ */
+bool
+tpcbox_below(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return stbox_below((const STBox *) box1, (const STBox *) box2);
+}
 
 /**
  * @ingroup meos_pointcloud_box_pos
@@ -1169,8 +1292,21 @@ below_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_below(box1, box2);
+}
 
-  return below_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 does not extend above box2.
+ */
+bool
+tpcbox_overbelow(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return stbox_overbelow((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1186,8 +1322,21 @@ overbelow_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_overbelow(box1, box2);
+}
 
-  return overbelow_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 is strictly above box2 (Y-axis).
+ */
+bool
+tpcbox_above(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return stbox_above((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1203,8 +1352,21 @@ above_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_above(box1, box2);
+}
 
-  return above_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 does not extend below box2.
+ */
+bool
+tpcbox_overabove(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return stbox_overabove((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1220,11 +1382,25 @@ overabove_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_X(T_TPCBOX, box1->flags) ||
       ! ensure_has_X(T_TPCBOX, box2->flags))
     return false;
-
-  return overabove_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+  return tpcbox_overabove(box1, box2);
 }
 
+
 /* Z axis — front/back only meaningful when both boxes have Z */
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 is strictly in front of box2 (Z-axis).
+ * @details Returns @p false if either box lacks a Z dimension.
+ */
+bool
+tpcbox_front(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_Z(box1->flags));
+  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  return stbox_front((const STBox *) box1, (const STBox *) box2);
+}
 
 /**
  * @ingroup meos_pointcloud_box_pos
@@ -1240,8 +1416,21 @@ front_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_Z(T_TPCBOX, box1->flags) ||
       ! ensure_has_Z(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_front(box1, box2);
+}
 
-  return front_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 does not extend behind box2.
+ */
+bool
+tpcbox_overfront(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_Z(box1->flags));
+  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  return stbox_overfront((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1257,8 +1446,21 @@ overfront_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_Z(T_TPCBOX, box1->flags) ||
       ! ensure_has_Z(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_overfront(box1, box2);
+}
 
-  return overfront_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 is strictly behind box2 (Z-axis).
+ */
+bool
+tpcbox_back(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_Z(box1->flags));
+  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  return stbox_back((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1274,8 +1476,21 @@ back_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_Z(T_TPCBOX, box1->flags) ||
       ! ensure_has_Z(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_back(box1, box2);
+}
 
-  return back_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 does not extend in front of box2.
+ */
+bool
+tpcbox_overback(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_Z(box1->flags));
+  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  return stbox_overback((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1291,11 +1506,25 @@ overback_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_Z(T_TPCBOX, box1->flags) ||
       ! ensure_has_Z(T_TPCBOX, box2->flags))
     return false;
-
-  return overback_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+  return tpcbox_overback(box1, box2);
 }
 
+
 /* Time axis — before/after only meaningful when both boxes have T */
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 is strictly before box2 in time.
+ * @details Returns @p false if either box lacks a T dimension.
+ */
+bool
+tpcbox_before(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return stbox_before((const STBox *) box1, (const STBox *) box2);
+}
 
 /**
  * @ingroup meos_pointcloud_box_pos
@@ -1311,8 +1540,21 @@ before_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_before(box1, box2);
+}
 
-  return before_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 does not extend after box2 in time.
+ */
+bool
+tpcbox_overbefore(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return stbox_overbefore((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1328,8 +1570,21 @@ overbefore_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_overbefore(box1, box2);
+}
 
-  return overbefore_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 is strictly after box2 in time.
+ */
+bool
+tpcbox_after(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return stbox_after((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1345,8 +1600,21 @@ after_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
+  return tpcbox_after(box1, box2);
+}
 
-  return after_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+
+/**
+ * @ingroup meos_internal_pointcloud_box_pos
+ * @brief Return @p true if box1 does not extend before box2 in time.
+ */
+bool
+tpcbox_overafter(const TPCBox *box1, const TPCBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return stbox_overafter((const STBox *) box1, (const STBox *) box2);
 }
 
 /**
@@ -1362,8 +1630,8 @@ overafter_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
       ! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
-
-  return overafter_stbox_stbox((const STBox *) box1, (const STBox *) box2);
+  return tpcbox_overafter(box1, box2);
 }
+
 
 /*****************************************************************************/

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -148,6 +148,25 @@ contains_span_timestamptz(const Span *s, TimestampTz t)
 }
 
 /**
+ * @ingroup meos_internal_setspan_topo
+ * @brief Return true if the first span contains the second one
+ * @param[in] s1,s2 Spans
+ */
+bool
+span_contains(const Span *s1, const Span *s2)
+{
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
+  int cmp1 = datum_cmp(s1->lower, s2->lower, s1->basetype);
+  int cmp2 = datum_cmp(s1->upper, s2->upper, s1->basetype);
+  if (
+    (cmp1 < 0 || (cmp1 == 0 && (s1->lower_inc || ! s2->lower_inc))) &&
+    (cmp2 > 0 || (cmp2 == 0 && (s1->upper_inc || ! s2->upper_inc))) )
+    return true;
+  return false;
+}
+
+/**
  * @ingroup meos_setspan_topo
  * @brief Return true if the first span contains the second one
  * @param[in] s1,s2 Spans
@@ -159,14 +178,9 @@ contains_span_span(const Span *s1, const Span *s2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_span_span(s1, s2))
     return false;
+  return span_contains(s1, s2);
+}
 
-  int cmp1 = datum_cmp(s1->lower, s2->lower, s1->basetype);
-  int cmp2 = datum_cmp(s1->upper, s2->upper, s1->basetype);
-  if (
-    (cmp1 < 0 || (cmp1 == 0 && (s1->lower_inc || ! s2->lower_inc))) &&
-    (cmp2 > 0 || (cmp2 == 0 && (s1->upper_inc || ! s2->upper_inc))) )
-    return true;
-  return false;}
 
 /*****************************************************************************
  * Contained
@@ -185,6 +199,19 @@ contained_value_span(Datum value, const Span *s)
 }
 
 /**
+ * @ingroup meos_internal_setspan_topo
+ * @brief Return true if the first span is contained in the second one
+ * @param[in] s1,s2 Spans
+ */
+bool
+span_contained(const Span *s1, const Span *s2)
+{
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
+  return span_contains(s2, s1);
+}
+
+/**
  * @ingroup meos_setspan_topo
  * @brief Return true if the first span is contained in the second one
  * @param[in] s1,s2 Spans
@@ -193,12 +220,35 @@ contained_value_span(Datum value, const Span *s)
 bool
 contained_span_span(const Span *s1, const Span *s2)
 {
-  return contains_span_span(s2, s1);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_span_span(s1, s2))
+    return false;
+  return span_contained(s1, s2);
 }
+
 
 /*****************************************************************************
  * Overlaps
  *****************************************************************************/
+
+/**
+ * @ingroup meos_internal_setspan_topo
+ * @brief Return true if two spans overlap
+ * @param[in] s1,s2 Spans
+ */
+bool
+span_overlaps(const Span *s1, const Span *s2)
+{
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
+  int cmp1 = datum_cmp(s1->lower, s2->upper, s1->basetype);
+  int cmp2 = datum_cmp(s2->lower, s1->upper, s1->basetype);
+  if (
+    (cmp1 < 0 || (cmp1 == 0 && s1->lower_inc && s2->upper_inc)) &&
+    (cmp2 < 0 || (cmp2 == 0 && s2->lower_inc && s1->upper_inc)) )
+    return true;
+  return false;
+}
 
 /**
  * @ingroup meos_setspan_topo
@@ -212,15 +262,9 @@ overlaps_span_span(const Span *s1, const Span *s2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_span_span(s1, s2))
     return false;
-
-  int cmp1 = datum_cmp(s1->lower, s2->upper, s1->basetype);
-  int cmp2 = datum_cmp(s2->lower, s1->upper, s1->basetype);
-  if (
-    (cmp1 < 0 || (cmp1 == 0 && s1->lower_inc && s2->upper_inc)) &&
-    (cmp2 < 0 || (cmp2 == 0 && s2->lower_inc && s1->upper_inc)) )
-    return true;
-  return false;
+  return span_overlaps(s1, s2);
 }
+
 
 /**
  * @ingroup meos_internal_setspan_topo
@@ -261,18 +305,15 @@ adjacent_span_value(const Span *s, Datum value)
 }
 
 /**
- * @ingroup meos_setspan_topo
+ * @ingroup meos_internal_setspan_topo
  * @brief Return true if two spans are adjacent
  * @param[in] s1,s2 Spans
- * @csqlfn #Adjacent_span_span()
  */
 bool
-adjacent_span_span(const Span *s1, const Span *s2)
+span_adjacent(const Span *s1, const Span *s2)
 {
-  /* Ensure the validity of the arguments */
-  if (! ensure_valid_span_span(s1, s2))
-    return false;
-
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
   /*
    * Canonical span-adjacency rule: set-theoretic share-a-boundary.
    * Two spans are adjacent iff their closures meet at a single boundary value
@@ -292,9 +333,43 @@ adjacent_span_span(const Span *s1, const Span *s2)
           datum_eq(s2->upper, s1->lower, s1->basetype));
 }
 
+/**
+ * @ingroup meos_setspan_topo
+ * @brief Return true if two spans are adjacent
+ * @param[in] s1,s2 Spans
+ * @csqlfn #Adjacent_span_span()
+ */
+bool
+adjacent_span_span(const Span *s1, const Span *s2)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_span_span(s1, s2))
+    return false;
+  return span_adjacent(s1, s2);
+}
+
+
 /*****************************************************************************
  * Same
  *****************************************************************************/
+
+/**
+ * @ingroup meos_internal_setspan_topo
+ * @brief Return true if two spans are equal in the common dimensions
+ * @param[in] s1,s2 Spans
+ */
+bool
+span_same(const Span *s1, const Span *s2)
+{
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
+  /* A span is a single dimension, so `same` (`~=`) reduces to span equality.
+   * This is the base case of the bounding-box `same` family (#same_tbox_tbox(),
+   * #same_stbox_stbox()), letting the temporal/span bounding-box wrappers
+   * dispatch on `~=` uniformly instead of borrowing the equality (`=`)
+   * function #span_eq(). */
+  return span_eq(s1, s2);
+}
 
 /**
  * @ingroup meos_setspan_topo
@@ -304,13 +379,12 @@ adjacent_span_span(const Span *s1, const Span *s2)
 bool
 same_span_span(const Span *s1, const Span *s2)
 {
-  /* A span is a single dimension, so `same` (`~=`) reduces to span equality.
-   * This is the base case of the bounding-box `same` family (#same_tbox_tbox(),
-   * #same_stbox_stbox()), letting the temporal/span bounding-box wrappers
-   * dispatch on `~=` uniformly instead of borrowing the equality (`=`)
-   * function #span_eq(). */
-  return span_eq(s1, s2);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_span_span(s1, s2))
+    return false;
+  return span_same(s1, s2);
 }
+
 
 /*****************************************************************************
  * Left of
@@ -345,6 +419,20 @@ left_span_value(const Span *s, Datum value)
 }
 
 /**
+ * @ingroup meos_internal_setspan_pos
+ * @brief Return true if the first span is to the left of the second one
+ * @param[in] s1,s2 Spans
+ */
+bool
+span_left(const Span *s1, const Span *s2)
+{
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
+  int cmp = datum_cmp(s1->upper, s2->lower, s1->basetype);
+  return (cmp < 0 || (cmp == 0 && (! s1->upper_inc || ! s2->lower_inc)));
+}
+
+/**
  * @ingroup meos_setspan_pos
  * @brief Return true if the first span is to the left of the second one
  * @param[in] s1,s2 Spans
@@ -356,10 +444,9 @@ left_span_span(const Span *s1, const Span *s2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_span_span(s1, s2))
     return false;
-
-  int cmp = datum_cmp(s1->upper, s2->lower, s1->basetype);
-  return (cmp < 0 || (cmp == 0 && (! s1->upper_inc || ! s2->lower_inc)));
+  return span_left(s1, s2);
 }
+
 
 /**
  * @ingroup meos_internal_setspan_pos
@@ -405,6 +492,19 @@ right_span_value(const Span *s, Datum value)
 }
 
 /**
+ * @ingroup meos_internal_setspan_pos
+ * @brief Return true if the first span is to right the of the second one
+ * @param[in] s1,s2 Spans
+ */
+bool
+span_right(const Span *s1, const Span *s2)
+{
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
+  return span_left(s2, s1);
+}
+
+/**
  * @ingroup meos_setspan_pos
  * @brief Return true if the first span is to right the of the second one
  * @param[in] s1,s2 Spans
@@ -413,8 +513,12 @@ right_span_value(const Span *s, Datum value)
 bool
 right_span_span(const Span *s1, const Span *s2)
 {
-  return left_span_span(s2, s1);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_span_span(s1, s2))
+    return false;
+  return span_right(s1, s2);
 }
+
 
 /*****************************************************************************
  * Does not extend to right of
@@ -452,6 +556,21 @@ overleft_span_value(const Span *s, Datum value)
 }
 
 /**
+ * @ingroup meos_internal_setspan_pos
+ * @brief Return true if the first span does not extend to the right of the
+ * second one
+ * @param[in] s1,s2 Spans
+ */
+bool
+span_overleft(const Span *s1, const Span *s2)
+{
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
+  int cmp = datum_cmp(s1->upper, s2->upper, s1->basetype);
+  return (cmp < 0 || (cmp == 0 && (! s1->upper_inc || s2->upper_inc)));
+}
+
+/**
  * @ingroup meos_setspan_pos
  * @brief Return true if the first span does not extend to the right of the
  * second one
@@ -464,10 +583,9 @@ overleft_span_span(const Span *s1, const Span *s2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_span_span(s1, s2))
     return false;
-
-  int cmp = datum_cmp(s1->upper, s2->upper, s1->basetype);
-  return (cmp < 0 || (cmp == 0 && (! s1->upper_inc || s2->upper_inc)));
+  return span_overleft(s1, s2);
 }
+
 
 /*****************************************************************************
  * Does not extend to left of
@@ -501,6 +619,21 @@ overright_span_value(const Span *s, Datum value)
 }
 
 /**
+ * @ingroup meos_internal_setspan_pos
+ * @brief Return true if the first span does not extend to the left of the
+ * second one
+ * @param[in] s1,s2 Spans
+ */
+bool
+span_overright(const Span *s1, const Span *s2)
+{
+  assert(s1); assert(s2);
+  assert(s1->spantype == s2->spantype);
+  int cmp = datum_cmp(s2->lower, s1->lower, s1->basetype);
+  return (cmp < 0 || (cmp == 0 && (! s1->lower_inc || s2->lower_inc)));
+}
+
+/**
  * @ingroup meos_setspan_pos
  * @brief Return true if the first span does not extend to the left of the
  * second one
@@ -513,10 +646,9 @@ overright_span_span(const Span *s1, const Span *s2)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_span_span(s1, s2))
     return false;
-
-  int cmp = datum_cmp(s2->lower, s1->lower, s1->basetype);
-  return (cmp < 0 || (cmp == 0 && (! s1->lower_inc || s2->lower_inc)));
+  return span_overright(s1, s2);
 }
+
 
 /*****************************************************************************
  * Set union

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -1519,6 +1519,20 @@ tbox_expand_time(const TBox *box, const Interval *interv)
  *****************************************************************************/
 
 /**
+ * @brief Set the ouput variables with the flag values of the boxes
+ * @param[in] box1,box2 Input boxes
+ * @param[out] hasx,hast Boolean variables
+ */
+static void
+tbox_tbox_flags(const TBox *box1, const TBox *box2, bool *hasx, bool *hast)
+{
+  assert(box1); assert(box2); assert(hasx); assert(hast);
+  *hasx = MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags);
+  *hast = MEOS_FLAGS_GET_T(box1->flags) && MEOS_FLAGS_GET_T(box2->flags);
+  return;
+}
+
+/**
  * @brief Return the ouput variables initialized  with the flag values of the
  * boxes
  * @param[in] box1,box2 Input boxes
@@ -1531,9 +1545,26 @@ ensure_valid_tbox_tbox(const TBox *box1, const TBox *box2, bool *hasx,
   assert(box1); assert(box2); assert(hasx); assert(hast);
   if (! ensure_common_dimension(box1->flags, box2->flags))
     return false;
-  *hasx = MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags);
-  *hast = MEOS_FLAGS_GET_T(box1->flags) && MEOS_FLAGS_GET_T(box2->flags);
+  tbox_tbox_flags(box1, box2, hasx, hast);
   if (*hasx && ! ensure_same_span_type(&box1->span, &box2->span))
+    return false;
+  return true;
+}
+
+/**
+ * @ingroup meos_internal_box_bbox_topo
+ * @brief Return true if the first temporal box contains the second one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_contains(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  bool hasx, hast;
+  tbox_tbox_flags(box1, box2, &hasx, &hast);
+  if (hasx && ! span_contains(&box1->span, &box2->span))
+    return false;
+  if (hast && ! span_contains(&box1->period, &box2->period))
     return false;
   return true;
 }
@@ -1552,12 +1583,20 @@ contains_tbox_tbox(const TBox *box1, const TBox *box2)
   bool hasx, hast;
   if (! ensure_valid_tbox_tbox(box1, box2, &hasx, &hast))
     return false;
+  return tbox_contains(box1, box2);
+}
 
-  if (hasx && ! contains_span_span(&box1->span, &box2->span))
-    return false;
-  if (hast && ! contains_span_span(&box1->period, &box2->period))
-    return false;
-  return true;
+
+/**
+ * @ingroup meos_internal_box_bbox_topo
+ * @brief Return true if the first temporal box is contained in the second one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_contained(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  return tbox_contains(box2, box1);
 }
 
 /**
@@ -1569,7 +1608,31 @@ contains_tbox_tbox(const TBox *box1, const TBox *box2)
 bool
 contained_tbox_tbox(const TBox *box1, const TBox *box2)
 {
-  return contains_tbox_tbox(box2, box1);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
+  bool hasx, hast;
+  if (! ensure_valid_tbox_tbox(box1, box2, &hasx, &hast))
+    return false;
+  return tbox_contained(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_box_bbox_topo
+ * @brief Return true if two temporal boxes overlap
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_overlaps(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  bool hasx, hast;
+  tbox_tbox_flags(box1, box2, &hasx, &hast);
+  if (hasx && ! span_overlaps(&box1->span, &box2->span))
+    return false;
+  if (hast && ! span_overlaps(&box1->period, &box2->period))
+    return false;
+  return true;
 }
 
 /**
@@ -1586,10 +1649,24 @@ overlaps_tbox_tbox(const TBox *box1, const TBox *box2)
   bool hasx, hast;
   if (! ensure_valid_tbox_tbox(box1, box2, &hasx, &hast))
     return false;
+  return tbox_overlaps(box1, box2);
+}
 
-  if (hasx && ! overlaps_span_span(&box1->span, &box2->span))
+
+/**
+ * @ingroup meos_internal_box_bbox_topo
+ * @brief Return true if two temporal boxes are equal in the common dimensions
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_same(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  bool hasx, hast;
+  tbox_tbox_flags(box1, box2, &hasx, &hast);
+  if (hasx && ! span_eq(&box1->span, &box2->span))
     return false;
-  if (hast && ! overlaps_span_span(&box1->period, &box2->period))
+  if (hast && ! span_eq(&box1->period, &box2->period))
     return false;
   return true;
 }
@@ -1608,12 +1685,39 @@ same_tbox_tbox(const TBox *box1, const TBox *box2)
   bool hasx, hast;
   if (! ensure_valid_tbox_tbox(box1, box2, &hasx, &hast))
     return false;
+  return tbox_same(box1, box2);
+}
 
-  if (hasx && ! span_eq(&box1->span, &box2->span))
-    return false;
-  if (hast && ! span_eq(&box1->period, &box2->period))
-    return false;
-  return true;
+
+/**
+ * @ingroup meos_internal_box_bbox_topo
+ * @brief Return true if two temporal boxes are adjacent
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_adjacent(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  bool hasx, hast;
+  tbox_tbox_flags(box1, box2, &hasx, &hast);
+  /* Boxes are adjacent if they meet in every common dimension and touch in at
+   * least one of them. A dimension in which the boxes are apart separates them
+   * whatever the remaining dimensions do, so an adjacency in one dimension is
+   * an adjacency of the boxes only when the others at least overlap */
+  bool adjx = false, adjt = false;
+  if (hasx)
+  {
+    adjx = span_adjacent(&box1->span, &box2->span);
+    if (! adjx && ! span_overlaps(&box1->span, &box2->span))
+      return false;
+  }
+  if (hast)
+  {
+    adjt = span_adjacent(&box1->period, &box2->period);
+    if (! adjt && ! span_overlaps(&box1->period, &box2->period))
+      return false;
+  }
+  return (adjx || adjt);
 }
 
 /**
@@ -1630,30 +1734,28 @@ adjacent_tbox_tbox(const TBox *box1, const TBox *box2)
   bool hasx, hast;
   if (! ensure_valid_tbox_tbox(box1, box2, &hasx, &hast))
     return false;
-
-  /* Boxes are adjacent if they meet in every common dimension and touch in at
-   * least one of them. A dimension in which the boxes are apart separates them
-   * whatever the remaining dimensions do, so an adjacency in one dimension is
-   * an adjacency of the boxes only when the others at least overlap */
-  bool adjx = false, adjt = false;
-  if (hasx)
-  {
-    adjx = adjacent_span_span(&box1->span, &box2->span);
-    if (! adjx && ! overlaps_span_span(&box1->span, &box2->span))
-      return false;
-  }
-  if (hast)
-  {
-    adjt = adjacent_span_span(&box1->period, &box2->period);
-    if (! adjt && ! overlaps_span_span(&box1->period, &box2->period))
-      return false;
-  }
-  return (adjx || adjt);
+  return tbox_adjacent(box1, box2);
 }
+
 
 /*****************************************************************************
  * Position operators
  *****************************************************************************/
+
+/**
+ * @ingroup meos_internal_box_bbox_pos
+ * @brief Return true if the first temporal box is to the left of the second
+ * one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_left(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return span_left(&box1->span, &box2->span);
+}
 
 /**
  * @ingroup meos_box_bbox_pos
@@ -1667,11 +1769,26 @@ left_tbox_tbox(const TBox *box1, const TBox *box2)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
-  assert(box1); assert(box2);
-  if (! ensure_has_X(T_TBOX, box1->flags) || 
+  if (! ensure_has_X(T_TBOX, box1->flags) ||
       ! ensure_has_X(T_TBOX, box2->flags))
     return false;
-  return left_span_span(&box1->span, &box2->span);
+  return tbox_left(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_box_bbox_pos
+ * @brief Return true if the first temporal box does not extend to the right
+ * of the second one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_overleft(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return span_overleft(&box1->span, &box2->span);
 }
 
 /**
@@ -1689,7 +1806,23 @@ overleft_tbox_tbox(const TBox *box1, const TBox *box2)
   if (! ensure_has_X(T_TBOX, box1->flags) ||
       ! ensure_has_X(T_TBOX, box2->flags))
     return false;
-  return overleft_span_span(&box1->span, &box2->span);
+  return tbox_overleft(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_box_bbox_pos
+ * @brief Return true if the first temporal box is to the right of the second
+ * one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_right(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return span_right(&box1->span, &box2->span);
 }
 
 /**
@@ -1707,7 +1840,23 @@ right_tbox_tbox(const TBox *box1, const TBox *box2)
   if (! ensure_has_X(T_TBOX, box1->flags) || 
       ! ensure_has_X(T_TBOX, box2->flags))
     return false;
-  return right_span_span(&box1->span, &box2->span);
+  return tbox_right(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_box_bbox_pos
+ * @brief Return true if the first temporal box does not extend to the left of
+ * the second one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_overright(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  return span_overright(&box1->span, &box2->span);
 }
 
 /**
@@ -1725,7 +1874,22 @@ overright_tbox_tbox(const TBox *box1, const TBox *box2)
   if (! ensure_has_X(T_TBOX, box1->flags) || 
       ! ensure_has_X(T_TBOX, box2->flags))
     return false;
-  return overright_span_span(&box1->span, &box2->span);
+  return tbox_overright(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_box_bbox_pos
+ * @brief Return true if the first temporal box is before the second one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_before(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return span_left(&box1->period, &box2->period);
 }
 
 /**
@@ -1742,7 +1906,22 @@ before_tbox_tbox(const TBox *box1, const TBox *box2)
   if (! ensure_has_T(T_TBOX, box1->flags) || 
       ! ensure_has_T(T_TBOX, box2->flags))
     return false;
-  return left_span_span(&box1->period, &box2->period);
+  return tbox_before(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_box_bbox_pos
+ * @brief Return true if the first temporal box is not after the second one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_overbefore(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return span_overleft(&box1->period, &box2->period);
 }
 
 /**
@@ -1759,7 +1938,22 @@ overbefore_tbox_tbox(const TBox *box1, const TBox *box2)
   if (! ensure_has_T(T_TBOX, box1->flags) || 
       ! ensure_has_T(T_TBOX, box2->flags))
     return false;
-  return overleft_span_span(&box1->period, &box2->period);
+  return tbox_overbefore(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_box_bbox_pos
+ * @brief Return true if the first temporal box is after the second one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_after(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return span_right(&box1->period, &box2->period);
 }
 
 /**
@@ -1776,7 +1970,22 @@ after_tbox_tbox(const TBox *box1, const TBox *box2)
   if (! ensure_has_T(T_TBOX, box1->flags) || 
       ! ensure_has_T(T_TBOX, box2->flags))
     return false;
-  return right_span_span(&box1->period, &box2->period);
+  return tbox_after(box1, box2);
+}
+
+
+/**
+ * @ingroup meos_internal_box_bbox_pos
+ * @brief Return true if the first temporal box is not before the second one
+ * @param[in] box1,box2 Temporal boxes
+ */
+bool
+tbox_overafter(const TBox *box1, const TBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_T(box1->flags));
+  assert(MEOS_FLAGS_GET_T(box2->flags));
+  return span_overright(&box1->period, &box2->period);
 }
 
 /**
@@ -1793,8 +2002,9 @@ overafter_tbox_tbox(const TBox *box1, const TBox *box2)
   if (! ensure_has_T(T_TBOX, box1->flags) || 
       ! ensure_has_T(T_TBOX, box2->flags))
     return false;
-  return overright_span_span(&box1->period, &box2->period);
+  return tbox_overafter(box1, box2);
 }
+
 
 /*****************************************************************************
  * Set operators


### PR DESCRIPTION
The bounding box operators of the four box types test their arguments on
every call, and an index calls them once per node it visits, so one
descent validates the same box repeatedly.

Each of the 64 operators is a pair. The external form carries the name and
the argument tests, and answers the sentinel a caller expects; the
internal form carries the computation behind an assert, in the idiom the
rest of MEOS follows, and the external form calls it.

| type | operators | internal declared in |
|---|---|---|
| span | 9 | `meos_internal.h` |
| tbox | 13 | `meos_internal.h` |
| stbox | 21 | `meos_internal_geo.h` |
| tpcbox | 21 | `pointcloud/tpcbox.h` |

The box operators are themselves callers of this surface. A temporal box
compares its dimensions through the span operators and a point cloud box
through the spatiotemporal ones, and those calls reach the internal forms,
so a temporal box comparison performs one `ensure_valid_tbox_tbox` and a
point cloud box comparison one `ensure_valid_tpcbox_tpcbox`.

Both forms called in one process, three million calls each:

| | external | internal |
|---|---|---|
| span | 0.019 s | 0.010 s |
| tbox | 0.071 s | 0.051 s |
| stbox | 0.071 s | 0.018 s |

The two validators of the spatiotemporal box operators read the SRID
directly from the box. Both reads sit inside a condition that establishes
that the two boxes carry X, which is what the validating accessor tests
for.