### PR TITLE
Expand the argument tests of the hot path where they are called

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -47,6 +47,7 @@
 #include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
+#include <meos_error.h>
 /* PostGIS */
 #include <liblwgeom.h>
 /* MEOS */
@@ -196,11 +197,36 @@ extern bool ensure_geodetic_geo(const GSERIALIZED *gs);
 extern bool ensure_not_geodetic_geo(const GSERIALIZED *gs);
 extern bool ensure_geodetic(int16 flags);
 extern bool ensure_not_geodetic(int16 flags);
-extern bool ensure_same_geodetic(int16 flags1, int16 flags2);
+/**
+ * @brief Ensure that two temporal values have the same geodetic flag
+ */
+static inline bool
+ensure_same_geodetic(int16 flags1, int16 flags2)
+{
+  if (MEOS_FLAGS_GET_X(flags1) && MEOS_FLAGS_GET_X(flags2) &&
+    MEOS_FLAGS_GET_GEODETIC(flags1) != MEOS_FLAGS_GET_GEODETIC(flags2))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Operation on mixed planar and geodetic coordinates");
+    return false;
+  }
+  return true;
+}
 extern bool ensure_same_geodetic_geo(const GSERIALIZED *gs1,
   const GSERIALIZED *gs2);
 extern bool ensure_srid_known(int32_t srid);
-extern bool ensure_same_srid(int32_t srid1, int32_t srid2);
+/**
+ * @brief Ensure that two values have the same SRID
+ */
+static inline bool
+ensure_same_srid(int32_t srid1, int32_t srid2)
+{
+  if (srid1 == srid2)
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "Operation on mixed SRID");
+  return false;
+}
 extern bool ensure_srid_reconcile(int32_t srid1, int32_t srid2, int32_t *result);
 extern bool ensure_same_dimensionality(int16 flags1, int16 flags2);
 extern bool ensure_same_spatial_dimensionality(int16 flags1, int16 flags2);

--- a/meos/include/temporal/span.h
+++ b/meos/include/temporal/span.h
@@ -80,8 +80,29 @@ typedef struct
 
 extern bool ensure_span_isof_type(const Span *s, MeosType spantype);
 extern bool ensure_span_isof_basetype(const Span *s, MeosType basetype);
-extern bool ensure_same_span_type(const Span *s1, const Span *s2);
-extern bool ensure_valid_span_span(const Span *s1, const Span *s2);
+/**
+ * @brief Ensure that two spans have the same type
+ */
+static inline bool
+ensure_same_span_type(const Span *s1, const Span *s2)
+{
+  if (s1->spantype == s2->spantype)
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+    "Operation on mixed span types: %s and %s",
+    meostype_name(s1->spantype), meostype_name(s2->spantype));
+  return false;
+}
+
+/**
+ * @brief Ensure that two spans are valid
+ */
+static inline bool
+ensure_valid_span_span(const Span *s1, const Span *s2)
+{
+  VALIDATE_NOT_NULL(s1, false); VALIDATE_NOT_NULL(s2, false);
+  return ensure_same_span_type(s1, s2);
+}
 
 extern void span_deserialize(const Span *s, SpanBound *lower,
   SpanBound *upper);

--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -44,6 +44,7 @@
 #include <meos_internal.h>
 #include <meos_geo.h>
 #include "temporal/doublen.h"
+#include <meos_error.h>
 #include "temporal/meos_catalog.h"
 
 /* To avoid including pg_collation_d */
@@ -396,9 +397,44 @@ typedef int (*tpfunc_temp)(Datum, Datum, Datum, Datum, Datum, TimestampTz,
 
 /* Parameter tests */
 
-extern bool ensure_has_X(MeosType type, int16 flags);
-extern bool ensure_has_Z(MeosType type, int16 flags);
-extern bool ensure_has_T(MeosType type, int16 flags);
+/**
+ * @brief Ensure that a MEOS type has X dimension
+ */
+static inline bool
+ensure_has_X(MeosType type, int16 flags)
+{
+  if (MEOS_FLAGS_GET_X(flags))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "The %s must have X dimension", meostype_name(type));
+  return false;
+}
+
+/**
+ * @brief Ensure that a MEOS type has Z dimension
+ */
+static inline bool
+ensure_has_Z(MeosType type, int16 flags)
+{
+  if (MEOS_FLAGS_GET_Z(flags))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "The %s must have Z dimension", meostype_name(type));
+  return false;
+}
+
+/**
+ * @brief Ensure that a MEOS type has T dimension
+ */
+static inline bool
+ensure_has_T(MeosType type, int16 flags)
+{
+  if (MEOS_FLAGS_GET_T(flags))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "The %s must have T dimension", meostype_name(type));
+  return false;
+}
 extern bool ensure_has_not_Z(MeosType type, int16 flags);
 extern bool ensure_not_null(void *ptr);
 extern bool ensure_one_not_null(void *ptr1, void *ptr2);
@@ -409,7 +445,19 @@ extern bool ensure_same_interp(const Temporal *temp1, const Temporal *temp2);
 extern bool ensure_same_continuous_interp(int16 flags1, int16 flags2);
 extern bool ensure_linear_interp(int16 flags);
 extern bool ensure_nonlinear_interp(int16 flags);
