### PR TITLE
Build a point cloud value from the coordinates of every dimension

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3313,6 +3313,12 @@
 						<para><link linkend="pcpoint_xy_xyz"><varname>pcpoint</varname></link>: Construye un pcpoint 2D o 3D directamente a partir de coordenadas x/y(/z)</para>
 					</listitem>
 					<listitem>
+						<para><link linkend="pcpoint_coordinates"><varname>pcpoint</varname></link>: Construye un pcpoint a partir de las coordenadas de cada dimensión de la disposición del esquema, incluidas las dimensiones inactivas, que es como se dan sus valores a un esquema con más dimensiones de las que alcanzan las sobrecargas anteriores. Ese número es el que toma <varname>PC_MakePoint</varname> y NO es el número de dimensiones activas que informa <varname>pointCloudSchemaNDims</varname></para>
+					</listitem>
+					<listitem>
+						<para><link linkend="pcpatch_coordinates"><varname>pcpatch</varname></link>: Construye un pcpatch a partir de las coordenadas de sus puntos, un punto tras otro, dando para cada punto cada dimensión de la disposición del esquema, incluidas las dimensiones inactivas. Ese número es el que toma <varname>PC_MakePatch</varname> y NO es el número de dimensiones activas que informa <varname>pointCloudSchemaNDims</varname>; un número que sea múltiplo del que no corresponde construye un parche de puntos erróneos en lugar de informar un error. Un parche construido así declara él mismo el esquema, al no haber ningún punto del que leerlo</para>
+					</listitem>
+					<listitem>
 						<para><link linkend="pcpatch_variadic"><varname>pcpatch</varname></link>: Construye un pcpatch a partir de una lista variádica de pcpoints que comparten el mismo pcid</para>
 					</listitem>
 				</itemizedlist>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -196,6 +196,24 @@ SELECT pcpoint(1, 10.0, 20.0, 30.0);
 </programlisting>
 				</listitem>
 
+				<listitem xml:id="pcpoint_coordinates">
+					<indexterm significance="normal"><primary><varname>pcpoint</varname></primary></indexterm>
+					<para>Construye un pcpoint a partir de las coordenadas de cada dimensión de la disposición del esquema, incluidas las dimensiones inactivas, que es como se dan sus valores a un esquema con más dimensiones de las que alcanzan las sobrecargas anteriores. Ese número es el que toma <varname>PC_MakePoint</varname> y NO es el número de dimensiones activas que informa <varname>pointCloudSchemaNDims</varname></para>
+					<para><varname>pcpoint(pcid integer, coordinates float[]) → pcpoint</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pcpoint(1, ARRAY[10.0, 20.0, 30.0]::float[]);
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="pcpatch_coordinates">
+					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
+					<para>Construye un pcpatch a partir de las coordenadas de sus puntos, un punto tras otro, dando para cada punto cada dimensión de la disposición del esquema, incluidas las dimensiones inactivas. Ese número es el que toma <varname>PC_MakePatch</varname> y NO es el número de dimensiones activas que informa <varname>pointCloudSchemaNDims</varname>; un número que sea múltiplo del que no corresponde construye un parche de puntos erróneos en lugar de informar un error. Un parche construido así declara él mismo el esquema, al no haber ningún punto del que leerlo</para>
+					<para><varname>pcpatch(pcid integer, coordinates float[]) → pcpatch</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pcpatch(1, ARRAY[1.0, 1.0, 1.0, 2.0, 2.0, 2.0]::float[]);
+</programlisting>
+				</listitem>
+
 				<listitem xml:id="pcpatch_variadic">
 					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
 					<para>Construye un pcpatch a partir de una lista variádica de pcpoints que comparten el mismo pcid</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3322,6 +3322,12 @@
 						<para><link linkend="pcpoint_xy_xyz"><varname>pcpoint</varname></link>: Build a 2D or 3D pcpoint directly from x/y(/z) coordinates</para>
 					</listitem>
 					<listitem>
