### PR TITLE
Validate the arguments of the functions taking an array of geometries

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -227,6 +227,7 @@ ensure_same_srid(int32_t srid1, int32_t srid2)
     "Operation on mixed SRID");
   return false;
 }
+extern bool ensure_same_srid_geoarr(const GSERIALIZED **geoms, int count);
 extern bool ensure_srid_reconcile(int32_t srid1, int32_t srid2, int32_t *result);
 extern bool ensure_same_dimensionality(int16 flags1, int16 flags2);
 extern bool ensure_same_spatial_dimensionality(int16 flags1, int16 flags2);

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -2680,6 +2680,24 @@ ensure_not_geodetic(int16 flags)
     "Only planar coordinates supported");
   return false;
 }
+
+/**
+ * @brief Ensure that every member of an array of geometries carries the SRID
+ * the first one does
+ * @param[in] geoms Geometries
+ * @param[in] count Number of elements in the array
+ */
+bool
+ensure_same_srid_geoarr(const GSERIALIZED **geoms, int count)
+{
+  assert(geoms);
+  int32_t srid = gserialized_get_srid(geoms[0]);
+  for (int i = 1; i < count; i++)
+    if (! ensure_same_srid(srid, gserialized_get_srid(geoms[i])))
+      return false;
+  return true;
+}
+
 /**
  * @brief Ensure that two geometries/geographies have the same dimensionality
  */

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2253,6 +2253,9 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   VALIDATE_NOT_NULL(gsarr, NULL);
   if (! ensure_positive(count))
     return NULL;
+  /* The members of the array carry one SRID */
+  if (! ensure_same_srid_geoarr((const GSERIALIZED **) gsarr, count))
+    return NULL;
 
   /* One geom geom? Return it */
   if (count == 1)
@@ -2317,10 +2320,7 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   */
   for (int i = 0; i < count; i++)
   {
-    /* Check for SRID mismatch in array elements */
-    if (gotsrid)
-      assert(gserialized_get_srid(gsarr[i]) == srid);
-    else
+    if (! gotsrid)
     {
       /* Initialize SRID/dimensions info */
       srid = gserialized_get_srid(gsarr[i]);

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1521,10 +1521,10 @@ geo_cluster_kmeans(const GSERIALIZED **geoms, uint32_t n, uint32_t k,
   int *count)
 {
   /* The out parameter is defined even when a later check fails */
-  VALIDATE_NOT_NULL(geoms, NULL); 
+  VALIDATE_NOT_NULL(count, NULL);
   *count = 0;
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(count, NULL);
+  VALIDATE_NOT_NULL(geoms, NULL);
   if (! ensure_positive(n) || ! ensure_positive(k))
     return NULL;
   if (n < k)
@@ -1534,6 +1534,10 @@ geo_cluster_kmeans(const GSERIALIZED **geoms, uint32_t n, uint32_t k,
       k, n);
     return NULL;
   }
+
+  /* The members of the array carry one SRID */
+  if (! ensure_same_srid_geoarr(geoms, (int) n))
+    return NULL;
 
   /* Read all the input geometries into a list */
   LWGEOM **lwgeoms = palloc(sizeof(LWGEOM *) * n);
@@ -1587,6 +1591,10 @@ geo_cluster_dbscan(const GSERIALIZED **geoms, uint32_t ngeoms,
       "Minpoints must be a positive number, got %d", minpoints);
     return NULL;
   }
+
+  /* The members of the array carry one SRID */
+  if (! ensure_same_srid_geoarr(geoms, (int) ngeoms))
+    return NULL;
 
   uint32_t i;
   char *is_in_cluster = NULL;
@@ -1652,10 +1660,8 @@ geo_cluster_intersecting(const GSERIALIZED **geoms, uint32_t ngeoms,
    * whose intersection it asks about, and for the predicate itself. The
    * bounding boxes answer the narrowing and the native engine answers the
    * predicate */
-  int32_t srid = gserialized_get_srid(geoms[0]);
-  for (i = 1; i < ngeoms; i++)
-    if (! ensure_same_srid(srid, gserialized_get_srid(geoms[i])))
-      return NULL;
+  if (! ensure_same_srid_geoarr(geoms, (int) ngeoms))
+    return NULL;
 
   LWGEOM **lwgeoms = palloc(ngeoms * sizeof(LWGEOM *));
   for (i = 0; i < ngeoms; i++)
@@ -1710,6 +1716,10 @@ geo_cluster_within(const GSERIALIZED **geoms, uint32_t ngeoms,
       "Tolerance must be a positive number, got %g", tolerance);
     return NULL;
   }
+
+  /* The members of the array carry one SRID */
+  if (! ensure_same_srid_geoarr(geoms, (int) ngeoms))
+    return NULL;
 
   uint32_t i;
   LWGEOM **lwgeoms = lwalloc(ngeoms * sizeof(LWGEOM *));

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -566,6 +566,34 @@ int main(void)
   assert(meos_errno() != 0);
   meos_errno_reset();
 
+  /* Every entry taking an array of geometries reads one reference system, so
+   * each of them reports the mixture rather than answering about it */
+  int nbad = 0;
+  assert(geo_cluster_kmeans(mixed, 2, 1, &nbad) == NULL);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  assert(geo_cluster_dbscan(mixed, 2, 1.0, 1, &nbad) == NULL);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  assert(geo_cluster_within(mixed, 2, 1.0, &nbad) == NULL);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  GSERIALIZED *mixedarr[2];
+  mixedarr[0] = (GSERIALIZED *) mixed[0];
+  mixedarr[1] = (GSERIALIZED *) mixed[1];
+  assert(geom_array_union(mixedarr, 2) == NULL);
+  printf("the five array entries all report a mixture of SRIDs\n");
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+
+  /* The k-means clustering reports a missing output parameter, which it reads
+   * before the count of clusters is written to it */
+  assert(geo_cluster_kmeans(cl, 4, 2, NULL) == NULL);
+  printf("clusterKMeans without an output parameter: errno %d\n",
+    meos_errno());
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
The five functions taking an array of geometries read one reference system for the whole array. A validator `ensure_same_srid_geoarr` states that condition, and `geo_cluster_kmeans`, `geo_cluster_dbscan`, `geo_cluster_within`, `geo_cluster_intersecting` and `geom_array_union` read it.

In `geom_array_union` the condition is stated at the entry, so it governs both the branch answering an array of surfaces natively and the branch reaching GEOS.

`geo_cluster_kmeans` validates its output parameter before writing to it, in the order its three siblings write the two validations.

`meos/test/geo_test.c` asserts that each of the five reports a mixture of reference systems, and that the k-means clustering reports a missing output parameter.