### PR TITLE
Answer what a point cloud schema states without a value of it

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3273,6 +3273,23 @@
 	<sect1>
 		<title>Temporal Point Clouds</title>
 		<sect2>
+			<title>Inicio rápido</title>
+			<sect3>
+				<title>Registrar un esquema</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pointcloud_schema_srid"><varname>pointCloudSchemaSRID</varname></link>: Devuelve el sistema de referencia espacial en el que se expresa todo valor de un esquema</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="pointcloud_schema_compression"><varname>pointCloudSchemaCompression</varname></link>: Devuelve cómo se almacena un parche de un esquema</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="pointcloud_schema_ndims"><varname>pointCloudSchemaNDims</varname></link>: Devuelve cuántas dimensiones de un esquema contienen valores</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+		</sect2>
+		<sect2>
 			<title>Tipos estáticos <varname>pcpoint</varname> y <varname>pcpatch</varname></title>
 			<sect3>
 				<title>Constructores ergonómicos</title>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -42,6 +42,36 @@ INSERT INTO pointcloud_dimensions
 </programlisting>
 			<para>El tamaño de cada dimensión y su desplazamiento dentro de un punto no aparecen porque se derivan de la interpretación, y las dimensiones X, Y, Z y M tampoco porque se resuelven a partir de los nombres. La columna <varname>position</varname> declara el orden en el que se almacenan las dimensiones, de modo que no depende del orden en el que se insertan las filas. Un esquema es global a la base de datos y suele registrarse una sola vez, al cargar los datos; el SRID es por esquema y lo heredan todos los valores que llevan ese <varname>pcid</varname>.</para>
 			<para>Una base de datos cuyos esquemas ya están registrados en el catálogo <varname>pointcloud_formats</varname> de pgPointCloud, como documento XML, sigue funcionando: ese catálogo se lee para un <varname>pcid</varname> que las dos tablas anteriores no declaren.</para>
+			<para>Tres funciones auxiliares responden lo que declara un <varname>pcid</varname> sin disponer de un valor de ese esquema y sin depender de la disposición de las tablas. Cada una responde <varname>NULL</varname> para un <varname>pcid</varname> que ningún esquema declara.</para>
+			<itemizedlist>
+				<listitem xml:id="pointcloud_schema_srid">
+					<indexterm significance="normal"><primary><varname>pointCloudSchemaSRID</varname></primary></indexterm>
+					<para>Devuelve el sistema de referencia espacial en el que se expresa todo valor de un esquema</para>
+					<para><varname>pointCloudSchemaSRID(integer) &#x2192; integer</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pointCloudSchemaSRID(1);
+-- 4326
+</programlisting>
+				</listitem>
+				<listitem xml:id="pointcloud_schema_compression">
+					<indexterm significance="normal"><primary><varname>pointCloudSchemaCompression</varname></primary></indexterm>
+					<para>Devuelve cómo se almacena un parche de un esquema</para>
+					<para><varname>pointCloudSchemaCompression(integer) &#x2192; text</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pointCloudSchemaCompression(1);
+-- none
+</programlisting>
+				</listitem>
+				<listitem xml:id="pointcloud_schema_ndims">
+					<indexterm significance="normal"><primary><varname>pointCloudSchemaNDims</varname></primary></indexterm>
+					<para>Devuelve cuántas dimensiones de un esquema contienen valores</para>
+					<para><varname>pointCloudSchemaNDims(integer) &#x2192; integer</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pointCloudSchemaNDims(1);
+-- 3
+</programlisting>
+				</listitem>
+			</itemizedlist>
 		</sect2>
 
 		<sect2 xml:id="tpointcloud_quickstart_construct">

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3282,6 +3282,23 @@
 	<sect1>
 		<title>Temporal Point Clouds</title>
 		<sect2>
