### PR TITLE
Remove the GEOS arms no geometry pair can reach

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1792,7 +1792,8 @@ GEOS2POSTGIS(GEOSGeom geom, char want3d)
 /**
  * @brief Return the type that keeps a pair of geometries from the native engine
  * @details The native engine answers every type #geom_meos_supported() accepts,
- * which is every type the edge decomposition reaches.
+ * which is every type the edge decomposition reaches, and a type it declines is
+ * answered by nobody.
  * @param[in] geom1,geom2 Geometries the operation is asked about
  */
 static uint8_t
@@ -1803,79 +1804,19 @@ geo_unsupported_type(const LWGEOM *geom1, const LWGEOM *geom2)
 
 /**
  * @brief Report that an operation has no answer for a geometry type
- * @details GEOS answers a TIN, so a build excluding it names the option that
- * restores the answer. It has no polyhedral surface of its own — the type
- * reaches the @p default arm of @p LWGEOM2GEOS, whose @p lwerror terminates
- * the process rather than returning — so that type is reported the same way in
- * either build and is never handed to GEOS.
+ * @details The report does not depend on the build carrying GEOS, because a
+ * type the edges decline is not handed to GEOS in either build.
  * @param[in] what Noun naming the operation
  * @param[in] type Type the operation has no answer for
  */
 static void
 geo_error_unsupported_type(const char *what, uint8_t type)
 {
-#if ! GEOS
-  if (type != POLYHEDRALSURFACETYPE)
-  {
-    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
-      "The %s of a geometry of type %s is answered by the GEOS library, which "
-      "this build excludes: configure with -DGEOS=ON", what,
-      lwtype_name(type));
-    return;
-  }
-#endif /* ! GEOS */
   meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
     "The %s of a geometry of type %s is not supported", what,
     lwtype_name(type));
   return;
 }
-
-#if GEOS
-/**
- * @brief Transform two @p GSERIALIZED geometries into @p GEOSGeometry and
- * call the GEOS function passed as argument
- */
-static bool
-meos_call_geos2(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
-  char (*func)(GEOSContextHandle_t ctx, const GEOSGeometry *geos1,
-    const GEOSGeometry *geos2))
-{
-  assert(gs1); assert(gs2); assert(func);
-  GEOSContextHandle_t ctx = geos_get_context();
-
-  GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
-  if (! geos1)
-  {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "First argument geometry could not be converted to GEOS");
-    return false;
-  }
-  GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
-  if (! geos2)
-  {
-    GEOSGeom_destroy_r(ctx, geos1);
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "Second argument geometry could not be converted to GEOS");
-    return false;
-  }
-
-  char result = func(ctx, geos1, geos2);
-
-  GEOSGeom_destroy_r(ctx, geos1); GEOSGeom_destroy_r(ctx, geos2);
-  /* GEOS reports a failure as 2, which is the relationship reporting nothing.
-   * The answer is false, the one every other failure of these functions gives;
-   * an error handler that returns, which is the handler a language binding
-   * installs, would otherwise read a relationship that was never evaluated as
-   * holding */
-  if (result == 2)
-  {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "GEOS returned error");
-    return false;
-  }
-  return (bool) result;
-}
-#endif /* GEOS */
 
 /**
  * @ingroup meos_internal_geo_base_rel
@@ -1947,25 +1888,6 @@ geom_spatialrel(const GSERIALIZED *gs1, const GSERIALIZED *gs2, spatialRel rel)
   lwgeom_free(geom1); lwgeom_free(geom2);
   if (! answered)
   {
-#if GEOS
-    /* A type the edges do not decompose is answered by GEOS, which carries no
-     * polyhedral surface of its own */
-    if (badtype != POLYHEDRALSURFACETYPE)
-      switch (rel)
-      {
-        case INTERSECTS:
-          return meos_call_geos2(gs1, gs2, &GEOSIntersects_r);
-        case CONTAINS:
-          return meos_call_geos2(gs1, gs2, &GEOSContains_r);
-        case TOUCHES:
-          return meos_call_geos2(gs1, gs2, &GEOSTouches_r);
-        case COVERS:
-          return meos_call_geos2(gs1, gs2, &GEOSCovers_r);
-        default:
-          /* keep compiler quiet */
-          return false;
-      }
-#endif /* GEOS */
     geo_error_unsupported_type("spatial relationship", badtype);
     return false;
   }
