### PR TITLE
Answer a TIN and the intersection matrix natively

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -430,6 +430,7 @@ extern bool geom_dwithin3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2, doubl
 extern bool geom_intersects(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geom_intersects2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geom_intersects3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
+extern char *geom_relate(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 extern bool geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *patt);
 extern bool geom_touches(const GSERIALIZED *gs1, const GSERIALIZED *gs2);
 

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -6108,15 +6108,24 @@ relate_union_edges(const LWGEOM *geom)
 
 /**
  * @brief Return the edges a DE-9IM cell is computed on
- * @details Every geometry answers with its own edges, except a collection,
- * whose topology is that of the union of its components
+ * @details Every geometry answers with its own edges, except a value holding
+ * several components, whose topology is that of their union. Two members of a
+ * multipolygon may share a boundary edge -- edge-adjacent polygons are a valid
+ * multipolygon -- and that edge lies in the interior of what they cover
+ * together, so reading the members' own edges reports it as boundary
  */
 static MeosArray *
 relate_extract_edges(const LWGEOM *geom)
 {
-  if (geom->type == COLLECTIONTYPE)
-    return relate_union_edges(geom);
-  return geom_extract_edges(geom);
+  switch (geom->type)
+  {
+    case MULTIPOLYGONTYPE:
+    case MULTISURFACETYPE:
+    case COLLECTIONTYPE:
+      return relate_union_edges(geom);
+    default:
+      return geom_extract_edges(geom);
+  }
 }
 
 /*****************************************************************************

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -475,12 +475,14 @@ geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
       break;
 
     /* A compound curve (chain of line/circular strings), a multicurve
-     * (collection of line/circular/compound curves) and a multisurface
-     * (collection of polygons/curve polygons) all share the collection memory
-     * layout, so their components are extracted the same way as a collection */
+     * (collection of line/circular/compound curves), a multisurface
+     * (collection of polygons/curve polygons) and a TIN (collection of
+     * triangles) all share the collection memory layout, so their components
+     * are extracted the same way as a collection */
     case COMPOUNDTYPE:
     case MULTICURVETYPE:
     case MULTISURFACETYPE:
+    case TINTYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
@@ -549,11 +551,12 @@ geom_meos_supported(const LWGEOM *geom)
     case COMPOUNDTYPE:
     case MULTICURVETYPE:
     case MULTISURFACETYPE:
+    case TINTYPE:
     case COLLECTIONTYPE:
     {
-      /* A multicurve/multisurface is supported when every component is: its
-       * components are line/circular/compound curves and polygons/curve
-       * polygons, each validated by the recursive call */
+      /* A multicurve/multisurface/TIN is supported when every component is:
+       * its components are line/circular/compound curves, polygons/curve
+       * polygons and triangles, each validated by the recursive call */
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       for (uint32_t i = 0; i < col->ngeoms; i++)
         if (! geom_meos_supported(col->geoms[i]))
@@ -2451,6 +2454,7 @@ meos_is_simple(const LWGEOM *geom, bool *result)
       *result = true;
       return true;
     }
+    case TINTYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
@@ -3563,6 +3567,7 @@ relate_is_areal(const LWGEOM *geom)
     case TRIANGLETYPE:
     case CURVEPOLYTYPE:
     case MULTISURFACETYPE:
+    case TINTYPE:
       return true;
     case COLLECTIONTYPE:
     {
@@ -5815,6 +5820,7 @@ relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
   {
     case MULTIPOLYGONTYPE:
     case MULTISURFACETYPE:
+    case TINTYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
@@ -6121,6 +6127,7 @@ relate_extract_edges(const LWGEOM *geom)
   {
     case MULTIPOLYGONTYPE:
     case MULTISURFACETYPE:
+    case TINTYPE:
     case COLLECTIONTYPE:
       return relate_union_edges(geom);
     default:
@@ -6168,8 +6175,9 @@ relate_dim_mask(const LWGEOM *geom)
     case MULTISURFACETYPE:
       return 4;
     case MULTIPOLYGONTYPE:
+    case TINTYPE:
     {
-      /* A multipolygon carrying any surface is areal: a member enclosing no
+      /* A multipolygon or a TIN carrying any surface is areal: a member enclosing no
        * area draws linework the surfaces already account for, and reporting
        * both dimensions would send a value every member of which is a polygon
        * down the mixed-dimension path */

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2049,6 +2049,42 @@ geom_disjoint2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
 /**
  * @ingroup meos_geo_base_rel
+ * @brief Return the DE-9IM intersection matrix of two geometries
+ * @param[in] gs1,gs2 Geometries
+ * @details The matrix is the native one, so a circular arc is met on its own
+ * circle rather than on the chords a linearization would put in its place.
+ * @ref geom_relate_pattern() answers whether a pattern matches it, which is
+ * the question a caller holding a pattern asks; this entry answers the matrix
+ * itself, which is what a caller without one needs
+ * @return A newly allocated string of nine characters, @p NULL on error
+ * @note PostGIS function: @p ST_Relate(geometry, geometry)
+ * @csqlfn #Geom_relate()
+ */
+char *
+geom_relate(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_geo_geo(gs1, gs2) || ! ensure_not_geodetic_geo(gs1))
+    return NULL;
+
+  LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
+  LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
+  char matrix[10];
+  bool covered = meos_relate(geom1, geom2, matrix);
+  lwgeom_free(geom1); lwgeom_free(geom2);
+  if (! covered)
+  {
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "The intersection matrix of the geometries is not supported");
+    return NULL;
+  }
+  char *result = palloc(10);
+  strcpy(result, matrix);
+  return result;
+}
+
+/**
+ * @ingroup meos_geo_base_rel
  * @brief Return true if two geometries satisfy a spatial relationship given
  * by a pattern
  * @param[in] gs1,gs2 Geometries

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -610,6 +610,20 @@ int main(void)
   assert(meos_errno() == 0);
   meos_errno_reset();
 
+  /* Two members of a multipolygon may share a boundary edge, and that edge
+   * lies in the INTERIOR of what they cover together. The same region written
+   * as one polygon is the control: both must report a line running along that
+   * edge as meeting their interior */
+  GSERIALIZED *adjmp = geom_in("MULTIPOLYGON(((0 0,0 1,1 1,0 0)),"
+    "((0 0,1 1,1 0,0 0)))", -1);
+  GSERIALIZED *adjsq = geom_in("POLYGON((0 0,0 1,1 1,1 0,0 0))", -1);
+  GSERIALIZED *diag = geom_in("LINESTRING(0 0,2 2)", -1);
+  assert(geom_relate_pattern(adjmp, diag, "1********") == true);
+  assert(geom_relate_pattern(adjsq, diag, "1********") == true);
+  printf("the members of a multipolygon share the interior they cover\n");
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -624,6 +624,16 @@ int main(void)
   assert(meos_errno() == 0);
   meos_errno_reset();
 
+  /* A TIN is a set of triangles, so it covers what the same triangles cover
+   * written any other way. GEOS carries no TIN at all, so what answers for it
+   * is that identity rather than a foreign answer */
+  GSERIALIZED *adjtin = geom_in("TIN Z (((0 0 0,0 1 0,1 1 0,0 0 0)),"
+    "((0 0 0,1 1 0,1 0 0,0 0 0)))", -1);
+  assert(geom_relate_pattern(adjtin, diag, "1********") == true);
+  printf("a TIN covers what its triangles cover written any other way\n");
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 

--- a/mobilitydb/sql/geo/049_geo_funcs.in.sql
+++ b/mobilitydb/sql/geo/049_geo_funcs.in.sql
@@ -47,6 +47,15 @@ CREATE FUNCTION convexHull(geometry)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /*****************************************************************************
+ * Intersection matrix
+ *****************************************************************************/
+
+CREATE FUNCTION relate(geometry, geometry)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Geom_relate'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************
  * Simple geometries
  *****************************************************************************/
 

--- a/mobilitydb/src/geo/geo_funcs.c
+++ b/mobilitydb/src/geo/geo_funcs.c
@@ -89,6 +89,32 @@ Geom_convex_hull(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
+ * Intersection matrix
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Geom_relate(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Geom_relate);
+/**
+ * @ingroup mobilitydb_geo_base_rel
+ * @brief Return the DE-9IM intersection matrix of two geometries
+ * @sqlfn relate()
+ */
+Datum
+Geom_relate(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs1 = PG_GETARG_GSERIALIZED_P(0);
+  GSERIALIZED *gs2 = PG_GETARG_GSERIALIZED_P(1);
+  char *str = geom_relate(gs1, gs2);
+  PG_FREE_IF_COPY(gs1, 0);
+  PG_FREE_IF_COPY(gs2, 1);
+  if (! str)
+    PG_RETURN_NULL();
+  text *result = cstring_to_text(str);
+  pfree(str);
+  PG_RETURN_TEXT_P(result);
+}
+
+/*****************************************************************************
  * Simple geometries
  *****************************************************************************/
 

--- a/mobilitydb/test/geo/expected/049_geo_funcs.test.out
+++ b/mobilitydb/test/geo/expected/049_geo_funcs.test.out
@@ -240,3 +240,53 @@ SELECT ST_GeometryType(buffer(geometry 'Multilinestring((0 0,10 0),(0 20,10 20))
  ST_MultiSurface
 (1 row)
 
+SELECT relate(geometry 'Point(1 1)', geometry 'Point(1 1)');
+  relate   
+-----------
+ 0FFFFFFF2
+(1 row)
+
+SELECT relate(geometry 'Point(1 1)', geometry 'Point(2 2)');
+  relate   
+-----------
+ FF0FFF0F2
+(1 row)
+
+SELECT relate(geometry 'Linestring(0 0,2 2)', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+  relate   
+-----------
+ 1FFF0F212
+(1 row)
+
+SELECT relate(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+  relate   
+-----------
+ 2FF11F212
+(1 row)
+
+SELECT relate(geometry 'Multipolygon(((0 0,0 1,1 1,0 0)),((0 0,1 1,1 0,0 0)))',
+  geometry 'Linestring(0 0,2 2)');
+  relate   
+-----------
+ 1F2001102
+(1 row)
+
+SELECT relate(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))', geometry 'Linestring(0 0,2 2)');
+  relate   
+-----------
+ 1F2001102
+(1 row)
+
+SELECT relate(geometry 'Tin Z (((0 0 0,0 1 0,1 1 0,0 0 0)),((0 0 0,1 1 0,1 0 0,0 0 0)))',
+  geometry 'Linestring(0 0,2 2)');
+  relate   
+-----------
+ 1F2001102
+(1 row)
+
+SELECT ST_Relate(geometry 'Point(1 1)', geometry 'Point(1 1)', '0FFFFFFF2');
+ st_relate 
+-----------
+ t
+(1 row)
+

--- a/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
+++ b/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
@@ -128,3 +128,26 @@ SELECT ST_GeometryType(buffer(geometry 'Multipoint(0 0,10 0)', 1));
 SELECT ST_GeometryType(buffer(geometry 'Multilinestring((0 0,10 0),(0 20,10 20))', 1));
 
 -------------------------------------------------------------------------------
+-- Intersection matrix
+-------------------------------------------------------------------------------
+
+SELECT relate(geometry 'Point(1 1)', geometry 'Point(1 1)');
+SELECT relate(geometry 'Point(1 1)', geometry 'Point(2 2)');
+SELECT relate(geometry 'Linestring(0 0,2 2)', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+SELECT relate(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
+
+-- The members of a multipolygon may share a boundary edge, and that edge lies
+-- in the interior of what they cover together, as it does when the same region
+-- is written as one polygon
+SELECT relate(geometry 'Multipolygon(((0 0,0 1,1 1,0 0)),((0 0,1 1,1 0,0 0)))',
+  geometry 'Linestring(0 0,2 2)');
+SELECT relate(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))', geometry 'Linestring(0 0,2 2)');
+
+-- A TIN covers what its triangles cover written any other way
+SELECT relate(geometry 'Tin Z (((0 0 0,0 1 0,1 1 0,0 0 0)),((0 0 0,1 1 0,1 0 0,0 0 0)))',
+  geometry 'Linestring(0 0,2 2)');
+
+-- A pattern is matched against that matrix
+SELECT ST_Relate(geometry 'Point(1 1)', geometry 'Point(1 1)', '0FFFFFFF2');
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
Three topics, one commit each, in the order they build on one another.

**Read the edges of a multipolygon as those of the union of its members.** A value holding several components covers what its components cover together, so the edges the relate engine reads for it are those of their union. A geometry collection reads that union; a multipolygon and a multisurface read their members' own edges. Two members of a multipolygon may share a boundary edge — edge-adjacent polygons are a valid multipolygon — and such an edge lies in the interior of what they cover together. Two triangles sharing a diagonal report a line drawn along that diagonal as meeting their boundary, where the same region written as one polygon reports it as meeting their interior.

**Answer a TIN through the native engine.** A TIN is a collection of triangles, which the engine answers, so it joins the types the engine covers. The seven places that dispatch on the kind of a value give it the branch a collection of surfaces takes, `LWTIN` carrying the collection layout those branches read. Its members share edges by construction, so it reads the union as a multipolygon does.

**Answer the intersection matrix of two geometries.** `geom_relate` answers the DE-9IM matrix, which `ST_Relate` answers for PostGIS and which `geom_relate_pattern` has so far answered only through a pattern. A caller holding a pattern asks whether it matches; a caller holding none needs the matrix, and a build carrying no GEOS has nowhere else to ask. The PostgreSQL function `relate(geometry, geometry)` exposes it.

What answers for a TIN is the identity that it covers what its triangles cover written any other way: GEOS carries no TIN, so a foreign answer is one about the geometry collection its conversion produces. `meos/test/geo_test.c` asserts that identity and the multipolygon one; `049_geo_funcs` asserts the matrix over both.

Over the relate corpora — 54 adversarial, 324 small areal, 1444 areal, 202 trajectory and 12880 geometry pairs — no matrix moves. Those corpora carry 1448 multipolygons, none with edge-adjacent members, so they are blind to the case the first commit answers.