### PR TITLE
Render the document of a point cloud schema stated as dimensions

### DIFF
--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -83,7 +83,7 @@ SELECT pointCloudSchemaNDims(1);
 SELECT pcpoint(1, 1.0, 2.0, 3.0);
 
 -- a patch holding two points
-SELECT pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0),
+SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
                   pcpoint(1, 4.0, 5.0, 6.0));
 
 -- a single-instant tpcpoint at (10, 20, 30) at 2024-01-01
@@ -104,7 +104,7 @@ INSERT INTO scans VALUES (1,
   tpcpointSeq(ARRAY[
     tpcpoint(pcpoint(1, 0, 0, 0), '2024-01-01'::timestamptz),
     tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-02'::timestamptz)]),
-  tpcpatch(pcpatch(1, pcpoint(1,1,1,1), pcpoint(1,2,2,2)),
+  tpcpatch(pcpatch(pcpoint(1,1,1,1), pcpoint(1,2,2,2)),
            '2024-01-01'::timestamptz));
 </programlisting>
 			<para>Insertar un valor cuyo pcid no coincide con el typmod de la columna genera <varname>ERROR: Pcid of tpcpoint value (N) does not match column typmod pcid (M)</varname>; mezclar pcids en una columna sin restricciones también se rechaza en el momento de la agregación con <varname>extent</varname>.</para>
@@ -199,9 +199,9 @@ SELECT pcpoint(1, 10.0, 20.0, 30.0);
 				<listitem xml:id="pcpatch_variadic">
 					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
 					<para>Construye un pcpatch a partir de una lista variádica de pcpoints que comparten el mismo pcid</para>
-					<para><varname>pcpatch(pcid integer, VARIADIC points pcpoint[]) → pcpatch</varname></para>
+					<para><varname>pcpatch(VARIADIC points pcpoint[]) → pcpatch</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
 -- equivalent to PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
 --                              PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])])
 </programlisting>
@@ -268,7 +268,7 @@ SELECT SRID(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), PC_MakePoin
 					<para>Devuelve el multipunto de las posiciones que ocupan los puntos de un parche. El esquema que nombra el <varname>pcid</varname> decide el SRID y si el resultado lleva una dimensión Z</para>
 					<para><varname>geometry(pcpatch) &#8594; geometry</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText(geometry(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
+SELECT ST_AsText(geometry(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 -- MULTIPOINT Z ((1 1 1),(2 2 2))
 </programlisting>
 				</listitem>
@@ -647,7 +647,7 @@ CREATE TABLE scans (id int, traj tpcpoint(1), full_scan tpcpatch(1));
 -- accepts pcid 1
 INSERT INTO scans VALUES (1,
   tpcpoint(pcpoint(1, 1.0, 2.0, 3.0), '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
            '2024-01-01'::timestamptz));
 -- rejects any other pcid:
 -- ERROR: Pcid of tpcpoint value (2) does not match column typmod pcid (1)
@@ -1370,7 +1370,7 @@ SELECT tDwithin(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
 					<para>Construir un pcpatch temporal de subtipo instante</para>
 					<para><varname>tpcpatch(pcpatch,timestamptz) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tempSubtype(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT tempSubtype(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz));
 -- Instant
 </programlisting>
@@ -1383,13 +1383,13 @@ SELECT tempSubtype(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))
 					<para><varname>tpcpatchSeq(tpcpatch[],text) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)])), interp(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]));
 -- 2 | Step
 </programlisting>
@@ -1401,9 +1401,9 @@ SELECT numInstants(tpcpatchSeq(ARRAY[
 					<para><varname>tpcpatchSeqSet(tpcpatch[]) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSequences(tpcpatchSeqSet(ARRAY[tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)])]));
 -- 1
 </programlisting>
@@ -1475,7 +1475,7 @@ SELECT t, point FROM points(tpcpatch(
 					<para><varname>tpcpatchSeq(tpcpatch,interp='step') → tpcpatch</varname></para>
 					<para><varname>tpcpatchSeqSet(tpcpatch) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2,
+SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2,
   2)), '2001-01-01'::timestamptz)));
 -- Sequence
 </programlisting>
@@ -1486,9 +1486,9 @@ SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(
 					<para><varname>setInterp(tpcpatch,interp) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT interp(setInterp(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)], 'discrete'), 'step'));
 -- Step
 </programlisting>
@@ -1513,18 +1513,18 @@ SELECT interp(setInterp(tpcpatchSeq(ARRAY[
 -- The matching value is held up to the next instant; the closing bound
 -- is stored as a second instant.
 SELECT numInstants(atValue(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
-  pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
+  pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 -- 2
 SELECT numInstants(minusValue(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
-  pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
+  pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 -- 1
 </programlisting>
 				</listitem>
@@ -1537,18 +1537,18 @@ SELECT numInstants(minusValue(tpcpatchSeq(ARRAY[
 					<para><varname>minusTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
 -- The dropped patch stays present on the open interval before its instant,
 -- so the complement keeps two instants.
 SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 2
@@ -1562,9 +1562,9 @@ SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[
 					<para><varname>minusTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   tpcbox_xt(0, 0, 1, 1, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
@@ -1580,16 +1580,16 @@ SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[
 -- The polygon boundary touches the point (3 3) of the patch at
 -- 2001-01-02, so that patch survives both the at and the minus side.
 SELECT numInstants(atGeometry(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   geometry 'POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))'));
 -- 2
 SELECT numInstants(minusGeometry(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   geometry 'POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))'));
 -- 1
@@ -1604,19 +1604,19 @@ SELECT numInstants(minusGeometry(tpcpatchSeq(ARRAY[
 					<para><varname>afterTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
   timestamptz '2001-01-02'));
 -- [2001-01-01, 2001-01-02)
 SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
   timestamptz '2001-01-02'));
 -- (2001-01-02, 2001-01-03]
 </programlisting>
@@ -1635,13 +1635,13 @@ SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[
 					<para><varname>update(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(insert(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]), tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)])));
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)])));
 -- 3
 </programlisting>
 				</listitem>
@@ -1658,11 +1658,11 @@ SELECT numInstants(insert(tpcpatchSeq(ARRAY[
 -- {[2001-01-01, 2001-01-02), (2001-01-02, 2001-01-03]}; each half stores
 -- its bound at the deleted timestamp, giving four instants.
 SELECT numInstants(deleteTime(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
   timestamptz '2001-01-02'));
 -- 4
 </programlisting>
@@ -1676,11 +1676,11 @@ SELECT numInstants(deleteTime(tpcpatchSeq(ARRAY[
 					<para><varname>appendSequence(tpcpatch,tpcpatch) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(appendInstant(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)));
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)));
 -- 3
 </programlisting>
 				</listitem>
@@ -1697,11 +1697,11 @@ SELECT numInstants(appendInstant(tpcpatchSeq(ARRAY[
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (un).time
 FROM (SELECT unnest(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
   '2024-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-03'::timestamptz)])) AS un) t;
 -- {[2024-01-02, 2024-01-03)}
 -- {[2024-01-01, 2024-01-02), [2024-01-03, 2024-01-03]}
@@ -1715,11 +1715,11 @@ FROM (SELECT unnest(tpcpatchSeq(ARRAY[
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (ts).time, numInstants((ts).temp)
 FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
   '2024-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-03'::timestamptz)]),
   interval '1 day', '2024-01-01'::timestamptz) AS ts) t;
 -- 2024-01-01 | 2
@@ -1734,11 +1734,11 @@ FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
 					<para><varname>spans(tpcpatch) → tstzspan[]</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spans(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
   '2024-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-03'::timestamptz)]));
 -- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
 </programlisting>
@@ -1752,11 +1752,11 @@ SELECT spans(tpcpatchSeq(ARRAY[
 					<para><varname>splitEachNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
   '2024-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-03'::timestamptz)]), 2);
 -- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
 </programlisting>
@@ -1785,9 +1785,9 @@ SELECT splitNSpans(tpcpatchSeq(ARRAY[
 					<para>Las relaciones alguna vez y siempre cubren la misma matriz: <varname>eContains</varname>, <varname>eCovers</varname>, <varname>eDisjoint</varname>, <varname>eIntersects</varname>, <varname>eTouches</varname> y <varname>eDwithin</varname>, cada una en los tres órdenes de argumentos, y sus gemelas siempre. <varname>eIntersects(tpcpatch,geometry)</varname> es la que el tipo responde de forma nativa, recorriendo los puntos de cada instante y deteniéndose en el primer acierto; las demás convierten el parche a la geometría temporal de sus multipuntos.</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eIntersects(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]), geometry 'POINT(1 1)');
 -- t
 </programlisting>
@@ -1803,7 +1803,7 @@ SELECT eIntersects(tpcpatchSeq(ARRAY[
 					<para>Convierte un parche temporal en la geometría temporal de los multipuntos que ocupan sus parches. El parche de cada instante se convierte en el multipunto de las posiciones que ocupan sus puntos, leídas a través del esquema que nombra su <varname>pcid</varname></para>
 					<para><varname>tgeometry(tpcpatch) &#8594; tgeometry</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asText(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)::tgeometry);
 -- MULTIPOINT Z ((1 1 1),(2 2 2))@2001-01-01
 </programlisting>
@@ -1831,18 +1831,18 @@ SELECT asText(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
 					<para><varname>tTouches({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
 					<para>Un parche llega al motor de geometría como el multipunto de las posiciones que ocupan sus puntos, de modo que declara la matriz que declara la geometría temporal: cada predicado en cada dirección. Las planares responden para un esquema cuyas dimensiones no incluyen Z, y un esquema que lleva Z encuentra el rechazo <varname>The tgeometry cannot have Z dimension</varname>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tIntersects(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)),
+SELECT tIntersects(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)),
   '2001-01-01'::timestamptz), geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
 -- t@2001-01-01
-SELECT tDisjoint(tpcpatch(pcpatch(1, pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz),
+SELECT tDisjoint(tpcpatch(pcpatch(pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz),
   geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
 -- t@2001-01-02
-SELECT tDwithin(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz),
+SELECT tDwithin(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz),
   geometry 'Point(1 5)', 2.0);
 -- f@2001-01-01
 SELECT tIntersects(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz)]),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz),
+  tpcpatch(pcpatch(pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz)]),
   geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
 -- [t@2001-01-01, f@2001-01-02]
 </programlisting>
@@ -1892,17 +1892,17 @@ SELECT tIntersects(tpcpatchSeq(ARRAY[
 					<para><varname>tpcpatch ?= tpcpatch → boolean</varname></para>
 					<para>Los operadores <varname>%=</varname>, <varname>?&lt;&gt;</varname> y <varname>%&lt;&gt;</varname> reciben los mismos tres pares de operandos</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT eEq(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT eEq(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]));
 -- t
 SELECT aEq(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
-  '2001-01-02'::timestamptz)]), pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)));
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  '2001-01-02'::timestamptz)]), pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)));
 -- f
 </programlisting>
 				</listitem>
@@ -1922,10 +1922,10 @@ SELECT aEq(tpcpatchSeq(ARRAY[
 					<para>El operador <varname>#&lt;&gt;</varname> recibe los mismos tres pares de operandos</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
-  '2001-01-02'::timestamptz)]), pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)));
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  '2001-01-02'::timestamptz)]), pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)));
 -- [t@2001-01-01, f@2001-01-02]
 </programlisting>
 				</listitem>
