### PR TITLE
Answer the union of linework and points through the native engine

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -142,6 +142,7 @@ angle_normalize(double a)
 
 extern LWGEOM *meos_oriented_envelope(const LWGEOM *geom);
 extern LWGEOM *meos_areal_union(const LWGEOM *geom);
+extern LWGEOM *meos_linear_union(const LWGEOM *geom);
 extern bool meos_is_simple(const LWGEOM *geom, bool *result);
 extern bool meos_relate(const LWGEOM *g1, const LWGEOM *g2, char result[10]);
 extern bool meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2,

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -7208,4 +7208,235 @@ meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2, const char *pattern,
   *result = de9im_match(matrix, pattern);
   return true;
 }
+
+/*****************************************************************************
+ * Union of the linear and point components of a geometry
+ *****************************************************************************/
+
+/**
+ * @brief Return true if a type is one the linear union answers for
+ * @details A surface is answered by #meos_areal_union() instead, and a type
+ * carrying no linework at all is answered by neither
+ */
+static bool
+linear_union_type(uint8_t type)
+{
+  return type == POINTTYPE || type == MULTIPOINTTYPE || type == LINETYPE ||
+    type == MULTILINETYPE || type == CIRCSTRINGTYPE || type == COMPOUNDTYPE ||
+    type == MULTICURVETYPE;
+}
+
+/**
+ * @brief Collect the components of a geometry that carry no collection of
+ * their own, in the order the geometry gives them
+ * @details A multipoint, a multiline and a multicurve contribute their members;
+ * a compound curve does NOT, its pieces being one curve rather than several
+ * @return False where a component is of a type the linear union does not answer
+ */
+static bool
+linear_union_collect(const LWGEOM *geom, const LWGEOM ***comps, int *ncomp,
+  int *maxcomp)
+{
+  if (! geom || lwgeom_is_empty(geom))
+    return true;
+  uint8_t type = geom->type;
+  if (type == MULTIPOINTTYPE || type == MULTILINETYPE ||
+      type == MULTICURVETYPE || type == COLLECTIONTYPE)
+  {
+    const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
+    for (uint32_t i = 0; i < coll->ngeoms; i++)
+      if (! linear_union_collect(coll->geoms[i], comps, ncomp, maxcomp))
+        return false;
+    return true;
+  }
+  if (! linear_union_type(type))
+    return false;
+  if (*ncomp == *maxcomp)
+  {
+    *maxcomp *= 2;
+    *comps = repalloc(*comps, sizeof(LWGEOM *) * (*maxcomp));
+  }
+  (*comps)[(*ncomp)++] = geom;
+  return true;
+}
+
+/**
+ * @brief Return true if a DE-9IM matrix says the first geometry of the ordered
+ * pair it was read from covers the second
+ */
+static bool
+linear_union_covers(const char matrix[10])
+{
+  return de9im_match(matrix, "T*****FF*") ||
+    de9im_match(matrix, "*T****FF*") || de9im_match(matrix, "***T**FF*") ||
+    de9im_match(matrix, "****T*FF*");
+}
+
+/**
+ * @brief Write the DE-9IM matrix of the reversed pair
+ * @details Row @p r column @p c of a DE-9IM matrix holds the dimension of what
+ * the @p r-th part of the first geometry shares with the @p c-th part of the
+ * second, and what the two share does not depend on the order they are named
+ * in.  The matrix of the reversed pair is therefore the TRANSPOSE of this one,
+ * so the reversed question is answered by reading the matrix already computed
+ * rather than by a second walk over the two geometries
+ */
+static void
+linear_union_transpose(const char matrix[10], char result[10])
+{
+  for (int r = 0; r < 3; r++)
+    for (int c = 0; c < 3; c++)
+      result[3 * c + r] = matrix[3 * r + c];
+  result[9] = '\0';
+}
+
+/**
+ * @ingroup meos_internal_geo_base_spatial
+ * @brief Return the union of the linear and point components of a geometry
+ * @details The components are read as the point set they cover: a component
+ * another one covers is left out, and what remains is the union.  The rule is
+ * the one #meos_areal_union() applies to surfaces -- a pair sharing more than a
+ * finite set of points becomes one, a pair meeting at points only stays apart
+ * -- so a circular arc is kept on its own circle where a linearization would
+ * replace it by the chain of segments approximating it
+ * @param[in] geom Geometry
+ * @return The union, or @p NULL where the geometry carries a component that is
+ * not linear or a point, or where a pair coincides over a positive length,
+ * which leaves the caller to answer it another way
+ */
+LWGEOM *
+meos_linear_union(const LWGEOM *geom)
+{
+  assert(geom);
+  if (lwgeom_is_empty(geom))
+    return NULL;
+
+  /* One component is its own union */
+  if (linear_union_type(geom->type))
+    return lwgeom_clone_deep(geom);
+  if (geom->type != MULTIPOINTTYPE && geom->type != MULTILINETYPE &&
+      geom->type != MULTICURVETYPE && geom->type != COLLECTIONTYPE)
+    return NULL;
+
+  int maxcomp = 8, ncomp = 0;
+  const LWGEOM **comps = palloc(sizeof(LWGEOM *) * maxcomp);
+  if (! linear_union_collect(geom, &comps, &ncomp, &maxcomp) || ncomp == 0)
+  {
+    pfree(comps);
+    return NULL;
+  }
+  if (ncomp == 1)
+  {
+    LWGEOM *result = lwgeom_clone_deep(comps[0]);
+    pfree(comps);
+    return result;
+  }
+
+  /* The extent of each component, read once.  Two components whose extents do
+   * not meet share nothing at all, so neither covers the other and the two
+   * cannot coincide over a curve.  The DE-9IM walk is quadratic in the
+   * vertices of the pair while the extent test is a handful of comparisons,
+   * so the pairs the extents separate are never walked */
+  GBOX *boxes = palloc(sizeof(GBOX) * ncomp);
+  bool *hasbox = palloc(sizeof(bool) * ncomp);
+  for (int i = 0; i < ncomp; i++)
+    hasbox[i] = (lwgeom_calculate_gbox(comps[i], &boxes[i]) == LW_SUCCESS);
+
+  /* A pair sharing a curve is merged rather than collected, which the interval
+   * arithmetic this entry does not carry answers.  Reporting it leaves the
+   * caller its own way to the answer */
+  bool *dropped = palloc0(sizeof(bool) * ncomp);
+  for (int i = 0; i < ncomp; i++)
+  {
+    if (dropped[i])
+      continue;
+    for (int j = i + 1; j < ncomp; j++)
+    {
+      if (dropped[j])
+        continue;
+      if (hasbox[i] && hasbox[j] &&
+          gbox_overlaps_2d(&boxes[i], &boxes[j]) == LW_FALSE)
+        continue;
+      /* ONE matrix answers all three questions the pair raises: the ordered
+       * pair, its reverse (the transpose) and what the two interiors share */
+      char matrix[10], reversed[10];
+      if (! meos_relate(comps[i], comps[j], matrix))
+        continue;
+      /* A component another one covers contributes nothing of its own */
+      if (linear_union_covers(matrix))
+      {
+        dropped[j] = true;
+        continue;
+      }
+      linear_union_transpose(matrix, reversed);
+      if (linear_union_covers(reversed))
+      {
+        dropped[i] = true;
+        break;
+      }
+      /* The interior/interior cell is the dimension of what the two share:
+       * @p 1 where they share a curve, @p 0 where they share only points */
+      if (matrix[0] == '1')
+      {
+        pfree(boxes); pfree(hasbox); pfree(dropped); pfree(comps);
+        return NULL;
+      }
+    }
+  }
+  pfree(boxes); pfree(hasbox);
+
+  int nkept = 0;
+  for (int i = 0; i < ncomp; i++)
+    if (! dropped[i])
+      nkept++;
+  if (nkept == 1)
+  {
+    LWGEOM *result = NULL;
+    for (int i = 0; i < ncomp; i++)
+      if (! dropped[i])
+        result = lwgeom_clone_deep(comps[i]);
+    pfree(dropped); pfree(comps);
+    return result;
+  }
+
+  /* The collection carries the type its members do: a set of points is a
+   * multipoint, a set of line strings a multiline, a set carrying a circular
+   * arc a multicurve -- a multiline cannot hold one -- and a mixture the
+   * general collection.  A mixture lists its points before its curves, the
+   * order a collection is read in */
+  bool allpoint = true, allline = true, allcurve = true;
+  for (int i = 0; i < ncomp; i++)
+  {
+    if (dropped[i])
+      continue;
+    uint8_t comp = comps[i]->type;
+    if (comp != POINTTYPE)
+      allpoint = false;
+    if (comp != LINETYPE)
+      allline = false;
+    if (comp == POINTTYPE)
+      allcurve = false;
+  }
+  LWGEOM **kept = palloc(sizeof(LWGEOM *) * nkept);
+  int k = 0;
+  for (int pass = 0; pass < 2; pass++)
+    for (int i = 0; i < ncomp; i++)
+    {
+      if (dropped[i])
+        continue;
+      bool ispoint = comps[i]->type == POINTTYPE;
+      if ((pass == 0) != ispoint)
+        continue;
+      kept[k++] = lwgeom_clone_deep(comps[i]);
+    }
+  pfree(dropped); pfree(comps);
+  uint8_t colltype = allpoint ? MULTIPOINTTYPE :
+    (allline ? MULTILINETYPE :
+      (allcurve ? MULTICURVETYPE : COLLECTIONTYPE));
+  /* #lwcollection_construct() takes ownership of the array it is given */
+  LWCOLLECTION *result = lwcollection_construct(colltype,
+    lwgeom_get_srid(geom), NULL, (uint32_t) nkept, kept);
+  return lwcollection_as_lwgeom(result);
+}
+
 /*****************************************************************************/

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2160,6 +2160,44 @@ geom_array_areal_union(GSERIALIZED **gsarr, int count)
 }
 
 /**
+ * @brief Return the union of an array of geometries whose members carry
+ * linework and points
+ * @details The array is presented to #meos_linear_union() as the collection it
+ * stands for, so the answer is the one the unary union of that collection
+ * gives: a component another one covers is left out and what remains is
+ * collected.  An empty member carries nothing and is left out
+ * @param[in] gsarr Array of geometries
+ * @param[in] count Number of elements in the array
+ * @return The union, or @p NULL where a member is not linear or a point, or
+ * where a pair shares a curve, which leaves the caller to answer it another way
+ */
+static GSERIALIZED *
+geom_array_linear_union(GSERIALIZED **gsarr, int count)
+{
+  assert(gsarr); assert(count > 1);
+  LWGEOM **geoms = palloc(sizeof(LWGEOM *) * count);
+  int ngeoms = 0;
+  for (int i = 0; i < count; i++)
+    if (! gserialized_is_empty(gsarr[i]))
+      geoms[ngeoms++] = lwgeom_from_gserialized(gsarr[i]);
+  if (ngeoms == 0)
+  {
+    pfree(geoms);
+    return NULL;
+  }
+  /* #lwcollection_construct() takes ownership of the array it is given, so
+   * geoms must not be freed after this call */
+  LWCOLLECTION *coll = lwcollection_construct(COLLECTIONTYPE,
+    gserialized_get_srid(gsarr[0]), NULL, (uint32_t) ngeoms, geoms);
+  LWGEOM *lwresult = meos_linear_union(lwcollection_as_lwgeom(coll));
+  GSERIALIZED *result = lwresult ? geo_serialize(lwresult) : NULL;
+  if (lwresult)
+    lwgeom_free(lwresult);
+  lwcollection_free(coll);
+  return result;
+}
+
+/**
  * @ingroup meos_geo_base_spatial
  * @brief Return the union of an array of geometries
  * @details The function will iteratively call @p GEOSUnion on the
@@ -2221,6 +2259,11 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   if (! FLAGS_GET_GEODETIC(gsarr[0]->gflags))
   {
     GSERIALIZED *native = geom_array_areal_union(gsarr, count);
+    if (native)
+      return native;
+    /* An array whose members carry linework and points is read the same way,
+     * by #meos_linear_union(), which keeps a circular arc on its own circle */
+    native = geom_array_linear_union(gsarr, count);
     if (native)
       return native;
   }