+			<title>Quickstart</title>
+			<sect3>
+				<title>Register a schema</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="pointcloud_schema_srid"><varname>pointCloudSchemaSRID</varname></link>: Return the spatial reference system every value of a schema is expressed in</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="pointcloud_schema_compression"><varname>pointCloudSchemaCompression</varname></link>: Return how a patch of a schema is stored</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="pointcloud_schema_ndims"><varname>pointCloudSchemaNDims</varname></link>: Return how many dimensions of a schema hold values</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+		</sect2>
+		<sect2>
 			<title>Static Types <varname>pcpoint</varname> and <varname>pcpatch</varname></title>
 			<sect3>
 				<title>Ergonomic constructors</title>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -43,6 +43,36 @@ INSERT INTO pointcloud_dimensions
 </programlisting>
 			<para>The size of each dimension and its offset within a point are absent because they follow from the interpretation, and the X, Y, Z and M dimensions are absent because they resolve from the names. The <varname>position</varname> column states the order the dimensions are stored in, so it does not depend on the order the rows are inserted in. A schema is global to the database and usually registered once, at fixture-load time; the SRID is per schema and is inherited by every value carrying that <varname>pcid</varname>.</para>
 			<para>A database whose schemas are already registered in the <varname>pointcloud_formats</varname> catalog of pgPointCloud, as an XML document, keeps working: that catalog is read for a <varname>pcid</varname> that the two tables above do not state.</para>
+			<para>Three helpers answer what a <varname>pcid</varname> names without a value of that schema in hand and without depending on the table layout. Each answers <varname>NULL</varname> for a <varname>pcid</varname> no schema states.</para>
+			<itemizedlist>
+				<listitem xml:id="pointcloud_schema_srid">
+					<indexterm significance="normal"><primary><varname>pointCloudSchemaSRID</varname></primary></indexterm>
+					<para>Return the spatial reference system every value of a schema is expressed in</para>
+					<para><varname>pointCloudSchemaSRID(integer) &#x2192; integer</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pointCloudSchemaSRID(1);
+-- 4326
+</programlisting>
+				</listitem>
+				<listitem xml:id="pointcloud_schema_compression">
+					<indexterm significance="normal"><primary><varname>pointCloudSchemaCompression</varname></primary></indexterm>
+					<para>Return how a patch of a schema is stored</para>
+					<para><varname>pointCloudSchemaCompression(integer) &#x2192; text</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pointCloudSchemaCompression(1);
+-- none
+</programlisting>
+				</listitem>
+				<listitem xml:id="pointcloud_schema_ndims">
+					<indexterm significance="normal"><primary><varname>pointCloudSchemaNDims</varname></primary></indexterm>
+					<para>Return how many dimensions of a schema hold values</para>
+					<para><varname>pointCloudSchemaNDims(integer) &#x2192; integer</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pointCloudSchemaNDims(1);
+-- 3
+</programlisting>
+				</listitem>
+			</itemizedlist>
 		</sect2>
 
 		<sect2 xml:id="tpointcloud_quickstart_construct">

--- a/mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
+++ b/mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
@@ -112,6 +112,30 @@ COMMENT ON COLUMN pointcloud_dimensions.active IS
 COMMENT ON COLUMN pointcloud_dimensions.description IS
   'Free-form description for human readers.';
 
+/* Helper SQL functions that answer what a pcid names without a value of that
+ * schema in hand and without exposing the table layout, as the geopose_frames
+ * registry answers for a frame. They read a table a user may edit, so they are
+ * STABLE rather than IMMUTABLE. */
+
+CREATE FUNCTION pointCloudSchemaSRID(pcid integer) RETURNS integer
+  LANGUAGE SQL STABLE STRICT PARALLEL SAFE
+  AS $$ SELECT srid FROM pointcloud_schemas WHERE pointcloud_schemas.pcid = $1 $$;
+
+CREATE FUNCTION pointCloudSchemaCompression(pcid integer) RETURNS text
+  LANGUAGE SQL STABLE STRICT PARALLEL SAFE
+  AS $$ SELECT compression FROM pointcloud_schemas
+        WHERE pointcloud_schemas.pcid = $1 $$;
+
+/* A pcid no schema names answers NULL, as the other two do; a schema every
+ * dimension of which is inactive answers 0. A bare count over the dimensions
+ * cannot tell those apart, so the count hangs off the schema row. */
+CREATE FUNCTION pointCloudSchemaNDims(pcid integer) RETURNS integer
+  LANGUAGE SQL STABLE STRICT PARALLEL SAFE
+  AS $$ SELECT count(d.pcid)::integer FROM pointcloud_schemas s
+        LEFT JOIN pointcloud_dimensions d
+          ON d.pcid = s.pcid AND d.active
+        WHERE s.pcid = $1 GROUP BY s.pcid $$;
+
 /* Mark both catalogs as configuration tables so that pg_dump preserves the
  * schemas a user registers, as the geopose_frames registry does. */
 SELECT pg_catalog.pg_extension_config_dump('pointcloud_schemas', '');

