### PR TITLE
Copy the tail of the timezone buffer forward over itself

### DIFF
--- a/pgtypes/timezone/localtime.c
+++ b/pgtypes/timezone/localtime.c
@@ -416,7 +416,18 @@ tzloadbody(char const *name, char *canonname, struct state *sp, bool doextend,
     if (up->tzhead.tzh_version[0] == '\0')
       break;
     nread -= p - up->buf;
-    memmove(up->buf, p, nread);
+    /* MEOS: the destination sits below the source and the two overlap, so the
+     * copy has to run forward. Written as a loop because the compiler rewrites
+     * a memmove here as a memcpy, which is undefined over overlapping memory
+     * and which the C library may run backwards -- the direction that
+     * overwrites a source byte before reading it. A loop the compiler cannot
+     * prove non-overlapping is left alone. */
+    {
+      char *dst = up->buf;
+      const char *src = p;
+      for (int k = 0; k < nread; k++)
+        dst[k] = src[k];
+    }
   }
   if (doextend && nread > 2 &&
     up->buf[0] == '\n' && up->buf[nread - 1] == '\n' &&


### PR DESCRIPTION
Reading a timezone file, `localtime.c` shifts the bytes it has not consumed down to the front of the buffer it read them into. The source and the destination overlap by construction and the destination sits below the source, so the copy has to run forward.

The call the file makes is a `memmove`, which says exactly that. Compiling with optimization the compiler rewrites it as a `memcpy`, which is undefined over overlapping memory and which the C library may run backwards — the direction that overwrites a source byte before it is read. Valgrind reports the rewritten call as an overlap in `memcpy_chk`, at three separate reads of the system timezone during `meos_initialize`, and the six MEOS smoke suites that run under valgrind fail on it.

A loop copies forward and states the direction the bytes require. The compiler leaves it alone, having no proof the regions are disjoint.

The trace names the rewrite: `__memcpy_chk` from `memmove (string_fortified.h:36)` from `tzloadbody (localtime.c:419)`. It appears only under optimization — a build at `-O0` reports no errors, one carrying both optimization and symbols reports three. The object file alone shows `__memmove_chk`, the call the source asks for, so the rewrite is visible only in a run.

Afterwards the six suites pass, the object carries no `memmove`, and the six remaining `memcpy` calls are the ones the file makes for other reasons.