### PR TITLE
Name the two vector tile and clip wrappers after the function they implement

### DIFF
--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -2020,7 +2020,7 @@ tpoint_decouple(const Temporal *temp, int64 **timesarr, int *count)
  * @param[in] clip_geom True when the geometry is clipped
  * @return Structure with the geometry, the parallel array of timestamps,
  * and the number of timestamps
- * @csqlfn #Tpoint_AsMVTGeom()
+ * @csqlfn #AsMVTGeom()
  */
 MvtGeom
 tpoint_as_mvtgeom(const Temporal *temp, const STBox *bounds, int32_t extent,

--- a/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
@@ -391,7 +391,7 @@ CREATE FUNCTION _mdb_internal_clip_difference(geometry, geometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION _mdb_internal_clip_sym_difference(geometry, geometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'cl_symDifference'
+  AS 'MODULE_PATHNAME', 'symDifference'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 

--- a/mobilitydb/sql/geo/076_tgeo_analytics.in.sql
+++ b/mobilitydb/sql/geo/076_tgeo_analytics.in.sql
@@ -143,7 +143,7 @@ LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- CREATE FUNCTION asMVTGeom(tgeo tgeometry, bounds stbox,
   -- extent integer DEFAULT 4096, buffer integer DEFAULT 256, clip boolean DEFAULT TRUE)
 -- RETURNS geom_times
--- AS 'MODULE_PATHNAME','Tgeo_AsMVTGeom'
+-- AS 'MODULE_PATHNAME','AsMVTGeom'
 -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/

--- a/mobilitydb/sql/geo/076_tpoint_analytics.in.sql
+++ b/mobilitydb/sql/geo/076_tpoint_analytics.in.sql
@@ -207,7 +207,7 @@ CREATE FUNCTION asMVTGeom(tpoint tgeompoint, bounds stbox,
   extent integer DEFAULT 4096, buffer integer DEFAULT 256, clip boolean DEFAULT TRUE)
 -- RETURNS tgeompoint
 RETURNS geom_times
-AS 'MODULE_PATHNAME','Tpoint_AsMVTGeom'
+AS 'MODULE_PATHNAME','AsMVTGeom'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/

--- a/mobilitydb/src/geo/tgeo_spatialfuncs.c
+++ b/mobilitydb/src/geo/tgeo_spatialfuncs.c
@@ -337,8 +337,8 @@ Tgeo_scale(PG_FUNCTION_ARGS)
  * Mapbox Vector Tile functions for temporal points
  *****************************************************************************/
 
-PGDLLEXPORT Datum Tpoint_AsMVTGeom(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tpoint_AsMVTGeom);
+PGDLLEXPORT Datum AsMVTGeom(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(AsMVTGeom);
 /**
  * @ingroup mobilitydb_geo_transf
  * @brief Return a temporal point transformed to the Mapbox Vector Tile
@@ -346,7 +346,7 @@ PG_FUNCTION_INFO_V1(Tpoint_AsMVTGeom);
  * @sqlfn asMVTGeom()
  */
 Datum
-Tpoint_AsMVTGeom(PG_FUNCTION_ARGS)
+AsMVTGeom(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   STBox *bounds = PG_GETARG_STBOX_P(1);
@@ -925,9 +925,9 @@ cl_difference(PG_FUNCTION_ARGS)
   return clip_ext(fcinfo, CL_DIFFERENCE);
 }
 
-PG_FUNCTION_INFO_V1(cl_symDifference);
+PG_FUNCTION_INFO_V1(symDifference);
 Datum
-cl_symDifference(PG_FUNCTION_ARGS)
+symDifference(PG_FUNCTION_ARGS)
 {
   return clip_ext(fcinfo, CL_XOR);
 }


### PR DESCRIPTION
The Mapbox Vector Tile wrapper is AsMVTGeom and the symmetric difference clip wrapper is symDifference, each carrying the name of the SQL function it stands behind rather than a type or library prefix. The commented declaration of the temporal geometry overload names AsMVTGeom as well, so both sites reach the one implementation the file holds. The SQL surface is unchanged: asMVTGeom and the clip function answer as they do, which the clipping test records byte for byte.