### PR TITLE
Name the polygon Boolean functions after the PostGIS functions they answer for

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -928,6 +928,18 @@
 				<listitem>
 					<para><link linkend="geo_buffer"><varname>Buffer</varname></link>: Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>
 				</listitem>
+				<listitem>
+					<para><link linkend="geo_intersection"><varname>intersection</varname></link>: Devuelve la región que dos geometrías comparten</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="geo_geounion"><varname>geoUnion</varname></link>: Devuelve la región que dos geometrías cubren en conjunto</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="geo_difference"><varname>difference</varname></link>: Devuelve la región de la primera geometría que la segunda no cubre</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="geo_symdifference"><varname>symDifference</varname></link>: Devuelve la región que cubre exactamente una de dos geometrías</para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 		<sect2>

--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -106,6 +106,66 @@ SELECT ST_AsText(round(Buffer(geometry
 -- CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(-1 0,2 3,5 0),CIRCULARSTRING(5 0,2 -3,-1 0)))
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="geo_intersection">
+				<indexterm significance="normal"><primary><varname>intersection</varname></primary></indexterm>
+				<para>Devuelve la región que dos geometrías comparten</para>
+				<para><varname>intersection(geometry,geometry) → geometry</varname></para>
+				<para>Las cuatro operaciones booleanas de esta sección responden sobre los (multi)polígonos que llevan los tipos temporales cuyos valores son regiones, y cada una toma el nombre de la función de PostGIS para la que responde sin el prefijo <varname>ST_</varname>, de modo que una consulta alcanza este motor quitando el prefijo y PostGIS conservándolo. Son planas y bidimensionales: se rechazan una geografía, una dimensión Z y una geometría que no sea un (multi)polígono. Un resultado vacío se responde como <varname>NULL</varname>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
+-- POLYGON((5 3,3 3,3 5,5 5,5 3))
+SELECT ST_AsText(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'MultiPolygon(((2 2,2 4,3 4,3 2,2 2)),((4 2,4 4,6 4,6 2,4 2)))'));
+-- MULTIPOLYGON(((3 2,2 2,2 4,3 4,3 2)),((5 2,4 2,4 4,5 4,5 2)))
+SELECT intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+  geometry 'Polygon((10 10,10 11,11 11,11 10,10 10))') IS NULL;
+-- true
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="geo_geounion">
+				<indexterm significance="normal"><primary><varname>geoUnion</varname></primary></indexterm>
+				<para>Devuelve la región que dos geometrías cubren en conjunto</para>
+				<para><varname>geoUnion(geometry,geometry) → geometry</varname></para>
+				<para><varname>UNION</varname> es una palabra reservada de SQL, por lo que esta lleva el nombre del tipo sobre el que responde, como hacen <varname>setUnion</varname> y <varname>spanUnion</varname>. Dos geometrías que no se tocan se responden como un multipolígono.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(geoUnion(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
+-- POLYGON((5 1,1 1,1 5,3 5,3 7,7 7,7 3,5 3,5 1))
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="geo_difference">
+				<indexterm significance="normal"><primary><varname>difference</varname></primary></indexterm>
+				<para>Devuelve la región de la primera geometría que la segunda no cubre</para>
+				<para><varname>difference(geometry,geometry) → geometry</varname></para>
+				<para>Una segunda geometría situada dentro de la primera deja un agujero en lugar de dividirla.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
+-- POLYGON((5 1,1 1,1 5,3 5,3 3,5 3,5 1))
+SELECT ST_AsText(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((2 2,2 4,4 4,4 2,2 2))'));
+-- POLYGON((5 1,1 1,1 5,5 5,5 1),(2 4,2 2,4 2,4 4,2 4))
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="geo_symdifference">
+				<indexterm significance="normal"><primary><varname>symDifference</varname></primary></indexterm>
+				<para>Devuelve la región que cubre exactamente una de dos geometrías</para>
+				<para><varname>symDifference(geometry,geometry) → geometry</varname></para>
+				<para>Es la unión de las dos geometrías menos la región que comparten, por lo que una geometría contra sí misma se responde como <varname>NULL</varname>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(symDifference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
+-- MULTIPOLYGON(((7 3,5 3,5 5,3 5,3 7,7 7,7 3)),((5 1,1 1,1 5,3 5,3 3,5 3,5 1)))
+SELECT symDifference(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
+  geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))') IS NULL;
+-- true
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -928,6 +928,18 @@
 				<listitem>
 					<para><link linkend="geo_buffer"><varname>Buffer</varname></link>: Return the geometry holding every point within a distance of a geometry</para>
 				</listitem>
+				<listitem>
+					<para><link linkend="geo_intersection"><varname>intersection</varname></link>: Return the region two geometries share</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="geo_geounion"><varname>geoUnion</varname></link>: Return the region two geometries cover together</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="geo_difference"><varname>difference</varname></link>: Return the region of the first geometry that the second does not cover</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="geo_symdifference"><varname>symDifference</varname></link>: Return the region exactly one of two geometries covers</para>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 		<sect2>

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -106,6 +106,66 @@ SELECT ST_AsText(round(Buffer(geometry
 -- CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(-1 0,2 3,5 0),CIRCULARSTRING(5 0,2 -3,-1 0)))
 </programlisting>
 			</listitem>
+
+			<listitem xml:id="geo_intersection">
+				<indexterm significance="normal"><primary><varname>intersection</varname></primary></indexterm>
+				<para>Return the region two geometries share</para>
+				<para><varname>intersection(geometry,geometry) → geometry</varname></para>
+				<para>The four Boolean operations of this section answer over the (multi)polygons the temporal types whose values are regions carry, and each takes the name of the PostGIS function it answers for without the <varname>ST_</varname> prefix, so a query reaches this engine by dropping the prefix and PostGIS by keeping it. They are planar and two-dimensional: a geography, a Z dimension and a geometry that is not a (multi)polygon are refused. An empty result is answered as <varname>NULL</varname>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
+-- POLYGON((5 3,3 3,3 5,5 5,5 3))
+SELECT ST_AsText(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'MultiPolygon(((2 2,2 4,3 4,3 2,2 2)),((4 2,4 4,6 4,6 2,4 2)))'));
+-- MULTIPOLYGON(((3 2,2 2,2 4,3 4,3 2)),((5 2,4 2,4 4,5 4,5 2)))
+SELECT intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+  geometry 'Polygon((10 10,10 11,11 11,11 10,10 10))') IS NULL;
+-- true
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="geo_geounion">
+				<indexterm significance="normal"><primary><varname>geoUnion</varname></primary></indexterm>
+				<para>Return the region two geometries cover together</para>
+				<para><varname>geoUnion(geometry,geometry) → geometry</varname></para>
+				<para><varname>UNION</varname> is a reserved word of SQL, so this one carries the name of the type it answers over, as <varname>setUnion</varname> and <varname>spanUnion</varname> do. Two geometries that do not meet are answered as a multipolygon.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(geoUnion(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
+-- POLYGON((5 1,1 1,1 5,3 5,3 7,7 7,7 3,5 3,5 1))
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="geo_difference">
+				<indexterm significance="normal"><primary><varname>difference</varname></primary></indexterm>
+				<para>Return the region of the first geometry that the second does not cover</para>
+				<para><varname>difference(geometry,geometry) → geometry</varname></para>
+				<para>A second geometry lying inside the first leaves a hole rather than dividing it.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
+-- POLYGON((5 1,1 1,1 5,3 5,3 3,5 3,5 1))
+SELECT ST_AsText(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((2 2,2 4,4 4,4 2,2 2))'));
+-- POLYGON((5 1,1 1,1 5,5 5,5 1),(2 4,2 2,4 2,4 4,2 4))
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="geo_symdifference">
+				<indexterm significance="normal"><primary><varname>symDifference</varname></primary></indexterm>
+				<para>Return the region exactly one of two geometries covers</para>
+				<para><varname>symDifference(geometry,geometry) → geometry</varname></para>
+				<para>It is the union of the two geometries less the region they share, so a geometry against itself is answered as <varname>NULL</varname>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(symDifference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+  geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
+-- MULTIPOLYGON(((7 3,5 3,5 5,3 5,3 7,7 7,7 3)),((5 1,1 1,1 5,3 5,3 3,5 3,5 1)))
+SELECT symDifference(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
+  geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))') IS NULL;
+-- true
+</programlisting>
+			</listitem>
 		</itemizedlist>
 	</sect1>
 

--- a/meos/include/geo/clip_clipper2.h
+++ b/meos/include/geo/clip_clipper2.h
@@ -22,7 +22,8 @@
  * @brief Clipper2-backed polygon Boolean engine for MEOS.
  *
  * Replaces the bespoke Martinez-Rueda port with vendored Clipper2 v2.0.1.
- * Public C entry point used by the @c _mdb_internal_clip_* SQL functions
+ * Public C entry point used by the intersection, geoUnion, difference and
+ * symDifference SQL functions
  * (and ultimately by the temporal-point clipping path in
  * @c tgeo_spatialfuncs.c).
  */

--- a/meos/include/geo/geo_poly_clip.h
+++ b/meos/include/geo/geo_poly_clip.h
@@ -37,8 +37,8 @@
 /**
  * @brief Boolean operation selector for #clip_poly_poly.
  *
- * Numeric values are part of the SQL ABI used by the four
- * @c _mdb_internal_clip_* SQL functions defined in
+ * Numeric values are part of the SQL ABI used by the intersection, geoUnion,
+ * difference and symDifference SQL functions defined in
  * @c mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql; do not renumber.
  */
 typedef enum

--- a/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
@@ -368,30 +368,31 @@ CREATE FUNCTION minusElevation(tgeompoint, floatspan)
 /*****************************************************************************
  * Polygon clipping (Clipper2 backend)
  *
- * INTERNAL — these functions expose the in-process polygon Boolean engine
- * used by the temporal types whose values are 2D regions (trgeo, tcbuffer,
- * tgeometry, tgeography). They exist so the engine can be unit-tested and
- * benchmarked from SQL; end users should keep using PostGIS ST_Intersection
- * / ST_Union / ST_Difference / ST_SymDifference, which are more robust on
- * degenerate inputs and handle curves / geography / 3D. The `_mdb_internal_`
- * prefix marks them as not part of the public API.
+ * The in-process polygon Boolean engine over the geometries carried by the
+ * temporal types whose values are 2D regions (trgeo, tcbuffer, tgeometry,
+ * tgeography). Each function carries the name of the PostGIS function it
+ * answers for without the ST_ prefix, so a query reaches this engine by
+ * dropping the prefix and PostGIS by keeping it. UNION is a reserved word, so
+ * the union carries the name of the type it answers over, geoUnion, as
+ * setUnion and spanUnion do. The engine is planar and two-dimensional: it
+ * refuses a geography, a Z dimension and anything that is not a (multi)polygon.
  *****************************************************************************/
 
-CREATE FUNCTION _mdb_internal_clip_intersection(geometry, geometry)
+CREATE FUNCTION intersection(geometry, geometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'cl_intersection'
+  AS 'MODULE_PATHNAME', 'Geom_intersection'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION _mdb_internal_clip_union(geometry, geometry)
+CREATE FUNCTION geoUnion(geometry, geometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'cl_union'
+  AS 'MODULE_PATHNAME', 'Geom_union'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION _mdb_internal_clip_difference(geometry, geometry)
+CREATE FUNCTION difference(geometry, geometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'cl_difference'
+  AS 'MODULE_PATHNAME', 'Geom_difference'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION _mdb_internal_clip_sym_difference(geometry, geometry)
+CREATE FUNCTION symDifference(geometry, geometry)
   RETURNS geometry
-  AS 'MODULE_PATHNAME', 'symDifference'
+  AS 'MODULE_PATHNAME', 'Geom_sym_difference'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 

--- a/mobilitydb/src/geo/tgeo_spatialfuncs.c
+++ b/mobilitydb/src/geo/tgeo_spatialfuncs.c
@@ -904,30 +904,50 @@ clip_ext(FunctionCallInfo fcinfo, ClipOper operation)
   PG_RETURN_POINTER(result);
 }
 
-PG_FUNCTION_INFO_V1(cl_intersection);
+PG_FUNCTION_INFO_V1(Geom_intersection);
+/**
+ * @ingroup mobilitydb_geo_base_spatial
+ * @brief Return the region two geometries share
+ * @sqlfn intersection()
+ */
 Datum
-cl_intersection(PG_FUNCTION_ARGS)
+Geom_intersection(PG_FUNCTION_ARGS)
 {
   return clip_ext(fcinfo, CL_INTERSECTION);
 }
 
-PG_FUNCTION_INFO_V1(cl_union);
+PG_FUNCTION_INFO_V1(Geom_union);
+/**
+ * @ingroup mobilitydb_geo_base_spatial
+ * @brief Return the region two geometries cover together
+ * @sqlfn geoUnion()
+ */
 Datum
-cl_union(PG_FUNCTION_ARGS)
+Geom_union(PG_FUNCTION_ARGS)
 {
   return clip_ext(fcinfo, CL_UNION);
 }
 
-PG_FUNCTION_INFO_V1(cl_difference);
+PG_FUNCTION_INFO_V1(Geom_difference);
+/**
+ * @ingroup mobilitydb_geo_base_spatial
+ * @brief Return the region of the first geometry that the second does not cover
+ * @sqlfn difference()
+ */
 Datum
-cl_difference(PG_FUNCTION_ARGS)
+Geom_difference(PG_FUNCTION_ARGS)
 {
   return clip_ext(fcinfo, CL_DIFFERENCE);
 }
 
-PG_FUNCTION_INFO_V1(symDifference);
+PG_FUNCTION_INFO_V1(Geom_sym_difference);
+/**
+ * @ingroup mobilitydb_geo_base_spatial
+ * @brief Return the region exactly one of two geometries covers
+ * @sqlfn symDifference()
+ */
 Datum
-symDifference(PG_FUNCTION_ARGS)
+Geom_sym_difference(PG_FUNCTION_ARGS)
 {
   return clip_ext(fcinfo, CL_XOR);
 }

--- a/mobilitydb/test/geo/expected/078_tpoint_clipping.test.out
+++ b/mobilitydb/test/geo/expected/078_tpoint_clipping.test.out
@@ -1,102 +1,102 @@
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))'));
                    st_astext                    
 ------------------------------------------------
  POLYGON((4 1,2 1,1 2,1 4,2 5,4 5,5 4,5 2,4 1))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 1,3 5,7 5,7 1,3 1))'));
            st_astext            
 --------------------------------
  POLYGON((5 1,3 1,3 5,5 5,5 1))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((1 3,1 7,5 7,5 3,1 3))'));
            st_astext            
 --------------------------------
  POLYGON((5 3,1 3,1 5,5 5,5 3))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))',
+SELECT st_astext(intersection(geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))',
   geometry 'Polygon((1 4,4 1,7 4,4 7,1 4))'));
            st_astext            
 --------------------------------
  POLYGON((6 3,4 1,1 4,3 6,6 3))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 1,3 6,7 6,7 1,3 1))'));
            st_astext            
 --------------------------------
  POLYGON((5 1,3 1,3 5,5 5,5 1))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((1 3,1 7,6 8,6 3,1 3))'));
            st_astext            
 --------------------------------
  POLYGON((5 3,1 3,1 5,5 5,5 3))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))',