@@ -2034,9 +2034,9 @@ SELECT wCount(v, interval '1 day') FROM (VALUES
 				<para><varname>tnpoints(tpcpatch) → tint</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoints(v) FROM (VALUES
-  (tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  (tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)),
-  (tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  (tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz))) t(v);
 -- {2@2001-01-01, 2@2001-01-02}
 </programlisting>
@@ -2049,9 +2049,9 @@ SELECT tnpoints(v) FROM (VALUES
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Each patch holds 2 points over a 1x1 xy-bbox.
 SELECT tdensity(v) FROM (VALUES
-  (tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  (tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)),
-  (tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  (tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz))) t(v);
 -- {2@2001-01-01, 2@2001-01-02}
 </programlisting>
@@ -2127,7 +2127,7 @@ SELECT asText(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 				<para><varname>tpcpatch::text → text</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The pcpatch payload renders as hex-encoded WKB.
-SELECT left(asText(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT left(asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)), 24);
 -- EC0100000100000000000000
 </programlisting>
@@ -2157,7 +2157,7 @@ SELECT asMFJSON(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 				<para>Para <varname>tpcpatch</varname>, la etiqueta de tipo es <varname>"MovingPCPatch"</varname> y cada instante emite un pequeño objeto <varname>{"pcid":N, "npoints":N, "bounds":[xmin,xmax,ymin,ymax]}</varname>. La carga de puntos comprimida no está intencionadamente en el JSON, use <varname>asBinary</varname> / <varname>asHexWKB</varname> para el ida y vuelta.</para>
 				<para><varname>asMFJSON(tpcpatch, options int=0, flags int=0, maxdecimaldigits int=15) → text</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz));
 -- {"type":"MovingPCPatch","values":[{"pcid":1,"npoints":2,"bounds":[1,2,1,2]}],
 --  "datetimes":["2001-01-01T00:00:00"],"interpolation":"None"}

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -84,7 +84,7 @@ SELECT pointCloudSchemaNDims(1);
 SELECT pcpoint(1, 1.0, 2.0, 3.0);
 
 -- a patch holding two points
-SELECT pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0),
+SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
                   pcpoint(1, 4.0, 5.0, 6.0));
 
 -- a single-instant tpcpoint at (10, 20, 30) at 2024-01-01
@@ -105,7 +105,7 @@ INSERT INTO scans VALUES (1,
   tpcpointSeq(ARRAY[
     tpcpoint(pcpoint(1, 0, 0, 0), '2024-01-01'::timestamptz),
     tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-02'::timestamptz)]),
-  tpcpatch(pcpatch(1, pcpoint(1,1,1,1), pcpoint(1,2,2,2)),
+  tpcpatch(pcpatch(pcpoint(1,1,1,1), pcpoint(1,2,2,2)),
            '2024-01-01'::timestamptz));
 </programlisting>
 			<para>Inserting a value whose pcid disagrees with the column's typmod raises <varname>ERROR: Pcid of tpcpoint value (N) does not match column typmod pcid (M)</varname>; mixing pcids in an unconstrained column is also rejected at <varname>extent</varname> aggregation time.</para>
@@ -201,9 +201,9 @@ SELECT pcpoint(1, 10.0, 20.0, 30.0);
 				<listitem xml:id="pcpatch_variadic">
 					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
 					<para>Build a pcpatch from a variadic list of pcpoints sharing the same pcid</para>
-					<para><varname>pcpatch(pcid integer, VARIADIC points pcpoint[]) → pcpatch</varname></para>
+					<para><varname>pcpatch(VARIADIC points pcpoint[]) → pcpatch</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
 -- equivalent to PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
 --                              PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])])
 </programlisting>
@@ -270,7 +270,7 @@ SELECT SRID(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), PC_MakePoin
 					<para>Return the multipoint of the positions the points of a patch occupy. The schema the <varname>pcid</varname> names decides the SRID and whether the result carries a Z dimension</para>
 					<para><varname>geometry(pcpatch) &#8594; geometry</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText(geometry(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
+SELECT ST_AsText(geometry(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 -- MULTIPOINT Z ((1 1 1),(2 2 2))
 </programlisting>
 				</listitem>
@@ -652,7 +652,7 @@ CREATE TABLE scans (id int, traj tpcpoint(1), full_scan tpcpatch(1));
 -- accepts pcid 1
 INSERT INTO scans VALUES (1,
   tpcpoint(pcpoint(1, 1.0, 2.0, 3.0), '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
            '2024-01-01'::timestamptz));
 -- rejects any other pcid:
 -- ERROR: Pcid of tpcpoint value (2) does not match column typmod pcid (1)
@@ -1376,7 +1376,7 @@ SELECT tDwithin(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
 					<para>Construct a temporal pcpatch of instant subtype</para>
 					<para><varname>tpcpatch(pcpatch,timestamptz) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tempSubtype(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT tempSubtype(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz));
 -- Instant
 </programlisting>
@@ -1389,13 +1389,13 @@ SELECT tempSubtype(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))
 					<para><varname>tpcpatchSeq(tpcpatch[],text) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)])), interp(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]));
 -- 2 | Step
 </programlisting>
