### PR TITLE
Begin the name of every SQL function with a lower case letter

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -917,16 +917,16 @@
 			<title>Funciones sobre Geometrías</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="geo_orientedenvelope"><varname>OrientedEnvelope</varname></link>: Devuelve el rectángulo de área mínima que encierra una geometría</para>
+					<para><link linkend="geo_orientedenvelope"><varname>orientedEnvelope</varname></link>: Devuelve el rectángulo de área mínima que encierra una geometría</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="geo_convexhull"><varname>ConvexHull</varname></link>: Devuelve la geometría convexa más pequeña que encierra una geometría</para>
+					<para><link linkend="geo_convexhull"><varname>convexHull</varname></link>: Devuelve la geometría convexa más pequeña que encierra una geometría</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="geo_issimple"><varname>isSimple</varname></link>: Devuelve verdadero si una geometría no tiene ningún punto en el que se cruce o se toque a sí misma</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="geo_buffer"><varname>Buffer</varname></link>: Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>
+					<para><link linkend="geo_buffer"><varname>buffer</varname></link>: Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -45,31 +45,31 @@
 
 		<itemizedlist>
 			<listitem xml:id="geo_orientedenvelope">
-				<indexterm significance="normal"><primary><varname>OrientedEnvelope</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>orientedEnvelope</varname></primary></indexterm>
 				<para>Devuelve el rectángulo de área mínima que encierra una geometría</para>
-				<para><varname>OrientedEnvelope(geometry) → geometry</varname></para>
+				<para><varname>orientedEnvelope(geometry) → geometry</varname></para>
 				<para>El rectángulo se orienta en el ángulo que lo hace más pequeño, que en general no es el ángulo de los ejes. Se devuelve como una línea cuando la geometría está contenida en una y como un punto cuando la geometría es uno. Una geometría que lleva un arco circular se responde sobre el arco mismo: el rectángulo se coloca contra el círculo en el que se encuentra el arco y no contra la cadena de segmentos que lo aproxima.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
 -- POLYGON((0 0,3 4,-1 7,-4 3,0 0))
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
 -- LINESTRING(0 0,10 0)
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Circularstring(0 0,0.5 0.1,1 0)'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Circularstring(0 0,0.5 0.1,1 0)'), 6));
 -- POLYGON((1 0.1,0 0.1,0 0,1 0,1 0.1))
 </programlisting>
 			</listitem>
 
 			<listitem xml:id="geo_convexhull">
-				<indexterm significance="normal"><primary><varname>ConvexHull</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Devuelve la geometría convexa más pequeña que encierra una geometría</para>
-				<para><varname>ConvexHull(geometry) → geometry</varname></para>
+				<para><varname>convexHull(geometry) → geometry</varname></para>
 				<para>El resultado es un polígono en el que cada esquina es un punto de la geometría, una línea cuando la geometría está contenida en una y un punto cuando la geometría es uno. Una geometría que lleva un arco circular se responde sobre el arco mismo, por lo que la envolvente está delimitada por el arco y se devuelve como una geometría curva y no como un polígono que la aproxima.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
 -- POLYGON((0 0,0 10,10 10,10 0,0 0))
-SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
 -- POLYGON((0 0,0 10,10 10,10 0,0 0))
-SELECT ST_AsText(round(ConvexHull(geometry 'Circularstring(5 0,0 5,-5 0)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Circularstring(5 0,0 5,-5 0)'), 6));
 -- CURVEPOLYGON(COMPOUNDCURVE((5 0,-5 0),CIRCULARSTRING(-5 0,0 5,5 0)))
 </programlisting>
 			</listitem>
@@ -90,18 +90,18 @@ SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(10 0,10 10))');
 			</listitem>
 
 			<listitem xml:id="geo_buffer">
-				<indexterm significance="normal"><primary><varname>Buffer</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>buffer</varname></primary></indexterm>
 				<para>Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>
