### PR TITLE
Register only a point cloud schema the library accepts

### DIFF
--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -57,6 +57,11 @@ static int cache_cap = 0;
 meos_pc_schema_fn_t meos_pc_schema_fn = NULL;
 meos_pc_parse_xml_fn_t meos_pc_parse_xml_fn = NULL;
 
+/* Registration, answering whether the cache took the schema; the public
+ * entries below answer nothing, so a caller that must know reads this */
+static bool schema_register(uint32_t pcid, PCSCHEMA *schema,
+  const char *xml_text);
+
 /*****************************************************************************
  * Public API
  *****************************************************************************/
@@ -106,6 +111,34 @@ ensure_cache_capacity(void)
 #if ! MEOS
   MemoryContextSwitchTo(oldctx);
 #endif
+}
+
+/**
+ * @brief Return true if a schema is one the point cloud library accepts
+ * @details The library states what a schema must hold — an X and a Y
+ *   dimension, at least one dimension, and a dimension at every position of
+ *   its layout — and every reader of the cache takes those for granted. The
+ *   document parser applies this test itself, so a schema reaching the cache
+ *   any other way is the one that would otherwise arrive unchecked.
+ */
+static bool
+pcschema_registrable(uint32_t pcid, const PCSCHEMA *schema)
+{
+  if (! schema)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The schema of pcid %u is null", pcid);
+    return false;
+  }
+  if (! pc_schema_is_valid(schema))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The schema of pcid %u is not one the point cloud library accepts: it "
+      "states an X and a Y dimension and a dimension at every position of its "
+      "layout", pcid);
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -248,7 +281,13 @@ meos_pc_schema_register_dims(uint32_t pcid, int32_t srid,
     ndims);
   if (! schema)
     return false;
-  meos_pc_schema_register(pcid, schema);
+  /* Registration refuses a schema the library does not accept, and nothing
+   * else owns one it refused */
+  if (! schema_register(pcid, schema, NULL))
+  {
+    pc_schema_free(schema);
+    return false;
+  }
   return true;
 }
 
@@ -257,14 +296,21 @@ meos_pc_schema_register_dims(uint32_t pcid, int32_t srid,
  * @brief Register a parsed PCSCHEMA along with its source XML in the
  *   MEOS-owned cache.
  */
-void
-meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
-  const char *xml_text)
+/**
+ * @brief Register a schema, answering whether the cache took it
+ * @details The two public entries answer nothing, so this is what a caller
+ *   that must know reads — the registration entry stating its own outcome and
+ *   the lookup deciding what to answer for a schema a hook supplied.
+ */
+static bool
+schema_register(uint32_t pcid, PCSCHEMA *schema, const char *xml_text)
 {
   /* If already present, replace; preserve previously-cached XML when
    * the new call passes NULL for xml_text (so a parse-only re-register
    * doesn't accidentally drop a prior XML registration). */
-  int32_t srid = schema ? (int32_t) schema->srid : SRID_INVALID;
+  if (! pcschema_registrable(pcid, schema))
+    return false;
+  int32_t srid = (int32_t) schema->srid;
   for (int i = 0; i < cache_count; i++)
   {
     if (cache_buf[i].pcid == pcid)
@@ -277,7 +323,7 @@ meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
           pfree(cache_buf[i].xml_text);
         cache_buf[i].xml_text = copy_xml_long_lived(xml_text);
       }
-      return;
+      return true;
     }
   }
   ensure_cache_capacity();
@@ -286,6 +332,19 @@ meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
   cache_buf[cache_count].srid = srid;
   cache_buf[cache_count].xml_text = copy_xml_long_lived(xml_text);
   cache_count++;
+  return true;
+}
+
+/**
+ * @ingroup meos_pointcloud_schema_cache
+ * @brief Variant of @ref meos_pc_schema_register that also caches the document
+ *   a schema is stated by
+ */
+void
+meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
+  const char *xml_text)
+{
+  (void) schema_register(pcid, schema, xml_text);
 }
 
 /**
@@ -617,8 +676,12 @@ meos_pc_schema_lookup(uint32_t pcid)
   if (meos_pc_schema_fn)
   {
     PCSCHEMA *s = meos_pc_schema_fn(pcid);
-    if (s)
-      meos_pc_schema_register(pcid, s);
+    if (! s)
+      return NULL;
+    /* Registration refuses a schema the library does not accept, and a schema
+     * the cache would not take is not one to answer with either */
+    if (! schema_register(pcid, s, NULL))
+      return NULL;
     return s;
   }
   /* (3) A host that installs no hook states its schemas in a document */

