### PR TITLE
Answer the reference system, compression and dimension count of a schema

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -216,6 +216,9 @@ extern void meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
   const char *xml_text);
 extern const char *meos_pc_schema_xml(uint32_t pcid);
 extern void meos_pc_schema_clear(void);
+extern int32_t meos_pc_schema_get_srid(uint32_t pcid);
+extern int32_t meos_pc_schema_get_compression(uint32_t pcid);
+extern int32_t meos_pc_schema_get_ndims(uint32_t pcid);
 
 /* Comparison */
 

--- a/meos/include/pointcloud/meos_schema_hook.h
+++ b/meos/include/pointcloud/meos_schema_hook.h
@@ -128,16 +128,6 @@ extern void meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
 extern const char *meos_pc_schema_xml(uint32_t pcid);
 
 /**
- * @brief Return the SRID cached for @p pcid (SRID_INVALID on miss).
- *
- * The SRID is extracted from the PCSCHEMA at registration time so
- * callers do not need the full PCSCHEMA struct definition (which lives
- * in pointcloud-pg/lib/pc_api.h, unavailable outside the pointcloud
- * build target).
- */
-extern int32_t meos_pc_schema_get_srid(uint32_t pcid);
-
-/**
  * @brief Drop every entry from the MEOS schema cache.
  *
  * Does NOT free the cached PCSCHEMA values themselves — they belong

--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -430,6 +430,36 @@ meos_pc_schema_get_srid(uint32_t pcid)
 
 /**
  * @ingroup meos_pointcloud_schema_cache
+ * @brief Return the compression a point cloud schema states
+ * @param[in] pcid Identifier of the schema
+ * @return On a pcid no schema is registered for return -1
+ * @details The compression is read off the resolved schema, so a caller
+ *   answers it without the PCSCHEMA definition, as for the reference system
+ */
+int32_t
+meos_pc_schema_get_compression(uint32_t pcid)
+{
+  const PCSCHEMA *s = meos_pc_schema_lookup(pcid);
+  return s ? (int32_t) s->compression : -1;
+}
+
+/**
+ * @ingroup meos_pointcloud_schema_cache
+ * @brief Return the number of dimensions a point cloud schema states
+ * @param[in] pcid Identifier of the schema
+ * @return On a pcid no schema is registered for return -1
+ * @details The count is read off the resolved schema, so a caller answers it
+ *   without the PCSCHEMA definition, as for the reference system
+ */
+int32_t
+meos_pc_schema_get_ndims(uint32_t pcid)
+{
+  const PCSCHEMA *s = meos_pc_schema_lookup(pcid);
+  return s ? (int32_t) s->ndims : -1;
+}
+
+/**
+ * @ingroup meos_pointcloud_schema_cache
  * @brief Resolve a parsed PCSCHEMA by pcid, with hook fallback, answering
  *   @p NULL where neither the cache nor a hook holds one.
  *


### PR DESCRIPTION
A binding reads what a point cloud identifier names through the MEOS surface. The reference system is answered by meos_pc_schema_get_srid, which meos_schema_hook.h keeps to the point cloud sources, so the surface a binding compiles against does not carry it, and the compression and the number of dimensions are answered by nothing at all. The three sit on meos_pointcloud.h and read the schema the cache resolves, so a binding answers them from the public header alone rather than through the PCSCHEMA definition of the vendored library. A pcid no schema is registered for answers the invalid reference system, and -1 for the other two.
