### PR TITLE
Name a point cloud schema accessor after the property it answers

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -216,9 +216,9 @@ extern void meos_pc_schema_register_xml(uint32_t pcid, PCSCHEMA *schema,
   const char *xml_text);
 extern const char *meos_pc_schema_xml(uint32_t pcid);
 extern void meos_pc_schema_clear(void);
-extern int32_t meos_pc_schema_get_srid(uint32_t pcid);
-extern const char *meos_pc_schema_get_compression(uint32_t pcid);
-extern int32_t meos_pc_schema_get_ndims(uint32_t pcid);
+extern int32_t meos_pc_schema_srid(uint32_t pcid);
+extern const char *meos_pc_schema_compression(uint32_t pcid);
+extern int32_t meos_pc_schema_ndims(uint32_t pcid);
 extern void meos_set_pointcloud_schemas_xml(const char *path);
 
 /* Comparison */

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1103,7 +1103,7 @@ spatial_set_stbox(Datum d, MeosType basetype, STBox *result)
     {
       const Pcpatch *pa = DatumGetPcpatchP(d);
       TPCBox *box = pcpatch_to_tpcbox(pa,
-        meos_pc_schema_get_srid(pcpatch_get_pcid(pa)));
+        meos_pc_schema_srid(pcpatch_get_pcid(pa)));
       if (! box)
         return false;
       tpcbox_set_stbox(box, result);

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -431,7 +431,7 @@ pcpoint_flags(const Pcpoint *pt)
 static int16
 pcpatch_flags(const Pcpatch *pa)
 {
-  int32_t srid = meos_pc_schema_get_srid(pcpatch_get_pcid(pa));
+  int32_t srid = meos_pc_schema_srid(pcpatch_get_pcid(pa));
   TPCBox *box = pcpatch_to_tpcbox(pa, srid);
   if (! box)
   {

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -142,11 +142,11 @@ spatial_srid(Datum d, MeosType basetype)
 #if POINTCLOUD
     case T_PCPOINT: {
       const Pcpoint *pt = DatumGetPcpointP(d);
-      return meos_pc_schema_get_srid(pcpoint_get_pcid(pt));
+      return meos_pc_schema_srid(pcpoint_get_pcid(pt));
     }
     case T_PCPATCH: {
       const Pcpatch *pa = DatumGetPcpatchP(d);
-      return meos_pc_schema_get_srid(pcpatch_get_pcid(pa));
+      return meos_pc_schema_srid(pcpatch_get_pcid(pa));
     }
 #endif
 #if QUADBIN

--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -467,7 +467,7 @@ meos_pc_schema_clear(void)
  * PCSCHEMA struct definition.
  */
 int32_t
-meos_pc_schema_get_srid(uint32_t pcid)
+meos_pc_schema_srid(uint32_t pcid)
 {
   /* Cache hit */
   for (int i = 0; i < cache_count; i++)
@@ -504,7 +504,7 @@ meos_pc_schema_get_srid(uint32_t pcid)
  *   reads it and never frees it
  */
 const char *
-meos_pc_schema_get_compression(uint32_t pcid)
+meos_pc_schema_compression(uint32_t pcid)
 {
   const PCSCHEMA *s = meos_pc_schema_lookup(pcid);
   return s ? pc_compression_name((int) s->compression) : NULL;
@@ -522,7 +522,7 @@ meos_pc_schema_get_compression(uint32_t pcid)
  *   it and it is a different quantity, not this one under another name
  */
 int32_t
-meos_pc_schema_get_ndims(uint32_t pcid)
+meos_pc_schema_ndims(uint32_t pcid)
 {
   const PCSCHEMA *s = meos_pc_schema_lookup(pcid);
   if (! s)

--- a/meos/test/pcschema_dims_test.c
+++ b/meos/test/pcschema_dims_test.c
@@ -181,18 +181,16 @@ main(void)
    * active, and the accessor answers the ACTIVE count, which is what the SQL
    * function pointCloudSchemaNDims answers for the same schema */
   check(inactive && inactive->ndims == 3, "the layout of the schema is 3 wide");
-  check(meos_pc_schema_get_ndims(90) == 2,
-    "2 dimensions of the schema are active");
-  const char *compression = meos_pc_schema_get_compression(90);
+  check(meos_pc_schema_ndims(90) == 2, "2 dimensions of the schema are active");
+  const char *compression = meos_pc_schema_compression(90);
   check(compression && strcmp(compression, "dimensional") == 0,
     "the compression of the schema is named");
-  check(meos_pc_schema_get_srid(90) == 4326,
-    "the reference system of the schema");
+  check(meos_pc_schema_srid(90) == 4326, "the reference system of the schema");
   /* A pcid no schema is registered for */
   printf("The reference system naming no schema: %d\n",
-    meos_pc_schema_get_srid(999));
-  check(meos_pc_schema_get_ndims(999) == -1, "no schema states no dimensions");
-  check(meos_pc_schema_get_compression(999) == NULL,
+    meos_pc_schema_srid(999));
+  check(meos_pc_schema_ndims(999) == -1, "no schema states no dimensions");
+  check(meos_pc_schema_compression(999) == NULL,
     "no schema states no compression");
 
   /* The cache holds only what the point cloud library accepts, so a schema
@@ -206,8 +204,7 @@ main(void)
     meos_errno_reset();
     meos_pc_schema_register(93, empty);
     check(meos_errno() != 0, "a schema of no dimensions is refused");
-    check(meos_pc_schema_get_ndims(93) == -1,
-      "and no schema answers for its pcid");
+    check(meos_pc_schema_ndims(93) == -1, "and no schema answers for its pcid");
     /* Refused at registration, the schema never reaches the constructor, which
      * keeps its own guard as the last of the two rather than the only one */
     double one = 1.0;
@@ -228,8 +225,7 @@ main(void)
   meos_errno_reset();
   check(! meos_pc_schema_register_dims(94, 4326, "none", noxy, 2),
     "dimensions the library refuses register as false");
-  check(meos_pc_schema_get_ndims(94) == -1,
-    "and no schema answers for that pcid");
+  check(meos_pc_schema_ndims(94) == -1, "and no schema answers for that pcid");
   meos_errno_reset();
 
   printf("%s: %d field(s) disagree\n", failures ? "FAILED" : "PASSED",

--- a/mobilitydb/src/pointcloud/pcset.c
+++ b/mobilitydb/src/pointcloud/pcset.c
@@ -311,7 +311,7 @@ Datum
 Pcpoint_srid(PG_FUNCTION_ARGS)
 {
   Pcpoint *pt = PG_GETARG_PCPOINT_P(0);
-  int32_t srid = meos_pc_schema_get_srid(pcpoint_get_pcid(pt));
+  int32_t srid = meos_pc_schema_srid(pcpoint_get_pcid(pt));
   PG_FREE_IF_COPY(pt, 0);
   PG_RETURN_INT32(srid);
 }
@@ -327,7 +327,7 @@ Datum
 Pcpatch_srid(PG_FUNCTION_ARGS)
 {
   Pcpatch *pa = PG_GETARG_PCPATCH_P(0);
-  int32_t srid = meos_pc_schema_get_srid(pcpatch_get_pcid(pa));
+  int32_t srid = meos_pc_schema_srid(pcpatch_get_pcid(pa));
   PG_FREE_IF_COPY(pa, 0);
   PG_RETURN_INT32(srid);
 }


### PR DESCRIPTION
The three accessors of the point cloud schema cache are named for the property they answer — meos_pc_schema_srid, meos_pc_schema_compression and meos_pc_schema_ndims — which is the shape their sibling meos_pc_schema_xml states and the shape of every other value accessor of the public surface, none of which carries a get infix. The declarations, the definitions, the six callers and the coverage test read the same names, and the SQL functions they back, pointCloudSchemaSRID, pointCloudSchemaCompression and pointCloudSchemaNDims, are unchanged.