### PR TITLE
State the GeoPose frames in MEOS and seed the registry from them

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1608,6 +1608,9 @@
 				<title>Registro de metadatos de marcos</title>
 				<itemizedlist>
 					<listitem>
+						<para><link linkend="pose_geopose_frames_fn"><varname>geoPoseFrames</varname></link>: Devuelve todos los marcos que nombran el estándar y los codificadores</para>
+					</listitem>
+					<listitem>
 						<para><link linkend="pose_geopose_frame_srid"><varname>geoPoseFrameSRID</varname></link>: Devuelve el SRID de un marco, o <varname>NULL</varname> si el marco es paramétrico (LTP, BODY)</para>
 					</listitem>
 					<listitem>

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -1477,7 +1477,19 @@ FROM geopose_frames ORDER BY frame_id;
 -- 7 | /geopose/1.0 | /Extrinsic/LTP-ENU          | GeoPose outer frame of a Chain                     | f
 -- 8 | /geopose/1.0 | /Intrinsic/Translate-Rotate | GeoPose inner frame of a Chain                     | f
 </programlisting>
-			<para>Tres funciones auxiliares SQL proporcionan una interfaz de consulta estable que es independiente de la disposición de la tabla:</para>
+			<para>Las filas anteriores provienen de MEOS, que las construye a partir de los identificadores que escriben los codificadores, de modo que un marco que esta compilación puede emitir nunca falta en el catálogo. Un usuario registra marcos adicionales insertándolos en la tabla.</para>
+			<itemizedlist>
+				<listitem xml:id="pose_geopose_frames_fn">
+					<indexterm significance="normal"><primary><varname>geoPoseFrames</varname></primary></indexterm>
+					<para>Devuelve todos los marcos que nombran el estándar y los codificadores</para>
+					<para><varname>geoPoseFrames() &#x2192; setof record</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT count(*) FROM geoPoseFrames();
+-- 8
+</programlisting>
+				</listitem>
+			</itemizedlist>
+			<para>Tres funciones auxiliares SQL proporcionan una interfaz de consulta estable que es independiente de la disposición de la tabla, y leen la tabla para que también se encuentre un marco que registre un usuario:</para>
 			<itemizedlist>
 				<listitem xml:id="pose_geopose_frame_srid">
 					<indexterm significance="normal"><primary><varname>geoPoseFrameSRID</varname></primary></indexterm>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1611,6 +1611,9 @@
 				<title>Frame Metadata Registry</title>
 				<itemizedlist>
 					<listitem>
+						<para><link linkend="pose_geopose_frames_fn"><varname>geoPoseFrames</varname></link>: Return every frame the standard and the encoders name</para>
+					</listitem>
+					<listitem>
 						<para><link linkend="pose_geopose_frame_srid"><varname>geoPoseFrameSRID</varname></link>: Return the SRID for a frame, or <varname>NULL</varname> if the frame is parametric (LTP, BODY)</para>
 					</listitem>
 					<listitem>

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -1495,7 +1495,19 @@ FROM geopose_frames ORDER BY frame_id;
 -- 7 | /geopose/1.0 | /Extrinsic/LTP-ENU          | GeoPose outer frame of a Chain                     | f
 -- 8 | /geopose/1.0 | /Intrinsic/Translate-Rotate | GeoPose inner frame of a Chain                     | f
 </programlisting>
-			<para>Three SQL helpers provide a stable lookup interface that is independent of the table layout:</para>
+			<para>The rows above come from MEOS, which builds them from the identifiers the encoders write, so a frame this build can emit is never absent from the registry. A user registers further frames by inserting into the table.</para>
+			<itemizedlist>
+				<listitem xml:id="pose_geopose_frames_fn">
+					<indexterm significance="normal"><primary><varname>geoPoseFrames</varname></primary></indexterm>
+					<para>Return every frame the standard and the encoders name</para>
+					<para><varname>geoPoseFrames() &#x2192; setof record</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT count(*) FROM geoPoseFrames();
+-- 8
+</programlisting>
+				</listitem>
+			</itemizedlist>
+			<para>Three SQL helpers provide a stable lookup interface that is independent of the table layout, and read the table so that a frame a user registers is found too:</para>
 			<itemizedlist>
 				<listitem xml:id="pose_geopose_frame_srid">
 					<indexterm significance="normal"><primary><varname>geoPoseFrameSRID</varname></primary></indexterm>

