### PR TITLE
Cluster geometries through the native engine in every build

### DIFF
--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1595,16 +1595,10 @@ geo_cluster_dbscan(const GSERIALIZED **geoms, uint32_t ngeoms,
   for (i = 0; i < ngeoms; i++)
     lwgeoms[i] = lwgeom_from_gserialized(geoms[i]);
 
-  bool success =
-#if GEOS
-    union_dbscan(lwgeoms, ngeoms, uf, tolerance, minpoints,
-      minpoints > 1 ? &is_in_cluster : NULL);
-#else
-    /* The clustering of liblwgeom reaches GEOS only for the index narrowing
-     * the pairs whose distance it computes, which the bounding boxes answer */
-    geo_union_dbscan(lwgeoms, ngeoms, uf, tolerance, (uint32_t) minpoints,
-      minpoints > 1 ? &is_in_cluster : NULL);
-#endif /* GEOS */
+  /* The clustering of liblwgeom reaches GEOS only for the index narrowing
+   * the pairs whose distance it computes, which the bounding boxes answer */
+  bool success = geo_union_dbscan(lwgeoms, ngeoms, uf, tolerance,
+    (uint32_t) minpoints, minpoints > 1 ? &is_in_cluster : NULL);
 
   for (i = 0; i < ngeoms; i++)
     lwgeom_free(lwgeoms[i]);
@@ -1654,96 +1648,38 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
 
   /* TODO short-circuit for one element? */
 
-#if ! GEOS
   /* The clustering of liblwgeom reaches GEOS for the index narrowing the pairs
    * whose intersection it asks about, and for the predicate itself. The
    * bounding boxes answer the narrowing and the native engine answers the
-   * predicate, so a build carrying no GEOS clusters as well as one that does */
+   * predicate */
+  int32_t srid = gserialized_get_srid(geoms[0]);
+  for (i = 1; i < ngeoms; i++)
+    if (! ensure_same_srid(srid, gserialized_get_srid(geoms[i])))
+      return NULL;
+
   LWGEOM **lwgeoms = palloc(ngeoms * sizeof(LWGEOM *));
   for (i = 0; i < ngeoms; i++)
     lwgeoms[i] = lwgeom_from_gserialized(geoms[i]);
   LWGEOM **lw_results;
-  uint32_t nclusters_n;
+  uint32_t nclusters;
   bool ok = geo_cluster_intersecting_geoms(lwgeoms, ngeoms, &lw_results,
-    &nclusters_n);
+    &nclusters);
   /* The collections take ownership of the geometries they are built from */
   pfree(lwgeoms);
   if (! ok)
   {
-    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
-      "The clustering of geometries the native engine does not cover is "
-      "answered by the GEOS library, which this build excludes: configure "
-      "with -DGEOS=ON");
+    meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR, "Error during clustering");
     return NULL;
   }
-  GSERIALIZED **res_n = palloc(nclusters_n * sizeof(GSERIALIZED *));
-  for (i = 0; i < nclusters_n; i++)
+  GSERIALIZED **result = palloc(nclusters * sizeof(GSERIALIZED *));
+  for (i = 0; i < nclusters; i++)
   {
-    res_n[i] = geo_serialize(lw_results[i]);
+    result[i] = geo_serialize(lw_results[i]);
     lwgeom_free(lw_results[i]);
   }
   lwfree(lw_results);
-  *count = (int) nclusters_n;
-  return res_n;
-#else
-  int is3d = 0;
-  uint32_t nclusters, j;
-  int32_t srid = SRID_UNKNOWN;
-  bool gotsrid = false;
-
-  /* Ok, we really need geos now ;) */
-  GEOSContextHandle_t ctx = geos_get_context();
-  GEOSGeometry **geos_inputs = palloc(ngeoms * sizeof(GEOSGeometry *));
-  for (i = 0; i < ngeoms; i++)
-  {
-    is3d = is3d || gserialized_has_z(geoms[i]);
-    geos_inputs[i] = POSTGIS2GEOS(geoms[i]);
-    if (! geos_inputs[i])
-    {
-      lwerror("Geometry could not be converted to GEOS");
-      for (j = 0; j < i; j++)
-        GEOSGeom_destroy_r(ctx, geos_inputs[j]);
-      return NULL;
-    }
-
-    if (! gotsrid)
-    {
-      srid = gserialized_get_srid(geoms[i]);
-      gotsrid = true;
-    }
-    else if (! ensure_same_srid(srid, gserialized_get_srid(geoms[i])))
-    {
-      for (j = 0; j <= i; j++)
-        GEOSGeom_destroy_r(ctx, geos_inputs[j]);
-      return NULL;
-    }
-  }
-
-  /* Perform the clustering */
-  GEOSGeometry **geos_results;
-  if (cluster_intersecting(geos_inputs, ngeoms, &geos_results, &nclusters) !=
-    LW_SUCCESS)
-  {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
-      "clusterintersecting: Error performing clustering");
-    return NULL;
-  }
-  /* Don't need to destroy items because GeometryCollections have taken ownership */
-  pfree(geos_inputs);
-
-  if (!geos_results)
-    return NULL;
-
-  GSERIALIZED **result = palloc(nclusters * sizeof(GSERIALIZED *));
-  for (i = 0; i < nclusters; ++i)
-  {
-    result[i] = GEOS2POSTGIS(geos_results[i], is3d);
-    GEOSGeom_destroy_r(ctx, geos_results[i]);
-  }
-  lwfree(geos_results);
-  *count = nclusters;
+  *count = (int) nclusters;
   return result;
