### PR TITLE
Name in every @csqlfn tag a wrapper the extension declares

### DIFF
--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -3254,7 +3254,7 @@ mindist_tpoint_tpoint_threshold(const Temporal *temp1, const Temporal *temp2,
  * @return Minimum spatial distance; falls back to `geom_distance2d` for
  *   subtype combinations the inline kernel does not handle (e.g.
  *   `TInstant`).
- * @csqlfn #Mindistance_tgeo_tgeo()
+ * @csqlfn #Mindistance_transfn()
  */
 double
 mindistance_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -1089,7 +1089,7 @@ trgeometry_set_interp(const Temporal *temp, interpType interp)
  * @note This function does a bounding box test for the temporal types
  * different from instant. The singleton tests are done in the functions for
  * the specific temporal types.
- * @csqlfn #Temporal_restrict_value()
+ * @csqlfn #Temporal_at_value(), #Temporal_minus_value()
  */
 Temporal *
 trgeometry_restrict_value(const Temporal *temp, Datum value, bool atfunc)
@@ -1148,7 +1148,7 @@ trgeometry_minus_value(const Temporal *temp, const Pose *pose)
  * @note The base values of a temporal rigid geometry are poses. As the other
  * restrictions do, the function strips the value to its temporal pose,
  * restricts that, and puts the reference geometry back on the result
- * @csqlfn #Temporal_restrict_values()
+ * @csqlfn #Temporal_at_values(), #Temporal_minus_values()
  */
 Temporal *
 trgeometry_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
@@ -1201,7 +1201,7 @@ trgeometry_minus_values(const Temporal *temp, const Set *s)
  * @param[in] temp Temporal rigid geometry
  * @param[in] t Timestamptz
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @csqlfn #Temporal_restrict_timestamptz()
+ * @csqlfn #Temporal_at_timestamptz(), #Temporal_minus_timestamptz()
  */
 Temporal *
 trgeometry_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
@@ -1255,7 +1255,7 @@ trgeometry_minus_timestamptz(const Temporal *temp, TimestampTz t)
  * @param[in] temp Temporal rigid geometry
  * @param[in] s Timestamp set
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @csqlfn #Temporal_restrict_tstzset()
+ * @csqlfn #Temporal_at_tstzset(), #Temporal_minus_tstzset()
  */
 Temporal *
 trgeometry_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
@@ -1308,7 +1308,7 @@ trgeometry_minus_tstzset(const Temporal *temp, const Set *s)
  * @param[in] temp Temporal rigid geometry
  * @param[in] s Span
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @csqlfn #Temporal_restrict_tstzspan()
+ * @csqlfn #Temporal_at_tstzspan(), #Temporal_minus_tstzspan()
  */
 Temporal *
 trgeometry_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
@@ -1361,7 +1361,7 @@ trgeometry_minus_tstzspan(const Temporal *temp, const Span *s)
  * @param[in] temp Temporal rigid geometry
  * @param[in] ss Span set
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @csqlfn #Temporal_restrict_tstzspanset()
+ * @csqlfn #Temporal_at_tstzspanset(), #Temporal_minus_tstzspanset()
  */
 Temporal *
 trgeometry_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -3061,7 +3061,7 @@ tsequenceset_segm_duration(const TSequenceSet *ss, int64 tunits,
  * @param[in] atleast True when the operator is at least, false for at most
  * @param[in] strict True when the duration is strictly smaller or greater
  * @param[in] duration Duration
- * @csqlfn #Temporal_segm_duration()
+ * @csqlfn #Temporal_segm_min_duration(), #Temporal_segm_max_duration()
  */
 TSequenceSet *
 temporal_segm_duration(const Temporal *temp, const Interval *duration, 

--- a/meos/src/temporal/temporal_compops_meos.c
+++ b/meos/src/temporal/temporal_compops_meos.c
@@ -1685,7 +1685,7 @@ always_ge_ttext_text(const Temporal *temp, const text *txt)
  * @brief Return the temporal equality of a big integer and a temporal big integer
  * @param[in] i Value
  * @param[in] temp Temporal value
- * @csqlfn #TEq_base_temporal()
+ * @csqlfn #Teq_base_temporal()
  */
 Temporal *
 teq_bigint_tbigint(int64 i, const Temporal *temp)
@@ -1762,7 +1762,7 @@ teq_text_ttext(const text *txt, const Temporal *temp)
  * @brief Return the temporal equality of a temporal big integer and a big integer
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @csqlfn #TEq_temporal_base()
+ * @csqlfn #Teq_temporal_base()
  */
 Temporal *
 teq_tbigint_bigint(const Temporal *temp, int64 i)
@@ -1841,7 +1841,7 @@ teq_ttext_text(const Temporal *temp, const text *txt)
  * @brief Return the temporal difference of a big integer and a temporal big integer
  * @param[in] i Value
  * @param[in] temp Temporal value
- * @csqlfn #TNe_base_temporal()
+ * @csqlfn #Tne_base_temporal()
  */
 Temporal *
 tne_bigint_tbigint(int64 i, const Temporal *temp)
@@ -1918,7 +1918,7 @@ tne_text_ttext(const text *txt, const Temporal *temp)
  * @brief Return the temporal difference of a temporal big integer and a big integer
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @csqlfn #TNe_temporal_base()
+ * @csqlfn #Tne_temporal_base()
  */
 Temporal *
 tne_tbigint_bigint(const Temporal *temp, int64 i)
@@ -2012,7 +2012,7 @@ tlt_int_tint(int i, const Temporal *temp)
  * @brief Return the temporal less than of a big integer and a temporal big integer
  * @param[in] i Value
  * @param[in] temp Temporal value
- * @csqlfn #TLt_base_temporal()
+ * @csqlfn #Tlt_base_temporal()
  */
 Temporal *
 tlt_bigint_tbigint(int64 i, const Temporal *temp)
@@ -2059,7 +2059,7 @@ tlt_text_ttext(const text *txt, const Temporal *temp)
  * @brief Return the temporal less than of a temporal big integer and a big integer
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @csqlfn #TLt_temporal_base()
+ * @csqlfn #Tlt_temporal_base()
  */
 Temporal *
 tlt_tbigint_bigint(const Temporal *temp, int64 i)
@@ -2141,7 +2141,7 @@ tle_int_tint(int i, const Temporal *temp)
  * @brief Return the temporal less than or equal to of a big integer and a temporal big integer
  * @param[in] i Value
  * @param[in] temp Temporal value
- * @csqlfn #TLe_base_temporal()
+ * @csqlfn #Tle_base_temporal()
  */
 Temporal *
 tle_bigint_tbigint(int64 i, const Temporal *temp)
@@ -2190,7 +2190,7 @@ tle_text_ttext(const text *txt, const Temporal *temp)
  * @brief Return the temporal less than or equal to of a temporal big integer and a big integer
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @csqlfn #TLe_temporal_base()
+ * @csqlfn #Tle_temporal_base()
  */
 Temporal *
 tle_tbigint_bigint(const Temporal *temp, int64 i)
@@ -2274,7 +2274,7 @@ tgt_int_tint(int i, const Temporal *temp)
  * @brief Return the temporal greater than of a big integer and a temporal big integer
  * @param[in] i Value
  * @param[in] temp Temporal value
- * @csqlfn #TGt_base_temporal()
+ * @csqlfn #Tgt_base_temporal()
  */
 Temporal *
 tgt_bigint_tbigint(int64 i, const Temporal *temp)
@@ -2321,7 +2321,7 @@ tgt_text_ttext(const text *txt, const Temporal *temp)
  * @brief Return the temporal greater than of a temporal big integer and a big integer
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @csqlfn #TGt_temporal_base()
+ * @csqlfn #Tgt_temporal_base()
  */
 Temporal *
 tgt_tbigint_bigint(const Temporal *temp, int64 i)
@@ -2403,7 +2403,7 @@ tge_int_tint(int i, const Temporal *temp)
  * @brief Return the temporal greater than or equal to of a big integer and a temporal big integer
  * @param[in] i Value
  * @param[in] temp Temporal value
- * @csqlfn #TGe_base_temporal()
+ * @csqlfn #Tge_base_temporal()
  */
 Temporal *
 tge_bigint_tbigint(int64 i, const Temporal *temp)
@@ -2452,7 +2452,7 @@ tge_text_ttext(const text *txt, const Temporal *temp)
  * @brief Return the temporal greater than or equal to of a temporal big integer and a big integer
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @csqlfn #TGe_temporal_base()
+ * @csqlfn #Tge_temporal_base()
  */
 Temporal *
 tge_tbigint_bigint(const Temporal *temp, int64 i)


### PR DESCRIPTION
Each @csqlfn tag of the MEOS sources names a PG wrapper the extension declares, so the catalog resolves the SQL name of the function carrying it. The twelve temporal comparison kernels name Teq, Tne, Tlt, Tle, Tgt and Tge over both operand orders, as the four blocks beside each of them already do; the six trgeometry restrictions name the at and minus wrapper pair their temporal sibling names; the segment duration kernel names the minimum and maximum duration pair; and the pairwise minimum distance kernel, which takes the running minimum as its threshold, names the aggregate transition function that calls it. Twenty functions resolve to a SQL name in the catalog and reach the bindings the codegen emits.