-				<para><varname>Buffer(geometry,float,options text='') → geometry</varname></para>
+				<para><varname>buffer(geometry,float,options text='') → geometry</varname></para>
 				<para>La frontera del resultado está formada por los dos desplazamientos de la geometría a la distancia dada, por la unión que rellena el lado exterior de cada giro y por el extremo que cierra cada final de una línea abierta. Una distancia negativa contrae una geometría de área y devuelve una geometría vacía para una de cualquier otra dimensión.</para>
 				<para>La cadena <varname>options</varname> lleva los estilos como pares <varname>clave=valor</varname> separados por espacios: <varname>endcap</varname> es uno de <varname>round</varname>, <varname>flat</varname> o <varname>square</varname>, <varname>join</varname> uno de <varname>round</varname>, <varname>mitre</varname> o <varname>bevel</varname>, y <varname>mitre_limit</varname> la razón a partir de la cual una unión en inglete pasa a ser biselada.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Point(0 0)', 1), 6));
 -- CURVEPOLYGON(CIRCULARSTRING(-1 0,1 0,-1 0))
-SELECT ST_AsText(round(Buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', -1,
+SELECT ST_AsText(round(buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', -1,
   'join=mitre'), 6));
 -- CURVEPOLYGON(COMPOUNDCURVE((1 1,9 1),(9 1,9 9),(9 9,1 9),(1 9,1 1)))
-SELECT ST_AsText(round(Buffer(geometry
+SELECT ST_AsText(round(buffer(geometry
   'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))', 1), 6));
 -- CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(-1 0,2 3,5 0),CIRCULARSTRING(5 0,2 -3,-1 0)))
 </programlisting>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -917,16 +917,16 @@
 			<title>Functions on Geometries</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="geo_orientedenvelope"><varname>OrientedEnvelope</varname></link>: Return the rectangle of minimum area enclosing a geometry</para>
+					<para><link linkend="geo_orientedenvelope"><varname>orientedEnvelope</varname></link>: Return the rectangle of minimum area enclosing a geometry</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="geo_convexhull"><varname>ConvexHull</varname></link>: Return the smallest convex geometry enclosing a geometry</para>
+					<para><link linkend="geo_convexhull"><varname>convexHull</varname></link>: Return the smallest convex geometry enclosing a geometry</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="geo_issimple"><varname>isSimple</varname></link>: Return true if a geometry has no point at which it crosses or touches itself</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="geo_buffer"><varname>Buffer</varname></link>: Return the geometry holding every point within a distance of a geometry</para>
+					<para><link linkend="geo_buffer"><varname>buffer</varname></link>: Return the geometry holding every point within a distance of a geometry</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -45,31 +45,31 @@
 
 		<itemizedlist>
 			<listitem xml:id="geo_orientedenvelope">
-				<indexterm significance="normal"><primary><varname>OrientedEnvelope</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>orientedEnvelope</varname></primary></indexterm>
 				<para>Return the rectangle of minimum area enclosing a geometry</para>
-				<para><varname>OrientedEnvelope(geometry) → geometry</varname></para>
+				<para><varname>orientedEnvelope(geometry) → geometry</varname></para>
 				<para>The rectangle is at the angle that makes it smallest, which is not in general the angle of the axes. It is answered as a line when the geometry is contained in one and as a point when the geometry is one. A geometry carrying a circular arc is answered on the arc itself, the rectangle being placed against the circle the arc lies on rather than against the chain of segments approximating it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
 -- POLYGON((0 0,3 4,-1 7,-4 3,0 0))
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
 -- LINESTRING(0 0,10 0)
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Circularstring(0 0,0.5 0.1,1 0)'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Circularstring(0 0,0.5 0.1,1 0)'), 6));
 -- POLYGON((1 0.1,0 0.1,0 0,1 0,1 0.1))
 </programlisting>
 			</listitem>
 
 			<listitem xml:id="geo_convexhull">
-				<indexterm significance="normal"><primary><varname>ConvexHull</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Return the smallest convex geometry enclosing a geometry</para>
-				<para><varname>ConvexHull(geometry) → geometry</varname></para>
+				<para><varname>convexHull(geometry) → geometry</varname></para>
 				<para>The result is a polygon whose every corner is a point of the geometry, a line when the geometry is contained in one, and a point when the geometry is one. A geometry carrying a circular arc is answered on the arc itself, so the hull is bounded by the arc and is returned as a curved geometry rather than as a polygon approximating it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
 -- POLYGON((0 0,0 10,10 10,10 0,0 0))
-SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
 -- POLYGON((0 0,0 10,10 10,10 0,0 0))
-SELECT ST_AsText(round(ConvexHull(geometry 'Circularstring(5 0,0 5,-5 0)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Circularstring(5 0,0 5,-5 0)'), 6));
 -- CURVEPOLYGON(COMPOUNDCURVE((5 0,-5 0),CIRCULARSTRING(-5 0,0 5,5 0)))
 </programlisting>
 			</listitem>
@@ -90,18 +90,18 @@ SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(10 0,10 10))');
 			</listitem>
 
 			<listitem xml:id="geo_buffer">
-				<indexterm significance="normal"><primary><varname>Buffer</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>buffer</varname></primary></indexterm>
 				<para>Return the geometry holding every point within a distance of a geometry</para>
-				<para><varname>Buffer(geometry,float,options text='') → geometry</varname></para>
+				<para><varname>buffer(geometry,float,options text='') → geometry</varname></para>
 				<para>The boundary of the result is made of the two offsets of the geometry at the given distance, of the join filling the outer side of each turn, and of the cap closing each end of an open line. A negative distance shrinks an areal geometry and answers an empty geometry for one of any other dimension.</para>
 				<para>The <varname>options</varname> string carries the styles as space-separated <varname>key=value</varname> pairs: <varname>endcap</varname> is one of <varname>round</varname>, <varname>flat</varname> or <varname>square</varname>, <varname>join</varname> one of <varname>round</varname>, <varname>mitre</varname> or <varname>bevel</varname>, and <varname>mitre_limit</varname> the ratio at which a mitre join falls back to a bevel.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Point(0 0)', 1), 6));
 -- CURVEPOLYGON(CIRCULARSTRING(-1 0,1 0,-1 0))
-SELECT ST_AsText(round(Buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', -1,
+SELECT ST_AsText(round(buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', -1,
   'join=mitre'), 6));
 -- CURVEPOLYGON(COMPOUNDCURVE((1 1,9 1),(9 1,9 9),(9 9,1 9),(1 9,1 1)))
-SELECT ST_AsText(round(Buffer(geometry
+SELECT ST_AsText(round(buffer(geometry
   'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))', 1), 6));
 -- CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(-1 0,2 3,5 0),CIRCULARSTRING(5 0,2 -3,-1 0)))
 </programlisting>

--- a/mobilitydb/sql/geo/049_geo_funcs.in.sql
+++ b/mobilitydb/sql/geo/049_geo_funcs.in.sql
@@ -37,11 +37,11 @@
  * Oriented envelope (a.k.a minimum rotated rectangle) and convex hull
  *****************************************************************************/
 
-CREATE FUNCTION OrientedEnvelope(geometry)
+CREATE FUNCTION orientedEnvelope(geometry)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Geom_oriented_envelope'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION ConvexHull(geometry)
+CREATE FUNCTION convexHull(geometry)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Geom_convex_hull'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -59,7 +59,7 @@ CREATE FUNCTION isSimple(geometry)
  * Buffer
  *****************************************************************************/
 
-CREATE FUNCTION Buffer(geom geometry, float, options text DEFAULT '')
+CREATE FUNCTION buffer(geom geometry, float, options text DEFAULT '')
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Geom_buffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/src/geo/geo_funcs.c
+++ b/mobilitydb/src/geo/geo_funcs.c
@@ -57,7 +57,7 @@ PG_FUNCTION_INFO_V1(Geom_oriented_envelope);
 /**
  * @ingroup mobilitydb_geo_base_spatial
  * @brief Return the oriented envelope of a geometry
- * @sqlfn OrientedEnvelope()
+ * @sqlfn orientedEnvelope()
  */
 Datum
 Geom_oriented_envelope(PG_FUNCTION_ARGS)
@@ -75,7 +75,7 @@ PG_FUNCTION_INFO_V1(Geom_convex_hull);
 /**
  * @ingroup mobilitydb_geo_base_spatial
  * @brief Return the convex hull of a geometry
- * @sqlfn ConvexHull()
+ * @sqlfn convexHull()
  */
 Datum
 Geom_convex_hull(PG_FUNCTION_ARGS)
@@ -119,7 +119,7 @@ PG_FUNCTION_INFO_V1(Geom_buffer);
  * @ingroup mobilitydb_geo_base_spatial
  * @brief Return a geometry that represents all the points whose distance from
  * a geometry is less than or equal to a distance
- * @sqlfn Buffer()
+ * @sqlfn buffer()
  */
 Datum
 Geom_buffer(PG_FUNCTION_ARGS)

--- a/mobilitydb/test/geo/expected/049_geo_funcs.test.out
+++ b/mobilitydb/test/geo/expected/049_geo_funcs.test.out
@@ -1,70 +1,70 @@
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Point(1 2)'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Point(1 2)'), 6));
  st_astext  
 ------------
  POINT(1 2)
 (1 row)
 
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
       st_astext       
 ----------------------
  LINESTRING(0 0,10 0)
 (1 row)
 
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,10 0,10 5,0 5,0 0))'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Polygon((0 0,10 0,10 5,0 5,0 0))'), 6));
             st_astext             
 ----------------------------------
  POLYGON((0 0,10 0,10 5,0 5,0 0))
 (1 row)
 
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
             st_astext             
 ----------------------------------
  POLYGON((0 0,3 4,-1 7,-4 3,0 0))
 (1 row)
 