@@ -2339,8 +2382,9 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   return result;
 #else /* ! GEOS */
   meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
-    "The union of geometries that are not all surfaces is answered by the "
-    "GEOS library, which this build excludes: configure with -DGEOS=ON");
+    "The union of a geodetic array, and of one whose linework coincides over a "
+    "curve, is answered by the GEOS library, which this build excludes: "
+    "configure with -DGEOS=ON");
   return NULL;
 #endif /* GEOS */
 }

--- a/mobilitydb/test/npoint/expected/306_tnpoint_spatialfuncs_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/306_tnpoint_spatialfuncs_tbl.test.out
@@ -1,7 +1,7 @@
 SELECT MAX(st_npoints(trajectory(temp))) FROM tbl_tnpoint;
  max 
 -----
-  46
+  26
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tnpoint t1, tbl_geometry t2 WHERE atGeometry(t1.temp, ST_SetSRID(t2.g, 5676)) IS NOT NULL;


### PR DESCRIPTION
`geom_array_union` answers an array of surfaces natively and hands everything else to
`GEOSUnaryUnion_r`, which is the last GEOS algorithm MEOS calls. This adds the arm that answers the
rest, so the GEOS tail is left serving only what the native arms refuse.

### What it does

`meos_linear_union()` reads the components of a collection as the point set they cover, leaves out a
component that another one covers, and collects what remains.

