### PR TITLE
Name the dimension columns so no host needs to quote them

### DIFF
--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -35,12 +35,12 @@ INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
   (1, 4326, 'none', 'Esquema 3D mínimo');
 
 INSERT INTO pointcloud_dimensions
-    (pcid, position, name, interpretation, scale, "offset", active, description) VALUES
+    (pcid, dim_no, dim_name, interpretation, dim_scale, dim_offset, active, description) VALUES
   (1, 1, 'X', 'int32_t', 1, 0, true, 'Este'),
   (1, 2, 'Y', 'int32_t', 1, 0, true, 'Norte'),
   (1, 3, 'Z', 'int32_t', 1, 0, true, 'Elevación');
 </programlisting>
-			<para>El tamaño de cada dimensión y su desplazamiento dentro de un punto no aparecen porque se derivan de la interpretación, y las dimensiones X, Y, Z y M tampoco porque se resuelven a partir de los nombres. La columna <varname>position</varname> declara el orden en el que se almacenan las dimensiones, de modo que no depende del orden en el que se insertan las filas. Un esquema es global a la base de datos y suele registrarse una sola vez, al cargar los datos; el SRID es por esquema y lo heredan todos los valores que llevan ese <varname>pcid</varname>.</para>
+			<para>El tamaño de cada dimensión y su desplazamiento dentro de un punto no aparecen porque se derivan de la interpretación, y las dimensiones X, Y, Z y M tampoco porque se resuelven a partir de los nombres. La columna <varname>dim_no</varname> declara el orden en el que se almacenan las dimensiones, de modo que no depende del orden en el que se insertan las filas, y <varname>dim_name</varname> es el nombre por el que se resuelven. Ningún nombre de columna necesita comillas en ninguno de los hosts en los que se materializan estas tablas. Un esquema es global a la base de datos y suele registrarse una sola vez, al cargar los datos; el SRID es por esquema y lo heredan todos los valores que llevan ese <varname>pcid</varname>.</para>
 			<para>Una base de datos cuyos esquemas ya están registrados en el catálogo <varname>pointcloud_formats</varname> de pgPointCloud, como documento XML, sigue funcionando: ese catálogo se lee para un <varname>pcid</varname> que las dos tablas anteriores no declaren.</para>
 			<para>Tres funciones auxiliares responden lo que declara un <varname>pcid</varname> sin disponer de un valor de ese esquema y sin depender de la disposición de las tablas. Cada una responde <varname>NULL</varname> para un <varname>pcid</varname> que ningún esquema declara.</para>
 			<itemizedlist>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -36,12 +36,12 @@ INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
   (1, 4326, 'none', 'Minimal 3D schema');
 
 INSERT INTO pointcloud_dimensions
-    (pcid, position, name, interpretation, scale, "offset", active, description) VALUES
+    (pcid, dim_no, dim_name, interpretation, dim_scale, dim_offset, active, description) VALUES
   (1, 1, 'X', 'int32_t', 1, 0, true, 'Easting'),
   (1, 2, 'Y', 'int32_t', 1, 0, true, 'Northing'),
   (1, 3, 'Z', 'int32_t', 1, 0, true, 'Elevation');
 </programlisting>
-			<para>The size of each dimension and its offset within a point are absent because they follow from the interpretation, and the X, Y, Z and M dimensions are absent because they resolve from the names. The <varname>position</varname> column states the order the dimensions are stored in, so it does not depend on the order the rows are inserted in. A schema is global to the database and usually registered once, at fixture-load time; the SRID is per schema and is inherited by every value carrying that <varname>pcid</varname>.</para>
+			<para>The size of each dimension and its offset within a point are absent because they follow from the interpretation, and the X, Y, Z and M dimensions are absent because they resolve from the names. The <varname>dim_no</varname> column states the order the dimensions are stored in, so it does not depend on the order the rows are inserted in, and <varname>dim_name</varname> is the name they resolve by. No column name needs quoting in any host these tables are materialised in. A schema is global to the database and usually registered once, at fixture-load time; the SRID is per schema and is inherited by every value carrying that <varname>pcid</varname>.</para>
 			<para>A database whose schemas are already registered in the <varname>pointcloud_formats</varname> catalog of pgPointCloud, as an XML document, keeps working: that catalog is read for a <varname>pcid</varname> that the two tables above do not state.</para>
 			<para>Three helpers answer what a <varname>pcid</varname> names without a value of that schema in hand and without depending on the table layout. Each answers <varname>NULL</varname> for a <varname>pcid</varname> no schema states.</para>
 			<itemizedlist>

