### PR TITLE
Construct a pcpoint and a pcpatch through the schema MEOS resolves

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -158,6 +158,7 @@ extern char *pcpoint_as_hexwkb(const Pcpoint *pt);
 
 /* Constructor */
 
+extern Pcpoint *pcpoint_make(uint32_t pcid, const double *values, int count);
 extern Pcpoint *pcpoint_copy(const Pcpoint *pt);
 
 /* Accessor */
@@ -239,6 +240,7 @@ extern char *pcpatch_as_hexwkb(const Pcpatch *pa);
 
 /* Constructor */
 
+extern Pcpatch *pcpatch_make(const Pcpoint **points, int count);
 extern Pcpatch *pcpatch_copy(const Pcpatch *pa);
 
 /* Accessor */

--- a/meos/include/pointcloud/doxygen_meos_pointcloud.h
+++ b/meos/include/pointcloud/doxygen_meos_pointcloud.h
@@ -69,6 +69,10 @@
  * @ingroup meos_pointcloud_base
  * @brief Hex-WKB input / output functions for pcpoint and pcpatch
  *
+ * @defgroup meos_pointcloud_base_constructor Constructor functions
+ * @ingroup meos_pointcloud_base
+ * @brief Constructor functions for pcpoint and pcpatch
+ *
  * @defgroup meos_pointcloud_base_accessor Accessor functions
  * @ingroup meos_pointcloud_base
  * @brief Schema-aware coordinate accessors and metadata for pcpoint / pcpatch

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -249,7 +249,7 @@ pcpatch_as_hexwkb(const Pcpatch *pa)
  *****************************************************************************/
 
 /**
- * @ingroup meos_pointcloud_constructor
+ * @ingroup meos_pointcloud_base_constructor
  * @brief Return a palloc'd copy of a pcpatch
  */
 Pcpatch *

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -30,10 +30,16 @@
 #include <common/hashfn.h>
 /* PostGIS */
 #include <liblwgeom.h>       /* parse_hex, deparse_hex */
+/* pgPointCloud */
+#include "pc_api.h"
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
+#include <meos_pointcloud.h>
 #include "temporal/temporal.h"
+#include "pointcloud/pcpoint.h"
+#include "pointcloud/meos_schema_hook.h"
+#include "pointcloud/pgsql_compat.h"
 
 /*****************************************************************************
  * Reserved tail
@@ -247,6 +253,65 @@ pcpatch_as_hexwkb(const Pcpatch *pa)
 /*****************************************************************************
  * Constructor + accessors
  *****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_base_constructor
+ * @brief Return a pcpatch from an array of pcpoints
+ * @param[in] points Array of points, all of the same schema
+ * @param[in] count Number of points
+ * @return On error return @p NULL
+ * @note The schema is resolved through the MEOS cache, so a schema stated in
+ *   SQL and one parsed from an XML document build a value alike.
+ * @csqlfn #Pcpatch_make()
+ */
+Pcpatch *
+pcpatch_make(const Pcpoint **points, int count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(points, NULL);
+  if (! ensure_positive(count))
+    return NULL;
+  for (int i = 0; i < count; i++)
+    VALIDATE_NOT_NULL(points[i], NULL);
+  for (int i = 1; i < count; i++)
+    if (! ensure_same_pcid_pcpoint(points[0], points[i]))
+      return NULL;
+  uint32_t pcid = pcpoint_get_pcid(points[0]);
+  const PCSCHEMA *schema = meos_pc_schema(pcid);
+  if (! schema)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "No schema registered for pcid %u", pcid);
+    return NULL;
+  }
+
+  PCPOINTLIST *pl = pc_pointlist_make(count);
+  for (int i = 0; i < count; i++)
+  {
+    PCPOINT *pt = meos_pc_point_deserialize(
+      (const SERIALIZED_POINT *) points[i], schema);
+    if (! pt)
+    {
+      pc_pointlist_free(pl);
+      return NULL;
+    }
+    pc_pointlist_add_point(pl, pt);
+  }
+  PCPATCH *pa = pc_patch_from_pointlist(pl);
+  pc_pointlist_free(pl);
+  if (! pa)
+    return NULL;
+  Pcpatch *result = (Pcpatch *) meos_pc_patch_serialize(pa, NULL);
+  pc_patch_free(pa);
+  if (! result)
+    return NULL;
+  /* Zero the reserved tail described at the top of this file so that two
+   * patches holding the same points hold the same bytes, as pcpatch_hex_out
+   * prints them */
+  size_t meaningful = pcpatch_meaningful_size(result);
+  memset(((uint8_t *) result) + meaningful, 0, VARSIZE(result) - meaningful);
+  return result;
+}
 
 /**
  * @ingroup meos_pointcloud_base_constructor

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -282,7 +282,7 @@ pcpoint_as_hexwkb(const Pcpoint *pt)
  *****************************************************************************/
 
 /**
- * @ingroup meos_pointcloud_constructor
+ * @ingroup meos_pointcloud_base_constructor
  * @brief Return a palloc'd copy of a pcpoint
  */
 Pcpoint *

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -44,6 +44,7 @@
 #include <meos_pointcloud.h>
 #include "temporal/temporal.h"
 #include "pointcloud/meos_schema_hook.h"
