### PR TITLE
Read a point cloud index query argument at the type its operator declares

### DIFF
--- a/meos/include/pointcloud/tpc_boxops.h
+++ b/meos/include/pointcloud/tpc_boxops.h
@@ -23,6 +23,7 @@
 
 extern void tpcbox_expand(const TPCBox *box1, TPCBox *box2);
 
+extern void tstzspan_set_tpcbox(const Span *s, TPCBox *box);
 extern void tpointcloudinst_set_tpcbox(const TInstant *inst, TPCBox *box);
 extern void tpointcloudinstarr_set_tpcbox(TInstant **instants, int count,
   bool lower_inc, bool upper_inc, interpType interp, TPCBox *box);

--- a/meos/src/pointcloud/tpc_boxops.c
+++ b/meos/src/pointcloud/tpc_boxops.c
@@ -117,6 +117,25 @@ pcpatch_fill_tpcbox_spatial(const Pcpatch *pa, TPCBox *box)
 }
 
 /**
+ * @brief Set a temporal pointcloud bounding box from a timestamptz span
+ * @param[in] s Timestamptz span
+ * @param[out] box Bounding box carrying the span and no spatial dimension
+ * @note Mirrors @p tstzspan_set_stbox. The span names no schema, so @p pcid
+ *   stays 0 — the "unknown" value @p ensure_same_pcid_tpcbox accepts against
+ *   any schema, which is what lets a time-only query meet an indexed box.
+ */
+void
+tstzspan_set_tpcbox(const Span *s, TPCBox *box)
+{
+  assert(s); assert(box); assert(s->spantype == T_TSTZSPAN);
+  /* Note: zero-fill is required here, just as in heap tuples */
+  memset(box, 0, sizeof(TPCBox));
+  memcpy(&box->period, s, sizeof(Span));
+  MEOS_FLAGS_SET_T(box->flags, true);
+  return;
+}
+
+/**
  * @brief Set the bounding box of a temporal pointcloud instant
  * @param[in] inst Temporal instant of type @p T_TPCPOINT or @p T_TPCPATCH
  * @param[out] box Bounding box

--- a/mobilitydb/src/pointcloud/tpcbox_gist.c
+++ b/mobilitydb/src/pointcloud/tpcbox_gist.c
@@ -48,6 +48,7 @@
 #include <meos.h>
 #include <meos_internal.h>
 #include <meos_pointcloud.h>
+#include "temporal/span.h"              /* PG_GETARG_SPAN_P */
 #include "temporal/stratnum.h"
 #include "temporal/type_util.h"
 #include "pointcloud/tpcbox.h"
@@ -64,6 +65,42 @@
  * GiST consistent
  *****************************************************************************/
 
+/**
+ * @brief Transform a query argument into a box, initializing the dimensions
+ * that must not be taken into account by the operators
+ * @note Mirrors @p tspatial_gist_get_stbox. The opclass declares members
+ *   against @p tstzspan and against the temporal type itself as well as
+ *   against @p tpcbox, so the query datum carries whichever of those types
+ *   the operator names.
+ */
+static bool
+tpc_gist_get_tpcbox(FunctionCallInfo fcinfo, TPCBox *result, MeosType type)
+{
+  if (type == T_TSTZSPAN)
+  {
+    Span *s = PG_GETARG_SPAN_P(1);
+    tstzspan_set_tpcbox(s, result);
+  }
+  else if (type == T_TPCBOX)
+  {
+    TPCBox *box = PG_GETARG_TPCBOX_P(1);
+    if (! box)
+      return false;
+    memcpy(result, box, sizeof(TPCBox));
+  }
+  else if (tpointcloud_temptype(type))
+  {
+    if (PG_ARGISNULL(1))
+      return false;
+    Datum tempdatum = PG_GETARG_DATUM(1);
+    Temporal *temp = temporal_slice(tempdatum);
+    temporal_set_bbox(temp, result);
+  }
+  else
+    elog(ERROR, "Unsupported type for indexing: %d", type);
+  return true;
+}
+
 PGDLLEXPORT Datum Tpcbox_gist_consistent(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tpcbox_gist_consistent);
 /**
@@ -75,21 +112,25 @@ Datum
 Tpcbox_gist_consistent(PG_FUNCTION_ARGS)
 {
   GISTENTRY *entry = (GISTENTRY *) PG_GETARG_POINTER(0);
-  TPCBox *query = PG_GETARG_TPCBOX_P(1);
   StrategyNumber strategy = (StrategyNumber) PG_GETARG_UINT16(2);
-  /* Oid typid = PG_GETARG_OID(3); -- always TPCBox in this opclass */
+  Oid typid = PG_GETARG_OID(3);
   bool *recheck = (bool *) PG_GETARG_POINTER(4);
