### PR TITLE
Order the point cloud topological sections like their siblings

### DIFF
--- a/mobilitydb/sql/pointcloud/436_tpc_topops.in.sql
+++ b/mobilitydb/sql/pointcloud/436_tpc_topops.in.sql
@@ -32,76 +32,6 @@
  */
 
 /******************************************************************************
- * Overlaps (&&)
- ******************************************************************************/
-
--- tpcpoint
-CREATE FUNCTION overlaps(tstzspan, tpcpoint) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_tstzspan_temporal'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION overlaps(tpcpoint, tstzspan) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_temporal_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION overlaps(tpcbox, tpcpoint) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_tpcbox_tpointcloud'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION overlaps(tpcpoint, tpcbox) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpcbox'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION overlaps(tpcpoint, tpcpoint) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpointcloud'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tstzspan, RIGHTARG = tpcpoint, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tpcpoint, RIGHTARG = tstzspan, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tpcbox, RIGHTARG = tpcpoint, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tpcpoint, RIGHTARG = tpcbox, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tpcpoint, RIGHTARG = tpcpoint, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-
--- tpcpatch
-CREATE FUNCTION overlaps(tstzspan, tpcpatch) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_tstzspan_temporal'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION overlaps(tpcpatch, tstzspan) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_temporal_tstzspan'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION overlaps(tpcbox, tpcpatch) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_tpcbox_tpointcloud'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION overlaps(tpcpatch, tpcbox) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpcbox'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION overlaps(tpcpatch, tpcpatch) RETURNS boolean
-  AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpointcloud'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tstzspan, RIGHTARG = tpcpatch, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tpcpatch, RIGHTARG = tstzspan, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tpcbox, RIGHTARG = tpcpatch, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tpcpatch, RIGHTARG = tpcbox, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-CREATE OPERATOR && (PROCEDURE = overlaps,
-  LEFTARG = tpcpatch, RIGHTARG = tpcpatch, COMMUTATOR = &&,
-  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
-
-/******************************************************************************
  * Contains (@>)
  ******************************************************************************/
 
@@ -239,6 +169,76 @@ CREATE OPERATOR <@ (PROCEDURE = contained,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
 CREATE OPERATOR <@ (PROCEDURE = contained,
   LEFTARG = tpcpatch, RIGHTARG = tpcpatch, COMMUTATOR = @>,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+
+/******************************************************************************
+ * Overlaps (&&)
+ ******************************************************************************/
+
+-- tpcpoint
+CREATE FUNCTION overlaps(tstzspan, tpcpoint) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_tstzspan_temporal'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION overlaps(tpcpoint, tstzspan) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_temporal_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION overlaps(tpcbox, tpcpoint) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_tpcbox_tpointcloud'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION overlaps(tpcpoint, tpcbox) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpcbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION overlaps(tpcpoint, tpcpoint) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpointcloud'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tstzspan, RIGHTARG = tpcpoint, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tpcpoint, RIGHTARG = tstzspan, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tpcbox, RIGHTARG = tpcpoint, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tpcpoint, RIGHTARG = tpcbox, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tpcpoint, RIGHTARG = tpcpoint, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+
+-- tpcpatch
+CREATE FUNCTION overlaps(tstzspan, tpcpatch) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_tstzspan_temporal'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION overlaps(tpcpatch, tstzspan) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_temporal_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION overlaps(tpcbox, tpcpatch) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_tpcbox_tpointcloud'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION overlaps(tpcpatch, tpcbox) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpcbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION overlaps(tpcpatch, tpcpatch) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpointcloud'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tstzspan, RIGHTARG = tpcpatch, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tpcpatch, RIGHTARG = tstzspan, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tpcbox, RIGHTARG = tpcpatch, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tpcpatch, RIGHTARG = tpcbox, COMMUTATOR = &&,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
+CREATE OPERATOR && (PROCEDURE = overlaps,
+  LEFTARG = tpcpatch, RIGHTARG = tpcpatch, COMMUTATOR = &&,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel);
 
 /******************************************************************************


### PR DESCRIPTION
Every spatial bounding-box operator file declares Contains, then Contained, Overlaps, Same and Adjacent, and the topops template emits that order. The point cloud file reads that way with the other ten. Reordering only: every line removed is a line added, and the file sorts to the same bytes as before.