+#include "pointcloud/pgsql_compat.h"
 
 /*****************************************************************************
  * Struct-tail padding
@@ -280,6 +281,56 @@ pcpoint_as_hexwkb(const Pcpoint *pt)
 /*****************************************************************************
  * Constructor
  *****************************************************************************/
+
+/**
+ * @ingroup meos_pointcloud_base_constructor
+ * @brief Return a pcpoint from the coordinates of the dimensions of the
+ *   schema a point cloud identifier names
+ * @param[in] pcid Point cloud identifier naming the schema
+ * @param[in] values Coordinate of each dimension, in the order the schema
+ *   states the dimensions
+ * @param[in] count Number of coordinates
+ * @return On error return @p NULL
+ * @note The schema is resolved through the MEOS cache, so a schema stated in
+ *   SQL and one parsed from an XML document build a value alike.
+ * @csqlfn #Pcpoint_make()
+ */
+Pcpoint *
+pcpoint_make(uint32_t pcid, const double *values, int count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(values, NULL);
+  if (! ensure_positive(count))
+    return NULL;
+  const PCSCHEMA *schema = meos_pc_schema(pcid);
+  if (! schema)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "No schema registered for pcid %u", pcid);
+    return NULL;
+  }
+  if (count != (int) schema->ndims)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The number of coordinates must be the number of dimensions of the "
+      "schema %u: %d vs %u", pcid, count, schema->ndims);
+    return NULL;
+  }
+
+  PCPOINT *pcpt = pc_point_from_double_array(schema, (double *) values, 0,
+    (uint32_t) count);
+  if (! pcpt)
+    return NULL;
+  Pcpoint *result = (Pcpoint *) meos_pc_point_serialize(pcpt);
+  pc_point_free(pcpt);
+  /* The bytes past the meaningful prefix are pgpointcloud's struct-tail
+   * padding, which the serialization leaves uninitialized. They are zeroed
+   * so that two pcpoints holding the same point hold the same bytes, as
+   * pcpoint_hex_out prints them (see the file header) */
+  size_t meaningful = pcpoint_meaningful_size(result);
+  memset(((uint8_t *) result) + meaningful, 0, VARSIZE(result) - meaningful);
+  return result;
+}
 
 /**
  * @ingroup meos_pointcloud_base_constructor

--- a/mobilitydb/pg_include/pg_pointcloud/doxygen_mobilitydb_pointcloud.h
+++ b/mobilitydb/pg_include/pg_pointcloud/doxygen_mobilitydb_pointcloud.h
@@ -65,6 +65,10 @@
  *****************************************************************************/
 
 /**
+ * @defgroup mobilitydb_pointcloud_base_constructor Constructor functions
+ * @ingroup mobilitydb_pointcloud_base
+ * @brief Constructor functions for pcpoint / pcpatch
+ *
  * @defgroup mobilitydb_pointcloud_base_accessor Accessor functions
  * @ingroup mobilitydb_pointcloud_base
  * @brief Schema-aware accessors (pcid, getX, getY, getZ, getDim) for

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -155,28 +155,28 @@ CREATE CAST (tpcpoint AS text) WITH FUNCTION asText(tpcpoint);
 -- GENERATED-REPRESENTATIONS-END pointcloud
 
 /******************************************************************************
- * Ergonomic pcpoint constructors
+ * pcpoint constructors
  *
- * pgPointCloud's `pcpoint_in` only accepts hex-WKB; the canonical
- * builder is `PC_MakePoint(pcid, ARRAY[…]::float[])` whose argument
- * shape is verbose at the test-literal level. These two-/three-arg
- * overloads wrap that builder so tests and ad-hoc queries can write
- * `pcpoint(1, 1.0, 1.0, 1.0)`. Pure SQL; no new C code.
+ * pgPointCloud's `pcpoint_in` only accepts hex-WKB, so a coordinate is given
+ * to a constructor instead. The schema the pcid names is resolved through the
+ * MEOS cache, which reads the pointcloud_schemas and pointcloud_dimensions
+ * tables and falls back to the XML document pgPointCloud's own catalog
+ * carries, so a schema stated either way builds a value.
  *
- * The schema dimension count is enforced downstream by PC_MakePoint
- * — these wrappers inherit that behaviour.
+ * The number of coordinates must be the number of dimensions the schema
+ * states, which the constructor enforces.
  ******************************************************************************/
 
 CREATE FUNCTION pcpoint(pcid integer, x double precision, y double precision)
   RETURNS pcpoint