@@ -1407,9 +1407,9 @@ SELECT numInstants(tpcpatchSeq(ARRAY[
 					<para><varname>tpcpatchSeqSet(tpcpatch[]) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSequences(tpcpatchSeqSet(ARRAY[tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)])]));
 -- 1
 </programlisting>
@@ -1481,7 +1481,7 @@ SELECT t, point FROM points(tpcpatch(
 					<para><varname>tpcpatchSeq(tpcpatch,interp='step') → tpcpatch</varname></para>
 					<para><varname>tpcpatchSeqSet(tpcpatch) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2,
+SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2,
   2)), '2001-01-01'::timestamptz)));
 -- Sequence
 </programlisting>
@@ -1492,9 +1492,9 @@ SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(
 					<para><varname>setInterp(tpcpatch,interp) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT interp(setInterp(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)], 'discrete'), 'step'));
 -- Step
 </programlisting>
@@ -1519,18 +1519,18 @@ SELECT interp(setInterp(tpcpatchSeq(ARRAY[
 -- The matching value is held up to the next instant; the closing bound
 -- is stored as a second instant.
 SELECT numInstants(atValue(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
-  pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
+  pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 -- 2
 SELECT numInstants(minusValue(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
-  pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
+  pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 -- 1
 </programlisting>
 				</listitem>
@@ -1543,18 +1543,18 @@ SELECT numInstants(minusValue(tpcpatchSeq(ARRAY[
 					<para><varname>minusTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
 -- The dropped patch stays present on the open interval before its instant,
 -- so the complement keeps two instants.
 SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 2
@@ -1568,9 +1568,9 @@ SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[
 					<para><varname>minusTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   tpcbox_xt(0, 0, 1, 1, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
@@ -1586,16 +1586,16 @@ SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[
 -- The polygon boundary touches the point (3 3) of the patch at
 -- 2001-01-02, so that patch survives both the at and the minus side.
 SELECT numInstants(atGeometry(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   geometry 'POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))'));
 -- 2
 SELECT numInstants(minusGeometry(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
   geometry 'POLYGON((0 0, 0 3, 3 3, 3 0, 0 0))'));
 -- 1
@@ -1610,19 +1610,19 @@ SELECT numInstants(minusGeometry(tpcpatchSeq(ARRAY[
 					<para><varname>afterTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
   timestamptz '2001-01-02'));
 -- [2001-01-01, 2001-01-02)
 SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
   timestamptz '2001-01-02'));
 -- (2001-01-02, 2001-01-03]
 </programlisting>
@@ -1641,13 +1641,13 @@ SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[
 					<para><varname>update(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(insert(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]), tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)])));
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)])));
 -- 3
 </programlisting>
 				</listitem>
@@ -1664,11 +1664,11 @@ SELECT numInstants(insert(tpcpatchSeq(ARRAY[
 -- {[2001-01-01, 2001-01-02), (2001-01-02, 2001-01-03]}; each half stores
 -- its bound at the deleted timestamp, giving four instants.
 SELECT numInstants(deleteTime(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)]),
   timestamptz '2001-01-02'));
 -- 4
 </programlisting>
@@ -1682,11 +1682,11 @@ SELECT numInstants(deleteTime(tpcpatchSeq(ARRAY[
 					<para><varname>appendSequence(tpcpatch,tpcpatch) → tpcpatch</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(appendInstant(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)));
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5)), '2001-01-03'::timestamptz)));
 -- 3
 </programlisting>
 				</listitem>
@@ -1703,11 +1703,11 @@ SELECT numInstants(appendInstant(tpcpatchSeq(ARRAY[
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (un).time
 FROM (SELECT unnest(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
   '2024-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-03'::timestamptz)])) AS un) t;
 -- {[2024-01-02, 2024-01-03)}
 -- {[2024-01-01, 2024-01-02), [2024-01-03, 2024-01-03]}
@@ -1721,11 +1721,11 @@ FROM (SELECT unnest(tpcpatchSeq(ARRAY[
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (ts).time, numInstants((ts).temp)
 FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
   '2024-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-03'::timestamptz)]),
   interval '1 day', '2024-01-01'::timestamptz) AS ts) t;
 -- 2024-01-01 | 2
@@ -1740,11 +1740,11 @@ FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
 					<para><varname>spans(tpcpatch) → tstzspan[]</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spans(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
   '2024-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-03'::timestamptz)]));
 -- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
 </programlisting>
@@ -1758,11 +1758,11 @@ SELECT spans(tpcpatchSeq(ARRAY[
 					<para><varname>splitEachNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
+  tpcpatch(pcpatch(pcpoint(1, 5, 5, 5), pcpoint(1, 6, 6, 6)),
   '2024-01-02'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2024-01-03'::timestamptz)]), 2);
 -- {"[2024-01-01, 2024-01-02]","[2024-01-02, 2024-01-03]"}
 </programlisting>
@@ -1791,9 +1791,9 @@ SELECT splitNSpans(tpcpatchSeq(ARRAY[
 					<para>The ever and always relationships cover the same matrix: <varname>eContains</varname>, <varname>eCovers</varname>, <varname>eDisjoint</varname>, <varname>eIntersects</varname>, <varname>eTouches</varname> and <varname>eDwithin</varname>, each in the three argument orders, and their always twins. <varname>eIntersects(tpcpatch,geometry)</varname> is the one the type answers natively, walking the points of each instant and stopping at the first hit; the rest convert the patch to the temporal geometry of its multipoints.</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eIntersects(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]), geometry 'POINT(1 1)');
 -- t
 </programlisting>
@@ -1809,7 +1809,7 @@ SELECT eIntersects(tpcpatchSeq(ARRAY[
 					<para>Convert a temporal patch into the temporal geometry of the multipoints its patches occupy. Each instant's patch becomes the multipoint of the positions its points occupy, read through the schema its <varname>pcid</varname> names</para>
 					<para><varname>tgeometry(tpcpatch) &#8594; tgeometry</varname></para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asText(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)::tgeometry);
 -- MULTIPOINT Z ((1 1 1),(2 2 2))@2001-01-01
 </programlisting>
@@ -1837,18 +1837,18 @@ SELECT asText(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
 					<para><varname>tTouches({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
 					<para>A patch reaches the geometry engine as the multipoint of the positions its points occupy, so it declares the matrix that temporal geometry declares: every predicate in every direction. The planar ones answer for a schema whose dimensions do not include Z, and a schema carrying Z meets the refusal <varname>The tgeometry cannot have Z dimension</varname>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tIntersects(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)),
+SELECT tIntersects(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)),
   '2001-01-01'::timestamptz), geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
 -- t@2001-01-01
-SELECT tDisjoint(tpcpatch(pcpatch(1, pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz),
+SELECT tDisjoint(tpcpatch(pcpatch(pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz),
   geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
 -- t@2001-01-02
-SELECT tDwithin(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz),
+SELECT tDwithin(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz),
   geometry 'Point(1 5)', 2.0);
 -- f@2001-01-01
 SELECT tIntersects(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz)]),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz),
+  tpcpatch(pcpatch(pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz)]),
   geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
 -- [t@2001-01-01, f@2001-01-02]
 </programlisting>
@@ -1898,17 +1898,17 @@ SELECT tIntersects(tpcpatchSeq(ARRAY[
 					<para><varname>tpcpatch ?= tpcpatch → boolean</varname></para>
 					<para>The operators <varname>%=</varname>, <varname>?&lt;&gt;</varname> and <varname>%&lt;&gt;</varname> take the same three operand pairs</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT eEq(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT eEq(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), tpcpatchSeq(ARRAY[
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz)]));
 -- t
 SELECT aEq(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
-  '2001-01-02'::timestamptz)]), pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)));
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  '2001-01-02'::timestamptz)]), pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)));
 -- f
 </programlisting>
 				</listitem>
@@ -1928,10 +1928,10 @@ SELECT aEq(tpcpatchSeq(ARRAY[
 					<para>The operator <varname>#&lt;&gt;</varname> takes the same three operand pairs</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(tpcpatchSeq(ARRAY[
-  tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz),
-  tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
-  '2001-01-02'::timestamptz)]), pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)));
+  tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  '2001-01-02'::timestamptz)]), pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)));
 -- [t@2001-01-01, f@2001-01-02]
 </programlisting>
 				</listitem>
