### PR TITLE
Offer the index to a point cloud topological call as the siblings do

### DIFF
--- a/mobilitydb/sql/pointcloud/436_tpc_topops.in.sql
+++ b/mobilitydb/sql/pointcloud/436_tpc_topops.in.sql
@@ -38,18 +38,23 @@
 -- tpcpoint
 CREATE FUNCTION contains(tstzspan, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tpcpoint, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tpcbox, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tpcpoint, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tpcpoint, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (PROCEDURE = contains,
@@ -71,18 +76,23 @@ CREATE OPERATOR @> (PROCEDURE = contains,
 -- tpcpatch
 CREATE FUNCTION contains(tstzspan, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tpcpatch, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tpcbox, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tpcpatch, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contains(tpcpatch, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contains_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR @> (PROCEDURE = contains,
@@ -108,18 +118,23 @@ CREATE OPERATOR @> (PROCEDURE = contains,
 -- tpcpoint
 CREATE FUNCTION contained(tstzspan, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tpcpoint, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tpcbox, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tpcpoint, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tpcpoint, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (PROCEDURE = contained,
@@ -141,18 +156,23 @@ CREATE OPERATOR <@ (PROCEDURE = contained,
 -- tpcpatch
 CREATE FUNCTION contained(tstzspan, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tpcpatch, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tpcbox, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tpcpatch, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION contained(tpcpatch, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Contained_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR <@ (PROCEDURE = contained,
@@ -178,18 +198,23 @@ CREATE OPERATOR <@ (PROCEDURE = contained,
 -- tpcpoint
 CREATE FUNCTION overlaps(tstzspan, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tpcpoint, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tpcbox, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tpcpoint, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tpcpoint, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (PROCEDURE = overlaps,
@@ -211,18 +236,23 @@ CREATE OPERATOR && (PROCEDURE = overlaps,
 -- tpcpatch
 CREATE FUNCTION overlaps(tstzspan, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tpcpatch, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tpcbox, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tpcpatch, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION overlaps(tpcpatch, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Overlaps_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR && (PROCEDURE = overlaps,
@@ -248,18 +278,23 @@ CREATE OPERATOR && (PROCEDURE = overlaps,
 -- tpcpoint
 CREATE FUNCTION same(tstzspan, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION same(tpcpoint, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION same(tpcbox, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION same(tpcpoint, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION same(tpcpoint, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR ~= (PROCEDURE = same,
@@ -281,18 +316,23 @@ CREATE OPERATOR ~= (PROCEDURE = same,
 -- tpcpatch
 CREATE FUNCTION same(tstzspan, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION same(tpcpatch, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION same(tpcbox, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION same(tpcpatch, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION same(tpcpatch, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Same_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR ~= (PROCEDURE = same,
@@ -318,18 +358,23 @@ CREATE OPERATOR ~= (PROCEDURE = same,
 -- tpcpoint
 CREATE FUNCTION adjacent(tstzspan, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tpcpoint, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tpcbox, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tpcpoint, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tpcpoint, tpcpoint) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (PROCEDURE = adjacent,
@@ -351,18 +396,23 @@ CREATE OPERATOR -|- (PROCEDURE = adjacent,
 -- tpcpatch
 CREATE FUNCTION adjacent(tstzspan, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tstzspan_temporal'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tpcpatch, tstzspan) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_temporal_tstzspan'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tpcbox, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tpcbox_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tpcpatch, tpcbox) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tpointcloud_tpcbox'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION adjacent(tpcpatch, tpcpatch) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Adjacent_tpointcloud_tpointcloud'
+  SUPPORT tspatial_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR -|- (PROCEDURE = adjacent,

--- a/mobilitydb/test/pointcloud/expected/439_tpc_gist_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/439_tpc_gist_tbl.test.out
@@ -250,6 +250,78 @@ RESET enable_indexscan;
 RESET
 RESET enable_bitmapscan;
 RESET
+CREATE INDEX tbl_tpcpoint_gist_idx ON tbl_tpcpoint USING gist(temp);
+CREATE INDEX
+CREATE INDEX tbl_tpcpatch_gist_idx ON tbl_tpcpatch USING gist(temp);
+CREATE INDEX
+SET enable_seqscan = on;
+SET
+SET enable_indexscan = off;
+SET
+SET enable_bitmapscan = off;
+SET
+SELECT COUNT(*) AS seq_fn_box FROM tbl_tpcpoint
+WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+ seq_fn_box 
+------------
+         26
+(1 row)
+
+SELECT COUNT(*) AS seq_fn_span FROM tbl_tpcpoint
+WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
+ seq_fn_span 
+-------------
+          49
+(1 row)
+
+SELECT COUNT(*) AS seq_fn_patch FROM tbl_tpcpatch
+WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+ seq_fn_patch 
+--------------
+           46
+(1 row)
+
+SET enable_seqscan = off;
+SET
+SET enable_indexscan = on;
+SET
+SET enable_bitmapscan = on;
+SET
+SELECT COUNT(*) AS idx_fn_box FROM tbl_tpcpoint
+WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+ idx_fn_box 
+------------
+         26
+(1 row)
+
+SELECT COUNT(*) AS idx_fn_span FROM tbl_tpcpoint
+WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
+ idx_fn_span 
+-------------
+          49
+(1 row)
+
+SELECT COUNT(*) AS idx_fn_patch FROM tbl_tpcpatch
+WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+ idx_fn_patch 
+--------------
+           46
+(1 row)
+
+DROP INDEX tbl_tpcpoint_gist_idx;
+DROP INDEX
+DROP INDEX tbl_tpcpatch_gist_idx;
+DROP INDEX
+RESET enable_seqscan;
+RESET
+RESET enable_indexscan;
+RESET
+RESET enable_bitmapscan;
+RESET
 ANALYZE tbl_tpcpoint;
 ANALYZE
 ANALYZE tbl_tpcpatch;

--- a/mobilitydb/test/pointcloud/queries/439_tpc_gist_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/439_tpc_gist_tbl.test.sql
@@ -161,6 +161,42 @@ RESET enable_seqscan;
 RESET enable_indexscan;
 RESET enable_bitmapscan;
 
+-------------------------------------------------------------------------------
+-- Functional call form. The planner support function rewrites a call such as
+-- overlaps(temp, box) into the indexable temp && box, so the counts a scan
+-- produces and the counts an index produces must agree for the call form
+-- exactly as they do for the operator form.
+-------------------------------------------------------------------------------
+
+CREATE INDEX tbl_tpcpoint_gist_idx ON tbl_tpcpoint USING gist(temp);
+CREATE INDEX tbl_tpcpatch_gist_idx ON tbl_tpcpatch USING gist(temp);
+
+SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
+SELECT COUNT(*) AS seq_fn_box FROM tbl_tpcpoint
+WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+SELECT COUNT(*) AS seq_fn_span FROM tbl_tpcpoint
+WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
+SELECT COUNT(*) AS seq_fn_patch FROM tbl_tpcpatch
+WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+
+SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
+SELECT COUNT(*) AS idx_fn_box FROM tbl_tpcpoint
+WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+SELECT COUNT(*) AS idx_fn_span FROM tbl_tpcpoint
+WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
+SELECT COUNT(*) AS idx_fn_patch FROM tbl_tpcpatch
+WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+
+DROP INDEX tbl_tpcpoint_gist_idx;
+DROP INDEX tbl_tpcpatch_gist_idx;
+RESET enable_seqscan;
+RESET enable_indexscan;
+RESET enable_bitmapscan;
+
 -- typanalyze: ANALYZE must succeed on the temporal pointcloud columns; tspatial_analyze
 -- projects each TPCBox bounding box to an STBox for the spatial statistics
 ANALYZE tbl_tpcpoint;


### PR DESCRIPTION
Every topological function of the other ten spatial families names tspatial_supportfn, which rewrites a call such as overlaps(temp, box) into the indexable temp && box. The fifty point cloud functions name it too, so a call over a tstzspan or a tpcbox reaches the operator class its operator form already reaches. Under enable_seqscan off such a call plans an Index Cond over the gist index where it planned a disabled sequential scan, no index path existing for it to take. The gist test runs the call form against both temporal types and matches every count to the sequential one.