### PR TITLE
Name the SQL function that registers a point cloud schema from its dimensions

### DIFF
--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -271,7 +271,7 @@ meos_pc_schema_from_dims(uint32_t pcid, int32_t srid,
  * @param[in] dims Dimensions the schema states, in any order
  * @param[in] ndims Number of dimensions
  * @return True on success, false on error
- * @csqlfn #Pointcloud_schema_register_dims()
+ * @sqlfn pointCloudSchemaRegister()
  */
 bool
 meos_pc_schema_register_dims(uint32_t pcid, int32_t srid,


### PR DESCRIPTION
meos_pc_schema_register_dims states its SQL name as @sqlfn pointCloudSchemaRegister(), the name the host extension that publishes it uses. MobilityDB registers a schema through the pointcloud_formats and pointcloud_dimensions tables and declares no function of its own for it, so the catalog reads the name from the MEOS block directly rather than through a PG wrapper.