+						<para><link linkend="pcpoint_coordinates"><varname>pcpoint</varname></link>: Build a pcpoint from the coordinates of every dimension of the layout of the schema, inactive dimensions included, which is how a schema of more dimensions than the overloads above reach is given its values. That count is the one <varname>PC_MakePoint</varname> takes and is NOT the count of active dimensions that <varname>pointCloudSchemaNDims</varname> reports</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="pcpatch_coordinates"><varname>pcpatch</varname></link>: Build a pcpatch from the coordinates of its points, one point after another, every dimension of the layout of the schema given for each point, inactive dimensions included. That count is the one <varname>PC_MakePatch</varname> takes and is NOT the count of active dimensions that <varname>pointCloudSchemaNDims</varname> reports; a count that divides evenly by the wrong one of the two builds a patch of the wrong points rather than reporting an error. A patch built this way states the schema itself, there being no point to read it from</para>
+					</listitem>
+					<listitem>
 						<para><link linkend="pcpatch_variadic"><varname>pcpatch</varname></link>: Build a pcpatch from a variadic list of pcpoints sharing the same pcid</para>
 					</listitem>
 				</itemizedlist>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -198,6 +198,24 @@ SELECT pcpoint(1, 10.0, 20.0, 30.0);
 </programlisting>
 				</listitem>
 
+				<listitem xml:id="pcpoint_coordinates">
+					<indexterm significance="normal"><primary><varname>pcpoint</varname></primary></indexterm>
+					<para>Build a pcpoint from the coordinates of every dimension of the layout of the schema, inactive dimensions included, which is how a schema of more dimensions than the overloads above reach is given its values. That count is the one <varname>PC_MakePoint</varname> takes and is NOT the count of active dimensions that <varname>pointCloudSchemaNDims</varname> reports</para>
+					<para><varname>pcpoint(pcid integer, coordinates float[]) → pcpoint</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pcpoint(1, ARRAY[10.0, 20.0, 30.0]::float[]);
+</programlisting>
+				</listitem>
+
+				<listitem xml:id="pcpatch_coordinates">
+					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
+					<para>Build a pcpatch from the coordinates of its points, one point after another, every dimension of the layout of the schema given for each point, inactive dimensions included. That count is the one <varname>PC_MakePatch</varname> takes and is NOT the count of active dimensions that <varname>pointCloudSchemaNDims</varname> reports; a count that divides evenly by the wrong one of the two builds a patch of the wrong points rather than reporting an error. A patch built this way states the schema itself, there being no point to read it from</para>
+					<para><varname>pcpatch(pcid integer, coordinates float[]) → pcpatch</varname></para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pcpatch(1, ARRAY[1.0, 1.0, 1.0, 2.0, 2.0, 2.0]::float[]);
+</programlisting>
+				</listitem>
+
 				<listitem xml:id="pcpatch_variadic">
 					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
 					<para>Build a pcpatch from a variadic list of pcpoints sharing the same pcid</para>

--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -245,6 +245,8 @@ extern char *pcpatch_as_hexwkb(const Pcpatch *pa);
 /* Constructor */
 
 extern Pcpatch *pcpatch_make(const Pcpoint **points, int count);