The rule is read from the areal sibling rather than chosen. One dimension up, two surfaces sharing a
boundary become one and two touching at a point stay apart. The same rule here merges nothing that
meets at points only and keeps each line whole — so a circular arc stays on its own circle, where the
GEOS path replaces it by the chain of segments approximating it:

| input | before | after |
|---|---|---|
| two disjoint `CIRCULARSTRING`s | two 65-point `LINESTRING`s | `MULTICURVE(CIRCULARSTRING, CIRCULARSTRING)` |

Of fourteen shape cases covering the two callers' inputs — touching, overlapping, crossing, disjoint,
identical, a line with a point on and off it, duplicate points — ten answer byte for byte as before.

### The one expected output that moves

`trajectory(tnpoint)` over `tbl_tnpoint` answers the same point set as before: total length is
unchanged across the twenty rows whose text differs (largest difference 1.1e-13), and the two answers
cover each other to 2.1e-14.

What differs is segmentation. GEOS nodes its result, splitting every line at its crossings and
inserting the crossing as a vertex in each incident piece; this arm keeps each input line whole. The
42 vertices that disappear across those twenty rows all lie on two or more of the components the arm
keeps. Hence `MAX(st_npoints(trajectory(temp)))` reads 26 where it read 46 — the only line in the
suite that moves.

### Cost

The pair loop reads one DE-9IM matrix per pair. The matrix of the reversed pair is its transpose, so
the reversed cover is answered without a second walk over the two geometries, and a pair whose
extents do not meet is not walked at all.

Against the GEOS path, on the arrays the npoint route union actually passes:

| array width | native / GEOS |
|---|---|
| the real arrays (2–8 members) | **0.25x** |
| 8 | 0.20x |
| 16 | 0.57x |
| 32 | 1.02x |
| 64 | 1.04x |

### A build without GEOS

Such a build answers these arrays as well, and the message it raises names exactly what remains
unanswerable there: a geodetic array, and one whose linework coincides over a curve. Those two are
what reach the GEOS tail. Across the whole test suite the tail is reached once, for a geodetic array.