@@ -2041,9 +2041,9 @@ SELECT wCount(v, interval '1 day') FROM (VALUES
 				<para><varname>tnpoints(tpcpatch) → tint</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoints(v) FROM (VALUES
-  (tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  (tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)),
-  (tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  (tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz))) t(v);
 -- {2@2001-01-01, 2@2001-01-02}
 </programlisting>
@@ -2056,9 +2056,9 @@ SELECT tnpoints(v) FROM (VALUES
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Each patch holds 2 points over a 1x1 xy-bbox.
 SELECT tdensity(v) FROM (VALUES
-  (tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  (tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)),
-  (tpcpatch(pcpatch(1, pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
+  (tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),
   '2001-01-02'::timestamptz))) t(v);
 -- {2@2001-01-01, 2@2001-01-02}
 </programlisting>
@@ -2134,7 +2134,7 @@ SELECT asText(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 				<para><varname>tpcpatch::text → text</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The pcpatch payload renders as hex-encoded WKB.
-SELECT left(asText(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT left(asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)), 24);
 -- EC0100000100000000000000
 </programlisting>
@@ -2164,7 +2164,7 @@ SELECT asMFJSON(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 				<para>For <varname>tpcpatch</varname>, the type tag is <varname>"MovingPCPatch"</varname> and each instant emits a small object <varname>{"pcid":N, "npoints":N, "bounds":[xmin,xmax,ymin,ymax]}</varname>. The compressed point payload is intentionally not in the JSON, use <varname>asBinary</varname> / <varname>asHexWKB</varname> for round-trip.</para>
 				<para><varname>asMFJSON(tpcpatch, options int=0, flags int=0, maxdecimaldigits int=15) → text</varname></para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz));
 -- {"type":"MovingPCPatch","values":[{"pcid":1,"npoints":2,"bounds":[1,2,1,2]}],
 --  "datetimes":["2001-01-01T00:00:00"],"interpolation":"None"}

--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -21,6 +21,7 @@
 /* pgPointcloud */
 #include "pc_api.h"
 #include "pc_api_internal.h"
+#include "stringbuffer.h"
 /* PostGIS */
 #include <liblwgeom.h>
 /* MEOS */
@@ -285,17 +286,91 @@ meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
 }
 
 /**
+ * @brief Return the pgPointCloud document describing a schema
+ * @details The element set is the one @c pc_schema_from_xml reads and the
+ *   layout is the one the library's own documents carry: a @c pc:dimension
+ *   per dimension holding its position, size, name, interpretation, scale,
+ *   offset and active flag, and a @c pc:metadata naming the compression.
+ *   @c pc_interpretation_string and @c pc_compression_number are the
+ *   library's, so the spelling of an interpretation and of a compression is
+ *   the library's too.
+ * @note The document is what the library parses, so the only proof that it is
+ *   right is the library reading it back: the test registers a schema as rows
+ *   and compares the schema this document parses to the schema the rows build.
+ */
+static char *
+pc_schema_as_xml(const PCSCHEMA *schema)
+{
+  assert(schema);
+  const char *comp = "none";
+  if (schema->compression == PC_DIMENSIONAL)
+    comp = "dimensional";
+  else if (schema->compression == PC_LAZPERF)
+    comp = "laz";
+
+  stringbuffer_t *sb = stringbuffer_create();
+  stringbuffer_append(sb,
+    "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
+    "<pc:PointCloudSchema xmlns:pc=\"http://pointcloud.org/schemas/PC/1.1\"\n"
+    "    xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\">\n");
+  for (int i = 0; i < (int) schema->ndims; i++)
+  {
+    const PCDIMENSION *d = schema->dims[i];
+    if (! d)
+      continue;
+    stringbuffer_append(sb, "  <pc:dimension>\n");
+    /* The parser reads a position counting from one and subtracts one */
+    stringbuffer_aprintf(sb, "    <pc:position>%u</pc:position>\n",
+      d->position + 1);
+    stringbuffer_aprintf(sb, "    <pc:size>%u</pc:size>\n", d->size);
+    stringbuffer_aprintf(sb, "    <pc:name>%s</pc:name>\n", d->name);
+    stringbuffer_aprintf(sb,
+      "    <pc:interpretation>%s</pc:interpretation>\n",
+      pc_interpretation_string(d->interpretation));
+    stringbuffer_aprintf(sb, "    <pc:scale>%.17g</pc:scale>\n", d->scale);
+    stringbuffer_aprintf(sb, "    <pc:offset>%.17g</pc:offset>\n", d->offset);
+    /* The parser reads the flag with atoi, so it is a number, not a word */
+    stringbuffer_aprintf(sb, "    <pc:active>%u</pc:active>\n",
+      (uint32_t) d->active);
+    stringbuffer_append(sb, "  </pc:dimension>\n");
+  }
+  stringbuffer_append(sb, "  <pc:metadata>\n");
+  stringbuffer_aprintf(sb,
+    "    <Metadata name=\"compression\">%s</Metadata>\n", comp);
+  stringbuffer_append(sb, "  </pc:metadata>\n"
+    "</pc:PointCloudSchema>\n");
+  char *result = stringbuffer_getstringcopy(sb);
+  stringbuffer_destroy(sb);
+  return result;
+}
+
+/**
  * @ingroup meos_pointcloud_schema_cache
- * @brief Return the cached XML text for a registered pcid (NULL on miss
- *   or parse-only registration).
+ * @brief Return the pgPointCloud document of a registered pcid
+ * @details A schema parsed from a document keeps the document it came from. A
+ *   schema stated as dimensions has none, so one describing it is rendered on
+ *   the first call and kept, which is what lets a schema stated either way
+ *   reach a reader that takes a document.
+ * @return On a pcid no schema is registered for return @p NULL
  */
 const char *
 meos_pc_schema_xml(uint32_t pcid)
 {
   for (int i = 0; i < cache_count; i++)
   {
-    if (cache_buf[i].pcid == pcid)
-      return cache_buf[i].xml_text;
+    if (cache_buf[i].pcid != pcid)
+      continue;
+    if (! cache_buf[i].xml_text && cache_buf[i].schema)
+    {
+      char *rendered = pc_schema_as_xml(cache_buf[i].schema);
+      /* The cache outlives the call, so the document is copied the way a
+       * parsed one is. ⛔ The stringbuffer symbols the link resolves are
+       * PostGIS's, not pgPointCloud's (see pc_stringbuffer_shim.c), so the
+       * buffer comes from lwalloc and is released with pfree, never free */
+      cache_buf[i].xml_text = copy_xml_long_lived(rendered);
+      pfree(rendered);
+    }
+    return cache_buf[i].xml_text;
   }
   return NULL;
 }

--- a/meos/test/pcschema_dims_test.c
+++ b/meos/test/pcschema_dims_test.c
@@ -71,6 +71,32 @@ check(bool ok, const char *what)
   }
 }
 
