### PR TITLE
Answer the absence where the overlay declines a unary union

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2370,6 +2370,15 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
   if (! lwresult)
   {
     lwresult = lwgeom_unaryunion_prec(lwgeom, prec);
+    /* MEOS: the overlay answers NULL for a geometry it cannot read -- a
+     * polyhedral surface reaches the default arm of #LWGEOM2GEOS, whose
+     * lwerror the MEOS handler reports and RETURNS from -- so the answer is
+     * absent rather than empty and every step below would read a null pointer */
+    if (! lwresult)
+    {
+      lwgeom_free(lwgeom);
+      return NULL;
+    }
     /* MEOS: PostGIS function #lwgeom_unaryunion_prec only propagates the SRID
      * and the Z flag. The GEODETIC flag must be set BEFORE serialization,
      * since the bounding box of a geodetic value is computed on the unit

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -647,6 +647,31 @@ int main(void)
   meos_errno_reset();
   free(cube);
 
+  /* The overlay answers NULL for a geometry it cannot read -- a polyhedral
+   * surface reaches the default arm of LWGEOM2GEOS, whose lwerror the MEOS
+   * handler reports and returns from -- so the union has to answer the absence
+   * rather than read the null pointer it was handed. Every step after that
+   * read one, and the process died in lwgeom_set_geodetic */
+  GSERIALIZED *phsurf = geom_in("PolyhedralSurface Z ("
+    "((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)))", -1);
+  assert(phsurf != NULL);
+  meos_errno_reset();
+  GSERIALIZED *uu = geom_unary_union(phsurf, -1);
+  printf("geom_unary_union of a polyhedral surface: %s, errno %d\n",
+    uu ? "answered" : "declined", meos_errno());
+  assert(uu == NULL);
+  assert(meos_errno() != 0);
+  /* The control is a geometry the overlay does read */
+  meos_errno_reset();
+  GSERIALIZED *mp = geom_in("MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),"
+    "((1 0,1 1,2 1,2 0,1 0)))", -1);
+  GSERIALIZED *uu2 = geom_unary_union(mp, -1);
+  assert(uu2 != NULL);
+  assert(meos_errno() == 0);
+  printf("the union of a multipolygon is answered as before\n");
+  free(phsurf); free(mp); free(uu2);
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
`geom_unary_union` read the answer of `lwgeom_unaryunion_prec` without testing it. The
overlay answers NULL for a geometry it cannot read — a polyhedral surface reaches the
`default` arm of `LWGEOM2GEOS`, whose `lwerror` the MEOS handler reports and *returns*
from — so the union then called `lwgeom_set_geodetic` on a null pointer and the process
died with a segmentation fault.

Proven at the fault rather than read off the frame: the faulting argument register holds
`0x0`.

    Program received signal SIGSEGV, Segmentation fault.
    #0  lwgeom_set_geodetic ()
    #1  geom_unary_union ()
    #2  trgeo_geoms_merge ()
    #3  trgeometry_traversed_area ()
    rdi  0x0

The null answer is now the union's own, which is what the absence of an answer is in this
family. All six call sites already return what this function gives without reading it, so
the report reaches the caller unchanged.

### It is reachable from a documented input

`trgeo_inst.c` accepts a polyhedral surface as the reference geometry of a temporal rigid
geometry, and `traversedArea` unions the placements of that body. Both a 2D and a 3D
surface crashed there; both are reported now. In the extension this took the backend down.

### The witness

Added to `geo_test.c`, which CI compiles and runs: it segfaults on the previous code and
passes on this one, and asserts beside it that a multipolygon still unions as before.