-#endif /* ! GEOS */
 }
 
 /**
@@ -1783,13 +1719,8 @@ geo_cluster_within(const GSERIALIZED **geoms, uint32_t ngeoms,
   LWGEOM **lw_results;
   uint32_t nclusters;
   bool success =
-#if GEOS
-    cluster_within_distance(lwgeoms, ngeoms, tolerance, &lw_results,
-      &nclusters);
-#else
     geo_cluster_within_distance(lwgeoms, ngeoms, tolerance, &lw_results,
       &nclusters);
-#endif /* GEOS */
   /* don't need to destroy items because GeometryCollections have taken ownership */
   pfree(lwgeoms);
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -526,6 +526,46 @@ int main(void)
   assert(meos_errno() != 0);
   meos_errno_reset();
 
+  /* The clustering entries partition an array of geometries: the three points
+   * about the origin and the line string joining two of them meet, the far
+   * point stands alone, and a member carrying another SRID is refused */
+  meos_errno_reset();
+  const GSERIALIZED *cl[4];
+  cl[0] = geom_in("SRID=4326;Point(0 0)", -1);
+  cl[1] = geom_in("SRID=4326;Point(1 1)", -1);
+  cl[2] = geom_in("SRID=4326;Linestring(0 0,1 1)", -1);
+  cl[3] = geom_in("SRID=4326;Point(50 50)", -1);
+  int nclusters = 0;
+  GSERIALIZED **clusters = geo_cluster_intersecting(cl, 4, &nclusters);
+  printf("clusterIntersecting of 4 geometries: %d clusters, errno %d\n",
+    nclusters, meos_errno());
+  assert(clusters != NULL);
+  assert(nclusters == 2);
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+
+  /* The same array within a distance reaching every member is one cluster */
+  int nwithin = 0;
+  GSERIALIZED **within = geo_cluster_within(cl, 4, 100.0, &nwithin);
+  printf("clusterWithin of the same 4 at distance 100: %d cluster(s)\n",
+    nwithin);
+  assert(within != NULL);
+  assert(nwithin == 1);
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+
+  /* Clustering geometries of different SRIDs is an error */
+  const GSERIALIZED *mixed[2];
+  mixed[0] = geom_in("SRID=4326;Point(0 0)", -1);
+  mixed[1] = geom_in("SRID=3812;Point(0 1)", -1);
+  int nmixed = 0;
+  GSERIALIZED **bad = geo_cluster_intersecting(mixed, 2, &nmixed);
+  printf("clusterIntersecting on mixed SRID: %s, errno %d\n",
+    bad ? "non-NULL" : "NULL", meos_errno());
+  assert(bad == NULL);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
The three clustering entries carry two implementations and select between
them on whether the build links GEOS, so the native one answers a build
configured without it and the library a user installs reaches the other.

Each entry calls the native implementation, which narrows the pairs
through their bounding boxes and asks the engine for the distance or the
intersection.

| entry | native implementation |
|---|---|
| `geo_cluster_dbscan` | `geo_union_dbscan` |
| `geo_cluster_intersecting` | `geo_cluster_intersecting_geoms` |
| `geo_cluster_within` | `geo_cluster_within_distance` |

The clustering of an array whose members carry different SRIDs raises the
error a mixed SRID calls for, which the native path of the intersecting
entry does not perform on its own.

Both implementations answer the same partition of 24 points, line strings
and polygons: 28 tolerance and minimum-point settings of dbscan, 7
tolerances of the within-distance entry, and the intersecting entry, over
a build linking GEOS and a build configured without it.

The three entries reach no SQL surface, so the MEOS test suite carries the
witness: the partition of four geometries, the single cluster a distance
reaching all of them answers, and the error a mixed SRID raises. Removing
the SRID test from the entry ends that binary on its assertion.