### PR TITLE
Give every manual label its own PDF destination

### DIFF
--- a/doc/texstyle.sty
+++ b/doc/texstyle.sty
@@ -12,3 +12,6 @@
 \usepackage{listings}
 \lstset{upquote=true}
 \usepackage{upquote}
+
+%% Give every label its own PDF destination, so no internal link is dropped as a duplicate
+\hypersetup{hypertexnames=false}


### PR DESCRIPTION
The PDF build of both manuals names hyperref destinations independently of the section and float counters, so every label keeps a destination of its own and no internal link is dropped as a duplicate of another.