-  AS $$ SELECT PC_MakePoint($1, ARRAY[$2, $3]::float[]) $$
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Pcpoint_make'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION pcpoint(pcid integer, x double precision, y double precision,
     z double precision)
   RETURNS pcpoint
-  AS $$ SELECT PC_MakePoint($1, ARRAY[$2, $3, $4]::float[]) $$
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Pcpoint_make'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -145,23 +145,21 @@ CREATE CAST (tpcpatch AS text) WITH FUNCTION asText(tpcpatch);
 -- GENERATED-REPRESENTATIONS-END pointcloud_patch
 
 /******************************************************************************
- * Ergonomic pcpatch constructor
+ * pcpatch constructor
  *
- * Variadic wrapper around PC_Patch so test literals can write
- * `pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))` instead of
- * `PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
- *                 PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])])`.
+ * The schema the pcid names is resolved through the MEOS cache, which reads
+ * the pointcloud_schemas and pointcloud_dimensions tables and falls back to
+ * the XML document pgPointCloud's own catalog carries, so a schema stated
+ * either way builds a value.
  *
- * pcid is the first arg purely for readability — PC_Patch already
- * validates that every input pcpoint shares the same pcid, so we
- * pass the array straight through. (The pcid parameter is unused
- * inside the body — it's there to hint to the reader.)
+ * Every point must be of the schema the pcid names, which the constructor
+ * enforces.
  ******************************************************************************/
 
 CREATE FUNCTION pcpatch(pcid integer, VARIADIC points pcpoint[])
   RETURNS pcpatch
-  AS $$ SELECT PC_Patch($2) $$
-  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
+  AS 'MODULE_PATHNAME', 'Pcpatch_make'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
  * Constructors

--- a/mobilitydb/src/pointcloud/pcset.c
+++ b/mobilitydb/src/pointcloud/pcset.c
@@ -39,9 +39,12 @@
  * @c getDim) that build on top of the PCSCHEMA cache.
  */
 