+/**
+ * @brief Compare two schemas field by field
+ */
+static void
+compare(const PCSCHEMA *a, const PCSCHEMA *b)
+{
+  check(a->ndims == b->ndims, "ndims");
+  check(a->size == b->size, "size");
+  check(a->compression == b->compression, "compression");
+  for (uint32_t i = 0; i < b->ndims; i++)
+  {
+    PCDIMENSION *x = a->dims[i], *y = b->dims[i];
+    check(x && y, "dimension present");
+    if (! x || ! y)
+      continue;
+    check(strcmp(x->name, y->name) == 0, "dimension name");
+    check(x->position == y->position, "dimension position");
+    check(x->size == y->size, "dimension size");
+    check(x->byteoffset == y->byteoffset, "dimension byteoffset");
+    check(x->interpretation == y->interpretation, "dimension interpretation");
+    check(x->scale == y->scale, "dimension scale");
+    check(x->offset == y->offset, "dimension offset");
+    check(x->active == y->active, "dimension active");
+  }
+}
+
 int
 main(void)
 {
@@ -97,25 +123,26 @@ main(void)
   }
 
   printf("The schema stated as dimensions against the same document:\n");
-  check(stated->ndims == parsed->ndims, "ndims");
-  check(stated->size == parsed->size, "size");
-  check(stated->compression == parsed->compression, "compression");
+  compare(stated, parsed);
   check(stated->srid == 4326, "srid");
   check(stated->pcid == 1, "pcid");
-  for (uint32_t i = 0; i < parsed->ndims; i++)
+
+  /* The document describing a schema stated as dimensions is rendered on
+   * demand, and the only proof it is right is the library reading it back:
+   * the schema its own parser builds from that document holds the fields the
+   * dimensions state */
+  const char *rendered = meos_pc_schema_xml(1);
+  check(rendered != NULL, "a schema stated as dimensions renders a document");
+  if (rendered)
   {
-    PCDIMENSION *a = stated->dims[i], *b = parsed->dims[i];
-    check(a && b, "dimension present");
-    if (! a || ! b)
-      continue;
-    check(strcmp(a->name, b->name) == 0, "dimension name");
-    check(a->position == b->position, "dimension position");
-    check(a->size == b->size, "dimension size");
-    check(a->byteoffset == b->byteoffset, "dimension byteoffset");
-    check(a->interpretation == b->interpretation, "dimension interpretation");
-    check(a->scale == b->scale, "dimension scale");
-    check(a->offset == b->offset, "dimension offset");
-    check(a->active == b->active, "dimension active");
+    PCSCHEMA *reparsed = pc_schema_from_xml(rendered);
+    check(reparsed != NULL, "the rendered document parses");
+    if (reparsed)
+    {
+      printf("The rendered document read back by the library:\n");
+      compare(stated, reparsed);
+      pc_schema_free(reparsed);
+    }
   }
   /* The X, Y and Z dimensions are resolved from the names */
   check(stated->xdim && strcmp(stated->xdim->name, "X") == 0, "xdim");

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -147,16 +147,17 @@ CREATE CAST (tpcpatch AS text) WITH FUNCTION asText(tpcpatch);
 /******************************************************************************
  * pcpatch constructor
  *
- * The schema the pcid names is resolved through the MEOS cache, which reads
- * the pointcloud_schemas and pointcloud_dimensions tables and falls back to
- * the XML document pgPointCloud's own catalog carries, so a schema stated
- * either way builds a value.
+ * The points state the schema of the patch they form, so the patch takes no
+ * identifier of its own: one stated beside them could only contradict them.
+ * The schema is resolved through the MEOS cache, which reads the
+ * pointcloud_schemas and pointcloud_dimensions tables and falls back to the
+ * XML document pgPointCloud's own catalog carries, so a schema stated either
+ * way builds a value.
  *
- * Every point must be of the schema the pcid names, which the constructor
- * enforces.
+ * Every point is of one schema, which the constructor enforces.
  ******************************************************************************/
 
-CREATE FUNCTION pcpatch(pcid integer, VARIADIC points pcpoint[])
+CREATE FUNCTION pcpatch(VARIADIC points pcpoint[])
   RETURNS pcpatch
   AS 'MODULE_PATHNAME', 'Pcpatch_make'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/src/pointcloud/pcset.c
+++ b/mobilitydb/src/pointcloud/pcset.c
@@ -94,32 +94,20 @@ PGDLLEXPORT Datum Pcpatch_make(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Pcpatch_make);
 /**
  * @ingroup mobilitydb_pointcloud_base_constructor
- * @brief Return a pcpatch from a point cloud identifier and an array of
- *   pcpoints of the schema it names
+ * @brief Return a pcpatch from an array of pcpoints
+ * @details The points state the schema of the patch they form, so the patch
+ *   takes no identifier of its own
  * @sqlfn pcpatch()
  */
 Datum
 Pcpatch_make(PG_FUNCTION_ARGS)
 {
-  uint32_t pcid = (uint32_t) PG_GETARG_INT32(0);
-  ArrayType *array = PG_GETARG_ARRAYTYPE_P(1);
+  ArrayType *array = PG_GETARG_ARRAYTYPE_P(0);
   int count;
   Pcpoint **points = (Pcpoint **) datumarr_extract(array, &count);
-  /* The points state the schema the patch is built from, so a pcid the points
-   * disagree with would state a schema the value does not carry. The points
-   * agreeing among themselves is what pcpatch_make ensures */
-  uint32_t pcid_pt = (count > 0) ? pcpoint_get_pcid(points[0]) : pcid;
-  if (pcid_pt != pcid)
-  {
-    pfree(points);
-    PG_FREE_IF_COPY(array, 1);
-    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-      errmsg("The points must be of the schema the patch states: %u vs %u",
-        pcid_pt, pcid)));
-  }
   Pcpatch *result = pcpatch_make((const Pcpoint **) points, count);
   pfree(points);
-  PG_FREE_IF_COPY(array, 1);
+  PG_FREE_IF_COPY(array, 0);
   PG_RETURN_PCPATCH_P(result);
 }
 

--- a/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
+++ b/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
@@ -27,7 +27,7 @@ SELECT pcid(pcpoint(90, 1, 2, 3)), SRID(pcpoint(90, 1, 2, 3));
    90 | 4326
 (1 row)
 
-SELECT ST_AsText(geometry(pcpatch(90, pcpoint(90, 1, 2, 3),
+SELECT ST_AsText(geometry(pcpatch(pcpoint(90, 1, 2, 3),
   pcpoint(90, 4, 5, 6))));
            st_astext            
 --------------------------------
@@ -43,8 +43,8 @@ INSERT 0 1
 INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
   (92, 1, 'X', 'double'), (92, 2, 'Y', 'double'), (92, 3, 'Z', 'double');
 INSERT 0 3
-SELECT pcpatch(90, pcpoint(92, 1, 2, 3));
-ERROR:  The points must be of the schema the patch states: 92 vs 90
+SELECT pcpatch(pcpoint(90, 1, 2, 3), pcpoint(92, 4, 5, 6));
+ERROR:  Operation on pcpoint values with different schemas: 90 vs 92
 DELETE FROM pointcloud_schemas WHERE pcid = 92;
 DELETE 1
 INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES

--- a/mobilitydb/test/pointcloud/expected/400_pcpoint_compops.test.out
+++ b/mobilitydb/test/pointcloud/expected/400_pcpoint_compops.test.out
@@ -107,84 +107,84 @@ FROM ordered a JOIN ordered b ON b.rn = a.rn + 1;
  t
 (1 row)
 
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
-  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
+  pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
-  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
+  pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) = 0;
+SELECT cmp(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) = 0;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
-  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) <> 0;
+SELECT cmp(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) <> 0;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
-  (cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) < 0);
+SELECT (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (cmp(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) < 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) >
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
-  (cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) > 0);
+SELECT (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) >
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (cmp(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) > 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
-  (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)) >
-    pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)) >
+    pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <=
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <=
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
  ?column? 
 ----------
  t
@@ -192,9 +192,9 @@ SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <=
 
 WITH v(pa) AS (
   VALUES
-    (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))),
-    (pcpatch(1, pcpoint(1, 3.0, 3.0, 3.0), pcpoint(1, 4.0, 4.0, 4.0))),
-    (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)))
+    (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))),
+    (pcpatch(pcpoint(1, 3.0, 3.0, 3.0), pcpoint(1, 4.0, 4.0, 4.0))),
+    (pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)))
 ), ordered AS (
   SELECT pa, row_number() OVER (ORDER BY pa) AS rn FROM v
 )

