### PR TITLE
Report the reference geometry the distance walk cannot read

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2259,6 +2259,30 @@ dist2d_trgeoseqset_trgeoseqset(const TSequenceSet *ss1, const TSequenceSet *ss2,
 }
 
 /**
+ * @brief Ensure that the closest-feature walk can read a reference geometry
+ * @details The sequence kernels of this file read the body as an @p LWPOLY --
+ * the closest-feature walk is written on a convex polygon -- and answer nothing
+ * for a reference geometry of another type, which the constructor nevertheless
+ * accepts: a polyhedral surface is a legal reference geometry.  Reporting it
+ * here is what keeps such a pair from reaching a cast that answers NULL and a
+ * walk that reads it.
+ * @note The INSTANT paths need no such reference: they place the body with
+ * #pose_apply_geo and measure it whole, so they answer for any body and are
+ * left unguarded.
+ */
+static bool
+ensure_trgeo_ref_walkable(const GSERIALIZED *ref_gs)
+{
+  uint32_t type = gserialized_get_type(ref_gs);
+  if (type == POLYGONTYPE)
+    return true;
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "The temporal distance of a rigid geometry with a reference geometry of "
+    "type %s is not supported", lwtype_name(type));
+  return false;
+}
+
+/**
  * @ingroup meos_rgeo_dist
  * @brief Return the temporal distance between a temporal rigid geometry and a
  * geometry/geography point
@@ -2285,6 +2309,9 @@ tdistance_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
    * from the temporal value because a sequence set stores it once and not in
    * each of its composing sequences */
   const GSERIALIZED *ref_gs = trgeo_geom_p(temp);
+
+  if (temp->subtype != TINSTANT && ! ensure_trgeo_ref_walkable(ref_gs))
+    return NULL;
 
   Temporal *result;
   assert(temptype_subtype(temp->subtype));
@@ -2452,6 +2479,14 @@ tdistance_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
   if (! intersection_temporal_temporal(temp1, temp2, SYNCHRONIZE_NOCROSS,
     &sync1, &sync2))
     return NULL;
+
+  if (sync1->subtype != TINSTANT &&
+      (! ensure_trgeo_ref_walkable(ref_gs1) ||
+       ! ensure_trgeo_ref_walkable(ref_gs2)))
+  {
+    pfree(sync1); pfree(sync2);
+    return NULL;
+  }
 
   Temporal *result;
   assert(temptype_subtype(sync1->subtype));

--- a/meos/test/trgeo_test.c
+++ b/meos/test/trgeo_test.c
@@ -314,6 +314,52 @@ int main(void)
   free(trgeo4); free(trgeo5); free(coll); free(point3d); free(point2d);
   free(box3d);
 
+  /* The constructor accepts a polyhedral surface as a reference geometry, and
+   * the closest-feature walk the sequence kernels run reads the body as a
+   * polygon: the cast answered NULL and the walk read it, which ended the
+   * process.  A pair it cannot walk is reported instead */
+  {
+    Temporal *psurf = trgeometry_in("PolyhedralSurface(((0 0,0 1,1 1,1 0,"
+      "0 0)));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(2 0),0.5)@2001-01-02]");
+    GSERIALIZED *away = geom_in("Point(9 9)", -1);
+    if (! psurf || ! away)
+    {
+      printf("FAILED: the polyhedral surface witness did not parse\n");
+      result = 1;
+    }
+    else
+    {
+      meos_errno_reset();
+      Temporal *dist = tdistance_trgeometry_geo(psurf, away);
+      if (dist != NULL || meos_errno() == 0)
+      {
+        printf("FAILED: tdistance_trgeometry_geo(polyhedral surface, point) "
+          "answered, errno %d\n", meos_errno());
+        result = 1;
+      }
+      else
+        printf("OK: tdistance_trgeometry_geo(polyhedral surface, point) is "
+          "reported, errno %d\n", meos_errno());
+      /* The instant path needs no polygon -- it places the body and measures
+       * it whole -- so it must keep answering */
+      meos_errno_reset();
+      Temporal *inst = trgeometry_in("PolyhedralSurface(((0 0,0 1,1 1,1 0,"
+        "0 0)));Pose(Point(0 0),0)@2001-01-01");
+      Temporal *idist = inst ? tdistance_trgeometry_geo(inst, away) : NULL;
+      if (! idist || meos_errno() != 0)
+      {
+        printf("FAILED: the instant path stopped answering, errno %d\n",
+          meos_errno());
+        result = 1;
+      }
+      else
+        printf("OK: the instant path still measures a polyhedral body\n");
+      free(idist); free(inst);
+    }
+    free(psurf); free(away);
+    meos_errno_reset();
+  }
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
The closest-feature walk of the temporal distance reads the body of a rigid geometry as an
`LWPOLY`, and `lwgeom_as_lwpoly` answers NULL for anything else. `trgeo_inst.c` accepts a
polyhedral surface as a reference geometry, so that NULL reached `poly_is_ccw`, which
dereferences `rings[0]`, and the process died with a segmentation fault.

    Program received signal SIGSEGV, Segmentation fault.
    #0  poly_is_ccw ()
    #1  v_clip_tpoly_point ()
    #2  dist2d_trgeoseq_point ()

A 3D body is turned away earlier by the 3D guard, so the 2D one is the case that reached
it. In the extension this took the backend down.

The two public entries now report such a pair, with the same
`MEOS_ERR_FEATURE_NOT_SUPPORTED` the dispatch already gives a *target* geometry it cannot
read.

### The guard spares the instant paths, deliberately

They need no polygon: `dist2d_trgeoinst_geo` takes no reference geometry at all, and
`dist2d_trgeoinst_trgeoinst` places both bodies with `pose_apply_geo` and measures them
whole with `geom_distance2d`, casting nothing. Refusing there would remove an answer the
family gives today, so the guard is conditioned on the subtype.

### The witness

Added to `trgeo_test.c`, which CI compiles and runs: it segfaults on the previous code and
passes on this one, and asserts beside it that the instant path still measures a polyhedral
body.