+/* C */
+#include <assert.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <fmgr.h>
+#include <utils/array.h>
 /* pgpointcloud */
 #include "pc_api.h"
 /* MEOS */
@@ -54,7 +57,71 @@
 #include "pointcloud/meos_schema_hook.h"
 /* MobilityDB */
 #include "pg_geo/postgis.h"  /* PG_RETURN_GSERIALIZED_P */
+#include "pg_temporal/type_util.h"  /* datumarr_extract */
 #include "pg_pointcloud/schema_cache.h"
+
+/*****************************************************************************
+ * Constructors
+ *****************************************************************************/
+
+/**
+ * @brief Maximum number of coordinates a pcpoint constructor call carries,
+ *   which is the number of arguments of its widest SQL signature
+ */
+#define PCPOINT_MAX_COORDS 3
+
+PGDLLEXPORT Datum Pcpoint_make(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_make);
+/**
+ * @ingroup mobilitydb_pointcloud_base_constructor
+ * @brief Return a pcpoint from a point cloud identifier and the coordinates
+ *   of the dimensions of the schema it names
+ * @sqlfn pcpoint()
+ */
+Datum
+Pcpoint_make(PG_FUNCTION_ARGS)
+{
+  uint32_t pcid = (uint32_t) PG_GETARG_INT32(0);
+  int count = PG_NARGS() - 1;
+  assert(count > 0 && count <= PCPOINT_MAX_COORDS);
+  double values[PCPOINT_MAX_COORDS];
+  for (int i = 0; i < count; i++)
+    values[i] = PG_GETARG_FLOAT8(i + 1);
+  PG_RETURN_PCPOINT_P(pcpoint_make(pcid, values, count));
+}
+
+PGDLLEXPORT Datum Pcpatch_make(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_make);
+/**
+ * @ingroup mobilitydb_pointcloud_base_constructor
+ * @brief Return a pcpatch from a point cloud identifier and an array of
+ *   pcpoints of the schema it names
+ * @sqlfn pcpatch()
+ */
+Datum
+Pcpatch_make(PG_FUNCTION_ARGS)
+{
+  uint32_t pcid = (uint32_t) PG_GETARG_INT32(0);
+  ArrayType *array = PG_GETARG_ARRAYTYPE_P(1);
+  int count;
+  Pcpoint **points = (Pcpoint **) datumarr_extract(array, &count);
+  /* The points state the schema the patch is built from, so a pcid the points
+   * disagree with would state a schema the value does not carry. The points
+   * agreeing among themselves is what pcpatch_make ensures */
+  uint32_t pcid_pt = (count > 0) ? pcpoint_get_pcid(points[0]) : pcid;
+  if (pcid_pt != pcid)
+  {
+    pfree(points);
+    PG_FREE_IF_COPY(array, 1);
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+      errmsg("The points must be of the schema the patch states: %u vs %u",
+        pcid_pt, pcid)));
+  }
+  Pcpatch *result = pcpatch_make((const Pcpoint **) points, count);
+  pfree(points);
+  PG_FREE_IF_COPY(array, 1);
+  PG_RETURN_PCPATCH_P(result);
+}
 
 /*****************************************************************************
  * pcid accessors

--- a/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
+++ b/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
@@ -14,6 +14,39 @@ SELECT asMFJSON(tpcpoint '230000005A000000000000000000F03F0000000000000040000000
  {"type":"MovingPCPoint","crs":{"type":"Name","properties":{"name":"EPSG:4326"}},"coordinates":[[1,2,3]],"datetimes":["2024-01-01T00:00:00-08"],"interpolation":"None"}
 (1 row)
 
+SELECT getX(pcpoint(90, 1, 2, 3)), getY(pcpoint(90, 1, 2, 3)),
+  getZ(pcpoint(90, 1, 2, 3));
+ getx | gety | getz 
+------+------+------
+    1 |    2 |    3
+(1 row)
+
+SELECT pcid(pcpoint(90, 1, 2, 3)), SRID(pcpoint(90, 1, 2, 3));
+ pcid | srid 
+------+------
+   90 | 4326
+(1 row)
+
+SELECT ST_AsText(geometry(pcpatch(90, pcpoint(90, 1, 2, 3),
+  pcpoint(90, 4, 5, 6))));
+           st_astext            
+--------------------------------
+ MULTIPOINT Z ((1 2 3),(4 5 6))
+(1 row)
+
+SELECT pcpoint(90, 1, 2);
+ERROR:  The number of coordinates must be the number of dimensions of the schema 90: 2 vs 3
+SELECT pcpoint(999, 1, 2, 3);
+ERROR:  No schema registered for pcid 999
+INSERT INTO pointcloud_schemas (pcid, srid, compression) VALUES (92, 4326, 'none');
+INSERT 0 1
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (92, 1, 'X', 'double'), (92, 2, 'Y', 'double'), (92, 3, 'Z', 'double');
+INSERT 0 3
+SELECT pcpatch(90, pcpoint(92, 1, 2, 3));
+ERROR:  The points must be of the schema the patch states: 92 vs 90
+DELETE FROM pointcloud_schemas WHERE pcid = 92;
+DELETE 1
 INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
   (90, 1, 'W', 'double');
 ERROR:  duplicate key value violates unique constraint "pointcloud_dimensions_pkey"

--- a/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
+++ b/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
@@ -35,6 +35,34 @@ INSERT INTO pointcloud_dimensions
 -- the rendered coordinates are what states that the schema resolved.
 SELECT asMFJSON(tpcpoint '230000005A000000000000000000F03F00000000000000400000000000000840000000@2024-01-01');
 
+-- A value is BUILT from the schema the rows state, and not only read: the
+-- constructors resolve the schema the way the readers do, so a schema stated
+-- in SQL needs no XML document for a value of it to exist. The coordinates
+-- are read back rather than the text form, which is the stored bytes and
+-- reads alike under a schema that does not describe them.
+SELECT getX(pcpoint(90, 1, 2, 3)), getY(pcpoint(90, 1, 2, 3)),
+  getZ(pcpoint(90, 1, 2, 3));
+SELECT pcid(pcpoint(90, 1, 2, 3)), SRID(pcpoint(90, 1, 2, 3));
+
+-- A patch of that schema is built from the points of it
+SELECT ST_AsText(geometry(pcpatch(90, pcpoint(90, 1, 2, 3),
+  pcpoint(90, 4, 5, 6))));
+
+-- The number of coordinates is the number of dimensions the schema states
+SELECT pcpoint(90, 1, 2);
+
+-- A schema no row states and no XML document describes builds nothing
+SELECT pcpoint(999, 1, 2, 3);
+
+-- A second schema, stated the same way, to read the points of a patch against
+INSERT INTO pointcloud_schemas (pcid, srid, compression) VALUES (92, 4326, 'none');
+INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+  (92, 1, 'X', 'double'), (92, 2, 'Y', 'double'), (92, 3, 'Z', 'double');
+
+-- Every point of a patch is of the schema the patch states
+SELECT pcpatch(90, pcpoint(92, 1, 2, 3));
+DELETE FROM pointcloud_schemas WHERE pcid = 92;
+
 -- A position is stated once within a schema
 INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
   (90, 1, 'W', 'double');


### PR DESCRIPTION
A schema a point cloud identifier names is stated either as rows of pointcloud_schemas and pointcloud_dimensions or as an XML document of pgPointCloud's own catalog, and the MEOS schema cache resolves both. pcpoint_make and pcpatch_make on the MEOS surface build the two static values from the schema that cache resolves, so a schema stated either way builds a value, and a binding with no PostgreSQL catalog reaches the same constructor. The pcpoint and pcpatch SQL functions call them. The identifier a patch states is the schema of its points, and points that disagree with it are an error.