--- a/mobilitydb/test/pointcloud/expected/415_tpc_typmod.test.out
+++ b/mobilitydb/test/pointcloud/expected/415_tpc_typmod.test.out
@@ -79,7 +79,7 @@ SELECT bool_and(pcid(unconstrained) IN (1, 2)) FROM tbl_typmod
 (1 row)
 
 INSERT INTO tbl_typmod (pat1) VALUES
-  (tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  (tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
             '2024-01-01'::timestamptz));
 INSERT 0 1
 INSERT INTO tbl_typmod (pat1) VALUES

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -1,4 +1,4 @@
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))::text =
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))::text =
   (PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]))::text;
  ?column? 
 ----------
@@ -6,20 +6,20 @@ SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))::text =
 (1 row)
 
 SELECT numPoints(tpcpatch(
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
   '2024-01-01'::timestamptz)) = 2;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT SRID(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT SRID(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
  srid 
 ------
     0
 (1 row)
 
-SELECT SRID(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) =
+SELECT SRID(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) =
   SRID(pcpoint(1, 1.0, 1.0, 1.0));
  ?column? 
 ----------

--- a/mobilitydb/test/pointcloud/expected/431_tpcpatch_cmp.test.out
+++ b/mobilitydb/test/pointcloud/expected/431_tpcpatch_cmp.test.out
@@ -1,115 +1,115 @@
 INSERT INTO pointcloud_formats (pcid, srid, schema)
 SELECT 2, srid, schema FROM pointcloud_formats WHERE pcid = 1;
 INSERT 0 1
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) = (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) = (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) IS FALSE;
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) IS FALSE;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) IS FALSE;
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) IS FALSE;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) > (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) IS FALSE;
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) > (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) IS FALSE;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <= (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <= (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) >= (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) >= (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT ((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz))) AND ((tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) > (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)));
+SELECT ((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz))) AND ((tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) > (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT NOT ((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) AND (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) > (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)));
+SELECT NOT ((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) AND (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) > (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT ((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) = (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz))) = NOT ((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)));
+SELECT ((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) = (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz))) = NOT ((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT ((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) = (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz))) = NOT ((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)));
+SELECT ((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) = (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz))) = NOT ((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) <> (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(2, pcpoint(2, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(2, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(2, pcpoint(2, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(2, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(2, pcpoint(2, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(2, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz)) < (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
@@ -119,10 +119,10 @@ DROP TABLE IF EXISTS tbl_cmp_ordered;
 NOTICE:  table "tbl_cmp_ordered" does not exist, skipping
 DROP TABLE
 CREATE TABLE tbl_cmp_ordered AS
-  SELECT 1::int AS k, (tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz))::tpcpatch AS pa
-  UNION ALL SELECT 2, (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz))
-  UNION ALL SELECT 3, (tpcpatch(pcpatch(2, pcpoint(2, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz))
-  UNION ALL SELECT 4, (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
+  SELECT 1::int AS k, (tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz))::tpcpatch AS pa
+  UNION ALL SELECT 2, (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz))
+  UNION ALL SELECT 3, (tpcpatch(pcpatch(pcpoint(2, 1.0, 1.0, 1.0)), '2024-01-01'::timestamptz))
+  UNION ALL SELECT 4, (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2024-01-01'::timestamptz));
 SELECT 4
 SELECT array_agg(k ORDER BY pa) FROM tbl_cmp_ordered;
  array_agg 

--- a/mobilitydb/test/pointcloud/expected/432_tpcpatch_mfjson.test.out
+++ b/mobilitydb/test/pointcloud/expected/432_tpcpatch_mfjson.test.out
@@ -1,117 +1,117 @@
-SELECT asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb ->> 'type' = 'MovingPCPatch';
+SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb ->> 'type' = 'MovingPCPatch';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb ->> 'type' = 'MovingPCPatch';
+SELECT asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb ->> 'type' = 'MovingPCPatch';
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT asMFJSON(tpcpatchSeqSet(ARRAY[
-  tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz)]),
-  tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)])]))::jsonb ->> 'type' = 'MovingPCPatch';
+  tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz)]),
+  tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)])]))::jsonb ->> 'type' = 'MovingPCPatch';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb -> 'values' -> 0 ->> 'pcid')::int = 1;
+SELECT (asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb -> 'values' -> 0 ->> 'pcid')::int = 1;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb -> 'values' -> 0 ->> 'npoints')::int = 2;
+SELECT (asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb -> 'values' -> 0 ->> 'npoints')::int = 2;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz))::jsonb -> 'values' -> 0 ->> 'npoints')::int = 1;
+SELECT (asMFJSON(tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz))::jsonb -> 'values' -> 0 ->> 'npoints')::int = 1;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT jsonb_array_length(asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb -> 'values' -> 0 -> 'bounds') = 4;
+SELECT jsonb_array_length(asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb -> 'values' -> 0 -> 'bounds') = 4;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb -> 'values' -> 0 -> 'bounds') = '[1, 4, 2, 5]'::jsonb;
+SELECT (asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb -> 'values' -> 0 -> 'bounds') = '[1, 4, 2, 5]'::jsonb;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT jsonb_array_length(asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb -> 'values') = 2;
+SELECT jsonb_array_length(asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb -> 'values') = 2;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb -> 'values' -> 1 ->> 'npoints')::int = 1;
+SELECT (asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb -> 'values' -> 1 ->> 'npoints')::int = 1;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb ->> 'pcid')::int = 1;
+SELECT (asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb ->> 'pcid')::int = 1;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb ? 'bbox';
+SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb ? 'bbox';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT jsonb_array_length(asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb -> 'bbox') = 2;
+SELECT jsonb_array_length(asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb -> 'bbox') = 2;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb ? 'period';
+SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb ? 'period';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb -> 'period' ? 'begin';
+SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb -> 'period' ? 'begin';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb -> 'period' ? 'end';
+SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), options := 1)::jsonb -> 'period' ? 'end';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT asMFJSON(tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb ->> 'interpolation' = 'None';
+SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz))::jsonb ->> 'interpolation' = 'None';
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb ->> 'interpolation' = 'Step';
+SELECT asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb ->> 'interpolation' = 'Step';
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT jsonb_array_length(
-  asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb -> 'datetimes') =
+  asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb -> 'datetimes') =
   jsonb_array_length(
-  asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb -> 'values');
+  asMFJSON(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), '2024-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), '2024-01-02'::timestamptz)]))::jsonb -> 'values');
  ?column? 
 ----------
  t