--- a/mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
+++ b/mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
@@ -54,27 +54,34 @@ CREATE TABLE pointcloud_schemas (
 );
 
 /*
- * The position a dimension holds is a column rather than the order the rows
- * happen to arrive in: a reload, a COPY or a parallel insert would otherwise
- * reorder the layout of a point. Stating it makes a duplicate or a gap a
- * constraint violation rather than a wrong byte offset, and the unique name
- * is what lets the X, Y, Z and M dimensions resolve unambiguously.
+ * A dimension is identified two ways, by number and by name, and both are
+ * stated rather than derived: the number is the order the dimension is stored
+ * in, which the order the rows happen to arrive in must not decide, because a
+ * reload, a COPY or a parallel insert would silently relayout a point; the
+ * name is what the X, Y, Z and M dimensions resolve from. Stating the number
+ * makes a duplicate or a gap a constraint violation rather than a wrong byte
+ * offset.
+ *
+ * No column name needs quoting in any host the tables are materialised in:
+ * `offset` is a reserved word in PostgreSQL and in DuckDB, and `position`,
+ * while usable as a column, cannot be called as a bare function in DuckDB,
+ * which an accessor mirroring the column would have to be.
  */
 CREATE TABLE pointcloud_dimensions (
   pcid            integer NOT NULL REFERENCES pointcloud_schemas(pcid)
                           ON DELETE CASCADE,
-  position        integer NOT NULL CHECK (position >= 1),
-  name            text    NOT NULL,
+  dim_no          integer NOT NULL CHECK (dim_no >= 1),
+  dim_name        text    NOT NULL,
   interpretation  text    NOT NULL
                           CHECK (interpretation IN ('int8_t','uint8_t',
                                  'int16_t','uint16_t','int32_t','uint32_t',
                                  'int64_t','uint64_t','double','float')),
-  scale           double precision NOT NULL DEFAULT 1,
-  "offset"        double precision NOT NULL DEFAULT 0,
+  dim_scale       double precision NOT NULL DEFAULT 1,
+  dim_offset      double precision NOT NULL DEFAULT 0,
   active          boolean NOT NULL DEFAULT true,
   description     text,
-  PRIMARY KEY (pcid, position),
-  UNIQUE (pcid, name)
+  PRIMARY KEY (pcid, dim_no),
+  UNIQUE (pcid, dim_name)
 );
 
 COMMENT ON TABLE  pointcloud_schemas IS
@@ -95,17 +102,17 @@ COMMENT ON TABLE  pointcloud_dimensions IS
   'from the interpretation and from the dimensions before it.';
 COMMENT ON COLUMN pointcloud_dimensions.pcid IS
   'Schema this dimension belongs to.';
-COMMENT ON COLUMN pointcloud_dimensions.position IS
-  'Order this dimension is stored in, from 1, stated rather than taken from '
-  'the order the rows arrive in.';
-COMMENT ON COLUMN pointcloud_dimensions.name IS
-  'Dimension name, unique within the schema. The X, Y, Z and M dimensions '
-  'resolve from it.';
+COMMENT ON COLUMN pointcloud_dimensions.dim_no IS
+  'Number of this dimension within the schema, from 1, which is the order it '
+  'is stored in, stated rather than taken from the order the rows arrive in.';
+COMMENT ON COLUMN pointcloud_dimensions.dim_name IS
+  'Name of this dimension, unique within the schema. The X, Y, Z and M '
+  'dimensions resolve from it.';
 COMMENT ON COLUMN pointcloud_dimensions.interpretation IS
   'Name of the numeric type a value of this dimension is stored as.';
