### PR TITLE
Answer a polyhedral surface through the native engine

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -476,13 +476,15 @@ geom_extract_edges_iter(const LWGEOM *geom, MeosArray *edges)
 
     /* A compound curve (chain of line/circular strings), a multicurve
      * (collection of line/circular/compound curves), a multisurface
-     * (collection of polygons/curve polygons) and a TIN (collection of
-     * triangles) all share the collection memory layout, so their components
-     * are extracted the same way as a collection */
+     * (collection of polygons/curve polygons), a TIN (collection of triangles)
+     * and a polyhedral surface (collection of polygonal faces) all share the
+     * collection memory layout, so their components are extracted the same way
+     * as a collection */
     case COMPOUNDTYPE:
     case MULTICURVETYPE:
     case MULTISURFACETYPE:
     case TINTYPE:
+    case POLYHEDRALSURFACETYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
@@ -552,11 +554,13 @@ geom_meos_supported(const LWGEOM *geom)
     case MULTICURVETYPE:
     case MULTISURFACETYPE:
     case TINTYPE:
+    case POLYHEDRALSURFACETYPE:
     case COLLECTIONTYPE:
     {
-      /* A multicurve/multisurface/TIN is supported when every component is:
-       * its components are line/circular/compound curves, polygons/curve
-       * polygons and triangles, each validated by the recursive call */
+      /* A multicurve/multisurface/TIN/polyhedral surface is supported when
+       * every component is: its components are line/circular/compound curves,
+       * polygons/curve polygons and triangles, each validated by the recursive
+       * call */
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       for (uint32_t i = 0; i < col->ngeoms; i++)
         if (! geom_meos_supported(col->geoms[i]))
@@ -2455,6 +2459,7 @@ meos_is_simple(const LWGEOM *geom, bool *result)
       return true;
     }
     case TINTYPE:
+    case POLYHEDRALSURFACETYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
@@ -3568,6 +3573,7 @@ relate_is_areal(const LWGEOM *geom)
     case CURVEPOLYTYPE:
     case MULTISURFACETYPE:
     case TINTYPE:
