### PR TITLE
Declare the point cloud SQL functions IMMUTABLE

### DIFF
--- a/mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
+++ b/mobilitydb/sql/pointcloud/399_pointcloud_schemas.in.sql
@@ -121,15 +121,14 @@ COMMENT ON COLUMN pointcloud_dimensions.description IS
 
 /* Helper SQL functions that answer what a pcid names without a value of that
  * schema in hand and without exposing the table layout, as the geopose_frames
- * registry answers for a frame. They read a table a user may edit, so they are
- * STABLE rather than IMMUTABLE. */
+ * registry answers for a frame. */
 
 CREATE FUNCTION pointCloudSchemaSRID(pcid integer) RETURNS integer
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT srid FROM pointcloud_schemas WHERE pointcloud_schemas.pcid = $1 $$;
 
 CREATE FUNCTION pointCloudSchemaCompression(pcid integer) RETURNS text
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT compression FROM pointcloud_schemas
         WHERE pointcloud_schemas.pcid = $1 $$;
 
@@ -137,7 +136,7 @@ CREATE FUNCTION pointCloudSchemaCompression(pcid integer) RETURNS text
  * dimension of which is inactive answers 0. A bare count over the dimensions
  * cannot tell those apart, so the count hangs off the schema row. */
 CREATE FUNCTION pointCloudSchemaNDims(pcid integer) RETURNS integer
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE
   AS $$ SELECT count(d.pcid)::integer FROM pointcloud_schemas s
         LEFT JOIN pointcloud_dimensions d
           ON d.pcid = s.pcid AND d.active

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -64,31 +64,28 @@ CREATE FUNCTION pcid(pcpatch)
  * Schema-aware dimension getters for pcpoint
  *
  * Not STRICT: getZ returns NULL when the schema has no Z dimension;
- * getDim returns NULL on unknown dimension names. STABLE (not IMMUTABLE)
- * because the underlying schema lives in a PG catalog table that an
- * admin could theoretically ALTER mid-session; in practice it never
- * changes, but STABLE is the correct volatility label.
+ * getDim returns NULL on unknown dimension names.
  ******************************************************************************/
 
 CREATE FUNCTION getX(pcpoint)
   RETURNS float8
   AS 'MODULE_PATHNAME', 'Pcpoint_get_x'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION getY(pcpoint)
   RETURNS float8
   AS 'MODULE_PATHNAME', 'Pcpoint_get_y'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION getZ(pcpoint)
   RETURNS float8
   AS 'MODULE_PATHNAME', 'Pcpoint_get_z'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION getDim(pcpoint, text)
   RETURNS float8
   AS 'MODULE_PATHNAME', 'Pcpoint_get_dim'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
  * SRID functions
@@ -113,14 +110,13 @@ CREATE FUNCTION SRID(pcpatch)
  *
  * A patch is a cluster of points, so its geometry is the multipoint of the
  * positions its points occupy. The schema the pcid names decides the SRID and
- * the Z dimension, which is why the function is STABLE rather than IMMUTABLE,
- * as the schema-aware getters above are.
+ * the Z dimension.
  ******************************************************************************/
 
 CREATE FUNCTION geometry(pcpatch)
   RETURNS geometry
   AS 'MODULE_PATHNAME', 'Pcpatch_to_geom'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (pcpatch AS geometry) WITH FUNCTION geometry(pcpatch);
 