@@ -2118,39 +2040,6 @@ geom_relate_pattern(const GSERIALIZED *gs1, const GSERIALIZED *gs2, char *p)
   lwgeom_free(geom1); lwgeom_free(geom2);
   if (! covered)
   {
-#if GEOS
-    if (badtype != POLYHEDRALSURFACETYPE)
-    {
-      GEOSContextHandle_t ctx = geos_get_context();
-      GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
-      if (! geos1)
-      {
-        meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-          "First argument geometry could not be converted to GEOS");
-        return false;
-      }
-      GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
-      if (! geos2)
-      {
-        GEOSGeom_destroy_r(ctx, geos1);
-        meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-          "Second argument geometry could not be converted to GEOS");
-        return false;
-      }
-      char georesult = GEOSRelatePattern_r(ctx, geos1, geos2, p);
-      GEOSGeom_destroy_r(ctx, geos1); GEOSGeom_destroy_r(ctx, geos2);
-      /* GEOS reports a failure as 2, which is the pattern reporting nothing.
-       * The answer is false, the one every other failure of this function
-       * gives */
-      if (georesult == 2)
-      {
-        meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-          "GEOSRelatePattern returned error");
-        return false;
-      }
-      return (bool) georesult;
-    }
-#endif /* GEOS */
     geo_error_unsupported_type("relationship", badtype);
     return false;
   }
@@ -2653,36 +2542,6 @@ geo_equals(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   lwgeom_free(geom1); lwgeom_free(geom2);
   if (! covered)
   {
-#if GEOS
-    if (badtype != POLYHEDRALSURFACETYPE)
-    {
-      GEOSContextHandle_t ctx = geos_get_context();
-      GEOSGeometry *geos1 = POSTGIS2GEOS(gs1);
-      if (! geos1)
-      {
-        meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-          "First argument geometry could not be converted to GEOS");
-        return -1;
-      }
-      GEOSGeometry *geos2 = POSTGIS2GEOS(gs2);
-      if (! geos2)
-      {
-        GEOSGeom_destroy_r(ctx, geos1);
-        meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-          "Second argument geometry could not be converted to GEOS");
-        return -1;
-      }
-      int georesult = GEOSEquals_r(ctx, geos1, geos2);
-      GEOSGeom_destroy_r(ctx, geos1); GEOSGeom_destroy_r(ctx, geos2);
-      if (georesult == 2)
-      {
-        meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-          "GEOS equals() threw an error !");
-        return -1;
-      }
-      return georesult;
-    }
-#endif /* GEOS */
     geo_error_unsupported_type("equality", badtype);
     return -1;
   }


### PR DESCRIPTION
`geom_spatialrel`, `geom_relate_pattern` and `geo_equals` each carried a GEOS arm for a
pair the edges decline, and each guarded it with `badtype != POLYHEDRALSURFACETYPE`. No
pair reaches one.

`geom_meos_supported()` names 14 of the 15 geometry types liblwgeom defines, and the one it
leaves out is exactly `POLYHEDRALSURFACETYPE`, so a declined pair always carries that type —
which is what the guard excludes. Measured the same way rather than only argued: over the
225 ordered pairs of the 15 types, every decline names a polyhedral surface. It appears in
30 of them, and every other type in exactly the 2 that pair it with a surface.

So the arms are removed, `meos_call_geos2` with them since nothing else called it, and the
decline each function already ends with is what answers.

The report no longer branches on the build either. It named the GEOS option as the way to
restore an answer; with the arms gone that option restores nothing, and a type the edges
decline is not handed to GEOS in either build.

### What moves

Nothing. Over the five relate corpora — 54 adversarial, 324 small areal, 1444 areal, 202
real trip and 12880 fixture pairs — **0 of 14904 answers change**, and a polyhedral surface
still declines with the same errno and the same `false` that a language binding reads
safely.

### The surface it removes, read from the object file

`postgis_funcs.o` goes from **12 undefined GEOS symbols to 6**, and the six it drops are exactly the
predicate entry points the arms called:

    GEOSContains_r  GEOSCovers_r  GEOSEquals_r  GEOSIntersects_r  GEOSRelatePattern_r  GEOSTouches_r

The six that remain — `GEOSUnaryUnion_r` with `GEOS2LWGEOM`, `LWGEOM2GEOS`,
`GEOSGeom_createCollection_r`, `GEOSGeom_destroy_r` and `GEOSSetSRID_r` — are `geom_array_union` and
its scaffolding, so that union is now the only GEOS algorithm MEOS calls.

Under `-DGEOS=OFF` MEOS's own objects reference no GEOS symbol at all.
a `#if GEOS` — but it is the configuration the arms were the remaining reason to read carefully, and
it is worth stating that it still holds.

### Relation to the other two open pull requests

Independent of both. #2258 wires a polyhedral surface into the engine and #2257 buffers it;
this one removes code that no pair reaches either before or after them. It touches
`postgis_funcs.c` at the three arm sites, where #2258 touches only the comment at line 1791,
so the two do not overlap and either order of merging works.