--- a/mobilitydb/test/pointcloud/expected/434_tpcpatch_compops.test.out
+++ b/mobilitydb/test/pointcloud/expected/434_tpcpatch_compops.test.out
@@ -1,112 +1,112 @@
-SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) ?= (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz));
+SELECT (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) ?= (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) ?= (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) ?= (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) ?= (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) ?= (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) ?= (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)));
+SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) ?= (pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) ?= (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) ?= (pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)));
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) %= (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) %= (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) %= (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) %= (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)])) %= (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)])) %= (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)])) %= (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)]));
+SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)])) %= (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)]));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) ?<> (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)]));
+SELECT (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) ?<> (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)]));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) ?<> (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) ?<> (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) %<> (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)));
+SELECT (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) %<> (pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) ?<> (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)]));
+SELECT (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) ?<> (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)]));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT NOT ((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) ?= (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) AND (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) %<> (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))));
+SELECT NOT ((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) ?= (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) AND (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) %<> (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT asText((pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) #= (tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)));
+SELECT asText((pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) #= (tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) #= (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))));
+SELECT asText((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) #= (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText((tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) #= (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))));
+SELECT asText((tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) #= (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))));
                               astext                              
 ------------------------------------------------------------------
  [t@Mon Jan 01 00:00:00 2001 PST, f@Tue Jan 02 00:00:00 2001 PST]
 (1 row)
 
-SELECT asText((tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) #<> (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))));
+SELECT asText((tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz)) #<> (pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText((tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) #<> (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)])));
+SELECT asText((tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)), '2001-01-02'::timestamptz)])) #<> (tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), '2001-01-02'::timestamptz)])));
                               astext                              
 ------------------------------------------------------------------
  [f@Mon Jan 01 00:00:00 2001 PST, t@Tue Jan 02 00:00:00 2001 PST]

--- a/mobilitydb/test/pointcloud/expected/448_tpcpatch_tempspatialrels.test.out
+++ b/mobilitydb/test/pointcloud/expected/448_tpcpatch_tempspatialrels.test.out
@@ -1,88 +1,88 @@
-SELECT ST_AsText(geometry(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
+SELECT ST_AsText(geometry(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
            st_astext            
 --------------------------------
  MULTIPOINT Z ((1 1 1),(2 2 2))
 (1 row)
 
-SELECT ST_AsText(pcpatch(1, pcpoint(1, 1, 1, 1))::geometry);
+SELECT ST_AsText(pcpatch(pcpoint(1, 1, 1, 1))::geometry);
        st_astext        
 ------------------------
  MULTIPOINT Z ((1 1 1))
 (1 row)
 
-SELECT asText(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)), '2001-01-01'::timestamptz)::tgeometry);
+SELECT asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)), '2001-01-01'::timestamptz)::tgeometry);
                            astext                            
 -------------------------------------------------------------
  MULTIPOINT Z ((1 1 1),(9 9 9))@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tIntersects(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+SELECT asText(tIntersects(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tIntersects(geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))', tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz)));
+SELECT asText(tIntersects(geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))', tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz)));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tIntersects(tpcpatch(pcpatch(1, pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+SELECT asText(tIntersects(tpcpatch(pcpatch(pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
              astext             
 --------------------------------
  f@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tDisjoint(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+SELECT asText(tDisjoint(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
              astext             
 --------------------------------
  f@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tDisjoint(tpcpatch(pcpatch(1, pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+SELECT asText(tDisjoint(tpcpatch(pcpatch(pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
              astext             
 --------------------------------
  t@Tue Jan 02 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tIntersects(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+SELECT asText(tIntersects(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tDisjoint(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+SELECT asText(tDisjoint(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
              astext             
 --------------------------------
  f@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tDwithin(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))', 0.0));
+SELECT asText(tDwithin(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))', 0.0));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tDwithin(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Point(1 2)', 2.0));
+SELECT asText(tDwithin(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Point(1 2)', 2.0));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tDwithin(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Point(1 5)', 2.0));
+SELECT asText(tDwithin(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), geometry 'SRID=0;Point(1 5)', 2.0));
              astext             
 --------------------------------
  f@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tDwithin(tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), 0.0));
+SELECT asText(tDwithin(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), 0.0));
              astext             
 --------------------------------
  t@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT asText(tIntersects(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(1, pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz)]), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
+SELECT asText(tIntersects(tpcpatchSeq(ARRAY[tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz), tpcpatch(pcpatch(pcpoint(1, 9, 9, 9)), '2001-01-02'::timestamptz)]), geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'));
                               astext                              
 ------------------------------------------------------------------
  [t@Mon Jan 01 00:00:00 2001 PST, f@Tue Jan 02 00:00:00 2001 PST]
@@ -154,6 +154,6 @@ SELECT tContains(geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))', tpcpatch(PC_P
 (1 row)
 
 /* Errors: a schema carrying Z in a planar relationship */
-SELECT tContains(geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))', tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz));
+SELECT tContains(geometry 'SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))', tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz));
 ERROR:  The tgeometry cannot have Z dimension
 CONTEXT:  SQL function "tcontains" statement 1

--- a/mobilitydb/test/pointcloud/expected/449_tpcpatch_spatialrels.test.out
+++ b/mobilitydb/test/pointcloud/expected/449_tpcpatch_spatialrels.test.out
@@ -97,6 +97,6 @@ SELECT eDwithin(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(8, ARRAY[1.0, 1.0]::float[]
 (1 row)
 
 /* Errors: a schema carrying Z in a planar relationship */
-SELECT eContains(geometry 'SRID=0;Polygon((0 0,0 4,4 4,4 0,0 0))', tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz));
+SELECT eContains(geometry 'SRID=0;Polygon((0 0,0 4,4 4,4 0,0 0))', tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), '2001-01-01'::timestamptz));
 ERROR:  The tgeometry cannot have Z dimension
 CONTEXT:  SQL function "econtains" statement 1

--- a/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
+++ b/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
@@ -45,7 +45,7 @@ SELECT getX(pcpoint(90, 1, 2, 3)), getY(pcpoint(90, 1, 2, 3)),
 SELECT pcid(pcpoint(90, 1, 2, 3)), SRID(pcpoint(90, 1, 2, 3));
 
 -- A patch of that schema is built from the points of it
-SELECT ST_AsText(geometry(pcpatch(90, pcpoint(90, 1, 2, 3),
+SELECT ST_AsText(geometry(pcpatch(pcpoint(90, 1, 2, 3),
   pcpoint(90, 4, 5, 6))));
 
 -- The number of coordinates is the number of dimensions the schema states
@@ -54,13 +54,13 @@ SELECT pcpoint(90, 1, 2);
 -- A schema no row states and no XML document describes builds nothing
 SELECT pcpoint(999, 1, 2, 3);
 
--- A second schema, stated the same way, to read the points of a patch against
+-- A second schema, stated the same way, to build a point of another schema with
 INSERT INTO pointcloud_schemas (pcid, srid, compression) VALUES (92, 4326, 'none');
 INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
   (92, 1, 'X', 'double'), (92, 2, 'Y', 'double'), (92, 3, 'Z', 'double');
 
--- Every point of a patch is of the schema the patch states
-SELECT pcpatch(90, pcpoint(92, 1, 2, 3));
+-- The points of a patch are of one schema, which is the schema of the patch
+SELECT pcpatch(pcpoint(90, 1, 2, 3), pcpoint(92, 4, 5, 6));
 DELETE FROM pointcloud_schemas WHERE pcid = 92;
 
 -- A position is stated once within a schema

--- a/mobilitydb/test/pointcloud/queries/400_pcpoint_compops.test.sql
+++ b/mobilitydb/test/pointcloud/queries/400_pcpoint_compops.test.sql
@@ -82,49 +82,49 @@ FROM ordered a JOIN ordered b ON b.rn = a.rn + 1;
 -------------------------------------------------------------------------------
 
 -- Equality of two identical patches built independently.
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
-  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) =
+  pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
 
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
-  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <>
+  pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0));
 
 -- cmp() is reflexive and zero only for equal values.
-SELECT cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) = 0;
-SELECT cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
-  pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) <> 0;
+SELECT cmp(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) = 0;
+SELECT cmp(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) <> 0;
 
 -- The </<=/>/>= operators agree with the sign of cmp().
-SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
-  (cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) < 0);
-SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) >
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
-  (cmp(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) > 0);
+SELECT (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (cmp(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) < 0);
+SELECT (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) >
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (cmp(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) > 0);
 -- Antisymmetry.
-SELECT (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
-    pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
-  (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)) >
-    pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+    pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))) =
+  (pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)) >
+    pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
 -- Irreflexivity of the strict operators.
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <=
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)) <=
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
 
 -- ORDER BY over three distinct values produces a sequence that is
 -- non-decreasing with respect to the <= operator.
 WITH v(pa) AS (
   VALUES
-    (pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))),
-    (pcpatch(1, pcpoint(1, 3.0, 3.0, 3.0), pcpoint(1, 4.0, 4.0, 4.0))),
-    (pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)))
+    (pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))),
+    (pcpatch(pcpoint(1, 3.0, 3.0, 3.0), pcpoint(1, 4.0, 4.0, 4.0))),
+    (pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0)))
 ), ordered AS (
   SELECT pa, row_number() OVER (ORDER BY pa) AS rn FROM v
 )

