### PR TITLE
Build the geodetic union before releasing the value it reads

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2353,9 +2353,13 @@ geom_array_union(GSERIALIZED **gsarr, int count)
       LWGEOM *lwgeom = lwgeom_from_gserialized(result);
       lwgeom_drop_bbox(lwgeom);
       lwgeom_set_geodetic(lwgeom, true);
-      pfree(result);
+      /* The deserialized value reads its coordinates OUT OF @p result, so the
+       * geodetic serialization below walks that buffer. It is released once
+       * the new value is built, never before */
+      GSERIALIZED *planar = result;
       result = geo_serialize(lwgeom);
       lwgeom_free(lwgeom);
+      pfree(planar);
     }
     GEOSGeom_destroy_r(ctx, g_union);
   }

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -672,6 +672,27 @@ int main(void)
   free(phsurf); free(mp); free(uu2);
   meos_errno_reset();
 
+  /* The union of a GEODETIC array is serialized twice: GEOS answers a planar
+   * value, and the geodetic flag cannot be set on it because the planar
+   * bounding box already written occupies a different number of floats. The
+   * deserialization that carries the value across reads its coordinates OUT OF
+   * the planar buffer, so releasing that buffer before the geodetic value is
+   * built leaves the second serialization walking freed memory -- it answered
+   * a MULTIPOINT of denormal coordinates, and valgrind reported the read in
+   * ll2cart under lwgeom_calculate_gbox_geodetic */
+  GSERIALIZED *gg1 = geog_in("POINT(1 1)", -1);
+  GSERIALIZED *gg2 = geog_in("POINT(2 2)", -1);
+  assert(gg1 != NULL); assert(gg2 != NULL);
+  GSERIALIZED *ggarr[2] = {gg1, gg2};
+  meos_errno_reset();
+  GSERIALIZED *ggu = geom_array_union(ggarr, 2);
+  assert(ggu != NULL);
+  char *ggwkt = geo_as_ewkt(ggu, 6);
+  printf("the union of two geography points: %s\n", ggwkt);
+  assert(strcmp(ggwkt, "SRID=4326;MULTIPOINT(1 1,2 2)") == 0);
+  free(gg1); free(gg2); free(ggu); free(ggwkt);
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
The union of a geodetic array reads freed memory, and answers denormal
coordinates.

```
SELECT ST_AsEWKT(ST_Union(ARRAY[
  'SRID=4326;POINT(1 1)'::geography, 'SRID=4326;POINT(2 2)'::geography]));
```

answers

```
SRID=4326;MULTIPOINT(2.121996e-314 2.121996e-314,2.121996e-314 2.121996e-314)
```

where `SRID=4326;MULTIPOINT(1 1,2 2)` is the answer. A geography reaches this
through the merge of two temporal geography points, so it is reachable from
SQL.

### The cause

`geom_array_union` serializes a geodetic answer twice. GEOS answers a planar
value, and the geodetic flag cannot be set on it in place, because the planar
bounding box already written occupies `2 * ndims` floats where a geodetic one
occupies 6. The value is therefore deserialized, flagged, and serialized again:

```c
LWGEOM *lwgeom = lwgeom_from_gserialized(result);
lwgeom_drop_bbox(lwgeom);
lwgeom_set_geodetic(lwgeom, true);
pfree(result);                    /* released here */
result = geo_serialize(lwgeom);   /* and read here */
lwgeom_free(lwgeom);
```

The deserialized value reads its coordinates out of the serialized buffer
rather than owning a copy of them, so `geo_serialize` walks a buffer released
two lines earlier. valgrind names it:

```
Invalid read of size 8
   at ll2cart
   by ptarray_calculate_gbox_geodetic
   by lwgeom_calculate_gbox_geodetic
   by gserialized2_from_lwgeom
   by geog_serialize
   by geom_array_union
 Address is 40 bytes inside a block of size 80 free'd
   by geom_array_union
```

Releasing the planar buffer once the geodetic value is built, rather than
before, leaves valgrind reporting `0 errors from 0 contexts` on the same call
and the answers correct.

### Why the suite is silent about it

Under PostgreSQL `pfree` returns the block to a memory context, which commonly
leaves the bytes readable, so the path is exercised without a visible failure.
The standalone library, where the same call reaches `free`, shows the
corruption. It is undefined behaviour either way.

`geo_test` asserts the answer, so the assertion fails wherever the freed bytes
do not survive, and the `Smoke + valgrind` job reports the read itself.