--- a/meos/include/meos_pose.h
+++ b/meos/include/meos_pose.h
@@ -117,6 +117,25 @@ extern char *tpose_as_geopose(const Temporal *temp, int conformance, int precisi
 extern char *tpose_as_geopose_stream_header(const Temporal *temp, int precision);
 extern char *tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst, int precision);
 extern char *tpose_as_geopose_stream(const Temporal *temp, int precision);
+
+/**
+ * @brief One frame of the OGC GeoPose registry, as the standard names it
+ * @details A frame whose position depends on a runtime anchor states no
+ * spatial reference system, and carries @p srid 0 for it.
+ */
+typedef struct
+{
+  int32_t frame_id;       /**< Stable key the registry states the frame under */
+  const char *authority;  /**< Naming authority: EPSG, OGC or /geopose/1.0 */
+  const char *code;       /**< Identifier the authority names the frame by */
+  const char *name;       /**< Human-readable frame name */
+  int32_t srid;           /**< Spatial reference system, 0 where parametric */
+  bool is_geographic;     /**< True for a lat/lon/h frame */
+  const char *description;/**< Free-form description for human readers */
+} GeoPoseFrame;
+
+extern const GeoPoseFrame *geopose_frames(int *count);
+extern const GeoPoseFrame *geopose_frame(int32_t frame_id);
 extern GSERIALIZED *pose_apply_geo(const Pose *pose, const GSERIALIZED *body);
 extern Temporal *tpose_apply_geo(const Temporal *temp, const GSERIALIZED *body);
 extern Temporal *tpose_compose_pose(const Temporal *body, const Pose *frame);

--- a/meos/include/pose/doxygen_meos_pose.h
+++ b/meos/include/pose/doxygen_meos_pose.h
@@ -118,8 +118,9 @@
  * @ingroup meos_pose_base
  * @brief Functions implementing the OGC GeoPose v1.0 standard surface for
  * static poses — JSON I/O for the Basic conformance classes, quaternion
- * renormalization, and Euler-angle (yaw / pitch / roll) accessors using
- * the ZYX intrinsic Tait-Bryan convention required by the standard.
+ * renormalization, Euler-angle (yaw / pitch / roll) accessors using
+ * the ZYX intrinsic Tait-Bryan convention required by the standard, and the
+ * registry of the frames a document names.
  */
 
 /*****************************************************************************/

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -144,6 +144,88 @@
 #define GEOPOSE_ID_CHAIN_OUTER_FRAME  "/Extrinsic/LTP-ENU"
 #define GEOPOSE_ID_CHAIN_INNER_FRAME  "/Intrinsic/Translate-Rotate"
 