--- a/mobilitydb/test/pointcloud/queries/415_tpc_typmod.test.sql
+++ b/mobilitydb/test/pointcloud/queries/415_tpc_typmod.test.sql
@@ -95,7 +95,7 @@ SELECT bool_and(pcid(unconstrained) IN (1, 2)) FROM tbl_typmod
 -------------------------------------------------------------------------------
 
 INSERT INTO tbl_typmod (pat1) VALUES
-  (tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
+  (tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
             '2024-01-01'::timestamptz));
 
 -- mismatch: pcid 2 into pat1 (typmod 1) raises

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -30,11 +30,11 @@
 -- Ergonomic pcpatch constructor — same value as the verbose form.
 -------------------------------------------------------------------------------
 
-SELECT pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))::text =
+SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))::text =
   (:patch1)::text;
 -- inline use inside tpcpatch + numPoints round-trip
 SELECT numPoints(tpcpatch(
-  pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
+  pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)),
   '2024-01-01'::timestamptz)) = 2;
 
 -------------------------------------------------------------------------------
@@ -42,10 +42,10 @@ SELECT numPoints(tpcpatch(
 -------------------------------------------------------------------------------
 
 -- pcid 1 is registered with SRID 0 in the test fixture.
-SELECT SRID(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
+SELECT SRID(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)));
 -- A patch and a point sharing the same pcid resolve the same SRID: both
 -- go through the same schema lookup.
-SELECT SRID(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) =
+SELECT SRID(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))) =
   SRID(pcpoint(1, 1.0, 1.0, 1.0));
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/431_tpcpatch_cmp.test.sql
+++ b/mobilitydb/test/pointcloud/queries/431_tpcpatch_cmp.test.sql
@@ -37,11 +37,11 @@
 INSERT INTO pointcloud_formats (pcid, srid, schema)
 SELECT 2, srid, schema FROM pointcloud_formats WHERE pcid = 1;
 
-\set p1 'tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), ''2024-01-01''::timestamptz)'
-\set p1_dup 'tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0)), ''2024-01-01''::timestamptz)'
-\set p2 'tpcpatch(pcpatch(1, pcpoint(1, 2.0, 2.0, 2.0)), ''2024-01-01''::timestamptz)'
-\set p3 'tpcpatch(pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), ''2024-01-01''::timestamptz)'
-\set p_pcid2 'tpcpatch(pcpatch(2, pcpoint(2, 1.0, 1.0, 1.0)), ''2024-01-01''::timestamptz)'
+\set p1 'tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), ''2024-01-01''::timestamptz)'
+\set p1_dup 'tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0)), ''2024-01-01''::timestamptz)'
+\set p2 'tpcpatch(pcpatch(pcpoint(1, 2.0, 2.0, 2.0)), ''2024-01-01''::timestamptz)'
+\set p3 'tpcpatch(pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0)), ''2024-01-01''::timestamptz)'
+\set p_pcid2 'tpcpatch(pcpatch(pcpoint(2, 1.0, 1.0, 1.0)), ''2024-01-01''::timestamptz)'
 
 -------------------------------------------------------------------------------
 -- Reflexivity, equality, and inequality

--- a/mobilitydb/test/pointcloud/queries/432_tpcpatch_mfjson.test.sql
+++ b/mobilitydb/test/pointcloud/queries/432_tpcpatch_mfjson.test.sql
@@ -25,8 +25,8 @@
 -- 421_tpcpoint_mfjson.test.sql for the tpcpoint side. Every assertion
 -- collapses to a scalar so the diff stays diff-able.
 
-\set inst1 'tpcpatch(pcpatch(1, pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), ''2024-01-01''::timestamptz)'
-\set inst2 'tpcpatch(pcpatch(1, pcpoint(1, 7.0, 8.0, 9.0)), ''2024-01-02''::timestamptz)'
+\set inst1 'tpcpatch(pcpatch(pcpoint(1, 1.0, 2.0, 3.0), pcpoint(1, 4.0, 5.0, 6.0)), ''2024-01-01''::timestamptz)'
+\set inst2 'tpcpatch(pcpatch(pcpoint(1, 7.0, 8.0, 9.0)), ''2024-01-02''::timestamptz)'
 
 -------------------------------------------------------------------------------
 -- type tag — MovingPCPatch on every subtype

--- a/mobilitydb/test/pointcloud/queries/434_tpcpatch_compops.test.sql
+++ b/mobilitydb/test/pointcloud/queries/434_tpcpatch_compops.test.sql
@@ -30,8 +30,8 @@
 -- deterministic. Patches: A holds (1,1,1) and (2,2,2), B holds (5,5,5) and
 -- (6,6,6).
 
-\set pA 'pcpatch(1, pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))'
-\set pB 'pcpatch(1, pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))'
+\set pA 'pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0))'
+\set pB 'pcpatch(pcpoint(1, 5.0, 5.0, 5.0), pcpoint(1, 6.0, 6.0, 6.0))'
 \set iA 'tpcpatch(:pA, ''2001-01-01''::timestamptz)'
 \set iB 'tpcpatch(:pB, ''2001-01-02''::timestamptz)'
 \set seqAB 'tpcpatchSeq(ARRAY[:iA, :iB])'

--- a/mobilitydb/test/pointcloud/queries/448_tpcpatch_tempspatialrels.test.sql
+++ b/mobilitydb/test/pointcloud/queries/448_tpcpatch_tempspatialrels.test.sql
@@ -20,16 +20,16 @@
 -- three predicates its Z-carrying values can answer.
 
 \set square 'geometry ''SRID=0;Polygon((0 0,0 2,2 2,2 0,0 0))'''
-\set inside 'tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), ''2001-01-01''::timestamptz)'
-\set straddling 'tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)), ''2001-01-01''::timestamptz)'
-\set far 'tpcpatch(pcpatch(1, pcpoint(1, 9, 9, 9)), ''2001-01-02''::timestamptz)'
+\set inside 'tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), ''2001-01-01''::timestamptz)'
+\set straddling 'tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)), ''2001-01-01''::timestamptz)'
+\set far 'tpcpatch(pcpatch(pcpoint(1, 9, 9, 9)), ''2001-01-02''::timestamptz)'
 
 -------------------------------------------------------------------------------
 -- The geometry a patch reaches the engine as
 -------------------------------------------------------------------------------
 
-SELECT ST_AsText(geometry(pcpatch(1, pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
-SELECT ST_AsText(pcpatch(1, pcpoint(1, 1, 1, 1))::geometry);
+SELECT ST_AsText(geometry(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
+SELECT ST_AsText(pcpatch(pcpoint(1, 1, 1, 1))::geometry);
 SELECT asText(:straddling::tgeometry);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/449_tpcpatch_spatialrels.test.sql
+++ b/mobilitydb/test/pointcloud/queries/449_tpcpatch_spatialrels.test.sql
@@ -33,7 +33,7 @@
 -------------------------------------------------------------------------------
 
 \set square 'geometry ''SRID=0;Polygon((0 0,0 4,4 4,4 0,0 0))'''
-\set zpatch 'tpcpatch(pcpatch(1, pcpoint(1, 1, 1, 1)), ''2001-01-01''::timestamptz)'
+\set zpatch 'tpcpatch(pcpatch(pcpoint(1, 1, 1, 1)), ''2001-01-01''::timestamptz)'
 
 INSERT INTO pointcloud_formats (pcid, srid, schema) VALUES (8, 0,
 '<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
A schema parsed from a pgPointCloud document keeps the document it came from, and one stated as dimensions has none, so meos_pc_schema_xml answers NULL for it. The WKB encoder embeds the document to make a blob portable across clusters and embeds it only where there is one, so a temporal point cloud value of a schema stated as dimensions is written without its schema. meos_pc_schema_xml renders a document from the schema and keeps it, so a schema stated either way reaches a reader that takes a document. The element set is the one pc_schema_from_xml reads, and the test states a schema as dimensions and compares it field by field to the schema the library parses back out of the rendered document.