### PR TITLE
Buffer a TIN and a polyhedral surface through their components

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -5788,8 +5788,14 @@ meos_buffer(const LWGEOM *geom, double radius, JoinStyle join_style,
     case CURVEPOLYTYPE:
       return meos_buffer_curvepoly((const LWCURVEPOLY *) geom, radius,
         join_style, mitre_limit, false);
+    /* A TIN (collection of triangles) and a polyhedral surface (collection of
+     * polygonal faces) share the collection memory layout, and the collection
+     * branch buffers each component through this same dispatch, so a triangle
+     * and a face are each buffered by the entry that owns them */
     case MULTICURVETYPE:
     case MULTISURFACETYPE:
+    case TINTYPE:
+    case POLYHEDRALSURFACETYPE:
     case COLLECTIONTYPE:
       return meos_buffer_collection((const LWCOLLECTION *) geom, radius,
         join_style, cap_style, mitre_limit);


### PR DESCRIPTION
A TIN collects triangles and a polyhedral surface collects polygonal faces, and both share
the collection memory layout, so the collection branch of `meos_buffer` serves them: it
buffers every component through the same dispatch, where a triangle and a face each reach
the entry that owns them. Both types reached the `default` arm instead and answered
nothing.

### What it is measured against

The answer has to equal what the same faces answer when they are spelled as a multipolygon,
which is the one geometry the buffer already covers. Buffered by 0.5, a TIN and a two-face
surface now return a geometry identical to their multipolygon spelling character for
character.

A closed surface still declines, and so does its multipolygon spelling: the component
buffers overlap, and the collection branch returns nothing rather than the overlapping
surfaces, as its own comment states. That is the branch's limitation and not a property of
the type, and the identity holds there too — both spellings decline together.

The GEOS buffer corpus is unmoved: 102 buffers, 93 covering their input, 0 not covering
and 9 declined, at radius 1, 5 and 50 alike.

### Left alone deliberately

The non-positive-radius branch above the switch calls only a polygon and a multipolygon
areal, so a multisurface, a collection, a TIN and a polyhedral surface all answer
`POLYGON EMPTY` at radius 0 where a multipolygon answers itself. That is uniform across
those four types, so this change leaves them consistent with each other; correcting it
changes answers for a multisurface and a collection too, and is its own question.
