### PR TITLE
Answer a point cloud schema as the SQL functions of the same names answer

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -217,7 +217,7 @@ extern void meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
 extern const char *meos_pc_schema_xml(uint32_t pcid);
 extern void meos_pc_schema_clear(void);
 extern int32_t meos_pc_schema_get_srid(uint32_t pcid);
-extern int32_t meos_pc_schema_get_compression(uint32_t pcid);
+extern const char *meos_pc_schema_get_compression(uint32_t pcid);
 extern int32_t meos_pc_schema_get_ndims(uint32_t pcid);
 
 /* Comparison */

--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -432,30 +432,44 @@ meos_pc_schema_get_srid(uint32_t pcid)
  * @ingroup meos_pointcloud_schema_cache
  * @brief Return the compression a point cloud schema states
  * @param[in] pcid Identifier of the schema
- * @return On a pcid no schema is registered for return -1
- * @details The compression is read off the resolved schema, so a caller
- *   answers it without the PCSCHEMA definition, as for the reference system
+ * @return On a pcid no schema is registered for return @p NULL
+ * @details The name the catalog states is answered — @p none, @p dimensional
+ *   or @p laz — which is what the SQL function of the same name answers. The
+ *   compression field of the schema is an enumerator of the point cloud
+ *   library, declared in its own header, so a number leaves a caller of this
+ *   surface nothing to decode it with
+ * @note The result is a string constant owned by that library, so a caller
+ *   reads it and never frees it
  */
-int32_t
+const char *
 meos_pc_schema_get_compression(uint32_t pcid)
 {
   const PCSCHEMA *s = meos_pc_schema_lookup(pcid);
-  return s ? (int32_t) s->compression : -1;
+  return s ? pc_compression_name((int) s->compression) : NULL;
 }
 
 /**
  * @ingroup meos_pointcloud_schema_cache
- * @brief Return the number of dimensions a point cloud schema states
+ * @brief Return the number of active dimensions a point cloud schema states
  * @param[in] pcid Identifier of the schema
  * @return On a pcid no schema is registered for return -1
- * @details The count is read off the resolved schema, so a caller answers it
- *   without the PCSCHEMA definition, as for the reference system
+ * @details The ACTIVE dimensions are counted, which is what the SQL function
+ *   of the same name answers. The @p ndims field of the schema is the width
+ *   of its layout: an inactive dimension still occupies a slot and still
+ *   contributes to the width of a point, so the byte offsets are indexed by
+ *   it and it is a different quantity, not this one under another name
  */
 int32_t
 meos_pc_schema_get_ndims(uint32_t pcid)
 {
   const PCSCHEMA *s = meos_pc_schema_lookup(pcid);
-  return s ? (int32_t) s->ndims : -1;
+  if (! s)
+    return -1;
+  int32_t result = 0;
+  for (uint32_t i = 0; i < s->ndims; i++)
+    if (s->dims[i] && s->dims[i]->active)
+      result++;
+  return result;
 }
 
 /**

--- a/meos/test/pcschema_dims_test.c
+++ b/meos/test/pcschema_dims_test.c
@@ -36,6 +36,10 @@
  * are two statements of one thing, so every field of the result must agree,
  * including the ones the engine computes: the size of a dimension, the offset
  * of a dimension within a point, and the width of a point.
+ *
+ * The three accessors a binding reads a schema through are exercised on a
+ * schema carrying an inactive dimension, which is the state that tells the
+ * number of dimensions apart from the width of the layout.
  */
 
 #include <stdio.h>
@@ -151,6 +155,41 @@ main(void)
   /* The name hash table answers, as a schema built from a document does */
   check(pc_schema_get_dimension_by_name(stated, "Y") == stated->dims[1],
     "dimension by name");
+
+  /* The three accessors a binding reads a schema through, on a schema whose
+   * last dimension is INACTIVE, which is the state that tells the number of
+   * dimensions apart from the width of the layout */
+  PCDimensionSpec dims90[3] = {
+    { "X", NULL, 1, "int32_t", 1, 0, true },
+    { "Y", NULL, 2, "int32_t", 1, 0, true },
+    { "Intensity", NULL, 3, "int32_t", 1, 0, false }
+  };
+  if (! meos_pc_schema_register_dims(90, 4326, "dimensional", dims90, 3))
+  {
+    printf("FAILED: the schema with an inactive dimension is not registered\n");
+    return 1;
+  }
+  PCSCHEMA *inactive = meos_pc_schema(90);
+  check(inactive != NULL, "the schema with an inactive dimension resolves");
+  /* Both quantities of ONE schema are asserted here, so answering the width
+   * where the count is asked does not pass: an inactive dimension still
+   * occupies a slot, so the layout is three wide while two dimensions are
+   * active, and the accessor answers the ACTIVE count, which is what the SQL
+   * function pointCloudSchemaNDims answers for the same schema */
+  check(inactive && inactive->ndims == 3, "the layout of the schema is 3 wide");
+  check(meos_pc_schema_get_ndims(90) == 2,
+    "2 dimensions of the schema are active");
+  const char *compression = meos_pc_schema_get_compression(90);
+  check(compression && strcmp(compression, "dimensional") == 0,
+    "the compression of the schema is named");
+  check(meos_pc_schema_get_srid(90) == 4326,
+    "the reference system of the schema");
+  /* A pcid no schema is registered for */
+  printf("The reference system naming no schema: %d\n",
+    meos_pc_schema_get_srid(999));
+  check(meos_pc_schema_get_ndims(999) == -1, "no schema states no dimensions");
+  check(meos_pc_schema_get_compression(999) == NULL,
+    "no schema states no compression");
 
   printf("%s: %d field(s) disagree\n", failures ? "FAILED" : "PASSED",
     failures);


### PR DESCRIPTION
A binding projects the MEOS surface, so an accessor published as the twin of a SQL function carries that function's answer to every host at once. meos_pc_schema_get_ndims counts the ACTIVE dimensions, which is what pointCloudSchemaNDims counts. The ndims field of a schema is the width of its layout: an inactive dimension still occupies a slot and still contributes to the width of a point, so pc_schema_calculate_byteoffsets indexes the byte offsets by it, and it is a different quantity rather than this one under another name. Against the schema of pcid 90 of the regression fixture, whose third dimension is inactive, the field reads 3 where the SQL function reads 2. meos_pc_schema_get_compression answers the name the catalog states, none or dimensional or laz, which is what pointCloudSchemaCompression answers, and a null name for a pcid no schema is registered for. The compression field of a schema is an enumerator of the point cloud library declared in its own header, so a number leaves a caller of this surface nothing to decode it with. The name comes from that library's own pc_compression_name, so the three spellings are the ones the catalog constrains its column to, and it is a string constant the library owns that a caller reads and never frees. pcschema_dims_test registers the schema with the inactive dimension and asserts both quantities of it, the width of the layout beside the number of active dimensions, so answering one where the other is asked does not pass.