--- a/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
+++ b/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
@@ -34,6 +34,40 @@ INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
   (91, 1, 'X', 'double');
 ERROR:  insert or update on table "pointcloud_dimensions" violates foreign key constraint "pointcloud_dimensions_pcid_fkey"
 DETAIL:  Key (pcid)=(91) is not present in table "pointcloud_schemas".
+SELECT pointCloudSchemaSRID(90), pointCloudSchemaCompression(90),
+  pointCloudSchemaNDims(90);
+ pointcloudschemasrid | pointcloudschemacompression | pointcloudschemandims 
+----------------------+-----------------------------+-----------------------
+                 4326 | none                        |                     3
+(1 row)
+
+UPDATE pointcloud_schemas SET compression = 'dimensional' WHERE pcid = 90;
+UPDATE 1
+SELECT pointCloudSchemaCompression(90);
+ pointcloudschemacompression 
+-----------------------------
+ dimensional
+(1 row)
+
+UPDATE pointcloud_schemas SET compression = 'none' WHERE pcid = 90;
+UPDATE 1
+UPDATE pointcloud_dimensions SET active = false WHERE pcid = 90 AND position = 3;
+UPDATE 1
+SELECT pointCloudSchemaNDims(90);
+ pointcloudschemandims 
+-----------------------
+                     2
+(1 row)
+
+UPDATE pointcloud_dimensions SET active = true WHERE pcid = 90 AND position = 3;
+UPDATE 1
+SELECT pointCloudSchemaSRID(999) IS NULL AS unknown_srid,
+  pointCloudSchemaNDims(999) AS unknown_ndims;
+ unknown_srid | unknown_ndims 
+--------------+---------------
+ t            |              
+(1 row)
+
 DELETE FROM pointcloud_schemas WHERE pcid = 90;
 DELETE 1
 SELECT count(*) FROM pointcloud_dimensions WHERE pcid = 90;

--- a/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
+++ b/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
@@ -55,6 +55,24 @@ INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
 INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
   (91, 1, 'X', 'double');
 
+-- What a pcid names is answered without a value of that schema in hand
+SELECT pointCloudSchemaSRID(90), pointCloudSchemaCompression(90),
+  pointCloudSchemaNDims(90);
+
+-- The lookups answer what the rows state, so an edit is seen
+UPDATE pointcloud_schemas SET compression = 'dimensional' WHERE pcid = 90;
+SELECT pointCloudSchemaCompression(90);
+UPDATE pointcloud_schemas SET compression = 'none' WHERE pcid = 90;
+
+-- A dimension that holds no value is not counted
+UPDATE pointcloud_dimensions SET active = false WHERE pcid = 90 AND position = 3;
+SELECT pointCloudSchemaNDims(90);
+UPDATE pointcloud_dimensions SET active = true WHERE pcid = 90 AND position = 3;
+
+-- An unregistered pcid answers NULL rather than erroring
+SELECT pointCloudSchemaSRID(999) IS NULL AS unknown_srid,
+  pointCloudSchemaNDims(999) AS unknown_ndims;
+
 -- The dimensions of a schema go when the schema goes
 DELETE FROM pointcloud_schemas WHERE pcid = 90;
 SELECT count(*) FROM pointcloud_dimensions WHERE pcid = 90;


### PR DESCRIPTION
pointCloudSchemaSRID, pointCloudSchemaCompression and pointCloudSchemaNDims answer what the schema a pcid names states, so a caller reaches it without a value of that schema in hand and without depending on the layout of pointcloud_schemas and pointcloud_dimensions, as geoPoseFrameSRID answers for a frame. The three read tables a user may edit, so they are STABLE. A pcid no schema states answers NULL in all three: the dimension count hangs off the schema row rather than counting dimensions alone, which would report a schema that does not exist and one whose every dimension is inactive alike as zero. Both manuals state the three and the reference appendix projects them.