+/*****************************************************************************
+ * The frame registry
+ *****************************************************************************/
+
+/**
+ * @brief Every frame an encoder in this file names, and the two systems the
+ * Basic classes rest on
+ * @details The four rows under #GEOPOSE_AUTHORITY take their identifiers from
+ * the very macros the encoders write, so a frame this file learns to emit
+ * cannot be absent here, and a host that materialises the registry as a table
+ * states what the documents state.
+ */
+static const GeoPoseFrame GEOPOSE_FRAME_REGISTRY[] =
+{
+  { 1, "EPSG", "4326", "WGS-84 geographic (lat/lon/h)", 4326, true,
+    "OGC GeoPose Basic-class default outer frame. Position parsed as "
+    "{lat, lon, h} in degrees / metres." },
+  { 2, "EPSG", "4978", "WGS-84 ECEF (Earth-Centred Earth-Fixed)", 4978, false,
+    "Cartesian X/Y/Z geocentric. Used as an intermediate by frame transforms; "
+    "rotation between this frame and WGS-84 geographic at point P is given by "
+    "the East-North-Up basis at P." },
+  { 3, "OGC", "LTP", "Local Tangent Plane (East-North-Up)", 0, false,
+    "Parameterised at runtime by an anchor (lat, lon, h). The outer-frame "
+    "conversion to ECEF is the standard ENU rotation matrix at the anchor." },
+  { 4, "OGC", "BODY", "Right-handed body axes (default inner frame)", 0, false,
+    "Conventional inner frame: X forward, Y left, Z up. The pose's quaternion "
+    "takes vectors from this body frame to the outer frame." },
+  { 5, GEOPOSE_AUTHORITY, GEOPOSE_ID_OUTER_FRAME,
+    "GeoPose outer frame of a Composite Sequence Series", 0, false,
+    "Authority and id emitted as the outerFrame of a Series. Parameterised by "
+    "the tangent point of the first pose as "
+    "'longitude=<degrees>&latitude=<degrees>&height=<metres>'." },
+  { 6, GEOPOSE_AUTHORITY, GEOPOSE_ID_INNER_FRAME,
+    "GeoPose inner frame of a Composite Sequence Series", 0, false,
+    "Authority and id emitted for each inner frame of a Series. Parameterised "
+    "as 'translation=[e, n, u]&rotation=[w, x, y, z]', the translation in "
+    "metres in the outer frame and the rotation taking body axes to the outer "
+    "frame." },
+  { 7, GEOPOSE_AUTHORITY, GEOPOSE_ID_CHAIN_OUTER_FRAME,
+    "GeoPose outer frame of a Chain", 0, false,
+    "The frame a Chain document names where a Series names 'LTP-ENU'. Same "
+    "frame, same authority, the name its own class uses; a Chain is read "
+    "accepting either." },
+  { 8, GEOPOSE_AUTHORITY, GEOPOSE_ID_CHAIN_INNER_FRAME,
+    "GeoPose inner frame of a Chain", 0, false,
+    "The frame a Chain document names where a Series names 'RotateTranslate'. "
+    "Same frame, same authority, the name its own class uses; a Chain is read "
+    "accepting either." }
+};
+
+/**
+ * @ingroup meos_pose_base_geopose
+ * @brief Return every frame of the OGC GeoPose registry
+ * @param[out] count Number of frames returned
+ * @csqlfn #Geopose_frames()
+ */
+const GeoPoseFrame *
+geopose_frames(int *count)
+{
+  VALIDATE_NOT_NULL(count, NULL);
+  *count = (int) (sizeof(GEOPOSE_FRAME_REGISTRY) /
+    sizeof(GEOPOSE_FRAME_REGISTRY[0]));
+  return GEOPOSE_FRAME_REGISTRY;
+}
+
+/**
+ * @ingroup meos_pose_base_geopose
+ * @brief Return the frame the registry states under an identifier, or `NULL`
+ * where it states none
+ * @param[in] frame_id Identifier of the frame
+ */
+const GeoPoseFrame *
+geopose_frame(int32_t frame_id)
+{
+  int count = (int) (sizeof(GEOPOSE_FRAME_REGISTRY) /
+    sizeof(GEOPOSE_FRAME_REGISTRY[0]));
+  for (int i = 0; i < count; i++)
+    if (GEOPOSE_FRAME_REGISTRY[i].frame_id == frame_id)
+      return &GEOPOSE_FRAME_REGISTRY[i];
+  return NULL;
+}
+
 /**
  * @brief Return true if @p srid names the WGS-84 geographic frame the
  * GeoPose classes require, or is unknown.

--- a/mobilitydb/sql/pose/120_geopose_frames.in.sql
+++ b/mobilitydb/sql/pose/120_geopose_frames.in.sql
@@ -73,23 +73,21 @@ COMMENT ON COLUMN geopose_frames.name       IS 'Human-readable frame name.';
 COMMENT ON COLUMN geopose_frames.srid       IS 'PostGIS SRID, or NULL if the frame is parametric (e.g., LTP at runtime).';
 COMMENT ON COLUMN geopose_frames.is_geographic IS 'TRUE for lat/lon/h frames, FALSE for Cartesian / projected.';
 
-INSERT INTO geopose_frames(frame_id, authority, code, name, srid, is_geographic, description) VALUES
-  (1, 'EPSG', '4326', 'WGS-84 geographic (lat/lon/h)', 4326, true,
-     'OGC GeoPose Basic-class default outer frame. Position parsed as {lat, lon, h} in degrees / metres.'),
-  (2, 'EPSG', '4978', 'WGS-84 ECEF (Earth-Centred Earth-Fixed)', 4978, false,
-     'Cartesian X/Y/Z geocentric. Used as an intermediate by frame transforms; rotation between this frame and WGS-84 geographic at point P is given by the East-North-Up basis at P.'),
-  (3, 'OGC',  'LTP',  'Local Tangent Plane (East-North-Up)', NULL, false,
-     'Parameterised at runtime by an anchor (lat, lon, h). The outer-frame conversion to ECEF is the standard ENU rotation matrix at the anchor.'),
-  (4, 'OGC',  'BODY', 'Right-handed body axes (default inner frame)', NULL, false,
-     'Conventional inner frame: X forward, Y left, Z up. The pose''s quaternion takes vectors from this body frame to the outer frame.'),
-  (5, '/geopose/1.0', 'LTP-ENU', 'GeoPose outer frame of a Composite Sequence Series', NULL, false,
-     'Authority and id emitted as the outerFrame of a Series. Parameterised by the tangent point of the first pose as ''longitude=<degrees>&latitude=<degrees>&height=<metres>''.'),
-  (6, '/geopose/1.0', 'RotateTranslate', 'GeoPose inner frame of a Composite Sequence Series', NULL, false,
-     'Authority and id emitted for each inner frame of a Series. Parameterised as ''translation=[e, n, u]&rotation=[w, x, y, z]'', the translation in metres in the outer frame and the rotation taking body axes to the outer frame.'),
-  (7, '/geopose/1.0', '/Extrinsic/LTP-ENU', 'GeoPose outer frame of a Chain', NULL, false,
-     'The frame a Chain document names where a Series names ''LTP-ENU''. Same frame, same authority, the name its own class uses; a Chain is read accepting either.'),
-  (8, '/geopose/1.0', '/Intrinsic/Translate-Rotate', 'GeoPose inner frame of a Chain', NULL, false,
-     'The frame a Chain document names where a Series names ''RotateTranslate''. Same frame, same authority, the name its own class uses; a Chain is read accepting either.');
+/* The frames the standard and the encoders name come from MEOS, which builds
+ * them from the very macros pose_geopose.c writes, so a frame this build can
+ * emit cannot be absent from the registry. A user registers further frames by
+ * inserting into the table. */
+
+CREATE FUNCTION geoPoseFrames()
+  RETURNS TABLE (frame_id integer, authority text, code text, name text,
+                 srid integer, is_geographic boolean, description text)
+  AS 'MODULE_PATHNAME', 'Geopose_frames'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+INSERT INTO geopose_frames(frame_id, authority, code, name, srid,
+  is_geographic, description)
+SELECT frame_id, authority, code, name, srid, is_geographic, description
+FROM geoPoseFrames();
 
 /* Helper SQL functions to query the registry without exposing the schema. */
 

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -335,6 +335,58 @@ Pose_from_geopose(PG_FUNCTION_ARGS)
   PG_RETURN_POSE_P(result);
 }
 