-COMMENT ON COLUMN pointcloud_dimensions.scale IS
+COMMENT ON COLUMN pointcloud_dimensions.dim_scale IS
   'Factor a stored value is multiplied by to give the coordinate.';
-COMMENT ON COLUMN pointcloud_dimensions."offset" IS
+COMMENT ON COLUMN pointcloud_dimensions.dim_offset IS
   'Value added to a scaled stored value to give the coordinate.';
 COMMENT ON COLUMN pointcloud_dimensions.active IS
   'True when the dimension holds values.';

--- a/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
+++ b/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
@@ -2,7 +2,7 @@ INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
   (90, 4326, 'none', 'Three doubles');
 INSERT 0 1
 INSERT INTO pointcloud_dimensions
-    (pcid, position, name, interpretation, scale, "offset", active, description)
+    (pcid, dim_no, dim_name, interpretation, dim_scale, dim_offset, active, description)
   VALUES
   (90, 1, 'X', 'double', 1, 0, true, 'Easting'),
   (90, 2, 'Y', 'double', 1, 0, true, 'Northing'),
@@ -40,30 +40,30 @@ SELECT pcpoint(999, 1, 2, 3);
 ERROR:  No schema registered for pcid 999
 INSERT INTO pointcloud_schemas (pcid, srid, compression) VALUES (92, 4326, 'none');
 INSERT 0 1
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (92, 1, 'X', 'double'), (92, 2, 'Y', 'double'), (92, 3, 'Z', 'double');
 INSERT 0 3
 SELECT pcpatch(pcpoint(90, 1, 2, 3), pcpoint(92, 4, 5, 6));
 ERROR:  Operation on pcpoint values with different schemas: 90 vs 92
 DELETE FROM pointcloud_schemas WHERE pcid = 92;
 DELETE 1
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (90, 1, 'W', 'double');
 ERROR:  duplicate key value violates unique constraint "pointcloud_dimensions_pkey"
-DETAIL:  Key (pcid, "position")=(90, 1) already exists.
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+DETAIL:  Key (pcid, dim_no)=(90, 1) already exists.
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (90, 4, 'X', 'double');
-ERROR:  duplicate key value violates unique constraint "pointcloud_dimensions_pcid_name_key"
-DETAIL:  Key (pcid, name)=(90, X) already exists.
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+ERROR:  duplicate key value violates unique constraint "pointcloud_dimensions_pcid_dim_name_key"
+DETAIL:  Key (pcid, dim_name)=(90, X) already exists.
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (90, 4, 'W', 'float128');
 ERROR:  new row for relation "pointcloud_dimensions" violates check constraint "pointcloud_dimensions_interpretation_check"
 DETAIL:  Failing row contains (90, 4, W, float128, 1, 0, t, null).
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (90, 0, 'W', 'double');
-ERROR:  new row for relation "pointcloud_dimensions" violates check constraint "pointcloud_dimensions_position_check"
+ERROR:  new row for relation "pointcloud_dimensions" violates check constraint "pointcloud_dimensions_dim_no_check"
 DETAIL:  Failing row contains (90, 0, W, double, 1, 0, t, null).
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (91, 1, 'X', 'double');
 ERROR:  insert or update on table "pointcloud_dimensions" violates foreign key constraint "pointcloud_dimensions_pcid_fkey"
 DETAIL:  Key (pcid)=(91) is not present in table "pointcloud_schemas".
@@ -84,7 +84,7 @@ SELECT pointCloudSchemaCompression(90);
 
 UPDATE pointcloud_schemas SET compression = 'none' WHERE pcid = 90;
 UPDATE 1
-UPDATE pointcloud_dimensions SET active = false WHERE pcid = 90 AND position = 3;
+UPDATE pointcloud_dimensions SET active = false WHERE pcid = 90 AND dim_no = 3;
 UPDATE 1
 SELECT pointCloudSchemaNDims(90);
  pointcloudschemandims 