-  TPCBox *key = DatumGetTpcboxP(entry->key);
-  if (! key || ! query)
+  TPCBox *key = DatumGetTpcboxP(entry->key), query;
+  if (! key)
     PG_RETURN_BOOL(false);
 
+  /* Determine whether the index is lossy depending on the strategy */
   *recheck = tpcbox_index_recheck(strategy);
+
+  /* Transform the query into a box */
+  if (! tpc_gist_get_tpcbox(fcinfo, &query, oid_meostype(typid)))
+    PG_RETURN_BOOL(false);
 
   bool result;
   if (GIST_LEAF(entry))
-    result = tpcbox_index_leaf_consistent(key, query, strategy);
+    result = tpcbox_index_leaf_consistent(key, &query, strategy);
   else
-    result = tpcbox_gist_inner_consistent(key, query, strategy);
+    result = tpcbox_gist_inner_consistent(key, &query, strategy);
 
   PG_RETURN_BOOL(result);
 }

--- a/mobilitydb/test/pointcloud/expected/439_tpc_gist_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/439_tpc_gist_tbl.test.out
@@ -168,6 +168,88 @@ RESET enable_indexscan;
 RESET
 RESET enable_bitmapscan;
 RESET
+CREATE INDEX tbl_tpcpoint_gist_idx ON tbl_tpcpoint USING gist(temp);
+CREATE INDEX
+CREATE INDEX tbl_tpcpatch_gist_idx ON tbl_tpcpatch USING gist(temp);
+CREATE INDEX
+SET enable_seqscan = on;
+SET
+SET enable_indexscan = off;
+SET
+SET enable_bitmapscan = off;
+SET
+SELECT COUNT(*) AS seq_span FROM tbl_tpcpoint
+WHERE temp && tstzspan '[2001-06-01, 2001-12-31]';
+ seq_span 
+----------
+       49
+(1 row)
+
+SELECT COUNT(*) AS seq_span_patch FROM tbl_tpcpatch
+WHERE temp && tstzspan '[2001-06-01, 2001-12-31]';
+ seq_span_patch 
+----------------
+             48
+(1 row)
+
+SELECT COUNT(*) AS seq_contained_span FROM tbl_tpcpoint
+WHERE temp <@ tstzspan '[2001-01-01, 2002-01-01]';
+ seq_contained_span 
+--------------------
+                100
+(1 row)
+
+SELECT COUNT(*) AS seq_self FROM tbl_tpcpoint t1
+WHERE t1.temp && (SELECT temp FROM tbl_tpcpoint WHERE temp IS NOT NULL ORDER BY k LIMIT 1);
+ seq_self 
+----------
+        1
+(1 row)
+
+SET enable_seqscan = off;
+SET
+SET enable_indexscan = on;
+SET
+SET enable_bitmapscan = on;
+SET
+SELECT COUNT(*) AS idx_span FROM tbl_tpcpoint
+WHERE temp && tstzspan '[2001-06-01, 2001-12-31]';
+ idx_span 
+----------
+       49
+(1 row)
+
+SELECT COUNT(*) AS idx_span_patch FROM tbl_tpcpatch
+WHERE temp && tstzspan '[2001-06-01, 2001-12-31]';
+ idx_span_patch 
+----------------
+             48
+(1 row)
+
+SELECT COUNT(*) AS idx_contained_span FROM tbl_tpcpoint
+WHERE temp <@ tstzspan '[2001-01-01, 2002-01-01]';
+ idx_contained_span 
+--------------------
+                100
+(1 row)
+
+SELECT COUNT(*) AS idx_self FROM tbl_tpcpoint t1
+WHERE t1.temp && (SELECT temp FROM tbl_tpcpoint WHERE temp IS NOT NULL ORDER BY k LIMIT 1);
+ idx_self 
+----------
+        1
+(1 row)
+
+DROP INDEX tbl_tpcpoint_gist_idx;
+DROP INDEX
+DROP INDEX tbl_tpcpatch_gist_idx;
+DROP INDEX
+RESET enable_seqscan;
+RESET
+RESET enable_indexscan;
+RESET
+RESET enable_bitmapscan;
+RESET
 ANALYZE tbl_tpcpoint;
 ANALYZE
 ANALYZE tbl_tpcpatch;

