### PR TITLE
Name the last underscored SQL functions in camelCase

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -31,7 +31,7 @@ Use the commands:
 ```SQL
 SELECT version();
 SELECT postgis_full_version();
-SELECT mobilitydb_full_version();
+SELECT mobilitydbFullVersion();
 ```
 
 **Additional context**

--- a/.github/workflows/clang.yml
+++ b/.github/workflows/clang.yml
@@ -83,7 +83,7 @@ jobs:
         run: |
           sudo service postgresql start
           sudo -u postgres createdb -p ${PGPORT}  ___mobdb___test___
-          sudo -u postgres psql -p ${PGPORT}  -d ___mobdb___test___ -c "CREATE EXTENSION mobilitydb CASCADE; SELECT mobilitydb_full_version()"
+          sudo -u postgres psql -p ${PGPORT}  -d ___mobdb___test___ -c "CREATE EXTENSION mobilitydb CASCADE; SELECT mobilitydbFullVersion()"
 
       - name: Test
         run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -61,7 +61,7 @@ jobs:
           initdb -D $HOME/pgdata -E UTF8 --locale=C
           pg_ctl -D $HOME/pgdata -l logfile start
           createdb ___mobdb___test___
-          psql -d ___mobdb___test___ -c "CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydb_full_version();"
+          psql -d ___mobdb___test___ -c "CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydbFullVersion();"
           # btree_gist owns the base-type <-> distance operators, so mobilitydb
           # and btree_gist must load together in either order without a clash.
           createdb ___mobdb___btgist1___

--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -168,7 +168,7 @@ jobs:
         run: |
           sudo service postgresql start
           sudo -u postgres createdb -p ${PGPORT}  ___mobdb___test___
-          sudo -u postgres psql -p ${PGPORT}  -d ___mobdb___test___ -c "CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydb_full_version();"
+          sudo -u postgres psql -p ${PGPORT}  -d ___mobdb___test___ -c "CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydbFullVersion();"
 
       - name: Test coexistence with btree_gist
         # btree_gist defines <-> distance operators on base types (integer,

--- a/.github/workflows/windows_msys2.yml
+++ b/.github/workflows/windows_msys2.yml
@@ -83,7 +83,7 @@ jobs:
           pg_ctl start
           # Create database and add the MobilityDB extension
           createdb -U runneradmin mydb
-          psql -p 5432 -U runneradmin -d mydb -v ON_ERROR_STOP=1 -c "CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydb_full_version(); SELECT tfloat '[1@2000-01-01]';"
+          psql -p 5432 -U runneradmin -d mydb -v ON_ERROR_STOP=1 -c "CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydbFullVersion(); SELECT tfloat '[1@2000-01-01]';"
       - name: Dump postgres log
         if: always()
         shell: msys2 {0}

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -776,10 +776,10 @@
 			<title>Funciones de utilidad</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="mobilitydb_version"><varname>mobilitydb_version</varname></link>: Versión de la extensión MobilityDB</para>
+					<para><link linkend="mobilitydb_version"><varname>mobilitydbVersion</varname></link>: Versión de la extensión MobilityDB</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="mobilitydb_full_version"><varname>mobilitydb_full_version</varname></link>: Versión de la extensión MobilityDB y de sus dependencias</para>
+					<para><link linkend="mobilitydb_full_version"><varname>mobilitydbFullVersion</varname></link>: Versión de la extensión MobilityDB y de sus dependencias</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_types_p2.xml
+++ b/doc/es/temporal_types_p2.xml
@@ -638,19 +638,19 @@ SELECT 'AAA'::text #&gt; ttext '{[AAA@2001-01-01, AAA@2001-01-03),
 		<title>Funciones de utilidad</title>
 		<itemizedlist>
 			<listitem xml:id="mobilitydb_version">
-				<indexterm significance="normal"><primary><varname>mobilitydb_version</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mobilitydbVersion</varname></primary></indexterm>
 				<para>Versión de la extensión MobilityDB</para>
-				<para><varname>mobilitydb_version() → text</varname></para>
+				<para><varname>mobilitydbVersion() → text</varname></para>
 				<programlisting language="sql" xml:space="preserve">
