### PR TITLE
Read the point cloud schemas of a host that has no SQL from a document

### DIFF
--- a/doc/contributing/tpointcloud_schema_design_notes.md
+++ b/doc/contributing/tpointcloud_schema_design_notes.md
@@ -159,10 +159,10 @@ a query**, and that is their whole scope: the ergonomics of a SQL host. It is no
 XML is wrong for a host with no SQL, where there is no table to write into and a file is the only
 thing a user has.
 
-⛔ **THE ENCODING OF THE VENDORED FILE IS ACCIDENTAL.** What matters is that MEOS ships the catalog
-for hosts that have no catalog of their own, under a default path a `meos_set_…` entry overrides.
-XML is chosen for point cloud schemas only because `pc_schema_from_xml` already reads it, so the
-payload costs no parser and stays the vendor's format rather than one of ours.
+⛔ **THE ENCODING OF THE VENDORED FILE IS ACCIDENTAL.** What matters is that MEOS ships a catalog for
+hosts that have no catalog of their own, which a `meos_set_…` entry names. XML is chosen for point
+cloud schemas only because `pc_schema_from_xml` already reads it, so the payload costs no parser and
+stays the vendor's format rather than one of ours.
 
 ⭐ **THIS IS THE ESTABLISHED PATTERN, NOT A NEW ONE.** Two catalogs in this tree already have exactly
 these two front ends, which is the strongest argument that a third should not invent a third shape:
@@ -183,10 +183,16 @@ reconciles them, and the same holds here. ⇒ A trigger keeping one front end in
 is NOT the answer: it would exist in PostgreSQL alone, where the other hosts have nothing to
 synchronise, which is a host-specific special case rather than a shared mechanism.
 
-⚠️ **WHERE THE ANALOGY WITH `spatial_ref_sys.csv` STOPS.** The EPSG registry is universal reference
-data — every user wants 4326 — whereas a point cloud schema describes one user's own instrument.
-A vendored schema document is therefore a starting set, and the path override is the primary route
-rather than a fallback.
+⚠️⛔ **WHERE THE ANALOGY WITH `spatial_ref_sys.csv` STOPS, AND IT DECIDES THE DEFAULT.** The EPSG
+registry is universal reference data — 4326 means the same thing to everybody — whereas a `pcid`
+names one user's own instrument. So the two rows above differ in one respect the table cannot show:
+`meos_set_spatial_ref_sys_csv` and `meos_set_ways_csv` each OVERRIDE a default the loader reads
+without being asked, while **nothing reads the schema document unless a host names it**. A bundled
+schema answering `pcid` 1 by default would decode a value of somebody else's `pcid` 1 into silently
+wrong coordinates instead of reporting that none is registered — and a wrong schema is invisible in
+the text form, since the same bytes are printed whichever schema decodes them. The vendored document
+is therefore a starting point to copy, not a registry, and naming a file is the only route rather
+than the primary one.
 
 ⛔ **THE DOCUMENT CARRIES NEITHER `pcid` NOR `srid`.** `pc_schema_from_xml` reads neither; both are
 columns of `pointcloud_formats`, which is precisely why a table exists on the PostgreSQL side at all.

--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -405,6 +405,11 @@ if(MEOS)
   install(
     FILES "${CMAKE_SOURCE_DIR}/meos/src/geo/spatial_ref_sys.csv"
     DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}")