+PGDLLEXPORT Datum Geopose_frames(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Geopose_frames);
+/**
+ * @ingroup mobilitydb_pose_base_inout
+ * @brief Set-returning function emitting one row per frame of the OGC GeoPose
+ *   registry
+ * @details The rows come from MEOS, which builds them from the very macros the
+ * encoders write, so the table this function seeds states what the documents
+ * state.
+ * @sqlfn geoPoseFrames()
+ */
+Datum
+Geopose_frames(PG_FUNCTION_ARGS)
+{
+  FuncCallContext *funcctx;
+
+  if (SRF_IS_FIRSTCALL())
+  {
+    funcctx = SRF_FIRSTCALL_INIT();
+    MemoryContext oldctx = MemoryContextSwitchTo(
+      funcctx->multi_call_memory_ctx);
+    int count;
+    funcctx->user_fctx = (void *) geopose_frames(&count);
+    funcctx->max_calls = (uint64) count;
+    get_call_result_type(fcinfo, 0, &funcctx->tuple_desc);
+    BlessTupleDesc(funcctx->tuple_desc);
+    MemoryContextSwitchTo(oldctx);
+  }
+
+  funcctx = SRF_PERCALL_SETUP();
+  if (funcctx->call_cntr >= funcctx->max_calls)
+    SRF_RETURN_DONE(funcctx);
+
+  const GeoPoseFrame *frames = (const GeoPoseFrame *) funcctx->user_fctx;
+  const GeoPoseFrame *f = &frames[funcctx->call_cntr];
+  Datum values[7];
+  bool isnull[7] = {false, false, false, false, false, false, false};
+  values[0] = Int32GetDatum(f->frame_id);
+  values[1] = PointerGetDatum(cstring_to_text(f->authority));
+  values[2] = PointerGetDatum(cstring_to_text(f->code));
+  values[3] = PointerGetDatum(cstring_to_text(f->name));
+  /* A frame parameterised at runtime states no reference system */
+  if (f->srid == 0)
+    isnull[4] = true;
+  else
+    values[4] = Int32GetDatum(f->srid);
+  values[5] = BoolGetDatum(f->is_geographic);
+  values[6] = PointerGetDatum(cstring_to_text(f->description));
+  HeapTuple tuple = heap_form_tuple(funcctx->tuple_desc, values, isnull);
+  SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+}
+
 PGDLLEXPORT Datum Pose_as_geopose(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Pose_as_geopose);
 /**

--- a/mobilitydb/test/pose/expected/107_geopose_frames.test.out
+++ b/mobilitydb/test/pose/expected/107_geopose_frames.test.out
@@ -47,6 +47,17 @@ SELECT count(*) FROM geopose_frames;
      8
 (1 row)
 
+SELECT count(*) AS meos_frames_absent_from_the_table FROM (
+  SELECT frame_id, authority, code, name, srid, is_geographic
+  FROM geoPoseFrames()
+  EXCEPT
+  SELECT frame_id, authority, code, name, srid, is_geographic
+  FROM geopose_frames) d;
+ meos_frames_absent_from_the_table 
+-----------------------------------
+                                 0
+(1 row)
+
 INSERT INTO geopose_frames(frame_id, authority, name) VALUES (0, 'CUSTOM', 'Zero');
 ERROR:  new row for relation "geopose_frames" violates check constraint "geopose_frames_frame_id_check"
 DETAIL:  Failing row contains (0, CUSTOM, null, Zero, null, f, null).

--- a/mobilitydb/test/pose/queries/107_geopose_frames.test.sql
+++ b/mobilitydb/test/pose/queries/107_geopose_frames.test.sql
@@ -36,6 +36,16 @@ SELECT geoPoseFrameSRID(1000), geoPoseFrameName(1000);
 DELETE FROM geopose_frames WHERE frame_id = 1000;
 SELECT count(*) FROM geopose_frames;
 
+-- Every frame MEOS states is in the table, so a host that materialises the
+-- registry from geoPoseFrames() states what this database states. The reverse
+-- direction is deliberately not asserted: a user registers further frames.
+SELECT count(*) AS meos_frames_absent_from_the_table FROM (
+  SELECT frame_id, authority, code, name, srid, is_geographic
+  FROM geoPoseFrames()
+  EXCEPT
+  SELECT frame_id, authority, code, name, srid, is_geographic
+  FROM geopose_frames) d;
+
 -- A frame is stated from one. (103_pose_geopose asserts that the registry
 -- states every authority and id pair the encoder emits.)
 INSERT INTO geopose_frames(frame_id, authority, name) VALUES (0, 'CUSTOM', 'Zero');

--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -667,6 +667,10 @@ TPOSE_CONFIG = dict(
     type_label="tpose       ",
     header="meos_pose.h",
     out="tpose_smoketest.c",
+    # Both read the static GeoPose frame registry and return a pointer into
+    # it, so the caller frees nothing, as for route_geom's view of the ways
+    # cache.
+    no_free={"geopose_frames", "geopose_frame"},
     extra_includes='#include <meos_pose.h>',
     arg_map={
         "Temporal *":          "tpose1",


### PR DESCRIPTION
geopose_frames() and geopose_frame() state every frame of the OGC GeoPose registry on the MEOS surface, so a binding that reaches no PostgreSQL catalog materialises the registry in its own host, as it materialises a point cloud schema. The four rows under the /geopose/1.0 authority take their identifiers from the very macros the encoders in pose_geopose.c write, so a frame this build can emit cannot be absent from the registry. The geopose_frames table is seeded from geoPoseFrames() rather than from a second statement of the same frames, and 107_geopose_frames asserts that every frame MEOS states is in the table. The reverse direction is left unasserted because a user registers further frames by inserting into the table. The three lookups read a table a user may edit, so they are STABLE rather than IMMUTABLE, which is what PostgreSQL requires of a function that reads the database. Both manuals state geoPoseFrames and where the seeded rows come from, and the reference appendix projects it.