-SELECT mobilitydb_version();
+SELECT mobilitydbVersion();
 -- MobilityDB 1.3.0
 </programlisting>
 			</listitem>
 
 			<listitem xml:id="mobilitydb_full_version">
-				<indexterm significance="normal"><primary><varname>mobilitydb_full_version</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mobilitydbFullVersion</varname></primary></indexterm>
 				<para>Versión de la extensión MobilityDB y de sus dependencias</para>
-				<para><varname>mobilitydb_full_version() → text</varname></para>
+				<para><varname>mobilitydbFullVersion() → text</varname></para>
 				<programlisting language="sql" xml:space="preserve">
 /* MobilityDB 1.3.0, PostgreSQL 17.2, PostGIS 3.5.2, GEOS 3.12.0-CAPI-1.18.0, PROJ 9.2.0,
    JSON-C 0.13.1 */

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -776,10 +776,10 @@
 			<title>Miscellaneous</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="mobilitydb_version"><varname>mobilitydb_version</varname></link>: Version of the MobilityDB extension</para>
+					<para><link linkend="mobilitydb_version"><varname>mobilitydbVersion</varname></link>: Version of the MobilityDB extension</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="mobilitydb_full_version"><varname>mobilitydb_full_version</varname></link>: Versions of the MobilityDB extension and its dependencies</para>
+					<para><link linkend="mobilitydb_full_version"><varname>mobilitydbFullVersion</varname></link>: Versions of the MobilityDB extension and its dependencies</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_types_p2.xml
+++ b/doc/temporal_types_p2.xml
@@ -646,21 +646,21 @@ SELECT 'AAA'::text #&gt; ttext '{[AAA@2001-01-01, AAA@2001-01-03),
 		<title>Miscellaneous</title>
 		<itemizedlist>
 			<listitem xml:id="mobilitydb_version">
-				<indexterm significance="normal"><primary><varname>mobilitydb_version</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mobilitydbVersion</varname></primary></indexterm>
 				<para>Version of the MobilityDB extension</para>
-				<para><varname>mobilitydb_version() → text</varname></para>
+				<para><varname>mobilitydbVersion() → text</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT mobilitydb_version();
+SELECT mobilitydbVersion();
 -- MobilityDB 1.3.0
 </programlisting>
 			</listitem>
 
 			<listitem xml:id="mobilitydb_full_version">
-				<indexterm significance="normal"><primary><varname>mobilitydb_full_version</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>mobilitydbFullVersion</varname></primary></indexterm>
 				<para>Versions of the MobilityDB extension and its dependencies</para>
-				<para><varname>mobilitydb_full_version() → text</varname></para>
+				<para><varname>mobilitydbFullVersion() → text</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT mobilitydb_full_version();
+SELECT mobilitydbFullVersion();
 /* MobilityDB 1.3.0, PostgreSQL 17.2, PostGIS 3.5.2, GEOS 3.12.0-CAPI-1.18.0, PROJ 9.2.0,
    JSON-C 0.13.1 */
 </programlisting>