+extern Pcpatch *pcpatch_make_coords(uint32_t pcid, const double *values,
+  int count);
 extern Pcpatch *pcpatch_copy(const Pcpatch *pa);
 
 /* Accessor */

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -256,6 +256,78 @@ pcpatch_as_hexwkb(const Pcpatch *pa)
 
 /**
  * @ingroup meos_pointcloud_base_constructor
+ * @brief Return a pcpatch from the coordinates of its points
+ * @param[in] pcid Point cloud identifier naming the schema
+ * @param[in] values Coordinate of each dimension of each point, one point
+ *   after another, in the order the schema states the dimensions
+ * @param[in] count Number of coordinates, a whole number of points
+ * @return On error return @p NULL
+ * @note The schema is resolved through the MEOS cache, so a schema stated in
+ *   SQL and one parsed from an XML document build a value alike.
+ * @csqlfn #Pcpatch_make_coords()
+ */
+Pcpatch *
+pcpatch_make_coords(uint32_t pcid, const double *values, int count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(values, NULL);
+  if (! ensure_positive(count))
+    return NULL;
+  const PCSCHEMA *schema = meos_pc_schema(pcid);
+  if (! schema)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "No schema registered for pcid %u", pcid);
+    return NULL;
+  }
+  int ndims = (int) schema->ndims;
+  /* A schema states at least one dimension, so a caller reaching this with
+   * none has built one outside the registration entries, which validate it.
+   * The count below divides by this, and a zero divisor is undefined */
+  if (ndims < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The schema %u states no dimensions", pcid);
+    return NULL;
+  }
+  if (count % ndims != 0)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The number of coordinates must be a whole number of points of the "
+      "schema %u: %d is not a multiple of %d", pcid, count, ndims);
+    return NULL;
+  }
+
+  int npoints = count / ndims;
+  PCPOINTLIST *pl = pc_pointlist_make(npoints);
+  for (int i = 0; i < npoints; i++)
+  {
+    PCPOINT *pt = pc_point_from_double_array(schema, (double *) values,
+      (uint32_t) (i * ndims), (uint32_t) ndims);
+    if (! pt)
+    {
+      pc_pointlist_free(pl);
+      return NULL;
+    }
+    pc_pointlist_add_point(pl, pt);
+  }
+  PCPATCH *pa = pc_patch_from_pointlist(pl);
+  pc_pointlist_free(pl);
+  if (! pa)
+    return NULL;
+  Pcpatch *result = (Pcpatch *) meos_pc_patch_serialize(pa, NULL);
+  pc_patch_free(pa);
+  if (! result)
+    return NULL;
+  /* Zero the reserved tail described at the top of this file so that two
+   * patches holding the same points hold the same bytes */
+  size_t meaningful = pcpatch_meaningful_size(result);
+  memset(((uint8_t *) result) + meaningful, 0, VARSIZE(result) - meaningful);
+  return result;
+}
+
+/**
+ * @ingroup meos_pointcloud_base_constructor
  * @brief Return a pcpatch from an array of pcpoints
  * @param[in] points Array of points, all of the same schema
  * @param[in] count Number of points

--- a/meos/test/pcschema_dims_test.c
+++ b/meos/test/pcschema_dims_test.c
@@ -105,6 +105,10 @@ int
 main(void)
 {
   meos_initialize();
+  /* A schema stating no dimensions is reported rather than answered, and the
+   * default handler ends the process on a report, so the error reaches the
+   * caller as an errno instead */
+  meos_initialize_noexit_error_handler();
 
   /* The same schema, stated as its dimensions */
   PCDimensionSpec dims[3] = {
@@ -190,6 +194,25 @@ main(void)
   check(meos_pc_schema_get_ndims(999) == -1, "no schema states no dimensions");
   check(meos_pc_schema_get_compression(999) == NULL,
     "no schema states no compression");
+
+  /* A schema stating NO dimension reaches the constructors only from a caller
+   * that builds one itself: both registration entries refuse it, so nothing a
+   * SQL host can write produces one. The patch constructor divides the count
+   * of coordinates by the number of dimensions, and a zero divisor is
+   * undefined, so it reports the schema instead of dividing by it */
+  PCSCHEMA *empty = pc_schema_new(0);
+  check(empty != NULL, "a schema of no dimensions is built");
+  if (empty)
+  {
+    empty->pcid = 92;
+    meos_pc_schema_register(92, empty);
+    double one = 1.0;
+    meos_errno_reset();
+    check(pcpatch_make_coords(92, &one, 1) == NULL,
+      "a schema of no dimensions builds no patch");
+    check(meos_errno() != 0, "and it reports why");
+    meos_errno_reset();
+  }
 
   printf("%s: %d field(s) disagree\n", failures ? "FAILED" : "PASSED",
     failures);

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -178,6 +178,16 @@ CREATE FUNCTION pcpoint(pcid integer, x double precision, y double precision,
   AS 'MODULE_PATHNAME', 'Pcpoint_make'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/* The coordinates of every dimension of the schema's LAYOUT, inactive
+ * dimensions included, which is how a schema of more dimensions than the
+ * overloads above reach is given its values. The shape is the one
+ * pgPointCloud's own PC_MakePoint takes, and that count is NOT the count of
+ * ACTIVE dimensions pointCloudSchemaNDims reports. */
+CREATE FUNCTION pcpoint(pcid integer, coordinates double precision[])
+  RETURNS pcpoint
+  AS 'MODULE_PATHNAME', 'Pcpoint_make_coords'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * Constructors
  ******************************************************************************/

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -162,6 +162,18 @@ CREATE FUNCTION pcpatch(VARIADIC points pcpoint[])
   AS 'MODULE_PATHNAME', 'Pcpatch_make'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/* The coordinates of every point, one point after another, every dimension of
+ * the schema's LAYOUT given for each point, inactive dimensions included. That
+ * count is NOT the count of ACTIVE dimensions pointCloudSchemaNDims reports,
+ * and a count that divides evenly by the wrong one of the two builds a patch
+ * of the wrong points rather than reporting an error. A patch built this way
+ * states the schema itself, there being no point to read it from, and the
+ * shape is the one pgPointCloud's own PC_MakePatch takes. */
+CREATE FUNCTION pcpatch(pcid integer, coordinates double precision[])
+  RETURNS pcpatch
+  AS 'MODULE_PATHNAME', 'Pcpatch_make_coords'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * Constructors
  ******************************************************************************/

--- a/mobilitydb/src/pointcloud/pcset.c
+++ b/mobilitydb/src/pointcloud/pcset.c
@@ -45,6 +45,7 @@
 #include <postgres.h>
 #include <fmgr.h>
 #include <utils/array.h>
+#include <catalog/pg_type_d.h>  /* FLOAT8OID, without the fmgrprotos of utils/builtins.h */
 /* pgpointcloud */
 #include "pc_api.h"
 /* MEOS */
@@ -88,6 +89,65 @@ Pcpoint_make(PG_FUNCTION_ARGS)
   for (int i = 0; i < count; i++)
     values[i] = PG_GETARG_FLOAT8(i + 1);
   PG_RETURN_PCPOINT_P(pcpoint_make(pcid, values, count));
+}
+
+/**
+ * @brief Return the coordinates a float8 array holds
+ */
+static const double *
+float8arr_extract(ArrayType *array, int *count)
+{
+  if (ARR_ELEMTYPE(array) != FLOAT8OID)
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+      errmsg("The array must be of float8 values")));
+  if (ARR_NDIM(array) != 1)
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+      errmsg("The array must have one dimension")));
+  if (ARR_HASNULL(array))
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+      errmsg("The array must have no null value")));
+  *count = ARR_DIMS(array)[0];
+  return (double *) ARR_DATA_PTR(array);
+}
+
+PGDLLEXPORT Datum Pcpoint_make_coords(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpoint_make_coords);
+/**
+ * @ingroup mobilitydb_pointcloud_base_constructor
+ * @brief Return a pcpoint from a point cloud identifier and the coordinates
+ *   of the dimensions of the schema it names
+ * @sqlfn pcpoint()
+ */
+Datum
+Pcpoint_make_coords(PG_FUNCTION_ARGS)
+{
+  uint32_t pcid = (uint32_t) PG_GETARG_INT32(0);
+  ArrayType *array = PG_GETARG_ARRAYTYPE_P(1);
+  int count;
+  const double *values = float8arr_extract(array, &count);
+  Pcpoint *result = pcpoint_make(pcid, values, count);
+  PG_FREE_IF_COPY(array, 1);
+  PG_RETURN_PCPOINT_P(result);
+}
+
+PGDLLEXPORT Datum Pcpatch_make_coords(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Pcpatch_make_coords);
+/**
+ * @ingroup mobilitydb_pointcloud_base_constructor
+ * @brief Return a pcpatch from a point cloud identifier and the coordinates
+ *   of the points of the schema it names
+ * @sqlfn pcpatch()
+ */
+Datum
+Pcpatch_make_coords(PG_FUNCTION_ARGS)
+{
+  uint32_t pcid = (uint32_t) PG_GETARG_INT32(0);
+  ArrayType *array = PG_GETARG_ARRAYTYPE_P(1);
+  int count;
+  const double *values = float8arr_extract(array, &count);
+  Pcpatch *result = pcpatch_make_coords(pcid, values, count);
+  PG_FREE_IF_COPY(array, 1);
+  PG_RETURN_PCPATCH_P(result);
 }
 
 PGDLLEXPORT Datum Pcpatch_make(PG_FUNCTION_ARGS);