+SELECT st_astext(intersection(geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))',
   geometry 'Polygon((0 5,4 1,7 4,3 8,0 5))'));
            st_astext            
 --------------------------------
  POLYGON((6 3,4 1,1 4,3 6,6 3))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,3 4,3 2,2 2))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,3 4,3 2,2 2))',
   geometry 'Polygon((4 1,4 5,8 5,8 1,4 1))'));
            st_astext            
 --------------------------------
  POLYGON((5 1,4 1,4 5,5 5,5 1))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,3 4,3 2,2 2))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,3 4,3 2,2 2))',
   geometry 'Polygon((3 1,3 5,6 5,6 1,3 1))'));
            st_astext            
 --------------------------------
  POLYGON((5 1,3 1,3 5,5 5,5 1))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,4 4,4 2,2 2))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,4 4,4 2,2 2))',
   geometry 'Polygon((3 1,3 5,6 5,6 1,3 1))'));
                    st_astext                    
 ------------------------------------------------
  POLYGON((5 1,3 1,3 2,4 2,4 4,3 4,3 5,5 5,5 1))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,4 2,4 4,2 4,2 2))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,4 2,4 4,2 4,2 2))',
   geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))'));
                               st_astext                               
 ----------------------------------------------------------------------
  POLYGON((4 1,2 1,1 2,1 4,2 5,4 5,5 4,5 2,4 1),(2 2,4 2,4 4,2 4,2 2))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_union(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(geoUnion(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
                    st_astext                    
 ------------------------------------------------
  POLYGON((5 1,1 1,1 5,3 5,3 7,7 7,7 3,5 3,5 1))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
                st_astext                
 ----------------------------------------
  POLYGON((5 1,1 1,1 5,3 5,3 3,5 3,5 1))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_sym_difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(symDifference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
                                    st_astext                                   
 -------------------------------------------------------------------------------
  MULTIPOLYGON(((7 3,5 3,5 5,3 5,3 7,7 7,7 3)),((5 1,1 1,1 5,3 5,3 3,5 3,5 1)))
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(
+SELECT st_astext(intersection(
   geometry 'MultiPolygon(((1 1,1 3,3 3,3 1,1 1)),((5 1,5 3,7 3,7 1,5 1)))',
   geometry 'Polygon((0 0,0 4,8 4,8 0,0 0))'));
                            st_astext                           
@@ -104,14 +104,14 @@ SELECT st_astext(_mdb_internal_clip_intersection(
  MULTIPOLYGON(((3 1,1 1,1 3,3 3,3 1)),((7 1,5 1,5 3,7 3,7 1)))
 (1 row)
 
-SELECT _mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+SELECT intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
   geometry 'Polygon((10 10,10 11,11 11,11 10,10 10))') IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT st_astext(_mdb_internal_clip_intersection(
+SELECT st_astext(intersection(
   geometry 'Polygon((0 0,0 4,8 4,8 0,0 0))',
   geometry 'MultiPolygon(((1 1,1 3,3 3,3 1,1 1)),((5 1,5 3,7 3,7 1,5 1)))'));
                            st_astext                           
@@ -119,6 +119,6 @@ SELECT st_astext(_mdb_internal_clip_intersection(
  MULTIPOLYGON(((3 1,1 1,1 3,3 3,3 1)),((7 1,5 1,5 3,7 3,7 1)))
 (1 row)
 
-SELECT _mdb_internal_clip_intersection(geometry 'Point(0 0)',
+SELECT intersection(geometry 'Point(0 0)',
   geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))');
 ERROR:  The function only accepts (multi)polygons

--- a/mobilitydb/test/geo/queries/078_tpoint_clipping.test.sql
+++ b/mobilitydb/test/geo/queries/078_tpoint_clipping.test.sql
@@ -32,56 +32,56 @@
 -------------------------------------------------------------------------------
 
 -- Point intersections
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))'));
 
 -- Overlapping Segments
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 1,3 5,7 5,7 1,3 1))'));
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((1 3,1 7,5 7,5 3,1 3))'));
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))',
+SELECT st_astext(intersection(geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))',
   geometry 'Polygon((1 4,4 1,7 4,4 7,1 4))'));
 
 -- Point and segment intersections
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 1,3 6,7 6,7 1,3 1))'));
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((1 3,1 7,6 8,6 3,1 3))'));
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))',
+SELECT st_astext(intersection(geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))',
   geometry 'Polygon((0 5,4 1,7 4,3 8,0 5))'));
 
 -- Hole that does not interact with the other polygon
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,3 4,3 2,2 2))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,3 4,3 2,2 2))',
   geometry 'Polygon((4 1,4 5,8 5,8 1,4 1))'));
 -- Hole whose countour intersects with the contour of the other polygon
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,3 4,3 2,2 2))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,3 4,3 2,2 2))',
   geometry 'Polygon((3 1,3 5,6 5,6 1,3 1))'));
 -- Hole that removes part of the contour of the other polygon
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,4 4,4 2,2 2))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,2 4,4 4,4 2,2 2))',
   geometry 'Polygon((3 1,3 5,6 5,6 1,3 1))'));
 
 -- Point intersections with a hole that does not interact with the other polygon
 -- (Re-enabled with the Clipper2 backend; Martinez wrong-answered this case.)