+    case POLYHEDRALSURFACETYPE:
       return true;
     case COLLECTIONTYPE:
     {
@@ -5821,6 +5827,7 @@ relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
     case MULTIPOLYGONTYPE:
     case MULTISURFACETYPE:
     case TINTYPE:
+    case POLYHEDRALSURFACETYPE:
     case COLLECTIONTYPE:
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
@@ -6128,6 +6135,7 @@ relate_extract_edges(const LWGEOM *geom)
     case MULTIPOLYGONTYPE:
     case MULTISURFACETYPE:
     case TINTYPE:
+    case POLYHEDRALSURFACETYPE:
     case COLLECTIONTYPE:
       return relate_union_edges(geom);
     default:
@@ -6176,11 +6184,15 @@ relate_dim_mask(const LWGEOM *geom)
       return 4;
     case MULTIPOLYGONTYPE:
     case TINTYPE:
+    case POLYHEDRALSURFACETYPE:
     {
-      /* A multipolygon or a TIN carrying any surface is areal: a member enclosing no
-       * area draws linework the surfaces already account for, and reporting
-       * both dimensions would send a value every member of which is a polygon
-       * down the mixed-dimension path */
+      /* A multipolygon, a TIN or a polyhedral surface carrying any surface is
+       * areal: a member enclosing no area draws linework the surfaces already
+       * account for, and reporting both dimensions would send a value every
+       * member of which is a polygon down the mixed-dimension path.  A face of
+       * a closed surface standing perpendicular to the plane is exactly such a
+       * member, so this is the ordinary case for a watertight solid rather than
+       * an edge case */
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       int mask = 0;
       for (uint32_t i = 0; i < col->ngeoms; i++)

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1791,8 +1791,8 @@ GEOS2POSTGIS(GEOSGeom geom, char want3d)
 
 /**
  * @brief Return the type that keeps a pair of geometries from the native engine
- * @details The native engine answers every type #geom_meos_supported() accepts;
- * a polyhedral surface and a TIN fall outside it.
+ * @details The native engine answers every type #geom_meos_supported() accepts,
+ * which is every type the edge decomposition reaches.
  * @param[in] geom1,geom2 Geometries the operation is asked about
  */
 static uint8_t

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -161,9 +161,8 @@ int main(void)
     errno_ok);
   assert(rel_ok == true);
   assert(errno_ok == 0);
-  /* A TIN is outside the edge decomposition and GEOS carries one, so a build
-   * including GEOS answers it and a build excluding GEOS reports the failure
-   * and answers false, the value a language binding reads safely */
+  /* A TIN decomposes into the triangles it collects, so the edges answer it
+   * and neither build consults GEOS for it */
   GSERIALIZED *tin = geom_in(
     "Tin(((0 0,0 1,1 1,0 0)),((0 0,1 0,1 1,0 0)))", -1);
   assert(tin != NULL);
@@ -172,21 +171,12 @@ int main(void)
   int errno_tin = meos_errno();
   printf("geom_relate_pattern(line, tin): %d, errno %d\n", rel_tin,
     errno_tin);
-  /* The option is read from the library at run time: this file is compiled
-   * against the installed headers, which carry no definition of it, so a
-   * preprocessor test here would describe the test's own build and not the
-   * library's */
-  if (strstr(meos_full_version(), "GEOS none") == NULL)
-    assert(errno_tin == 0);
-  else
-  {
-    assert(rel_tin == false);
-    assert(errno_tin != 0);
-  }
-  /* A polyhedral surface is outside the edge decomposition AND outside GEOS,
-   * whose LWGEOM2GEOS reaches an lwerror that ends the process rather than
-   * returning, so it is reported the same way in either build and reaches
-   * GEOS in neither */
+  assert(rel_tin == true);
+  assert(errno_tin == 0);
+  /* A polyhedral surface decomposes into its faces the same way, and it is the
+   * one type GEOS cannot be asked about at all -- LWGEOM2GEOS reaches an
+   * lwerror that ends the process rather than returning -- so the edges are
+   * what answer it in either build */
   GSERIALIZED *phs = geom_in(
     "PolyhedralSurface Z (((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),"
     "((0 0 0,0 1 0,0 1 1,0 0 1,0 0 0)))", -1);
@@ -196,8 +186,8 @@ int main(void)
   int errno_phs = meos_errno();
   printf("geom_relate_pattern(line, polyhedral surface): %d, errno %d\n",
     rel_phs, errno_phs);
-  assert(rel_phs == false);
-  assert(errno_phs != 0);
+  assert(rel_phs == true);
+  assert(errno_phs == 0);
   free(coll); free(away); free(through); free(tin); free(phs);
   meos_errno_reset();
 
@@ -633,6 +623,29 @@ int main(void)
   printf("a TIN covers what its triangles cover written any other way\n");
   assert(meos_errno() == 0);
   meos_errno_reset();
+
+  /* A polyhedral surface covers what its faces cover, and the unit cube is the
+   * case that says so about a WATERTIGHT SOLID: four of its six faces stand
+   * perpendicular to the plane, so each projects to a ring enclosing no area.
+   * What the cube covers in the plane is the unit square, which is exactly the
+   * control the two assertions above already use, so the identity is read
+   * against a geometry this test has independently checked */
+  GSERIALIZED *cube = geom_in("POLYHEDRALSURFACE Z ("
+    "((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),"
+    "((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),"
+    "((0 0 0,1 0 0,1 0 1,0 0 1,0 0 0)),"
+    "((1 1 1,1 0 1,0 0 1,0 1 1,1 1 1)),"
+    "((1 1 1,1 1 0,1 0 0,1 0 1,1 1 1)),"
+    "((1 1 1,0 1 1,0 1 0,1 1 0,1 1 1)))", -1);
+  assert(cube != NULL);
+  assert(geom_relate_pattern(cube, diag, "1********") == true);
+  /* And it is areal, not the linework its perpendicular faces draw */
+  assert(geom_relate_pattern(cube, diag, "2********") == false);
+  assert(geom_relate_pattern(adjsq, diag, "2********") == false);
+  printf("a closed polyhedral surface covers what it projects to\n");
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+  free(cube);
 
   /* Finalize MEOS */
   meos_finalize();

--- a/mobilitydb/test/geo/expected/049_geo_funcs.test.out
+++ b/mobilitydb/test/geo/expected/049_geo_funcs.test.out
@@ -284,6 +284,19 @@ SELECT relate(geometry 'Tin Z (((0 0 0,0 1 0,1 1 0,0 0 0)),((0 0 0,1 1 0,1 0 0,0
  1F2001102
 (1 row)
 
+SELECT relate(geometry 'Polyhedralsurface Z (
+  ((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),
+  ((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),
+  ((0 0 0,1 0 0,1 0 1,0 0 1,0 0 0)),
+  ((1 1 1,1 0 1,0 0 1,0 1 1,1 1 1)),
+  ((1 1 1,1 1 0,1 0 0,1 0 1,1 1 1)),
+  ((1 1 1,0 1 1,0 1 0,1 1 0,1 1 1)))',
+  geometry 'Linestring(0 0,2 2)');
+  relate   
+-----------
+ 1F2001102
+(1 row)
+
 SELECT ST_Relate(geometry 'Point(1 1)', geometry 'Point(1 1)', '0FFFFFFF2');
  st_relate 
 -----------

--- a/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
+++ b/mobilitydb/test/geo/queries/049_geo_funcs.test.sql
@@ -147,6 +147,19 @@ SELECT relate(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))', geometry 'Linestring(0 
 SELECT relate(geometry 'Tin Z (((0 0 0,0 1 0,1 1 0,0 0 0)),((0 0 0,1 1 0,1 0 0,0 0 0)))',
   geometry 'Linestring(0 0,2 2)');
 
+-- A polyhedral surface covers what its faces cover.  The unit cube is the case
+-- that says so about a watertight solid: four of its six faces stand
+-- perpendicular to the plane, so each projects to a ring enclosing no area, and
+-- what the cube covers is the unit square the row above answers for
+SELECT relate(geometry 'Polyhedralsurface Z (
+  ((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),
+  ((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),
+  ((0 0 0,1 0 0,1 0 1,0 0 1,0 0 0)),
+  ((1 1 1,1 0 1,0 0 1,0 1 1,1 1 1)),
+  ((1 1 1,1 1 0,1 0 0,1 0 1,1 1 1)),
+  ((1 1 1,0 1 1,0 1 0,1 1 0,1 1 1)))',
+  geometry 'Linestring(0 0,2 2)');
+
 -- A pattern is matched against that matrix
 SELECT ST_Relate(geometry 'Point(1 1)', geometry 'Point(1 1)', '0FFFFFFF2');
 


### PR DESCRIPTION
A polyhedral surface is a set of polygonal faces, and a polygon is a type the edge
decomposition already reaches, so the type needs no new geometry primitive. It joins the
collection branch at the seven sites a TIN occupies — `geom_extract_edges_iter`,
`geom_meos_supported`, `meos_is_simple`, `relate_is_areal`, `relate_area_comps_iter`,
`relate_extract_edges` and `relate_dim_mask` — its memory layout being the collection
layout.

It was the one type `geom_meos_supported()` still declined, so the native engine now
answers every geometry type it is asked about: over the 225 ordered pairs of the 15
types, the matrix, the pattern match and the four relationships each decline **none**,
against 29 declines before, every one of which named a polyhedral surface.

### The oracle

GEOS is not an oracle here and cannot be made one: it carries no polyhedral surface, and
`LWGEOM2GEOS` reaches an `lwerror` on the type that ends the process rather than
returning. What answers instead is the self-consistency identity, as it does for a TIN:
the point set a surface covers in the plane is the union of the projections of its faces,
so it must relate exactly as the same faces spelled as a multipolygon, spelled as a
collection, and as the one polygon their union draws.

Measured on three shapes — a flat surface, an open two-face tent and a closed unit cube —
every spelling agrees. The cube is the case worth stating: four of its six faces stand
perpendicular to the plane, so each projects to a ring enclosing no area. That is what
every watertight solid looks like from the plane, so it is the ordinary case for the type
rather than an edge case, and it is what the dimension-mask comment now records. All four
spellings of it answer `1F2001102`, in C and through SQL.

### What moves

Nothing but the type. Over the five relate corpora — 54 adversarial, 324 small areal,
1444 areal, 202 real trip and 12880 fixture pairs — **0 of 14904 answers move**. The zero
is explained rather than assumed: none of the five carries a polyhedral surface, so all of
them are blind to the class, and the three identity cases are the positive control that
the change bites. The witness added to `geo_test.c` aborts on the previous code
(`Assertion 'rel_phs == true' failed`) and passes on this one.

### One entry still declines the type, and it is its own change

`meos_buffer` reaches its `default` arm for a polyhedral surface, as it already does for a
TIN. That is not a regression — the buffer answered neither type before — and it is the
subject of #2257, which neither depends on this one nor is depended on by it: the two touch
disjoint files, and no test exercises either through the other.
