### PR TITLE
Name the vector tile wrapper after the MEOS function it calls

### DIFF
--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -2020,7 +2020,7 @@ tpoint_decouple(const Temporal *temp, int64 **timesarr, int *count)
  * @param[in] clip_geom True when the geometry is clipped
  * @return Structure with the geometry, the parallel array of timestamps,
  * and the number of timestamps
- * @csqlfn #AsMVTGeom()
+ * @csqlfn #Tpoint_as_mvtgeom()
  */
 MvtGeom
 tpoint_as_mvtgeom(const Temporal *temp, const STBox *bounds, int32_t extent,

--- a/mobilitydb/sql/geo/076_tgeo_analytics.in.sql
+++ b/mobilitydb/sql/geo/076_tgeo_analytics.in.sql
@@ -143,7 +143,7 @@ LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 -- CREATE FUNCTION asMVTGeom(tgeo tgeometry, bounds stbox,
   -- extent integer DEFAULT 4096, buffer integer DEFAULT 256, clip boolean DEFAULT TRUE)
 -- RETURNS geom_times
--- AS 'MODULE_PATHNAME','AsMVTGeom'
+-- AS 'MODULE_PATHNAME','Tpoint_as_mvtgeom'
 -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/

--- a/mobilitydb/sql/geo/076_tpoint_analytics.in.sql
+++ b/mobilitydb/sql/geo/076_tpoint_analytics.in.sql
@@ -207,7 +207,7 @@ CREATE FUNCTION asMVTGeom(tpoint tgeompoint, bounds stbox,
   extent integer DEFAULT 4096, buffer integer DEFAULT 256, clip boolean DEFAULT TRUE)
 -- RETURNS tgeompoint
 RETURNS geom_times
-AS 'MODULE_PATHNAME','AsMVTGeom'
+AS 'MODULE_PATHNAME','Tpoint_as_mvtgeom'
 LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************/

--- a/mobilitydb/src/geo/tgeo_spatialfuncs.c
+++ b/mobilitydb/src/geo/tgeo_spatialfuncs.c
@@ -337,8 +337,8 @@ Tgeo_scale(PG_FUNCTION_ARGS)
  * Mapbox Vector Tile functions for temporal points
  *****************************************************************************/
 
-PGDLLEXPORT Datum AsMVTGeom(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(AsMVTGeom);
+PGDLLEXPORT Datum Tpoint_as_mvtgeom(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tpoint_as_mvtgeom);
 /**
  * @ingroup mobilitydb_geo_transf
  * @brief Return a temporal point transformed to the Mapbox Vector Tile
@@ -346,7 +346,7 @@ PG_FUNCTION_INFO_V1(AsMVTGeom);
  * @sqlfn asMVTGeom()
  */
 Datum
-AsMVTGeom(PG_FUNCTION_ARGS)
+Tpoint_as_mvtgeom(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   STBox *bounds = PG_GETARG_STBOX_P(1);


### PR DESCRIPTION
The PostgreSQL wrapper behind asMVTGeom is Tpoint_as_mvtgeom, the name of the MEOS function tpoint_as_mvtgeom it calls with its first letter capitalised, as Geom_buffer, Geom_convex_hull and Geom_oriented_envelope carry the names of geom_buffer, geom_convex_hull and geom_oriented_envelope. It is the shape the surface holds: of the 2453 symbols bound through MODULE_PATHNAME, three carry a capital letter after the first and twelve begin with a lower case one. The commented declaration of the temporal geometry overload names it too, so both sites reach the one implementation the file holds. The SQL surface is unchanged: asMVTGeom answers as it does.