--- a/mobilitydb/test/pointcloud/queries/439_tpc_gist_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/439_tpc_gist_tbl.test.sql
@@ -125,6 +125,42 @@ RESET enable_seqscan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 
+-------------------------------------------------------------------------------
+-- Query arguments other than a tpcbox. The opclass declares members against
+-- tstzspan and against the temporal type itself, so the consistent method
+-- meets those types as the query and the counts it produces must equal the
+-- ones a scan produces.
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_tpcpoint_gist_idx ON tbl_tpcpoint USING gist(temp);
+CREATE INDEX tbl_tpcpatch_gist_idx ON tbl_tpcpatch USING gist(temp);
+
+SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
+SELECT COUNT(*) AS seq_span FROM tbl_tpcpoint
+WHERE temp && tstzspan '[2001-06-01, 2001-12-31]';
+SELECT COUNT(*) AS seq_span_patch FROM tbl_tpcpatch
+WHERE temp && tstzspan '[2001-06-01, 2001-12-31]';
+SELECT COUNT(*) AS seq_contained_span FROM tbl_tpcpoint
+WHERE temp <@ tstzspan '[2001-01-01, 2002-01-01]';
+SELECT COUNT(*) AS seq_self FROM tbl_tpcpoint t1
+WHERE t1.temp && (SELECT temp FROM tbl_tpcpoint WHERE temp IS NOT NULL ORDER BY k LIMIT 1);
+
+SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
+SELECT COUNT(*) AS idx_span FROM tbl_tpcpoint
+WHERE temp && tstzspan '[2001-06-01, 2001-12-31]';
+SELECT COUNT(*) AS idx_span_patch FROM tbl_tpcpatch
+WHERE temp && tstzspan '[2001-06-01, 2001-12-31]';
+SELECT COUNT(*) AS idx_contained_span FROM tbl_tpcpoint
+WHERE temp <@ tstzspan '[2001-01-01, 2002-01-01]';
+SELECT COUNT(*) AS idx_self FROM tbl_tpcpoint t1
+WHERE t1.temp && (SELECT temp FROM tbl_tpcpoint WHERE temp IS NOT NULL ORDER BY k LIMIT 1);
+
+DROP INDEX tbl_tpcpoint_gist_idx;
+DROP INDEX tbl_tpcpatch_gist_idx;
+RESET enable_seqscan;
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+
 -- typanalyze: ANALYZE must succeed on the temporal pointcloud columns; tspatial_analyze
 -- projects each TPCBox bounding box to an STBox for the spatial statistics
 ANALYZE tbl_tpcpoint;


### PR DESCRIPTION
The temporal pointcloud GiST operator class declares members against tstzspan and against the temporal type as well as against tpcbox, so the consistent method meets a span or a temporal value where it reads a TPCBox. It transforms the query argument by the type the operator names, the way the sibling spatiotemporal method does, and a timestamptz span becomes a box carrying the span alone whose schema stays unknown, the value the same-schema check accepts against any box. An index scan of temp && tstzspan answers with the same 49 rows a sequential scan answers, where reading a span as a box read a schema out of the span bytes and either answered nothing or raised a schema mismatch. The gist test covers the tstzspan and the temporal-type query against both tpcpoint and tpcpatch, each count matched against the sequential one.