-extern bool ensure_common_dimension(int16 flags1, int16 flags2);
+/**
+ * @brief Ensure that two temporal values have at least one common dimension
+ */
+static inline bool
+ensure_common_dimension(int16 flags1, int16 flags2)
+{
+  if (MEOS_FLAGS_GET_X(flags1) == MEOS_FLAGS_GET_X(flags2) ||
+      MEOS_FLAGS_GET_T(flags1) == MEOS_FLAGS_GET_T(flags2))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+    "The temporal values must have at least one common dimension");
+  return false;
+}
 extern bool ensure_temporal_isof_type(const Temporal *temp, MeosType type);
 extern bool ensure_temporal_isof_basetype(const Temporal *temp,
   MeosType basetype);

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -2681,22 +2681,6 @@ ensure_not_geodetic(int16 flags)
   return false;
 }
 /**
- * @brief Ensure that the spatiotemporal argument have the same type of
- * coordinates, either planar or geodetic
- */
-bool
-ensure_same_geodetic(int16 flags1, int16 flags2)
-{
-  if (MEOS_FLAGS_GET_X(flags1) && MEOS_FLAGS_GET_X(flags2) &&
-    MEOS_FLAGS_GET_GEODETIC(flags1) != MEOS_FLAGS_GET_GEODETIC(flags2))
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "Operation on mixed planar and geodetic coordinates");
-    return false;
-  }
-  return true;
-}
-/**
  * @brief Ensure that two geometries/geographies have the same dimensionality
  */
 bool
@@ -2718,18 +2702,6 @@ ensure_srid_known(int32_t srid)
     return true;
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
     "The SRID cannot be unknown");
-  return false;
-}
-/**
- * @brief Ensure that the two spatial objects have the same SRID
- */
-bool
-ensure_same_srid(int32_t srid1, int32_t srid2)
-{
-  if (srid1 == srid2)
-    return true;
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "Operation on mixed SRID");
   return false;
 }
 /**

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -93,32 +93,6 @@ ensure_span_isof_basetype(const Span *s, MeosType basetype)
   return false;
 }
 
-/**
- * @brief Ensure that the spans have the same type
- */
-bool
-ensure_same_span_type(const Span *s1, const Span *s2)
-{
-  if (s1->spantype == s2->spantype)
-    return true;
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
-    "Operation on mixed span types: %s and %s",
-    meostype_name(s1->spantype), meostype_name(s2->spantype));
-  return false;
-}
-
-/**
- * @brief Ensure that two span sets are of the same span type
- */
-bool
-ensure_valid_span_span(const Span *s1, const Span *s2)
-{
-  VALIDATE_NOT_NULL(s1, false); VALIDATE_NOT_NULL(s2, false);
-  if (! ensure_same_span_type(s1, s2))
-    return false;
-  return true;
-}
-
 /*****************************************************************************
  * General functions
  *****************************************************************************/

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -80,32 +80,6 @@
  *****************************************************************************/
 
 /**
- * @brief Ensure that a MEOS type has X dimension
- */
-bool
-ensure_has_X(MeosType type, int16 flags)
-{
-  if (MEOS_FLAGS_GET_X(flags))
-    return true;
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "The %s must have X dimension", meostype_name(type));
-  return false;
-}
-
-/**
- * @brief Ensure that a MEOS type has Z dimension
- */
-bool
-ensure_has_Z(MeosType type, int16 flags)
-{
-  if (MEOS_FLAGS_GET_Z(flags))
-    return true;
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "The %s must have Z dimension", meostype_name(type));
-  return false;
-}
-
-/**
  * @brief Ensure that a MEOS type has not Z dimension
  */
 bool
@@ -115,19 +89,6 @@ ensure_has_not_Z(MeosType type, int16 flags)
     return true;
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
     "The %s cannot have Z dimension", meostype_name(type));
-  return false;
-}
-
-/**
- * @brief Ensure that a MEOS type has Z dimension
- */
-bool
-ensure_has_T(MeosType type, int16 flags)
-{
-  if (MEOS_FLAGS_GET_T(flags))
-    return true;
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "The %s must have T dimension", meostype_name(type));
   return false;
 }
 
@@ -267,20 +228,6 @@ ensure_nonlinear_interp(int16 flags)
     return true;
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
     "Operation not supported for temporal values with linear interpolation");
-  return false;
-}
-
-/**
- * @brief Ensure that two temporal values have at least one common dimension
- */
-bool
-ensure_common_dimension(int16 flags1, int16 flags2)
-{
-  if (MEOS_FLAGS_GET_X(flags1) == MEOS_FLAGS_GET_X(flags2) ||
-      MEOS_FLAGS_GET_T(flags1) == MEOS_FLAGS_GET_T(flags2))
-    return true;
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "The temporal values must have at least one common dimension");
   return false;
 }
 


### PR DESCRIPTION
Eight parameter tests sit on the path every bounding box operator takes:
the three dimension tests, the common dimension test, the SRID and the
geodetic test, and the two span type tests. Each is a single comparison
followed by an error a caller rarely raises, and each costs a call across
a translation unit, which an index pays once per node it visits.

Each is a static inline definition in the header that declares it, so a
caller expands the comparison and keeps the error out of line.

| header | tests |
|---|---|
| `temporal/temporal.h` | `ensure_has_X`, `ensure_has_Z`, `ensure_has_T`, `ensure_common_dimension` |
| `geo/geo_funcs.h` | `ensure_same_srid`, `ensure_same_geodetic` |
| `temporal/span.h` | `ensure_same_span_type`, `ensure_valid_span_span` |

Counting the machine transfers to the eight over the whole library, since
`inline` is a hint and a definition in a header carries no guarantee that
a caller expands it:

| | transfers | `.text` |
|---|---|---|
| master | 268 | 2535502 |
| here | 0 | 2541118 |

Every one of the 268 sites carries the body, none loses it, for 5616
bytes of text, which is 0.22%. `ensure_same_srid` accounts for 93 of
them and reaches 27 files across seven families.