+  if(POINTCLOUD)
+    install(
+      FILES "${CMAKE_SOURCE_DIR}/meos/src/pointcloud/pointcloud_schemas.xml"
+      DESTINATION "${CMAKE_INSTALL_DATAROOTDIR}")
+  endif()
 
   if(CBUFFER)
     install(

--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -219,6 +219,7 @@ extern void meos_pc_schema_clear(void);
 extern int32_t meos_pc_schema_get_srid(uint32_t pcid);
 extern int32_t meos_pc_schema_get_compression(uint32_t pcid);
 extern int32_t meos_pc_schema_get_ndims(uint32_t pcid);
+extern void meos_set_pointcloud_schemas_xml(const char *path);
 
 /* Comparison */
 

--- a/meos/src/pointcloud/pointcloud_schemas.xml
+++ b/meos/src/pointcloud/pointcloud_schemas.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The point cloud schemas a host with no SQL resolves a pcid through. A host
+  with SQL states the same schemas as rows of pointcloud_schemas and
+  pointcloud_dimensions and never reads this file;
+  meos_set_pointcloud_schemas_xml() names a different one.
+
+  Each pc:PointCloudSchema below is a pgPointCloud document, read by that
+  library's own pc_schema_from_xml, so the dimensions are stated in the
+  vendor's format and no parser of ours reads them.
+
+  The enclosing element and its two attributes are what that format leaves
+  without a home. A document states the dimensions of ONE schema and carries
+  no identifier at all, and while the library's own fixtures write the
+  reference system as <Metadata name="spatialreference">, its parser reads
+  only the compression from that block: a schema parsed from a document
+  stating spatialreference=4326 comes back with srid 0. So pcid and srid are
+  stated here, as the columns of pointcloud_formats state them where
+  PostgreSQL holds them.
+
+  Nothing reads this file unless a host names it. A spatial reference system
+  is read from a vendored CSV without being asked because an EPSG code means
+  the same thing everywhere; a pcid names one user's instrument, so a schema
+  answering pcid 1 by default would decode a value of somebody else's pcid 1
+  into silently wrong coordinates instead of reporting that none is
+  registered. This file is a starting point to copy, not a registry.
+-->
+<pc:PointCloudSchemas xmlns:pc="http://pointcloud.org/schemas/PC/1.1">
+
+  <!-- The schema of section 19.1.1 of the manual, which the examples use -->
+  <pc:PointCloudSchema pcid="1" srid="0">
+    <pc:dimension>
+      <pc:position>1</pc:position>
+      <pc:size>4</pc:size>
+      <pc:description>X coordinate</pc:description>
+      <pc:name>X</pc:name>
+      <pc:interpretation>int32_t</pc:interpretation>
+      <pc:scale>0.01</pc:scale>
+      <pc:offset>0</pc:offset>
+      <pc:active>1</pc:active>
+    </pc:dimension>
+    <pc:dimension>
+      <pc:position>2</pc:position>
+      <pc:size>4</pc:size>
+      <pc:description>Y coordinate</pc:description>
+      <pc:name>Y</pc:name>
+      <pc:interpretation>int32_t</pc:interpretation>
+      <pc:scale>0.01</pc:scale>
+      <pc:offset>0</pc:offset>
+      <pc:active>1</pc:active>
+    </pc:dimension>
+    <pc:dimension>
+      <pc:position>3</pc:position>
+      <pc:size>4</pc:size>
+      <pc:description>Z coordinate</pc:description>
+      <pc:name>Z</pc:name>
+      <pc:interpretation>int32_t</pc:interpretation>
+      <pc:scale>0.01</pc:scale>
+      <pc:offset>0</pc:offset>
+      <pc:active>1</pc:active>
+    </pc:dimension>
+    <pc:metadata>
+      <Metadata name="compression">none</Metadata>
+    </pc:metadata>
+  </pc:PointCloudSchema>
+
+</pc:PointCloudSchemas>

--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -21,6 +21,9 @@
 /* pgPointcloud */
 #include "pc_api.h"
 #include "pc_api_internal.h"
+/* libxml2 — the pointcloud family already links it for pc_schema_from_xml */
+#include <libxml/parser.h>
+#include <libxml/tree.h>
 #include "stringbuffer.h"
 /* PostGIS */
 #include <liblwgeom.h>
@@ -467,6 +470,125 @@ meos_pc_schema_get_ndims(uint32_t pcid)
  * @ref meos_pc_schema, which states the miss as an error; a caller reading a
  * property it can answer without one asks here and reads the miss itself.
  */
+/*****************************************************************************
+ * The document a host with no SQL states its schemas in
+ *
+ * A host with SQL states a schema as rows of pointcloud_schemas and
+ * pointcloud_dimensions and installs the hook above, which reads them. A host
+ * with no SQL has no table to write into, so it states the same schemas in a
+ * pgPointCloud document, exactly as spatial reference systems reach a
+ * standalone MEOS through a CSV that meos_set_spatial_ref_sys_csv names and
+ * the road network through the one meos_set_ways_csv names.
+ *
+ * ⛔ The file is never a prerequisite: meos_pc_schema_register_dims alone
+ * registers a schema, so a host without a filesystem is not blocked.
+ *****************************************************************************/
+
+/* Location of the point cloud schemas document, which a host states before a
+ * schema is looked up. ⛔ There is NO default read, unlike the spatial
+ * reference systems a standalone MEOS reads from a vendored CSV without being
+ * asked: an EPSG code means the same thing everywhere, while a pcid names one
+ * user's instrument, so a bundled schema answering pcid 1 would decode a value
+ * of somebody else's pcid 1 into silently wrong coordinates rather than
+ * reporting that no schema is registered. The document beside this file is a
+ * starting point to copy, and a host names it like any other. */
+char *POINTCLOUD_SCHEMAS_XML = NULL;
+
+/* True once the document has been read, so a miss on a pcid it does not state
+ * does not re-read it on every lookup */
+static bool schemas_xml_read = false;
+
+/**
+ * @ingroup meos_pointcloud_schema_cache
+ * @brief Set the file the point cloud schemas are read from
+ * @param[in] path Location of the document
+ */
+void
+meos_set_pointcloud_schemas_xml(const char *path)
+{
+  if (! path)
+    return;
+  char *copy = malloc(strlen(path) + 1);
+  if (! copy)
+    return;
+  strcpy(copy, path);
+  POINTCLOUD_SCHEMAS_XML = copy;
+  /* A path named after a lookup already missed is still read */
+  schemas_xml_read = false;
+}
+
+/**
+ * @brief Register every schema the document states
+ * @details The enclosing element carries the identifier and the reference
+ *   system of each schema, which a pgPointCloud document states nowhere: it
+ *   holds the dimensions of one schema, carries no identifier, and its parser
+ *   reads only the compression out of the metadata, so a document stating
+ *   `spatialreference` still parses to srid 0. Each schema element is handed
+ *   to the library's own parser verbatim, so the dimensions are read by
+ *   pgPointCloud and by nothing of ours.
+ */
+static void
+read_pointcloud_schemas_xml(void)
+{
+  schemas_xml_read = true;
+  if (! POINTCLOUD_SCHEMAS_XML)
+    return;
+  xmlDoc *doc = xmlReadFile(POINTCLOUD_SCHEMAS_XML, NULL, XML_PARSE_NOERROR |
+    XML_PARSE_NOWARNING);
+  if (! doc)
+    return;
+  xmlNode *root = xmlDocGetRootElement(doc);
+  for (xmlNode *cur = root ? root->children : NULL; cur; cur = cur->next)
+  {
+    if (cur->type != XML_ELEMENT_NODE ||
+        strcmp((const char *) cur->name, "PointCloudSchema") != 0)
+      continue;
+    /* A schema element states nothing without the identifier a value carries */
+    xmlChar *pcid_str = xmlGetProp(cur, (const xmlChar *) "pcid");
+    if (! pcid_str)
+      continue;
+    xmlChar *srid_str = xmlGetProp(cur, (const xmlChar *) "srid");
+    {
+      /* Serialise the schema element back out so the library's parser reads
+       * the document it defines, not a tree of ours.
+       * ⛔ The element is copied into a document of its own and its namespaces
+       * reconciled first: the `pc` prefix is declared on the ENCLOSING
+       * element, so dumping the subtree alone yields prefixes bound to
+       * nothing, and the library's parser answers `Namespace prefix pc on
+       * PointCloudSchema is not defined` followed by an undefined-prefix XPath
+       * error. */
+      xmlDoc *one = xmlNewDoc((const xmlChar *) "1.0");
+      xmlNode *copy = one ? xmlDocCopyNode(cur, one, 1) : NULL;
+      if (copy)
+      {
+        xmlDocSetRootElement(one, copy);
+        xmlReconciliateNs(one, copy);
+        xmlChar *text = NULL;
+        int len = 0;
+        xmlDocDumpMemory(one, &text, &len);
+        if (text)
+        {
+          PCSCHEMA *schema = pc_schema_from_xml((const char *) text);
+          if (schema)
+          {
+            schema->pcid = (uint32_t) atoi((const char *) pcid_str);
+            schema->srid = srid_str ?
+              (uint32_t) atoi((const char *) srid_str) : 0;
+            meos_pc_schema_register(schema->pcid, schema);
+          }
+          xmlFree(text);
+        }
+      }
+      if (one)
+        xmlFreeDoc(one);
+    }
+    xmlFree(pcid_str);
+    if (srid_str)
+      xmlFree(srid_str);
+  }
+  xmlFreeDoc(doc);
+}
+
 PCSCHEMA *
 meos_pc_schema_lookup(uint32_t pcid)
 {
@@ -484,6 +606,16 @@ meos_pc_schema_lookup(uint32_t pcid)
     if (s)
       meos_pc_schema_register(pcid, s);
     return s;
+  }
+  /* (3) A host that installs no hook states its schemas in a document */
+  if (! schemas_xml_read)
+  {
+    read_pointcloud_schemas_xml();
+    for (int i = 0; i < cache_count; i++)
+    {
+      if (cache_buf[i].pcid == pcid)
+        return cache_buf[i].schema;
+    }
   }
   return NULL;
 }