--- a/meos/test/pcschema_dims_test.c
+++ b/meos/test/pcschema_dims_test.c
@@ -105,9 +105,9 @@ int
 main(void)
 {
   meos_initialize();
-  /* A schema stating no dimensions is reported rather than answered, and the
-   * default handler ends the process on a report, so the error reaches the
-   * caller as an errno instead */
+  /* A schema the library refuses is reported rather than answered, and the
+   * default handler ends the process on a report, so it reaches the caller as
+   * an errno instead */
   meos_initialize_noexit_error_handler();
 
   /* The same schema, stated as its dimensions */
@@ -195,24 +195,42 @@ main(void)
   check(meos_pc_schema_get_compression(999) == NULL,
     "no schema states no compression");
 
-  /* A schema stating NO dimension reaches the constructors only from a caller
-   * that builds one itself: both registration entries refuse it, so nothing a
-   * SQL host can write produces one. The patch constructor divides the count
-   * of coordinates by the number of dimensions, and a zero divisor is
-   * undefined, so it reports the schema instead of dividing by it */
+  /* The cache holds only what the point cloud library accepts, so a schema
+   * built by hand that states no dimension, or no X, is refused at
+   * registration rather than reaching a reader that takes them for granted */
   PCSCHEMA *empty = pc_schema_new(0);
   check(empty != NULL, "a schema of no dimensions is built");
   if (empty)
   {
-    empty->pcid = 92;
-    meos_pc_schema_register(92, empty);
+    empty->pcid = 93;
+    meos_errno_reset();
+    meos_pc_schema_register(93, empty);
+    check(meos_errno() != 0, "a schema of no dimensions is refused");
+    check(meos_pc_schema_get_ndims(93) == -1,
+      "and no schema answers for its pcid");
+    /* Refused at registration, the schema never reaches the constructor, which
+     * keeps its own guard as the last of the two rather than the only one */
     double one = 1.0;
     meos_errno_reset();
-    check(pcpatch_make_coords(92, &one, 1) == NULL,
+    check(pcpatch_make_coords(93, &one, 1) == NULL,
       "a schema of no dimensions builds no patch");
     check(meos_errno() != 0, "and it reports why");
     meos_errno_reset();
+    pc_schema_free(empty);
   }
+
+  /* A registration that states dimensions the library refuses answers false,
+   * so a caller is never told a schema is registered that no lookup finds */
+  PCDimensionSpec noxy[2] = {
+    { "Alpha", NULL, 1, "double", 1, 0, true },
+    { "Beta", NULL, 2, "double", 1, 0, true }
+  };
+  meos_errno_reset();
+  check(! meos_pc_schema_register_dims(94, 4326, "none", noxy, 2),
+    "dimensions the library refuses register as false");
+  check(meos_pc_schema_get_ndims(94) == -1,
+    "and no schema answers for that pcid");
+  meos_errno_reset();
 
   printf("%s: %d field(s) disagree\n", failures ? "FAILED" : "PASSED",
     failures);


### PR DESCRIPTION
The cache takes whatever a caller hands it, so a schema the point cloud library refuses reaches every reader that takes its shape for granted. The library states what a schema holds — an X and a Y dimension, at least one dimension, and a dimension at every position of its layout — and its own document parser applies that test before returning, so a schema arriving any other way is the one that arrives unchecked. Registration applies the same test and reports rather than caching. A schema resolved through the host hook is registered before it is answered, and registration is what refuses it, so the lookup answers what the cache holds rather than what the hook handed over. The two public registration entries answer nothing, so the refusal is read from an internal entry that states its outcome: meos_pc_schema_register_dims answers false for a schema the library refuses rather than answering true over a cache that holds none, and frees the schema it built, nothing else owning one that was refused. This changes what a caller may register, not only what a hook may return: pc_schema_is_valid resolves X and Y by dimension NAME, so dimensions named otherwise are refused where they were previously stored. pcschema_dims_test registers a schema of no dimensions and one whose dimensions carry neither name, and asserts each is refused and that no schema answers for its pcid.