--- a/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
+++ b/mobilitydb/test/pointcloud/expected/399_pointcloud_schemas.test.out
@@ -36,6 +36,29 @@ SELECT ST_AsText(geometry(pcpatch(pcpoint(90, 1, 2, 3),
 
 SELECT pcpoint(90, 1, 2);
 ERROR:  The number of coordinates must be the number of dimensions of the schema 90: 2 vs 3
+INSERT INTO pointcloud_schemas (pcid, srid, compression) VALUES (91, 4326, 'none');
+INSERT 0 1
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
+  (91, 1, 'X', 'double'), (91, 2, 'Y', 'double'),
+  (91, 3, 'Z', 'double'), (91, 4, 'Intensity', 'double');
+INSERT 0 4
+SELECT getX(pcpoint(91, ARRAY[1, 2, 3, 40]::float[])),
+  getDim(pcpoint(91, ARRAY[1, 2, 3, 40]::float[]), 'Intensity');
+ getx | getdim 
+------+--------
+    1 |     40
+(1 row)
+
+SELECT ST_AsText(geometry(pcpatch(91, ARRAY[1, 2, 3, 40, 4, 5, 6, 50]::float[])));
+           st_astext            
+--------------------------------
+ MULTIPOINT Z ((1 2 3),(4 5 6))
+(1 row)
+
+SELECT pcpatch(91, ARRAY[1, 2, 3]::float[]);
+ERROR:  The number of coordinates must be a whole number of points of the schema 91: 3 is not a multiple of 4
+DELETE FROM pointcloud_schemas WHERE pcid = 91;
+DELETE 1
 SELECT pcpoint(999, 1, 2, 3);
 ERROR:  No schema registered for pcid 999
 INSERT INTO pointcloud_schemas (pcid, srid, compression) VALUES (92, 4326, 'none');

--- a/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
+++ b/mobilitydb/test/pointcloud/queries/399_pointcloud_schemas.test.sql
@@ -51,6 +51,21 @@ SELECT ST_AsText(geometry(pcpatch(pcpoint(90, 1, 2, 3),
 -- The number of coordinates is the number of dimensions the schema states
 SELECT pcpoint(90, 1, 2);
 
+-- A schema of more dimensions than the two- and three-argument constructors
+-- reach is given its coordinates as an array, which is the shape pgPointCloud's
+-- own PC_MakePoint takes
+INSERT INTO pointcloud_schemas (pcid, srid, compression) VALUES (91, 4326, 'none');
+INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation) VALUES
+  (91, 1, 'X', 'double'), (91, 2, 'Y', 'double'),
+  (91, 3, 'Z', 'double'), (91, 4, 'Intensity', 'double');
+SELECT getX(pcpoint(91, ARRAY[1, 2, 3, 40]::float[])),
+  getDim(pcpoint(91, ARRAY[1, 2, 3, 40]::float[]), 'Intensity');
+SELECT ST_AsText(geometry(pcpatch(91, ARRAY[1, 2, 3, 40, 4, 5, 6, 50]::float[])));
+
+-- The coordinates of a patch are a whole number of points
+SELECT pcpatch(91, ARRAY[1, 2, 3]::float[]);
+DELETE FROM pointcloud_schemas WHERE pcid = 91;
+
 -- A schema no row states and no XML document describes builds nothing
 SELECT pcpoint(999, 1, 2, 3);
 


### PR DESCRIPTION
The pcpoint and pcpatch constructors take two and three coordinates, so a schema of more dimensions than that has no constructor, and the schema of section 19.1.1 of pgPointCloud's own manual holds four. The two functions take instead the coordinates of every dimension the schema states, and for a patch those of every point one after another, which is the shape PC_MakePoint and PC_MakePatch take. pcpoint_make on the MEOS surface already takes any number of coordinates; pcpatch_make_coords is its patch twin, named as tpointseq_make_coords is. The coordinates of a patch are a whole number of points, which the constructor enforces.