### PR DESCRIPTION
A host with SQL states a schema as rows of pointcloud_schemas and pointcloud_dimensions and installs the hook that reads them. A host with no SQL has no table to write into, so it states the same schemas in a pgPointCloud document, as spatial reference systems reach a standalone MEOS through the file meos_set_spatial_ref_sys_csv names and the road network through the one meos_set_ways_csv names. meos_set_pointcloud_schemas_xml names that file, and a lookup that no host hook answers reads it once. Nothing reads the document unless a host names it, which is where the two siblings differ: each of them overrides a default the loader reads without being asked, because an EPSG code and a road identifier mean the same thing to everybody, while a pcid names one user's instrument. A schema answering pcid 1 by default would decode a value of somebody else's pcid 1 into silently wrong coordinates instead of reporting that none is registered, and a wrong schema is invisible in the text form because the same bytes are printed whichever schema decodes them. The document installed beside the two comma-separated ones is a starting point to copy. The document is never a prerequisite either: meos_pc_schema_register_dims registers a schema on its own, so a host with no filesystem reaches the whole surface. Each schema element is handed to pc_schema_from_xml verbatim, so the dimensions are read by pgPointCloud. The enclosing element carries the identifier and the reference system, which the format states nowhere: a document holds the dimensions of one schema, carries no identifier, and its parser reads only the compression from the metadata, so one stating spatialreference parses to srid 0. The element is copied into a document of its own and its namespaces reconciled before it is parsed, because the prefix is declared on the enclosing element and a bare subtree leaves it bound to nothing.