@@ -92,7 +92,7 @@ SELECT pointCloudSchemaNDims(90);
                      2
 (1 row)
 
-UPDATE pointcloud_dimensions SET active = true WHERE pcid = 90 AND position = 3;
+UPDATE pointcloud_dimensions SET active = true WHERE pcid = 90 AND dim_no = 3;
 UPDATE 1
 SELECT pointCloudSchemaSRID(999) IS NULL AS unknown_srid,
   pointCloudSchemaNDims(999) AS unknown_ndims;

--- a/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
+++ b/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
@@ -24,7 +24,7 @@
 INSERT INTO pointcloud_schemas (pcid, srid, compression, description) VALUES
   (90, 4326, 'none', 'Three doubles');
 INSERT INTO pointcloud_dimensions
-    (pcid, position, name, interpretation, scale, "offset", active, description)
+    (pcid, dim_no, dim_name, interpretation, dim_scale, dim_offset, active, description)
   VALUES
   (90, 1, 'X', 'double', 1, 0, true, 'Easting'),
   (90, 2, 'Y', 'double', 1, 0, true, 'Northing'),
@@ -56,31 +56,31 @@ SELECT pcpoint(999, 1, 2, 3);
 
 -- A second schema, stated the same way, to build a point of another schema with
 INSERT INTO pointcloud_schemas (pcid, srid, compression) VALUES (92, 4326, 'none');
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (92, 1, 'X', 'double'), (92, 2, 'Y', 'double'), (92, 3, 'Z', 'double');
 
 -- The points of a patch are of one schema, which is the schema of the patch
 SELECT pcpatch(pcpoint(90, 1, 2, 3), pcpoint(92, 4, 5, 6));
 DELETE FROM pointcloud_schemas WHERE pcid = 92;
 
--- A position is stated once within a schema
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+-- A dimension number is stated once within a schema
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (90, 1, 'W', 'double');
 
--- A name is stated once within a schema
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+-- A dimension name is stated once within a schema
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (90, 4, 'X', 'double');
 
 -- An interpretation is one of those the library states
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (90, 4, 'W', 'float128');
 
--- A position is stated from one
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+-- A dimension number is stated from one
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (90, 0, 'W', 'double');
 
 -- A dimension belongs to a schema that is stated
-INSERT INTO pointcloud_dimensions (pcid, position, name, interpretation) VALUES
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
   (91, 1, 'X', 'double');
 
 -- What a pcid names is answered without a value of that schema in hand
@@ -93,9 +93,9 @@ SELECT pointCloudSchemaCompression(90);
 UPDATE pointcloud_schemas SET compression = 'none' WHERE pcid = 90;
 
 -- A dimension that holds no value is not counted
-UPDATE pointcloud_dimensions SET active = false WHERE pcid = 90 AND position = 3;
+UPDATE pointcloud_dimensions SET active = false WHERE pcid = 90 AND dim_no = 3;
 SELECT pointCloudSchemaNDims(90);
-UPDATE pointcloud_dimensions SET active = true WHERE pcid = 90 AND position = 3;
+UPDATE pointcloud_dimensions SET active = true WHERE pcid = 90 AND dim_no = 3;
 
 -- An unregistered pcid answers NULL rather than erroring
 SELECT pointCloudSchemaSRID(999) IS NULL AS unknown_srid,


### PR DESCRIPTION
A dimension is identified by number and by name, and the two columns say so: dim_no and dim_name. The two coefficients of the affine decode carry the same prefix, dim_scale and dim_offset, so the pair stays matched. The tables are materialised in every SQL host, so a name needing quotation marks in one of them is paid for in all of them. offset is a reserved word in PostgreSQL and in DuckDB, and PostgreSQL quotes position in the detail of its own constraint violations; position also names a DuckDB keyword of the category that a column may carry but a bare function call may not, which an accessor mirroring the column would be. None of the four names is a keyword in either host, so the tables carry no quoted identifier.