### PR TITLE
State the one-liner of three temporal type entries in the reference index

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -617,7 +617,7 @@
 					<para><link linkend="ttypeSeq"><varname>ttypeSeq</varname></link>: Constructores para tipos temporales de subtipo secuencia</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="ttypeSeqSet"><varname>ttypeSeqSet</varname>, <varname>ttypeSeqSetGaps</varname></link>: <varname>ttypeSeqSet(ttypeContSeq[]) → ttypeSeqSet</varname></para>
+					<para><link linkend="ttypeSeqSet"><varname>ttypeSeqSet</varname>, <varname>ttypeSeqSetGaps</varname></link>: Constructores para tipos temporales de subtipo conjunto de secuencias</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -698,7 +698,7 @@
 					<para><link linkend="ttype_setInterp"><varname>setInterp</varname></link>: Transformar un valor temporal a otra interpolación</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="ttype_shiftTime"><varname>shiftTime</varname>, <varname>scaleTime</varname>, <varname>shiftScaleTime</varname>, <varname>segmentMinDuration</varname>, <varname>segmentMaxDuration</varname></link>: Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada.</para>
+					<para><link linkend="ttype_shiftTime"><varname>shiftTime</varname>, <varname>scaleTime</varname>, <varname>shiftScaleTime</varname></link>: Desplazar y/o escalear el intervalo de tiempo de un valor temporal a uno o dos intervalos</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="ttype_segmentMinDuration"><varname>segmentMinDuration</varname>, <varname>segmentMaxDuration</varname></link>: Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada.</para>

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -750,9 +750,9 @@ SELECT tgeographySeq(ARRAY[tgeography 'Point(1 1)@2001-01-01 08:00:00',
 			</listitem>
 
 			<listitem xml:id="ttypeSeqSet">
-				<para>Constructores para tipos temporales de subtipo conjunto de secuencias</para>
 				<indexterm significance="normal"><primary><varname>ttypeSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttypeSeqSetGaps</varname></primary></indexterm>
+				<para>Constructores para tipos temporales de subtipo conjunto de secuencias</para>
 				<para><varname>ttypeSeqSet(ttypeContSeq[]) → ttypeSeqSet</varname></para>
 				<para><varname>ttypeSeqSetGaps(ttypeInst[],maxt=NULL,maxdist=NULL,interp='linear') → ttypeSeqSet</varname></para>
 				<para>Un primer conjunto de constructores tiene un solo argumento, que es una matriz de valores de los valores de <emphasis>secuencia</emphasis> correspondientes. La interpolación del valor temporal resultante depende de la interpolación de las secuencias que lo componen. Se genera un error si las secuencias que componen la matriz tienen una interpolación diferente.</para>
@@ -1230,6 +1230,7 @@ SELECT asText(shiftScaleTime(tgeometry '{[Point(1 1)@2001-01-01,
     POINT(1 1)@2001-01-02 12:00:00], [POINT(2 2)@2001-01-02 18:00:00, 
     POLYGON((1 1,2 2,3 1,1 1))@2001-01-03 00:00:00]} */
 </programlisting>
+			</listitem>
 
 			<listitem xml:id="ttype_segmentMinDuration">
 				<indexterm significance="normal"><primary><varname>segmentMinDuration</varname></primary></indexterm>
@@ -1252,9 +1253,6 @@ SELECT segmentMaxDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
   -1@2001-01-06]', '1 day', false);
 -- {[f@2001-01-01, t@2001-01-03, f@2001-01-04, f@2001-01-06)}
 </programlisting>
-			</listitem>
-
-
 			</listitem>
 
 			<listitem xml:id="ttype_unnest">

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -611,13 +611,13 @@
 			<title>Constructors</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="ttype_const"><varname>ttype</varname></link>: <varname>ttype(base,timestamptz) → ttypeInst</varname></para>
+					<para><link linkend="ttype_const"><varname>ttype</varname></link>: Constructors for temporal types having a constant value</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="ttypeSeq"><varname>ttypeSeq</varname></link>: Constructors for temporal types of sequence subtype</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="ttypeSeqSet"><varname>ttypeSeqSet</varname>, <varname>ttypeSeqSetGaps</varname></link>: <varname>ttypeSeqSet(ttypeContSeq[]) → ttypeSeqSet</varname></para>
+					<para><link linkend="ttypeSeqSet"><varname>ttypeSeqSet</varname>, <varname>ttypeSeqSetGaps</varname></link>: Constructors for temporal types of sequence set subtype</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -697,9 +697,9 @@ SELECT ttextFromHexWKB('01290001040000000000000041414100009C57D3C11C0000');
 
 		<itemizedlist>
 			<listitem xml:id="ttype_const">
+				<indexterm significance="normal"><primary><varname>ttype</varname></primary></indexterm>
 				<para>Constructors for temporal types having a constant value</para>
 				<para>These contructors have two arguments, a base type and a time value, where the latter is a <varname>timestamptz</varname>, a <varname>tstzset</varname>, a <varname>tstzspan</varname>, or a <varname>tstzspanset</varname> value for constructing, respectively, an instant, a sequence with discrete interpolation, a sequence with linear or step interpolation, or a sequence set value. The functions for sequence or sequence set values with continuous base type have an optional third argument stating whether the resulting temporal value has linear or step interpolation. Linear interpolation is assumed by default if the argument is not specified.</para>
-				<indexterm significance="normal"><primary><varname>ttype</varname></primary></indexterm>
 				<para><varname>ttype(base,timestamptz) → ttypeInst</varname></para>
 				<para><varname>ttype(base,tstzset) → ttypeDiscSeq</varname></para>
 				<para><varname>ttype(base,tstzspan,interp='linear') → ttypeContSeq</varname></para>
@@ -740,9 +740,9 @@ SELECT tgeographySeq(ARRAY[tgeography 'Point(1 1)@2001-01-01 08:00:00',
 			</listitem>
 
 			<listitem xml:id="ttypeSeqSet">
-				<para>Constructors for temporal types of sequence set subtype</para>
 				<indexterm significance="normal"><primary><varname>ttypeSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttypeSeqSetGaps</varname></primary></indexterm>
+				<para>Constructors for temporal types of sequence set subtype</para>
 				<para><varname>ttypeSeqSet(ttypeContSeq[]) → ttypeSeqSet</varname></para>
 				<para><varname>ttypeSeqSetGaps(ttypeInst[],maxt=NULL,maxdist=NULL,interp='linear') → ttypeSeqSet</varname></para>
 				<para>A first set of contructors have a single argument, which is an array of values of the corresponding <emphasis>sequence</emphasis> values. The interpolation of the resulting temporal value depends on the interpolation of the composing sequences. An error is raised if the sequences composing the array have different interpolation.</para>


### PR DESCRIPTION
The index row of a manual entry carries the one-liner its chapter states, read as the first paragraph after the entry's index terms. The index terms open the constant-value and sequence-set constructor entries, and the Spanish shiftTime and segment duration entries are siblings, so each of these rows carries its own names and its own description in both manuals.