### PR TITLE
Group the pcpoint and pcpatch constructors with the type they construct

### DIFF
--- a/meos/include/pointcloud/doxygen_meos_pointcloud.h
+++ b/meos/include/pointcloud/doxygen_meos_pointcloud.h
@@ -69,6 +69,10 @@
  * @ingroup meos_pointcloud_base
  * @brief Hex-WKB input / output functions for pcpoint and pcpatch
  *
+ * @defgroup meos_pointcloud_base_constructor Constructor functions
+ * @ingroup meos_pointcloud_base
+ * @brief Constructor functions for pcpoint and pcpatch
+ *
  * @defgroup meos_pointcloud_base_accessor Accessor functions
  * @ingroup meos_pointcloud_base
  * @brief Schema-aware coordinate accessors and metadata for pcpoint / pcpatch

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -249,7 +249,7 @@ pcpatch_as_hexwkb(const Pcpatch *pa)
  *****************************************************************************/
 
 /**
- * @ingroup meos_pointcloud_constructor
+ * @ingroup meos_pointcloud_base_constructor
  * @brief Return a palloc'd copy of a pcpatch
  */
 Pcpatch *

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -282,7 +282,7 @@ pcpoint_as_hexwkb(const Pcpoint *pt)
  *****************************************************************************/
 
 /**
- * @ingroup meos_pointcloud_constructor
+ * @ingroup meos_pointcloud_base_constructor
  * @brief Return a palloc'd copy of a pcpoint
  */
 Pcpoint *


### PR DESCRIPTION
The doxygen module a public MEOS function carries is what the api projection and the bindings generated from it read to decide which family the function belongs to. Every function of the two static pgpointcloud types carries a meos_pointcloud_base_* module except pcpoint_copy and pcpatch_copy, which carry meos_pointcloud_constructor, the module of the constructors of the temporal types. The static types have a constructor module of their own, meos_pointcloud_base_constructor, and the two functions carry it.