-SELECT st_astext(_mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,4 2,4 4,2 4,2 2))',
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1),(2 2,4 2,4 4,2 4,2 2))',
   geometry 'Polygon((0 3,3 0,6 3,3 6,0 3))'));
 
 -------------------------------------------------------------------------------
 -- Operations beyond intersection (cover map_clip_op dispatch + Clipper2 ops)
 -------------------------------------------------------------------------------
 
-SELECT st_astext(_mdb_internal_clip_union(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(geoUnion(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
-SELECT st_astext(_mdb_internal_clip_difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
-SELECT st_astext(_mdb_internal_clip_sym_difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
+SELECT st_astext(symDifference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
   geometry 'Polygon((3 3,3 7,7 7,7 3,3 3))'));
 
 -------------------------------------------------------------------------------
 -- MULTIPOLYGON input (cover the MULTIPOLYGONTYPE branch in lwgeom_to_paths64)
 -------------------------------------------------------------------------------
 
-SELECT st_astext(_mdb_internal_clip_intersection(
+SELECT st_astext(intersection(
   geometry 'MultiPolygon(((1 1,1 3,3 3,3 1,1 1)),((5 1,5 3,7 3,7 1,5 1)))',
   geometry 'Polygon((0 0,0 4,8 4,8 0,0 0))'));
 
@@ -89,14 +89,14 @@ SELECT st_astext(_mdb_internal_clip_intersection(
 -- Empty result (cover polys.empty() in polytree_to_lwgeom and NULL propagation)
 -------------------------------------------------------------------------------
 
-SELECT _mdb_internal_clip_intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+SELECT intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
   geometry 'Polygon((10 10,10 11,11 11,11 10,10 10))') IS NULL;
 
 -------------------------------------------------------------------------------
 -- MULTIPOLYGON result (cover polys.size() > 1 LWMPOLY wrapping)
 -------------------------------------------------------------------------------
 
-SELECT st_astext(_mdb_internal_clip_intersection(
+SELECT st_astext(intersection(
   geometry 'Polygon((0 0,0 4,8 4,8 0,0 0))',
   geometry 'MultiPolygon(((1 1,1 3,3 3,3 1,1 1)),((5 1,5 3,7 3,7 1,5 1)))'));
 
@@ -104,7 +104,7 @@ SELECT st_astext(_mdb_internal_clip_intersection(
 -- Non-polygon input rejection (cover the elog(ERROR,...) defensive path)
 -------------------------------------------------------------------------------
 
-SELECT _mdb_internal_clip_intersection(geometry 'Point(0 0)',
+SELECT intersection(geometry 'Point(0 0)',
   geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))');
 
 --------------------------------------------------------


### PR DESCRIPTION
intersection, geoUnion, difference and symDifference are the public names of the in-process polygon Boolean engine, each the name of its PostGIS counterpart without the ST_ prefix, so a query reaches this engine by dropping the prefix and PostGIS by keeping it. UNION is a reserved word of SQL, so the union carries the name of the type it answers over, as setUnion and spanUnion do. The PostgreSQL wrappers are Geom_intersection, Geom_union, Geom_difference and Geom_sym_difference beside Geom_buffer and Geom_convex_hull, each carrying the doxygen entry and the SQL name its group asks for. Both manuals hold the four entries with harvested examples, the reference appendix carries them, and the expected output of the clipping test is harvested.