-SELECT ST_AsText(OrientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
+SELECT ST_AsText(orientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
             st_astext             
 ----------------------------------
  POLYGON((4 2,0 2,0 -2,4 -2,4 2))
 (1 row)
 
-SELECT round(ST_Area(OrientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'))::numeric, 6);
+SELECT round(ST_Area(orientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'))::numeric, 6);
    round   
 -----------
  16.000000
 (1 row)
 
-SELECT ST_AsText(round(ConvexHull(geometry 'Point(1 2)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Point(1 2)'), 6));
  st_astext  
 ------------
  POINT(1 2)
 (1 row)
 
-SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,1 1,2 2)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Multipoint(0 0,1 1,2 2)'), 6));
       st_astext      
 ---------------------
  LINESTRING(0 0,2 2)
 (1 row)
 
-SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
              st_astext              
 ------------------------------------
  POLYGON((0 0,0 10,10 10,10 0,0 0))
 (1 row)
 
-SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
              st_astext              
 ------------------------------------
  POLYGON((0 0,0 10,10 10,10 0,0 0))
 (1 row)
 
-SELECT ST_AsText(ConvexHull(geometry 'Circularstring(0 0,2 2,4 0)'));
+SELECT ST_AsText(convexHull(geometry 'Circularstring(0 0,2 2,4 0)'));
                              st_astext                              
 --------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE((4 0,0 0),CIRCULARSTRING(0 0,2 2,4 0)))
 (1 row)
 
-SELECT ST_AsText(ConvexHull(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
+SELECT ST_AsText(convexHull(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
                                        st_astext                                       
 ---------------------------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(4 0,2 -2,0 0),CIRCULARSTRING(0 0,2 2,4 0)))
@@ -156,85 +156,85 @@ SELECT isSimple(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))') =
  t
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Point(0 0)', 1), 6));
                   st_astext                  
 ---------------------------------------------
  CURVEPOLYGON(CIRCULARSTRING(-1 0,1 0,-1 0))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', 0), 6));
+SELECT ST_AsText(round(buffer(geometry 'Point(0 0)', 0), 6));
    st_astext   
 ---------------
  POLYGON EMPTY
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', -1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Point(0 0)', -1), 6));
    st_astext   
 ---------------
  POLYGON EMPTY
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0)', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0)', 1), 6));
                                                      st_astext                                                      
 --------------------------------------------------------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE((0 1,10 1),CIRCULARSTRING(10 1,11 0,10 -1),(10 -1,0 -1),CIRCULARSTRING(0 -1,-1 0,0 1)))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0)', 1, 'endcap=flat'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0)', 1, 'endcap=flat'), 6));
                                   st_astext                                   
 ------------------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE((0 1,10 1),(10 1,10 -1),(10 -1,0 -1),(0 -1,0 1)))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0)', 1, 'endcap=square'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0)', 1, 'endcap=square'), 6));
                st_astext                
 ----------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE((0 1,0 1)))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0,10 10)', 1, 'join=bevel'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0,10 10)', 1, 'join=bevel'), 6));
                                                                         st_astext                                                                        
 ---------------------------------------------------------------------------------------------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE((0 1,9 1),(9 1,9 10),CIRCULARSTRING(9 10,10 11,11 10),(11 10,11 0),(11 0,10 -1),(10 -1,0 -1),CIRCULARSTRING(0 -1,-1 0,0 1)))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0,10 10)', 1, 'join=mitre'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0,10 10)', 1, 'join=mitre'), 6));
                                                                               st_astext                                                                              
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE((0 1,9 1),(9 1,9 10),CIRCULARSTRING(9 10,10 11,11 10),(11 10,11 0),(11 0,10 0),(10 0,10 -1),(10 -1,0 -1),CIRCULARSTRING(0 -1,-1 0,0 1)))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', 1, 'join=mitre'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', 1, 'join=mitre'), 6));
                                                                                       st_astext                                                                                       
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE((-1 0,0 0),(0 0,0 -1),(0 -1,10 -1),(10 -1,10 0),(10 0,11 0),(11 0,11 10),(11 10,10 10),(10 10,10 11),(10 11,0 11),(0 11,0 10),(0 10,-1 10),(-1 10,-1 0)))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', -1, 'join=mitre'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', -1, 'join=mitre'), 6));
                               st_astext                               
 ----------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE((1 1,9 1),(9 1,9 9),(9 9,1 9),(1 9,1 1)))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Circularstring(0 0,2 2,4 0)', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Circularstring(0 0,2 2,4 0)', 1), 6));
                                                                                                   st_astext                                                                                                   
 --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(-1 0,2 3,5 0),CIRCULARSTRING(5 0,4 -1,3 0),CIRCULARSTRING(3 0,2 1,1 0),CIRCULARSTRING(1 0,0.707107 -0.707107,0 -1),CIRCULARSTRING(0 -1,-0.707107 -0.707107,-1 0)))
 (1 row)
 