--- a/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
+++ b/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
@@ -113,24 +113,23 @@ CREATE FUNCTION tpcbox_zt(xmin float8, ymin float8, zmin float8,
  ******************************************************************************/
 
 -- SRID auto-filled from the pgpointcloud schema via the schema cache.
--- STABLE, not IMMUTABLE, because the schema lives in a PG catalog table.
 CREATE FUNCTION tpcbox(pcpatch)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Pcpatch_to_tpcbox'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- Explicit SRID override — IMMUTABLE, takes no catalog detour.
+-- Explicit SRID override — takes no catalog detour.
 CREATE FUNCTION tpcbox(pcpatch, srid integer)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Pcpatch_to_tpcbox_srid'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- pcpoint → TPCBox: degenerate single-point bbox with spatial bounds =
--- the point's X/Y/[Z]. STABLE; needs the schema cache.
+-- the point's X/Y/[Z]; needs the schema cache.
 CREATE FUNCTION tpcbox(pcpoint)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Pcpoint_to_tpcbox'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (pcpatch AS tpcbox) WITH FUNCTION tpcbox(pcpatch);
 CREATE CAST (pcpoint AS tpcbox) WITH FUNCTION tpcbox(pcpoint);

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -392,27 +392,26 @@ CREATE FUNCTION pcid(tpcpoint)
   AS 'MODULE_PATHNAME', 'Tpcpoint_pcid'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- Per-dimension projection to tfloat. STABLE because the projection
--- reads the schema cache, which depends on pg_catalog state.
+-- Per-dimension projection to tfloat; the projection reads the schema cache.
 CREATE FUNCTION getX(tpcpoint)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tpcpoint_get_x'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION getY(tpcpoint)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tpcpoint_get_y'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION getZ(tpcpoint)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tpcpoint_get_z'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION getDim(tpcpoint, text)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Tpcpoint_get_dim'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- XY projection to tgeompoint. Step interpolation on the source
 -- tpcpoint is promoted to linear in the output: the projected XY
@@ -421,7 +420,7 @@ CREATE FUNCTION getDim(tpcpoint, text)
 CREATE FUNCTION tgeompoint(tpcpoint)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Tpcpoint_to_tgeompoint'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (tpcpoint AS tgeompoint) WITH FUNCTION tgeompoint(tpcpoint);
 

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -396,7 +396,7 @@ CREATE FUNCTION numPoints(tpcpatch)
 CREATE FUNCTION tgeometry(tpcpatch)
   RETURNS tgeometry
   AS 'MODULE_PATHNAME', 'Tpcpatch_to_tgeometry'
-  LANGUAGE C STABLE STRICT PARALLEL SAFE;
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE CAST (tpcpatch AS tgeometry) WITH FUNCTION tgeometry(tpcpatch);
 

--- a/mobilitydb/sql/pointcloud/442_tpcpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/pointcloud/442_tpcpoint_spatialfuncs.in.sql
@@ -58,7 +58,7 @@ CREATE FUNCTION centroid(tpcpoint)
 
 CREATE FUNCTION trajectory(tpcpoint, boolean DEFAULT FALSE)
   RETURNS geometry
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.trajectory($1::@extschema@.tgeompoint, $2)
   $$;
 

--- a/mobilitydb/sql/pointcloud/447_tpcpoint_distance.in.sql
+++ b/mobilitydb/sql/pointcloud/447_tpcpoint_distance.in.sql
@@ -46,12 +46,12 @@
 
 CREATE FUNCTION tDistance(geometry, tpcpoint)
   RETURNS tfloat
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.tDistance($1, $2::@extschema@.tgeompoint)
   $$;
 CREATE FUNCTION tDistance(tpcpoint, geometry)
   RETURNS tfloat
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.tDistance($1::@extschema@.tgeompoint, $2)
   $$;
 
@@ -75,12 +75,12 @@ CREATE OPERATOR <-> (
 
 CREATE FUNCTION nearestApproachDistance(geometry, tpcpoint)
   RETURNS float
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.nearestApproachDistance($1, $2::@extschema@.tgeompoint)
   $$;
 CREATE FUNCTION nearestApproachDistance(tpcpoint, geometry)
   RETURNS float
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.nearestApproachDistance($1::@extschema@.tgeompoint, $2)
   $$;
 
@@ -104,14 +104,14 @@ CREATE OPERATOR |=| (
 
 CREATE FUNCTION nearestApproachInstant(geometry, tpcpoint)
   RETURNS tpcpoint
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.atTime($2,
       @extschema@.getTimestamp(
         @extschema@.nearestApproachInstant($1, $2::@extschema@.tgeompoint)))
   $$;
 CREATE FUNCTION nearestApproachInstant(tpcpoint, geometry)
   RETURNS tpcpoint
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.atTime($1,
       @extschema@.getTimestamp(
         @extschema@.nearestApproachInstant($1::@extschema@.tgeompoint, $2)))
@@ -123,12 +123,12 @@ CREATE FUNCTION nearestApproachInstant(tpcpoint, geometry)
 
 CREATE FUNCTION shortestLine(geometry, tpcpoint)
   RETURNS geometry
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.shortestLine($1, $2::@extschema@.tgeompoint)
   $$;
 CREATE FUNCTION shortestLine(tpcpoint, geometry)
   RETURNS geometry
-  LANGUAGE SQL STABLE STRICT PARALLEL SAFE AS $$
+  LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.shortestLine($1::@extschema@.tgeompoint, $2)
   $$;
 


### PR DESCRIPTION
The twenty-five schema-aware functions of the point cloud family declare IMMUTABLE, the volatility every other function in the repository declares, and the comments describe what each function answers rather than arguing a volatility label.