--- a/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/geo/056_tpoint_spatialfuncs.in.sql
@@ -125,12 +125,12 @@ CREATE FUNCTION transformPipeline(tgeogpoint, text, srid integer DEFAULT 0,
 
 -- Gauss Kruger transformation
 
-CREATE FUNCTION transform_gk(tgeompoint)
+CREATE FUNCTION transformGK(tgeompoint)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tgeompoint_transform_gk'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION transform_gk(geometry)
+CREATE FUNCTION transformGK(geometry)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Geometry_transform_gk'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/geo/078_tpoint_datagen.in.sql
+++ b/mobilitydb/sql/geo/078_tpoint_datagen.in.sql
@@ -32,7 +32,7 @@
  * @brief Data generator for MobilityDB
  */
 
-CREATE FUNCTION create_trip(record[], timestamptz, boolean, text)
+CREATE FUNCTION createTrip(record[], timestamptz, boolean, text)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Create_trip'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/rgeo/176_trgeo_vclip.in.sql
+++ b/mobilitydb/sql/rgeo/176_trgeo_vclip.in.sql
@@ -36,32 +36,32 @@
  * V-clip functions
  *****************************************************************************/
 
-CREATE FUNCTION v_clip_poly_point(geometry(Polygon), geometry(Point))
+CREATE FUNCTION vClipPolyPoint(geometry(Polygon), geometry(Point))
   RETURNS float
   AS 'MODULE_PATHNAME', 'VClip_poly_point'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION v_clip_poly_poly(geometry(Polygon), geometry(Polygon))
+CREATE FUNCTION vClipPolyPoly(geometry(Polygon), geometry(Polygon))
   RETURNS float
   AS 'MODULE_PATHNAME', 'VClip_poly_poly'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION v_clip_tpoly_point(trgeometry, geometry(Point), timestamptz)
+CREATE FUNCTION vClipTpolyPoint(trgeometry, geometry(Point), timestamptz)
   RETURNS float
   AS 'MODULE_PATHNAME', 'VClip_tpoly_point'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION v_clip_tpoly_poly(trgeometry, geometry(Polygon), timestamptz)
+CREATE FUNCTION vClipTpolyPoly(trgeometry, geometry(Polygon), timestamptz)
   RETURNS float
   AS 'MODULE_PATHNAME', 'VClip_tpoly_poly'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION v_clip_tpoly_tpoint(trgeometry, tgeompoint, timestamptz)
+CREATE FUNCTION vClip(trgeometry, tgeompoint, timestamptz)
   RETURNS float
   AS 'MODULE_PATHNAME', 'VClip_tpoly_tpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION v_clip_tpoly_tpoly(trgeometry, trgeometry, timestamptz)
+CREATE FUNCTION vClip(trgeometry, trgeometry, timestamptz)
   RETURNS float
   AS 'MODULE_PATHNAME', 'VClip_tpoly_tpoly'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/temporal/022_temporal.in.sql
+++ b/mobilitydb/sql/temporal/022_temporal.in.sql
@@ -43,12 +43,12 @@ CREATE TYPE ttext;
  *****************************************************************************/
 
 -- The function is not strict
-CREATE FUNCTION mobilitydb_version()
+CREATE FUNCTION mobilitydbVersion()
   RETURNS text
   AS 'MODULE_PATHNAME', 'Mobilitydb_version'
   LANGUAGE C IMMUTABLE;
 
-CREATE FUNCTION mobilitydb_full_version()
+CREATE FUNCTION mobilitydbFullVersion()
   RETURNS text
   AS 'MODULE_PATHNAME', 'Mobilitydb_full_version'
   LANGUAGE C IMMUTABLE;

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -279,7 +279,7 @@ PG_FUNCTION_INFO_V1(Mobilitydb_version);
 /**
  * @ingroup mobilitydb_misc
  * @brief Return the version of the MobilityDB extension
- * @sqlfn mobilitydb_version()
+ * @sqlfn mobilitydbVersion()
  */
 Datum
 Mobilitydb_version(PG_FUNCTION_ARGS UNUSED)
@@ -294,7 +294,7 @@ PG_FUNCTION_INFO_V1(Mobilitydb_full_version);
 /**
  * @ingroup mobilitydb_misc
  * @brief Return the versions of the MobilityDB extension and its dependencies
- * @sqlfn mobilitydb_full_version()
+ * @sqlfn mobilitydbFullVersion()
  */
 Datum
 Mobilitydb_full_version(PG_FUNCTION_ARGS UNUSED)

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs.test.out
@@ -478,37 +478,37 @@ FROM test1, test2;
  t
 (1 row)
 
-SELECT asEWKT(round(transform_gk(tgeompoint 'Point(13.43593 52.41721)@2018-12-20'), 6));
+SELECT asEWKT(round(transformGK(tgeompoint 'Point(13.43593 52.41721)@2018-12-20'), 6));
                                    asewkt                                   
 ----------------------------------------------------------------------------
  SRID=4326;POINT(3005602.001235 5835394.36209)@Thu Dec 20 00:00:00 2018 PST
 (1 row)
 
-SELECT asEWKT(round(transform_gk(tgeompoint '{Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00}'), 6));
+SELECT asEWKT(round(transformGK(tgeompoint '{Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00}'), 6));
                                                                      asewkt                                                                      
 -------------------------------------------------------------------------------------------------------------------------------------------------
  SRID=4326;{POINT(3005602.001235 5835394.36209)@Thu Dec 20 10:00:00 2018 PST, POINT(3005609.918253 5835397.425462)@Thu Dec 20 10:01:00 2018 PST}
 (1 row)
 
-SELECT asEWKT(round(transform_gk(tgeompoint '[Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00]'), 6));
+SELECT asEWKT(round(transformGK(tgeompoint '[Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00]'), 6));
                                                                      asewkt                                                                      
 -------------------------------------------------------------------------------------------------------------------------------------------------
  SRID=4326;[POINT(3005602.001235 5835394.36209)@Thu Dec 20 10:00:00 2018 PST, POINT(3005609.918253 5835397.425462)@Thu Dec 20 10:01:00 2018 PST]
 (1 row)
 
-SELECT asEWKT(round(transform_gk(tgeompoint '{[Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00],[Point(13.43705 52.41724)@2018-12-20 10:02:00,Point(13.43805 52.41730)@2018-12-20 10:03:00]}'), 6));
+SELECT asEWKT(round(transformGK(tgeompoint '{[Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00],[Point(13.43705 52.41724)@2018-12-20 10:02:00,Point(13.43805 52.41730)@2018-12-20 10:03:00]}'), 6));
                                                                                                                                           asewkt                                                                                                                                           
 -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
  SRID=4326;{[POINT(3005602.001235 5835394.36209)@Thu Dec 20 10:00:00 2018 PST, POINT(3005609.918253 5835397.425462)@Thu Dec 20 10:01:00 2018 PST], [POINT(3005677.692787 5835405.559112)@Thu Dec 20 10:02:00 2018 PST, POINT(3005744.892798 5835419.245296)@Thu Dec 20 10:03:00 2018 PST]}
 (1 row)
 
-SELECT ST_AsText(round(transform_gk(geometry 'Point Empty'), 6));
+SELECT ST_AsText(round(transformGK(geometry 'Point Empty'), 6));
   st_astext  
 -------------
  POINT EMPTY
 (1 row)
 
-SELECT ST_AsText(round(transform_gk(geometry 'Point(13.43593 52.41721)'), 6));
+SELECT ST_AsText(round(transformGK(geometry 'Point(13.43593 52.41721)'), 6));
               st_astext              
 -------------------------------------
  POINT(3005602.001235 5835394.36209)
@@ -520,14 +520,14 @@ SELECT ST_AsText(round(geometry 'Linestring empty', 6));
  LINESTRING EMPTY
 (1 row)
 
-SELECT ST_AsText(round(transform_gk(geometry 'Linestring(13.43593 52.41721,13.43593 52.41723)'), 6));
+SELECT ST_AsText(round(transformGK(geometry 'Linestring(13.43593 52.41721,13.43593 52.41723)'), 6));
                                st_astext                                
 ------------------------------------------------------------------------
  LINESTRING(3005602.001235 5835394.36209,3005601.771521 5835396.582726)
 (1 row)
 
 /* Error */
-SELECT transform_gk(round(geometry 'Polygon((0 0,0 10,10 10,10 0,0 0))', 6));
+SELECT transformGK(round(geometry 'Polygon((0 0,0 10,10 10,10 0,0 0))', 6));
 ERROR:  Component geometry/geography must be of type Point(Z)M or LineString
 SELECT ST_AsText(round(geometry 'Point(1.123456789 1.123456789)', 6));
         st_astext         

--- a/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs_tbl.test.out
+++ b/mobilitydb/test/geo/expected/056_tpoint_spatialfuncs_tbl.test.out
@@ -40,25 +40,25 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D WHERE startValue(transform(setSRID(temp, 5
    100
 (1 row)
 
-SELECT ST_AsText(transform_gk(geometry 'Linestring empty'));
+SELECT ST_AsText(transformGK(geometry 'Linestring empty'));
     st_astext     
 ------------------
  LINESTRING EMPTY
 (1 row)
 
-SELECT round(MAX(ST_X(startValue(transform_gk(temp)))), 6) FROM tbl_tgeompoint;
+SELECT round(MAX(ST_X(startValue(transformGK(temp)))), 6) FROM tbl_tgeompoint;
       round      
 -----------------
  12685412.960367
 (1 row)
 
-SELECT round(MAX(ST_X(transform_gk(g))), 6) FROM tbl_geom_point;
+SELECT round(MAX(ST_X(transformGK(g))), 6) FROM tbl_geom_point;
       round      
 -----------------
  15523281.670408
 (1 row)
 
-SELECT round(MAX(ST_X(ST_StartPoint(transform_gk(g)))), 6) FROM tbl_geom_linestring WHERE NOT ST_IsEmpty(g);
+SELECT round(MAX(ST_X(ST_StartPoint(transformGK(g)))), 6) FROM tbl_geom_linestring WHERE NOT ST_IsEmpty(g);
       round      
 -----------------
  13567136.086579

--- a/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs.test.sql
+++ b/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs.test.sql
@@ -202,19 +202,19 @@ FROM test1, test2;
 --------------------------------------------------------
 
 -- Temporal type
-SELECT asEWKT(round(transform_gk(tgeompoint 'Point(13.43593 52.41721)@2018-12-20'), 6));
-SELECT asEWKT(round(transform_gk(tgeompoint '{Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00}'), 6));
-SELECT asEWKT(round(transform_gk(tgeompoint '[Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00]'), 6));
-SELECT asEWKT(round(transform_gk(tgeompoint '{[Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00],[Point(13.43705 52.41724)@2018-12-20 10:02:00,Point(13.43805 52.41730)@2018-12-20 10:03:00]}'), 6));
+SELECT asEWKT(round(transformGK(tgeompoint 'Point(13.43593 52.41721)@2018-12-20'), 6));
+SELECT asEWKT(round(transformGK(tgeompoint '{Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00}'), 6));
+SELECT asEWKT(round(transformGK(tgeompoint '[Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00]'), 6));
+SELECT asEWKT(round(transformGK(tgeompoint '{[Point(13.43593 52.41721)@2018-12-20 10:00:00, Point(13.43605 52.41723)@2018-12-20 10:01:00],[Point(13.43705 52.41724)@2018-12-20 10:02:00,Point(13.43805 52.41730)@2018-12-20 10:03:00]}'), 6));
 
 -- PostGIS geometry
-SELECT ST_AsText(round(transform_gk(geometry 'Point Empty'), 6));
-SELECT ST_AsText(round(transform_gk(geometry 'Point(13.43593 52.41721)'), 6));
+SELECT ST_AsText(round(transformGK(geometry 'Point Empty'), 6));
+SELECT ST_AsText(round(transformGK(geometry 'Point(13.43593 52.41721)'), 6));
 SELECT ST_AsText(round(geometry 'Linestring empty', 6));
-SELECT ST_AsText(round(transform_gk(geometry 'Linestring(13.43593 52.41721,13.43593 52.41723)'), 6));
+SELECT ST_AsText(round(transformGK(geometry 'Linestring(13.43593 52.41721,13.43593 52.41723)'), 6));
 
 /* Error */
-SELECT transform_gk(round(geometry 'Polygon((0 0,0 10,10 10,10 0,0 0))', 6));
+SELECT transformGK(round(geometry 'Polygon((0 0,0 10,10 10,10 0,0 0))', 6));
 
 --------------------------------------------------------
 

--- a/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/056_tpoint_spatialfuncs_tbl.test.sql
@@ -47,12 +47,12 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D WHERE startValue(transform(setSRID(temp, 5
 -------------------------------------------------------------------------------
 -- Transform by using Gauss Kruger Projection that is used in Secondo
 
-SELECT ST_AsText(transform_gk(geometry 'Linestring empty'));
+SELECT ST_AsText(transformGK(geometry 'Linestring empty'));
 
-SELECT round(MAX(ST_X(startValue(transform_gk(temp)))), 6) FROM tbl_tgeompoint;
+SELECT round(MAX(ST_X(startValue(transformGK(temp)))), 6) FROM tbl_tgeompoint;
 
-SELECT round(MAX(ST_X(transform_gk(g))), 6) FROM tbl_geom_point;
-SELECT round(MAX(ST_X(ST_StartPoint(transform_gk(g)))), 6) FROM tbl_geom_linestring WHERE NOT ST_IsEmpty(g);
+SELECT round(MAX(ST_X(transformGK(g))), 6) FROM tbl_geom_point;
+SELECT round(MAX(ST_X(ST_StartPoint(transformGK(g)))), 6) FROM tbl_geom_linestring WHERE NOT ST_IsEmpty(g);
 
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/rgeo/expected/161_trgeo_vclip.test.out
+++ b/mobilitydb/test/rgeo/expected/161_trgeo_vclip.test.out
@@ -1,4 +1,4 @@
-SELECT round(v_clip_poly_point(
+SELECT round(vClipPolyPoint(
   'Polygon((0 0,2 0,2 2,0 2,0 0))'::geometry,
   'Point(1 1)'::geometry), 6);
  round 
@@ -6,7 +6,7 @@ SELECT round(v_clip_poly_point(
      0
 (1 row)
 
-SELECT round(v_clip_poly_point(
+SELECT round(vClipPolyPoint(
   'Polygon((0 0,2 0,2 2,0 2,0 0))'::geometry,
   'Point(3 3)'::geometry), 6);
   round   
@@ -14,7 +14,7 @@ SELECT round(v_clip_poly_point(
  1.414214
 (1 row)
 
-SELECT round(v_clip_poly_point(
+SELECT round(vClipPolyPoint(
   'Polygon((0 0,2 0,2 2,0 2,0 0))'::geometry,
   'Point(1 0)'::geometry), 6);
  round 
@@ -22,7 +22,7 @@ SELECT round(v_clip_poly_point(
      0
 (1 row)
 
-SELECT round(v_clip_poly_poly(
+SELECT round(vClipPolyPoly(
   'Polygon((0 0,2 0,2 2,0 2,0 0))'::geometry,
   'Polygon((1 1,3 1,3 3,1 3,1 1))'::geometry), 6);
  round 
@@ -30,7 +30,7 @@ SELECT round(v_clip_poly_poly(
      0
 (1 row)
 
-SELECT round(v_clip_poly_poly(
+SELECT round(vClipPolyPoly(
   'Polygon((0 0,1 0,1 1,0 1,0 0))'::geometry,
   'Polygon((2 2,3 2,3 3,2 3,2 2))'::geometry), 6);
   round   
@@ -38,7 +38,7 @@ SELECT round(v_clip_poly_poly(
  1.414214
 (1 row)
 
-SELECT round(v_clip_poly_poly(
+SELECT round(vClipPolyPoly(
   'Polygon((0 0,4 0,4 4,0 4,0 0))'::geometry,
   'Polygon((1 1,3 1,3 3,1 3,1 1))'::geometry), 6);
  round 
@@ -46,7 +46,7 @@ SELECT round(v_clip_poly_poly(
      0
 (1 row)
 
-SELECT round(v_clip_tpoly_point(
+SELECT round(vClipTpolyPoint(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2000-01-01',
   'Point(0.5 0.5)'::geometry,
   timestamptz '2000-01-01'), 6);
@@ -55,7 +55,7 @@ SELECT round(v_clip_tpoly_point(
      0
 (1 row)
 
-SELECT round(v_clip_tpoly_point(
+SELECT round(vClipTpolyPoint(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 5),0)@2000-01-01',
   'Point(0.5 0.5)'::geometry,
   timestamptz '2000-01-01'), 6);
@@ -64,7 +64,7 @@ SELECT round(v_clip_tpoly_point(
  6.363961
 (1 row)
 
-SELECT round(v_clip_tpoly_poly(
+SELECT round(vClipTpolyPoly(
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));Pose(Point(0 0),0)@2000-01-01',
   'Polygon((1 1,3 1,3 3,1 3,1 1))'::geometry,
   timestamptz '2000-01-01'), 6);
@@ -73,7 +73,7 @@ SELECT round(v_clip_tpoly_poly(
      0
 (1 row)
 
-SELECT round(v_clip_tpoly_poly(
+SELECT round(vClipTpolyPoly(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 5),0)@2000-01-01',
   'Polygon((1 1,3 1,3 3,1 3,1 1))'::geometry,
   timestamptz '2000-01-01'), 6);
@@ -82,7 +82,7 @@ SELECT round(v_clip_tpoly_poly(
  2.828427
 (1 row)
 
-SELECT round(v_clip_tpoly_tpoint(
+SELECT round(vClip(
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));Pose(Point(0 0),0)@2000-01-01',
   tgeompoint 'Point(1 1)@2000-01-01',
   timestamptz '2000-01-01'), 6);
@@ -91,7 +91,7 @@ SELECT round(v_clip_tpoly_tpoint(
      0
 (1 row)
 
-SELECT round(v_clip_tpoly_tpoint(
+SELECT round(vClip(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 5),0)@2000-01-01',
   tgeompoint 'Point(1 1)@2000-01-01',
   timestamptz '2000-01-01'), 6);
@@ -100,7 +100,7 @@ SELECT round(v_clip_tpoly_tpoint(
  5.656854
 (1 row)
 
-SELECT round(v_clip_tpoly_tpoly(
+SELECT round(vClip(
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));Pose(Point(0 0),0)@2000-01-01',
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));Pose(Point(1 1),0)@2000-01-01',
   timestamptz '2000-01-01'), 6);
@@ -109,7 +109,7 @@ SELECT round(v_clip_tpoly_tpoly(
      0
 (1 row)
 
-SELECT round(v_clip_tpoly_tpoly(
+SELECT round(vClip(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2000-01-01',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 5),0)@2000-01-01',
   timestamptz '2000-01-01'), 6);

--- a/mobilitydb/test/rgeo/queries/161_trgeo_vclip.test.sql
+++ b/mobilitydb/test/rgeo/queries/161_trgeo_vclip.test.sql
@@ -28,87 +28,87 @@
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
--- v_clip_poly_point
+-- vClipPolyPoint
 -------------------------------------------------------------------------------
 
 -- Point inside polygon
-SELECT round(v_clip_poly_point(
+SELECT round(vClipPolyPoint(
   'Polygon((0 0,2 0,2 2,0 2,0 0))'::geometry,
   'Point(1 1)'::geometry), 6);
 -- Point outside polygon
-SELECT round(v_clip_poly_point(
+SELECT round(vClipPolyPoint(
   'Polygon((0 0,2 0,2 2,0 2,0 0))'::geometry,
   'Point(3 3)'::geometry), 6);
 -- Point on boundary
-SELECT round(v_clip_poly_point(
+SELECT round(vClipPolyPoint(
   'Polygon((0 0,2 0,2 2,0 2,0 0))'::geometry,
   'Point(1 0)'::geometry), 6);
 
 -------------------------------------------------------------------------------
--- v_clip_poly_poly
+-- vClipPolyPoly
 -------------------------------------------------------------------------------
 
 -- Overlapping polygons
-SELECT round(v_clip_poly_poly(
+SELECT round(vClipPolyPoly(
   'Polygon((0 0,2 0,2 2,0 2,0 0))'::geometry,
   'Polygon((1 1,3 1,3 3,1 3,1 1))'::geometry), 6);
 -- Disjoint polygons
-SELECT round(v_clip_poly_poly(
+SELECT round(vClipPolyPoly(
   'Polygon((0 0,1 0,1 1,0 1,0 0))'::geometry,
   'Polygon((2 2,3 2,3 3,2 3,2 2))'::geometry), 6);
 -- One inside the other
-SELECT round(v_clip_poly_poly(
+SELECT round(vClipPolyPoly(
   'Polygon((0 0,4 0,4 4,0 4,0 0))'::geometry,
   'Polygon((1 1,3 1,3 3,1 3,1 1))'::geometry), 6);
 
 -------------------------------------------------------------------------------
--- v_clip_tpoly_point (trgeometry × static point at given timestamptz)
+-- vClipTpolyPoint (trgeometry × static point at given timestamptz)
 -------------------------------------------------------------------------------
 
-SELECT round(v_clip_tpoly_point(
+SELECT round(vClipTpolyPoint(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2000-01-01',
   'Point(0.5 0.5)'::geometry,
   timestamptz '2000-01-01'), 6);
-SELECT round(v_clip_tpoly_point(
+SELECT round(vClipTpolyPoint(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 5),0)@2000-01-01',
   'Point(0.5 0.5)'::geometry,
   timestamptz '2000-01-01'), 6);
 
 -------------------------------------------------------------------------------
--- v_clip_tpoly_poly (trgeometry × static polygon at given timestamptz)
+-- vClipTpolyPoly (trgeometry × static polygon at given timestamptz)
 -------------------------------------------------------------------------------
 
-SELECT round(v_clip_tpoly_poly(
+SELECT round(vClipTpolyPoly(
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));Pose(Point(0 0),0)@2000-01-01',
   'Polygon((1 1,3 1,3 3,1 3,1 1))'::geometry,
   timestamptz '2000-01-01'), 6);
-SELECT round(v_clip_tpoly_poly(
+SELECT round(vClipTpolyPoly(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 5),0)@2000-01-01',
   'Polygon((1 1,3 1,3 3,1 3,1 1))'::geometry,
   timestamptz '2000-01-01'), 6);
 
 -------------------------------------------------------------------------------
--- v_clip_tpoly_tpoint (trgeometry × tgeompoint at given timestamptz)
+-- vClip (trgeometry × tgeompoint at given timestamptz)
 -------------------------------------------------------------------------------
 
-SELECT round(v_clip_tpoly_tpoint(
+SELECT round(vClip(
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));Pose(Point(0 0),0)@2000-01-01',
   tgeompoint 'Point(1 1)@2000-01-01',
   timestamptz '2000-01-01'), 6);
-SELECT round(v_clip_tpoly_tpoint(
+SELECT round(vClip(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 5),0)@2000-01-01',
   tgeompoint 'Point(1 1)@2000-01-01',
   timestamptz '2000-01-01'), 6);
 
 -------------------------------------------------------------------------------
--- v_clip_tpoly_tpoly (trgeometry × trgeometry at given timestamptz)
+-- vClip (trgeometry × trgeometry at given timestamptz)
 -------------------------------------------------------------------------------
 
-SELECT round(v_clip_tpoly_tpoly(
+SELECT round(vClip(
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));Pose(Point(0 0),0)@2000-01-01',
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));Pose(Point(1 1),0)@2000-01-01',
   timestamptz '2000-01-01'), 6);
-SELECT round(v_clip_tpoly_tpoly(
+SELECT round(vClip(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2000-01-01',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 5),0)@2000-01-01',
   timestamptz '2000-01-01'), 6);

--- a/mobilitydb/test/scripts/test.cmake
+++ b/mobilitydb/test/scripts/test.cmake
@@ -164,7 +164,7 @@ if(TEST_OPER MATCHES "test_setup")
   endif()
   string(APPEND _create_ext "CREATE EXTENSION mobilitydb CASCADE; ")
   string(APPEND _create_ext "SELECT postgis_full_version(); ")
-  string(APPEND _create_ext "SELECT mobilitydb_full_version();")
+  string(APPEND _create_ext "SELECT mobilitydbFullVersion();")
   execute_process(
     COMMAND ${POSTGRESQL_BIN_DIR}/psql -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres -c "${_create_ext}"
     OUTPUT_FILE ${TEST_DIR_LOG}/create_ext.log

--- a/mobilitydb/test/temporal/expected/022_temporal.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal.test.out
@@ -1,10 +1,10 @@
-SELECT mobilitydb_version() LIKE 'MobilityDB%';
+SELECT mobilitydbVersion() LIKE 'MobilityDB%';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT left(mobilitydb_full_version(), 10) = 'MobilityDB';
+SELECT left(mobilitydbFullVersion(), 10) = 'MobilityDB';
  ?column? 
 ----------
  t

--- a/mobilitydb/test/temporal/queries/022_temporal.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal.test.sql
@@ -31,8 +31,8 @@
 -- Utility functions
 -------------------------------------------------------------------------------
 
-SELECT mobilitydb_version() LIKE 'MobilityDB%';
-SELECT left(mobilitydb_full_version(), 10) = 'MobilityDB';
+SELECT mobilitydbVersion() LIKE 'MobilityDB%';
+SELECT left(mobilitydbFullVersion(), 10) = 'MobilityDB';
 
 -------------------------------------------------------------------------------
 -- Input/output functions


### PR DESCRIPTION
transformGK, createTrip, mobilitydbVersion and mobilitydbFullVersion carry the camelCase of the words they hold, an acronym keeping its capitals as asEWKB and setSRID do. The V-clip family takes the bare polymorphic vClip wherever the signature is free, which is the pair over a temporal point and over a temporal rigid geometry; the four whose arguments differ only in a geometry typmod keep the operand stem, since PostgreSQL reads them as one signature and one name declares the same function twice. Both manuals and the reference appendix carry the version names, the test harness reads mobilitydbFullVersion, and the expected output of the four exercising tests is harvested. PostgreSQL folds an unquoted identifier, so each function answers to a query written either way.