-SELECT ST_AsText(round(Buffer(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))', 1), 6));
                                         st_astext                                        
 -----------------------------------------------------------------------------------------
  CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(-1 0,2 3,5 0),CIRCULARSTRING(5 0,2 -3,-1 0)))
 (1 row)
 
-SELECT ST_GeometryType(Buffer(geometry 'Multipoint(0 0,10 0)', 1));
+SELECT ST_GeometryType(buffer(geometry 'Multipoint(0 0,10 0)', 1));
  st_geometrytype 
 -----------------
  ST_MultiSurface
 (1 row)
 
-SELECT ST_GeometryType(Buffer(geometry 'Multilinestring((0 0,10 0),(0 20,10 20))', 1));
+SELECT ST_GeometryType(buffer(geometry 'Multilinestring((0 0,10 0),(0 20,10 20))', 1));
  st_geometrytype 
 -----------------
  ST_MultiSurface

--- a/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
+++ b/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
@@ -31,34 +31,34 @@
 -------------------------------------------------------------------------------
 
 -- The envelope of a point is that point, of two points the segment they span
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Point(1 2)'), 6));
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Point(1 2)'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Linestring(0 0,10 0)'), 6));
 
 -- A rectangle is its own envelope, whatever angle it is written at
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,10 0,10 5,0 5,0 0))'), 6));
-SELECT ST_AsText(round(OrientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Polygon((0 0,10 0,10 5,0 5,0 0))'), 6));
+SELECT ST_AsText(round(orientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
 
 -- An arc reaches past the points that define it, and is enclosed by reading
 -- how far its circle reaches in each direction. The envelope of a circle of
 -- radius 2 is the square of side 4 about it, of area 16; a rectangle placed on
 -- the points of that circle has area 8 and leaves a third of it outside
-SELECT ST_AsText(OrientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
-SELECT round(ST_Area(OrientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'))::numeric, 6);
+SELECT ST_AsText(orientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
+SELECT round(ST_Area(orientedEnvelope(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'))::numeric, 6);
 
 -- The hull of a point is that point, and of collinear points their segment
-SELECT ST_AsText(round(ConvexHull(geometry 'Point(1 2)'), 6));
-SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,1 1,2 2)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Point(1 2)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Multipoint(0 0,1 1,2 2)'), 6));
 
 -- A point inside the hull of the others does not reach its boundary
-SELECT ST_AsText(round(ConvexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
 
 -- The hull of a concave polygon closes over the notch
-SELECT ST_AsText(round(ConvexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
+SELECT ST_AsText(round(convexHull(geometry 'Polygon((0 0,10 0,10 10,5 5,0 10,0 0))'), 6));
 
 -- The hull of a geometry carrying an arc carries that arc, where a hull placed
 -- on the three points defining a semicircular arc leaves the whole arc outside
-SELECT ST_AsText(ConvexHull(geometry 'Circularstring(0 0,2 2,4 0)'));
-SELECT ST_AsText(ConvexHull(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
+SELECT ST_AsText(convexHull(geometry 'Circularstring(0 0,2 2,4 0)'));
+SELECT ST_AsText(convexHull(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))'));
 
 -------------------------------------------------------------------------------
 -- Simple geometries
@@ -96,35 +96,35 @@ SELECT isSimple(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))') =
   ST_IsSimple(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))');
 
 -------------------------------------------------------------------------------
--- Buffer
+-- buffer
 -- A buffer is bounded by the offsets of the geometry and by the joins and caps
 -- between them, and a circular arc is kept as an arc rather than sampled
 -------------------------------------------------------------------------------
 
 -- The buffer of a point is a disk, of a negative or zero distance nothing
-SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', 1), 6));
-SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', 0), 6));
-SELECT ST_AsText(round(Buffer(geometry 'Point(0 0)', -1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Point(0 0)', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Point(0 0)', 0), 6));
+SELECT ST_AsText(round(buffer(geometry 'Point(0 0)', -1), 6));
 
 -- The two offsets of a line, closed by a cap at each end
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0)', 1), 6));
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0)', 1, 'endcap=flat'), 6));
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0)', 1, 'endcap=square'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0)', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0)', 1, 'endcap=flat'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0)', 1, 'endcap=square'), 6));
 
 -- The outer side of a turn is filled by the join the style names
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0,10 10)', 1, 'join=bevel'), 6));
-SELECT ST_AsText(round(Buffer(geometry 'Linestring(0 0,10 0,10 10)', 1, 'join=mitre'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0,10 10)', 1, 'join=bevel'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Linestring(0 0,10 0,10 10)', 1, 'join=mitre'), 6));
 
 -- A polygon grows outwards and its holes inwards
-SELECT ST_AsText(round(Buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', 1, 'join=mitre'), 6));
-SELECT ST_AsText(round(Buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', -1, 'join=mitre'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', 1, 'join=mitre'), 6));
+SELECT ST_AsText(round(buffer(geometry 'Polygon((0 0,10 0,10 10,0 10,0 0))', -1, 'join=mitre'), 6));
 
 -- A circular string keeps its arcs, and so does the buffer of one
-SELECT ST_AsText(round(Buffer(geometry 'Circularstring(0 0,2 2,4 0)', 1), 6));
-SELECT ST_AsText(round(Buffer(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Circularstring(0 0,2 2,4 0)', 1), 6));
+SELECT ST_AsText(round(buffer(geometry 'Curvepolygon(Circularstring(0 0,2 2,4 0,2 -2,0 0))', 1), 6));
 
 -- The buffer of a geometry of several components is their union
-SELECT ST_GeometryType(Buffer(geometry 'Multipoint(0 0,10 0)', 1));
-SELECT ST_GeometryType(Buffer(geometry 'Multilinestring((0 0,10 0),(0 20,10 20))', 1));
+SELECT ST_GeometryType(buffer(geometry 'Multipoint(0 0,10 0)', 1));
+SELECT ST_GeometryType(buffer(geometry 'Multilinestring((0 0,10 0),(0 20,10 20))', 1));
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
orientedEnvelope, convexHull and buffer join isSimple, asMVTGeom and every other function of the surface in beginning with a lower case letter and capitalising each later word. SRID keeps its case, being an acronym rather than a sequence of words. Both manuals and the reference appendix carry the names, and the expected output of the geometry function tests is harvested. PostgreSQL folds an unquoted identifier, so each function answers to a query written either way.