### PR TITLE
Set the signature of every manual entry as a verbatim block

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -71,7 +71,9 @@ SELECT stbox 'SRID=4326;GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
 				<listitem xml:id="box_asText">
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<para>Return the Well-Known Text (WKT) representation</para>
-					<para><varname>asText(box,maxdecdigits=15) → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText(box,maxdecdigits=15) → text
+</programlisting>
 					<para>The <varname>maxdecdigits</varname> argument can be used to set the maximum number of decimal places in the output of floating point values (default 15).</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tbox 'TBOXFLOAT XT([1.123456789,2.123456789),[2001-01-01,2001-01-02))', 3);
@@ -85,8 +87,10 @@ SELECT asText(stbox 'STBOX Z((1.55,1.55,1.55),(2.55,2.55,2.55))', 0);
 					<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<para>Return the Well-Known Binary (WKB) or the Hexadecimal Well-Known Binary (HexWKB) representation</para>
-					<para><varname>asBinary(box,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(box,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(box,endian text='') → bytea
+asHexWKB(box,endian text='') → text
+</programlisting>
 					<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tbox 'TBOXFLOAT XT([1,2),[2001-01-01,2001-01-02))');
@@ -108,8 +112,10 @@ SELECT asHexWKB(stbox 'STBOX X((1,1),(2,2))');
 					<indexterm significance="normal"><primary><varname>boxFromBinary</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>boxFromHexWKB</varname></primary></indexterm>
 					<para>Input from the Well-Known Binary (WKB) or from the Hexadecimal Well-Known Binary (HexWKB) representation</para>
-					<para><varname>boxFromBinary(bytea) → box</varname></para>
-					<para><varname>boxFromHexWKB(text) → box</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+boxFromBinary(bytea) → box
+boxFromHexWKB(text) → box
+</programlisting>
 					<para>In the signatures above, <varname>box</varname> replaces any box type, that is, <varname>tbox</varname> or <varname>stbox</varname>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboxFromBinary(
@@ -141,9 +147,11 @@ SELECT stboxFromHexWKB(
 			<listitem xml:id="tbox">
 				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Constructor for <varname>tbox</varname></para>
-				<para><varname>tbox({number,numspan}) → tbox</varname></para>
-				<para><varname>tbox({timestamptz,tstzspan}) → tbox</varname></para>
-				<para><varname>tbox({number,numspan},{timestamptz,tstzspan}) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbox({number,numspan}) → tbox
+tbox({timestamptz,tstzspan}) → tbox
+tbox({number,numspan},{timestamptz,tstzspan}) → tbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Both value and time dimensions
 SELECT tbox(1.0, timestamptz '2001-01-01');
@@ -172,17 +180,19 @@ SELECT tbox(tstzspan '[2001-01-01,2001-01-02)');
 				<indexterm significance="normal"><primary><varname>geodstboxZT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Constructor for <varname>stbox</varname></para>
-				<para><varname>stboxX(float,float,float,float,srid=0) → stbox</varname></para>
-				<para><varname>stboxZ(float,float,float,float,float,float,srid=0) → stbox</varname></para>
-				<para><varname>stboxT({timestamptz,tstzspan}) → stbox</varname></para>
-				<para><varname>stboxXT(float,float,float,float,{timestamptz,tstzspan},srid=0) → stbox</varname></para>
-				<para><varname>stboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},srid=0) → stbox</varname></para>
-				<para><varname>geodstboxZ(float,float,float,float,float,float,srid=4326) → stbox</varname></para>
-				<para><varname>geodstboxT({timestamptz,tstzspan}) → stbox</varname></para>
-				<para><varname>geodstboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},srid=4326)</varname></para>
-				<para><varname>  → stbox</varname></para>
-				<para><varname>stbox(geo) → stbox</varname></para>
-				<para><varname>stbox(geo,{timestamptz,tstzspan}) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stboxX(float,float,float,float,srid=0) → stbox
+stboxZ(float,float,float,float,float,float,srid=0) → stbox
+stboxT({timestamptz,tstzspan}) → stbox
+stboxXT(float,float,float,float,{timestamptz,tstzspan},srid=0) → stbox
+stboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},srid=0) → stbox
+geodstboxZ(float,float,float,float,float,float,srid=4326) → stbox
+geodstboxT({timestamptz,tstzspan}) → stbox
+geodstboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},srid=4326)
+  → stbox
+stbox(geo) → stbox
+stbox(geo,{timestamptz,tstzspan}) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Only value dimension with X and Y coordinates
 SELECT stboxX(1.0,2.0,1.0,2.0);
@@ -221,10 +231,12 @@ SELECT stbox(geography 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03,2001-01-
 				<indexterm significance="normal"><primary><varname>floatspan</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tstzspan</varname></primary></indexterm>
 				<para>Convert a <varname>tbox</varname> to another type</para>
-				<para><varname>tbox::{intspan,floatspan,tstzspan}</varname></para>
-				<para><varname>intspan(tbox) → tbox</varname></para>
-				<para><varname>floatspan(tbox) → tbox</varname></para>
-				<para><varname>tstzspan(tbox) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbox::{intspan,floatspan,tstzspan}
+intspan(tbox) → tbox
+floatspan(tbox) → tbox
+tstzspan(tbox) → tbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,4),[2001-01-01,2001-01-02))'::intspan;
 -- [1,4)
@@ -239,8 +251,10 @@ SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02))'::tstzspan;
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Convert another type to a <varname>tbox</varname></para>
-				<para><varname>{numbers,times,tnumber}::tbox</varname></para>
-				<para><varname>tbox({numbers,times,tnumber}) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{numbers,times,tnumber}::tbox
+tbox({numbers,times,tnumber}) → tbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intset '{1,2}'::tbox;
 -- TBOXINT X([1, 3))
@@ -261,12 +275,14 @@ SELECT tstzspanset '{(2001-01-01,2001-01-02),(2001-01-03,2001-01-04)}'::tbox;
 				<indexterm significance="normal"><primary><varname>geography</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tstzspan</varname></primary></indexterm>
 				<para>Convert an <varname>stbox</varname> to a another type</para>
-				<para><varname>stbox::{box2d,box3d,geo,tstzspan}</varname></para>
-				<para><varname>box2d(stbox) → box2d</varname></para>
-				<para><varname>box3d(stbox) → box2d</varname></para>
-				<para><varname>geometry(stbox) → geometry</varname></para>
-				<para><varname>geography(stbox) → geography</varname></para>
-				<para><varname>tstzspan(stbox) → tstzspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stbox::{box2d,box3d,geo,tstzspan}
+box2d(stbox) → box2d
+box3d(stbox) → box2d
+geometry(stbox) → geometry
+geography(stbox) → geography
+tstzspan(stbox) → tstzspan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-03])'::box2d;
 -- BOX(1 2,3 4)
@@ -292,8 +308,10 @@ SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-03])'::tstzspan
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convert another type to an <varname>stbox</varname></para>
-				<para><varname>{box2d,box3d,geo,time,tgeo}::stbox</varname></para>
-				<para><varname>stbox({box2d,box3d,geo,time,tgeo}) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{box2d,box3d,geo,time,tgeo}::stbox
+stbox({box2d,box3d,geo,time,tgeo}) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geometry 'Linestring(1 1 1,2 2 2)'::box3d::stbox;
 -- STBOX Z((1,1,1),(2,2,2))
@@ -315,9 +333,11 @@ SELECT tstzspanset '{(2001-01-01,2001-01-02),(2001-01-03,2001-01-04)}'::stbox;
 				<indexterm significance="normal"><primary><varname>hasZ</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>hasT</varname></primary></indexterm>
 				<para>Has X/Z/T dimension?</para>
-				<para><varname>hasX(box) → boolean</varname></para>
-				<para><varname>hasZ(stbox) → boolean</varname></para>
-				<para><varname>hasT(box) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+hasX(box) → boolean
+hasZ(stbox) → boolean
+hasT(box) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT hasX(tbox 'TBOX T([2001-01-01,2001-01-03))');
 -- false
@@ -335,7 +355,9 @@ SELECT hasT(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
 			<listitem xml:id="stbox_isGeodetic">
 				<indexterm significance="normal"><primary><varname>isGeodetic</varname></primary></indexterm>
 				<para>Is geodetic?</para>
-				<para><varname>isGeodetic(stbox) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isGeodetic(stbox) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isGeodetic(stbox 'GEODSTBOX Z((1.0,1.0,0.0),(3.0,3.0,1.0))');
 -- true
@@ -350,10 +372,12 @@ SELECT isGeodetic(stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-02])
 				<indexterm significance="normal"><primary><varname>zMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMin</varname></primary></indexterm>
 				<para>Return the minimum X/Y/Z/T value</para>
-				<para><varname>xMin(box) → float</varname></para>
-				<para><varname>yMin(stbox) → float</varname></para>
-				<para><varname>zMin(stbox) → float</varname></para>
-				<para><varname>tMin(box) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+xMin(box) → float
+yMin(stbox) → float
+zMin(stbox) → float
+tMin(box) → timestamptz
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT xMin(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- 1
@@ -373,10 +397,12 @@ SELECT tMin(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<indexterm significance="normal"><primary><varname>zMax</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMax</varname></primary></indexterm>
 				<para>Return the maximum X/Y/Z/T value</para>
-				<para><varname>xMax(box) → float</varname></para>
-				<para><varname>yMax(stbox) → float</varname></para>
-				<para><varname>zMax(stbox) → float</varname></para>
-				<para><varname>tMax(box) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+xMax(box) → float
+yMax(stbox) → float
+zMax(stbox) → float
+tMax(box) → timestamptz
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT xMax(tbox 'TBOXINT X([1,4))');
 -- 3
@@ -394,8 +420,10 @@ SELECT tMax(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<indexterm significance="normal"><primary><varname>xMinInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMinInc</varname></primary></indexterm>
 				<para>Is the minimum X/T value inclusive?</para>
-				<para><varname>xMinInc(tbox) → boolean</varname></para>
-				<para><varname>tMinInc(box) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+xMinInc(tbox) → boolean
+tMinInc(box) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT xMinInc(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- false
@@ -408,8 +436,10 @@ SELECT tMinInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<indexterm significance="normal"><primary><varname>xMaxInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMaxInc</varname></primary></indexterm>
 				<para>Is the maximum X/T value inclusive?</para>
-				<para><varname>xMaxInc(tbox) → boolean</varname></para>
-				<para><varname>tMaxInc(box) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+xMaxInc(tbox) → boolean
+tMaxInc(box) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT xMaxInc(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- false
@@ -423,9 +453,11 @@ SELECT tMaxInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<indexterm significance="normal"><primary><varname>perimeter</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>volume</varname></primary></indexterm>
 				<para>Area, volume, perimeter</para>
-				<para><varname>area(stbox, spheroid boolean=true) → float</varname></para>
-				<para><varname>volume(stbox) → float</varname></para>
-				<para><varname>perimeter(stbox, spheroid boolean=true) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+area(stbox, spheroid boolean=true) → float
+volume(stbox) → float
+perimeter(stbox, spheroid boolean=true) → float
+</programlisting>
 				<para>For geodetic boxes, the computation is done on the WGS 84 spheroid by default. If the last argument is false, a faster spherical calculation is used. The <varname>volume</varname> function do not accept geodetic boxes.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT area(stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03))');
@@ -452,9 +484,11 @@ SELECT perimeter(stbox 'GEODSTBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03))', fa
 				<indexterm significance="normal"><primary><varname>scaleValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleValue</varname></primary></indexterm>
 				<para>Shift and/or scale the span of a bounding box by one or two values</para>
-				<para><varname>shiftValue(box,{integer,float}) → box</varname></para>
-				<para><varname>scaleValue(box,{integer,float}) → box</varname></para>
-				<para><varname>shiftScaleValue(tbox,{integer,float},{integer,float}) → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftValue(box,{integer,float}) → box
+scaleValue(box,{integer,float}) → box
+shiftScaleValue(tbox,{integer,float},{integer,float}) → box
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 1.0);
 -- TBOXFLOAT XT([2.5, 3.5],[2001-01-01, 2001-01-02])
@@ -470,9 +504,11 @@ SELECT shiftScaleValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 
 				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Shift and/or scale the span or the period of the bounding box to a value or interval</para>
-				<para><varname>shiftTime(box,interval) → box</varname></para>
-				<para><varname>scaleTime(box,interval) → box</varname></para>
-				<para><varname>shiftScaleTime(box,interval,interval) → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftTime(box,interval) → box
+scaleTime(box,interval) → box
+shiftScaleTime(box,interval,interval) → box
+</programlisting>
 				<para>For scaling, if the width or the time span of the period is zero (that is, the lower and upper bound are equal), the result is the box. The given value or interval must be strictly greater than zero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftTime(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])',
@@ -504,7 +540,9 @@ SELECT shiftScaleTime(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-02])
 			<listitem xml:id="box_getSpace">
 				<indexterm significance="normal"><primary><varname>getSpace</varname></primary></indexterm>
 				<para>Return the spatial dimension of the bounding box, removing the temporal dimension if any</para>
-				<para><varname>getSpace(stbox) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getSpace(stbox) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getSpace(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])');
 -- STBOX Z((1,1,1),(2,2,2))
@@ -521,9 +559,11 @@ SELECT getSpace(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])');
 				<indexterm significance="normal"><primary><varname>expandSpace</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>expandTime</varname></primary></indexterm>
 				<para>Expand the numeric, spatial, or temporal dimension of a bounding box by a value or an interval</para>
-				<para><varname>expandValue(tbox,{integer,float}) → tbox</varname></para>
-				<para><varname>expandSpace(stbox,float) → stbox</varname></para>
-				<para><varname>expandTime(box,interval) → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+expandValue(tbox,{integer,float}) → tbox
+expandSpace(stbox,float) → stbox
+expandTime(box,interval) → box
+</programlisting>
 				<para>The function returns NULL if the value or interval given as second argument is negative and the span resulting from shifting the bounds with the argument is empty.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expandValue(tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-03])', 1.0);
@@ -553,7 +593,9 @@ SELECT expandTime(tbox 'TBOX XT((1,2),[2001-01-01,2001-01-03])', interval '-2 da
 			<listitem xml:id="box_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Round the value or the coordinates of the bounding box to a number of decimal places</para>
-				<para><varname>round(box,integer=0) → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(box,integer=0) → box
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tbox 'TBOXFLOAT XT((1.12345,2.12345),[2001-01-01,2001-01-02])', 2);
 -- TBOXFLOAT XT((1.12,2.12),[2001-01-01, 2001-01-02])
@@ -575,8 +617,10 @@ SELECT round(tstzspan '[2000-01-01, 2001-01-02]'::tbox);
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Return or set the spatial reference identifier</para>
-				<para><varname>SRID(stbox) → integer</varname></para>
-				<para><varname>setSRID(stbox) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(stbox) → integer
+setSRID(stbox) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2001-01-01,2001-01-02])');
 -- 0
@@ -597,8 +641,10 @@ SELECT setSRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transform to a spatial reference identifier</para>
-				<para><varname>transform(stbox,to_srid integer) → stbox</varname></para>
-				<para><varname>transformPipeline(stbox,pipeline text,to_srid integer,is_forward boolean=true) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(stbox,to_srid integer) → stbox
+transformPipeline(stbox,pipeline text,to_srid integer,is_forward boolean=true) → stbox
+</programlisting>
 				<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input box has an unknown SRID (represented by 0). The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
 				<para>The SRID of the input box is ignored, and the SRID of the output box will be set to zero unless a value is provided via the optional <varname>to_srid</varname> parameter. As stated by the last parameter, the pipeline is executed by default in a forward direction; by setting the parameter to false, the pipeline is executed in the inverse direction.</para>
@@ -627,7 +673,9 @@ FROM test;
 				<indexterm significance="normal"><primary><varname>quadSplit</varname></primary></indexterm>
 				<para>Split the bounding box in quadrants or octants &SRF;
 </para>
-				<para><varname>quadSplit(stbox) → {stbox}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadSplit(stbox) → {stbox}
+</programlisting>
 				<para>As indicated by the &SRF;
  symbol, this function is a <emphasis>set-returning function</emphasis> (also known as a <emphasis>table function</emphasis>) since it typically return more than one value.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -665,7 +713,9 @@ SELECT quadSplit(stbox 'STBOX Z((0,0,0),(4,4,4))');
 				<indexterm significance="normal"><primary><varname>+</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 				<para>Union and intersection of two bounding boxes</para>
-				<para><varname>box {+, *} box → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+box {+, *} box → box
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,3),[2001-01-01,2001-01-03])' +
   tbox 'TBOXINT XT([2,4),[2001-01-02,2001-01-04])';
@@ -700,7 +750,9 @@ SELECT stbox 'STBOX ZT(((1,1,1),(3,3,3)),[2001-01-01,2001-01-02])' *
 				<listitem xml:id="box_overlap">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 					<para>Do the bounding boxes overlap?</para>
-					<para><varname>box &amp;&amp; box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box &amp;&amp; box → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,3),[2001-01-01,2001-01-03])' &amp;&amp;
   tbox 'TBOXFLOAT XT((2,4),[2001-01-02,2001-01-04])';
@@ -714,7 +766,9 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' &amp;&amp;
 				<listitem xml:id="box_contains">
 					<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
 					<para>Does the first bounding box contain the second one?</para>
-					<para><varname>box @&gt; box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box @&gt; box → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])' @&gt;
   tbox 'TBOXFLOAT XT((2,3),[2001-01-01,2001-01-02])';
@@ -728,7 +782,9 @@ SELECT stbox 'STBOX Z((1,1,1),(3,3,3))' @&gt;
 				<listitem xml:id="box_containedby">
 					<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
 					<para>Is the first bounding box contained in the second one?</para>
-					<para><varname>box &lt;@ box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box &lt;@ box → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;@
   tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])';
@@ -742,7 +798,9 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' &lt;@
 				<listitem xml:id="box_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Are the bounding boxes equal in their common dimensions?</para>
-					<para><varname>box ~= box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box ~= box → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' ~=
   tbox 'TBOXFLOAT T([2001-01-01,2001-01-02])';
@@ -756,7 +814,9 @@ SELECT stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03])' ~=
 				<listitem xml:id="box_adjacent">
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 					<para>Are the bounding boxes adjacent?</para>
-					<para><varname>box -|- box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box -|- box → boolean
+</programlisting>
 					<para>Two boxes are adjacent if their extents meet in every dimension the boxes share and touch at a single value in at least one of them. A dimension in which the boxes are apart separates them whatever the remaining dimensions do.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,2),[2001-01-01,2001-01-02])' -|-
@@ -786,8 +846,10 @@ SELECT stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03])' -|-
 					<indexterm significance="normal"><primary><varname>&lt;&lt;/</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
 					<para>Are the X/Y/Z/T values of the first bounding box strictly less than those of the second one?</para>
-					<para><varname>tbox {&lt;&lt;, &lt;&lt;#} tbox → boolean</varname></para>
-					<para><varname>stbox {&lt;&lt;, &lt;&lt;|, &lt;&lt;/, &lt;&lt;#} stbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tbox {&lt;&lt;, &lt;&lt;#} tbox → boolean
+stbox {&lt;&lt;, &lt;&lt;|, &lt;&lt;/, &lt;&lt;#} stbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;&lt;
   tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])';
@@ -811,8 +873,10 @@ SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;&lt;#
 					<indexterm significance="normal"><primary><varname>/&gt;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
 					<para>Are the X/Y/Z/T values of the first bounding box strictly greater than those of the second one?</para>
-					<para><varname>tbox {&gt;&gt;, #&gt;&gt;} tbox → boolean</varname></para>
-					<para><varname>stbox {&gt;&gt;, |&gt;&gt;, /&gt;&gt;, #&gt;&gt;} stbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tbox {&gt;&gt;, #&gt;&gt;} tbox → boolean
+stbox {&gt;&gt;, |&gt;&gt;, /&gt;&gt;, #&gt;&gt;} stbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])' &gt;&gt;
   tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])';
@@ -833,8 +897,10 @@ SELECT stbox 'STBOX XT(((3,3),(4,4)),[2001-01-03,2001-01-04])'  #&gt;&gt;
 					<indexterm significance="normal"><primary><varname>&amp;&lt;/</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&amp;&lt;#</varname></primary></indexterm>
 					<para>Are the X/Y/Z/T values of the first bounding box not greater than those of the second one?</para>
-					<para><varname>tbox {&amp;&lt;, &amp;&lt;#} {tbox,stbox} → boolean</varname></para>
-					<para><varname>stbox {&amp;&lt;, &amp;&lt;|, &amp;&lt;/, &amp;&lt;#} stbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tbox {&amp;&lt;, &amp;&lt;#} {tbox,stbox} → boolean
+stbox {&amp;&lt;, &amp;&lt;|, &amp;&lt;/, &amp;&lt;#} stbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])' &amp;&lt;
   tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])';
@@ -855,8 +921,10 @@ SELECT tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])' &amp;&lt;#
 					<indexterm significance="normal"><primary><varname>/&amp;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&amp;&gt;</varname></primary></indexterm>
 					<para>Are the X/Y/Z/T values of the first bounding box not less than those of the second one?</para>
-					<para><varname>tbox {&amp;&gt;, #&amp;&gt;} tbox → boolean</varname></para>
-					<para><varname>stbox {&amp;&gt;, |&amp;&gt;, /&amp;&gt;, #&amp;&gt;} stbox} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tbox {&amp;&gt;, #&amp;&gt;} tbox → boolean
+stbox {&amp;&gt;, |&amp;&gt;, /&amp;&gt;, #&amp;&gt;} stbox} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &amp;&gt;
   tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])';
@@ -889,9 +957,11 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' #&amp;&gt;
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
-				<para><varname>box {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} box → boolean</varname></para>
-				<para><varname>cmp(tbox,tbox) → int</varname></para>
-				<para><varname>cmp(stbox,stbox) → int</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+box {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} box → boolean
+cmp(tbox,tbox) → int
+cmp(stbox,stbox) → int
+</programlisting>
 				<para>Function <varname>cmp</varname> returns -1, 0, or 1 depending on whether the first argument is, respectively, less than, equal to, or greater than the second one.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,1],[2001-01-01,2001-01-04])' =
@@ -927,7 +997,9 @@ SELECT cmp(tbox 'TBOXFLOAT XT([1,1],[2001-01-01,2001-01-04])',
 			<listitem xml:id="box_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Bounding box extent</para>
-				<para><varname>extent(box) → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(box) → box
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH boxes(b) AS (
   SELECT tbox 'TBOXFLOAT XT((1,3),[2001-01-01,2001-01-03])' UNION

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -69,7 +69,9 @@ SELECT stbox 'SRID=4326;GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
 				<listitem xml:id="box_asText">
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<para>Devuelve la representación textual conocida (Well-Known Text o WKT)</para>
-					<para><varname>asText(box,maxdecdigits=15) → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText(box,maxdecdigits=15) → text
+</programlisting>
 					<para>El argumento <varname>maxdecdigits</varname> se puede utilizar para definir el número máximo de decimales para la salida de los valores de coma flotante (por defecto 15).</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT asText(tbox 'TBOXFLOAT XT([1.123456789,2.123456789),[2001-01-01,2001-01-02))', 3);
@@ -83,8 +85,10 @@ SELECT asText(stbox 'STBOX Z((1.55,1.55,1.55),(2.55,2.55,2.55))', 0);
 					<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB) o la representación hexadecimal binaria conocida (HexWKB)</para>
-					<para><varname>asBinary(box,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(box,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(box,endian text='') → bytea
+asHexWKB(box,endian text='') → text
+</programlisting>
 					<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT asBinary(tbox 'TBOXFLOAT XT([1,2),[2001-01-01,2001-01-02))');
@@ -106,8 +110,10 @@ SELECT asHexWKB(stbox 'STBOX X((1,1),(2,2))');
 					<indexterm significance="normal"><primary><varname>boxFromBinary</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>boxFromHexWKB</varname></primary></indexterm>
 					<para>Entrar a partir de representación binaria conocida (WKB) o de la representación hexadecimal binaria conocida (HexWKB)</para>
-					<para><varname>boxFromBinary(bytea) → box</varname></para>
-					<para><varname>boxFromHexWKB(text) → box</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+boxFromBinary(bytea) → box
+boxFromHexWKB(text) → box
+</programlisting>
 					<para>En las funciones anteriores, <varname>box</varname> reemplaza cualquier tipo de cuadro delimitador, a saber, <varname>tbox</varname> o <varname>stbox</varname>.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tboxFromBinary(
@@ -139,9 +145,11 @@ SELECT stboxFromHexWKB(
 			<listitem xml:id="tbox">
 				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Constructor para <varname>tbox</varname></para>
-				<para><varname>tbox({number,numspan}) → tbox</varname></para>
-				<para><varname>tbox({timestamptz,tstzspan}) → tbox</varname></para>
-				<para><varname>tbox({number,numspan},{timestamptz,tstzspan}) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbox({number,numspan}) → tbox
+tbox({timestamptz,tstzspan}) → tbox
+tbox({number,numspan},{timestamptz,tstzspan}) → tbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 -- Dimensiones de valores y de tiempo
 SELECT tbox(1.0, timestamptz '2001-01-01');
@@ -170,17 +178,19 @@ SELECT tbox(tstzspan '[2001-01-01,2001-01-02)');
 				<indexterm significance="normal"><primary><varname>geodstboxZT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Constructor para <varname>stbox</varname></para>
-				<para><varname>stboxX(float,float,float,float,srid=0) → stbox</varname></para>
-				<para><varname>stboxZ(float,float,float,float,float,float,srid=0) → stbox</varname></para>
-				<para><varname>stboxT({timestamptz,tstzspan}) → stbox</varname></para>
-				<para><varname>stboxXT(float,float,float,float,{timestamptz,tstzspan},srid=0) → stbox</varname></para>
-				<para><varname>stboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},srid=0) → stbox</varname></para>
-				<para><varname>geodstboxZ(float,float,float,float,float,float,srid=4326) → stbox</varname></para>
-				<para><varname>geodstboxT({timestamptz,tstzspan}) → stbox</varname></para>
-				<para><varname>geodstboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},srid=4326)</varname></para>
-				<para><varname>  → stbox</varname></para>
-				<para><varname>stbox(geo) → stbox</varname></para>
-				<para><varname>stbox(geo,{timestamptz,tstzspan}) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stboxX(float,float,float,float,srid=0) → stbox
+stboxZ(float,float,float,float,float,float,srid=0) → stbox
+stboxT({timestamptz,tstzspan}) → stbox
+stboxXT(float,float,float,float,{timestamptz,tstzspan},srid=0) → stbox
+stboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},srid=0) → stbox
+geodstboxZ(float,float,float,float,float,float,srid=4326) → stbox
+geodstboxT({timestamptz,tstzspan}) → stbox
+geodstboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},srid=4326)
+  → stbox
+stbox(geo) → stbox
+stbox(geo,{timestamptz,tstzspan}) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 -- Sólo dimensión de valores con coordenadas X e Y
 SELECT stboxX(1.0,2.0,1.0,2.0);
@@ -219,10 +229,12 @@ SELECT stbox(geography 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03, 2001-01
 				<indexterm significance="normal"><primary><varname>floatspan</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tstzspan</varname></primary></indexterm>
 				<para>Convertir un <varname>tbox</varname> a otro tipo</para>
-				<para><varname>tbox::{intspan,floatspan,tstzspan}</varname></para>
-				<para><varname>intspan(tbox) → tbox</varname></para>
-				<para><varname>floatspan(tbox) → tbox</varname></para>
-				<para><varname>tstzspan(tbox) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbox::{intspan,floatspan,tstzspan}
+intspan(tbox) → tbox
+floatspan(tbox) → tbox
+tstzspan(tbox) → tbox
+</programlisting>
           <programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXINT XT([1,4),[2001-01-01,2001-01-02))'::intspan;
 -- [1,4)
@@ -237,8 +249,10 @@ SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02))'::tstzspan;
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Convertir otro tipo a un <varname>tbox</varname></para>
-				<para><varname>{numbers,times,tnumber}::tbox</varname></para>
-				<para><varname>tbox({numbers,times,tnumber}) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{numbers,times,tnumber}::tbox
+tbox({numbers,times,tnumber}) → tbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT intset '{1,2}'::tbox;
 -- TBOXINT X([1, 3))
@@ -259,12 +273,14 @@ SELECT tstzspanset '{(2001-01-01,2001-01-02),(2001-01-03,2001-01-04)}'::tbox;
 				<indexterm significance="normal"><primary><varname>geography</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tstzspan</varname></primary></indexterm>
 				<para>Convertir un <varname>stbox</varname> a otro tipo</para>
-				<para><varname>stbox::{box2d,box2d,geo,tstzspan}</varname></para>
-				<para><varname>box2d(stbox) → box2d</varname></para>
-				<para><varname>box3d(stbox) → box2d</varname></para>
-				<para><varname>geometry(stbox) → geometry</varname></para>
-				<para><varname>geography(stbox) → geography</varname></para>
-				<para><varname>tstzspan(stbox) → tstzspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stbox::{box2d,box2d,geo,tstzspan}
+box2d(stbox) → box2d
+box3d(stbox) → box2d
+geometry(stbox) → geometry
+geography(stbox) → geography
+tstzspan(stbox) → tstzspan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-03])'::box2d;
 -- BOX(1 2,3 4)
@@ -290,8 +306,10 @@ SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-03])'::tstzspan
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convertir otro tipo a un <varname>stbox</varname></para>
-				<para><varname>{box2d,box3d,geo,times,tgeo}::stbox</varname></para>
-				<para><varname>stbox({box2d,box3d,geo,times,tgeo}) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{box2d,box3d,geo,times,tgeo}::stbox
+stbox({box2d,box3d,geo,times,tgeo}) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT geometry 'Linestring(1 1 1,2 2 2)'::box3d::stbox;
 -- STBOX Z((1,1,1),(2,2,2))
@@ -313,9 +331,11 @@ SELECT tstzspanset '{(2001-01-01,2001-01-02),(2001-01-03,2001-01-04)}'::stbox;
 				<indexterm significance="normal"><primary><varname>hasZ</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>hasT</varname></primary></indexterm>
 				<para>¿Tiene dimensión X/Z/T?</para>
-				<para><varname>hasX(box) → boolean</varname></para>
-				<para><varname>hasZ(stbox) → boolean</varname></para>
-				<para><varname>hasT(box) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+hasX(box) → boolean
+hasZ(stbox) → boolean
+hasT(box) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT hasX(tbox 'TBOX T([2001-01-01,2001-01-03))');
 -- false
@@ -333,7 +353,9 @@ SELECT hasT(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
 			<listitem xml:id="stbox_isGeodetic">
 				<indexterm significance="normal"><primary><varname>isGeodetic</varname></primary></indexterm>
 				<para>¿Es geodética?</para>
-				<para><varname>isGeodetic(stbox) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isGeodetic(stbox) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT isGeodetic(stbox 'GEODSTBOX Z((1.0,1.0,0.0),(3.0,3.0,1.0))');
 -- true
@@ -348,10 +370,12 @@ SELECT isGeodetic(stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-02])
 				<indexterm significance="normal"><primary><varname>zMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMin</varname></primary></indexterm>
 				<para>Devuelve el valor mínimo de X/Y/Z/T</para>
-				<para><varname>xMin(box) → float</varname></para>
-				<para><varname>yMin(stbox) → float</varname></para>
-				<para><varname>zMin(stbox) → float</varname></para>
-				<para><varname>tMin(box) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+xMin(box) → float
+yMin(stbox) → float
+zMin(stbox) → float
+tMin(box) → timestamptz
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT xMin(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- 1
@@ -370,10 +394,12 @@ SELECT tMin(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<indexterm significance="normal"><primary><varname>zMax</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMax</varname></primary></indexterm>
 				<para>Devuelve el valor máximo de X/Y/Z/T</para>
-				<para><varname>xMax(box) → float</varname></para>
-				<para><varname>yMax(stbox) → float</varname></para>
-				<para><varname>zMax(stbox) → float</varname></para>
-				<para><varname>tMax(box) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+xMax(box) → float
+yMax(stbox) → float
+zMax(stbox) → float
+tMax(box) → timestamptz
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT xMax(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
 -- 3
@@ -390,8 +416,10 @@ SELECT tMax(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<indexterm significance="normal"><primary><varname>xMinInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMinInc</varname></primary></indexterm>
 				<para>Es el mínimo valor X/T inclusivo?</para>
-				<para><varname>xMinInc(tbox) → boolean</varname></para>
-				<para><varname>tMinInc(box) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+xMinInc(tbox) → boolean
+tMinInc(box) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT xMinInc(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- false
@@ -404,8 +432,10 @@ SELECT tMinInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<indexterm significance="normal"><primary><varname>xMaxInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tMaxInc</varname></primary></indexterm>
 				<para>Es el máximo valor X/T inclusivo?</para>
-				<para><varname>xMaxInc(tbox) → boolean</varname></para>
-				<para><varname>tMaxInc(box) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+xMaxInc(tbox) → boolean
+tMaxInc(box) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT xMaxInc(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- false
@@ -419,9 +449,11 @@ SELECT tMaxInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 				<indexterm significance="normal"><primary><varname>perimeter</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>volume</varname></primary></indexterm>
 				<para>Área, volumen, perímetro</para>
-				<para><varname>area(stbox, spheroid boolean=true) → float</varname></para>
-				<para><varname>volume(stbox) → float</varname></para>
-				<para><varname>perimeter(stbox, spheroid boolean=true) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+area(stbox, spheroid boolean=true) → float
+volume(stbox) → float
+perimeter(stbox, spheroid boolean=true) → float
+</programlisting>
 				<para>Para cuadros geodésicos, el cálculo se realiza en el esferoide WGS 84 por defecto. Si el último argumento es falso, se utiliza un cálculo esférico más rápido. La función <varname>volume</varname> no acepta cuadros geodésicos.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT area(stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03))');
@@ -448,9 +480,11 @@ SELECT perimeter(stbox 'GEODSTBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03))', fa
 				<indexterm significance="normal"><primary><varname>scaleValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleValue</varname></primary></indexterm>
 				<para>Desplazar y/o escalear el rango de valores de un cuadro delimitador con uno o dos valores</para>
-				<para><varname>shiftValue(tbox,{integer,float}) → tbox</varname></para>
-				<para><varname>scaleValue(tbox,{integer,float}) → tbox</varname></para>
-				<para><varname>shiftScaleValue(tbox,{integer,float},{integer,float}) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftValue(tbox,{integer,float}) → tbox
+scaleValue(tbox,{integer,float}) → tbox
+shiftScaleValue(tbox,{integer,float},{integer,float}) → tbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT shiftValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 1.0);
 -- TBOXFLOAT XT([2.5, 3.5],[2001-01-01, 2001-01-02])
@@ -469,9 +503,11 @@ SELECT shiftScaleValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 
 				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Desplazar y/o escalar el período de un cuadro delimitador con uno o dos intervalos. Si el ancho o el lapso de tiempo del valor de tiempo es cero (es decir, los límites inferior y superior son iguales), el resultado es el cuadro delimitador. El valor o intervalo dado debe ser estrictamente mayor que cero.</para>
-				<para><varname>shiftTime(box,interval) → box</varname></para>
-				<para><varname>scaleTime(box,interval) → box</varname></para>
-				<para><varname>shiftScaleTime(box,interval,interval) → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftTime(box,interval) → box
+scaleTime(box,interval) → box
+shiftScaleTime(box,interval,interval) → box
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT shiftTime(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])',
   interval '1 day');
@@ -502,7 +538,9 @@ SELECT shiftScaleTime(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-02])
 			<listitem xml:id="box_getSpace">
 				<indexterm significance="normal"><primary><varname>getSpace</varname></primary></indexterm>
 				<para>Devuelve la dimensión espacial del cuadro delimitador, eliminando la dimensión temporal, si existe</para>
-				<para><varname>getSpace(stbox) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getSpace(stbox) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT getSpace(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])');
 -- STBOX Z((1,1,1),(2,2,2))
@@ -519,9 +557,11 @@ SELECT getSpace(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])');
 					<indexterm significance="normal"><primary><varname>expandSpace</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>expandTime</varname></primary></indexterm>
 					<para>Extender la dimensión numérica, espacial o temporal del cuadro delimitador con un valor o un intervalo</para>
-					<para><varname>expandValue(tbox,{integer,float}) → tbox</varname></para>
-					<para><varname>expandSpace(stbox,float) → stbox</varname></para>
-					<para><varname>expandTime(box,interval) → box</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+expandValue(tbox,{integer,float}) → tbox
+expandSpace(stbox,float) → stbox
+expandTime(box,interval) → box
+</programlisting>
 					<para>La función devuelve NULL si el valor o intervalo dado como segundo argumento es negativo y el rango resultante de desplazar los límites con el argumento está vacío.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT expandValue(tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-03])', 1.0);
@@ -551,7 +591,9 @@ SELECT expandTime(tbox 'TBOX XT((1,2),[2001-01-01,2001-01-03])', interval '-2 da
 				<listitem xml:id="box_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Redondear el valor o las coordenadas del cuadro delimitador a un número de decimales</para>
-					<para><varname>round(box,integer=0) → box</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(box,integer=0) → box
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT round(tbox 'TBOXFLOAT XT((1.12345,2.12345),[2001-01-01,2001-01-02])', 2);
 -- TBOXFLOAT XT((1.12, 2.12),[2001-01-01,2001-01-02])
@@ -574,8 +616,10 @@ SELECT round(tstzspan '[2000-01-01, 2001-01-02]'::tbox);
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Devuelve o especifica el identificador de referencia espacial</para>
-				<para><varname>SRID(stbox) → integer</varname></para>
-				<para><varname>setSRID(stbox) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(stbox) → integer
+setSRID(stbox) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT SRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2001-01-01,2001-01-02])');
 -- 0
@@ -593,9 +637,11 @@ SELECT setSRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transformar a una referencia espacial diferente</para>
-				<para><varname>transform(stbox,to_srid integer) → stbox</varname></para>
-				<para><varname>transformPipeline(stbox,pipeline text,to_srid integer,is_forward boolean=true) →</varname></para>
-				<para><varname> stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(stbox,to_srid integer) → stbox
+transformPipeline(stbox,pipeline text,to_srid integer,is_forward boolean=true) →
+  stbox
+</programlisting>
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el cuadro de entrada tiene un SRID desconocido (representado por 0).</para>
 				<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
@@ -624,7 +670,9 @@ FROM test;
 			<listitem xml:id="stbox_quadSplit">
 				<indexterm significance="normal"><primary><varname>quadSplit</varname></primary></indexterm>
 				<para>Dividir el cuadro delimitador en cuadrantes u octantes &SRF;</para>
-				<para><varname>quadSplit(stbox) → {stbox}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadSplit(stbox) → {stbox}
+</programlisting>
 				<para>Como lo indica el símbolo &SRF;, esta función es una <emphasis>función de retorno de conjuntos</emphasis> (también conocida como <emphasis>función de tabla</emphasis>) ya que normalmente devuelve más de un valor.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT quadSplit(stbox 'STBOX XT(((0,0),(4,4)),[2001-01-01,2001-01-05])');
@@ -661,7 +709,9 @@ SELECT quadSplit(stbox 'STBOX Z((0,0,0),(4,4,4))');
 				<indexterm significance="normal"><primary><varname>+</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 				<para>Unión e intersección de dos cuadros delimitadores</para>
-				<para><varname>box {+, *} box → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+box {+, *} box → box
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXINT XT([1,3),[2001-01-01,2001-01-03])' +
   tbox 'TBOXINT XT([2,4),[2001-01-02,2001-01-04])';
@@ -696,7 +746,9 @@ SELECT stbox 'STBOX ZT(((1,1,1),(3,3,3)),[2001-01-01,2001-01-02])' *
 				<listitem xml:id="box_overlap">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 					<para>¿Se superponen los cuadros delimitadores?</para>
-					<para><varname>box &amp;&amp; box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box &amp;&amp; box → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXFLOAT XT((1,3),[2001-01-01,2001-01-03])' &amp;&amp;
   tbox 'TBOXFLOAT XT((2,4),[2001-01-02,2001-01-04])';
@@ -710,7 +762,9 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' &amp;&amp;
 				<listitem xml:id="box_contains">
 					<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
 					<para>¿Contiene el primer cuadro delimitador el segundo?</para>
-					<para><varname>box @&gt; box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box @&gt; box → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])' @&gt;
   tbox 'TBOXFLOAT XT((2,3),[2001-01-01,2001-01-02])';
@@ -724,7 +778,9 @@ SELECT stbox 'STBOX Z((1,1,1),(3,3,3))' @&gt;
 				<listitem xml:id="box_containedby">
 					<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
 					<para>¿Está el primer cuadro delimitador contenido en el segundo?</para>
-					<para><varname>box &lt;@ box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box &lt;@ box → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;@
   tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])';
@@ -738,7 +794,9 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02)' &lt;@
 				<listitem xml:id="box_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>¿Son los cuadros delimitadores iguales en sus dimensiónes comunes?</para>
-					<para><varname>box ~= box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box ~= box → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' ~=
   tbox 'TBOXFLOAT XT([2001-01-01,2001-01-02])';
@@ -752,7 +810,9 @@ SELECT stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03])' ~=
 				<listitem xml:id="box_adjacent">
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 					<para>¿Son los cuadros delimitadores adyacentes?</para>
-					<para><varname>box -|- box → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+box -|- box → boolean
+</programlisting>
 					<para>Dos cuadros delimitadores son adyacentes si sus extensiones se encuentran en todas las dimensiones que los cuadros comparten y se tocan en un solo valor en al menos una de ellas. Una dimensión en la que los cuadros están separados los separa sea cual sea el comportamiento de las demás dimensiones.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXINT XT([1,2),[2001-01-01,2001-01-02])' -|-
@@ -782,8 +842,10 @@ SELECT stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03])' -|-
 					<indexterm significance="normal"><primary><varname>&lt;&lt;/</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
 					<para>¿Son los valores X/Y/Z/T del primer cuadro delimitador estrictamente menores que los del segundo?</para>
-					<para><varname>tbox {&lt;&lt;, &lt;&lt;#} tbox → boolean</varname></para>
-					<para><varname>stbox {&lt;&lt;, &lt;&lt;|, &lt;&lt;/, &lt;&lt;#} stbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tbox {&lt;&lt;, &lt;&lt;#} tbox → boolean
+stbox {&lt;&lt;, &lt;&lt;|, &lt;&lt;/, &lt;&lt;#} stbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;&lt;
   tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])';
@@ -809,8 +871,10 @@ SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;&lt;#
 					<indexterm significance="normal"><primary><varname>/&gt;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
 					<para>¿Son los valores X/Y/Z/T del primer cuadro delimitador estrictamente mayores que los del segundo?</para>
-					<para><varname>tbox {&gt;&gt;, #&gt;&gt;} tbox → boolean</varname></para>
-					<para><varname>stbox {&gt;&gt;, |&gt;&gt;, /&gt;&gt;, #&gt;&gt;} stbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tbox {&gt;&gt;, #&gt;&gt;} tbox → boolean
+stbox {&gt;&gt;, |&gt;&gt;, /&gt;&gt;, #&gt;&gt;} stbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])' &gt;&gt;
   tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])';
@@ -833,8 +897,10 @@ SELECT stbox 'STBOX XT((4,4),[2001-01-03,2001-01-04],((3,3)))'  #&gt;&gt;
 					<indexterm significance="normal"><primary><varname>&amp;&lt;/</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&amp;&lt;#</varname></primary></indexterm>
 					<para>¿No son los valores X/Y/Z/T del primer cuadro delimitador mayores que los del segundo?</para>
-					<para><varname>tbox {&amp;&lt;, &amp;&lt;#} {tbox,stbox} → boolean</varname></para>
-					<para><varname>stbox &amp;&lt;, &amp;&lt;|, &amp;&lt;/, &amp;&lt;#} stbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tbox {&amp;&lt;, &amp;&lt;#} {tbox,stbox} → boolean
+stbox &amp;&lt;, &amp;&lt;|, &amp;&lt;/, &amp;&lt;#} stbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])' &amp;&lt;
   tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])';
@@ -857,8 +923,10 @@ SELECT tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])' &amp;&lt;#
 					<indexterm significance="normal"><primary><varname>/&amp;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&amp;&gt;</varname></primary></indexterm>
 					<para>¿No son los valores X/Y/Z/T del primer cuadro delimitador menores que los del segundo?</para>
-					<para><varname>tbox {&amp;&gt;, #&amp;&gt;} tbox → boolean</varname></para>
-					<para><varname>stbox {&amp;&gt;, |&amp;&gt;, /&amp;&gt;, #&amp;&gt;} stbox} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tbox {&amp;&gt;, #&amp;&gt;} tbox → boolean
+stbox {&amp;&gt;, |&amp;&gt;, /&amp;&gt;, #&amp;&gt;} stbox} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &amp;&gt;
   tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])';
@@ -893,14 +961,16 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' #&amp;&gt;
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
-				<para><varname>box = box → boolean</varname></para>
-				<para><varname>box &lt;&gt; box → boolean</varname></para>
-				<para><varname>box &lt; box → boolean</varname></para>
-				<para><varname>box &gt; box → boolean</varname></para>
-				<para><varname>box &lt;= box → boolean</varname></para>
-				<para><varname>box &gt;= box → boolean</varname></para>
-				<para><varname>cmp(tbox,tbox) → int</varname></para>
-				<para><varname>cmp(stbox,stbox) → int</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+box = box → boolean
+box &lt;&gt; box → boolean
+box &lt; box → boolean
+box &gt; box → boolean
+box &lt;= box → boolean
+box &gt;= box → boolean
+cmp(tbox,tbox) → int
+cmp(stbox,stbox) → int
+</programlisting>
 				<para>La función <varname>cmp</varname> devuelve -1, 0 o 1 según que el primer argumento sea, respectivamente, menor que, igual a o mayor que el segundo.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tbox 'TBOXINT XT([1,1],[2001-01-01,2001-01-04])' =
@@ -933,7 +1003,9 @@ SELECT tbox 'TBOXFLOAT XT([1,1],[2001-01-01,2001-01-04])' &gt;=
 			<listitem xml:id="box_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Extensión del cuadro delimitador</para>
-				<para><varname>extent(box) → box</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(box) → box
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 WITH boxes(b) AS (
   SELECT tbox 'TBOXFLOAT XT((1,3),[2001-01-01,2001-01-03])' UNION

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -196,7 +196,9 @@ SELECT tstzspanset '{[2001-01-01 08:00:00, 2001-01-01 08:10:00),
 			<listitem xml:id="setspan_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Devuelve la representación textual conocida (Well-Known Text o WKT)</para>
-				<para><varname>asText({floatset,floatspans},maxdecdigits=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({floatset,floatspans},maxdecdigits=15) → text
+</programlisting>
 					<para>El argumento <varname>maxdecdigits</varname> se puede utilizar para definir el número máximo de decimales para la salida de los valores de coma flotante (por defecto 15).</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asText(floatset '{1.123456789,2.123456789}', 3);
@@ -210,8 +212,10 @@ SELECT asText(floatspanset '{[1.55,2.55],[4,5]}',0);
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB) o la representación hexadecimal binaria conocida (HexWKB)</para>
-				<para><varname>asBinary({set,spans},endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB({set,spans},endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary({set,spans},endian text='') → bytea
+asHexWKB({set,spans},endian text='') → text
+</programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asBinary(dateset '{2001-01-01, 2001-01-03}');
@@ -233,8 +237,12 @@ SELECT asHexWKB(floatspanset '{[1, 2], [4, 5]}', 'XDR');
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Devuelve la representación binaria extendida conocida (Extended Well-Known Binary o EWKB) o la representación hexadecimal binaria extendida conocida (HexEWKB) de un conjunto espacial</para>
-				<para><varname>asEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,pcpatchset},endian text='') → bytea</varname></para>
-				<para><varname>asHexEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,pcpatchset},endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,pcpatchset},
+  endian text='') → bytea
+asHexEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,
+  pcpatchset},endian text='') → text
+</programlisting>
 				<para>Para <varname>geomset</varname>, <varname>geogset</varname>, <varname>cbufferset</varname>, <varname>npointset</varname>, <varname>poseset</varname> y <varname>posechainset</varname> el SRID (cuando se conoce) se incluye una única vez en la cabecera del conjunto: <varname>asEWKB</varname> y <varname>asHexEWKB</varname> lo incluyen, mientras que <varname>asBinary</varname> y <varname>asHexWKB</varname> devuelven la representación binaria conocida (WKB) sin él, siguiendo la convención OGC y el <varname>asBinary</varname>/<varname>asHexWKB</varname> de los tipos base <varname>cbuffer</varname>, <varname>npoint</varname> y <varname>pose</varname>. Para <varname>pcpointset</varname> y <varname>pcpatchset</varname> el esquema, y su SRID, se resuelve fuera de banda a partir del catálogo <varname>pointcloud_formats</varname> en lugar de incluirse en el valor, por lo que las cuatro funciones siempre devuelven los mismos bytes para estos dos tipos.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asBinary(geomset 'SRID=4326;{Point(1 1)}');
@@ -257,9 +265,11 @@ SELECT asHexEWKB(npointset '{"NPoint(1,0.5)"}');
 				<indexterm significance="normal"><primary><varname>spantypeFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spansettypeFromBinary</varname></primary></indexterm>
 				<para>Entrar a partir de la representación binaria conocida (WKB)</para>
-				<para><varname>settypeFromBinary(bytea) → set</varname></para>
-				<para><varname>spantypeFromBinary(bytea) → span</varname></para>
-				<para><varname>spansettypeFromBinary(bytea) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+settypeFromBinary(bytea) → set
+spantypeFromBinary(bytea) → span
+spansettypeFromBinary(bytea) → spanset
+</programlisting>
 				<para>Hay una función por tipo de conjunto o de rango, el nombre de la función tiene como prefijo el nombre del tipo.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT datesetFromBinary('\x01050001020000006e01000070010000');
@@ -277,9 +287,11 @@ SELECT floatspansetFromBinary(
 				<indexterm significance="normal"><primary><varname>spantypeFromHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spansettypeFromHexWKB</varname></primary></indexterm>
 				<para>Entrar a partir de la representación hexadecimal binaria conocida (HexWKB)</para>
-				<para><varname>settypeFromHexWKB(text) → set</varname></para>
-				<para><varname>spantypeFromHexWKB(text) → span</varname></para>
-				<para><varname>spansettypeFromHexWKB(text) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+settypeFromHexWKB(text) → set
+spantypeFromHexWKB(text) → span
+spansettypeFromHexWKB(text) → spanset
+</programlisting>
 				<para>Hay una función por tipo de conjunto o de rango, el nombre de la función tiene como prefijo el nombre del tipo.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT datesetFromHexWKB('01050001020000006E01000070010000');
@@ -306,7 +318,9 @@ SELECT floatspansetFromHexWKB(
 			<listitem xml:id="set">
 				<indexterm significance="normal"><primary><varname>set</varname></primary></indexterm>
 				<para>Constructor para tipos de conjunto</para>
-				<para><varname>set(base[]) → set</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+set(base[]) → set
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT set(ARRAY['highway', 'primary', 'secondary']);
 -- {"highway", "primary", "secondary"}
@@ -322,7 +336,9 @@ SELECT set(ARRAY[timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00']);
 			<listitem xml:id="span">
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<para>Constructor para tipos de rango</para>
-				<para><varname>span(lower base,upper base,leftInc boolean=true,rightInc boolean=false) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+span(lower base,upper base,leftInc boolean=true,rightInc boolean=false) → span
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT span(20.5, 25);
 -- [20.5, 25)
@@ -340,7 +356,9 @@ SELECT span(timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00', false, tru
 			<listitem xml:id="spanset">
 					<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Constructor for conjunto de rangos</para>
-				<para><varname>spanset(span[]) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+spanset(span[]) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT spanset(ARRAY[intspan '[10,12]', '[13,15]']);
 -- {[10, 16)}
@@ -366,10 +384,12 @@ SELECT spanset(ARRAY[tstzspan '[2001-01-01 08:00, 2001-01-01 08:10]',
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convertir un valor de base en un valor de conjunto, rango o conjunto de rangos</para>
-				<para><varname>base::{set,span,spanset}</varname></para>
-				<para><varname>set(base) → set</varname></para>
-				<para><varname>span(base) → span</varname></para>
-				<para><varname>spanset(base) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+base::{set,span,spanset}
+set(base) → set
+span(base) → span
+spanset(base) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT CAST(timestamptz '2001-01-01 08:00:00' AS tstzset);
 -- {2001-01-01 08:00:00}
@@ -384,8 +404,10 @@ SELECT spanset(timestamptz '2001-01-01 08:00:00');
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convertir un valor de conjunto en un valor de conjunto de rangos</para>
-				<para><varname>set::spanset</varname></para>
-				<para><varname>spanset(set) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+set::spanset
+spanset(set) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT spanset(tstzset '{2001-01-01 08:00:00, 2001-01-01 08:15:00,
   2001-01-01 08:25:00}');
@@ -399,8 +421,10 @@ SELECT spanset(tstzset '{2001-01-01 08:00:00, 2001-01-01 08:15:00,
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convertir un valor de rango a un valor de conjunto de rangos</para>
-				<para><varname>span::spanset</varname></para>
-				<para><varname>spanset(span) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+span::spanset
+spanset(span) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT floatspan '[1.5,2.5]'::floatspanset;
 -- {[1.5, 2.5]}
@@ -412,8 +436,10 @@ SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-01 08:30:00)'::tstzspanset;
 			<listitem xml:id="setspan_span">
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<para>Convertir un conjunto de valores o un conjunto de rangos a un rango, ignorando las posibles brechas de tiempo</para>
-				<para><varname>{set,spanset}::span</varname></para>
-				<para><varname>span({set,spanset}) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{set,spanset}::span
+span({set,spanset}) → span
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT span(dateset '{2001-01-01, 2001-01-03, 2001-01-05}');
 -- [2001-01-01, 2001-01-06)
@@ -427,10 +453,12 @@ SELECT span(tstzspanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>range</varname></primary></indexterm>
 				<para>Convertir un valor de de rango en MobilityDB hacia y desde un valor de rango de PostgreSQL</para>
-				<para><varname>span::range</varname></para>
-				<para><varname>range::span</varname></para>
-				<para><varname>range(span) → range</varname></para>
-				<para><varname>span(range) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+span::range
+range::span
+range(span) → range
+span(range) → span
+</programlisting>
 				<para>Nótese que los valores de rango en PostgreSQL aceptan rangos vacíos y rangos con límites infinitos, que no están permitidos como valores de rango en MobilityDB</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT intspan '[10, 20)'::int4range;
@@ -453,10 +481,12 @@ SELECT tstzrange '[2001-01-01 08:00:00, 2001-01-01 08:30:00)'::tstzspan;
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>multirange</varname></primary></indexterm>
 				<para>Convertir un valor de conjunto de rangos de MobilityDB hacia y desde un valor de multirango de PostgreSQL</para>
-				<para><varname>spanset::multirange</varname></para>
-				<para><varname>multirange::spanset</varname></para>
-				<para><varname>multirange(spanset) → multirange</varname></para>
-				<para><varname>spanset(multirange) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+spanset::multirange
+multirange::spanset
+multirange(spanset) → multirange
+spanset(multirange) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT intspanset '{[1,2],[4,5]}'::int4multirange;
 -- {[1,3),[4,6)}
@@ -478,7 +508,9 @@ SELECT tstzmultirange '{[2001-01-01,2001-01-02],[2001-01-04,2001-01-05]}'::tstzs
 			<listitem xml:id="setspan_memSize">
 				<indexterm significance="normal"><primary><varname>memSize</varname></primary></indexterm>
 				<para>Devuelve el tamaño de la memoria en bytes</para>
-				<para><varname>memSize({set,spanset}) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+memSize({set,spanset}) → integer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT memSize(tstzset '{2001-01-01, 2001-01-02, 2001-01-03}');
 -- 48
@@ -492,8 +524,10 @@ SELECT memSize(tstzspanset '{[2001-01-01, 2001-01-02], [2001-01-03, 2001-01-04],
 				<indexterm significance="normal"><primary><varname>lower</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>upper</varname></primary></indexterm>
 				<para>Devuelve el límite inferior o superior</para>
-				<para><varname>lower(spans) → base</varname></para>
-				<para><varname>upper(spans) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lower(spans) → base
+upper(spans) → base
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT lower(tstzspan '[2001-01-01, 2001-01-05)');
 -- 2001-01-01
@@ -522,8 +556,10 @@ SELECT upper(tstzspan '[2001-01-01, 2001-01-05)');
 				<indexterm significance="normal"><primary><varname>lowerInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>upperInc</varname></primary></indexterm>
 				<para>¿Es el límite inferior or superior inclusivo?</para>
-				<para><varname>lowerInc(spans) → boolean</varname></para>
-				<para><varname>upperInc(spans) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lowerInc(spans) → boolean
+upperInc(spans) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT lowerInc(datespan '[2001-01-01, 2001-01-05)');
 -- true
@@ -545,8 +581,10 @@ SELECT upperInc(tstzspan '[2001-01-01, 2001-01-05)');
 			<listitem xml:id="setspan_width">
 				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
 				<para>Devuelve el ancho del rango como un número de punto flotante</para>
-				<para><varname>width(numspan) → float</varname></para>
-				<para><varname>width(numspanset,boundspan=false) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+width(numspan) → float
+width(numspanset,boundspan=false) → float
+</programlisting>
 				<para>Se puede establecer a verdadero un parámetro adicional para calcular el ancho del rango delimitador, ignorando así las posibles brechas de valors</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT width(floatspan '[1, 3)');
@@ -561,8 +599,10 @@ SELECT width(intspanset '{[1,3),[5,7)}', true);
 			<listitem xml:id="setspan_duration">
 				<indexterm significance="normal"><primary><varname>duration</varname></primary></indexterm>
 				<para>Devuelve el rango de tiempo</para>
-				<para><varname>duration({datespan,tstzspan}) → interval</varname></para>
-				<para><varname>duration({datespanset,tstzspanset},boundspan boolean=false) → interval</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+duration({datespan,tstzspan}) → interval
+duration({datespanset,tstzspanset},boundspan boolean=false) → interval
+</programlisting>
 				<para>Se puede establecer a verdadero un parámetro adicional para calcular la duración en el rango delimitador, ignorando así las posibles brechas de tiempo</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT duration(datespan '[2001-01-01, 2001-01-03)');
@@ -578,8 +618,10 @@ SELECT duration(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-05)
 				<indexterm significance="normal"><primary><varname>numValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Devuelve el número de valores o los valores</para>
-				<para><varname>numValues(set) → integer</varname></para>
-				<para><varname>getValues(set) → base[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numValues(set) → integer
+getValues(set) → base[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT numValues(intset '{1,3,5,7}');
 -- 4
@@ -593,9 +635,11 @@ SELECT getValues(tstzset '{2001-01-01, 2001-01-03, 2001-01-05, 2001-01-07}');
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
 				<para>Devuelve el valor inicial, final o enésimo</para>
-				<para><varname>startValue(set) → base</varname></para>
-				<para><varname>endValue(set) → base</varname></para>
-				<para><varname>valueN(set,integer) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(set) → base
+endValue(set) → base
+valueN(set,integer) → base
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT startValue(intset '{1,3,5,7}');
 -- 1
@@ -610,8 +654,10 @@ SELECT valueN(floatset '{1,3,5,7}',2);
 				<indexterm significance="normal"><primary><varname>numSpans</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
 				<para>Devuelve el número de rangos o los rangos</para>
-				<para><varname>numSpans(spanset) → integer</varname></para>
-				<para><varname>spans(spanset) → span[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numSpans(spanset) → integer
+spans(spanset) → span[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT numSpans(intspanset '{[1,3),[4,5),[6,7)}');
 -- 3
@@ -631,9 +677,11 @@ SELECT spans(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-04],
 				<indexterm significance="normal"><primary><varname>endSpan</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanN</varname></primary></indexterm>
 				<para>Devuelve el rango inicial, final o enésimo</para>
-				<para><varname>startSpan(spanset) → span</varname></para>
-				<para><varname>endSpan(spanset) → span</varname></para>
-				<para><varname>spanN(spanset,integer) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startSpan(spanset) → span
+endSpan(spanset) → span
+spanN(spanset,integer) → span
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT startSpan(intspanset '{[1,3),[4,5),[6,7)}');
 -- [1,3)
@@ -661,8 +709,10 @@ SELECT spanN(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-04],
 				<indexterm significance="normal"><primary><varname>numDates</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dates</varname></primary></indexterm>
 				<para>Devuelve el (number of) different dates</para>
-				<para><varname>numDates(datespanset) → integer</varname></para>
-				<para><varname>dates(datespanset) → dateset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numDates(datespanset) → integer
+dates(datespanset) → dateset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numDates(datespanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
 -- 4
@@ -676,9 +726,11 @@ SELECT dates(datespanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}')
 				<indexterm significance="normal"><primary><varname>endDate</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dateN</varname></primary></indexterm>
 				<para>Devuelve el start, end, or n-th date</para>
-				<para><varname>startDate(datespanset) → date</varname></para>
-				<para><varname>endDate(datespanset) → date</varname></para>
-				<para><varname>dateN(datespanset,integer) → date</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startDate(datespanset) → date
+endDate(datespanset) → date
+dateN(datespanset,integer) → date
+</programlisting>
 				<para>The functions do not take into account whether the bounds are inclusive or not.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startDate(datespanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
@@ -694,8 +746,10 @@ SELECT dateN(datespanset '{[2001-01-01, 2001-01-03), (2001-01-03, 2001-01-05)}',
 				<indexterm significance="normal"><primary><varname>numTimestamps</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timestamps</varname></primary></indexterm>
 				<para>Devuelve el número o las marcas de tiempo diferentes</para>
-				<para><varname>numTimestamps(tstzspanset) → integer</varname></para>
-				<para><varname>timestamps(tstzspanset) → tstzset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numTimestamps(tstzspanset) → integer
+timestamps(tstzspanset) → tstzset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numTimestamps(tstzspanset '{[2001-01-01, 2001-01-03), (2001-01-03, 2001-01-05)}');
 -- 3
@@ -709,9 +763,11 @@ SELECT timestamps(tstzspanset '{[2001-01-01, 2001-01-03), (2001-01-03, 2001-01-0
 				<indexterm significance="normal"><primary><varname>endTimestamp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timestampN</varname></primary></indexterm>
 				<para>Devuelve la marca de tiempo inicial, final, o enésima</para>
-				<para><varname>startTimestamp(tstzspanset) → timestamptz</varname></para>
-				<para><varname>endTimestamp(tstzspanset) → timestamptz</varname></para>
-				<para><varname>timestampN(tstzspanset,integer) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startTimestamp(tstzspanset) → timestamptz
+endTimestamp(tstzspanset) → timestamptz
+timestampN(tstzspanset,integer) → timestamptz
+</programlisting>
 				<para>The functions do not take into account whether the bounds are inclusive or not.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startTimestamp(tstzspanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
@@ -731,8 +787,10 @@ SELECT timestampN(tstzspanset '{[2001-01-01, 2001-01-03), (2001-01-03, 2001-01-0
 			<listitem xml:id="setspan_expand">
 				<indexterm significance="normal"><primary><varname>expand</varname></primary></indexterm>
 				<para>Expandir o reducir los límites de un rango con un valor o un intervalo de tiempo</para>
-				<para><varname>expand(numspan,base) → numspan</varname></para>
-				<para><varname>expand(tstzspan,interval) → tstzspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+expand(numspan,base) → numspan
+expand(tstzspan,interval) → tstzspan
+</programlisting>
 				<para>La función devuelve NULL si el valor o intervalo dado como segundo argumento es negativo y el rango resultante de desplazar los límites con el argumento está vacío.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expand(floatspan '[1, 3]', 1);
@@ -753,9 +811,11 @@ SELECT expand(tstzspan '[2001-01-01, 2001-01-03]', interval '-2 day');
 			<listitem xml:id="setspan_shift">
 				<indexterm significance="normal"><primary><varname>shift</varname></primary></indexterm>
 				<para>Desplazar con un valor o rango de tiempo</para>
-				<para><varname>shift(numbers,base) → numbers</varname></para>
-				<para><varname>shift(dates,integer) → dates</varname></para>
-				<para><varname>shift(times,interval) → times</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shift(numbers,base) → numbers
+shift(dates,integer) → dates
+shift(times,interval) → times
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT shift(dateset '{2001-01-01, 2001-01-03, 2001-01-05}', 1);
 -- {2001-01-02, 2001-01-04, 2001-01-06}
@@ -774,9 +834,11 @@ SELECT shift(tstzspanset '{[2001-01-01, 2001-01-03], [2001-01-04, 2001-01-05]}',
 			<listitem xml:id="setspan_scale">
 				<indexterm significance="normal"><primary><varname>scale</varname></primary></indexterm>
 				<para>Escalear con un valor o un rango de tiempo</para>
-				<para><varname>scale(numbers,base) → numbers</varname></para>
-				<para><varname>scale(dates,integer) → dates</varname></para>
-				<para><varname>scale(times,interval) → times</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+scale(numbers,base) → numbers
+scale(dates,integer) → dates
+scale(times,interval) → times
+</programlisting>
 				<para>Si el ancho o el lapso de tiempo del valor de entrada es cero (por ejemplo, para un conjunto de marcas de tiempo único), el resultado es el valor de entrada. El valor o rango de tiempo dado debe ser estrictamente mayor que cero.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT scale(tstzset '{2001-01-01}', interval '1 day');
@@ -802,9 +864,11 @@ SELECT scale(tstzset '{2001-01-01}', '-1 day');
 			<listitem xml:id="setspan_shiftScale">
 				<indexterm significance="normal"><primary><varname>shiftScale</varname></primary></indexterm>
 				<para>Desplazar y escalear con los valores o rangos de tiempo</para>
-				<para><varname>shiftScale(numbers,base,base) → numbers</varname></para>
-				<para><varname>shiftScale(dates,integer,integer) → dates</varname></para>
-				<para><varname>shiftScale(times,interval,interval) → times</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftScale(numbers,base,base) → numbers
+shiftScale(dates,integer,integer) → dates
+shiftScale(times,interval,interval) → times
+</programlisting>
 				<para>Estas funciones combinan las funciones <link linkend="setspan_shift"><varname>shift</varname></link> y <link linkend="setspan_scale"><varname>scale</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT shiftScale(tstzset '{2001-01-01}', '1 day', '1 day');
@@ -830,8 +894,10 @@ SELECT shiftScale(tstzspanset '{[2001-01-01, 2001-01-03], [2001-01-04, 2001-01-0
 				<indexterm significance="normal"><primary><varname>floor</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ceil</varname></primary></indexterm>
 				<para>Redondear al entero inferior o superior</para>
-				<para><varname>floor({floatset,floatspans}) → {floatset,floatspans}</varname></para>
-				<para><varname>ceil({floatset,floatspans}) → {floatset,floatspans}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+floor({floatset,floatspans}) → {floatset,floatspans}
+ceil({floatset,floatspans}) → {floatset,floatspans}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT floor(floatset '{1.5,2.5}');
 -- {1, 2}
@@ -847,7 +913,9 @@ SELECT ceil(floatspanset '{[1.5, 2.5],[3.5,4.5]}');
 			<listitem xml:id="floatsetspan_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Redondear a un número de decimales</para>
-				<para><varname>round({floatset,floatspans},integer=0) → {floatset,floatspans}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round({floatset,floatspans},integer=0) → {floatset,floatspans}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(floatset '{1.123456789,2.123456789}', 3);
 -- {1.123, 2.123}
@@ -864,8 +932,10 @@ SELECT round(floatspanset '{[1.123456789, 2.123456789],[3.123456789,4.123456789]
 				<indexterm significance="normal"><primary><varname>degrees</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>radians</varname></primary></indexterm>
 				<para>Convertir a grados o radianes</para>
-				<para><varname>degrees({floatset,floatspans}, normalize=false) → {floatset,floatspans}</varname></para>
-				<para><varname>radians({floatset,floatspans}) → {floatset,floatspans}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+degrees({floatset,floatspans}, normalize=false) → {floatset,floatspans}
+radians({floatset,floatspans}) → {floatset,floatspans}
+</programlisting>
 				<para>El parámetro adicional en la función <varname>degrees</varname> puede ser utilizado para normalizar los valores entre 0 y 360 grados.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(degrees(floatset '{0, 0.5, 0.7, 1.0}', true), 3);
@@ -880,9 +950,11 @@ SELECT round(radians(floatspanset '{[0, 45], [90, 135]}'), 3);
 				<indexterm significance="normal"><primary><varname>upper</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>initcap</varname></primary></indexterm>
 				<para>Transformar en minúsculas, majúsculas o initcap</para>
-				<para><varname>lower(textset) → textset</varname></para>
-				<para><varname>upper(textset) → textset</varname></para>
-				<para><varname>initcap(textset) → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lower(textset) → textset
+upper(textset) → textset
+initcap(textset) → textset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT lower(textset '{"AAA", "BBB", "CCC"}');
 -- {"aaa", "bbb", "ccc"}
@@ -896,7 +968,9 @@ SELECT initcap(textset '{"aaa", "bbb", "ccc"}');
 			<listitem xml:id="textset_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
 				<para>Concatenación de texto</para>
-				<para><varname>{text,textset} || {text,textset} → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{text,textset} || {text,textset} → textset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT textset '{aaa, bbb}' || text 'XX';
 -- {"aaaXX", "bbbXX"}
@@ -908,7 +982,9 @@ SELECT text 'XX' || textset '{aaa, bbb}';
 			<listitem xml:id="time_tprecision">
 				<indexterm significance="normal"><primary><varname>tprecision</varname></primary></indexterm>
 				<para>Establecer la precisión temporal del valor de tiempo al rango con respecto al origen</para>
-				<para><varname>tprecision(times,interval,origin timestamptz=’2000-01-03’) → times</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tprecision(times,interval,origin timestamptz=’2000-01-03’) → times
+</programlisting>
 				<para>Si el origen no se especifica, su valor se establece por defecto en lunes 3 de enero de 2000.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tprecision(timestamptz '2001-12-03', '30 days');
@@ -941,8 +1017,10 @@ SELECT tprecision(tstzspanset '{[2001-12-01 08:00, 2001-12-01 09:00],
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Devuelve o especifica el identificador de referencia espacial</para>
-				<para><varname>SRID(spatialset) → integer</varname></para>
-				<para><varname>setSRID(spatialset) → spatialset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(spatialset) → integer
+setSRID(spatialset) → spatialset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT SRID(geomset '{"Point(1 1)", "Point(2 2)"}');
 -- 0
@@ -967,9 +1045,11 @@ SELECT asEWKT(setSRID(cbufferset '{"Cbuffer(Point(1 1),0.5)",
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transformar a una referencia espacial diferente</para>
-				<para><varname>transform(spatialset,to_srid integer) → spatialset</varname></para>
-				<para><varname>transformPipeline(spatialset,pipeline text,to_srid integer,is_forward boolean=true) →</varname></para>
-				<para><varname>  spatialset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(spatialset,to_srid integer) → spatialset
+transformPipeline(spatialset,pipeline text,to_srid integer,is_forward boolean=true) →
+  spatialset
+</programlisting>
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el conjunto tiene un SRID desconocido (representado por 0). La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas en el siguiente formato:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
 				<para>El SRID del conjunto de entrada se ignora y el SRID de la conjunto de salida se establecerá en cero a menos que se proporcione un valor a través del parámetro opcional <varname>to_srid</varname>. Como se indica en el último parámetro, la canalización se ejecuta de forma predeterminada en dirección hacia adelante; al establecer el parámetro en falso, la canalización se ejecuta en la dirección inversa.</para>
@@ -1001,8 +1081,10 @@ FROM test;
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 				<para>Unión, diferencia o intersección de conjuntos o de rangos</para>
-				<para><varname>set {+, - , *} set → set</varname></para>
-				<para><varname>spans {+, - , *} spans → spans</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+set {+, - , *} set → set
+spans {+, - , *} spans → spans
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT dateset '{2001-01-01, 2001-01-03, 2001-01-05}' +
   dateset '{2001-01-03, 2001-01-06}';
@@ -1057,7 +1139,9 @@ SELECT tstzspan '[2001-01-01, 2001-01-05)' * tstzspan '[2001-01-03, 2001-01-07)'
 				<listitem xml:id="setspan_overlaps">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 					<para>¿Se superponen los valores (tienen valores en común)?</para>
-					<para><varname>{set,spans} &amp;&amp; {set,spans} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{set,spans} &amp;&amp; {set,spans} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT intset '{1, 3}' &amp;&amp; intset '{2, 3, 4}';
 -- true
@@ -1073,7 +1157,9 @@ SELECT tstzspan '[2001-01-01, 2001-01-05)' &amp;&amp; tstzspan '[2001-01-02, 200
 				<listitem xml:id="setspan_contains">
 					<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
 					<para>¿Contiene el primer valor el segundo?</para>
-					<para><varname>{set,spans} @&gt; {base,set,span} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{set,spans} @&gt; {base,set,span} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT floatset '{1.5, 2.5}' @&gt; 2.5;
 -- true
@@ -1087,7 +1173,9 @@ SELECT floatspanset '{[1, 2),(2, 3)}' @&gt; 2.0;
 				<listitem xml:id="setspan_containedby">
 					<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
 					<para>¿Está el primer valor contenido en el segundo?</para>
-					<para><varname>{base,set,spans} &lt;@ {set,spans} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{base,set,spans} &lt;@ {set,spans} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT timestamptz '2001-01-10' &lt;@ tstzspan '[2001-01-01, 2001-05-01)';
 -- true
@@ -1103,7 +1191,9 @@ SELECT tstzspan '[2001-02-01, 2001-03-01)' &lt;@ tstzspan '[2001-01-01, 2001-05-
 				<listitem xml:id="setspan_adjacent">
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 					<para>¿Es el primer valor adyacente al segundo? Dos valores son adyacentes cuando se tocan sin solaparse, es decir, cuando comparten una frontera y no tienen ningún valor en común en ella. Para los tipos base continuos <varname>float</varname> y <varname>timestamptz</varname>, un límite compartido es ese contacto. Para los tipos base discretos <varname>int</varname>, <varname>bigint</varname> y <varname>date</varname>, cuyos rangos se almacenan en forma normal, significa valores consecutivos.</para>
-					<para><varname>spans -|- spans → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spans -|- spans → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT intspan '[2, 6)' -|- intspan '[6, 7)';
 -- true
@@ -1144,8 +1234,10 @@ SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 12;
 					<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
 					<para>¿Está el primer valor estrictamente a la izquierda del segundo?</para>
-					<para><varname>numbers &lt;&lt; numbers → boolean</varname></para>
-					<para><varname>times &lt;&lt;# times → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numbers &lt;&lt; numbers → boolean
+times &lt;&lt;# times → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT intspan '[15, 20)' &lt;&lt; 20;
 -- true
@@ -1162,8 +1254,10 @@ SELECT dateset '{2001-01-01, 2001-01-02}' &lt;&lt;# dateset '{2001-01-03, 2001-0
 					<indexterm significance="normal"><primary><varname>&gt;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
 					<para>¿Está el primer valor estrictamente a la derecha del segundo?</para>
-					<para><varname>numbers &gt;&gt; numbers → boolean</varname></para>
-					<para><varname>times #&gt;&gt; times → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numbers &gt;&gt; numbers → boolean
+times #&gt;&gt; times → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT intspan '[15, 20)' &gt;&gt; 10;
 -- true
@@ -1181,8 +1275,10 @@ SELECT tstzspan '[2001-01-04, 2001-01-05)' #&gt;&gt;
 					<indexterm significance="normal"><primary><varname>&amp;&lt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&amp;&lt;#</varname></primary></indexterm>
 					<para>¿No está el primer valor a la derecha del segundo?</para>
-					<para><varname>numbers &amp;&lt; numbers → boolean</varname></para>
-					<para><varname>times &amp;&lt;# times → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numbers &amp;&lt; numbers → boolean
+times &amp;&lt;# times → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT intspan '[15, 20)' &amp;&lt; 18;
 -- false
@@ -1199,8 +1295,10 @@ SELECT dateset '{2001-01-02, 2001-01-05}' &amp;&lt;# dateset '{2001-01-01, 2001-
 					<indexterm significance="normal"><primary><varname>&amp;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&amp;&gt;</varname></primary></indexterm>
 					<para>¿No está el primer valor a la izquierda del segundo?</para>
-					<para><varname>numbers &amp;&gt; numbers → boolean</varname></para>
-					<para><varname>times #&amp;&gt; times → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numbers &amp;&gt; numbers → boolean
+times #&amp;&gt; times → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT intspan '[15, 20)' &amp;&gt; 30;
 -- true
@@ -1226,8 +1324,10 @@ SELECT timestamp '2001-01-01' #&amp;&gt; tstzspan '[2001-01-01, 2001-01-05)';
 				<listitem xml:id="setspan_splitNSpans">
 					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 					<para>Devuelve una matriz de N rangos obtenida fusionando los elementos de un conjunto o los rangos de un conjunto de rangos</para>
-					<para><varname>splitNSpans(set, integer) → span[]</varname></para>
-					<para><varname>splitNSpans(spanset, integer) → span[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+splitNSpans(set, integer) → span[]
+splitNSpans(spanset, integer) → span[]
+</programlisting>
 					<para>El último argumento especifica el número de rangos de salida. Si el número de elementos o rangos de entrada es menor que el número especificado, la matriz resultante tendrá un rango por elemento o rango de entrada. De lo contrario, el número especificado de rangos de salida se obtendrá fusionando elementos o rangos de entrada consecutivos.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT splitNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
@@ -1253,8 +1353,10 @@ SELECT splitNSpans(datespanset '{[2000-01-01, 2000-01-04), [2000-01-05, 2000-01-
 				<listitem xml:id="setspan_splitEachNSpans">
 					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 					<para>Devuelve una matriz de rangos obtenida fusionando N elementos consecutivos de un conjunto o N rangos consecutivos de un conjunto de rangos</para>
-					<para><varname>splitEachNSpans(set, integer) → span[]</varname></para>
-					<para><varname>splitEachNSpans(spanset, integer) → span[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+splitEachNSpans(set, integer) → span[]
+splitEachNSpans(spanset, integer) → span[]
+</programlisting>
 					<para>El último argumento especifica el número de elementos de entrada que se fusionan para producir un rango de salida. Si la cantidad de elementos de entrada es menor que el número especificado, la matriz resultante tendrá un rango de salida por elemento. De lo contrario, la cantidad especificada de elementos de entrada consecutivos se fusionará en un único rango de salida en la respuesta. Observe que, a diferencia de la función <link linkend="setspan_splitNSpans"><varname>splitNSpans</varname></link>, el número de rangos en el resultado depende del número de elementos o de rangos de entrada.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT splitEachNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
@@ -1281,9 +1383,11 @@ SELECT splitEachNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 12);
 			<listitem xml:id="smallest_distance_time">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Devuelve la distancia mínima</para>
-				<para><varname>numbers &lt;-&gt; numbers → base</varname></para>
-				<para><varname>dates &lt;-&gt; dates → integer</varname></para>
-				<para><varname>times &lt;-&gt; times → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numbers &lt;-&gt; numbers → base
+dates &lt;-&gt; dates → integer
+times &lt;-&gt; times → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT 3 &lt;-&gt; intspan '[6, 8)';
 -- 3
@@ -1318,8 +1422,10 @@ SELECT dateset '{2001-01-01, 2001-01-03, 2001-01-05}' &lt;-&gt;
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
-				<para><varname>set {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} set → boolean</varname></para>
-				<para><varname>spans {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} spans → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+set {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} set → boolean
+spans {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} spans → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT intspan '[1,3]' = intspan '[1,4)';
 -- true
@@ -1366,7 +1472,9 @@ SELECT intspanset '{[1, 4)}' &gt;= intspanset '{[1, 5), [6, 7)}';
 			<listitem xml:id="setspan_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Rango o período delimitador</para>
-				<para><varname>extent({set,spans}) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent({set,spans}) → span
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 WITH spans(r) AS (
   SELECT floatspan '[1, 4)' UNION SELECT floatspan '(5, 8)' UNION
@@ -1393,8 +1501,10 @@ SELECT extent(ps) FROM periods;
 				<indexterm significance="normal"><primary><varname>spanUnion</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spansetUnion</varname></primary></indexterm>
 				<para>Unión agregada</para>
-				<para><varname>setUnion({value,set}) → set</varname></para>
-				<para><varname>spanUnion(spans) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setUnion({value,set}) → set
+spanUnion(spans) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 WITH times(ts) AS (
   SELECT tstzset '{2001-01-01, 2001-01-03, 2001-01-05}' UNION
@@ -1414,7 +1524,9 @@ SELECT spanUnion(ps) FROM periods;
 			<listitem xml:id="setspan_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
-				<para><varname>tCount(times) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(times) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 WITH times(ts) AS (
   SELECT tstzset '{2001-01-01, 2001-01-03, 2001-01-05}' UNION

--- a/doc/es/temporal_alpha.xml
+++ b/doc/es/temporal_alpha.xml
@@ -51,10 +51,12 @@
 				<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Convertir un número temporal en un rango o un cuadro delimitador temporal</para>
-				<para><varname>tnumber::{span,tbox}</varname></para>
-				<para><varname>valueSpan(tnumber) → numspan</varname></para>
-				<para><varname>timeSpan(tnumber) → tstzspan</varname></para>
-				<para><varname>tbox(tnumber) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnumber::{span,tbox}
+valueSpan(tnumber) → numspan
+timeSpan(tnumber) → tstzspan
+tbox(tnumber) → tbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 2@2001-01-03]'::intspan;
 -- [1, 3)
@@ -78,8 +80,10 @@ SELECT tfloat '(1@2001-01-01, 3@2001-01-03, 2@2001-01-05]'::tbox;
 				<indexterm significance="normal"><primary><varname>tint(tbool)</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tint</varname></primary></indexterm>
 				<para>Convertir entre un booleano temporal y un entero temporal</para>
-				<para><varname>tbool::tint</varname></para>
-				<para><varname>tint(tbool) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbool::tint
+tint(tbool) → tint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
 -- [1@2001-01-01, 0@2001-01-03]
@@ -90,8 +94,10 @@ SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tnumber(tnumber)</varname></primary></indexterm>
 				<para>Convertir entre enteros temporales, enteros grandes temporales y flotantes temporales</para>
-				<para><varname>tnumber::tnumber</varname></para>
-				<para><varname>tnumber(tnumber) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnumber::tnumber
+tnumber(tnumber) → tnumber
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 2@2001-01-03]'::tfloat;
 -- Interp=Step;[1@2001-01-01, 2@2001-01-03]
@@ -112,7 +118,9 @@ SELECT tint(tfloat '[1.5@2001-01-01, 2.5@2001-01-03]');
 			<listitem xml:id="talpha_valueSpan">
 				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
 				<para>Devuelve el intervalo de valores ignorando las brechas potenciales</para>
-				<para><varname>valueSpan(tnumber) → numspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueSpan(tnumber) → numspan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueSpan(tint '{[1@2001-01-01, 1@2001-01-03), [4@2001-01-03, 6@2001-01-05]}');
 -- [1,7)
@@ -124,7 +132,9 @@ SELECT valueSpan(tfloat '{1@2001-01-01, 2@2001-01-03, 3@2001-01-05}');
 			<listitem xml:id="talpha_valueSet">
 				<indexterm significance="normal"><primary><varname>valueSet</varname></primary></indexterm>
 				<para>Devuelve el conjunto de valores de un número temporal</para>
-				<para><varname>valueSet(tnumber) → numset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueSet(tnumber) → numset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueSet(tint '[1@2001-01-01, 2@2001-01-03]');
 -- {1, 2}
@@ -138,9 +148,11 @@ SELECT valueSet(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 4@2001-01-
 				<indexterm significance="normal"><primary><varname>maxValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>avgValue</varname></primary></indexterm>
 				<para>Devuelve el valor mínimo, máximo, o promedio</para>
-				<para><varname>minValue(torder) → base</varname></para>
-				<para><varname>maxValue(torder) → base</varname></para>
-				<para><varname>avgValue(tnumber) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minValue(torder) → base
+maxValue(torder) → base
+avgValue(tnumber) → base
+</programlisting>
 				<para>Las funciones no tienen en cuenta si los límites son inclusivos o no.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minValue(tfloat '{1@2001-01-01, 2@2001-01-03, 3@2001-01-05}');
@@ -162,8 +174,10 @@ SELECT maxValue(ttext '{[A@2001-01-01, B@2001-01-02], [C@2001-01-03, E@2001-01-0
 				<indexterm significance="normal"><primary><varname>minInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>maxInstant</varname></primary></indexterm>
 				<para>Devuelve el instante con el valor mínimo o máximo</para>
-				<para><varname>minInstant(torder) → base</varname></para>
-				<para><varname>maxInstant(torder) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minInstant(torder) → base
+maxInstant(torder) → base
+</programlisting>
 				<para>Las funciones no tienen en cuenta si los límites son inclusivos o no. Si varios instantes tienen el valor mínimo, se devuelve el primero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minInstant(tfloat '{1@2001-01-01, 2@2001-01-03, 3@2001-01-05}');
@@ -183,9 +197,11 @@ SELECT maxInstant(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-0
 				<indexterm significance="normal"><primary><varname>scaleValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleValue</varname></primary></indexterm>
 				<para>Desplazar y/o escalear el rango de valores de un número temporal con uno o dos números</para>
-				<para><varname>shiftValue(tnumber,base) → tnumber</varname></para>
-				<para><varname>scaleValue(tnumber,width) → tnumber</varname></para>
-				<para><varname>shiftScaleValue(tnumber,base,base) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftValue(tnumber,base) → tnumber
+scaleValue(tnumber,width) → tnumber
+shiftScaleValue(tnumber,base,base) → tnumber
+</programlisting>
 				<para>Cuando se escalea, si el rango de valores del valor temporal es un valor único (por ejemplo, para un instante temporal), el resultado es el valor temporal. Además, el ancho data debe ser estrictamente superio que cero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftValue(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}', 1);
@@ -209,7 +225,9 @@ SELECT shiftScaleValue(tfloat '{[1@2001-01-01,2@2001-01-02],[3@2001-01-03,4@2001
 			<listitem xml:id="tnumber_stops">
 				<indexterm significance="normal"><primary><varname>stops</varname></primary></indexterm>
 				<para>Extraer de un flotante temporal con interpolación lineal las subsecuencias donde los valores permanecen en un rango de un ancho dado durante al menos una duración dada</para>
-				<para><varname>stops(tfloat,maxDist=0.0,minDuration='0 minutes') → tfloatSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stops(tfloat,maxDist=0.0,minDuration='0 minutes') → tfloatSeqSet
+</programlisting>
 				<para>Si <varname>maxDist</varname> no se especifica, el valor 0.0 se asume por defecto y por lo tanto, la functión extrae los segmentos constantes del flotante temporal.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stops(tfloat '[1@2001-01-01, 1@2001-01-02, 2@2001-01-03]');
@@ -230,10 +248,12 @@ SELECT stops(tfloat '[1@2001-01-01, 1@2001-01-02, 2@2001-01-03]', 0.0, '2 days')
 				<indexterm significance="normal"><primary><varname>minusMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusMax</varname></primary></indexterm>
 				<para>Restringir al (complemento del) valor mínimo o máximo</para>
-				<para><varname>atMin(torder) → torder</varname></para>
-				<para><varname>atMax(torder) → torder</varname></para>
-				<para><varname>minusMin(torder) → torder</varname></para>
-				<para><varname>minusMax(torder) → torder</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atMin(torder) → torder
+atMax(torder) → torder
+minusMin(torder) → torder
+minusMax(torder) → torder
+</programlisting>
 				<para>La función devuelve un valor nulo si el valor mínimo o máximo sólo ocurre en límites exclusivos.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT atMin(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}');
@@ -279,8 +299,10 @@ SELECT minusMax(tfloat '{[1@2001-01-01, 3@2001-01-03), (3@2001-01-03, 1@2001-01-
 				<indexterm significance="normal"><primary><varname>atTbox</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusTbox</varname></primary></indexterm>
 				<para>Restringir a (al complemento de) un <varname>tbox</varname></para>
-				<para><varname>atTbox(tnumber,tbox) → tnumber</varname></para>
-				<para><varname>minusTbox(tnumber,tbox) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atTbox(tnumber,tbox) → tnumber
+minusTbox(tnumber,tbox) → tnumber
+</programlisting>
 				<para>When the bounding box has both value and time dimensions, the functions restrict the temporal number with respect to the value <emphasis>and</emphasis> the time extents of the box.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT atTbox(tfloat '[0@2001-01-01, 3@2001-01-04)',
@@ -308,7 +330,9 @@ SELECT minusSpan(minusTime(temp, box::tstzspan), box::floatspan) FROM temp;
 				<indexterm significance="normal"><primary><varname>&amp;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>|</varname></primary></indexterm>
 				<para>Y temporal, o temporal</para>
-				<para><varname>{boolean,tbool} {&amp; |} {boolean,tbool} → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{boolean,tbool} {&amp; |} {boolean,tbool} → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tbool '[true@2001-01-03, true@2001-01-05)' &amp;
   tbool '[false@2001-01-03, false@2001-01-05)';
@@ -328,7 +352,9 @@ SELECT tbool '[true@2001-01-03, true@2001-01-05)' |
 			<listitem xml:id="tbool_not">
 				<indexterm significance="normal"><primary><varname>~</varname></primary></indexterm>
 				<para>No temporal</para>
-				<para><varname>~tbool → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+~tbool → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT ~tbool '[true@2001-01-03, true@2001-01-05)';
 -- [f@2001-01-03, f@2001-01-05)
@@ -338,7 +364,9 @@ SELECT ~tbool '[true@2001-01-03, true@2001-01-05)';
 			<listitem xml:id="tbool_whenTrue">
 				<indexterm significance="normal"><primary><varname>whenTrue</varname></primary></indexterm>
 				<para>Devuelve el tiempo cuando un booleano temporal toma el valor verdadero</para>
-				<para><varname>whenTrue(tbool) → tstzspanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+whenTrue(tbool) → tstzspanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT whenTrue(tfloat '[1@2001-01-01, 4@2001-01-04, 1@2001-01-07]' #> 2);
 -- {(2001-01-02, 2001-01-06)}
@@ -360,7 +388,9 @@ SELECT whenTrue(tdwithin(tgeompoint '[Point(1 1)@2001-01-01, Point(4 4)@2001-01-
 				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>/</varname></primary></indexterm>
 				<para>Adición, resta, multiplicación y división temporal</para>
-				<para><varname>{number,tnumber} {+, -, *, /} {number,tnumber} → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{number,tnumber} {+, -, *, /} {number,tnumber} → tnumber
+</programlisting>
 				<para>La división temporal genera un error si el denominador es alguna vez igual a cero durante el intervalo de tiempo común de los argumentos.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tint '[2@2001-01-01, 2@2001-01-04)' + 1;
@@ -403,7 +433,9 @@ SELECT tfloat '[-1@2001-01-04, 1@2001-01-05]' / tfloat '[-1@2001-01-01, 1@2001-0
 			<listitem xml:id="tnumber_abs">
 				<indexterm significance="normal"><primary><varname>abs</varname></primary></indexterm>
 				<para>Devuelve el valor absoluto del número temporal</para>
-				<para><varname>abs(tnumber) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+abs(tnumber) → tnumber
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT abs(tfloat '[1@2001-01-01, -1@2001-01-03, 1@2001-01-05]');
 -- [1@2001-01-01, 0@2001-01-02, 1@2001-01-03, 0@2001-01-04, 1@2001-01-05],
@@ -416,8 +448,10 @@ SELECT abs(tint '[1@2001-01-01, -1@2001-01-03, 1@2001-01-05]');
 				<indexterm significance="normal"><primary><varname>floor</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ceil</varname></primary></indexterm>
 				<para>Redondear al entero inferior o superior</para>
-				<para><varname>floor(tfloat) → tfloat</varname></para>
-				<para><varname>ceil(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+floor(tfloat) → tfloat
+ceil(tfloat) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT floor(tfloat '[0.5@2001-01-01, 1.5@2001-01-02]');
 -- [0@2001-01-01, 1@2001-01-02]
@@ -429,7 +463,9 @@ SELECT ceil(tfloat '[0.5@2001-01-01, 0.6@2001-01-02, 0.7@2001-01-03]');
 			<listitem xml:id="tnumber_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Redondear a un número de posiciones decimales</para>
-				<para><varname>round(tfloat,integer=0) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tfloat,integer=0) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(tfloat '[0.785398163397448@2001-01-01, 2.356194490192345@2001-01-02]', 2);
 -- [0.79@2001-01-01, 2.36@2001-01-02]
@@ -440,8 +476,10 @@ SELECT round(tfloat '[0.785398163397448@2001-01-01, 2.356194490192345@2001-01-02
 				<indexterm significance="normal"><primary><varname>degrees</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>radians</varname></primary></indexterm>
 				<para>Convertir a grados o radianes</para>
-				<para><varname>degrees({float,tfloat},normalize=false) → tfloat</varname></para>
-				<para><varname>radians(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+degrees({float,tfloat},normalize=false) → tfloat
+radians(tfloat) → tfloat
+</programlisting>
 				<para>El parámetro adicional en la función <varname>degrees</varname> puede ser utilizado para normalizar los valores entre 0 y 360 grados.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT degrees(pi() * 5);
@@ -458,7 +496,9 @@ SELECT radians(tfloat '[45@2001-01-01, 135@2001-01-02]');
 			<listitem xml:id="tnumber_deltaValue">
 				<indexterm significance="normal"><primary><varname>deltaValue</varname></primary></indexterm>
 				<para>Devuelve la diferencia de valor entre instantes consectivos del número temporal</para>
-				<para><varname>deltaValue(tnumber) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+deltaValue(tnumber) → tnumber
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT deltaValue(tint '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03]');
 -- [1@2001-01-01, -1@2001-01-02, -1@2001-01-03)
@@ -472,7 +512,9 @@ SELECT deltaValue(tfloat '{[1.5@2001-01-01, 2@2001-01-02, 1@2001-01-03],
 			<listitem xml:id="tfloat_trend">
 				<indexterm significance="normal"><primary><varname>trend</varname></primary></indexterm>
 				<para>Devuelve la tendencia de un flotante temporal con interpolación lineal, que indica si su valor es creciente, constante o decreciente, representado, respectivamente, por 1, 0 y -1.</para>
-				<para><varname>trend(tfloat) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trend(tfloat) → tint
+</programlisting>
 				<para>Nótese que la tendencia es NULL para secuencias instantáneas.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trend(tfloat '[1@2001-01-01, 2@2001-01-02, 4@2001-01-03, 4@2001-01-04,
@@ -486,7 +528,9 @@ SELECT trend(tfloat '[1@2001-01-01]');
 			<listitem xml:id="tnumber_derivative">
 				<indexterm significance="normal"><primary><varname>derivative</varname></primary></indexterm>
 				<para>Devuelve la derivada sobre el tiempo del número flotante temporal en unidades por segundo</para>
-				<para><varname>derivative(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+derivative(tfloat) → tfloat
+</programlisting>
 				<para>El número flotante temporal debe tener interpolación linear. Nótese que esta función corresponde a la función <link linkend="tgeo_speed"><varname>speed</varname></link> para los puntos temporales.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT derivative(tfloat '{[0@2001-01-01, 10@2001-01-02, 5@2001-01-03],
@@ -501,7 +545,9 @@ SELECT derivative(tfloat 'Interp=Step;[0@2001-01-01, 10@2001-01-02, 5@2001-01-03
 			<listitem xml:id="tnumber_integral">
 				<indexterm significance="normal"><primary><varname>integral</varname></primary></indexterm>
 				<para>Devuelve el área bajo la curva</para>
-				<para><varname>integral(tnumber) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+integral(tnumber) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT  integral(tint '[1@2001-01-01,2@2001-01-02]') / (24 * 3600 * 1e6);
 -- 1
@@ -513,7 +559,9 @@ SELECT integral(tfloat '[1@2001-01-01,2@2001-01-02]') / (24 * 3600 * 1e6);
 			<listitem xml:id="tnumber_twAvg">
 				<indexterm significance="normal"><primary><varname>twAvg</varname></primary></indexterm>
 				<para>Devuelve el promedio ponderado en el tiempo</para>
-				<para><varname>twAvg(tnumber) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+twAvg(tnumber) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT twAvg(tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-04, 2@2001-01-06)}');
 -- 1.75
@@ -524,8 +572,10 @@ SELECT twAvg(tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-04, 2@2001-01-06)
 				<indexterm significance="normal"><primary><varname>ln</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>log10</varname></primary></indexterm>
 				<para>Devuelve el logaritmo natural y el logaritmo base 10 de un número flotante temporal</para>
-				<para><varname>ln(tfloat) → tfloat</varname></para>
-				<para><varname>log10(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ln(tfloat) → tfloat
+log10(tfloat) → tfloat
+</programlisting>
 				<para>El número flotante temporal no puede ser cero o negativo</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT ln(tfloat '{[1@2001-01-01, 10@2001-01-02, 5@2001-01-03],
@@ -540,7 +590,9 @@ SELECT log10(tfloat 'Interp=Step;[-10@2001-01-01, 10@2001-01-02]');
 			<listitem xml:id="tnumber_exp">
 				<indexterm significance="normal"><primary><varname>exp</varname></primary></indexterm>
 				<para>Devuelve el exponencial (e elevado a la potencia dada) de un número flotante temporal</para>
-				<para><varname>exp(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+exp(tfloat) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT exp(tfloat '{[1@2001-01-01, 10@2001-01-02],
   [1@2001-01-04, 1@2001-01-05]}');
@@ -556,9 +608,11 @@ SELECT exp(tfloat '{-10@2001-01-01, 0@2001-01-02, 10@2001-01-03}');
 				<indexterm significance="normal"><primary><varname>cos</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tan</varname></primary></indexterm>
 				<para>Devuelve el seno, coseno o tangente de un número flotante temporal (argumento en radianes)</para>
-				<para><varname>sin(tfloat) → tfloat</varname></para>
-				<para><varname>cos(tfloat) → tfloat</varname></para>
-				<para><varname>tan(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+sin(tfloat) → tfloat
+cos(tfloat) → tfloat
+tan(tfloat) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(sin(tfloat '[0@2001-01-01, 6.283185307@2001-01-02]'), 6);
 -- [0@2001-01-01, -0.000000@2001-01-02]
@@ -578,7 +632,9 @@ SELECT round(tan(tfloat '{0@2001-01-01, 0.785398163@2001-01-02}'), 6);
 			<listitem xml:id="ttext_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
 				<para>Concatenación de texto</para>
-				<para><varname>{text,ttext} || {text,ttext} → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{text,ttext} || {text,ttext} → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT ttext '[AA@2001-01-01, AA@2001-01-04)' || text 'B';
 -- ["AAB"@2001-01-01, "AAB"@2001-01-04)
@@ -595,9 +651,11 @@ SELECT ttext '[A@2001-01-01, B@2001-01-03, C@2001-01-04]' ||
 				<indexterm significance="normal"><primary><varname>upper</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>initcap</varname></primary></indexterm>
 				<para>Transformar en minúsculas, mayúsculas o initcap</para>
-				<para><varname>lower(ttext) → ttext</varname></para>
-				<para><varname>upper(ttext) → ttext</varname></para>
-				<para><varname>initcap(ttext) → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lower(ttext) → ttext
+upper(ttext) → ttext
+initcap(ttext) → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT upper(ttext '[AA@2001-01-01, bb@2001-01-02]');
 -- ["AA"@2001-01-01, "BB"@2001-01-02]

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -54,8 +54,10 @@ SELECT cbuffer 'Cbuffer(Point(1 1), -2.0)';
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Devuelve la representación de texto conocido (Well-Known Text o WKT) o la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-					<para><varname>asText({cbuffer,cbuffer[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({cbuffer,cbuffer[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({cbuffer,cbuffer[]}) → {text,text[]}
+asEWKT({cbuffer,cbuffer[]}) → {text,text[]}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(cbuffer 'Cbuffer(Point(1 1), 0.5)');
 -- Cbuffer(POINT(1 1),0.5)
@@ -75,10 +77,12 @@ SELECT asEWKT(ARRAY[cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.2)',
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 					<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-					<para><varname>asBinary(cbuffer,endian text='') → bytea</varname></para>
-					<para><varname>asEWKB(cbuffer,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(cbuffer,endian text='') → text</varname></para>
-					<para><varname>asHexEWKB(cbuffer,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(cbuffer,endian text='') → bytea
+asEWKB(cbuffer,endian text='') → bytea
+asHexWKB(cbuffer,endian text='') → text
+asHexEWKB(cbuffer,endian text='') → text
+</programlisting>
 					<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina. Un búfer circular toma su SRID de su punto subyacente: <varname>asEWKB</varname> y <varname>asHexEWKB</varname> lo incluyen, mientras que las formas simples <varname>asBinary</varname> y <varname>asHexWKB</varname> lo omiten.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
@@ -96,8 +100,10 @@ SELECT asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
 					<indexterm significance="normal"><primary><varname>cbufferFromText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>cbufferFromEWKT</varname></primary></indexterm>
 					<para>Entrada desde la representación de texto conocido (Well-Known Text o WKT) o desde la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-					<para><varname>cbufferFromText(text) → cbuffer</varname></para>
-					<para><varname>cbufferFromEWKT(text) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+cbufferFromText(text) → cbuffer
+cbufferFromEWKT(text) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(cbufferFromText(text 'Cbuffer(Point(1 1),0.5)'));
 -- Cbuffer(POINT(1 1),0.5)
@@ -111,9 +117,11 @@ SELECT asEWKT(cbufferFromEWKT(text 'SRID=5676;Cbuffer(Point(1 1),0.5)'));
 					<indexterm significance="normal"><primary><varname>cbufferFromEWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>cbufferFromHexEWKB</varname></primary></indexterm>
 					<para>Entrada desde la representación binaria conocida (Well-Known Binary o WKB), desde la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o desde la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-					<para><varname>cbufferFromBinary(bytea) → cbuffer</varname></para>
-					<para><varname>cbufferFromEWKB(bytea) → cbuffer</varname></para>
-					<para><varname>cbufferFromHexEWKB(text) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+cbufferFromBinary(bytea) → cbuffer
+cbufferFromEWKB(bytea) → cbuffer
+cbufferFromHexEWKB(text) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(cbufferFromBinary(
   '\x0100000000000000f03f000000000000f03f000000000000e03f'));
@@ -135,7 +143,9 @@ SELECT asEWKT(cbufferFromHexEWKB(
 				<listitem xml:id="cbuffer">
 					<indexterm significance="normal"><primary><varname>cbuffer</varname></primary></indexterm>
 					<para>Constructor para búferes circulares</para>
-					<para><varname>cbuffer(geompoint,float) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+cbuffer(geompoint,float) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(cbuffer(ST_Point(1,1), 0.3));
 -- Cbuffer(POINT(1 1),0.3)
@@ -151,8 +161,10 @@ SELECT asText(cbuffer(ST_Point(1,1), 0.3));
 				<listitem xml:id="cbuffer_geometry">
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Convertir entre un búfer circular y una geometría</para>
-					<para><varname>geometry::cbuffer</varname></para>
-					<para><varname>cbuffer::geometry</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geometry::cbuffer
+cbuffer::geometry
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(cbuffer(ST_Point(1,1), 1)::geometry);
 -- CURVEPOLYGON(CIRCULARSTRING(0 1,2 1,0 1))
@@ -166,8 +178,10 @@ SELECT asText(geometry 'SRID=5676;LINESTRING(0 0,2 2)'::cbuffer);
 			<listitem xml:id="cbuffer_stbox">
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convertir un búfer circular y, opcionalmente, una marca de tiempo o un período, a un cuadro espaciotemporal</para>
-				<para><varname>stbox(cbuffer) → stbox</varname></para>
-				<para><varname>stbox(cbuffer,{timestamptz,tstzspan}) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stbox(cbuffer) → stbox
+stbox(cbuffer,{timestamptz,tstzspan}) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(cbuffer 'SRID=5676;Cbuffer(Point(1 1),0.3)');
 -- SRID=5676;STBOX X((0.7,0.7),(1.3,1.3))
@@ -186,7 +200,9 @@ SELECT stbox(cbuffer 'Cbuffer(Point(1 1),0.3)', tstzspan '[2001-01-01,2001-01-02
 				<listitem xml:id="cbuffer_point">
 					<indexterm significance="normal"><primary><varname>point</varname></primary></indexterm>
 					<para>Devuelve el punto</para>
-					<para><varname>point(cbuffer) → geompoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+point(cbuffer) → geompoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(point(cbuffer 'Cbuffer(Point(1 1), 0.3)'));
 -- Point(1 1)
@@ -196,7 +212,9 @@ SELECT ST_AsText(point(cbuffer 'Cbuffer(Point(1 1), 0.3)'));
 				<listitem xml:id="cbuffer_radius">
 					<indexterm significance="normal"><primary><varname>radius</varname></primary></indexterm>
 					<para>Devuelve el radio</para>
-					<para><varname>radius(cbuffer) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+radius(cbuffer) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT radius(cbuffer 'Cbuffer(Point(1 1), 0.3)');
 -- 0.3
@@ -211,7 +229,9 @@ SELECT radius(cbuffer 'Cbuffer(Point(1 1), 0.3)');
 				<listitem xml:id="cbuffer_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Redondear el punto y el radio del búfer circular en el número de lugares decimales</para>
-					<para><varname>round(cbuffer,integer=0) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(cbuffer,integer=0) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(cbuffer(ST_Point(1.123456789,1.123456789), 0.123456789), 6));
 -- Cbuffer(POINT(1.123457 1.123457),0.123457)
@@ -228,8 +248,10 @@ SELECT asText(round(cbuffer(ST_Point(1.123456789,1.123456789), 0.123456789), 6))
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Devuelve o establece el identificador de referencia espacial</para>
-					<para><varname>SRID(cbuffer) → integer</varname></para>
-					<para><varname>setSRID(cbuffer) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(cbuffer) → integer
+setSRID(cbuffer) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(cbuffer 'Cbuffer(SRID=5676;Point(1 1), 0.3)');
 -- 5676
@@ -242,9 +264,11 @@ SELECT asEWKT(setSRID(cbuffer 'Cbuffer(Point(0 0),1)', 4326));
 					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transformar a una referencia espacial diferente</para>
-					<para><varname>transform(cbuffer,integer) → cbuffer</varname></para>
-					<para><varname>transformPipeline(cbuffer,pipeline text,to_srid integer,is_forward boolean=true) → </varname></para>
-					<para><varname>  cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+transform(cbuffer,integer) → cbuffer
+transformPipeline(cbuffer,pipeline text,to_srid integer,is_forward boolean=true) → 
+  cbuffer
+</programlisting>
 					<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el búfer circular de entrada tiene un SRID desconocido (representado por 0).</para>
 					<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato de cadena:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
@@ -280,7 +304,9 @@ FROM test;
 					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Comparaciones tradicionales</para>
-					<para><varname>cbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+cbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT cbuffer 'Cbuffer(Point(3 3), 0.5)' = cbuffer 'Cbuffer(Point(3 3), 0.5)';
 -- true
@@ -360,8 +386,10 @@ SELECT tcbuffer 'Point(0 0)@2001-01-01 08:05:00';
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 				<para>Devuelve la representación de texto conocido (Well-Known Text o WKT) o la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-				<para><varname>asText({tcbuffer,tcbuffer[],cbuffer[]}) → {text,text[]}</varname></para>
-				<para><varname>asEWKT({tcbuffer,tcbuffer[],cbuffer[]}) → {text,text[]}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({tcbuffer,tcbuffer[],cbuffer[]}) → {text,text[]}
+asEWKT({tcbuffer,tcbuffer[],cbuffer[]}) → {text,text[]}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbuffer 'SRID=4326;[Cbuffer(Point(0 0),1)@2001-01-01,
   Cbuffer(Point(1 1),2)@2001-01-02)');
@@ -380,7 +408,9 @@ SELECT asEWKT(ARRAY[cbuffer 'Cbuffer(SRID=5676;Point(0 0),1)',
 			<listitem xml:id="tcbuffer_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Devuelve la representación JSON de características móviles (Moving Features JSON o MF-JSON)</para>
-				<para><varname>asMFJSON(tcbuffer) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tcbuffer) → text
+</programlisting>
 				<para>Un búfer circular siempre es planar 2D. Cada valor es un objeto con un miembro <varname>point</varname>, un arreglo de coordenadas <varname>[x, y]</varname> y un miembro numérico <varname>radius</varname>, que reflejan los accesores <varname>point</varname> y <varname>radius</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tcbuffer 'Cbuffer(Point(1 2),0.5)@2001-01-01', 3);
@@ -407,10 +437,12 @@ SELECT asMFJSON(tcbuffer 'SRID=4326;[Cbuffer(Point(1 1),0.2)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-				<para><varname>asBinary(tcbuffer,endian text='') → bytea</varname></para>
-				<para><varname>asEWKB(tcbuffer,endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB(tcbuffer,endian text='') → text</varname></para>
-				<para><varname>asHexEWKB(tcbuffer,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(tcbuffer,endian text='') → bytea
+asEWKB(tcbuffer,endian text='') → bytea
+asHexWKB(tcbuffer,endian text='') → text
+asHexEWKB(tcbuffer,endian text='') → text
+</programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tcbuffer 'Cbuffer(Point(1 2),1)@2001-01-01');
@@ -428,8 +460,10 @@ SELECT asHexEWKB(tcbuffer 'SRID=3812;Cbuffer(Point(1 2),1)@2001-01-01');
 				<indexterm significance="normal"><primary><varname>tcbufferFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferFromEWKT</varname></primary></indexterm>
 				<para>Entrar a partir de la representación de texto conocido (Well-Known Text o WKT) o de la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-				<para><varname>tcbufferFromText(text) → tcbuffer</varname></para>
-				<para><varname>tcbufferFromEWKT(text) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferFromText(text) → tcbuffer
+tcbufferFromEWKT(text) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tcbufferFromText(text '[Cbuffer(Point(1 2),1)@2001-01-01,
   Cbuffer(Point(3 4),2)@2001-01-02]'));
@@ -443,7 +477,9 @@ SELECT asEWKT(tcbufferFromEWKT(text 'SRID=3812;[Cbuffer(Point(1 2),1)@2001-01-01
 			<listitem xml:id="tcbufferFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tcbufferFromMFJSON</varname></primary></indexterm>
 				<para>Entrar a partir de la representación JSON de características móviles (Moving Features JSON o MF-JSON)</para>
-				<para><varname>tcbufferFromMFJSON(text) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferFromMFJSON(text) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tcbufferFromMFJSON(asMFJSON(tcbuffer
   'SRID=3812;Cbuffer(Point(1 2),0.5)@2001-01-01', 3)));
@@ -459,9 +495,11 @@ SELECT asEWKT(tcbufferFromMFJSON(asMFJSON(tcbuffer
 				<indexterm significance="normal"><primary><varname>tcbufferFromEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferFromHexEWKB</varname></primary></indexterm>
 				<para>Entrar a partir de la representación binaria conocida (WKB), de la representación extendida binaria conocida (EWKB), o de la representación hexadecimal extendida binaria conocida (HexEWKB)</para>
-				<para><varname>tcbufferFromBinary(bytea) → tcbuffer</varname></para>
-				<para><varname>tcbufferFromEWKB(bytea) → tcbuffer</varname></para>
-				<para><varname>tcbufferFromHexEWKB(text) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferFromBinary(bytea) → tcbuffer
+tcbufferFromEWKB(bytea) → tcbuffer
+tcbufferFromHexEWKB(text) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tcbufferFromBinary(
   '\x013b0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000'));
@@ -484,10 +522,12 @@ SELECT asEWKT(tcbufferFromHexEWKB(
 			<listitem xml:id="tcbuffer_const">
 				<indexterm significance="normal"><primary><varname>tcbuffer</varname></primary></indexterm>
 				<para>Constructor para búferes circulares temporales con valor constante</para>
-				<para><varname>tcbuffer(cbuffer,timestamptz) → tcbufferInst</varname></para>
-				<para><varname>tcbuffer(cbuffer,tstzset) → tcbufferDiscSeq</varname></para>
-				<para><varname>tcbuffer(cbuffer,tstzspan,interp='linear') → tcbufferContSeq</varname></para>
-				<para><varname>tcbuffer(cbuffer,tstzspanset,interp='linear') → tcbufferSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer(cbuffer,timestamptz) → tcbufferInst
+tcbuffer(cbuffer,tstzset) → tcbufferDiscSeq
+tcbuffer(cbuffer,tstzspan,interp='linear') → tcbufferContSeq
+tcbuffer(cbuffer,tstzspanset,interp='linear') → tcbufferSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.5)', timestamptz '2001-01-01'));
 -- Cbuffer(Point(1 1),0.5)@2001-01-01
@@ -507,8 +547,10 @@ SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.2)',
 			<listitem xml:id="tcbufferSeq">
 				<indexterm significance="normal"><primary><varname>tcbufferSeq</varname></primary></indexterm>
 				<para>Constructor para búferes circulares temporales de subtipo secuencia</para>
-				<para><varname>tcbufferSeq(tcbufferInst[],interp='linear',leftInc boolean=true,</varname></para>
-				<para><varname>  rightInc boolean=true) →tcbufferSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferSeq(tcbufferInst[],interp='linear',leftInc boolean=true,
+  rightInc boolean=true) →tcbufferSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.3)@2001-01-01',
   'Cbuffer(Point(2 2), 0.5)@2001-01-02', 'Cbuffer(Point(1 1), 0.5)@2001-01-03']));
@@ -530,9 +572,11 @@ SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.2)@2001-01-01',
 				<indexterm significance="normal"><primary><varname>tcbufferSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor para búferes circulares temporales de subtipo conjunto de secuencias</para>
-				<para><varname>tcbufferSeqSet(tcbuffer[]) → tcbufferSeqSet</varname></para>
-				<para><varname>tcbufferSeqSetGaps(tcbufferInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
-				<para><varname>  tcbufferSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferSeqSet(tcbuffer[]) → tcbufferSeqSet
+tcbufferSeqSetGaps(tcbufferInst[],maxt=NULL,maxdist=NULL,interp='linear') →
+  tcbufferSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeqSet(ARRAY[tcbuffer
   '[Cbuffer(Point(1 1),0.2)@2001-01-01, Cbuffer(Point(2 2),0.4)@2001-01-02]',
@@ -549,7 +593,9 @@ SELECT asText(tcbufferSeqSetGaps(ARRAY[tcbuffer 'Cbuffer(Point(1 1),0.1)@2001-01
 			<listitem xml:id="tgeompoint_tfloat_tcbuffer">
 				<indexterm significance="normal"><primary><varname>tcbuffer</varname></primary></indexterm>
 				<para>Construir un búfer circular temporal a partir de un punto de geometría temporal y un flotante temporal</para>
-				<para><varname>tcbuffer(tgeompoint, tfloat) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer(tgeompoint, tfloat) → tcbuffer
+</programlisting>
 				<para>El marco de tiempo del resultado es la intersección de los marcos de tiempo del punto temporal y el flotante temporal. Si no se intersecan, se devuelve un valor nulo</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbuffer(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02)',
@@ -570,7 +616,9 @@ SELECT asText(tcbuffer(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02
 			<listitem xml:id="tcbuffer_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir un búfer circular temporal a un punto de geometría temporal</para>
-				<para><varname>tcbuffer::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
   Cbuffer(Point(1 1), 0.3)@2001-01-02)')::tgeompoint);
@@ -581,7 +629,9 @@ SELECT asText((tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tcbuffer_tfloat">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir un búfer circular temporal a un flotante temporal</para>
-				<para><varname>tcbuffer::tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer::tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
   Cbuffer(Point(1 1), 0.3)@2001-01-02)')::tfloat;
@@ -597,7 +647,9 @@ SELECT (tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tcbuffer_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Devuelve los valores</para>
-				<para><varname>getValues(tcbuffer) → cbufferset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tcbuffer) → cbufferset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(getValues(tcbuffer '{[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02)}'));
@@ -612,8 +664,10 @@ SELECT asEWKT(getValues(tcbuffer 'SRID=5676;{[Cbuffer(Point(1 1), 0.3)@2001-01-0
 				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>radius</varname></primary></indexterm>
 				<para>Devuelve los puntos o los radios</para>
-				<para><varname>points(tcbuffer) → geomset</varname></para>
-				<para><varname>radius(tcbuffer) → floatset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+points(tcbuffer) → geomset
+radius(tcbuffer) → floatset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(points(tcbuffer 'SRID=5676;{Cbuffer(Point(3 3), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02}'));
@@ -627,7 +681,9 @@ SELECT radius(tcbuffer 'SRID=5676;{Cbuffer(Point(3 3), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(tcbuffer,timestamptz) → cbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tcbuffer,timestamptz) → cbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(valueAtTimestamp(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(3 3), 0.5)@2001-01-03)', '2001-01-02'));
@@ -645,9 +701,11 @@ SELECT asText(valueAtTimestamp(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tcbufferSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferSeqSet</varname></primary></indexterm>
 				<para>Transformar un búfer circular temporal en otro subtipo</para>
-				<para><varname>tcbufferInst(tcbuffer) → tcbufferInst</varname></para>
-				<para><varname>tcbufferSeq(tcbuffer) → tcbufferSeq</varname></para>
-				<para><varname>tcbufferSeqSet(tcbuffer) → tcbufferSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferInst(tcbuffer) → tcbufferInst
+tcbufferSeq(tcbuffer) → tcbufferSeq
+tcbufferSeqSet(tcbuffer) → tcbufferSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeq(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2001-01-01', 'discrete'));
 -- {Cbuffer(Point(1 1),0.5)@2001-01-01}
@@ -661,7 +719,9 @@ SELECT asText(tcbufferSeqSet(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2001-01-01'));
 			<listitem xml:id="tcbuffer_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transformar un búfer circular temporal en otra interpolación</para>
-				<para><varname>setInterp(tcbuffer, interp) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(tcbuffer, interp) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(setInterp(tcbuffer 'Cbuffer(Point(1 1),0.2)@2001-01-01','linear'));
 -- [Cbuffer(Point(1 1),0.2)@2001-01-01]
@@ -674,7 +734,9 @@ SELECT asText(setInterp(tcbuffer '{[Cbuffer(Point(1 1),0.1)@2001-01-01],
 			<listitem xml:id="tcbuffer_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Redondear los puntos y los radios del búfer circular temporal en el número de lugares decimales</para>
-				<para><varname>round(tcbuffer,integer) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tcbuffer,integer) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(tcbuffer '{[Cbuffer(Point(1 1.123456789),0.123456789)@2001-01-01,
   Cbuffer(Point(1 1),0.5)@2001-01-02)}', 3));
@@ -691,8 +753,10 @@ SELECT asText(round(tcbuffer '{[Cbuffer(Point(1 1.123456789),0.123456789)@2001-0
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Agregar un instante temporal o una secuencia temporal</para>
-				<para><varname>appendInstant(tcbuffer,tcbufferInst) → tcbuffer</varname></para>
-				<para><varname>appendSequence(tcbuffer,tcbufferSeq) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tcbuffer,tcbufferInst) → tcbuffer
+appendSequence(tcbuffer,tcbufferSeq) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendInstant(tcbuffer 'Cbuffer(Point(1 1), 0.1)@2001-01-01',
   'Cbuffer(Point(2 2), 0.2)@2001-01-02'));
@@ -707,9 +771,11 @@ SELECT asText(appendSequence(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01]',
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Fusionar los búferes circulares temporales</para>
-				<para><varname>merge(tcbuffer,tcbuffer) → tcbuffer</varname></para>
-				<para><varname>merge(tcbuffer[]) → tcbuffer</varname></para>
-				<para><varname>mergeAgg(tcbuffer) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(tcbuffer,tcbuffer) → tcbuffer
+merge(tcbuffer[]) → tcbuffer
+mergeAgg(tcbuffer) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1),
   0.3)@2001-01-03]',
@@ -736,8 +802,10 @@ SELECT asText(mergeAgg(inst)) FROM temp;
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Devuelve o establece el identificador de referencia espacial</para>
-				<para><varname>SRID(tcbuffer) → integer</varname></para>
-				<para><varname>setSRID(tcbuffer) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(tcbuffer) → integer
+setSRID(tcbuffer) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tcbuffer 'SRID=5676;[Cbuffer(Point(0 0),1)@2001-01-01,
   Cbuffer(Point(1 1),2)@2001-01-02)');
@@ -752,9 +820,11 @@ SELECT asEWKT(setSRID(tcbuffer '[Cbuffer(Point(0 0),1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transformar a una referencia espacial diferente</para>
-				<para><varname>transform(tcbuffer,integer) → tcbuffer</varname></para>
-				<para><varname>transformPipeline(tcbuffer,pipeline text,to_srid integer,is_forward boolean=true) →</varname></para>
-				<para><varname>  tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(tcbuffer,integer) → tcbuffer
+transformPipeline(tcbuffer,pipeline text,to_srid integer,is_forward boolean=true) →
+  tcbuffer
+</programlisting>
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el búfer circular temporal de entrada tiene un SRID desconocido (representado por 0).</para>
 				<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato de cadena: <varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname>. El SRID del búfer circular temporal de entrada se ignora y el SRID del búfer circular temporal de salida se establecerá en cero a menos que se proporcione un valor a través del parámetro opcional <varname>to_srid</varname>. Como se indica en el último parámetro, la canalización se ejecuta de forma predeterminada en dirección hacia adelante; al establecer el parámetro en falso, la canalización se ejecuta en la dirección inversa.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -778,7 +848,9 @@ FROM test;
 			<listitem xml:id="tcbuffer_traversedArea">
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
 				<para>Devuelve el área atravesada por el búfer circular temporal</para>
-				<para><varname>traversedArea(tcbuffer, unary_union=false) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+traversedArea(tcbuffer, unary_union=false) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02]'));
@@ -788,7 +860,9 @@ SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_centroid">
 				<indexterm significance="normal"><primary><varname>centroid</varname></primary></indexterm>
 				<para>Devuelve el punto geométrico temporal dado por los centros de un búfer circular temporal</para>
-				<para><varname>centroid(tcbuffer) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+centroid(tcbuffer) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
   Cbuffer(Point(3 3), 0.5)@2001-01-03]'));
@@ -799,7 +873,9 @@ SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
 			<listitem xml:id="tcbuffer_convexHull">
 				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Devuelve la envolvente convexa del área atravesada por el búfer circular temporal</para>
-				<para><varname>convexHull(tcbuffer) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+convexHull(tcbuffer) → geometry
+</programlisting>
 				<para>La envolvente convexa se calcula sobre el área atravesada linealizada: los arcos circulares que delimitan la región barrida se convierten primero en segmentos rectos y la envolvente se calcula luego con GEOS. Por lo tanto, el resultado es un <varname>POLYGON</varname> lineal que aproxima el contorno circular, no un <varname>CURVEDPOLYGON</varname> curvo. Utilice <varname>traversedArea</varname> para obtener la región barrida curva exacta.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_GeometryType(convexHull(tcbuffer
@@ -824,7 +900,9 @@ SELECT round(ST_Area(convexHull(tcbuffer
 			<listitem xml:id="tcbuffer_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Devuelve la distancia más cercana</para>
-				<para><varname>{geo,cbuffer,tcbuffer,stbox} |=| {geo,cbuffer,tcbuffer,stbox} → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,cbuffer,tcbuffer,stbox} |=| {geo,cbuffer,tcbuffer,stbox} → float
+</programlisting>
 				<para>El operador <varname>|=|</varname> se puede utilizar para realizar búsquedas del vecino más cercano utilizando un índice GiST o SP-GiST (ver <xref linkend="ttype_indexing"/>).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
@@ -839,7 +917,9 @@ SELECT tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_nearestApproachInstant">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>TODO Devuelve el instante del primer búfer circular temporal en el que los dos argumentos están a la distancia más cercana</para>
-				<para><varname>nearestApproachInstant({geo,cbuffer,tcbuffer},{geo,cbuffer,tcbuffer}) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geo,cbuffer,tcbuffer},{geo,cbuffer,tcbuffer}) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nearestApproachInstant(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
   Cbuffer(Point(2 2), 0.7)@2001-01-02]', geometry 'Linestring(50 50,55 55)');
@@ -853,7 +933,9 @@ SELECT nearestApproachInstant(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>TODO Devuelve la línea que conecta el punto de aproximación más cercano entre los dos argumentos</para>
-				<para><varname>shortestLine({geo,cbuffer,tcbuffer},{geo,cbuffer,tcbuffer}) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geo,cbuffer,tcbuffer},{geo,cbuffer,tcbuffer}) → geometry
+</programlisting>
 				<para>La función devuelve la primera línea que encuentre si hay más de una</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
@@ -868,7 +950,9 @@ SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>TODO Devuelve la distancia temporal</para>
-				<para><varname>{geo,cbuffer,tcbuffer} &lt;-&gt; {geo,cbuffer,tcbuffer} → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,cbuffer,tcbuffer} &lt;-&gt; {geo,cbuffer,tcbuffer} → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt; cbuffer 'Cbuffer(Point(1 1), 0.2)';
@@ -885,7 +969,9 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_minDistance">
 				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
 				<para>Devuelve la distancia espacial mínima, ignorando el tiempo</para>
-				<para><varname>minDistance(tcbuffer,{geo,cbuffer}) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minDistance(tcbuffer,{geo,cbuffer}) → float
+</programlisting>
 				<para><varname>minDistance(tcbuffer,tcbuffer) → float</varname> (agregado)</para>
 				<para>El resultado es la distancia espacial entre las áreas barridas por los dos argumentos durante toda su vida útil, igual a <varname>ST_Distance(traversedArea(...), traversedArea(...))</varname>. La forma de dos argumentos de búfer circular temporal es un agregado, de modo que una combinación cruzada agrupada por una clave produce el mínimo sobre cada par del grupo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -913,10 +999,12 @@ GROUP BY t1.ShipTypeLabel, t2.ShipTypeLabel;
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 				<para>Restringir al (complemento de) un valor o un conjunto de valores</para>
-				<para><varname>atValue(tcbuffer,value) → tcbuffer</varname></para>
-				<para><varname>minusValue(tcbuffer,value) → tcbuffer</varname></para>
-				<para><varname>atValues(tcbuffer,valueset) → tcbuffer</varname></para>
-				<para><varname>minusValues(tcbuffer,valueset) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(tcbuffer,value) → tcbuffer
+minusValue(tcbuffer,value) → tcbuffer
+atValues(tcbuffer,valueset) → tcbuffer
+minusValues(tcbuffer,valueset) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atValue(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
   Cbuffer(Point(2 2), 0.7)@2001-01-03]', cbuffer 'Cbuffer(Point(2 2), 0.5)'));
@@ -932,8 +1020,10 @@ SELECT asText(minusValue(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>TODO Restringir al (complemento de) una geometría</para>
-				<para><varname>atGeometry(tcbuffer,geometry) → tcbuffer</varname></para>
-				<para><varname>minusGeometry(tcbuffer,geometry) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tcbuffer,geometry) → tcbuffer
+minusGeometry(tcbuffer,geometry) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atGeometry(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
   Cbuffer(Point(2 2), 0.7)@2001-01-03]', 'Polygon((0 0,0 2,2 2,2 0,0 0))'));
@@ -948,8 +1038,10 @@ SELECT asText(minusGeometry(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atStbox</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusStbox</varname></primary></indexterm>
 				<para>Restringir un búfer circular temporal a (el complemento de) una caja espaciotemporal</para>
-				<para><varname>atStbox(tcbuffer,stbox,borderInc boolean=true) → tcbuffer</varname></para>
-				<para><varname>minusStbox(tcbuffer,stbox,borderInc boolean=true) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atStbox(tcbuffer,stbox,borderInc boolean=true) → tcbuffer
+minusStbox(tcbuffer,stbox,borderInc boolean=true) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2000-01-01,
   Cbuffer(Point(3 3), 0.5)@2000-01-03]', stbox 'STBOX X((0,0),(2,2))'));
@@ -970,7 +1062,9 @@ SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2000-01-01,
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
-				<para><varname>tcbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tcbuffer → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tcbuffer → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.1)@2001-01-01,
   Cbuffer(Point(1 1), 0.3)@2001-01-02),
@@ -992,7 +1086,9 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Comparaciones alguna vez y siempre</para>
-				<para><varname>{tcbuffer,cbuffer} {?=, %=} {tcbuffer,cbuffer} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tcbuffer,cbuffer} {?=, %=} {tcbuffer,cbuffer} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
   Cbuffer(Point(1 1), 0.4)@2001-01-03)' ?= cbuffer 'Cbuffer(Point(1 1), 0.3)';
@@ -1010,7 +1106,9 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tcbuffer_tcomp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Comparaciones temporales</para>
-				<para><varname>tcbuffer {#=, #&lt;&gt;} tcbuffer → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer {#=, #&lt;&gt;} tcbuffer → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
   Cbuffer(Point(1 1), 0.4)@2001-01-03)' #= cbuffer 'Cbuffer(Point(1 1), 0.3)';
@@ -1034,7 +1132,9 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Operadores topológicos</para>
-				<para><varname>{tstzspan,stbox,tcbuffer} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tcbuffer} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tstzspan,stbox,tcbuffer} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tcbuffer} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &amp;&amp; cbuffer 'Cbuffer(Point(1 1), 0.5)';
@@ -1055,9 +1155,11 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_pos">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Operadores de posición</para>
-				<para><varname>{stbox,tcbuffer} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tcbuffer} → boolean</varname></para>
-				<para><varname>{stbox,tcbuffer} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tcbuffer} → boolean</varname></para>
-				<para><varname>{tstzspan,stbox,tcbuffer} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tcbuffer} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{stbox,tcbuffer} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tcbuffer} → boolean
+{stbox,tcbuffer} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tcbuffer} → boolean
+{tstzspan,stbox,tcbuffer} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tcbuffer} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt; cbuffer 'Cbuffer(Point(1 1), 0.2)'
@@ -1094,16 +1196,18 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>eCovers</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aCovers</varname></primary></indexterm>
 				<para>TODO Relaciones alguna vez y siempre</para>
-				<para><varname>eContains(geometry,tcbuffer) → boolean</varname></para>
-				<para><varname>aContains(geometry,tcbuffer) → boolean</varname></para>
-				<para><varname>eDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>aDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>eDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean</varname></para>
-				<para><varname>aDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean</varname></para>
-				<para><varname>eIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>aIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>eTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>aTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eContains(geometry,tcbuffer) → boolean
+aContains(geometry,tcbuffer) → boolean
+eDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+aDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+eDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean
+aDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean
+eIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+aIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+eTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+aTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
   tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.3)@2001-01-03)');
@@ -1125,11 +1229,13 @@ SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 				<para>TODO Relaciones espaciotemporales</para>
-				<para><varname>tContains(geometry,tcbuffer) → boolean</varname></para>
-				<para><varname>tDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>tDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean</varname></para>
-				<para><varname>tIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>tTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tcbuffer) → boolean
+tDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+tDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean
+tIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+tTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tDisjoint(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
   tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.3)@2001-01-03)');
@@ -1153,7 +1259,9 @@ SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
-				<para><varname>tCount(tcbuffer) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tcbuffer) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
@@ -1171,7 +1279,9 @@ FROM Temp;
 			<listitem xml:id="tcbuffer_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Conteo de ventana</para>
-				<para><varname>wCount(tcbuffer) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tcbuffer) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
@@ -1190,7 +1300,9 @@ FROM Temp;
 			<listitem xml:id="tcbuffer_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
 				<para>Agregar los centros de un conjunto de búferes circulares temporales en su centroide temporal, convirtiendo a <varname>tgeompoint</varname></para>
-				<para><varname>tCentroid(tcbuffer::tgeompoint) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCentroid(tcbuffer::tgeompoint) → tgeompoint
+</programlisting>
 				<para>La agregación pertenece al tipo <varname>tgeompoint</varname>: la trayectoria del centro de un búfer circular es un punto temporal, de modo que la conversión alcanza la agregación en lugar de que el tipo búfer lleve su propia copia.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
@@ -1213,8 +1325,10 @@ SELECT asText(tCentroid(temp::tgeompoint)) FROM Temp;
 				<indexterm significance="normal"><primary><varname>minDistSimplify</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minTimeDeltaSimplify</varname></primary></indexterm>
 				<para>Devuelve un búfer circular temporal simplificado asegurándose de que los centros consecutivos estén al menos separados por una cierta distancia o intervalo de tiempo</para>
-				<para><varname>minDistSimplify(tcbuffer,mindist float) → tcbuffer</varname></para>
-				<para><varname>minTimeDeltaSimplify(tcbuffer,mint interval) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minDistSimplify(tcbuffer,mindist float) → tcbuffer
+minTimeDeltaSimplify(tcbuffer,mint interval) → tcbuffer
+</programlisting>
 				<para>La simplificación opera sobre la trayectoria de los centros del búfer circular temporal y conserva el radio en cada instante que sobrevive. La simplificación se aplica sólo a secuencias temporales o conjuntos de secuencias con interpolación lineal. En todos los demás casos, se devuelve una copia del valor dado.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(minDistSimplify(tcbuffer
@@ -1237,8 +1351,10 @@ SELECT asText(minTimeDeltaSimplify(tcbuffer
 				<indexterm significance="normal"><primary><varname>maxDistSimplify</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>douglasPeuckerSimplify</varname></primary></indexterm>
 				<para>Devuelve un búfer circular temporal simplificado usando el <ulink url="https://es.wikipedia.org/wiki/Algoritmo_de_Ramer%E2%80%93Douglas%E2%80%93Peucker">algoritmo de Douglas-Peucker</ulink></para>
-				<para><varname>maxDistSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer</varname></para>
-				<para><varname>douglasPeuckerSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+maxDistSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer
+douglasPeuckerSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer
+</programlisting>
 				<para>La diferencia entre las dos funciones es que <varname>maxDistSimplify</varname> utiliza una versión de un solo paso del algoritmo mientras que <varname>douglasPeuckerSimplify</varname> utiliza el algoritmo recursivo estándar. Al igual que las funciones anteriores, la simplificación opera sobre la trayectoria de los centros y conserva el radio en cada instante que sobrevive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(douglasPeuckerSimplify(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01,

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -52,8 +52,10 @@ SELECT th3indexFromHexWKB(asHexWKB(th3index '831c02fffffffff@2001-01-01'));
 			<listitem xml:id="th3_tbigint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir entre un <varname>th3index</varname> y un <varname>tbigint</varname> (explícita, sin coste)</para>
-				<para><varname>tbigint::th3index</varname></para>
-				<para><varname>th3index::tbigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbigint::th3index
+th3index::tbigint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tbigint '590464338553208831@2001-01-01')::th3index;
 -- 831c02fffffffff@2001-01-01
@@ -66,8 +68,10 @@ SELECT ((th3index '831c02fffffffff@2001-01-01')::tbigint)::th3index
 			<listitem xml:id="th3_tgeogpoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir una celda H3 temporal en un punto temporal geodésico o planar de los centroides de las celdas. Las dos sobrecargas dan al usuario una elección entre la representación geodésica (<varname>tgeogpoint</varname>) y la planar SRID 4326 (<varname>tgeompoint</varname>).</para>
-				<para><varname>th3index::tgeogpoint</varname></para>
-				<para><varname>th3index::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index::tgeogpoint
+th3index::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeogpoint;
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint;
@@ -85,7 +89,9 @@ SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint;
 			<listitem xml:id="th3_geoToH3Cell">
 				<indexterm significance="normal"><primary><varname>geoToH3Cell</varname></primary></indexterm>
 				<para>Devuelve la celda H3 que contiene una geometría de punto a la resolución dada. La geometría debe ser un <varname>POINT</varname>.</para>
-				<para><varname>geoToH3Cell(geometry,integer) → h3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoToH3Cell(geometry,integer) → h3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3Cell(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- 871fa4418ffffff
@@ -95,7 +101,9 @@ SELECT geoToH3Cell(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 			<listitem xml:id="th3_geoToH3IndexSet">
 				<indexterm significance="normal"><primary><varname>geoToH3IndexSet</varname></primary></indexterm>
 				<para>Devuelve el conjunto de celdas H3 que cubren una geometría a la resolución dada. Se admiten todos los tipos de geometría: un <varname>POINT</varname> produce una sola celda, una <varname>LINESTRING</varname> muestrea sus segmentos, un <varname>POLYGON</varname> rellena su interior, y los valores <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> devuelven la unión de sus componentes.</para>
-				<para><varname>geoToH3IndexSet(geometry,integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoToH3IndexSet(geometry,integer) → h3indexset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- {"871fa4418ffffff"}
@@ -105,8 +113,10 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 			<listitem xml:id="th3_ever_eq_set">
 				<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 				<para>Devuelve si una trayectoria H3 temporal toma alguna vez una de las celdas de un conjunto de celdas. Combinada con <varname>geoToH3IndexSet</varname> responde si un viaje pasa alguna vez por una región, sin materializar la geometría de la trayectoria, el prefiltro robusto y conservador para el predicado exacto <varname>eIntersects(geometry,th3index)</varname>.</para>
-				<para><varname>eEq(h3indexset,th3index) → boolean</varname></para>
-				<para><varname>h3indexset ?= th3index → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eEq(h3indexset,th3index) → boolean
+h3indexset ?= th3index → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
   th3index '871fa4418ffffff@2001-01-01';
@@ -123,8 +133,10 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
 				<indexterm significance="normal"><primary><varname>startValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<para>Devolver el primer o el último identificador de celda H3 de un valor temporal</para>
-				<para><varname>startValue(th3index) → h3index</varname></para>
-				<para><varname>endValue(th3index) → h3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(th3index) → h3index
+endValue(th3index) → h3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(th3index '831c02fffffffff@2001-01-01');
 -- 831c02fffffffff
@@ -136,7 +148,9 @@ SELECT endValue(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-0
 			<listitem xml:id="th3_valueN">
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
 				<para>Devolver el <varname>n</varname>-ésimo identificador de celda H3 distinto (indexado desde 1). Devuelve <varname>NULL</varname> si está fuera del rango.</para>
-				<para><varname>valueN(th3index,integer) → h3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueN(th3index,integer) → h3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}', 1);
 -- 831c02fffffffff
@@ -148,7 +162,9 @@ SELECT valueN(th3index '831c02fffffffff@2001-01-01', 99);
 			<listitem xml:id="th3_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Devolver el conjunto de identificadores de celda H3 distintos que toma la trayectoria</para>
-				<para><varname>getValues(th3index) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(th3index) → h3indexset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(th3index '831c02fffffffff@2001-01-01');
 -- {831c02fffffffff}
@@ -158,7 +174,9 @@ SELECT getValues(th3index '831c02fffffffff@2001-01-01');
 			<listitem xml:id="th3_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devolver el identificador de celda H3 en una marca de tiempo dada, utilizando interpolación de pasos</para>
-				<para><varname>valueAtTimestamp(th3index,timestamptz) → h3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(th3index,timestamptz) → h3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(th3index
   '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-05]',
@@ -175,7 +193,9 @@ SELECT valueAtTimestamp(th3index
 			<listitem xml:id="th3_h3_get_resolution">
 				<indexterm significance="normal"><primary><varname>th3GetResolution</varname></primary></indexterm>
 				<para>Devolver la resolución temporal (0–15) de cada celda en una trayectoria</para>
-				<para><varname>th3GetResolution(th3index) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3GetResolution(th3index) → tint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(th3index '831c02fffffffff@2001-01-01');
 -- 3@2001-01-01
@@ -185,7 +205,9 @@ SELECT th3GetResolution(th3index '831c02fffffffff@2001-01-01');
 			<listitem xml:id="th3_h3_get_base_cell_number">
 				<indexterm significance="normal"><primary><varname>th3GetBaseCellNumber</varname></primary></indexterm>
 				<para>Devolver el número de celda base temporal (0–121) de cada celda en una trayectoria</para>
-				<para><varname>th3GetBaseCellNumber(th3index) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3GetBaseCellNumber(th3index) → tint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetBaseCellNumber(th3index '831c02fffffffff@2001-01-01');
 </programlisting>
@@ -194,7 +216,9 @@ SELECT th3GetBaseCellNumber(th3index '831c02fffffffff@2001-01-01');
 			<listitem xml:id="th3_h3_is_valid_cell">
 				<indexterm significance="normal"><primary><varname>isValidCell</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica en cada instante si el valor es una celda H3 válida</para>
-				<para><varname>isValidCell(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidCell(th3index) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidCell(th3index '0@2001-01-01');
 -- f@2001-01-01
@@ -204,7 +228,9 @@ SELECT isValidCell(th3index '0@2001-01-01');
 			<listitem xml:id="th3_h3_is_res_class_iii">
 				<indexterm significance="normal"><primary><varname>th3IsResClassIii</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica si cada celda tiene orientación de Clase III. La Clase III se alterna con la resolución: las resoluciones impares son de clase III, las pares son de clase II.</para>
-				<para><varname>th3IsResClassIii(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3IsResClassIii(th3index) → tbool
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3IsResClassIii(th3index '871fa44a8ffffff@2001-01-01');
 -- t@2001-01-01
@@ -214,7 +240,9 @@ SELECT th3IsResClassIii(th3index '871fa44a8ffffff@2001-01-01');
 			<listitem xml:id="th3_h3_is_pentagon">
 				<indexterm significance="normal"><primary><varname>th3IsPentagon</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica si cada celda es un pentágono (12 celdas por resolución son pentágonos; las restantes 110 en cada celda base descienden como hexágonos)</para>
-				<para><varname>th3IsPentagon(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3IsPentagon(th3index) → tbool
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3IsPentagon(th3index '831c00fffffffff@2001-01-01');
 -- t@2001-01-01
@@ -231,8 +259,10 @@ SELECT th3IsPentagon(th3index '831c02fffffffff@2001-01-01');
 			<listitem xml:id="th3_h3_cell_to_parent">
 				<indexterm significance="normal"><primary><varname>th3CellToParent</varname></primary></indexterm>
 				<para>Devolver la celda padre temporal en la resolución dada. La forma sin argumento desciende a la siguiente resolución más gruesa.</para>
-				<para><varname>th3CellToParent(th3index,integer) → th3index</varname></para>
-				<para><varname>th3CellToParent(th3index) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToParent(th3index,integer) → th3index
+th3CellToParent(th3index) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(
   th3CellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
@@ -243,8 +273,10 @@ SELECT th3GetResolution(
 			<listitem xml:id="th3_h3_cell_to_center_child">
 				<indexterm significance="normal"><primary><varname>th3CellToCenterChild</varname></primary></indexterm>
 				<para>Devolver la celda hijo central temporal en la resolución dada. La forma sin argumento desciende a la siguiente resolución más fina.</para>
-				<para><varname>th3CellToCenterChild(th3index,integer) → th3index</varname></para>
-				<para><varname>th3CellToCenterChild(th3index) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToCenterChild(th3index,integer) → th3index
+th3CellToCenterChild(th3index) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01', 8);
 -- 881fa44a81fffff@2001-01-01
@@ -257,7 +289,9 @@ SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01');
 			<listitem xml:id="th3_h3_cell_to_child_pos">
 				<indexterm significance="normal"><primary><varname>th3CellToChildPos</varname></primary></indexterm>
 				<para>Devolver la posición ordinal (basada en 0) de cada celda entre los hijos de su padre en la resolución dada</para>
-				<para><varname>th3CellToChildPos(th3index,integer) → tbigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToChildPos(th3index,integer) → tbigint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellToChildPos(th3index '871fa44a8ffffff@2001-01-01', 6);
 -- 0@2001-01-01
@@ -267,7 +301,9 @@ SELECT th3CellToChildPos(th3index '871fa44a8ffffff@2001-01-01', 6);
 			<listitem xml:id="th3_h3_child_pos_to_cell">
 				<indexterm significance="normal"><primary><varname>th3ChildPosToCell</varname></primary></indexterm>
 				<para>Devolver la celda hijo temporal en una posición ordinal dada del padre dado, en la resolución de hijo dada. Los dos operandos temporales se sincronizan sobre su eje de tiempo compartido.</para>
-				<para><varname>th3ChildPosToCell(tbigint,th3index,integer) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3ChildPosToCell(tbigint,th3index,integer) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3ChildPosToCell(tbigint '0@2001-01-01', th3index '871fa44a8ffffff@2001-01-01',
   8);
@@ -283,8 +319,10 @@ SELECT th3ChildPosToCell(tbigint '0@2001-01-01', th3index '871fa44a8ffffff@2001-
 			<listitem xml:id="th3_tgeompoint_to_th3">
 				<indexterm significance="normal"><primary><varname>th3index</varname></primary></indexterm>
 				<para>Devolver la celda H3 temporal en la resolución dada que contiene cada punto de un punto temporal geodésico o planar (el SRID debe ser 4326 para la sobrecarga de <varname>tgeompoint</varname>)</para>
-				<para><varname>th3index(tgeogpoint,integer) → th3index</varname></para>
-				<para><varname>th3index(tgeompoint,integer) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index(tgeogpoint,integer) → th3index
+th3index(tgeompoint,integer) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(th3index(
   tgeogpoint 'POINT(-73.96 40.78)@2001-01-01', 9));
@@ -299,8 +337,10 @@ SELECT th3GetResolution(th3index(
 				<indexterm significance="normal"><primary><varname>th3CellToLatlng</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3CellToLatlngTgeompoint</varname></primary></indexterm>
 				<para>Devolver el centroide geodésico temporal de cada celda en una trayectoria. Una sobrecarga planar (SRID 4326) está disponible bajo el nombre <varname>th3CellToLatlngTgeompoint</varname>.</para>
-				<para><varname>th3CellToLatlng(th3index) → tgeogpoint</varname></para>
-				<para><varname>th3CellToLatlngTgeompoint(th3index) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToLatlng(th3index) → tgeogpoint
+th3CellToLatlngTgeompoint(th3index) → tgeompoint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3CellToLatlng(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
@@ -312,7 +352,9 @@ SELECT asText(th3CellToLatlngTgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 
 			<listitem xml:id="th3_h3_cell_to_boundary">
 				<indexterm significance="normal"><primary><varname>th3CellToBoundary</varname></primary></indexterm>
 				<para>Devolver el límite poligonal temporal de cada celda en una trayectoria, como una geografía temporal</para>
-				<para><varname>th3CellToBoundary(th3index) → tgeography</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToBoundary(th3index) → tgeography
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_GeometryType(getValue(th3CellToBoundary(th3index
   '871fa44a8ffffff@2001-01-01'))::geometry);
@@ -333,7 +375,9 @@ SELECT ST_NPoints(getValue(th3CellToBoundary(th3index
 			<listitem xml:id="th3_h3_are_neighbor_cells">
 				<indexterm significance="normal"><primary><varname>th3AreNeighborCells</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica si dos celdas temporales son vecinas en la cuadrícula en cada instante. Los dos operandos se sincronizan.</para>
-				<para><varname>th3AreNeighborCells(th3index,th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3AreNeighborCells(th3index,th3index) → tbool
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3AreNeighborCells(
   th3index '880326b885fffff@2001-01-01',
@@ -345,7 +389,9 @@ SELECT th3AreNeighborCells(
 			<listitem xml:id="th3_h3_cells_to_directed_edge">
 				<indexterm significance="normal"><primary><varname>th3CellsToDirectedEdge</varname></primary></indexterm>
 				<para>Devolver un identificador de arista dirigida temporal a partir de un par de celdas temporales origen/destino</para>
-				<para><varname>th3CellsToDirectedEdge(th3index,th3index) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellsToDirectedEdge(th3index,th3index) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
     th3index '871fa44aeffffff@2001-01-01');
@@ -356,7 +402,9 @@ SELECT th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
 			<listitem xml:id="th3_h3_is_valid_directed_edge">
 				<indexterm significance="normal"><primary><varname>isValidDirectedEdge</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica en cada instante si el valor es una arista dirigida H3 válida</para>
-				<para><varname>isValidDirectedEdge(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidDirectedEdge(th3index) → tbool
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidDirectedEdge(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
     th3index '871fa44aeffffff@2001-01-01'));
@@ -370,8 +418,10 @@ SELECT isValidDirectedEdge(th3index '871fa44a8ffffff@2001-01-01');
 				<indexterm significance="normal"><primary><varname>th3GetDirectedEdgeOrigin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3GetDirectedEdgeDestination</varname></primary></indexterm>
 				<para>Devolver la celda origen o destino temporal de una arista dirigida temporal</para>
-				<para><varname>th3GetDirectedEdgeOrigin(th3index) → th3index</varname></para>
-				<para><varname>th3GetDirectedEdgeDestination(th3index) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3GetDirectedEdgeOrigin(th3index) → th3index
+th3GetDirectedEdgeDestination(th3index) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetDirectedEdgeOrigin(th3CellsToDirectedEdge(th3index
   '871fa44a8ffffff@2001-01-01',
@@ -387,7 +437,9 @@ SELECT th3GetDirectedEdgeDestination(th3CellsToDirectedEdge(th3index
 			<listitem xml:id="th3_h3_directed_edge_to_boundary">
 				<indexterm significance="normal"><primary><varname>th3DirectedEdgeToBoundary</varname></primary></indexterm>
 				<para>Devolver el límite poligonal temporal de cada arista dirigida en una trayectoria, como una geografía temporal</para>
-				<para><varname>th3DirectedEdgeToBoundary(th3index) → tgeography</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3DirectedEdgeToBoundary(th3index) → tgeography
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_NPoints(getValue(th3DirectedEdgeToBoundary(
   th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
@@ -404,7 +456,9 @@ SELECT ST_NPoints(getValue(th3DirectedEdgeToBoundary(
 			<listitem xml:id="th3_h3_cell_to_vertex">
 				<indexterm significance="normal"><primary><varname>th3CellToVertex</varname></primary></indexterm>
 				<para>Devolver el vértice H3 temporal en el número de vértice dado (0–5 para hexágonos, 0–4 para pentágonos)</para>
-				<para><varname>th3CellToVertex(th3index,integer) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToVertex(th3index,integer) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0);
 -- 2071fa44a8ffffff@2001-01-01
@@ -414,7 +468,9 @@ SELECT th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0);
 			<listitem xml:id="th3_h3_vertex_to_latlng">
 				<indexterm significance="normal"><primary><varname>th3VertexToLatlng</varname></primary></indexterm>
 				<para>Devolver las coordenadas geodésicas temporales de cada vértice en una trayectoria</para>
-				<para><varname>th3VertexToLatlng(th3index) → tgeogpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3VertexToLatlng(th3index) → tgeogpoint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3VertexToLatlng(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01',
   0)), 6);
@@ -425,7 +481,9 @@ SELECT asText(th3VertexToLatlng(th3CellToVertex(th3index '871fa44a8ffffff@2001-0
 			<listitem xml:id="th3_h3_is_valid_vertex">
 				<indexterm significance="normal"><primary><varname>isValidVertex</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica en cada instante si el valor es un vértice H3 válido</para>
-				<para><varname>isValidVertex(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidVertex(th3index) → tbool
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
 -- t@2001-01-01
@@ -441,8 +499,10 @@ SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
 				<indexterm significance="normal"><primary><varname>th3GridDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Devolver la distancia temporal de saltos en la cuadrícula (número de pasos de una sola celda) entre dos celdas temporales. De forma equivalente, el operador <varname>&lt;-&gt;</varname> devuelve la misma distancia. Los dos operandos se sincronizan sobre su eje de tiempo compartido.</para>
-				<para><varname>th3GridDistance(th3index,th3index) → tbigint</varname></para>
-				<para><varname>th3index &lt;-&gt; th3index → tbigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3GridDistance(th3index,th3index) → tbigint
+th3index &lt;-&gt; th3index → tbigint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '880326b885fffff@2001-01-01'
    &lt;-&gt; th3index '880326b88dfffff@2001-01-01';
@@ -454,8 +514,10 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<indexterm significance="normal"><primary><varname>th3CellToLocalIj</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3LocalIjToCell</varname></primary></indexterm>
 				<para>Convertir entre una celda temporal y un par de coordenadas locales (I, J) temporales relativas a una celda temporal de origen. La coordenada local se expone como un <varname>tgeompoint</varname> con el eje I en el slot <varname>x</varname> y J en <varname>y</varname>.</para>
-				<para><varname>th3CellToLocalIj(th3index,th3index) → tgeompoint</varname></para>
-				<para><varname>th3LocalIjToCell(th3index,tgeompoint) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToLocalIj(th3index,th3index) → tgeompoint
+th3LocalIjToCell(th3index,tgeompoint) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3CellToLocalIj(th3index '871fa44a8ffffff@2001-01-01',
   th3index '871fa44aeffffff@2001-01-01'));
@@ -477,7 +539,9 @@ SELECT th3LocalIjToCell(th3index '871fa44a8ffffff@2001-01-01',
 			<listitem xml:id="th3_h3_cell_area">
 				<indexterm significance="normal"><primary><varname>th3CellArea</varname></primary></indexterm>
 				<para>Devolver el área temporal de cada celda en una trayectoria, en la unidad solicitada</para>
-				<para><varname>th3CellArea(th3index,text='km2') → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellArea(th3index,text='km2') → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellArea(th3index '871fa44a8ffffff@2001-01-01');
 -- 4.441914270110932@2001-01-01
@@ -489,7 +553,9 @@ SELECT th3CellArea(th3index '871fa44a8ffffff@2001-01-01', 'm2');
 			<listitem xml:id="th3_h3_edge_length">
 				<indexterm significance="normal"><primary><varname>th3EdgeLength</varname></primary></indexterm>
 				<para>Devolver la longitud temporal de cada arista dirigida en una trayectoria, en la unidad solicitada</para>
-				<para><varname>th3EdgeLength(th3index,text='km') → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3EdgeLength(th3index,text='km') → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
     th3index '871fa44aeffffff@2001-01-01'));
@@ -500,7 +566,9 @@ SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01
 			<listitem xml:id="th3_h3_great_circle_distance">
 				<indexterm significance="normal"><primary><varname>greatCircleDistance</varname></primary></indexterm>
 				<para>Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas). Los dos operandos se sincronizan.</para>
-				<para><varname>greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
   tgeogpoint 'Point(1 0)@2001-01-01');
@@ -522,10 +590,12 @@ SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
 					<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 					<para>Devolver <varname>true</varname> si una celda H3 temporal es alguna vez igual a la prueba en al menos un instante</para>
-					<para><varname>eEq({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>eEq(th3index,h3index) → boolean</varname></para>
-					<para><varname>{h3index,th3index} ?= th3index</varname></para>
-					<para><varname>th3index ?= h3index</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eEq({h3index,th3index},th3index) → boolean
+eEq(th3index,h3index) → boolean
+{h3index,th3index} ?= th3index
+th3index ?= h3index
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index
   '[831c02fffffffff@2001-01-01, 880326b885fffff@2001-01-05]'
@@ -538,10 +608,12 @@ SELECT th3index
 					<indexterm significance="normal"><primary><varname>aEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 					<para>Devolver <varname>true</varname> si una celda H3 temporal es siempre igual a la prueba a lo largo de todo su eje de tiempo</para>
-					<para><varname>aEq({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>aEq(th3index,h3index) → boolean</varname></para>
-					<para><varname>{h3index,th3index} %= th3index</varname></para>
-					<para><varname>th3index %= h3index</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+aEq({h3index,th3index},th3index) → boolean
+aEq(th3index,h3index) → boolean
+{h3index,th3index} %= th3index
+th3index %= h3index
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT aEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 -- t
@@ -552,8 +624,10 @@ SELECT aEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 					<indexterm significance="normal"><primary><varname>eNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
 					<para>Devolver <varname>true</varname> si una celda H3 temporal es alguna vez diferente de la prueba</para>
-					<para><varname>eNe({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>eNe(th3index,h3index) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eNe({h3index,th3index},th3index) → boolean
+eNe(th3index,h3index) → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 -- t
@@ -564,8 +638,10 @@ SELECT eNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 					<indexterm significance="normal"><primary><varname>aNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%&lt;&gt;</varname></primary></indexterm>
 					<para>Devolver <varname>true</varname> si una celda H3 temporal es siempre diferente de la prueba</para>
-					<para><varname>aNe({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>aNe(th3index,h3index) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+aNe({h3index,th3index},th3index) → boolean
+aNe(th3index,h3index) → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT aNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 -- t
@@ -583,10 +659,12 @@ SELECT aNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 					<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&lt;&gt;</varname></primary></indexterm>
 					<para>Devolver un booleano temporal que da la igualdad (o desigualdad) por instante entre una celda H3 temporal y una prueba</para>
-					<para><varname>tEq({h3index,th3index},th3index) → tbool</varname></para>
-					<para><varname>tEq(th3index,h3index) → tbool</varname></para>
-					<para><varname>tNe({h3index,th3index},th3index) → tbool</varname></para>
-					<para><varname>tNe(th3index,h3index) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tEq({h3index,th3index},th3index) → tbool
+tEq(th3index,h3index) → tbool
+tNe({h3index,th3index},th3index) → tbool
+tNe(th3index,h3index) → tbool
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 -- t@2001-01-01
@@ -614,11 +692,13 @@ SELECT tNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Solapamiento de caja envolvente, contiene, contenido por, igual y adyacente</para>
-				<para><varname>th3index &amp;&amp; {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index @&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &lt;@ {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index ~= {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index -|- {tstzspan,stbox,th3index} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index &amp;&amp; {tstzspan,stbox,th3index} → boolean
+th3index @&gt; {tstzspan,stbox,th3index} → boolean
+th3index &lt;@ {tstzspan,stbox,th3index} → boolean
+th3index ~= {tstzspan,stbox,th3index} → boolean
+th3index -|- {tstzspan,stbox,th3index} → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '871fa44a8ffffff@2001-01-01' &amp;&amp; tstzspan '[2001-01-01, 2001-01-02]';
 -- t
@@ -637,14 +717,16 @@ SELECT th3index '871fa44a8ffffff@2001-01-01' ~= th3index '871fa44a8ffffff@2001-0
 				<indexterm significance="normal"><primary><varname>|&amp;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>|&gt;&gt;</varname></primary></indexterm>
 				<para>Posición relativa a lo largo de los ejes espaciales (estrictamente a la izquierda, solapa a la izquierda, solapa a la derecha, estrictamente a la derecha; estrictamente abajo, solapa abajo, solapa arriba, estrictamente arriba)</para>
-				<para><varname>th3index &lt;&lt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &amp;&lt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &amp;&gt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &gt;&gt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &lt;&lt;| {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &amp;&lt;| {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index |&amp;&gt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index |&gt;&gt; {stbox,th3index} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index &lt;&lt; {stbox,th3index} → boolean
+th3index &amp;&lt; {stbox,th3index} → boolean
+th3index &amp;&gt; {stbox,th3index} → boolean
+th3index &gt;&gt; {stbox,th3index} → boolean
+th3index &lt;&lt;| {stbox,th3index} → boolean
+th3index &amp;&lt;| {stbox,th3index} → boolean
+th3index |&amp;&gt; {stbox,th3index} → boolean
+th3index |&gt;&gt; {stbox,th3index} → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;
   th3index '871fa44aeffffff@2001-01-01';
@@ -658,10 +740,12 @@ SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;
 				<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>#&amp;&gt;</varname></primary></indexterm>
 				<para>Posición relativa a lo largo del eje de tiempo (estrictamente antes, solapa antes, estrictamente después, solapa después)</para>
-				<para><varname>th3index &lt;&lt;# {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &amp;&lt;# {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index #&gt;&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index #&amp;&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index &lt;&lt;# {tstzspan,stbox,th3index} → boolean
+th3index &amp;&lt;# {tstzspan,stbox,th3index} → boolean
+th3index #&gt;&gt; {tstzspan,stbox,th3index} → boolean
+th3index #&amp;&gt; {tstzspan,stbox,th3index} → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;#
   th3index '871fa44aeffffff@2001-01-05';
@@ -682,7 +766,9 @@ SELECT th3index '871fa44a8ffffff@2001-01-01' #&gt;&gt;
 			<listitem xml:id="th3_h3_grid_disk">
 				<indexterm significance="normal"><primary><varname>h3GridDisk</varname></primary></indexterm>
 				<para>Todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (incluyendo el origen cuando k=0).</para>
-				<para><varname>h3GridDisk(h3index, integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3GridDisk(h3index, integer) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GridDisk(h3index '871fa44a8ffffff', 1);
 -- {"871fa44a8ffffff", "871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff",
@@ -693,7 +779,9 @@ SELECT h3GridDisk(h3index '871fa44a8ffffff', 1);
 			<listitem xml:id="th3_h3_grid_ring">
 				<indexterm significance="normal"><primary><varname>h3GridRing</varname></primary></indexterm>
 				<para>Las celdas a <emphasis>exactamente</emphasis> <varname>k</varname> pasos de cuadrícula del origen. Falla cerca de pentágonos.</para>
-				<para><varname>h3GridRing(h3index, integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3GridRing(h3index, integer) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
 -- {"871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff", "871fa44acffffff",
@@ -704,7 +792,9 @@ SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
 			<listitem xml:id="th3_h3_grid_path_cells">
 				<indexterm significance="normal"><primary><varname>h3GridPathCells</varname></primary></indexterm>
 				<para>El camino inclusivo de celdas entre dos celdas de la misma resolución.</para>
-				<para><varname>h3GridPathCells(h3index, h3index) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3GridPathCells(h3index, h3index) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GridPathCells(h3index '871fa44a8ffffff', h3index '871fa44b1ffffff');
 -- {"871fa4484ffffff", "871fa44a3ffffff", "871fa44a8ffffff", "871fa44aeffffff",
@@ -715,7 +805,9 @@ SELECT h3GridPathCells(h3index '871fa44a8ffffff', h3index '871fa44b1ffffff');
 			<listitem xml:id="th3_h3_cell_to_children">
 				<indexterm significance="normal"><primary><varname>h3CellToChildren</varname></primary></indexterm>
 				<para>Todas las celdas hijas de una celda en la resolución objetivo.</para>
-				<para><varname>h3CellToChildren(h3index, integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3CellToChildren(h3index, integer) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3CellToChildren(h3index '831c02fffffffff', 4);
 -- {"841c021ffffffff", "841c023ffffffff", "841c025ffffffff", "841c027ffffffff",
@@ -726,7 +818,9 @@ SELECT h3CellToChildren(h3index '831c02fffffffff', 4);
 			<listitem xml:id="th3_h3_compact_cells">
 				<indexterm significance="normal"><primary><varname>h3CompactCells</varname></primary></indexterm>
 				<para>Representación compactada de un conjunto de celdas, las celdas más finas se fusionan en su padre cuando el conjunto hexagonal completo de hermanas está presente.</para>
-				<para><varname>h3CompactCells(h3indexset) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3CompactCells(h3indexset) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4));
 -- {"831c02fffffffff"}
@@ -736,7 +830,9 @@ SELECT h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4));
 			<listitem xml:id="th3_h3_uncompact_cells">
 				<indexterm significance="normal"><primary><varname>h3UncompactCells</varname></primary></indexterm>
 				<para>Representación descompactada a la resolución dada, la inversa de <varname>h3CompactCells</varname>.</para>
-				<para><varname>h3UncompactCells(h3indexset, integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3UncompactCells(h3indexset, integer) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(h3UncompactCells(
   h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4)), 4));
@@ -747,7 +843,9 @@ SELECT numValues(h3UncompactCells(
 			<listitem xml:id="th3_h3_origin_to_directed_edges">
 				<indexterm significance="normal"><primary><varname>h3OriginToDirectedEdges</varname></primary></indexterm>
 				<para>Todas las aristas dirigidas salientes de una celda (6 para hexágonos, 5 para pentágonos).</para>
-				<para><varname>h3OriginToDirectedEdges(h3index) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3OriginToDirectedEdges(h3index) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3OriginToDirectedEdges(h3index '871fa44a8ffffff');
 -- {"1171fa44a8ffffff", "1271fa44a8ffffff", "1371fa44a8ffffff",
@@ -758,7 +856,9 @@ SELECT h3OriginToDirectedEdges(h3index '871fa44a8ffffff');
 			<listitem xml:id="th3_h3_cell_to_vertexes">
 				<indexterm significance="normal"><primary><varname>h3CellToVertexes</varname></primary></indexterm>
 				<para>Todos los vértices de una celda (6 para hexágonos, 5 para pentágonos).</para>
-				<para><varname>h3CellToVertexes(h3index) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3CellToVertexes(h3index) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3CellToVertexes(h3index '871fa44a8ffffff');
 -- {"2071fa44a8ffffff", "2171fa44a8ffffff", "2271fa44a8ffffff",
@@ -769,7 +869,9 @@ SELECT h3CellToVertexes(h3index '871fa44a8ffffff');
 			<listitem xml:id="th3_h3_get_icosahedron_faces">
 				<indexterm significance="normal"><primary><varname>h3GetIcosahedronFaces</varname></primary></indexterm>
 				<para>Los índices de caras del icosaedro (0..19) intersectadas por una celda.</para>
-				<para><varname>h3GetIcosahedronFaces(h3index) → intset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3GetIcosahedronFaces(h3index) → intset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GetIcosahedronFaces(h3index '831c02fffffffff');
 -- {6, 11}
@@ -789,7 +891,9 @@ SELECT h3GetIcosahedronFaces(h3index '831c02fffffffff');
 				<indexterm significance="normal"><primary><varname>aContains</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tContains</varname></primary></indexterm>
 				<para>Si una huella contiene a la otra (solo interiores)</para>
-				<para><varname>eContains, aContains, tContains</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eContains, aContains, tContains
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'SRID=4326;Polygon((-123 37,-123 38,-122 38,-122 37,-123 37))',
   th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]');
@@ -804,7 +908,9 @@ SELECT tContains(geometry 'SRID=4326;Polygon((-123 37,-123 38,-122 38,-122 37,-1
 				<indexterm significance="normal"><primary><varname>aCovers</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tCovers</varname></primary></indexterm>
 				<para>Si una huella cubre a la otra (frontera incluida)</para>
-				<para><varname>eCovers, aCovers, tCovers</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eCovers, aCovers, tCovers
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eCovers(geometry 'SRID=4326;Polygon((-123 37,-123 38,-122 38,-122 37,-123 37))',
   th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]');
@@ -819,7 +925,9 @@ SELECT tCovers(geometry 'SRID=4326;Polygon((-123 37,-123 38,-122 38,-122 37,-123
 				<indexterm significance="normal"><primary><varname>aDisjoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>
 				<para>Si las huellas no comparten ningún punto</para>
-				<para><varname>eDisjoint, aDisjoint, tDisjoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eDisjoint, aDisjoint, tDisjoint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eDisjoint(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]',
   th3index '[88283082b3fffff@2001-01-01, 88283082b1fffff@2001-01-02]');
@@ -834,7 +942,9 @@ SELECT tDisjoint(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-
 				<indexterm significance="normal"><primary><varname>aIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 				<para>Si las huellas comparten al menos un punto</para>
-				<para><varname>eIntersects, aIntersects, tIntersects</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eIntersects, aIntersects, tIntersects
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eIntersects(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]',
   th3index '[8828308281fffff@2001-01-01, 88283082b1fffff@2001-01-02]');
@@ -849,7 +959,9 @@ SELECT tIntersects(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-0
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 				<para>Si las huellas comparten un punto de frontera pero ningún punto interior</para>
-				<para><varname>eTouches, aTouches, tTouches</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eTouches, aTouches, tTouches
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eTouches(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]',
   th3index '[8828308283fffff@2001-01-01, 8828308285fffff@2001-01-02]');
@@ -864,7 +976,9 @@ SELECT tTouches(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-0
 				<indexterm significance="normal"><primary><varname>aDwithin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
 				<para>Si las huellas se encuentran dentro de una distancia dada, pasada como tercer argumento</para>
-				<para><varname>eDwithin, aDwithin, tDwithin (…, dist float)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eDwithin, aDwithin, tDwithin (…, dist float)
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eDwithin(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]',
   th3index '[88283082b3fffff@2001-01-01, 88283082b1fffff@2001-01-02]', 5000);
@@ -893,7 +1007,9 @@ SELECT eContains(
 			<listitem xml:id="th3_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
-				<para><varname>tCount(th3index) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(th3index) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
@@ -908,7 +1024,9 @@ FROM Temp;
 			<listitem xml:id="th3_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Conteo en ventana</para>
-				<para><varname>wCount(th3index) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(th3index) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -46,10 +46,12 @@ SELECT tjsonb '[{"unit": "km", "speed": 10}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>jsonbsetObjectField</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetObjectFieldText</varname></primary></indexterm>
 				<para>Extraer un campo de objeto JSON especificado por una clave</para>
-				<para><varname>{textset,jsonbset} -> text → {textset,jsonbset}</varname></para>
-				<para><varname>jsonbset ->> text → textset</varname></para>
-				<para><varname>jsonbsetObjectField(jsonbset,text,null_handle text='use_json_null') → jsonbset</varname></para>
-				<para><varname>jsonbsetObjectFieldText(jsonbset,text,null_handle text='use_json_null') → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{textset,jsonbset} -> text → {textset,jsonbset}
+jsonbset ->> text → textset
+jsonbsetObjectField(jsonbset,text,null_handle text='use_json_null') → jsonbset
+jsonbsetObjectFieldText(jsonbset,text,null_handle text='use_json_null') → textset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT textset '{[{"unit": "km", "speed": 10},
   {"unit": "km", "speed": 20}]}' -> text 'speed';
@@ -88,9 +90,11 @@ SELECT jsonbsetObjectField(textset '{[{"unit": "km", "speed": 10},
 				<indexterm significance="normal"><primary><varname>jsonbsetExtractPath</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetExtractPathText</varname></primary></indexterm>
 				<para>Extraer un campo de objeto JSON especificado por una ruta</para>
-				<para><varname>{textset,jsonbset} #> text[] → {textset,jsonbset}</varname></para>
-				<para><varname>jsonbsetExtractPath(jsonbset,text[],null_handle text='use_json_null') → jsonbset</varname></para>
-				<para><varname>jsonbsetExtractPathText(jsonbset,text[],null_handle text='use_json_null') → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{textset,jsonbset} #> text[] → {textset,jsonbset}
+jsonbsetExtractPath(jsonbset,text[],null_handle text='use_json_null') → jsonbset
+jsonbsetExtractPathText(jsonbset,text[],null_handle text='use_json_null') → textset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT textset '[{"speed": {"unit": "km", "value": 10}},
   {"speed": {"unit": "km", "value": 20}}]' #> ARRAY[text 'speed', 'value'];
@@ -106,8 +110,10 @@ SELECT jsonbset '[{"position":"Point(1 1)", "PoIs":["Grand Place", "La Bourse"]}
 				<indexterm significance="normal"><primary><varname>jsonbsetArrayElement</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetArrayElementText</varname></primary></indexterm>
 				<para>Extraer un elemento de un arreglo JSON</para>
-				<para><varname>jsonbsetArrayElement(jsonbset,integer,null_handle text='use_json_null') → jsonbset</varname></para>
-				<para><varname>jsonbsetArrayElementText(jsonbset,integer,null_handle text='use_json_null') → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetArrayElement(jsonbset,integer,null_handle text='use_json_null') → jsonbset
+jsonbsetArrayElementText(jsonbset,integer,null_handle text='use_json_null') → jsonbset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetArrayElement(textset '[["Grand Place", "La Bourse"],
   ["Palais Royal", "Manneken Pis"]]', 0);
@@ -123,9 +129,11 @@ SELECT jsonbsetArrayElement(jsonbset '[["Grand Place", "La Bourse"],
 				<indexterm significance="normal"><primary><varname>floatset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>textset</varname></primary></indexterm>
 				<para>Extraer un valor alfanumérico de un conjunto JSONB dado por una clave</para>
-				<para><varname>intset(jsonbset,text,null_handle text='raise_exception') → tint</varname></para>
-				<para><varname>floatset(jsonbset,text,null_handle text='raise_exception') → tfloat</varname></para>
-				<para><varname>textset(jsonbset,text,null_handle text='raise_exception') → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+intset(jsonbset,text,null_handle text='raise_exception') → tint
+floatset(jsonbset,text,null_handle text='raise_exception') → tfloat
+textset(jsonbset,text,null_handle text='raise_exception') → textset
+</programlisting>
 				<para>Tenga en cuenta que el valor <varname>use_json_null</varname> no puede utilizarse para las funciones anteriores y por lo tanto se utiliza el valor por defecto <varname>'raise_exception'</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intset(jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}",
@@ -143,7 +151,9 @@ SELECT textset(jsonbset '{"{\"road\": \"Bvd Gén. Jacques\", \"category\": \"pri
 			<listitem xml:id="jsonbset_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
 				<para>Concatenación JSONB temporal</para>
-				<para><varname>jsonbset || {jsonb,jsonbset} → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset || {jsonb,jsonbset} → jsonbset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbset '{[{"speed":10}, {"speed":20}]}' ||
   '{"unit":"km"}'::jsonb;
@@ -158,8 +168,10 @@ SELECT jsonbset '{[{"speed":10}, {"speed":20}]}' ||
 			<listitem xml:id="jsonbset_delete">
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
 				<para>Eliminación JSONB temporal</para>
-				<para><varname>jsonbset - {int,text,text[]} → jsonbset</varname></para>
-				<para><varname>jsonbset #- text[] → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset - {int,text,text[]} → jsonbset
+jsonbset #- text[] → jsonbset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbset '{[{"unit": "km", "speed": 10},
   {"unit": "km", "speed": 20}]}' - 'unit';
@@ -195,9 +207,11 @@ SELECT minusValues(jsonbset '[["Grand Place", "La Bourse"],
 			<listitem xml:id="jsonbset_exists">
 				<indexterm significance="normal"><primary><varname>?</varname></primary></indexterm>
 				<para>Existencia en un conjunto JSONB</para>
-				<para><varname>jsonbset ? text → boolean[]</varname></para>
-				<para><varname>jsonbset ?| text[] → boolean[]</varname></para>
-				<para><varname>jsonbset ?&amp; text[] → boolean[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset ? text → boolean[]
+jsonbset ?| text[] → boolean[]
+jsonbset ?&amp; text[] → boolean[]
+</programlisting>
 				<para>Como en PostgreSQL, los operadores <varname>?|</varname> y <varname>?&amp;</varname> comprueban, respectivamente, si <emphasis>alguna</emphasis> o <emphasis>todas</emphasis> las cadenas del arreglo de texto existen como claves de nivel superior o elementos de arreglo.</para>
 				<para>El resultado es un booleano por cada valor del conjunto, en el orden de los valores del conjunto.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -220,8 +234,11 @@ SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}'
 				<indexterm significance="normal"><primary><varname>jsonbsetSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetSetLax</varname></primary></indexterm>
 				<para>Asignación JSONB temporal</para>
-				<para><varname>jsonbsetSet(jsonbset,path text[],jsonb,create boolean=true) → jsonbset</varname></para>
-				<para><varname>jsonbsetSetLax(jsonbset,path text[],jsonb,create boolean=true,handle_null text) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetSet(jsonbset,path text[],jsonb,create boolean=true) → jsonbset
+jsonbsetSetLax(jsonbset,path text[],jsonb,create boolean=true,
+  handle_null text) → jsonbset
+</programlisting>
 				<para>Devuelve el valor <varname>jsonbset</varname> con el elemento especificado por la ruta reemplazado por <varname>jsonb</varname>, o añadido si <varname>create</varname> es verdadero y el elemento no existe. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, y create_if_missing es verdadero, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo.
         </para>
 				<para>La función <varname>jsonbsetSetLax</varname> se comporta de forma idéntica a <varname>jsonbsetSet</varname> si el valor dado no es NULL; de lo contrario, se comporta según el valor de <varname>handle_null</varname>, que debe ser uno de <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname> o <varname>'return_source'</varname>. Como se indicó anteriormente, mantuvimos el comportamiento de PostgreSQL para esta función habilitando el valor <varname>'return_source'</varname>, mientras que para todas las demás operaciones de <emphasis>consulta</emphasis>, este valor se ha reemplazado por <varname>'return_null'</varname>.</para>
@@ -244,7 +261,9 @@ SELECT jsonbsetSetLax(jsonbset '[{"speed": 10, "units": "km/h"},
 			<listitem xml:id="jsonbset_insert">
 				<indexterm significance="normal"><primary><varname>jsonbsetInsert</varname></primary></indexterm>
 				<para>Inserción JSONB temporal</para>
-				<para><varname>jsonbsetInsert(jsonbset,path text[],jsonb,after boolean=false) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetInsert(jsonbset,path text[],jsonb,after boolean=false) → jsonbset
+</programlisting>
 				<para>Devuelve el valor <varname>jsonbset</varname> con <varname>jsonb</varname> insertado. Si el elemento especificado por la ruta es un elemento de arreglo, el nuevo valor se insertará antes de ese elemento si <varname>after</varname> es falso, o después en caso contrario. Si el elemento especificado por la ruta es un campo de objeto, el nuevo valor se insertará solo si el objeto no contiene ya esa clave. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetInsert(jsonbset '[{"speed":10}, {"speed":20}]',
@@ -262,7 +281,9 @@ SELECT jsonbsetInsert(jsonbset '[{"speed": 10, "units": "km/h"},
 			<listitem xml:id="jsonbset_strip_nulls">
 				<indexterm significance="normal"><primary><varname>jsonbsetStripNulls</varname></primary></indexterm>
 				<para>Devolver un conjunto JSONB sin nulos</para>
-				<para><varname>jsonbsetStripNulls(jsonbset,strip_in_arrays boolean=false) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetStripNulls(jsonbset,strip_in_arrays boolean=false) → jsonbset
+</programlisting>
 				<para>El último argumento indica si los elementos de arreglo nulos también se eliminan. Los valores nulos simples nunca se eliminan.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetStripNulls(textset '[{"speed": 10, "lights": null},
@@ -300,9 +321,11 @@ SELECT minusValues(textset '[{"speed": 10}, null,
 				<indexterm significance="normal"><primary><varname>jsonbsetPathExists</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetPathExistsTz</varname></primary></indexterm>
 				<para>¿Devuelve la ruta JSON algún elemento para el conjunto JSONB especificado?</para>
-				<para><varname>jsonbset @? jsonpath → boolean[]</varname></para>
-				<para><varname>jsonbsetPathExists(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
-				<para><varname>jsonbsetPathExistsTz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset @? jsonpath → boolean[]
+jsonbsetPathExists(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]
+jsonbsetPathExistsTz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]
+</programlisting>
 				<para>El operador <varname>@?</varname> suprime los siguientes errores: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Las funciones anteriores también pueden suprimir estos tipos de errores estableciendo el último argumento en verdadero. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
 				<para>El resultado es un booleano por cada valor del conjunto, en el orden de los valores del conjunto.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -323,9 +346,11 @@ SELECT jsonbsetPathExists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20,
 				<indexterm significance="normal"><primary><varname>jsonbsetPathMatch</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetPathMatchTz</varname></primary></indexterm>
 				<para>Devolver el resultado de una comprobación de predicado de ruta JSON para un conjunto JSONB</para>
-				<para><varname>jsonbset @@ jsonpath → boolean[]</varname></para>
-				<para><varname>jsonbsetPathMatch(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
-				<para><varname>jsonbsetPathMatchTz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset @@ jsonpath → boolean[]
+jsonbsetPathMatch(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]
+jsonbsetPathMatchTz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]
+</programlisting>
 				<para>El operador <varname>@@</varname> suprime los siguientes errores: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Las funciones anteriores también pueden suprimir estos tipos de errores estableciendo el último argumento en verdadero. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
 				<para>El resultado es un booleano por cada valor del conjunto, en el orden de los valores del conjunto.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -345,8 +370,10 @@ SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20,
 				<indexterm significance="normal"><primary><varname>jsonbsetPathQueryArray</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetPathQueryArrayTz</varname></primary></indexterm>
 				<para>Devolver todos los elementos devueltos por una ruta JSON de un conjunto JSONB, como un arreglo JSON</para>
-				<para><varname>jsonbsetPathQueryArray(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset</varname></para>
-				<para><varname>jsonbsetPathQueryArrayTz(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetPathQueryArray(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset
+jsonbsetPathQueryArrayTz(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset
+</programlisting>
 				<para>La función anterior puede suprimir los siguientes errores estableciendo el último argumento en verdadero: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetPathQueryArray(jsonbset
@@ -367,8 +394,10 @@ SELECT jsonbsetPathQueryArrayTz(jsonbset
 				<indexterm significance="normal"><primary><varname>jsonbsetPathQueryFirst</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetPathQueryFirstTz</varname></primary></indexterm>
 				<para>Devolver el primer elemento devuelto por una ruta JSON de un conjunto JSONB</para>
-				<para><varname>jsonbsetPathQueryFirst(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset</varname></para>
-				<para><varname>jsonbsetPathQueryFirstTz(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetPathQueryFirst(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset
+jsonbsetPathQueryFirstTz(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset
+</programlisting>
 				<para>Las funciones anteriores pueden suprimir los siguientes errores estableciendo el último argumento en verdadero: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetPathQueryFirst(jsonbset
@@ -455,7 +484,9 @@ SELECT tjsonb 'Point(0 0)@2001-01-01 08:05:00';
 			<listitem xml:id="tjsonb_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Devolver la representación en texto bien conocido (WKT)</para>
-				<para><varname>asText({tjsonb,tjsonb[]}) → {text,text[]}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({tjsonb,tjsonb[]}) → {text,text[]}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]');
@@ -473,8 +504,10 @@ SELECT asText(ARRAY[tjsonb '"{\"vehicleId\":1, \"location\": \"Point(1 1)\"}"@20
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Devolver la representación en binario bien conocido (WKB) o en binario bien conocido extendido hexadecimal (HexWKB)</para>
-				<para><varname>asBinary(tjsonb,endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB(tjsonb,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(tjsonb,endian text='') → bytea
+asHexWKB(tjsonb,endian text='') → text
+</programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tjsonb '"{\"vehicleId\": 1, \"location\": \"Point(1 2)\"}"@2001-01-01');
@@ -487,7 +520,9 @@ SELECT asHexWKB(tjsonb '"{\"vehicleId\": 1, \"location\": \"Point(1 2)\"}"@2001-
 			<listitem xml:id="tjsonb_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Devolver la representación JSON de objetos en movimiento (MF-JSON)</para>
-				<para><varname>asMFJSON(text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(text) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tjsonb '[{"Position": "Point(1 1)"}@2001-01-01,
   {"Position": "Point(2 2)"}@2001-01-02]');
@@ -500,7 +535,9 @@ SELECT asMFJSON(tjsonb '[{"Position": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonbFromText">
 				<indexterm significance="normal"><primary><varname>tjsonbFromText</varname></primary></indexterm>
 				<para>Entrada a partir de la representación en texto bien conocido (WKT)</para>
-				<para><varname>tjsonbFromText(text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbFromText(text) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbFromText(text
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -514,8 +551,10 @@ SELECT tjsonbFromText(text
 				<indexterm significance="normal"><primary><varname>tjsonbFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbFromHexWKB</varname></primary></indexterm>
 				<para>Entrada a partir de la representación en binario bien conocido (WKB) o en binario bien conocido hexadecimal (HexWKB)</para>
-				<para><varname>tjsonbFromBinary(bytea) → tjsonb</varname></para>
-				<para><varname>tjsonbFromHexWKB(text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbFromBinary(bytea) → tjsonb
+tjsonbFromHexWKB(text) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbFromBinary(asBinary(
   tjsonb '[{"vehicleId": 1, "location": "Point(1 2)"}@2001-01-01]'));
@@ -529,7 +568,9 @@ SELECT tjsonbFromHexWKB(asHexWKB(
 			<listitem xml:id="tjsonbFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tjsonbFromMFJSON</varname></primary></indexterm>
 				<para>Entrada a partir de la representación JSON de objetos en movimiento (MF-JSON)</para>
-				<para><varname>tjsonbFromMFJSON(text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbFromMFJSON(text) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbFromMFJSON('{"type": "MovingJsonb", "interpolation": "Step",
   "values": [{"Position": "Point(1 1)"}, {"Position": "Point(2 2)"}],
@@ -548,10 +589,12 @@ SELECT tjsonbFromMFJSON('{"type": "MovingJsonb", "interpolation": "Step",
 			<listitem xml:id="tjsonb_const">
 				<indexterm significance="normal"><primary><varname>tjsonb</varname></primary></indexterm>
 				<para>Constructor de valores JSONB temporales que tienen un valor constante</para>
-				<para><varname>tjsonb(jsonb,timestamptz) → tjsonbInst</varname></para>
-				<para><varname>tjsonb(jsonb,tstzset) → tjsonbDiscSeq</varname></para>
-				<para><varname>tjsonb(jsonb,tstzspan) → tjsonbContSeq</varname></para>
-				<para><varname>tjsonb(jsonb,tstzspanset) → tjsonbSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb(jsonb,timestamptz) → tjsonbInst
+tjsonb(jsonb,tstzset) → tjsonbDiscSeq
+tjsonb(jsonb,tstzspan) → tjsonbContSeq
+tjsonb(jsonb,tstzspanset) → tjsonbSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb('{"vehicleId": 1, "location": "Point(1 1)"}', timestamptz '2001-01-01');
 -- {"location": "Point(1 1)", "vehicleId": 1}@2001-01-01
@@ -576,7 +619,9 @@ SELECT tjsonb('{"vehicleId": 1, "location": "Point(1 1)"}',
 			<listitem xml:id="tjsonbSeq">
 				<indexterm significance="normal"><primary><varname>tjsonbSeq</varname></primary></indexterm>
 				<para>Constructor de valores JSONB temporales del subtipo secuencia</para>
-				<para><varname>tjsonbSeq(tjsonbInst[]},leftInc boolean=true,rightInc boolean=true) →tjsonbSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbSeq(tjsonbInst[]},leftInc boolean=true,rightInc boolean=true) →tjsonbSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeq(ARRAY[tjsonb
   '"{\"vehicleId\": 1, \"location\": \"Point(1 1)\"}"@2001-01-01',
@@ -592,8 +637,10 @@ SELECT tjsonbSeq(ARRAY[tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor de valores JSONB temporales del subtipo conjunto de secuencias</para>
-				<para><varname>tjsonbSeqSet(tjsonb[]) → tjsonbSeqSet</varname></para>
-				<para><varname>tjsonbSeqSetGaps(tjsonbInst[],maxt=NULL,maxdist=NULL) → tjsonbSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbSeqSet(tjsonb[]) → tjsonbSeqSet
+tjsonbSeqSetGaps(tjsonbInst[],maxt=NULL,maxdist=NULL) → tjsonbSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeqSet(ARRAY[tjsonb
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -622,7 +669,9 @@ SELECT tjsonbSeqSetGaps(ARRAY[tjsonb
 			<listitem xml:id="tjsonb_tstzspan">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir un JSONB temporal a un <varname>tstzspan</varname></para>
-				<para><varname>tjsonb::tstzpan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb::tstzpan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]'::tstzspan;
@@ -633,8 +682,10 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_text">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir entre un JSONB temporal y un texto</para>
-				<para><varname>tjsonb::text</varname></para>
-				<para><varname>text::tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb::text
+text::tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (text '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]')::jsonb;
@@ -649,8 +700,10 @@ SELECT pg_typeof(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_ttext">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir entre un JSONB temporal y un texto temporal</para>
-				<para><varname>tjsonb::ttext</varname></para>
-				<para><varname>ttext::tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb::ttext
+ttext::tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (ttext '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]')::tjsonb;
@@ -670,7 +723,9 @@ SELECT pg_typeof(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Devolver los valores</para>
-				<para><varname>getValues(tjsonb) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tjsonb) → jsonbset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(tjsonb
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -682,7 +737,9 @@ SELECT getValues(tjsonb
 			<listitem xml:id="tjsonb_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devolver el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(tjsonb,timestamptz) → jsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tjsonb,timestamptz) → jsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tjsonb
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -701,9 +758,11 @@ SELECT valueAtTimestamp(tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSet</varname></primary></indexterm>
 				<para>Transformar un JSONB temporal a otro subtipo</para>
-				<para><varname>tjsonbInst(tjsonb) → tjsonbInst</varname></para>
-				<para><varname>tjsonbSeq(tjsonb,interp='step') → tjsonbSeq</varname></para>
-				<para><varname>tjsonbSeqSet(tjsonb) → tjsonbSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbInst(tjsonb) → tjsonbInst
+tjsonbSeq(tjsonb,interp='step') → tjsonbSeq
+tjsonbSeqSet(tjsonb) → tjsonbSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeq(tjsonb '"{\"vehicleId\": 1, \"location\": \"Point(1 1)\"}"@2001-01-01');
 -- [{"location": "Point(1 1)", "vehicleId": 1}@2001-01-01]
@@ -718,7 +777,9 @@ SELECT tjsonbSeqSet(tjsonb '"{\"vehicleId\": 1,\"location\":\"Point(1 1)\"}"@200
 			<listitem xml:id="tjsonb_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transformar un valor JSONB temporal a otra interpolación</para>
-				<para><varname>setInterp(tjsonb,interp) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(tjsonb,interp) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT setInterp(tjsonb
   '"{\"vehicleId\": 1,\"location\": \"Point(1 1)\"}"@2001-01-01','step');
@@ -764,11 +825,13 @@ SELECT tjsonb '{[{"unit": "km", "speed": 10}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tjsonbObjectField</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbObjectFieldText</varname></primary></indexterm>
 				<para>Extraer un campo de objeto JSON temporal especificado por una clave</para>
-				<para><varname>{ttext,tjsonb} -> text → {ttext,tjsonb}</varname></para>
-				<para><varname>tjsonb ->> text → ttext</varname></para>
-				<para><varname>tjsonObjectField(ttext,text,null_handle text='use_json_null') → ttext</varname></para>
-				<para><varname>tjsonbObjectField(tjsonb,text,null_handle text='use_json_null') → tjsonb</varname></para>
-				<para><varname>tjsonbObjectFieldText(tjsonb,text,null_handle text='use_json_null') → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{ttext,tjsonb} -> text → {ttext,tjsonb}
+tjsonb ->> text → ttext
+tjsonObjectField(ttext,text,null_handle text='use_json_null') → ttext
+tjsonbObjectField(tjsonb,text,null_handle text='use_json_null') → tjsonb
+tjsonbObjectFieldText(tjsonb,text,null_handle text='use_json_null') → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '{[{"unit": "km", "speed": 10}@2001-01-01,
   {"unit": "km", "speed": 20}@2001-01-02]}' -> text 'speed';
@@ -808,10 +871,12 @@ SELECT tjsonObjectField(ttext '{[{"unit": "km", "speed": 10}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tjsonbExtractPath</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbExtractPathText</varname></primary></indexterm>
 				<para>Extraer un campo de objeto JSON temporal especificado por una ruta</para>
-				<para><varname>{ttext,tjsonb} #> text[] → {ttext,tjsonb}</varname></para>
-				<para><varname>tjsonExtractPath(ttext,text[],null_handle text='use_json_null') → ttext</varname></para>
-				<para><varname>tjsonbExtractPath(tjsonb,text[],null_handle text='use_json_null') → tjsonb</varname></para>
-				<para><varname>tjsonbExtractPathText(tjsonb,text[],null_handle text='use_json_null') → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{ttext,tjsonb} #> text[] → {ttext,tjsonb}
+tjsonExtractPath(ttext,text[],null_handle text='use_json_null') → ttext
+tjsonbExtractPath(tjsonb,text[],null_handle text='use_json_null') → tjsonb
+tjsonbExtractPathText(tjsonb,text[],null_handle text='use_json_null') → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '[{"speed": {"unit": "km", "value": 10}}@2001-01-01,
   {"speed": {"unit": "km", "value": 20}}@2001-01-02]' #> ARRAY[text 'speed', 'value'];
@@ -828,9 +893,11 @@ SELECT tjsonb '[{"position":"Point(1 1)", "PoIs":["Grand Place", "La Bourse"]}@2
 				<indexterm significance="normal"><primary><varname>tjsonbArrayElement</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbArrayElementText</varname></primary></indexterm>
 				<para>Extraer un elemento de un arreglo JSON temporal</para>
-				<para><varname>tjsonArrayElement(tjsonb,integer,null_handle text='use_json_null') → tjsonb</varname></para>
-				<para><varname>tjsonbArrayElement(tjsonb,integer,null_handle text='use_json_null') → tjsonb</varname></para>
-				<para><varname>tjsonbArrayElementText(tjsonb,integer,null_handle text='use_json_null') → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonArrayElement(tjsonb,integer,null_handle text='use_json_null') → tjsonb
+tjsonbArrayElement(tjsonb,integer,null_handle text='use_json_null') → tjsonb
+tjsonbArrayElementText(tjsonb,integer,null_handle text='use_json_null') → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonArrayElement(ttext '[["Grand Place", "La Bourse"]@2001-01-01,
   ["Palais Royal", "Manneken Pis"]@2001-01-02]', 0);
@@ -847,10 +914,12 @@ SELECT tjsonbArrayElement(tjsonb '[["Grand Place", "La Bourse"]@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tfloat</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttext</varname></primary></indexterm>
 				<para>Extraer un valor alfanumérico temporal de un valor JSONB temporal dado por una clave</para>
-				<para><varname>tbool(tjsonb,text,null_handle text='raise_exception') → tbool</varname></para>
-				<para><varname>tint(tjsonb,text,null_handle text='raise_exception') → tint</varname></para>
-				<para><varname>tfloat(tjsonb,text,interp='linear',null_handle text='raise_exception') → tfloat</varname></para>
-				<para><varname>ttext(tjsonb,text, null_handle text='raise_exception') → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbool(tjsonb,text,null_handle text='raise_exception') → tbool
+tint(tjsonb,text,null_handle text='raise_exception') → tint
+tfloat(tjsonb,text,interp='linear',null_handle text='raise_exception') → tfloat
+ttext(tjsonb,text, null_handle text='raise_exception') → ttext
+</programlisting>
 				<para>Tenga en cuenta que el valor <varname>use_json_null</varname> no puede utilizarse para las funciones anteriores y por lo tanto se utiliza el valor por defecto <varname>'raise_exception'</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool(tjsonb '[{"speed": 10, "lights": "on"}@2001-01-01,
@@ -873,7 +942,9 @@ SELECT ttext(tjsonb '[{"road": "Bvd Gén. Jacques", "category": "primary"}@2001-
 			<listitem xml:id="tjsonb_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
 				<para>Concatenación JSONB temporal</para>
-				<para><varname>tjsonb || {jsonb,tjsonb} → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb || {jsonb,tjsonb} → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '{[{"speed":10}@2001-01-01, {"speed":20}@2001-01-02]}' ||
   '{"unit":"km"}'::jsonb;
@@ -888,8 +959,10 @@ SELECT tjsonb '{[{"speed":10}@2001-01-01, {"speed":20}@2001-01-03]}' ||
 			<listitem xml:id="tjsonb_delete">
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
 				<para>Eliminación JSONB temporal</para>
-				<para><varname>tjsonb - {int,text,text[]} → tjsonb</varname></para>
-				<para><varname>tjsonb #- text[] → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb - {int,text,text[]} → tjsonb
+tjsonb #- text[] → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '{[{"unit": "km", "speed": 10}@2001-01-01,
   {"unit": "km", "speed": 20}@2001-01-02]}' - 'unit';
@@ -925,9 +998,11 @@ SELECT minusValues(tjsonb '[["Grand Place", "La Bourse"]@2001-01-01,
 			<listitem xml:id="tjsonb_exists">
 				<indexterm significance="normal"><primary><varname>?</varname></primary></indexterm>
 				<para>Existencia JSONB temporal</para>
-				<para><varname>tjsonb ? jsonb → tbool</varname></para>
-				<para><varname>tjsonb ?| jsonb[] → tbool</varname></para>
-				<para><varname>tjsonb ?&amp; jsonb[] → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb ? jsonb → tbool
+tjsonb ?| jsonb[] → tbool
+tjsonb ?&amp; jsonb[] → tbool
+</programlisting>
 				<para>Como en PostgreSQL, los operadores <varname>?|</varname> y <varname>?&amp;</varname> comprueban, respectivamente, si <emphasis>alguna</emphasis> o <emphasis>todas</emphasis> las cadenas del arreglo de texto existen como claves de nivel superior o elementos de arreglo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2001-01-01' ? text 'geom';
@@ -945,8 +1020,10 @@ SELECT tjsonb '[{"speed": 10, "units": "km/h"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
 				<para>Contiene/contenido JSONB temporal</para>
-				<para><varname>{tjsonb,jsonb} @&gt; {tjsonb,jsonb} → tbool</varname></para>
-				<para><varname>{tjsonb,jsonb} &lt;@ {tjsonb,jsonb} → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tjsonb,jsonb} @&gt; {tjsonb,jsonb} → tbool
+{tjsonb,jsonb} &lt;@ {tjsonb,jsonb} → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2001-01-01' @&gt; jsonb '{"geom": "Point(1 1)"}';
 -- t@2001-01-01
@@ -964,8 +1041,10 @@ SELECT jsonb '{"geom": "Point(1 1)"}' &lt;@ tjsonb '{[{"geom": "Point(1 1)"}@200
 				<indexterm significance="normal"><primary><varname>tjsonbSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbSetLax</varname></primary></indexterm>
 				<para>Asignación JSONB temporal</para>
-				<para><varname>tjsonbSet(tjsonb,path text[],jsonb,create boolean=true) → tjsonb</varname></para>
-				<para><varname>tjsonbSetLax(tjsonb,path text[],jsonb,create boolean=true,handle_null text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbSet(tjsonb,path text[],jsonb,create boolean=true) → tjsonb
+tjsonbSetLax(tjsonb,path text[],jsonb,create boolean=true,handle_null text) → tjsonb
+</programlisting>
 				<para>Devuelve el valor <varname>tjsonb</varname> con el elemento especificado por la ruta reemplazado por <varname>jsonb</varname>, o añadido si <varname>create</varname> es verdadero y el elemento no existe. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, y create_if_missing es verdadero, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo.
         </para>
 				<para>La función <varname>tjsonbSetLax</varname> se comporta de forma idéntica a <varname>tjsonbSet</varname> si el valor dado no es NULL; de lo contrario, se comporta según el valor de <varname>handle_null</varname>, que debe ser uno de <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname> o <varname>'return_source'</varname>. Como se indicó anteriormente, mantuvimos el comportamiento de PostgreSQL para esta función habilitando el valor <varname>'return_source'</varname>, mientras que para todas las demás operaciones de <emphasis>consulta</emphasis>, este valor se ha reemplazado por <varname>'return_null'</varname>.</para>
@@ -988,7 +1067,9 @@ SELECT tjsonbSetLax(tjsonb '[{"speed": 10, "units": "km/h"}@2001-01-01,
 			<listitem xml:id="tjsonb_insert">
 				<indexterm significance="normal"><primary><varname>tjsonbInsert</varname></primary></indexterm>
 				<para>Inserción JSONB temporal</para>
-				<para><varname>tjsonbInsert(tjsonb,path text[],jsonb,after boolean=false) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbInsert(tjsonb,path text[],jsonb,after boolean=false) → tjsonb
+</programlisting>
 				<para>Devuelve el valor <varname>tjsonb</varname> con <varname>jsonb</varname> insertado. Si el elemento especificado por la ruta es un elemento de arreglo, el nuevo valor se insertará antes de ese elemento si <varname>after</varname> es falso, o después en caso contrario. Si el elemento especificado por la ruta es un campo de objeto, el nuevo valor se insertará solo si el objeto no contiene ya esa clave. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbInsert(tjsonb '[{"speed":10}@2001-01-01, {"speed":20}@2001-01-02]',
@@ -1007,8 +1088,10 @@ SELECT tjsonbInsert(tjsonb '[{"speed": 10, "units": "km/h"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tjsonStripNulls</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbStripNulls</varname></primary></indexterm>
 				<para>Devolver un valor JSON temporal sin nulos</para>
-				<para><varname>tjsonStripNulls(ttext,strip_in_arrays boolean=false) → ttext</varname></para>
-				<para><varname>tjsonbStripNulls(tjsonb,strip_in_arrays boolean=false) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonStripNulls(ttext,strip_in_arrays boolean=false) → ttext
+tjsonbStripNulls(tjsonb,strip_in_arrays boolean=false) → tjsonb
+</programlisting>
 				<para>El último argumento indica si los elementos de arreglo nulos también se eliminan. Los valores nulos simples nunca se eliminan.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonStripNulls(ttext '[{"speed": 10, "lights": null}@2001-01-01,
@@ -1046,9 +1129,11 @@ SELECT minusValues(ttext '[{"speed": 10}@2001-01-01, null@2001-01-02,
 				<indexterm significance="normal"><primary><varname>tjsonbPathExists</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbPathExistsTz</varname></primary></indexterm>
 				<para>¿Devuelve la ruta JSON algún elemento para el valor JSONB temporal especificado?</para>
-				<para><varname>tjsonb @? jsonpath → tbool</varname></para>
-				<para><varname>tjsonbPathExists(tjsonb,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
-				<para><varname>tjsonbPathExistsTz(tjsonb,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb @? jsonpath → tbool
+tjsonbPathExists(tjsonb,vars jsonb='{}',silent boolean=false) → tbool
+tjsonbPathExistsTz(tjsonb,vars jsonb='{}',silent boolean=false) → tbool
+</programlisting>
 				<para>El operador <varname>@?</varname> suprime los siguientes errores: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Las funciones anteriores también pueden suprimir estos tipos de errores estableciendo el último argumento en verdadero. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"speed":10}@2001-01-01, {"speed": 20, "units": "km/h"}@2001-01-02]' @?
@@ -1074,9 +1159,11 @@ SELECT tjsonbPathExistsTz(tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbPathMatch</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbPathMatchTz</varname></primary></indexterm>
 				<para>Devolver el resultado de una comprobación de predicado de ruta JSON para un valor JSONB temporal</para>
-				<para><varname>tjsonb @@ jsonpath → tbool</varname></para>
-				<para><varname>tjsonbPathMatch(tjsonb,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
-				<para><varname>tjsonbPathMatchTz(tjsonb,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb @@ jsonpath → tbool
+tjsonbPathMatch(tjsonb,vars jsonb='{}',silent boolean=false) → tbool
+tjsonbPathMatchTz(tjsonb,vars jsonb='{}',silent boolean=false) → tbool
+</programlisting>
 				<para>El operador <varname>@@</varname> suprime los siguientes errores: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Las funciones anteriores también pueden suprimir estos tipos de errores estableciendo el último argumento en verdadero. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"speed":10}@2001-01-01, {"speed": 20, "units": "km/h"}@2001-01-02]' @@
@@ -1101,8 +1188,10 @@ SELECT tjsonbPathMatchTz(tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbPathQueryArray</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbPathQueryArrayTz</varname></primary></indexterm>
 				<para>Devolver todos los elementos devueltos por una ruta JSON de un valor JSONB temporal, como un arreglo JSON</para>
-				<para><varname>tjsonbPathQueryArray(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb</varname></para>
-				<para><varname>tjsonbPathQueryArrayTz(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbPathQueryArray(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb
+tjsonbPathQueryArrayTz(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb
+</programlisting>
 				<para>La función anterior puede suprimir los siguientes errores estableciendo el último argumento en verdadero: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbPathQueryArray(tjsonb
@@ -1123,8 +1212,10 @@ SELECT tjsonbPathQueryArrayTz(tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbPathQueryFirst</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbPathQueryFirstTz</varname></primary></indexterm>
 				<para>Devolver el primer elemento devuelto por una ruta JSON de un valor JSONB temporal</para>
-				<para><varname>tjsonbPathQueryFirst(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb</varname></para>
-				<para><varname>tjsonbPathQueryFirstTz(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbPathQueryFirst(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb
+tjsonbPathQueryFirstTz(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb
+</programlisting>
 				<para>Las funciones anteriores pueden suprimir los siguientes errores estableciendo el último argumento en verdadero: campo de objeto o elemento de arreglo faltante, tipo de elemento JSON inesperado, errores de fecha/hora y numéricos. Este comportamiento puede ser útil al buscar en colecciones de documentos JSON de estructura variable.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbPathQueryFirst(tjsonb
@@ -1153,10 +1244,12 @@ SELECT tjsonbPathQueryArrayTz(tjsonb
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 				<para>Restringir a (el complemento de) un valor o un conjunto de valores</para>
-				<para><varname>atValue(tjsonb,value) → tjsonb</varname></para>
-				<para><varname>minusValue(tjsonb,value) → tjsonb</varname></para>
-				<para><varname>atValues(tjsonb,valueset) → tjsonb</varname></para>
-				<para><varname>minusValues(tjsonb,valueset) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(tjsonb,value) → tjsonb
+minusValue(tjsonb,value) → tjsonb
+atValues(tjsonb,valueset) → tjsonb
+minusValues(tjsonb,valueset) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atValue(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-03]',
@@ -1183,7 +1276,9 @@ SELECT minusValue(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
-				<para><varname>tjsonb {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tjsonb → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tjsonb → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '{[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(1 1)"}@2001-01-02),
@@ -1209,7 +1304,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Comparaciones siempre y alguna vez</para>
-				<para><varname>{jsonb,tjsonb} {?=, %=} {jsonb,tjsonb} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{jsonb,tjsonb} {?=, %=} {jsonb,tjsonb} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]' ?=
@@ -1225,7 +1322,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_tcomp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Comparaciones temporales</para>
-				<para><varname>{jsonb,tjsonb} {#=, #&lt;&gt;} {jsonb,tjsonb} → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{jsonb,tjsonb} {#=, #&lt;&gt;} {jsonb,tjsonb} → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(1 1)"}@2001-01-03)' #=
@@ -1251,7 +1350,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Operadores topológicos</para>
-				<para><varname>{tjsonb,tstzspan} {&amp;&amp;, &lt;@#, #@&gt;, ~=, -|-} {tjsonb,tstzspan} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tjsonb,tstzspan} {&amp;&amp;, &lt;@#, #@&gt;, ~=, -|-} {tjsonb,tstzspan} → boolean
+</programlisting>
 				<para>Los operadores temporales contiene y contenido se marcan con un <varname>#</varname> para distinguirlos de los operadores JSONB correspondientes.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -1273,7 +1374,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_pos">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Operadores de posición</para>
-				<para><varname>{tjsonb,tstzspan} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tjsonb,tstzspan} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tjsonb,tstzspan} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tjsonb,tstzspan} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
     {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]' &lt;&lt;#
@@ -1301,7 +1404,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-02,
 			<listitem xml:id="tjsonb_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
-				<para><varname>tCount(tjsonb) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tjsonb) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -1317,7 +1422,9 @@ FROM Temp;
 			<listitem xml:id="tjsonb_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Conteo en ventana</para>
-				<para><varname>wCount(tjsonb) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tjsonb) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -94,8 +94,10 @@ SELECT npoint 'Npoint(99999999, 1.0)';
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Devuelve la representación de texto conocido (Well-Known Text o WKT) o la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-					<para><varname>asText({npoint,npoint[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({npoint,npoint[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({npoint,npoint[]}) → {text,text[]}
+asEWKT({npoint,npoint[]}) → {text,text[]}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(npoint 'SRID=5676;Npoint(1,0.5)');
 -- NPoint(1,0.5)
@@ -114,10 +116,12 @@ SELECT asEWKT(ARRAY[npoint 'SRID=5676;Npoint(1,0.2)', 'SRID=5676;Npoint(1,0.5)']
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 					<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-					<para><varname>asBinary(npoint,endian text='') → bytea</varname></para>
-					<para><varname>asEWKB(npoint,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(npoint,endian text='') → text</varname></para>
-					<para><varname>asHexEWKB(npoint,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(npoint,endian text='') → bytea
+asEWKB(npoint,endian text='') → bytea
+asHexWKB(npoint,endian text='') → text
+asHexEWKB(npoint,endian text='') → text
+</programlisting>
 					<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina. Un punto de red toma su SRID de la red de rutas subyacente: <varname>asEWKB</varname> y <varname>asHexEWKB</varname> lo incluyen, mientras que las formas simples <varname>asBinary</varname> y <varname>asHexWKB</varname> lo omiten.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(npoint 'SRID=5676;Npoint(1,0.5)');
@@ -135,8 +139,10 @@ SELECT asHexEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
 					<indexterm significance="normal"><primary><varname>npointFromText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>npointFromEWKT</varname></primary></indexterm>
 					<para>Entrada desde la representación de texto conocido (Well-Known Text o WKT) o desde la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-					<para><varname>npointFromText(text) → npoint</varname></para>
-					<para><varname>npointFromEWKT(text) → npoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+npointFromText(text) → npoint
+npointFromEWKT(text) → npoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(npointFromText(text 'Npoint(1,0.5)'));
 -- SRID=5676;NPoint(1,0.5)
@@ -150,9 +156,11 @@ SELECT asEWKT(npointFromEWKT(text 'SRID=5676;Npoint(1,0.5)'));
 					<indexterm significance="normal"><primary><varname>npointFromEWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>npointFromHexEWKB</varname></primary></indexterm>
 					<para>Entrada desde la representación binaria conocida (Well-Known Binary o WKB), desde la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o desde la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-					<para><varname>npointFromBinary(bytea) → npoint</varname></para>
-					<para><varname>npointFromEWKB(bytea) → npoint</varname></para>
-					<para><varname>npointFromHexEWKB(text) → npoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+npointFromBinary(bytea) → npoint
+npointFromEWKB(bytea) → npoint
+npointFromHexEWKB(text) → npoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(npointFromEWKB(
   '\x01412c1600000100000000000000000000000000e03f'));
@@ -173,8 +181,10 @@ SELECT asEWKT(npointFromHexEWKB(
 					<indexterm significance="normal"><primary><varname>npoint</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>nsegment</varname></primary></indexterm>
 					<para>Constructores de puntos o segmentos de red</para>
-					<para><varname>npoint(bigint,double precision) → npoint</varname></para>
-					<para><varname>nsegment(bigint,double precision,double precision) → nsegment</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+npoint(bigint,double precision) → npoint
+nsegment(bigint,double precision,double precision) → nsegment
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT npoint(76, 0.3);
 SELECT nsegment(76, 0.3, 0.5);
@@ -190,8 +200,10 @@ SELECT nsegment(76, 0.3, 0.5);
 				<listitem xml:id="npoint_geometry">
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Convertir entre un punto o un segmento de red y una geometría</para>
-					<para><varname>{npoint,nsegment}::geometry</varname></para>
-					<para><varname>geometry::{npoint,nsegment}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{npoint,nsegment}::geometry
+geometry::{npoint,nsegment}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT ST_AsText(npoint(76, 0.33)::geometry);
 -- POINT(21.6338731332283 50.0545869554067)
@@ -216,8 +228,10 @@ SELECT geometry 'SRID=5676;LINESTRING(406.7 702.6,383.6 845.1)'::nsegment;
 				<listitem xml:id="npoint_stbox">
 					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 					<para>Construir una caja espaciotemporal a partir de un punto de red y, opcionalmente, una marca de tiempo o un período</para>
-					<para><varname>stbox(npoint) → stbox</varname></para>
-					<para><varname>stbox(npoint,{timestamptz,tstzspan}) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+stbox(npoint) → stbox
+stbox(npoint,{timestamptz,tstzspan}) → stbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(npoint 'NPoint(1,0.3)');
 -- SRID=5676;STBOX X((62.786633,80.143556),(62.786633,80.143556))
@@ -239,7 +253,9 @@ SELECT stbox(npoint 'NPoint(1,0.3)', tstzspan '[2001-01-01,2001-01-02]');
 				<listitem xml:id="npoint_route">
 					<indexterm significance="normal"><primary><varname>route</varname></primary></indexterm>
 					<para>Devuelve el identificador de ruta</para>
-					<para><varname>route({npoint,nsegment}) → bigint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+route({npoint,nsegment}) → bigint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT route(npoint 'Npoint(63, 0.3)');
 -- 63
@@ -251,7 +267,9 @@ SELECT route(nsegment 'Nsegment(76, 0.3, 0.3)');
 				<listitem xml:id="npoint_getPosition">
 					<indexterm significance="normal"><primary><varname>getPosition</varname></primary></indexterm>
 					<para>Devuelve la posición</para>
-					<para><varname>getPosition(npoint) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getPosition(npoint) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT getPosition(npoint 'Npoint(63, 0.3)');
 -- 0.3
@@ -262,8 +280,10 @@ SELECT getPosition(npoint 'Npoint(63, 0.3)');
 					<indexterm significance="normal"><primary><varname>startPosition</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>endPosition</varname></primary></indexterm>
 					<para>Devuelve la posición inicial/final</para>
-					<para><varname>startPosition(nsegment) → float</varname></para>
-					<para><varname>endPosition(nsegment) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+startPosition(nsegment) → float
+endPosition(nsegment) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT startPosition(nsegment 'Nsegment(76, 0.3, 0.5)');
 -- 0.3
@@ -280,7 +300,9 @@ SELECT endPosition(nsegment 'Nsegment(76, 0.3, 0.5)');
 				<listitem xml:id="npoint_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Redondear la(s) posición(es) del punto de red or el segmento de red en el número de posiciones decimales</para>
-					<para><varname>round({npoint,nsegment},integer=0) → {npoint,nsegment}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round({npoint,nsegment},integer=0) → {npoint,nsegment}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT round(npoint(76, 0.123456789), 6);
 --  NPoint(76,0.123457)
@@ -298,7 +320,9 @@ SELECT round(nsegment(76, 0.123456789, 0.223456789), 6);
 				<listitem xml:id="npoint_srid">
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<para>Devuelve el identificador de referencia espacial</para>
-					<para><varname>SRID({npoint,nsegment}) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID({npoint,nsegment}) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT SRID(npoint 'Npoint(76, 0.3)');
 -- 5676
@@ -313,7 +337,9 @@ SELECT SRID(nsegment 'Nsegment(76, 0.3, 0.5)');
 				<listitem xml:id="npoint_same">
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Igualdad espacial para puntos de red</para>
-					<para><varname>equals(npoint, npoint)::Boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+equals(npoint, npoint)::Boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 WITH inter(geom) AS (
   SELECT st_intersection(t1.the_geom, t2.the_geom)
@@ -341,8 +367,10 @@ SELECT equals(npoint(1, f1), npoint(2, f2)) FROM fractions;
 					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Comparaciones tradicionales</para>
-					<para><varname>npoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} npoint</varname></para>
-					<para><varname>nsegment {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} nsegment</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+npoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} npoint
+nsegment {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} nsegment
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT npoint 'Npoint(3, 0.5)' = npoint 'Npoint(3, 0.5)';
 -- true
@@ -423,10 +451,12 @@ SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01 09:00:00, Npoint(2, 0.2)@2001-01-01 0
 					<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
 					<para>Constructor para puntos de red temporales con valor constante</para>
-					<para><varname>tnpoint(npoint,timestamptz) → tnpointInst</varname></para>
-					<para><varname>tnpoint(npoint,tstzset) → tnpointDiscSeq</varname></para>
-					<para><varname>tnpoint(npoint,tstzspan,interp='linear') → tnpointContSeq</varname></para>
-					<para><varname>tnpoint(npoint,tstzspanset,interp='linear') → tnpointSeqSet</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tnpoint(npoint,timestamptz) → tnpointInst
+tnpoint(npoint,tstzset) → tnpointDiscSeq
+tnpoint(npoint,tstzspan,interp='linear') → tnpointContSeq
+tnpoint(npoint,tstzspanset,interp='linear') → tnpointSeqSet
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tnpoint('Npoint(1, 0.5)', timestamptz '2001-01-01');
 -- NPoint(1,0.5)@2001-01-01
@@ -442,8 +472,10 @@ SELECT tnpoint('Npoint(1, 0.2)', tstzspanset '{[2001-01-01, 2001-01-03]}', 'step
 				<listitem xml:id="tnpointSeq">
 					<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 					<para>Constructor para puntos de red temporal de subtipo secuencia</para>
-					<para><varname>tnpointSeq(tnpointInst[],interp={'step','linear'},leftInc boolean=true,</varname></para>
-					<para><varname>  rightInc boolean=true) → tnpointSeq</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tnpointSeq(tnpointInst[],interp={'step','linear'},leftInc boolean=true,
+  rightInc boolean=true) → tnpointSeq
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.3)@2001-01-01',
   'Npoint(1, 0.5)@2001-01-02', 'Npoint(1, 0.5)@2001-01-03']);
@@ -458,9 +490,11 @@ SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.2)@2001-01-01',
 					<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tnpointSeqSetGaps</varname></primary></indexterm>
 					<para>Constructor para puntos de red temporal de subtipo conjunto de secuencias</para>
-					<para><varname>tnpointSeqSet(tnpoint[]) → tnpointSeqSet</varname></para>
-					<para><varname>tnpointSeqSetGaps(tnpointInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
-					<para><varname>  tnpointSeqSet</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tnpointSeqSet(tnpoint[]) → tnpointSeqSet
+tnpointSeqSetGaps(tnpointInst[],maxt=NULL,maxdist=NULL,interp='linear') →
+  tnpointSeqSet
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tnpointSeqSet(ARRAY[tnpoint '[Npoint(1,0.2)@2001-01-01, Npoint(1,0.4)@2001-01-02,
   Npoint(1,0.5)@2001-01-03]', '[Npoint(2,0.6)@2001-01-04, Npoint(2,0.6)@2001-01-05]']);
@@ -481,8 +515,10 @@ SELECT tnpointSeqSetGaps(ARRAY[tnpoint 'NPoint(1,0.1)@2001-01-01',
 			<listitem xml:id="tnpoint_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir entre un punto de red temporal y un punto de geometría temporal</para>
-				<para><varname>tnpoint::tgeompoint</varname></para>
-				<para><varname>tgeompoint::tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpoint::tgeompoint
+tgeompoint::tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT astext((tnpoint '[NPoint(1, 0.2)@2001-01-01,
   NPoint(1, 0.3)@2001-01-02)')::tgeompoint);
@@ -508,8 +544,10 @@ SELECT tgeompoint '[POINT(23.057077727326 28.7666335767956)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tnpointFromMFJSON</varname></primary></indexterm>
 				<para>Genera un punto de red temporal como MF-JSON y lo lee de vuelta; el ciclo de ida y vuelta es sin pérdida. La salida toma los argumentos de opciones, banderas y dígitos decimales compartidos con los demás tipos temporales.</para>
-				<para><varname>asMFJSON(tnpoint,integer,integer,integer) → text</varname></para>
-				<para><varname>tnpointFromMFJSON(text) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tnpoint,integer,integer,integer) → text
+tnpointFromMFJSON(text) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointFromMFJSON(asMFJSON(tnpoint 'NPoint(1, 0.5)@2001-01-01'))
   = tnpoint 'NPoint(1, 0.5)@2001-01-01';
@@ -526,7 +564,9 @@ SELECT tnpointFromMFJSON(asMFJSON(tnpoint 'NPoint(1, 0.5)@2001-01-01'))
 			<listitem xml:id="tnpoint_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Devuelve los valores</para>
-				<para><varname>getValues(tnpoint) → npoint[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tnpoint) → npoint[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT getValues(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02)}');
 -- {"NPoint(1,0.3)","NPoint(1,0.5)"}
@@ -538,7 +578,9 @@ SELECT getValues(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.3)@2001-01-02
 			<listitem xml:id="tnpoint_routes">
 				<indexterm significance="normal"><primary><varname>routes</varname></primary></indexterm>
 				<para>Devuelve los identificadores de ruta</para>
-				<para><varname>routes(tnpoint) → bigintset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+routes(tnpoint) → bigintset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT routes(tnpoint '{NPoint(3, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02}');
 -- {1, 3}
@@ -548,7 +590,9 @@ SELECT routes(tnpoint '{NPoint(3, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02}');
 			<listitem xml:id="tnpoint_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(tnpoint,timestamptz) → npoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tnpoint,timestamptz) → npoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT valueAtTimestamp(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03)',
   '2001-01-02');
@@ -559,7 +603,9 @@ SELECT valueAtTimestamp(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001
 			<listitem xml:id="tnpoint_length">
 				<indexterm significance="normal"><primary><varname>length</varname></primary></indexterm>
 				<para>Devuelve la longitud atravesada por el punto de red temporal</para>
-				<para><varname>length(tnpoint) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+length(tnpoint) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT length(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]');
 -- 54.3757408468784
@@ -569,7 +615,9 @@ SELECT length(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]');
 			<listitem xml:id="tnpoint_cumulativeLength">
 				<indexterm significance="normal"><primary><varname>cumulativeLength</varname></primary></indexterm>
 				<para>Devuelve la longitud acumulada atravesada por el punto de red temporal</para>
-				<para><varname>cumulativeLength(tnpoint) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+cumulativeLength(tnpoint) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT cumulativeLength(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02,
   NPoint(1, 0.5)@2001-01-03], [NPoint(1, 0.6)@2001-01-04, NPoint(1, 0.7)@2001-01-05]}');
@@ -581,7 +629,9 @@ SELECT cumulativeLength(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@200
 			<listitem xml:id="tnpoint_speed">
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Devuelve la velocidad del punto de red temporal en unidades por segundo</para>
-				<para><varname>speed({tnpointSeq, tnpointSeqSet}) → tfloatSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+speed({tnpointSeq, tnpointSeqSet}) → tfloatSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT speed(tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.4)@2001-01-02,
   NPoint(1, 0.6)@2001-01-03]') * 3600 * 24;
@@ -600,9 +650,11 @@ SELECT speed(tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.4)@2001-01-02,
 				<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
 				<para>Transformar un punto de red temporal en otro subtipo</para>
-				<para><varname>tnpointInst(tnpoint) → tnpointInst</varname></para>
-				<para><varname>tnpointSeq(tnpoint,interp) → tnpointSeq</varname></para>
-				<para><varname>tnpointSeqSet(tnpoint) → tnpointSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpointInst(tnpoint) → tnpointInst
+tnpointSeq(tnpoint,interp) → tnpointSeq
+tnpointSeqSet(tnpoint) → tnpointSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tnpointSeq(tnpoint 'NPoint(1, 0.5)@2001-01-01', 'discrete');
 -- {NPoint(1,0.5)@2001-01-01}
@@ -616,7 +668,9 @@ SELECT tnpointSeqSet(tnpoint 'NPoint(1, 0.5)@2001-01-01');
 			<listitem xml:id="tnpoint_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transformar un punto de red temporal en otra interpolación</para>
-				<para><varname>setInterp(tnpoint, interp) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(tnpoint, interp) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT setInterp(tnpoint 'NPoint(1,0.2)@2001-01-01','linear');
 -- [NPoint(1,0.2)@2001-01-01]
@@ -629,7 +683,9 @@ SELECT setInterp(tnpoint '{[NPoint(1,0.1)@2001-01-01], [NPoint(1,0.2)@2001-01-02
 			<listitem xml:id="tnpoint_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Redondear la fracción del punto de red temporal en el número de lugares decimales</para>
-				<para><varname>round(tnpoint,integer=0) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tnpoint,integer=0) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(tnpoint '{[NPoint(1,0.123456789)@2001-01-01, NPoint(1,0.5)@2001-01-02)}', 6);
 -- {[NPoint(1,0.123457)@2001-01-01, NPoint(1,0.5)@2001-01-02)}
@@ -645,8 +701,10 @@ SELECT round(tnpoint '{[NPoint(1,0.123456789)@2001-01-01, NPoint(1,0.5)@2001-01-
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Agregar un instante temporal o una secuencia temporal</para>
-				<para><varname>appendInstant(tnpoint,tnpointInst) → tnpoint</varname></para>
-				<para><varname>appendSequence(tnpoint,tnpointSeq) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tnpoint,tnpointInst) → tnpoint
+appendSequence(tnpoint,tnpointSeq) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendInstant(tnpoint 'Npoint(1, 0.1)@2001-01-01',
   'Npoint(1, 0.2)@2001-01-02'));
@@ -661,9 +719,11 @@ SELECT asText(appendSequence(tnpoint '[Npoint(1, 0.1)@2001-01-01]',
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Fusionar los puntos de red temporales</para>
-				<para><varname>merge(tnpoint,tnpoint) → tnpoint</varname></para>
-				<para><varname>merge(tnpoint[]) → tnpoint</varname></para>
-				<para><varname>mergeAgg(tnpoint) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(tnpoint,tnpoint) → tnpoint
+merge(tnpoint[]) → tnpoint
+mergeAgg(tnpoint) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]',
   '[Npoint(1, 0.3)@2001-01-03, Npoint(1, 0.5)@2001-01-05]'));
@@ -692,10 +752,12 @@ SELECT asText(mergeAgg(inst)) FROM temp;
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 				<para>Restringir al (complemento de) un valor o un conjunto de valores</para>
-				<para><varname>atValue(tnpoint,value) → tnpoint</varname></para>
-				<para><varname>minusValue(tnpoint,value) → tnpoint</varname></para>
-				<para><varname>atValues(tnpoint,valueset) → tnpoint</varname></para>
-				<para><varname>minusValues(tnpoint,valueset) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(tnpoint,value) → tnpoint
+minusValue(tnpoint,value) → tnpoint
+atValues(tnpoint,valueset) → tnpoint
+minusValues(tnpoint,valueset) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT atValue(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03]',
   'NPoint(2, 0.5)');
@@ -711,8 +773,10 @@ SELECT minusValue(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restringir al (complemento de) una geometría</para>
-				<para><varname>atGeometry(tnpoint,geometry) → tnpoint</varname></para>
-				<para><varname>minusGeometry(tnpoint,geometry) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tnpoint,geometry) → tnpoint
+minusGeometry(tnpoint,geometry) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT atGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03]',
   'Polygon((40 40,40 50,50 50,50 40,40 40))');
@@ -731,7 +795,9 @@ SELECT minusGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01
 			<listitem xml:id="tnpoint_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Devuelve la distancia más cercana</para>
-				<para><varname>{geo,npoint,tnpoint,stbox} |=| {geo,npoint,tnpoint,stbox} → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,npoint,tnpoint,stbox} |=| {geo,npoint,tnpoint,stbox} → float
+</programlisting>
 				<para>El operador <varname>|=|</varname> se puede utilizar para realizar búsquedas más cercanas utilizando un índice GiST o SP-GIST (ver <xref linkend="ttype_indexing" />).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-02]' |=|
@@ -749,7 +815,9 @@ SELECT tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-02]' |=|
 			<listitem xml:id="tnpoint_nearestApproachInstant">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Devuelve el instante del primer punto de red temporal en el que los dos argumentos están a la distancia más cercana</para>
-				<para><varname>nearestApproachInstant({geo,npoint,tnpoint},{geo,npoint,tnpoint}) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geo,npoint,tnpoint},{geo,npoint,tnpoint}) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT nearestApproachInstant(tnpoint '[NPoint(2, 0.3)@2001-01-01,
   NPoint(2, 0.7)@2001-01-02]', geometry 'Linestring(50 50,55 55)');
@@ -763,7 +831,9 @@ SELECT nearestApproachInstant(tnpoint '[NPoint(2, 0.3)@2001-01-01,
 			<listitem xml:id="tnpoint_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Devuelve la línea que conecta el punto de aproximación más cercano entre los dos argumentos</para>
-				<para><varname>shortestLine({geo,npoint,tpoint},{geo,npoint,tpoint}) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geo,npoint,tpoint},{geo,npoint,tpoint}) → geometry
+</programlisting>
 				<para>La función devuelve la primera línea que encuentre si hay más de una.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT ST_AsText(shortestLine(tnpoint '[NPoint(2, 0.3)@2001-01-01,
@@ -778,7 +848,9 @@ SELECT ST_AsText(shortestLine(tnpoint '[NPoint(2, 0.3)@2001-01-01,
 			<listitem xml:id="tnpoint_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Devuelve la distancia temporal</para>
-				<para><varname>tgeompoint &lt;-&gt; tnpoint → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tgeompoint &lt;-&gt; tnpoint → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;-&gt;
   npoint 'NPoint(1, 0.2)';
@@ -800,7 +872,9 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;-&gt
 			<listitem xml:id="tnpoint_twCentroid">
 				<indexterm significance="normal"><primary><varname>twCentroid</varname></primary></indexterm>
 				<para>Devuelve el centroide ponderado en el tiempo</para>
-				<para><varname>twCentroid(tnpoint) → geometry(Point)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+twCentroid(tnpoint) → geometry(Point)
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT ST_AsText(twCentroid(tnpoint '{[NPoint(1, 0.3)@2001-01-01,
   NPoint(1, 0.5)@2001-01-02, NPoint(1, 0.5)@2001-01-03, NPoint(1, 0.7)@2001-01-04)}'));
@@ -819,7 +893,10 @@ SELECT ST_AsText(twCentroid(tnpoint '{[NPoint(1, 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>@@</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>@=</varname></primary></indexterm>
 				<para>Operadores de rutas, que comparan los identificadores de ruta que visita un punto de red temporal: contenido en, contiene, se superpone e igual</para>
-				<para><varname>{bigint,bigintset,npoint,tnpoint} {?@, @?, @@, @=} {bigint,bigintset,npoint,tnpoint} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{bigint,bigintset,npoint,tnpoint} {?@, @?, @@, @=} {bigint,bigintset,npoint,
+  tnpoint} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT bigint '1' ?@ tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]';
 -- true
@@ -844,7 +921,9 @@ SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01, NPoint(3, 0.5)@2001-01-02}' @=
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Operadores topológicos</para>
-				<para><varname>{tstzspan,stbox,tnpoint} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tnpoint} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tstzspan,stbox,tnpoint} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tnpoint} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]' &amp;&amp;
   tstzspan '[2001-01-02,2001-01-03]';
@@ -862,9 +941,11 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' ~=
 			<listitem xml:id="tnpoint_pos">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Operadores de posición</para>
-				<para><varname>{stbox,tnpoint} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tnpoint} → boolean</varname></para>
-				<para><varname>{stbox,tnpoint} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tnpoint} → boolean</varname></para>
-				<para><varname>{tstzspan,stbox,tnpoint} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tnpoint} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{stbox,tnpoint} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tnpoint} → boolean
+{stbox,tnpoint} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tnpoint} → boolean
+{tstzspan,stbox,tnpoint} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tnpoint} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]' &lt;&lt;
   stbox(npoint 'NPoint(1, 0.2)');
@@ -904,20 +985,22 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-03, NPoint(1, 0.3)@2001-01-05]' #&gt;&gt
 				<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 				<para>Las relaciones <emphasis>alguna vez</emphasis> y <emphasis>siempre</emphasis> determinan si la relación topológica o de distancia se satisface alguna vez o siempre y dan como resultado un <varname>boolean</varname>. Un punto de red temporal las responde en la posición a la que se resuelven su ruta y su fracción, de modo que una secuencia con interpolación lineal se responde a lo largo de su ruta y no solo en sus instantes. El punto de red temporal declara las relaciones que responde un punto en movimiento: <varname>eContains</varname>, <varname>aContains</varname>, <varname>eCovers</varname> y <varname>aCovers</varname> toman la geometría en primer lugar únicamente, y <varname>eTouches</varname> y <varname>aTouches</varname> no tienen dirección entre dos puntos de red temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
-				<para><varname>eContains(geometry,tnpoint) → boolean</varname></para>
-				<para><varname>eCovers(geometry,tnpoint) → boolean</varname></para>
-				<para><varname>eDisjoint({geometry,tnpoint},{geometry,tnpoint}) → boolean</varname></para>
-				<para><varname>eDwithin({geometry,tnpoint},{geometry,tnpoint},float) → boolean</varname></para>
-				<para><varname>eIntersects({geometry,tnpoint},{geometry,tnpoint}) → boolean</varname></para>
-				<para><varname>eTouches(geometry,tnpoint) → boolean</varname></para>
-				<para><varname>eTouches(tnpoint,geometry) → boolean</varname></para>
-				<para><varname>aContains(geometry,tnpoint) → boolean</varname></para>
-				<para><varname>aCovers(geometry,tnpoint) → boolean</varname></para>
-				<para><varname>aDisjoint({geometry,tnpoint},{geometry,tnpoint}) → boolean</varname></para>
-				<para><varname>aDwithin({geometry,tnpoint},{geometry,tnpoint},float) → boolean</varname></para>
-				<para><varname>aIntersects({geometry,tnpoint},{geometry,tnpoint}) → boolean</varname></para>
-				<para><varname>aTouches(geometry,tnpoint) → boolean</varname></para>
-				<para><varname>aTouches(tnpoint,geometry) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eContains(geometry,tnpoint) → boolean
+eCovers(geometry,tnpoint) → boolean
+eDisjoint({geometry,tnpoint},{geometry,tnpoint}) → boolean
+eDwithin({geometry,tnpoint},{geometry,tnpoint},float) → boolean
+eIntersects({geometry,tnpoint},{geometry,tnpoint}) → boolean
+eTouches(geometry,tnpoint) → boolean
+eTouches(tnpoint,geometry) → boolean
+aContains(geometry,tnpoint) → boolean
+aCovers(geometry,tnpoint) → boolean
+aDisjoint({geometry,tnpoint},{geometry,tnpoint}) → boolean
+aDwithin({geometry,tnpoint},{geometry,tnpoint},float) → boolean
+aIntersects({geometry,tnpoint},{geometry,tnpoint}) → boolean
+aTouches(geometry,tnpoint) → boolean
+aTouches(tnpoint,geometry) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT eContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
   tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
@@ -948,13 +1031,15 @@ SELECT aDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]'
 				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 				<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Un punto de red temporal las responde en la posición a la que se resuelven su ruta y su fracción. El punto de red temporal declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos puntos de red temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
-				<para><varname>tContains(geometry,tnpoint) → tbool</varname></para>
-				<para><varname>tCovers(geometry,tnpoint) → tbool</varname></para>
-				<para><varname>tDisjoint({geometry,tnpoint},{geometry,tnpoint}) → tbool</varname></para>
-				<para><varname>tDwithin({geometry,tnpoint},{geometry,tnpoint},float) → tbool</varname></para>
-				<para><varname>tIntersects({geometry,tnpoint},{geometry,tnpoint}) → tbool</varname></para>
-				<para><varname>tTouches(geometry,tnpoint) → tbool</varname></para>
-				<para><varname>tTouches(tnpoint,geometry) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tnpoint) → tbool
+tCovers(geometry,tnpoint) → tbool
+tDisjoint({geometry,tnpoint},{geometry,tnpoint}) → tbool
+tDwithin({geometry,tnpoint},{geometry,tnpoint},float) → tbool
+tIntersects({geometry,tnpoint},{geometry,tnpoint}) → tbool
+tTouches(geometry,tnpoint) → tbool
+tTouches(tnpoint,geometry) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
   tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
@@ -987,7 +1072,9 @@ SELECT tDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]'
 			<listitem xml:id="tnpoint_comp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
-				<para><varname>tnpoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tnpoint → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tnpoint → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tnpoint '{[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-02),
   [NPoint(1, 0.3)@2001-01-02, NPoint(1, 0.5)@2001-01-03]}' =
@@ -1006,7 +1093,9 @@ SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Comparaciones alguna vez y siempre</para>
-				<para><varname>{npoint,tnpoint} {?=, %=} {npoint,tnpoint} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{npoint,tnpoint} {?=, %=} {npoint,tnpoint} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.4)@2001-01-04)' ?= Npoint(1, 0.3);
 -- true
@@ -1018,7 +1107,9 @@ SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.2)@2001-01-04)' &amp;= N
 			<listitem xml:id="tnpoint_tcomp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Comparaciones temporales</para>
-				<para><varname>{npoint,tnpoint} {#=, #&lt;&gt;} {npoint,tnpoint} → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{npoint,tnpoint} {#=, #&lt;&gt;} {npoint,tnpoint} → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tnpoint '[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.4)@2001-01-03)' #=
   npoint 'NPoint(1, 0.3)';
@@ -1040,7 +1131,9 @@ SELECT tnpoint '[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.8)@2001-01-03)' #&lt;&gt
 			<listitem xml:id="tnpoint_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
-				<para><varname>tCount(tnpoint) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tnpoint) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 WITH Temp(temp) AS (
 SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
@@ -1055,7 +1148,9 @@ FROM Temp
 			<listitem xml:id="tnpoint_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Conteo de ventana</para>
-				<para><varname>wCount(tnpoint) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tnpoint) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 WITH Temp(temp) AS (
 SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
@@ -1071,7 +1166,9 @@ FROM Temp
 			<listitem xml:id="tnpoint_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
 				<para>Centroide temporal</para>
-				<para><varname>tCentroid(tnpoint) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCentroid(tnpoint) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 WITH Temp(temp) AS (
 SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
@@ -1116,7 +1213,9 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 			<listitem xml:id="tnpoint_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Devuelve el cuadro delimitador espaciotemporal que cubre cada posición materializada en un conjunto de puntos de red. El agregado es polimórfico con los agregados <varname>extent</varname> de los demás tipos temporales espaciales, por lo que una sola consulta puede calcular un único cuadro a través de un conjunto heterogéneo de columnas <varname>tgeompoint</varname>, <varname>tgeometry</varname> y <varname>tnpoint</varname>. La extensión espacial de cada instante se resuelve a través del registro de ways, lo que domina el coste sobre una entrada grande.</para>
-				<para><varname>extent(tnpoint) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(tnpoint) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(temp) FROM tbl_tnpoint;
 </programlisting>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -47,7 +47,9 @@ INSERT INTO pointcloud_dimensions
 				<listitem xml:id="pointcloud_schema_srid">
 					<indexterm significance="normal"><primary><varname>pointCloudSchemaSRID</varname></primary></indexterm>
 					<para>Devuelve el sistema de referencia espacial en el que se expresa todo valor de un esquema</para>
-					<para><varname>pointCloudSchemaSRID(integer) &#x2192; integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pointCloudSchemaSRID(integer) &#x2192; integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pointCloudSchemaSRID(1);
 -- 4326
@@ -56,7 +58,9 @@ SELECT pointCloudSchemaSRID(1);
 				<listitem xml:id="pointcloud_schema_compression">
 					<indexterm significance="normal"><primary><varname>pointCloudSchemaCompression</varname></primary></indexterm>
 					<para>Devuelve cómo se almacena un parche de un esquema</para>
-					<para><varname>pointCloudSchemaCompression(integer) &#x2192; text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pointCloudSchemaCompression(integer) &#x2192; text
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pointCloudSchemaCompression(1);
 -- none
@@ -65,7 +69,9 @@ SELECT pointCloudSchemaCompression(1);
 				<listitem xml:id="pointcloud_schema_ndims">
 					<indexterm significance="normal"><primary><varname>pointCloudSchemaNDims</varname></primary></indexterm>
 					<para>Devuelve cuántas dimensiones de un esquema contienen valores</para>
-					<para><varname>pointCloudSchemaNDims(integer) &#x2192; integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pointCloudSchemaNDims(integer) &#x2192; integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pointCloudSchemaNDims(1);
 -- 3
@@ -188,8 +194,10 @@ SELECT id, numPoints(full_scan) FROM scans;
 				<listitem xml:id="pcpoint_xy_xyz">
 					<indexterm significance="normal"><primary><varname>pcpoint</varname></primary></indexterm>
 					<para>Construye un pcpoint 2D o 3D directamente a partir de coordenadas x/y(/z)</para>
-					<para><varname>pcpoint(pcid integer, x float, y float) → pcpoint</varname></para>
-					<para><varname>pcpoint(pcid integer, x float, y float, z float) → pcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpoint(pcid integer, x float, y float) → pcpoint
+pcpoint(pcid integer, x float, y float, z float) → pcpoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcpoint(1, 10.0, 20.0, 30.0);
 -- equivalent to PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]::float[])
@@ -199,7 +207,9 @@ SELECT pcpoint(1, 10.0, 20.0, 30.0);
 				<listitem xml:id="pcpoint_coordinates">
 					<indexterm significance="normal"><primary><varname>pcpoint</varname></primary></indexterm>
 					<para>Construye un pcpoint a partir de las coordenadas de cada dimensión de la disposición del esquema, incluidas las dimensiones inactivas, que es como se dan sus valores a un esquema con más dimensiones de las que alcanzan las sobrecargas anteriores. Ese número es el que toma <varname>PC_MakePoint</varname> y NO es el número de dimensiones activas que informa <varname>pointCloudSchemaNDims</varname></para>
-					<para><varname>pcpoint(pcid integer, coordinates float[]) → pcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpoint(pcid integer, coordinates float[]) → pcpoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcpoint(1, ARRAY[10.0, 20.0, 30.0]::float[]);
 </programlisting>
@@ -208,7 +218,9 @@ SELECT pcpoint(1, ARRAY[10.0, 20.0, 30.0]::float[]);
 				<listitem xml:id="pcpatch_coordinates">
 					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
 					<para>Construye un pcpatch a partir de las coordenadas de sus puntos, un punto tras otro, dando para cada punto cada dimensión de la disposición del esquema, incluidas las dimensiones inactivas. Ese número es el que toma <varname>PC_MakePatch</varname> y NO es el número de dimensiones activas que informa <varname>pointCloudSchemaNDims</varname>; un número que sea múltiplo del que no corresponde construye un parche de puntos erróneos en lugar de informar un error. Un parche construido así declara él mismo el esquema, al no haber ningún punto del que leerlo</para>
-					<para><varname>pcpatch(pcid integer, coordinates float[]) → pcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpatch(pcid integer, coordinates float[]) → pcpatch
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcpatch(1, ARRAY[1.0, 1.0, 1.0, 2.0, 2.0, 2.0]::float[]);
 </programlisting>
@@ -217,7 +229,9 @@ SELECT pcpatch(1, ARRAY[1.0, 1.0, 1.0, 2.0, 2.0, 2.0]::float[]);
 				<listitem xml:id="pcpatch_variadic">
 					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
 					<para>Construye un pcpatch a partir de una lista variádica de pcpoints que comparten el mismo pcid</para>
-					<para><varname>pcpatch(VARIADIC points pcpoint[]) → pcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpatch(VARIADIC points pcpoint[]) → pcpatch
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
 -- equivalent to PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
@@ -234,8 +248,10 @@ SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
 				<listitem xml:id="pcpoint_pcid">
 					<indexterm significance="normal"><primary><varname>pcid</varname></primary></indexterm>
 					<para>Devuelve el identificador de esquema de un pcpoint o pcpatch</para>
-					<para><varname>pcid(pcpoint) → integer</varname></para>
-					<para><varname>pcid(pcpatch) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcid(pcpoint) → integer
+pcid(pcpatch) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcid(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 -- 1
@@ -247,9 +263,11 @@ SELECT pcid(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 					<indexterm significance="normal"><primary><varname>getY</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getZ</varname></primary></indexterm>
 					<para>Devuelve una coordenada de un pcpoint, NULL si la dimensión está ausente del esquema</para>
-					<para><varname>getX(pcpoint) → float</varname></para>
-					<para><varname>getY(pcpoint) → float</varname></para>
-					<para><varname>getZ(pcpoint) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getX(pcpoint) → float
+getY(pcpoint) → float
+getZ(pcpoint) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH pt AS (SELECT PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]) p)
   SELECT getX(p), getY(p), getZ(p) FROM pt;
@@ -260,7 +278,9 @@ WITH pt AS (SELECT PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]) p)
 				<listitem xml:id="pcpoint_getDim">
 					<indexterm significance="normal"><primary><varname>getDim</varname></primary></indexterm>
 					<para>Devuelve cualquier dimensión con nombre de un pcpoint, NULL si el nombre es desconocido para el esquema</para>
-					<para><varname>getDim(pcpoint,text) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getDim(pcpoint,text) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getDim(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), 'X');
 -- 10
@@ -270,8 +290,10 @@ SELECT getDim(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), 'X');
 				<listitem xml:id="pcpoint_SRID">
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<para>Devuelve el identificador de referencia espacial (heredado del esquema)</para>
-					<para><varname>SRID(pcpoint) → integer</varname></para>
-					<para><varname>SRID(pcpatch) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(pcpoint) → integer
+SRID(pcpatch) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 -- 0
@@ -284,7 +306,9 @@ SELECT SRID(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), PC_MakePoin
 				<listitem xml:id="pcpatch_geometry">
 					<indexterm significance="normal"><primary><varname>geometry</varname></primary></indexterm>
 					<para>Devuelve el multipunto de las posiciones que ocupan los puntos de un parche. El esquema que nombra el <varname>pcid</varname> decide el SRID y si el resultado lleva una dimensión Z</para>
-					<para><varname>geometry(pcpatch) &#8594; geometry</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geometry(pcpatch) &#8594; geometry
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(geometry(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 -- MULTIPOINT Z ((1 1 1),(2 2 2))
@@ -307,8 +331,10 @@ SELECT ST_AsText(geometry(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 				<listitem xml:id="pcpointset_set">
 					<indexterm significance="normal"><primary><varname>set</varname></primary></indexterm>
 					<para>Construye un conjunto a partir de un array de valores, todos los cuales deben compartir el mismo pcid</para>
-					<para><varname>set(pcpoint[]) → pcpointset</varname></para>
-					<para><varname>set(pcpatch[]) → pcpatchset</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+set(pcpoint[]) → pcpointset
+set(pcpatch[]) → pcpatchset
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(set(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
   PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),  -- duplicate, deduped
@@ -335,11 +361,13 @@ SELECT numValues(set(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 					<indexterm significance="normal"><primary><varname>tpcbox_xt</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcbox_zt</varname></primary></indexterm>
 					<para>Construir un tpcbox a partir de límites X/Y/Z/T explícitos y un pcid</para>
-					<para><varname>tpcbox(xmin,ymin,xmax,ymax,pcid,srid=0) → tpcbox</varname></para>
-					<para><varname>tpcbox_z(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid=0) → tpcbox</varname></para>
-					<para><varname>tpcbox_t(period,pcid) → tpcbox</varname></para>
-					<para><varname>tpcbox_xt(xmin,ymin,xmax,ymax,period,pcid,srid=0) → tpcbox</varname></para>
-					<para><varname>tpcbox_zt(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid=0) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox(xmin,ymin,xmax,ymax,pcid,srid=0) → tpcbox
+tpcbox_z(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid=0) → tpcbox
+tpcbox_t(period,pcid) → tpcbox
+tpcbox_xt(xmin,ymin,xmax,ymax,period,pcid,srid=0) → tpcbox
+tpcbox_zt(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid=0) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 10, 10, 1, 0);
 -- TPCBOX(X((0,0),(10,10)), 1)
@@ -356,7 +384,9 @@ SELECT tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0)
 				<listitem xml:id="tpcbox_pcpoint_to_tpcbox">
 					<indexterm significance="normal"><primary><varname>tpcbox</varname></primary></indexterm>
 					<para>Convertir un pcpoint a un tpcbox degenerado (de extensión cero); el SRID y el pcid provienen del esquema</para>
-					<para><varname>tpcbox(pcpoint) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox(pcpoint) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 -- TPCBOX(Z((10,20,30),(10,20,30)), 1)
@@ -366,8 +396,10 @@ SELECT tpcbox(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 				<listitem xml:id="tpcbox_pcpatch_to_tpcbox">
 					<indexterm significance="normal"><primary><varname>tpcbox</varname></primary></indexterm>
 					<para>Convertir un pcpatch a un tpcbox usando los límites PCBOUNDS 2D integrados en el parche; la segunda forma acepta un SRID explícito en lugar de buscarlo en el esquema</para>
-					<para><varname>tpcbox(pcpatch) → tpcbox</varname></para>
-					<para><varname>tpcbox(pcpatch,integer) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox(pcpatch) → tpcbox
+tpcbox(pcpatch,integer) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])));
 </programlisting>
@@ -383,9 +415,11 @@ SELECT tpcbox(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])));
 					<indexterm significance="normal"><primary><varname>hasZ</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>hasT</varname></primary></indexterm>
 					<para>Devuelve si un tpcbox tiene establecidas las dimensiones X/Y, Z o T</para>
-					<para><varname>hasX(tpcbox) → boolean</varname></para>
-					<para><varname>hasZ(tpcbox) → boolean</varname></para>
-					<para><varname>hasT(tpcbox) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+hasX(tpcbox) → boolean
+hasZ(tpcbox) → boolean
+hasT(tpcbox) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
   SELECT hasX(b), hasZ(b) FROM b;
@@ -401,12 +435,14 @@ WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
 					<indexterm significance="normal"><primary><varname>zmin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>zmax</varname></primary></indexterm>
 					<para>Devuelve un límite de coordenada, NULL si la dimensión correspondiente está ausente</para>
-					<para><varname>xmin(tpcbox) → float</varname></para>
-					<para><varname>xmax(tpcbox) → float</varname></para>
-					<para><varname>ymin(tpcbox) → float</varname></para>
-					<para><varname>ymax(tpcbox) → float</varname></para>
-					<para><varname>zmin(tpcbox) → float</varname></para>
-					<para><varname>zmax(tpcbox) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+xmin(tpcbox) → float
+xmax(tpcbox) → float
+ymin(tpcbox) → float
+ymax(tpcbox) → float
+zmin(tpcbox) → float
+zmax(tpcbox) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
   SELECT xmin(b), xmax(b) FROM b;
@@ -418,8 +454,10 @@ WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
 					<indexterm significance="normal"><primary><varname>tmin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tmax</varname></primary></indexterm>
 					<para>Devuelve un límite temporal, NULL si la caja no tiene dimensión T</para>
-					<para><varname>tmin(tpcbox) → timestamptz</varname></para>
-					<para><varname>tmax(tpcbox) → timestamptz</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tmin(tpcbox) → timestamptz
+tmax(tpcbox) → timestamptz
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tmin(tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1));
 -- 2024-01-01
@@ -430,8 +468,10 @@ SELECT tmin(tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1));
 					<indexterm significance="normal"><primary><varname>pcid</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<para>Devuelve el identificador de esquema y el SRID</para>
-					<para><varname>pcid(tpcbox) → integer</varname></para>
-					<para><varname>SRID(tpcbox) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcid(tpcbox) → integer
+SRID(tpcbox) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH b AS (SELECT tpcbox(0, 0, 10, 10, 7, 4326) AS b)
   SELECT pcid(b), SRID(b) FROM b;
@@ -447,7 +487,9 @@ WITH b AS (SELECT tpcbox(0, 0, 10, 10, 7, 4326) AS b)
 				<listitem xml:id="tpcbox_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Devuelve un tpcbox con las coordenadas redondeadas al número de dígitos decimales indicado</para>
-					<para><varname>round(tpcbox,integer=0) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(tpcbox,integer=0) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tpcbox(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
 -- TPCBOX(X((0.12,1.23),(2.35,3.46)), 1)
@@ -457,7 +499,9 @@ SELECT round(tpcbox(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
 				<listitem xml:id="tpcbox_setSRID">
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Devuelve un tpcbox con el SRID sobreescrito. No reproyecta las coordenadas, para ello, proyecte primero el tpcpoint subyacente y tome la caja delimitadora del resultado</para>
-					<para><varname>setSRID(tpcbox,integer) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+setSRID(tpcbox,integer) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(setSRID(tpcbox(0, 0, 10, 10, 1, 0), 4326));
 -- 4326
@@ -472,8 +516,10 @@ SELECT SRID(setSRID(tpcbox(0, 0, 10, 10, 1, 0), 4326));
 				<listitem xml:id="tpcbox_union">
 					<indexterm significance="normal"><primary><varname>tpcbox_union</varname></primary></indexterm>
 					<para>Devuelve la unión de dos tpcboxes; ambas deben compartir el mismo pcid</para>
-					<para><varname>tpcbox_union(tpcbox,tpcbox) → tpcbox</varname></para>
-					<para><varname>tpcbox + tpcbox → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox_union(tpcbox,tpcbox) → tpcbox
+tpcbox + tpcbox → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
 -- TPCBOX(X((0,0),(10,10)), 1)
@@ -483,8 +529,10 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
 				<listitem xml:id="tpcbox_intersection">
 					<indexterm significance="normal"><primary><varname>tpcbox_intersection</varname></primary></indexterm>
 					<para>Devuelve la intersección de dos tpcboxes, NULL si son disjuntas o el pcid no coincide</para>
-					<para><varname>tpcbox_intersection(tpcbox,tpcbox) → tpcbox</varname></para>
-					<para><varname>tpcbox * tpcbox → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox_intersection(tpcbox,tpcbox) → tpcbox
+tpcbox * tpcbox → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
 -- TPCBOX(X((3,3),(5,5)), 1)
@@ -501,7 +549,9 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
 				<listitem xml:id="tpcbox_contains">
 					<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
 					<para>Devuelve true si el primer tpcbox contiene al segundo</para>
-					<para><varname>tpcbox @&gt; tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox @&gt; tpcbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 10, 10, 1, 0) @&gt; tpcbox(2, 2, 8, 8, 1, 0);
 -- t
@@ -511,7 +561,9 @@ SELECT tpcbox(0, 0, 10, 10, 1, 0) @&gt; tpcbox(2, 2, 8, 8, 1, 0);
 				<listitem xml:id="tpcbox_contained">
 					<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
 					<para>Devuelve true si el primer tpcbox está contenido en el segundo</para>
-					<para><varname>tpcbox &lt;@ tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox &lt;@ tpcbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(2, 2, 8, 8, 1, 0) &lt;@ tpcbox(0, 0, 10, 10, 1, 0);
 -- t
@@ -521,7 +573,9 @@ SELECT tpcbox(2, 2, 8, 8, 1, 0) &lt;@ tpcbox(0, 0, 10, 10, 1, 0);
 				<listitem xml:id="tpcbox_overlaps">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 					<para>Devuelve true si dos tpcboxes se solapan</para>
-					<para><varname>tpcbox &amp;&amp; tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox &amp;&amp; tpcbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(3, 3, 10, 10, 1, 0);  -- t
 SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);
@@ -532,7 +586,9 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);
 				<listitem xml:id="tpcbox_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Devuelve true si dos tpcboxes son iguales en las dimensiones que comparten</para>
-					<para><varname>tpcbox ~= tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox ~= tpcbox → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 2, 2) ~= tpcbox(0, 0, 2, 2);
 -- t
@@ -542,7 +598,9 @@ SELECT tpcbox(0, 0, 2, 2) ~= tpcbox(0, 0, 2, 2);
 				<listitem xml:id="tpcbox_adjacent">
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 					<para>Devuelve true si dos tpcboxes son adyacentes (comparten un límite)</para>
-					<para><varname>tpcbox -|- tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox -|- tpcbox → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 2, 2) -|- tpcbox(5, 5, 7, 7);
 -- f
@@ -634,12 +692,14 @@ SELECT tpcbox(0, 0, 2, 2) &lt;&lt;# tpcbox(5, 5, 7, 7);
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 					<para>Compara dos tpcboxes; orden total sobre la codificación canónica (pcid, srid, flags, período y a continuación límites espaciales en orden XYZ-min/max)</para>
-					<para><varname>tpcbox = tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &lt;&gt; tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &lt; tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &lt;= tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &gt; tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &gt;= tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox = tpcbox → boolean
+tpcbox &lt;&gt; tpcbox → boolean
+tpcbox &lt; tpcbox → boolean
+tpcbox &lt;= tpcbox → boolean
+tpcbox &gt; tpcbox → boolean
+tpcbox &gt;= tpcbox → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 2, 2) = tpcbox(0, 0, 2, 2);
 -- t
@@ -678,7 +738,9 @@ INSERT INTO scans VALUES (1,
 				<listitem xml:id="tpcpoint_inst">
 					<indexterm significance="normal"><primary><varname>tpcpoint</varname></primary></indexterm>
 					<para>Construir un pcpoint temporal de subtipo instante</para>
-					<para><varname>tpcpoint(pcpoint,timestamptz) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpoint(pcpoint,timestamptz) → tpcpoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), '2024-01-01 12:00+00');
 </programlisting>
@@ -687,8 +749,10 @@ SELECT tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), '2024-01-01 12:00+00')
 				<listitem xml:id="tpcpoint_seq">
 					<indexterm significance="normal"><primary><varname>tpcpointSeq</varname></primary></indexterm>
 					<para>Construir un pcpoint temporal de subtipo secuencia a partir de un array de instantes. La interpolación es una de <varname>'discrete'</varname>, <varname>'step'</varname>; <varname>'step'</varname> es el valor predeterminado para tpcpoint, ya que los pcpoints llevan dimensiones heterogéneas que no se interpolan de manera lineal</para>
-					<para><varname>tpcpointSeq(tpcpoint[]) → tpcpoint</varname></para>
-					<para><varname>tpcpointSeq(tpcpoint[],text) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpointSeq(tpcpoint[]) → tpcpoint
+tpcpointSeq(tpcpoint[],text) → tpcpoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 2.0, 3.0]),
   '2024-01-01'::timestamptz),
@@ -699,7 +763,9 @@ SELECT tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 2.0, 3.0]),
 				<listitem xml:id="tpcpoint_seqset">
 					<indexterm significance="normal"><primary><varname>tpcpointSeqSet</varname></primary></indexterm>
 					<para>Construir un pcpoint temporal de subtipo conjunto de secuencias a partir de un array de secuencias</para>
-					<para><varname>tpcpointSeqSet(tpcpoint[]) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpointSeqSet(tpcpoint[]) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSequences(tpcpointSeqSet(ARRAY[tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -721,7 +787,9 @@ SELECT numInstants(tpcpointSeqSet(ARRAY[tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_pcid">
 					<indexterm significance="normal"><primary><varname>pcid</varname></primary></indexterm>
 					<para>Devolver el id de esquema de pgPointCloud compartido por todos los instantes</para>
-					<para><varname>pcid(tpcpoint) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcid(tpcpoint) → integer
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcid(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 -- 1
@@ -731,8 +799,10 @@ SELECT pcid(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 				<listitem xml:id="tpcpoint_SRID">
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<para>Devolver el SRID heredado del esquema</para>
-					<para><varname>SRID(tpcpoint) → integer</varname></para>
-					<para><varname>SRID(tpcpatch) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(tpcpoint) → integer
+SRID(tpcpatch) → integer
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The SRID is that of the schema registered for the pcid.
 SELECT SRID(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
@@ -753,9 +823,11 @@ SELECT SRID(tpcpatch(PC_Patch(ARRAY[pcpoint(1, 1, 1, 1)]),
 					<indexterm significance="normal"><primary><varname>getY</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getZ</varname></primary></indexterm>
 					<para>Proyectar un tpcpoint sobre una dimensión espacial, produciendo un tfloat</para>
-					<para><varname>getX(tpcpoint) → tfloat</varname></para>
-					<para><varname>getY(tpcpoint) → tfloat</varname></para>
-					<para><varname>getZ(tpcpoint) → tfloat</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getX(tpcpoint) → tfloat
+getY(tpcpoint) → tfloat
+getZ(tpcpoint) → tfloat
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(getX(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
   '2024-01-01'::timestamptz)));
@@ -766,7 +838,9 @@ SELECT startValue(getX(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 				<listitem xml:id="tpcpoint_getDim">
 					<indexterm significance="normal"><primary><varname>getDim</varname></primary></indexterm>
 					<para>Proyectar un tpcpoint sobre cualquier dimensión de esquema con nombre, produciendo un tfloat</para>
-					<para><varname>getDim(tpcpoint,text) → tfloat</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getDim(tpcpoint,text) → tfloat
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getDim(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -784,7 +858,9 @@ SELECT getDim(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Convertir un tpcpoint a un punto de geometría temporal, proyectando todas las dimensiones no espaciales mientras se preservan las marcas temporales. El resultado tiene el mismo SRID que el esquema; su dimensionalidad (2D frente a 3D) sigue la presencia de Z en el esquema. No se proporciona una conversión inversa: reconstruir un pcpoint requiere un esquema destino que el valor temporal solo no puede suministrar</para>
 					<para><varname>tgeompoint::tpcpoint</varname> no está definida</para>
-					<para><varname>tpcpoint::tgeompoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpoint::tgeompoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
   '2024-01-01'::timestamptz)::tgeompoint));
@@ -803,9 +879,11 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 					<indexterm significance="normal"><primary><varname>tpcpointSeq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcpointSeqSet</varname></primary></indexterm>
 					<para>Transformar un tpcpoint en otro subtipo</para>
-					<para><varname>tpcpointInst(tpcpoint) → tpcpoint</varname></para>
-					<para><varname>tpcpointSeq(tpcpoint,interp='step') → tpcpoint</varname></para>
-					<para><varname>tpcpointSeqSet(tpcpoint) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpointInst(tpcpoint) → tpcpoint
+tpcpointSeq(tpcpoint,interp='step') → tpcpoint
+tpcpointSeqSet(tpcpoint) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(tpcpointInst(tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz)));
@@ -819,7 +897,9 @@ SELECT numInstants(tpcpointSeq(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_setInterp">
 					<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 					<para>Transformar un tpcpoint a otra interpolación</para>
-					<para><varname>setInterp(tpcpoint,interp) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+setInterp(tpcpoint,interp) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- A tpcpoint carries step interpolation.
 SELECT interp(tpcpointSeq(ARRAY[
@@ -846,12 +926,14 @@ SELECT interp(setInterp(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 					<para>Comparar dos tpcpoints lexicográficamente sobre sus codificaciones canónicas</para>
-					<para><varname>tpcpoint = tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &lt;&gt; tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &lt; tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &lt;= tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &gt; tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &gt;= tpcpoint → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpoint = tpcpoint → boolean
+tpcpoint &lt;&gt; tpcpoint → boolean
+tpcpoint &lt; tpcpoint → boolean
+tpcpoint &lt;= tpcpoint → boolean
+tpcpoint &gt; tpcpoint → boolean
+tpcpoint &gt;= tpcpoint → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz) = tpcpoint(pcpoint(1, 1,
   1, 1), '2001-01-01'::timestamptz);
@@ -873,13 +955,17 @@ SELECT tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz) &lt; tpcpoint(pc
 					<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 					<para>Comprobar si el valor en algún instante (alguna vez) o en todos los instantes (siempre) es igual a, o distinto de, un pcpoint u otro tpcpoint</para>
-					<para><varname>eEq(pcpoint,tpcpoint) → boolean</varname></para>
-					<para><varname>eEq(tpcpoint,pcpoint) → boolean</varname></para>
-					<para><varname>eEq(tpcpoint,tpcpoint) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eEq(pcpoint,tpcpoint) → boolean
+eEq(tpcpoint,pcpoint) → boolean
+eEq(tpcpoint,tpcpoint) → boolean
+</programlisting>
 					<para><varname>aEq</varname>, <varname>eNe</varname> y <varname>aNe</varname> reciben los mismos tres pares de argumentos</para>
-					<para><varname>pcpoint ?= tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint ?= pcpoint → boolean</varname></para>
-					<para><varname>tpcpoint ?= tpcpoint → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpoint ?= tpcpoint → boolean
+tpcpoint ?= pcpoint → boolean
+tpcpoint ?= tpcpoint → boolean
+</programlisting>
 					<para>Los operadores <varname>%=</varname>, <varname>?&lt;&gt;</varname> y <varname>%&lt;&gt;</varname> reciben los mismos tres pares de operandos</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eEq(pcpoint(1, 1, 1, 1), tpcpointSeq(ARRAY[
@@ -900,13 +986,17 @@ SELECT aEq(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#=</varname></primary></indexterm>
 					<para>Devolver la igualdad o desigualdad temporal de un tpcpoint con un pcpoint o con otro tpcpoint, como un tbool</para>
-					<para><varname>tEq(pcpoint,tpcpoint) → tbool</varname></para>
-					<para><varname>tEq(tpcpoint,pcpoint) → tbool</varname></para>
-					<para><varname>tEq(tpcpoint,tpcpoint) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tEq(pcpoint,tpcpoint) → tbool
+tEq(tpcpoint,pcpoint) → tbool
+tEq(tpcpoint,tpcpoint) → tbool
+</programlisting>
 					<para><varname>tNe</varname> recibe los mismos tres pares de argumentos</para>
-					<para><varname>pcpoint #= tpcpoint → tbool</varname></para>
-					<para><varname>tpcpoint #= pcpoint → tbool</varname></para>
-					<para><varname>tpcpoint #= tpcpoint → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpoint #= tpcpoint → tbool
+tpcpoint #= pcpoint → tbool
+tpcpoint #= tpcpoint → tbool
+</programlisting>
 					<para>El operador <varname>#&lt;&gt;</varname> recibe los mismos tres pares de operandos</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(tpcpointSeq(ARRAY[
@@ -928,10 +1018,12 @@ SELECT tEq(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 					<para>Restringir un tpcpoint a (al complemento de) un valor pcpoint o un conjunto de valores pcpoint</para>
-					<para><varname>atValue(tpcpoint,pcpoint) → tpcpoint</varname></para>
-					<para><varname>minusValue(tpcpoint,pcpoint) → tpcpoint</varname></para>
-					<para><varname>atValues(tpcpoint,pcpointset) → tpcpoint</varname></para>
-					<para><varname>minusValues(tpcpoint,pcpointset) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atValue(tpcpoint,pcpoint) → tpcpoint
+minusValue(tpcpoint,pcpoint) → tpcpoint
+atValues(tpcpoint,pcpointset) → tpcpoint
+minusValues(tpcpoint,pcpointset) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- With step interpolation the matching value is held on
 -- [2001-01-01, 2001-01-02); its closing bound is stored as a second instant.
@@ -952,14 +1044,16 @@ SELECT numInstants(minusValue(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTime</varname></primary></indexterm>
 					<para>Restringir un tpcpoint a un selector temporal (marca de tiempo, periodo, conjunto o spanset), o eliminarlo</para>
-					<para><varname>atTime(tpcpoint,timestamptz) → tpcpoint</varname></para>
-					<para><varname>atTime(tpcpoint,tstzspan) → tpcpoint</varname></para>
-					<para><varname>atTime(tpcpoint,tstzset) → tpcpoint</varname></para>
-					<para><varname>atTime(tpcpoint,tstzspanset) → tpcpoint</varname></para>
-					<para><varname>minusTime(tpcpoint,timestamptz) → tpcpoint</varname></para>
-					<para><varname>minusTime(tpcpoint,tstzspan) → tpcpoint</varname></para>
-					<para><varname>minusTime(tpcpoint,tstzset) → tpcpoint</varname></para>
-					<para><varname>minusTime(tpcpoint,tstzspanset) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTime(tpcpoint,timestamptz) → tpcpoint
+atTime(tpcpoint,tstzspan) → tpcpoint
+atTime(tpcpoint,tstzset) → tpcpoint
+atTime(tpcpoint,tstzspanset) → tpcpoint
+minusTime(tpcpoint,timestamptz) → tpcpoint
+minusTime(tpcpoint,tstzspan) → tpcpoint
+minusTime(tpcpoint,tstzset) → tpcpoint
+minusTime(tpcpoint,tstzspanset) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTime(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -979,8 +1073,10 @@ SELECT numInstants(atTime(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTpcbox</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTpcbox</varname></primary></indexterm>
 					<para>Restringir un tpcpoint al extent espacial / temporal de un tpcbox, o eliminarlo. Devuelve NULL cuando el pcid del tpcbox no coincide con el del tpcpoint. Internamente proyecta a un tgeompoint a través de la caché de esquemas, restringe la proyección mediante el stbox equivalente y devuelve el span temporal del resultado al tpcpoint original para preservar los valores pcpoint completos</para>
-					<para><varname>atTpcbox(tpcpoint,tpcbox,border_inc boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>minusTpcbox(tpcpoint,tpcbox,border_inc boolean=TRUE) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTpcbox(tpcpoint,tpcbox,border_inc boolean=TRUE) → tpcpoint
+minusTpcbox(tpcpoint,tpcbox,border_inc boolean=TRUE) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1002,8 +1098,10 @@ SELECT numInstants(minusTpcbox(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
 					<para>Restringir un tpcpoint a los instantes anteriores o posteriores a una marca de tiempo. El indicador strict excluye el instante en la marca de tiempo misma</para>
-					<para><varname>beforeTimestamp(tpcpoint,timestamptz,strict boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>afterTimestamp(tpcpoint,timestamptz,strict boolean=TRUE) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+beforeTimestamp(tpcpoint,timestamptz,strict boolean=TRUE) → tpcpoint
+afterTimestamp(tpcpoint,timestamptz,strict boolean=TRUE) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeSpan(beforeTimestamp(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1027,8 +1125,10 @@ SELECT timeSpan(afterTimestamp(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
 					<para>Insertar un tpcpoint en otro, o actualizar otro con él</para>
-					<para><varname>insert(tpcpoint,tpcpoint,connect boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>update(tpcpoint,tpcpoint,connect boolean=TRUE) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+insert(tpcpoint,tpcpoint,connect boolean=TRUE) → tpcpoint
+update(tpcpoint,tpcpoint,connect boolean=TRUE) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(insert(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1042,10 +1142,12 @@ SELECT numInstants(insert(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_deleteTime">
 					<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
 					<para>Eliminar un selector de tiempo (marca de tiempo, conjunto, período o conjunto de spans) de un tpcpoint</para>
-					<para><varname>deleteTime(tpcpoint,timestamptz,connect boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>deleteTime(tpcpoint,tstzset,connect boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>deleteTime(tpcpoint,tstzspan,connect boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>deleteTime(tpcpoint,tstzspanset,connect boolean=TRUE) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+deleteTime(tpcpoint,timestamptz,connect boolean=TRUE) → tpcpoint
+deleteTime(tpcpoint,tstzset,connect boolean=TRUE) → tpcpoint
+deleteTime(tpcpoint,tstzspan,connect boolean=TRUE) → tpcpoint
+deleteTime(tpcpoint,tstzspanset,connect boolean=TRUE) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Deleting the middle instant splits the sequence into
 -- {[2001-01-01, 2001-01-02), (2001-01-02, 2001-01-03]}; each half stores
@@ -1062,8 +1164,10 @@ SELECT numInstants(deleteTime(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 					<para>Añadir un instante o una secuencia a un tpcpoint</para>
-					<para><varname>appendInstant(tpcpoint,tpcpoint) → tpcpoint</varname></para>
-					<para><varname>appendSequence(tpcpoint,tpcpoint) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tpcpoint,tpcpoint) → tpcpoint
+appendSequence(tpcpoint,tpcpoint) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(appendInstant(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1081,7 +1185,9 @@ SELECT numInstants(appendInstant(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_unnest">
 					<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
 					<para>Devolver los valores distintos de un tpcpoint con el conjunto de spans durante el cual toma cada uno de ellos</para>
-					<para><varname>unnest(tpcpoint) → {(value,time)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+unnest(tpcpoint) → {(value,time)}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (un).time
 FROM (SELECT unnest(tpcpointSeq(ARRAY[
@@ -1096,7 +1202,10 @@ FROM (SELECT unnest(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_timeSplit">
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Fragmentar un tpcpoint en fragmentos, uno por cada intervalo de tiempo</para>
-					<para><varname>timeSplit(tpcpoint,bin_width interval,origin timestamptz='2000-01-03') → {(time,tpcpoint)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+timeSplit(tpcpoint,bin_width interval,
+  origin timestamptz='2000-01-03') → {(time,tpcpoint)}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (ts).time, numInstants((ts).temp)
 FROM (SELECT timeSplit(tpcpointSeq(ARRAY[
@@ -1113,7 +1222,9 @@ FROM (SELECT timeSplit(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_spans">
 					<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
 					<para>Devuelve el arreglo de lapsos de tiempo de los segmentos de un tpcpoint</para>
-					<para><varname>spans(tpcpoint) → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spans(tpcpoint) → tstzspan[]
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spans(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
@@ -1127,8 +1238,10 @@ SELECT spans(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 					<para>Devuelve los lapsos de tiempo de un tpcpoint dividido en un número dado de contenedores, o con un número dado de segmentos por contenedor</para>
-					<para><varname>splitNSpans(tpcpoint, integer) → tstzspan[]</varname></para>
-					<para><varname>splitEachNSpans(tpcpoint, integer) → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+splitNSpans(tpcpoint, integer) → tstzspan[]
+splitEachNSpans(tpcpoint, integer) → tstzspan[]
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
@@ -1195,8 +1308,10 @@ SELECT tpcbox 'TPCBOX(ZT(((0,0,0),(1,1,1)),[2024-01-01, 2024-01-02]), 1)' &lt;&l
 					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 					<para>Distancia de aproximación más cercana, ordenable KNN mediante la clase de operadores GiST: <varname>SELECT … ORDER BY temp |=| query LIMIT N</varname> se acelera con índice. El desajuste de pcid produce infinito.</para>
-					<para><varname>nearestApproachDistance(tpcpoint,tpcbox) → float</varname></para>
-					<para><varname>nearestApproachDistance(tpcpoint,tpcpoint) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+nearestApproachDistance(tpcpoint,tpcbox) → float
+nearestApproachDistance(tpcpoint,tpcpoint) → float
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(nearestApproachDistance(
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1249,10 +1364,12 @@ SELECT round((tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz) |=|
 					<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 					<para>Contiene, cubre y toca alguna vez / siempre</para>
-					<para><varname>{eContains,aContains}(geometry,tpcpoint) → boolean</varname></para>
-					<para><varname>{eCovers,aCovers}(geometry,tpcpoint) → boolean</varname></para>
-					<para><varname>{eTouches,aTouches}(geometry,tpcpoint) → boolean</varname></para>
-					<para><varname>{eTouches,aTouches}(tpcpoint,geometry) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{eContains,aContains}(geometry,tpcpoint) → boolean
+{eCovers,aCovers}(geometry,tpcpoint) → boolean
+{eTouches,aTouches}(geometry,tpcpoint) → boolean
+{eTouches,aTouches}(tpcpoint,geometry) → boolean
+</programlisting>
 					<para>Un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan, de modo que estas toman la geometría en primer lugar únicamente, salvo <varname>eTouches</varname> y <varname>aTouches</varname>, que leen cualquiera de los dos órdenes. Son relaciones planares: un punto cuyo esquema declara una dimensión Z es rechazado.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))',
@@ -1343,13 +1460,15 @@ SELECT aDwithin(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 					<para>Relaciones espaciales temporales</para>
-					<para><varname>tDisjoint({geometry,tpcpoint},{geometry,tpcpoint}) &#8594; tbool</varname></para>
-					<para><varname>tDwithin({geometry,tpcpoint},{geometry,tpcpoint},float) &#8594; tbool</varname></para>
-					<para><varname>tIntersects({geometry,tpcpoint},{geometry,tpcpoint}) &#8594; tbool</varname></para>
-					<para><varname>tContains(geometry,tpcpoint) &#8594; tbool</varname></para>
-					<para><varname>tCovers(geometry,tpcpoint) &#8594; tbool</varname></para>
-					<para><varname>tTouches(geometry,tpcpoint) &#8594; tbool</varname></para>
-					<para><varname>tTouches(tpcpoint,geometry) &#8594; tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tDisjoint({geometry,tpcpoint},{geometry,tpcpoint}) &#8594; tbool
+tDwithin({geometry,tpcpoint},{geometry,tpcpoint},float) &#8594; tbool
+tIntersects({geometry,tpcpoint},{geometry,tpcpoint}) &#8594; tbool
+tContains(geometry,tpcpoint) &#8594; tbool
+tCovers(geometry,tpcpoint) &#8594; tbool
+tTouches(geometry,tpcpoint) &#8594; tbool
+tTouches(tpcpoint,geometry) &#8594; tbool
+</programlisting>
 					<para>Un punto de nube de puntos temporal declara las relaciones que declara su destino de conversión, de modo que <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente y <varname>tTouches</varname> no tiene dirección entre dos puntos de nube de puntos. Las tres son relaciones planares: un esquema cuyas dimensiones no incluyen Z las responde, y uno que lleva Z encuentra el rechazo <varname>The tgeompoint cannot have Z dimension</varname>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1386,7 +1505,9 @@ SELECT tDwithin(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
 				<listitem xml:id="tpcpatch_inst">
 					<indexterm significance="normal"><primary><varname>tpcpatch</varname></primary></indexterm>
 					<para>Construir un pcpatch temporal de subtipo instante</para>
-					<para><varname>tpcpatch(pcpatch,timestamptz) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpatch(pcpatch,timestamptz) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tempSubtype(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz));
@@ -1397,8 +1518,10 @@ SELECT tempSubtype(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
 				<listitem xml:id="tpcpatch_seq">
 					<indexterm significance="normal"><primary><varname>tpcpatchSeq</varname></primary></indexterm>
 					<para>Construir un pcpatch temporal de subtipo secuencia</para>
-					<para><varname>tpcpatchSeq(tpcpatch[]) → tpcpatch</varname></para>
-					<para><varname>tpcpatchSeq(tpcpatch[],text) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpatchSeq(tpcpatch[]) → tpcpatch
+tpcpatchSeq(tpcpatch[],text) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1416,7 +1539,9 @@ SELECT numInstants(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_seqset">
 					<indexterm significance="normal"><primary><varname>tpcpatchSeqSet</varname></primary></indexterm>
 					<para>Construir un pcpatch temporal de subtipo conjunto de secuencias</para>
-					<para><varname>tpcpatchSeqSet(tpcpatch[]) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpatchSeqSet(tpcpatch[]) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSequences(tpcpatchSeqSet(ARRAY[tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1437,8 +1562,10 @@ SELECT numSequences(tpcpatchSeqSet(ARRAY[tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>startNumPoints</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>endNumPoints</varname></primary></indexterm>
 					<para>Devolver el número de puntos del parche contenido en el primer o último instante</para>
-					<para><varname>startNumPoints(tpcpatch) → integer</varname></para>
-					<para><varname>endNumPoints(tpcpatch) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+startNumPoints(tpcpatch) → integer
+endNumPoints(tpcpatch) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startNumPoints(tpcpatch(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])),
   '2024-02-01'::timestamptz));
@@ -1449,7 +1576,9 @@ SELECT startNumPoints(tpcpatch(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])
 				<listitem xml:id="tpcpatch_total_numpoints">
 					<indexterm significance="normal"><primary><varname>numPoints</varname></primary></indexterm>
 					<para>Devolver el número total de puntos de todos los parches de todos los instantes. Se lee directamente de la cabecera de cada parche, sin descompresión.</para>
-					<para><varname>numPoints(tpcpatch) → bigint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numPoints(tpcpatch) → bigint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numPoints(tpcpatchSeq(ARRAY[
   tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
@@ -1464,7 +1593,9 @@ SELECT numPoints(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_points">
 					<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
 					<para>Función devuelve-conjunto: emite una fila por cada (marca de tiempo de instante, punto) recorriendo el parche de cada instante y descomponiéndolo mediante la API C en memoria de pgPointCloud. Útil para combinar una columna tpcpatch con predicados por punto que los operadores de nivel de caja delimitadora no pueden expresar. El coste es O(total de puntos), una descompresión por instante más una emisión de fila por punto.</para>
-					<para><varname>points(tpcpatch) → setof (t timestamptz, point pcpoint)</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+points(tpcpatch) → setof (t timestamptz, point pcpoint)
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT t, point FROM points(tpcpatch(
   PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
@@ -1489,9 +1620,11 @@ SELECT t, point FROM points(tpcpatch(
 					<indexterm significance="normal"><primary><varname>tpcpatchSeq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcpatchSeqSet</varname></primary></indexterm>
 					<para>Transformar un tpcpatch en otro subtipo</para>
-					<para><varname>tpcpatchInst(tpcpatch) → tpcpatch</varname></para>
-					<para><varname>tpcpatchSeq(tpcpatch,interp='step') → tpcpatch</varname></para>
-					<para><varname>tpcpatchSeqSet(tpcpatch) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpatchInst(tpcpatch) → tpcpatch
+tpcpatchSeq(tpcpatch,interp='step') → tpcpatch
+tpcpatchSeqSet(tpcpatch) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2,
   2)), '2001-01-01'::timestamptz)));
@@ -1501,7 +1634,9 @@ SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 
 				<listitem xml:id="tpcpatch_setInterp">
 					<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 					<para>Transformar un tpcpatch a otra interpolación</para>
-					<para><varname>setInterp(tpcpatch,interp) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+setInterp(tpcpatch,interp) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT interp(setInterp(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1523,10 +1658,12 @@ SELECT interp(setInterp(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 					<para>Restringir un tpcpatch a (al complemento de) un valor pcpatch o un conjunto de valores pcpatch</para>
-					<para><varname>atValue(tpcpatch,pcpatch) → tpcpatch</varname></para>
-					<para><varname>minusValue(tpcpatch,pcpatch) → tpcpatch</varname></para>
-					<para><varname>atValues(tpcpatch,pcpatchset) → tpcpatch</varname></para>
-					<para><varname>minusValues(tpcpatch,pcpatchset) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atValue(tpcpatch,pcpatch) → tpcpatch
+minusValue(tpcpatch,pcpatch) → tpcpatch
+atValues(tpcpatch,pcpatchset) → tpcpatch
+minusValues(tpcpatch,pcpatchset) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The matching value is held up to the next instant; the closing bound
 -- is stored as a second instant.
@@ -1551,8 +1688,10 @@ SELECT numInstants(minusValue(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTpcbox</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTpcbox</varname></primary></indexterm>
 					<para>Restringir un tpcpatch a los instantes cuyo parche supera una prueba de superposición aproximada de PCBOUNDS frente al tpcbox, o eliminarlos. La granularidad es a nivel de parche: cada instante superviviente conserva su payload pcpatch textualmente, sin descompresión por punto. Como el <varname>PCBOUNDS</varname> de pgPointCloud es 2D, la dimensión Z de la caja se ignora a esta granularidad. Devuelve NULL cuando el pcid del tpcbox no coincide.</para>
-					<para><varname>atTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>minusTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch
+minusTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1576,8 +1715,10 @@ SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTpcboxFine</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTpcboxFine</varname></primary></indexterm>
 					<para>Variante por punto de la anterior: cada instante superviviente contiene un pcpatch recién construido que incluye solo los puntos dentro (o fuera, en el caso de minus) del tpcbox en 2D, y en 3D cuando la caja tiene dimensión Z. Los instantes cuyo parche filtra hasta cero puntos se descartan. Más lenta que la variante aproximada porque cada parche se descomprime y reconstruye; úsela cuando se necesite fidelidad a nivel de punto.</para>
-					<para><varname>atTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>minusTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch
+minusTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1592,8 +1733,10 @@ SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 					<para>Restringir un tpcpatch a los puntos cuya proyección XY intersecta (o no intersecta, en el caso de minus) una geometría 2D. Z se ignora. El llamador debe garantizar la compatibilidad de SRID entre el esquema del parche y la geometría.</para>
-					<para><varname>atGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
-					<para><varname>minusGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tpcpatch,geometry) → tpcpatch
+minusGeometry(tpcpatch,geometry) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The polygon boundary touches the point (3 3) of the patch at
 -- 2001-01-02, so that patch survives both the at and the minus side.
@@ -1618,8 +1761,10 @@ SELECT numInstants(minusGeometry(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
 					<para>Restringir un tpcpatch a los instantes anteriores o posteriores a una marca de tiempo. El indicador strict excluye el instante en la marca de tiempo misma</para>
-					<para><varname>beforeTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>afterTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+beforeTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch
+afterTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1649,8 +1794,10 @@ SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
 					<para>Insertar un tpcpatch en otro, o actualizar otro con él</para>
-					<para><varname>insert(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>update(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+insert(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch
+update(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(insert(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1667,10 +1814,12 @@ SELECT numInstants(insert(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_deleteTime">
 					<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
 					<para>Eliminar un selector de tiempo (marca de tiempo, conjunto, período o conjunto de spans) de un tpcpatch</para>
-					<para><varname>deleteTime(tpcpatch,timestamptz,connect boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>deleteTime(tpcpatch,tstzset,connect boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>deleteTime(tpcpatch,tstzspan,connect boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>deleteTime(tpcpatch,tstzspanset,connect boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+deleteTime(tpcpatch,timestamptz,connect boolean=TRUE) → tpcpatch
+deleteTime(tpcpatch,tstzset,connect boolean=TRUE) → tpcpatch
+deleteTime(tpcpatch,tstzspan,connect boolean=TRUE) → tpcpatch
+deleteTime(tpcpatch,tstzspanset,connect boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Deleting the middle instant splits the sequence into
 -- {[2001-01-01, 2001-01-02), (2001-01-02, 2001-01-03]}; each half stores
@@ -1690,8 +1839,10 @@ SELECT numInstants(deleteTime(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 					<para>Añadir un instante o una secuencia a un tpcpatch</para>
-					<para><varname>appendInstant(tpcpatch,tpcpatch) → tpcpatch</varname></para>
-					<para><varname>appendSequence(tpcpatch,tpcpatch) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tpcpatch,tpcpatch) → tpcpatch
+appendSequence(tpcpatch,tpcpatch) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(appendInstant(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1711,7 +1862,9 @@ SELECT numInstants(appendInstant(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_unnest">
 					<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
 					<para>Devolver los valores distintos de un tpcpatch con el conjunto de spans durante el cual toma cada uno de ellos</para>
-					<para><varname>unnest(tpcpatch) → {(value,time)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+unnest(tpcpatch) → {(value,time)}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (un).time
 FROM (SELECT unnest(tpcpatchSeq(ARRAY[
@@ -1729,7 +1882,10 @@ FROM (SELECT unnest(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_timeSplit">
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Fragmentar un tpcpatch en fragmentos, uno por cada intervalo de tiempo</para>
-					<para><varname>timeSplit(tpcpatch,bin_width interval,origin timestamptz='2000-01-03') → {(time,tpcpatch)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+timeSplit(tpcpatch,bin_width interval,
+  origin timestamptz='2000-01-03') → {(time,tpcpatch)}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (ts).time, numInstants((ts).temp)
 FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
@@ -1749,7 +1905,9 @@ FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_spans">
 					<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
 					<para>Devuelve el arreglo de lapsos de tiempo de los segmentos de un tpcpatch</para>
-					<para><varname>spans(tpcpatch) → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spans(tpcpatch) → tstzspan[]
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spans(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1766,8 +1924,10 @@ SELECT spans(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 					<para>Devuelve los lapsos de tiempo de un tpcpatch dividido en un número dado de contenedores, o con un número dado de segmentos por contenedor</para>
-					<para><varname>splitNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
-					<para><varname>splitEachNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+splitNSpans(tpcpatch, integer) → tstzspan[]
+splitEachNSpans(tpcpatch, integer) → tstzspan[]
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1799,7 +1959,9 @@ SELECT splitNSpans(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>eDwithin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aDwithin</varname></primary></indexterm>
 					<para>Devolver verdadero si y solo si al menos un punto de alguno de los instantes del tpcpatch intersecta la geometría (solo XY).</para>
-					<para><varname>eIntersects(tpcpatch,geometry) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eIntersects(tpcpatch,geometry) → boolean
+</programlisting>
 					<para>Las relaciones alguna vez y siempre cubren la misma matriz: <varname>eContains</varname>, <varname>eCovers</varname>, <varname>eDisjoint</varname>, <varname>eIntersects</varname>, <varname>eTouches</varname> y <varname>eDwithin</varname>, cada una en los tres órdenes de argumentos, y sus gemelas siempre. <varname>eIntersects(tpcpatch,geometry)</varname> es la que el tipo responde de forma nativa, recorriendo los puntos de cada instante y deteniéndose en el primer acierto; las demás convierten el parche a la geometría temporal de sus multipuntos.</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eIntersects(tpcpatchSeq(ARRAY[
@@ -1819,7 +1981,9 @@ SELECT eIntersects(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_tgeometry">
 					<indexterm significance="normal"><primary><varname>tgeometry</varname></primary></indexterm>
 					<para>Convierte un parche temporal en la geometría temporal de los multipuntos que ocupan sus parches. El parche de cada instante se convierte en el multipunto de las posiciones que ocupan sus puntos, leídas a través del esquema que nombra su <varname>pcid</varname></para>
-					<para><varname>tgeometry(tpcpatch) &#8594; tgeometry</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tgeometry(tpcpatch) &#8594; tgeometry
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)::tgeometry);
@@ -1841,12 +2005,14 @@ SELECT asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 					<para>Relaciones espaciales temporales</para>
-					<para><varname>tDisjoint({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
-					<para><varname>tDwithin({geometry,tpcpatch},{geometry,tpcpatch},float) &#8594; tbool</varname></para>
-					<para><varname>tIntersects({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
-					<para><varname>tContains({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
-					<para><varname>tCovers({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
-					<para><varname>tTouches({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tDisjoint({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+tDwithin({geometry,tpcpatch},{geometry,tpcpatch},float) &#8594; tbool
+tIntersects({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+tContains({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+tCovers({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+tTouches({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+</programlisting>
 					<para>Un parche llega al motor de geometría como el multipunto de las posiciones que ocupan sus puntos, de modo que declara la matriz que declara la geometría temporal: cada predicado en cada dirección. Las planares responden para un esquema cuyas dimensiones no incluyen Z, y un esquema que lleva Z encuentra el rechazo <varname>The tgeometry cannot have Z dimension</varname>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)),
@@ -1884,8 +2050,10 @@ SELECT tIntersects(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 					<para>La distancia de aproximación más cercana (<varname>|=|</varname>) es ordenable KNN a través de la clase de operador GiST.</para>
-					<para><varname>nearestApproachDistance(tpcpatch,tpcbox) → float</varname></para>
-					<para><varname>nearestApproachDistance(tpcpatch,tpcpatch) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+nearestApproachDistance(tpcpatch,tpcbox) → float
+nearestApproachDistance(tpcpatch,tpcpatch) → float
+</programlisting>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -1901,13 +2069,17 @@ SELECT tIntersects(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 					<para>Comprobar si el valor en algún instante (alguna vez) o en todos los instantes (siempre) es igual a, o distinto de, un pcpatch u otro tpcpatch</para>
-					<para><varname>eEq(pcpatch,tpcpatch) → boolean</varname></para>
-					<para><varname>eEq(tpcpatch,pcpatch) → boolean</varname></para>
-					<para><varname>eEq(tpcpatch,tpcpatch) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eEq(pcpatch,tpcpatch) → boolean
+eEq(tpcpatch,pcpatch) → boolean
+eEq(tpcpatch,tpcpatch) → boolean
+</programlisting>
 					<para><varname>aEq</varname>, <varname>eNe</varname> y <varname>aNe</varname> reciben los mismos tres pares de argumentos</para>
-					<para><varname>pcpatch ?= tpcpatch → boolean</varname></para>
-					<para><varname>tpcpatch ?= pcpatch → boolean</varname></para>
-					<para><varname>tpcpatch ?= tpcpatch → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpatch ?= tpcpatch → boolean
+tpcpatch ?= pcpatch → boolean
+tpcpatch ?= tpcpatch → boolean
+</programlisting>
 					<para>Los operadores <varname>%=</varname>, <varname>?&lt;&gt;</varname> y <varname>%&lt;&gt;</varname> reciben los mismos tres pares de operandos</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eEq(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), tpcpatchSeq(ARRAY[
@@ -1930,13 +2102,17 @@ SELECT aEq(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#=</varname></primary></indexterm>
 					<para>Devolver la igualdad o desigualdad temporal de un tpcpatch con un pcpatch o con otro tpcpatch, como un tbool</para>
-					<para><varname>tEq(pcpatch,tpcpatch) → tbool</varname></para>
-					<para><varname>tEq(tpcpatch,pcpatch) → tbool</varname></para>
-					<para><varname>tEq(tpcpatch,tpcpatch) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tEq(pcpatch,tpcpatch) → tbool
+tEq(tpcpatch,pcpatch) → tbool
+tEq(tpcpatch,tpcpatch) → tbool
+</programlisting>
 					<para><varname>tNe</varname> recibe los mismos tres pares de argumentos</para>
-					<para><varname>pcpatch #= tpcpatch → tbool</varname></para>
-					<para><varname>tpcpatch #= pcpatch → tbool</varname></para>
-					<para><varname>tpcpatch #= tpcpatch → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpatch #= tpcpatch → tbool
+tpcpatch #= pcpatch → tbool
+tpcpatch #= tpcpatch → tbool
+</programlisting>
 					<para>El operador <varname>#&lt;&gt;</varname> recibe los mismos tres pares de operandos</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(tpcpatchSeq(ARRAY[
@@ -2017,9 +2193,11 @@ CREATE INDEX ON my_table USING spgist(my_tpcpoint_column tpcpoint_kdtree_ops);
 			<listitem xml:id="tpcpoint_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Agregado de caja delimitadora sobre una columna de valores tpcpoint, tpcpatch o tpcbox. Devuelve el tpcbox más pequeño que contiene todas las entradas. Agregar a través de pcid distintos genera un error, la caja delimitadora sería ininterpretable ya que las dimensiones son relativas al pcid.</para>
-				<para><varname>extent(tpcpoint) → tpcbox</varname></para>
-				<para><varname>extent(tpcpatch) → tpcbox</varname></para>
-				<para><varname>extent(tpcbox) → tpcbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(tpcpoint) → tpcbox
+extent(tpcpatch) → tpcbox
+extent(tpcbox) → tpcbox
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(v) FROM (VALUES
   (tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz)),
@@ -2049,7 +2227,9 @@ SELECT wCount(v, interval '1 day') FROM (VALUES
 			<listitem xml:id="tpcpatch_tnpoints">
 				<indexterm significance="normal"><primary><varname>tnpoints</varname></primary></indexterm>
 				<para>Conteo de puntos de pcpatch por instante, sumado a través de las filas. Distinto de <varname>tCount(tpcpatch)</varname>, que cuenta el número de parches (siempre 1 por instante). <varname>tnpoints</varname> se lee como «cuántos puntos había en la nube en el tiempo t», la primitiva natural para el control de calidad de la ingesta y los paneles de densidad a lo largo del tiempo.</para>
-				<para><varname>tnpoints(tpcpatch) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpoints(tpcpatch) → tint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoints(v) FROM (VALUES
   (tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -2063,7 +2243,9 @@ SELECT tnpoints(v) FROM (VALUES
 			<listitem xml:id="tpcpatch_tdensity">
 				<indexterm significance="normal"><primary><varname>tdensity</varname></primary></indexterm>
 				<para>Densidad de puntos por instante (<varname>numPoints / área-bbox-xy</varname>) sumada a través de las filas. Cada pcpatch lleva el <varname>PCBOUNDS</varname> en línea (xmin / xmax / ymin / ymax) por lo que el término de área de la caja delimitadora se lee directamente, sin recálculo. Un parche de 1 punto o colineal produce <varname>+Infinity</varname> para ese instante; filtre con <varname>isfinite()</varname> en consultas posteriores si es necesario.</para>
-				<para><varname>tdensity(tpcpatch) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tdensity(tpcpatch) → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Each patch holds 2 points over a 1x1 xy-bbox.
 SELECT tdensity(v) FROM (VALUES
@@ -2128,9 +2310,11 @@ SELECT numInstants(appendInstant(v ORDER BY startTimestamp(v))) FROM (VALUES
 			<listitem xml:id="tpcpoint_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Devolver la representación textual de un tpcpoint, o de un arreglo de ellos, y convertir un tpcpoint a texto</para>
-				<para><varname>asText(tpcpoint) → text</varname></para>
-				<para><varname>asText(tpcpoint[]) → text[]</varname></para>
-				<para><varname>tpcpoint::text → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText(tpcpoint) → text
+asText(tpcpoint[]) → text[]
+tpcpoint::text → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The pcpoint payload renders as hex-encoded WKB.
 SELECT asText(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
@@ -2140,9 +2324,11 @@ SELECT asText(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 			<listitem xml:id="tpcpatch_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Devolver la representación textual de un tpcpatch, o de un arreglo de ellos, y convertir un tpcpatch a texto</para>
-				<para><varname>asText(tpcpatch) → text</varname></para>
-				<para><varname>asText(tpcpatch[]) → text[]</varname></para>
-				<para><varname>tpcpatch::text → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText(tpcpatch) → text
+asText(tpcpatch[]) → text[]
+tpcpatch::text → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The pcpatch payload renders as hex-encoded WKB.
 SELECT left(asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -2163,7 +2349,9 @@ SELECT left(asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
 			<listitem xml:id="tpcpoint_mfjson">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Para <varname>tpcpoint</varname>, el tipo temporal se emite como <varname>{"type":"MovingPCPoint", … "coordinates":[[X,Y,Z], …], "datetimes":[…]}</varname>. X/Y/[Z] se extraen del <varname>pcpoint</varname> de cada instante mediante la caché de esquemas; si el esquema carece de X/Y el array de coordenadas está vacío para ese instante.</para>
-				<para><varname>asMFJSON(tpcpoint, options int=0, flags int=0, maxdecimaldigits int=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tpcpoint, options int=0, flags int=0, maxdecimaldigits int=15) → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 -- {"type":"MovingPCPoint","coordinates":[[1,1,1]],
@@ -2173,7 +2361,9 @@ SELECT asMFJSON(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 			<listitem xml:id="tpcpatch_mfjson">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Para <varname>tpcpatch</varname>, la etiqueta de tipo es <varname>"MovingPCPatch"</varname> y cada instante emite un pequeño objeto <varname>{"pcid":N, "npoints":N, "bounds":[xmin,xmax,ymin,ymax]}</varname>. La carga de puntos comprimida no está intencionadamente en el JSON, use <varname>asBinary</varname> / <varname>asHexWKB</varname> para el ida y vuelta.</para>
-				<para><varname>asMFJSON(tpcpatch, options int=0, flags int=0, maxdecimaldigits int=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tpcpatch, options int=0, flags int=0, maxdecimaldigits int=15) → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz));

--- a/doc/es/temporal_pose_chains.xml
+++ b/doc/es/temporal_pose_chains.xml
@@ -29,8 +29,10 @@
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Devuelve la representación en texto conocido (WKT) o en texto conocido extendido (EWKT)</para>
-					<para><varname>asText({posechain,posechain[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({posechain,posechain[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({posechain,posechain[]}) → {text,text[]}
+asEWKT({posechain,posechain[]}) → {text,text[]}
+</programlisting>
 					<para>El eslabón exterior se escribe como una pose que lleva el marco de la cadena, y cada eslabón posterior se escribe sin él.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(posechain 'PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),1))');
@@ -49,10 +51,12 @@ SELECT asEWKT(posechain 'SRID=3812;PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 					<para>Devuelve la representación en binario conocido (WKB), en binario conocido extendido (EWKB), en binario conocido hexadecimal (HexWKB) o en binario conocido extendido hexadecimal (HexEWKB)</para>
-					<para><varname>asBinary(posechain,endian text='') → bytea</varname></para>
-					<para><varname>asEWKB(posechain,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(posechain,endian text='') → text</varname></para>
-					<para><varname>asHexEWKB(posechain,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(posechain,endian text='') → bytea
+asEWKB(posechain,endian text='') → bytea
+asHexWKB(posechain,endian text='') → text
+asHexEWKB(posechain,endian text='') → text
+</programlisting>
 					<para>La cadena escribe sus indicadores y su único SRID una sola vez, después el número de eslabones y después los valores de cada eslabón en orden. El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(posechain 'PoseChain(Pose(Point(1 2),1))');
@@ -68,8 +72,10 @@ SELECT asHexEWKB(posechain 'SRID=3812;PoseChain(Pose(Point(1 2),1))');
 					<indexterm significance="normal"><primary><varname>posechainFromText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>posechainFromEWKT</varname></primary></indexterm>
 					<para>Entrada desde la representación en texto conocido (WKT) o en texto conocido extendido (EWKT)</para>
-					<para><varname>posechainFromText(text) → posechain</varname></para>
-					<para><varname>posechainFromEWKT(text) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechainFromText(text) → posechain
+posechainFromEWKT(text) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(posechainFromText('PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),1))'));
 -- PoseChain(Pose(POINT(0 0),0),Pose(POINT(1 0),1))
@@ -83,9 +89,11 @@ SELECT asEWKT(posechainFromEWKT('SRID=3812;PoseChain(Pose(Point(0 0),0))'));
 					<indexterm significance="normal"><primary><varname>posechainFromEWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>posechainFromHexEWKB</varname></primary></indexterm>
 					<para>Entrada desde la representación en binario conocido (WKB), en binario conocido extendido (EWKB) o en binario conocido extendido hexadecimal (HexEWKB)</para>
-					<para><varname>posechainFromBinary(bytea) → posechain</varname></para>
-					<para><varname>posechainFromEWKB(bytea) → posechain</varname></para>
-					<para><varname>posechainFromHexEWKB(text) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechainFromBinary(bytea) → posechain
+posechainFromEWKB(bytea) → posechain
+posechainFromHexEWKB(text) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT posechainFromBinary(asBinary(posechain 'PoseChain(Pose(Point(1 2),0.5))')) =
   posechain 'PoseChain(Pose(Point(1 2),0.5))';
@@ -105,7 +113,9 @@ SELECT posechainFromHexEWKB(asHexEWKB(
 				<listitem xml:id="posechain_constructor">
 					<indexterm significance="normal"><primary><varname>posechain</varname></primary></indexterm>
 					<para>Construye una cadena de poses a partir de un arreglo de poses ordenadas desde el marco más exterior hacia dentro</para>
-					<para><varname>posechain(pose[]) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechain(pose[]) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(posechain(ARRAY[pose 'Pose(Point(0 0),0)', pose 'Pose(Point(1 0),0)']));
 -- PoseChain(Pose(POINT(0 0),0),Pose(POINT(1 0),0))
@@ -115,7 +125,9 @@ SELECT asEWKT(posechain(ARRAY[pose 'Pose(Point(0 0),0)', pose 'Pose(Point(1 0),0
 				<listitem xml:id="posechain_appendPose">
 					<indexterm significance="normal"><primary><varname>appendPose</varname></primary></indexterm>
 					<para>Devuelve una cadena de poses con una pose añadida como su eslabón más interior</para>
-					<para><varname>appendPose(posechain,pose) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendPose(posechain,pose) → posechain
+</programlisting>
 					<para>La pose se lee en el marco que define el último eslabón de la cadena, por lo que no lleva ni un SRID ni el marcador geodésico.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(appendPose(posechain 'PoseChain(Pose(Point(0 0),0))',
@@ -132,7 +144,9 @@ SELECT asEWKT(appendPose(posechain 'PoseChain(Pose(Point(0 0),0))',
 				<listitem xml:id="pose_to_posechain">
 					<indexterm significance="normal"><primary><varname>posechain</varname></primary></indexterm>
 					<para>Convierte una pose en una cadena de poses de un solo eslabón</para>
-					<para><varname>posechain(pose) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechain(pose) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(posechain(pose 'SRID=3812;Pose(Point(1 2),0.5)'));
 -- SRID=3812;PoseChain(Pose(POINT(1 2),0.5))
@@ -142,8 +156,10 @@ SELECT asEWKT(posechain(pose 'SRID=3812;Pose(Point(1 2),0.5)'));
 				<listitem xml:id="posechain_to_pose">
 					<indexterm significance="normal"><primary><varname>pose</varname></primary></indexterm>
 					<para>Devuelve la pose de un marco que define la cadena, leída en el marco exterior de la cadena</para>
-					<para><varname>pose(posechain) → pose</varname></para>
-					<para><varname>pose(posechain,integer) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose(posechain) → pose
+pose(posechain,integer) → pose
+</programlisting>
 					<para>Con un argumento se compone toda la cadena, lo que da la pose de su marco más interior. Con dos se componen los primeros <varname>n</varname> eslabones, lo que da la pose del marco que define el eslabón <varname>n</varname>-ésimo, es decir, dónde se sitúa esa articulación de la cadena.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(pose(posechain
@@ -158,7 +174,9 @@ SELECT asEWKT(pose(posechain
 				<listitem xml:id="posechain_to_point">
 					<indexterm significance="normal"><primary><varname>point</varname></primary></indexterm>
 					<para>Convierte una cadena de poses en el punto geométrico de su marco más interior</para>
-					<para><varname>point(posechain) → geometry</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+point(posechain) → geometry
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(point(posechain
   'PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),0))'));
@@ -169,7 +187,9 @@ SELECT ST_AsText(point(posechain
 				<listitem xml:id="posechain_to_stbox">
 					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 					<para>Convierte una cadena de poses en una caja espaciotemporal</para>
-					<para><varname>stbox(posechain) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+stbox(posechain) → stbox
+</programlisting>
 					<para>La caja cubre la posición compuesta de cada prefijo de la cadena y no solo la del conjunto: cada articulación es un lugar, y una ventana de consulta que alcanza el codo pero no la mano alcanza igualmente la cadena.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(posechain
@@ -186,7 +206,9 @@ SELECT stbox(posechain
 				<listitem xml:id="posechain_numPoses">
 					<indexterm significance="normal"><primary><varname>numPoses</varname></primary></indexterm>
 					<para>Devuelve el número de eslabones de una cadena de poses</para>
-					<para><varname>numPoses(posechain) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numPoses(posechain) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numPoses(posechain
   'PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),0),Pose(Point(2 0),0))');
@@ -200,10 +222,12 @@ SELECT numPoses(posechain
 					<indexterm significance="normal"><primary><varname>poseN</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poses</varname></primary></indexterm>
 					<para>Devuelve los eslabones de una cadena de poses</para>
-					<para><varname>startPose(posechain) → pose</varname></para>
-					<para><varname>endPose(posechain) → pose</varname></para>
-					<para><varname>poseN(posechain,integer) → pose</varname></para>
-					<para><varname>poses(posechain) → pose[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+startPose(posechain) → pose
+endPose(posechain) → pose
+poseN(posechain,integer) → pose
+poses(posechain) → pose[]
+</programlisting>
 					<para>Un eslabón se devuelve tal como está almacenado, es decir, en el marco que define el eslabón anterior. Dónde se sitúa ese marco en el marco exterior de la cadena es lo que responde <varname>pose(posechain,integer)</varname>. La función <varname>poseN</varname> devuelve <varname>NULL</varname> si la cadena tiene menos eslabones que el número dado.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(startPose(posechain
@@ -227,7 +251,9 @@ SELECT asEWKT(poses(posechain 'PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),0))'
 				<listitem xml:id="posechain_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Redondea los valores de los eslabones de una cadena de poses a un número de decimales</para>
-					<para><varname>round(posechain,integer=0) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(posechain,integer=0) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(round(posechain
   'PoseChain(Pose(Point(1.123456789 2.123456789),0.123456789))', 3));
@@ -244,8 +270,10 @@ SELECT asEWKT(round(posechain
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Devuelve o establece el identificador de referencia espacial del marco exterior de una cadena de poses</para>
-					<para><varname>SRID(posechain) → integer</varname></para>
-					<para><varname>setSRID(posechain,integer) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(posechain) → integer
+setSRID(posechain,integer) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(posechain 'SRID=3812;PoseChain(Pose(Point(1 2),0))');
 -- 3812
@@ -258,8 +286,11 @@ SELECT asEWKT(setSRID(posechain 'PoseChain(Pose(Point(1 2),0))', 3812));
 					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transforma a un identificador de referencia espacial</para>
-					<para><varname>transform(posechain,integer) → posechain</varname></para>
-					<para><varname>transformPipeline(posechain,pipeline text,to_srid integer,is_forward boolean=true) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+transform(posechain,integer) → posechain
+transformPipeline(posechain,pipeline text,to_srid integer,
+  is_forward boolean=true) → posechain
+</programlisting>
 					<para>Solo el eslabón exterior nombra un marco, por lo que solo se transforma el eslabón exterior: cada uno de los demás eslabones es una transformación rígida leída en los ejes de su marco padre, y un cambio del marco exterior deja esos ejes como estaban. Se genera un error cuando la cadena de entrada tiene un SRID desconocido (representado por 0).</para>
 					<para>Para una cadena tridimensional sobre un marco geográfico, la orientación del eslabón exterior se vuelve a expresar en la base del marco de destino en su punto, exactamente como ocurre con una pose. Para una cadena bidimensional el ángulo es intrínseco a la proyección de origen y se transmite sin cambios.</para>
 					<para>La función <varname>transformPipeline</varname> especifica la transformación con una tubería de transformación de coordenadas definida representada con el siguiente formato de cadena:</para>
@@ -289,7 +320,9 @@ SELECT asEWKT(round(transformPipeline(posechain
 					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Operadores de comparación tradicionales</para>
-					<para><varname>{posechain} {=,&lt;&gt;,&lt;,&gt;,&lt;=,&gt;=} {posechain} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{posechain} {=,&lt;&gt;,&lt;,&gt;,&lt;=,&gt;=} {posechain} → boolean
+</programlisting>
 					<para>El orden compara la dimensión, después el SRID, después los eslabones en orden y por último el número de eslabones, de modo que una cadena precede a toda cadena que la extiende.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT posechain 'PoseChain(Pose(Point(0 0),0))' =
@@ -304,7 +337,9 @@ SELECT posechain 'PoseChain(Pose(Point(0 0),0))' &lt;
 				<listitem xml:id="posechain_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Devuelve verdadero si dos cadenas de poses son iguales hasta la tolerancia de la comparación de valores de punto flotante</para>
-					<para><varname>posechain ~= posechain → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechain ~= posechain → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT posechain 'PoseChain(Pose(Point(0 0),0))' ~=
   posechain 'PoseChain(Pose(Point(0 0),0))';
@@ -375,8 +410,10 @@ SELECT tposechain(Sequence) 'PoseChain(Pose(Point(1 1), 0.2))@2001-01-01';
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Devuelve la representación de texto conocido (WKT) o de texto conocido extendido (EWKT)</para>
-					<para><varname>asText({tposechain,tposechain[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({tposechain,tposechain[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({tposechain,tposechain[]}) → {text,text[]}
+asEWKT({tposechain,tposechain[]}) → {text,text[]}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01');
 -- PoseChain(Pose(POINT(1 1),0.5))@2001-01-01
@@ -388,9 +425,11 @@ SELECT asText(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01');
 					<indexterm significance="normal"><primary><varname>tposechainFromBinary</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tposechainFromHexEWKB</varname></primary></indexterm>
 					<para>Devuelve una cadena de poses temporal a partir de su representación textual o binaria</para>
-					<para><varname>tposechainFromText(text) → tposechain</varname></para>
-					<para><varname>tposechainFromBinary(bytea) → tposechain</varname></para>
-					<para><varname>tposechainFromHexEWKB(text) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tposechainFromText(text) → tposechain
+tposechainFromBinary(bytea) → tposechain
+tposechainFromHexEWKB(text) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposechainFromText('SRID=5676;PoseChain(Pose(Point(1 1),0.5))@2001-01-01'));
 -- SRID=5676;PoseChain(Pose(POINT(1 1),0.5))@2001-01-01
@@ -406,7 +445,9 @@ SELECT asEWKT(tposechainFromHexEWKB(asHexEWKB(tposechain
 				<listitem xml:id="tposechain_asMFJSON">
 					<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 					<para>Devuelve la representación JSON de Moving Features</para>
-					<para><varname>asMFJSON(tposechain) → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tposechain) → text
+</programlisting>
 					<para>Una cadena se escribe como el arreglo de sus eslabones, en el orden que indica en el marco de quién se lee cada uno de ellos.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01');
@@ -423,10 +464,12 @@ SELECT asMFJSON(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01');
 				<listitem xml:id="tposechain_constructor">
 					<indexterm significance="normal"><primary><varname>tposechain</varname></primary></indexterm>
 					<para>Construye una cadena de poses temporal a partir de una cadena de poses y un valor de tiempo</para>
-					<para><varname>tposechain(posechain, timestamptz) → tposechain</varname></para>
-					<para><varname>tposechain(posechain, tstzset) → tposechain</varname></para>
-					<para><varname>tposechain(posechain, tstzspan, text DEFAULT 'linear') → tposechain</varname></para>
-					<para><varname>tposechain(posechain, tstzspanset, text DEFAULT 'linear') → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tposechain(posechain, timestamptz) → tposechain
+tposechain(posechain, tstzset) → tposechain
+tposechain(posechain, tstzspan, text DEFAULT 'linear') → tposechain
+tposechain(posechain, tstzspanset, text DEFAULT 'linear') → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposechain(posechain 'PoseChain(Pose(Point(1 1), 0.5))',
   timestamptz '2001-01-01'));
@@ -450,7 +493,9 @@ SELECT asEWKT(tposechain(posechain 'PoseChain(Pose(Point(1 1), 0.5))',
 				<listitem xml:id="tposechain_to_tpose">
 					<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
 					<para>Convierte una cadena de poses temporal en una pose temporal</para>
-					<para><varname>tpose(tposechain) → tpose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpose(tposechain) → tpose
+</programlisting>
 					<para>Cada instante contiene la pose a la que compone toda la cadena, que es donde se sitúa su marco más interno en el marco de la cadena. El resultado es una función escalonada: componer una cadena multiplica las rotaciones de sus eslabones, por lo que la pose de la cadena interpolada entre dos instantes no es la pose interpolada entre las dos poses compuestas, y un resultado lineal respondería una pose que la cadena nunca tiene. Una cadena de un solo eslabón se compone a sí misma, y allí la interpolación del argumento se conserva sin cambios.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(round(tpose(tposechain
@@ -473,7 +518,9 @@ SELECT asEWKT(round((tposechain
 				<listitem xml:id="tposechain_numPoses">
 					<indexterm significance="normal"><primary><varname>numPoses</varname></primary></indexterm>
 					<para>Devuelve el número de eslabones que tiene todo valor de una cadena de poses temporal</para>
-					<para><varname>numPoses(tposechain) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numPoses(tposechain) → integer
+</programlisting>
 					<para>El número es el mismo en todo instante, por lo que un instante responde por todo el valor.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numPoses(tposechain
@@ -487,9 +534,11 @@ SELECT numPoses(tposechain
 					<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
 					<para>Devuelve el valor de un instante temporal, el conjunto de valores o el lapso de tiempo</para>
-					<para><varname>getValue(tposechain) → posechain</varname></para>
-					<para><varname>getValues(tposechain) → posechainset</varname></para>
-					<para><varname>timeSpan(tposechain) → tstzspan</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getValue(tposechain) → posechain
+getValues(tposechain) → posechainset
+timeSpan(tposechain) → tstzspan
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(getValue(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01'));
 -- PoseChain(Pose(POINT(1 1),0.5))
@@ -505,7 +554,9 @@ SELECT timeSpan(tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 				<listitem xml:id="tposechain_stbox">
 					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 					<para>Devuelve la caja espaciotemporal de una cadena de poses temporal</para>
-					<para><varname>stbox(tposechain) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+stbox(tposechain) → stbox
+</programlisting>
 					<para>La caja abarca la posición compuesta de cada prefijo de la cadena, es decir, de cada una de sus articulaciones, y no solo la posición que almacenan sus eslabones.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(stbox(tposechain
@@ -524,8 +575,10 @@ SELECT round(stbox(tposechain
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>shiftTime</varname></primary></indexterm>
 					<para>Redondea las coordenadas a un número de decimales, o desplaza el tiempo</para>
-					<para><varname>round(tposechain, integer DEFAULT 0) → tposechain</varname></para>
-					<para><varname>shiftTime(tposechain, interval) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(tposechain, integer DEFAULT 0) → tposechain
+shiftTime(tposechain, interval) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(round(tposechain
   'PoseChain(Pose(Point(1.123456789 2.123456789), 0.5))@2001-01-01', 3));
@@ -545,8 +598,10 @@ SELECT asEWKT(shiftTime(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01'
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Devuelve o establece el identificador de referencia espacial del marco exterior de una cadena de poses temporal</para>
-					<para><varname>SRID(tposechain) &#8594; integer</varname></para>
-					<para><varname>setSRID(tposechain,integer) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(tposechain) &#8594; integer
+setSRID(tposechain,integer) &#8594; tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tposechain 'SRID=3812;{PoseChain(Pose(Point(1 2),0),
   Pose(Point(3 0),0.5))@2001-01-01, PoseChain(Pose(Point(2 3),0),
@@ -563,8 +618,11 @@ SELECT asEWKT(setSRID(tposechain '{PoseChain(Pose(Point(1 2),0))@2001-01-01,
 					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transforma a un identificador de referencia espacial</para>
-					<para><varname>transform(tposechain,integer) &#8594; tposechain</varname></para>
-					<para><varname>transformPipeline(tposechain,pipeline text,to_srid integer,is_forward boolean=true) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+transform(tposechain,integer) &#8594; tposechain
+transformPipeline(tposechain,pipeline text,to_srid integer,
+  is_forward boolean=true) &#8594; tposechain
+</programlisting>
 					<para>La cadena de cada instante se transforma como se transforma la cadena estática correspondiente, es decir, solo se transforma el eslabón exterior, tal como se describe para <link linkend="posechain_transform"><varname>transform</varname></link>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(round(transform(tposechain 'SRID=4326;PoseChain(
@@ -587,8 +645,10 @@ SELECT asEWKT(round(transformPipeline(tposechain
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tposechainFromGeoPose</varname></primary></indexterm>
 					<para>Escribe o lee un documento de cadena compuesta OGC GeoPose</para>
-					<para><varname>asGeoPose(tposechain,maxdecimaldigits integer=-1) &#8594; text</varname></para>
-					<para><varname>tposechainFromGeoPose(text) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPose(tposechain,maxdecimaldigits integer=-1) &#8594; text
+tposechainFromGeoPose(text) &#8594; tposechain
+</programlisting>
 					<para>Un documento de cadena es un marco exterior y una secuencia de transformaciones que alcanza un marco interior final, que es lo que contiene una cadena de poses. El documento nombra el marco LTP-ENU tangente en la posición del eslabón exterior y una transformación por eslabón: la primera lleva ese marco tangente al marco propio del eslabón exterior, y cada una posterior es el eslabón tal como se almacena, leído en los ejes de su padre.</para>
 					<para>El documento lleva un único tiempo de validez, por lo que se escribe a partir de un solo instante; <link linkend="tposechain_atTime"><varname>atTime</varname></link> obtiene uno de un valor más largo. Su cadena de marcos contiene al menos dos marcos, por lo que una cadena de un solo eslabón no tiene documento de cadena.</para>
 					<para>La clase de cadena nombra sus dos marcos <varname>/Extrinsic/LTP-ENU</varname> e <varname>/Intrinsic/Translate-Rotate</varname>, mientras que las clases Advanced, Series y Stream nombran esos mismos dos marcos <varname>LTP-ENU</varname> y <varname>RotateTranslate</varname>. Un documento se escribe con el par que usa su propia clase, y cualquiera de los dos pares se acepta al leer.</para>
@@ -614,7 +674,9 @@ SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(
 				<listitem xml:id="tposechainarr_asGeoPose">
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<para>Escribe un documento de grafo compuesto OGC GeoPose</para>
-					<para><varname>asGeoPose(tposechain[],maxdecimaldigits integer=-1) &#8594; text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPose(tposechain[],maxdecimaldigits integer=-1) &#8594; text
+</programlisting>
 					<para>Un documento de grafo es un conjunto de marcos y las transformaciones entre ellos, que es lo que contienen varias cadenas de poses que comparten su marco más exterior. La lista de marcos nombra el marco LTP-ENU tangente en ese eslabón más exterior seguido de los eslabones de cada cadena, y la lista de transformaciones nombra el padre y el hijo de cada arista por su posición en esa lista. Las aristas no llevan transformación propia; esta reside en los marcos que nombran.</para>
 					<para>El documento lleva un único tiempo de validez, por lo que se escribe a partir de cadenas leídas en uno y el mismo instante; <link linkend="tposechain_atTime"><varname>atTime</varname></link> las obtiene de valores más largos. Su lista de marcos contiene al menos dos marcos, que un solo eslabón de una sola cadena ya proporciona junto al marco tangente.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -649,8 +711,10 @@ SELECT asGeoPose(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
 					<para>Restringe una cadena de poses temporal a un tiempo o a un valor</para>
-					<para><varname>atTime(tposechain, time) → tposechain</varname></para>
-					<para><varname>atValue(tposechain, posechain) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTime(tposechain, time) → tposechain
+atValue(tposechain, posechain) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(atTime(tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
   PoseChain(Pose(Point(2 2), 0.5))@2001-01-03]', timestamptz '2001-01-02'));
@@ -670,8 +734,10 @@ SELECT asEWKT(atValue(tposechain '{PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 				<listitem xml:id="tposechain_eq">
 					<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 					<para>Compara dos cadenas de poses temporales, o una cadena de poses temporal y una cadena de poses</para>
-					<para><varname>tposechain operator tposechain → boolean</varname></para>
-					<para><varname>eEq(tposechain, posechain) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tposechain operator tposechain → boolean
+eEq(tposechain, posechain) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01' =
   tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01';
@@ -692,7 +758,9 @@ SELECT eEq(tposechain '{PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
 					<para>Compara la caja delimitadora de una cadena de poses temporal con otra caja delimitadora</para>
-					<para><varname>tposechain op {stbox,tposechain} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tposechain op {stbox,tposechain} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
   PoseChain(Pose(Point(2 2), 0.5))@2001-01-02]' &amp;&amp; stbox 'STBOX X((1,1),(2,2))';
@@ -716,13 +784,15 @@ SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 					<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Una cadena de poses temporal las responde en la posición que ocupa la pose que compone, de modo que una cadena con interpolación lineal se responde a lo largo de su trayectoria y no solo en sus instantes. La cadena declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos cadenas, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
-					<para><varname>tContains(geometry,tposechain) → tbool</varname></para>
-					<para><varname>tCovers(geometry,tposechain) → tbool</varname></para>
-					<para><varname>tDisjoint({geometry,tposechain},{geometry,tposechain}) → tbool</varname></para>
-					<para><varname>tDwithin({geometry,tposechain},{geometry,tposechain},float) → tbool</varname></para>
-					<para><varname>tIntersects({geometry,tposechain},{geometry,tposechain}) → tbool</varname></para>
-					<para><varname>tTouches(geometry,tposechain) → tbool</varname></para>
-					<para><varname>tTouches(tposechain,geometry) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tposechain) → tbool
+tCovers(geometry,tposechain) → tbool
+tDisjoint({geometry,tposechain},{geometry,tposechain}) → tbool
+tDwithin({geometry,tposechain},{geometry,tposechain},float) → tbool
+tIntersects({geometry,tposechain},{geometry,tposechain}) → tbool
+tTouches(geometry,tposechain) → tbool
+tTouches(tposechain,geometry) → tbool
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tposechain '{PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
   PoseChain(Pose(Point(3 3), 0.1))@2001-01-03}',
@@ -752,7 +822,9 @@ SELECT tDwithin(tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01',
 				<listitem xml:id="tposechain_tCount">
 					<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 					<para>Conteo temporal</para>
-					<para><varname>tCount(tposechain) → {tintSeq,tintSeqSet}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tCount(tposechain) → {tintSeq,tintSeqSet}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
@@ -770,7 +842,9 @@ FROM Temp;
 				<listitem xml:id="tposechain_wCount">
 					<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 					<para>Conteo de ventana</para>
-					<para><varname>wCount(tposechain, interval) → {tintSeq,tintSeqSet}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+wCount(tposechain, interval) → {tintSeq,tintSeqSet}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
@@ -787,7 +861,9 @@ FROM Temp;
 				<listitem xml:id="tposechain_extent">
 					<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 					<para>Extensión del cuadro delimitador</para>
-					<para><varname>extent(tposechain) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+extent(tposechain) → stbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(temp) FROM ( VALUES
   (NULL::tposechain),
@@ -801,7 +877,9 @@ SELECT extent(temp) FROM ( VALUES
 				<listitem xml:id="tposechain_mergeAgg">
 					<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 					<para>Fusionar las cadenas de poses temporales agregadas. El nombre <varname>merge</varname> denota la misma agregación</para>
-					<para><varname>mergeAgg(tposechain) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+mergeAgg(tposechain) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(mergeAgg(temp)) FROM (VALUES
   (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
@@ -814,7 +892,9 @@ SELECT asText(mergeAgg(temp)) FROM (VALUES
 				<listitem xml:id="tposechain_appendInstantAgg">
 					<indexterm significance="normal"><primary><varname>appendInstantAgg</varname></primary></indexterm>
 					<para>Agregar los instantes agregados en una secuencia. El nombre <varname>appendInstant</varname> denota la misma agregación</para>
-					<para><varname>appendInstantAgg(tposechain) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendInstantAgg(tposechain) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendInstantAgg(inst)) FROM (VALUES
   (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
@@ -827,7 +907,9 @@ SELECT asText(appendInstantAgg(inst)) FROM (VALUES
 				<listitem xml:id="tposechain_appendSequenceAgg">
 					<indexterm significance="normal"><primary><varname>appendSequenceAgg</varname></primary></indexterm>
 					<para>Agregar las secuencias agregadas en un conjunto de secuencias. El nombre <varname>appendSequence</varname> denota la misma agregación</para>
-					<para><varname>appendSequenceAgg(tposechain) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendSequenceAgg(tposechain) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendSequenceAgg(seq)) FROM (VALUES
   (tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01]'),

--- a/doc/es/temporal_poses.xml
+++ b/doc/es/temporal_poses.xml
@@ -99,8 +99,10 @@ SELECT pose 'Pose(Point Z(1 1 1), 1.0)';
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Devuelve la representación de texto conocido (Well-Known Text o WKT) o la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-					<para><varname>asText({pose,pose[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({pose,pose[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({pose,pose[]}) → {text,text[]}
+asEWKT({pose,pose[]}) → {text,text[]}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(pose 'SRID=4326;Pose(Point(0 0),1)');
 -- Pose(POINT(0 0),1)
@@ -119,10 +121,12 @@ SELECT asEWKT(ARRAY[pose 'Pose(SRID=5676;Point(0 0),1)', 'Pose(SRID=5676;Point(1
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 					<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-					<para><varname>asBinary(pose,endian text='') → bytea</varname></para>
-					<para><varname>asEWKB(pose,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(pose,endian text='') → text</varname></para>
-					<para><varname>asHexEWKB(pose,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(pose,endian text='') → bytea
+asEWKB(pose,endian text='') → bytea
+asHexWKB(pose,endian text='') → text
+asHexEWKB(pose,endian text='') → text
+</programlisting>
 					<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(pose 'Pose(Point(1 2),1)');
@@ -140,8 +144,10 @@ SELECT asHexEWKB(pose 'SRID=3812;Pose(Point(1 2),1)');
 					<indexterm significance="normal"><primary><varname>poseFromText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poseFromEWKT</varname></primary></indexterm>
 					<para>Entrada desde la representación de texto conocido (Well-Known Text o WKT) o desde la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-					<para><varname>poseFromText(text) → pose</varname></para>
-					<para><varname>poseFromEWKT(text) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+poseFromText(text) → pose
+poseFromEWKT(text) → pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(poseFromText(text 'Pose(Point(1 2),1)'));
 -- Pose(POINT(1 2),1)
@@ -155,9 +161,11 @@ SELECT asEWKT(poseFromEWKT(text 'SRID=3812;Pose(Point(1 2),1)'));
 					<indexterm significance="normal"><primary><varname>poseFromEWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poseFromHexEWKB</varname></primary></indexterm>
 					<para>Entrada desde la representación binaria conocida (Well-Known Binary o WKB), desde la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o desde la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-					<para><varname>poseFromBinary(bytea) → pose</varname></para>
-					<para><varname>poseFromEWKB(bytea) → pose</varname></para>
-					<para><varname>poseFromHexEWKB(text) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+poseFromBinary(bytea) → pose
+poseFromEWKB(bytea) → pose
+poseFromHexEWKB(text) → pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(poseFromBinary(
   '\x0101000000000000f03f0000000000000040000000000000f03f'));
@@ -179,9 +187,11 @@ SELECT asEWKT(poseFromHexEWKB(
 				<listitem xml:id="pose">
 					<indexterm significance="normal"><primary><varname>pose</varname></primary></indexterm>
 					<para>Constructor para poses</para>
-					<para><varname>pose(geompoint2D,float) → pose</varname></para>
-					<para><varname>pose(geompoint3D,float,float,float,float) → pose</varname></para>
-					<para><varname>pose(geompoint3D,yaw float,pitch float,roll float) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose(geompoint2D,float) → pose
+pose(geompoint3D,float,float,float,float) → pose
+pose(geompoint3D,yaw float,pitch float,roll float) → pose
+</programlisting>
 					<para>La forma de tres ángulos toma la orientación en la otra codificación que prescribe el estándar OGC GeoPose v1.0, una terna yaw / pitch / roll en radianes bajo la convención Tait-Bryan intrínseca ZYX, y almacena el cuaternión que denota. Es la inversa de <link linkend="pose_ypr"><varname>ypr</varname></link>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(pose(ST_Point(1,1), radians(45)), 6);
@@ -205,9 +215,11 @@ SELECT asText(pose(ST_PointZ(1,1,1), radians(90), 0, 0), 6);
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 					<para>Convertir una pose y, opcionalmente, una marca de tiempo o un período, en una caja espaciotemporal</para>
-					<para><varname>pose::stbox</varname></para>
-					<para><varname>stbox(pose) → stbox</varname></para>
-					<para><varname>stbox(pose,{timestamptz,tstzspan}) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose::stbox
+stbox(pose) → stbox
+stbox(pose,{timestamptz,tstzspan}) → stbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(pose 'SRID=5676;Pose(Point(1 1),0.3)');
 -- SRID=5676;STBOX X((1,1),(1,1))
@@ -221,7 +233,9 @@ SELECT stbox(pose 'Pose(Point(1 1),0.3)', tstzspan '[2001-01-01,2001-01-02]');
 				<listitem xml:id="pose_geometry">
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Convertir una pose en un punto geométrico</para>
-					<para><varname>pose::geompoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose::geompoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(pose(ST_Point(1, 1), 1)::geometry);
 -- Point(1 1)
@@ -238,7 +252,9 @@ SELECT ST_AsEWKT(pose(ST_PointZ(1, 1, 1, 5676), 1, 0, 0, 0)::geometry);
 				<listitem xml:id="pose_point">
 					<indexterm significance="normal"><primary><varname>point</varname></primary></indexterm>
 					<para>Devuelve el punto</para>
-					<para><varname>point(pose) → geompoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+point(pose) → geompoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(point(pose 'Pose(Point(1 1), 0.3)'));
 -- Point(1 1)
@@ -248,7 +264,9 @@ SELECT ST_AsText(point(pose 'Pose(Point(1 1), 0.3)'));
 				<listitem xml:id="pose_quaternion">
 					<indexterm significance="normal"><primary><varname>quaternion</varname></primary></indexterm>
 					<para>Devuelve el cuaternión de orientación de una pose</para>
-					<para><varname>quaternion(pose) → quaternion</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+quaternion(pose) → quaternion
+</programlisting>
 					<para>Las componentes se devuelven en el orden <varname>W</varname>, <varname>X</varname>, <varname>Y</varname>, <varname>Z</varname>, la convención de Hamilton en la que una pose 3D las almacena. Esta es una de las dos codificaciones de orientación que prescribe el estándar OGC GeoPose v1.0; la otra, yaw / pitch / roll, la proporciona <link linkend="pose_ypr"><varname>ypr</varname></link>. Ambas están definidas para las dos dimensiones: la orientación de una pose 2D es un giro alrededor de la vertical local por su ángulo almacenado, de modo que coloca la mitad de ese ángulo en <varname>W</varname> y <varname>Z</varname> y deja <varname>X</varname> e <varname>Y</varname> en cero. Este es el cuaternión que un documento GeoPose Basic-Quaternion lleva para una pose plana.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
@@ -266,7 +284,9 @@ SELECT quaternion(pose 'Pose(Point(1 1), 0)');
 				<listitem xml:id="pose_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Redondear el punto y la orientación de la pose al número de posiciones decimales</para>
-					<para><varname>round(pose,integer=0) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(pose,integer=0) → pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(pose(ST_Point(1.123456789,1.123456789), 0.123456789), 6));
 -- Pose(POINT(1.123457 1.123457),0.123457)
@@ -283,8 +303,10 @@ SELECT asText(round(pose(ST_Point(1.123456789,1.123456789), 0.123456789), 6));
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Devuelve o establece el identificador de referencia espacial</para>
-					<para><varname>SRID(pose) → integer</varname></para>
-					<para><varname>setSRID(pose) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(pose) → integer
+setSRID(pose) → pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(pose 'Pose(SRID=5676;Point(1 1), 0.3)');
 -- 5676
@@ -297,8 +319,10 @@ SELECT asEWKT(setSRID(pose 'Pose(Point(0 0),1)', 4326));
 					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transformar a un identificador de referencia espacial</para>
-					<para><varname>transform(pose,integer) → pose</varname></para>
-					<para><varname>transformPipeline(pose,pipeline text,to_srid integer,is_forward boolean=true) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+transform(pose,integer) → pose
+transformPipeline(pose,pipeline text,to_srid integer,is_forward boolean=true) → pose
+</programlisting>
 					<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando la pose de entrada tiene un SRID desconocido (representado por 0).</para>
 					<para>En una pose 3D, la orientación se reexpresa en la base del marco de destino en el punto de la pose. La corrección está definida para el par canónico de OGC GeoPose, WGS-84 geográfico (EPSG:4326) ↔ WGS-84 ECEF (EPSG:4978), y toma la base estándar Este-Norte-Arriba en el punto geográfico como pivote de rotación. Para cualquier otro par de SRID, <varname>transform</varname> emite un <varname>NOTICE</varname> y deja pasar la orientación sin cambios. En una pose 2D, el ángulo es intrínseco a la proyección de origen y se deja pasar sin cambios.</para>
 					<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato de cadena:</para>
@@ -341,9 +365,11 @@ FROM test;
 				<listitem xml:id="pose_distance_op">
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Devuelve la distancia</para>
-					<para><varname>distance({geo,stbox,pose},pose) → float</varname></para>
-					<para><varname>distance(pose,{geo,stbox,pose}) → float</varname></para>
-					<para><varname>{geo,stbox,pose} &lt;-&gt; pose → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+distance({geo,stbox,pose},pose) → float
+distance(pose,{geo,stbox,pose}) → float
+{geo,stbox,pose} &lt;-&gt; pose → float
+</programlisting>
 					<para>Solo se tiene en cuenta el componente de punto de la pose, la orientación se ignora. La distancia se calcula en dos dimensiones, incluso cuando los argumentos son tridimensionales. El resultado es <varname>NULL</varname> cuando la geometría está vacía.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
@@ -376,7 +402,9 @@ SELECT round(geometry 'Point empty' &lt;-&gt; pose 'Pose(Point(4 0),0)', 6);
 					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Comparaciones tradicionales</para>
-					<para><varname>pose {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pose 'Pose(Point(3 3), 0.5)' = pose 'Pose(Point(3 3), 0.5)';
 -- true
@@ -397,7 +425,9 @@ SELECT pose 'Pose(Point(1 1), 0.6)' &gt;= pose 'Pose(Point(1 1), 0.5)';
 				<listitem xml:id="pose_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>¿Son las poses aproximadamente iguales con respecto a un valor épsilon?</para>
-					<para><varname>pose ~= pose → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose ~= pose → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pose 'Pose(SRID=5676;Point(1 1), 0.3)' ~= 
   pose 'Pose(SRID=5676;Point(1 1.0000001), 0.30000001)';
@@ -468,8 +498,10 @@ SELECT tpose 'Point(0 0)@2001-01-01 08:05:00';
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 				<para>Devuelve la representación de texto conocido (Well-Known Text o WKT) o la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-				<para><varname>asText({tpose,tpose[]}) → {text,text[]}</varname></para>
-				<para><varname>asEWKT({tpose,tpose[]}) → {text,text[]}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({tpose,tpose[]}) → {text,text[]}
+asEWKT({tpose,tpose[]}) → {text,text[]}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpose 'SRID=4326;[Pose(Point(0 0),1)@2001-01-01, 
   Pose(Point(1 1),2)@2001-01-02)');
@@ -488,7 +520,9 @@ SELECT asEWKT(ARRAY[pose 'Pose(SRID=5676;Point(0 0),1)',
 			<listitem xml:id="tpose_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Devuelve la representación JSON de características móviles (Moving Features JSON o MF-JSON)</para>
-				<para><varname>asMFJSON(tpose) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tpose) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tpose 'Pose(Point(1 2),0.5)@2001-01-01', 3);
 /* {"type":"MovingPose","bbox":[[1,2],[1,2]],"period":{"begin":"2001-01-01T00:00:00",
@@ -510,10 +544,12 @@ SELECT asMFJSON(tpose 'Pose(Point Z(1 2 3),1,0,0,0)@2001-01-01', 3);
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), la representación hexadecimal binaria conocida (Hexadecimal Well-Known Binary o HexWKB), o la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-				<para><varname>asBinary(tpose,endian text='') → bytea</varname></para>
-				<para><varname>asEWKB(tpose,endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB(tpose,endian text='') → text</varname></para>
-				<para><varname>asHexEWKB(tpose,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(tpose,endian text='') → bytea
+asEWKB(tpose,endian text='') → bytea
+asHexWKB(tpose,endian text='') → text
+asHexEWKB(tpose,endian text='') → text
+</programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tpose 'Pose(Point(1 2),1)@2001-01-01');
@@ -531,8 +567,10 @@ SELECT asHexEWKB(tpose 'SRID=3812;Pose(Point(1 2),1)@2001-01-01');
 				<indexterm significance="normal"><primary><varname>tposeFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeFromEWKT</varname></primary></indexterm>
 				<para>Entrada desde la representación de texto conocido (Well-Known Text o WKT) o desde la representación extendida de texto conocido (Extended Well-Known Text o EWKT)</para>
-				<para><varname>tposeFromText(text) → tpose</varname></para>
-				<para><varname>tposeFromEWKT(text) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeFromText(text) → tpose
+tposeFromEWKT(text) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposeFromText(text '[Pose(Point(1 2),1)@2001-01-01, 
   Pose(Point(3 4),2)@2001-01-02]'));
@@ -546,7 +584,9 @@ SELECT asEWKT(tposeFromEWKT(text 'SRID=3812;[Pose(Point(1 2),1)@2001-01-01,
 			<listitem xml:id="tposeFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tposeFromMFJSON</varname></primary></indexterm>
 				<para>Entrada desde la representación JSON de características móviles (Moving Features JSON o MF-JSON)</para>
-				<para><varname>tposeFromMFJSON(bytea) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeFromMFJSON(bytea) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose 
   'SRID=3812;Pose(Point(1 2),0.5)@2001-01-01', 3)));
@@ -562,9 +602,11 @@ SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose
 				<indexterm significance="normal"><primary><varname>tposeFromEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeFromHexEWKB</varname></primary></indexterm>
 				<para>Entrada desde la representación binaria conocida (Well-Known Binary o WKB), desde la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o desde la representación hexadecimal extendida binaria conocida (Hexadecimal Extended Well-Known Binary o HexEWKB)</para>
-				<para><varname>tposeFromBinary(bytea) → tpose</varname></para>
-				<para><varname>tposeFromEWKB(bytea) → tpose</varname></para>
-				<para><varname>tposeFromHexEWKB(text) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeFromBinary(bytea) → tpose
+tposeFromEWKB(bytea) → tpose
+tposeFromHexEWKB(text) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposeFromBinary(
   '\x013a0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000'));
@@ -587,10 +629,12 @@ SELECT asEWKT(tposeFromHexEWKB(
 			<listitem xml:id="tpose_const">
 				<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
 				<para>Constructor para poses temporales con valor constante</para>
-				<para><varname>tpose(pose,timestamptz) → tposeInst</varname></para>
-				<para><varname>tpose(pose,tstzset) → tposeDiscSeq</varname></para>
-				<para><varname>tpose(pose,tstzspan,interp='linear') → tposeContSeq</varname></para>
-				<para><varname>tpose(pose,tstzspanset,interp='linear') → tposeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose(pose,timestamptz) → tposeInst
+tpose(pose,tstzset) → tposeDiscSeq
+tpose(pose,tstzspan,interp='linear') → tposeContSeq
+tpose(pose,tstzspanset,interp='linear') → tposeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpose('Pose(Point(1 1), 0.5)', timestamptz '2001-01-01'));
 -- Pose(Point(1 1),0.5)@2001-01-01
@@ -610,8 +654,10 @@ SELECT asText(tpose('Pose(Point(1 1), 0.2)',
 			<listitem xml:id="tposeSeq">
 				<indexterm significance="normal"><primary><varname>tposeSeq</varname></primary></indexterm>
 				<para>Constructor para poses temporales de subtipo secuencia</para>
-				<para><varname>tposeSeq(tposeInst[],interp={'step','linear'},leftInc boolean=true,</varname></para>
-				<para><varname>  rightInc boolean=true) → tposeSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeSeq(tposeInst[],interp={'step','linear'},leftInc boolean=true,
+  rightInc boolean=true) → tposeSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.3)@2001-01-01',
   'Pose(Point(2 2), 0.5)@2001-01-02', 'Pose(Point(1 1), 0.5)@2001-01-03']));
@@ -628,8 +674,10 @@ SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.2)@2001-01-01',
 				<indexterm significance="normal"><primary><varname>tposeSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor para poses temporales de subtipo conjunto de secuencias</para>
-				<para><varname>tposeSeqSet(tpose[]) → tposeSeqSet</varname></para>
-				<para><varname>tposeSeqSetGaps(tposeInst[],maxt=NULL,maxdist=NULL,interp='linear') → tposeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeSeqSet(tpose[]) → tposeSeqSet
+tposeSeqSetGaps(tposeInst[],maxt=NULL,maxdist=NULL,interp='linear') → tposeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposeSeqSet(ARRAY[tpose 
   '[Pose(Point(1 1),0.2)@2001-01-01, Pose(Point(2 2),0.4)@2001-01-02]', 
@@ -646,7 +694,9 @@ SELECT asText(tposeSeqSetGaps(ARRAY[tpose 'Pose(Point(1 1),0.1)@2001-01-01',
 			<listitem xml:id="tgeompoint_tfloat_tpose">
 				<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
 				<para>Construir una pose temporal 2D a partir de un punto geométrico temporal y un flotante temporal</para>
-				<para><varname>tpose(tgeompoint, tfloat) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose(tgeompoint, tfloat) → tpose
+</programlisting>
 				<para>El marco temporal del resultado es la intersección de los marcos temporales del punto temporal y el flotante temporal. Si no se intersecan, se devuelve un valor nulo</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpose(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02)',
@@ -667,7 +717,9 @@ SELECT asText(tpose(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02)',
 			<listitem xml:id="tpose_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir una pose temporal en un punto geométrico temporal</para>
-				<para><varname>tpose::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tpose '[Pose(Point(1 1), 0.2)@2001-01-01,
   Pose(Point(1 1), 0.3)@2001-01-02)')::tgeompoint);
@@ -681,7 +733,9 @@ SELECT asEWKT((tpose '[Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)@2001-01-01,
 			<listitem xml:id="tpose_tgeogpoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir una pose temporal geodésica en un punto geográfico temporal</para>
-				<para><varname>tpose::tgeogpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose::tgeogpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tpose '[GeodPose(Point(1 1), 0.2)@2001-01-01,
   GeodPose(Point(1 1), 0.3)@2001-01-02)')::tgeogpoint);
@@ -697,7 +751,9 @@ SELECT asText((tpose '[GeodPose(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tpose_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Devuelve los valores</para>
-				<para><varname>getValues(tpose) → poseset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tpose) → poseset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(getValues(tpose '{[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-02)}'));
@@ -711,7 +767,9 @@ SELECT asEWKT(getValues(tpose 'SRID=5676;{[Pose(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_points">
 				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
 				<para>Devuelve los puntos</para>
-				<para><varname>points(tpose) → geomset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+points(tpose) → geomset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(points(tpose 'SRID=5676;{Pose(Point(3 3), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-02}'));
@@ -722,7 +780,9 @@ SELECT asEWKT(points(tpose 'SRID=5676;{Pose(Point(3 3), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_trajectory">
 				<indexterm significance="normal"><primary><varname>trajectory</varname></primary></indexterm>
 				<para>Devuelve la trayectoria</para>
-				<para><varname>trajectory(tpose) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trajectory(tpose) → geometry
+</programlisting>
 				<para>Una pose tiene una posición y una orientación, pero no una extensión, por lo que la geometría que cubre a lo largo del tiempo es la trayectoria de su posición, como para un punto temporal. Una pose que interpola se desplaza por la línea entre dos posiciones consecutivas; una que no interpola permanece en cada una de ellas y no cubre nada entre ellas.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(trajectory(tpose '[Pose(Point(1 1),0.5)@2000-01-01, 
@@ -737,7 +797,9 @@ SELECT ST_AsText(trajectory(tpose 'Interp=Step;[Pose(Point(1 1),0.5)@2000-01-01,
 			<listitem xml:id="tpose_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(tpose,timestamptz) → pose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tpose,timestamptz) → pose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(valueAtTimestamp(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(3 3), 0.5)@2001-01-03)', '2001-01-02'));
@@ -752,7 +814,9 @@ SELECT asText(valueAtTimestamp(tpose
 			<listitem xml:id="tpose_speed">
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Devuelve la velocidad de una pose temporal como un flotante temporal: la magnitud de la velocidad de la componente de posición (distancia recorrida por unidad de tiempo). La orientación no es considerada; para la velocidad angular véase <varname>angularSpeed</varname>.</para>
-				<para><varname>speed(tpose) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+speed(tpose) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01,
   Pose(Point(1 1), 0.5)@2000-01-02]'));
@@ -764,7 +828,9 @@ SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01,
 			<listitem xml:id="tpose_angular_speed">
 				<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
 				<para>Devuelve la velocidad angular de una pose temporal como un flotante temporal con interpolación por pasos (radianes por unidad de tiempo). Para las poses 2D es el delta theta del arco más corto por segmento dividido por la duración del segmento; para las poses 3D es el ángulo de arco de SLERP <varname>2 · acos(|q1 · q2|)</varname> dividido por la duración del segmento. SLERP tiene por construcción velocidad angular constante a lo largo de un segmento, por lo que el resultado es constante a trozos.</para>
-				<para><varname>angularSpeed(tpose) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+angularSpeed(tpose) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- 90-degree yaw rotation over one day -> pi/2 rad / 86400 s
 SELECT asText(angularSpeed(tpose
@@ -784,9 +850,11 @@ SELECT asText(angularSpeed(tpose
 				<indexterm significance="normal"><primary><varname>tposeSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeSeqSet</varname></primary></indexterm>
 				<para>Transformar a otro subtipo</para>
-				<para><varname>tposeInst(tpose) → tposeInst</varname></para>
-				<para><varname>tposeSeq(tpose) → tposeSeq</varname></para>
-				<para><varname>tposeSeqSet(tpose) → tposeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeInst(tpose) → tposeInst
+tposeSeq(tpose) → tposeSeq
+tposeSeqSet(tpose) → tposeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposeSeq(tpose 'Pose(Point(1 1), 0.5)@2001-01-01', 'discrete'));
 -- {Pose(Point(1 1),0.5)@2001-01-01}
@@ -800,7 +868,9 @@ SELECT asText(tposeSeqSet(tpose 'Pose(PointZ(1 1 1), 0.5, 0.5, 0.5, 0.5)@2001-01
 			<listitem xml:id="tpose_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transformar a otra interpolación</para>
-				<para><varname>setInterp(tpose, interp) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(tpose, interp) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(setInterp(tpose 'Pose(Point(1 1),0.2)@2001-01-01','linear'));
 -- [Pose(Point(1 1),0.2)@2001-01-01]
@@ -813,7 +883,9 @@ SELECT asText(setInterp(tpose '{[Pose(Point Z(1 1 1),1,0,0,0)@2001-01-01],
 			<listitem xml:id="tpose_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Redondear los puntos y las orientaciones de la pose temporal al número de posiciones decimales</para>
-				<para><varname>round(tpose,integer=0) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tpose,integer=0) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(tpose '{[Pose(Point(1 1.123456789),0.123456789)@2001-01-01, 
   Pose(Point(1 1),0.5)@2001-01-02)}', 3));
@@ -830,8 +902,10 @@ SELECT asText(round(tpose '{[Pose(Point(1 1.123456789),0.123456789)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Agregar un instante temporal o una secuencia temporal</para>
-				<para><varname>appendInstant(tpose,tposeInst) → tpose</varname></para>
-				<para><varname>appendSequence(tpose,tposeSeq) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tpose,tposeInst) → tpose
+appendSequence(tpose,tposeSeq) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendInstant(tpose 'Pose(Point(1 1), 0.5)@2001-01-01',
   'Pose(Point(2 2), 1)@2001-01-02'));
@@ -846,10 +920,12 @@ SELECT asText(appendSequence(tpose '[Pose(Point(1 1), 0.5)@2001-01-01]',
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Fusionar las poses temporales</para>
-				<para><varname>merge(tpose,tpose) → tpose</varname></para>
-				<para><varname>merge(tpose[]) → tpose</varname></para>
-				<para><varname>merge(tpose) → tpose</varname></para>
-				<para><varname>mergeAgg(tpose) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(tpose,tpose) → tpose
+merge(tpose[]) → tpose
+merge(tpose) → tpose
+mergeAgg(tpose) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(tpose
   '[Pose(Point(1 1 1),1,0,0,0)@2001-01-01, Pose(Point(2 2 2),0,1,0,0)@2001-01-02]',
@@ -883,10 +959,12 @@ SELECT asText(mergeAgg(inst)) FROM temp;
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 				<para>Restringir al (complemento de) un valor o un conjunto de valores</para>
-				<para><varname>atValue(tpose,value) → tpose</varname></para>
-				<para><varname>minusValue(tpose,value) → tpose</varname></para>
-				<para><varname>atValues(tpose,valueset) → tpose</varname></para>
-				<para><varname>minusValues(tpose,valueset) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(tpose,value) → tpose
+minusValue(tpose,value) → tpose
+atValues(tpose,valueset) → tpose
+minusValues(tpose,valueset) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atValue(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
   Pose(Point(2 2), 0.7)@2001-01-03]', 'Pose(Point(2 2), 0.5)');
@@ -902,8 +980,10 @@ SELECT minusValue(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restringir al (complemento de) una geometría</para>
-				<para><varname>atGeometry(tpose,geometry) → tpose</varname></para>
-				<para><varname>minusGeometry(tpose,geometry) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tpose,geometry) → tpose
+minusGeometry(tpose,geometry) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atGeometry(tpose '[Pose(Point(2 2), 0.3)@2001-01-01, 
   Pose(Point(2 2), 0.7)@2001-01-03]',
@@ -920,8 +1000,10 @@ SELECT minusGeometry(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
 				<para>Restringir al (complemento de) un span de elevación</para>
-				<para><varname>atElevation(tpose,floatspan) → tpose</varname></para>
-				<para><varname>minusElevation(tpose,floatspan) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atElevation(tpose,floatspan) → tpose
+minusElevation(tpose,floatspan) → tpose
+</programlisting>
 				<para>La elevación de una pose es la elevación de su posición, por lo que la restricción conserva los tiempos en los que esa posición se encuentra dentro del span. La pose temporal debe tener dimensión Z.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
@@ -946,8 +1028,10 @@ SELECT asText(minusElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Devuelve o establece el identificador de referencia espacial</para>
-				<para><varname>SRID(tpose) → integer</varname></para>
-				<para><varname>setSRID(tpose) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(tpose) → integer
+setSRID(tpose) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tpose 'SRID=5676;[Pose(Point(0 0),1)@2001-01-01, 
   Pose(Point(1 1),2)@2001-01-02)'));
@@ -962,8 +1046,10 @@ SELECT asEWKT(setSRID(tpose '[Pose(Point(0 0),1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transformar a un identificador de referencia espacial</para>
-				<para><varname>transform(tpose,integer) → tpose</varname></para>
-				<para><varname>transformPipeline(tpose,pipeline text,to_srid integer,is_forward boolean=true) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(tpose,integer) → tpose
+transformPipeline(tpose,pipeline text,to_srid integer,is_forward boolean=true) → tpose
+</programlisting>
 				<para>La pose de cada instante se transforma igual que la pose estática correspondiente, con la corrección de orientación incluida, como se describe para <link linkend="pose_transform"><varname>transform</varname></link>. Lo mismo ocurre con un <varname>poseset</varname>. Una <varname>trgeometry</varname> asocia sus poses con una geometría de referencia que comparte su marco, y la transformación a otro SRID no está admitida para ese tipo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(tpose 'SRID=4326;Pose(Point(4.35 50.85),1)@2001-01-01', 
@@ -995,7 +1081,9 @@ FROM test;
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Operadores topológicos</para>
-				<para><varname>{tstzspan,stbox,tpose} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tpose} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tstzspan,stbox,tpose} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tpose} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-03]' &amp;&amp; tstzspan '[2001-01-02,2001-01-04]';
@@ -1013,10 +1101,12 @@ SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_pos">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Operadores de posición</para>
-				<para><varname>{stbox,tpose} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tpose}  → boolean</varname></para>
-				<para><varname>{stbox,tpose} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tpose}  → boolean</varname></para>
-				<para><varname>{stbox,tpose} {&lt;&lt;/, &amp;&lt;/, /&gt;&gt;, /&amp;&gt;} {stbox,tpose}  → boolean</varname></para>
-				<para><varname>{tstzspan,stbox,tpose} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tpose} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{stbox,tpose} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tpose}  → boolean
+{stbox,tpose} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tpose}  → boolean
+{stbox,tpose} {&lt;&lt;/, &amp;&lt;/, /&gt;&gt;, /&amp;&gt;} {stbox,tpose}  → boolean
+{tstzspan,stbox,tpose} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tpose} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-02]' &lt;&lt; stbox(pose 'Pose(Point(2 2), 0.5)');
@@ -1048,7 +1138,9 @@ SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-03,
 			<listitem xml:id="tpose_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Devuelve la distancia más pequeña alguna vez</para>
-				<para><varname>{geo,pose,tpose,stbox} |=| {geo,pose,tpose,stbox} → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,pose,tpose,stbox} |=| {geo,pose,tpose,stbox} → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(2 2), 0.3)@2001-01-01, Pose(Point(2 2), 0.7)@2001-01-02]' |=|
   geometry 'Linestring(50 50,55 55)';
@@ -1069,7 +1161,9 @@ SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_nearestApproachInstant">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Devuelve el instante de la primera pose temporal en el que los dos argumentos están a la distancia más cercana</para>
-				<para><varname>nearestApproachInstant({geo,pose,tpose},{geo,pose,tpose}) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geo,pose,tpose},{geo,pose,tpose}) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(nearestApproachInstant(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
   Pose(Point(2 2), 0.7)@2001-01-02]', geometry 'Linestring(50 50,55 55)'));
@@ -1083,7 +1177,9 @@ SELECT asText(nearestApproachInstant(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Devuelve la línea que conecta el punto de aproximación más cercano</para>
-				<para><varname>shortestLine({geo,pose,tpose},{geo,pose,tpose}) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geo,pose,tpose},{geo,pose,tpose}) → geometry
+</programlisting>
 				<para>La función devuelve la primera línea que encuentre si hay más de una.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
@@ -1098,7 +1194,9 @@ SELECT ST_AsText(shortestLine(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Devuelve la distancia temporal</para>
-				<para><varname>tpose &lt;-&gt; tpose → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose &lt;-&gt; tpose → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt; pose 'Pose(Point(2 2), 0.2)', 6);
@@ -1136,20 +1234,22 @@ SELECT round(tpose '[Pose(Point(1 1), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 				<para>Las relaciones <emphasis>alguna vez</emphasis> y <emphasis>siempre</emphasis> determinan si la relación topológica o de distancia se satisface alguna vez o siempre y dan como resultado un <varname>boolean</varname>. Una pose temporal las responde en la posición que ocupa, de modo que un valor con interpolación lineal se responde a lo largo de su trayectoria y no solo en sus instantes. La pose temporal declara las relaciones que responde un punto en movimiento: <varname>eContains</varname>, <varname>aContains</varname>, <varname>eCovers</varname> y <varname>aCovers</varname> toman la geometría en primer lugar únicamente, y <varname>eTouches</varname> y <varname>aTouches</varname> no tienen dirección entre dos poses temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
-				<para><varname>eContains(geometry,tpose) → boolean</varname></para>
-				<para><varname>eCovers(geometry,tpose) → boolean</varname></para>
-				<para><varname>eDisjoint({geometry,tpose},{geometry,tpose}) → boolean</varname></para>
-				<para><varname>eDwithin({geometry,tpose},{geometry,tpose},float) → boolean</varname></para>
-				<para><varname>eIntersects({geometry,tpose},{geometry,tpose}) → boolean</varname></para>
-				<para><varname>eTouches(geometry,tpose) → boolean</varname></para>
-				<para><varname>eTouches(tpose,geometry) → boolean</varname></para>
-				<para><varname>aContains(geometry,tpose) → boolean</varname></para>
-				<para><varname>aCovers(geometry,tpose) → boolean</varname></para>
-				<para><varname>aDisjoint({geometry,tpose},{geometry,tpose}) → boolean</varname></para>
-				<para><varname>aDwithin({geometry,tpose},{geometry,tpose},float) → boolean</varname></para>
-				<para><varname>aIntersects({geometry,tpose},{geometry,tpose}) → boolean</varname></para>
-				<para><varname>aTouches(geometry,tpose) → boolean</varname></para>
-				<para><varname>aTouches(tpose,geometry) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eContains(geometry,tpose) → boolean
+eCovers(geometry,tpose) → boolean
+eDisjoint({geometry,tpose},{geometry,tpose}) → boolean
+eDwithin({geometry,tpose},{geometry,tpose},float) → boolean
+eIntersects({geometry,tpose},{geometry,tpose}) → boolean
+eTouches(geometry,tpose) → boolean
+eTouches(tpose,geometry) → boolean
+aContains(geometry,tpose) → boolean
+aCovers(geometry,tpose) → boolean
+aDisjoint({geometry,tpose},{geometry,tpose}) → boolean
+aDwithin({geometry,tpose},{geometry,tpose},float) → boolean
+aIntersects({geometry,tpose},{geometry,tpose}) → boolean
+aTouches(geometry,tpose) → boolean
+aTouches(tpose,geometry) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
   tpose '[Pose(Point(1 1),0.1)@2001-01-01, Pose(Point(3 3),0.3)@2001-01-03]');
@@ -1181,13 +1281,15 @@ SELECT aDwithin(tpose '[Pose(Point(1 1),0.1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 				<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Una pose temporal las responde en la posición que ocupa, de modo que un valor con interpolación lineal se responde a lo largo de su trayectoria y no solo en sus instantes. La pose temporal declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos poses temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
-				<para><varname>tContains(geometry,tpose) → tbool</varname></para>
-				<para><varname>tCovers(geometry,tpose) → tbool</varname></para>
-				<para><varname>tDisjoint({geometry,tpose},{geometry,tpose}) → tbool</varname></para>
-				<para><varname>tDwithin({geometry,tpose},{geometry,tpose},float) → tbool</varname></para>
-				<para><varname>tIntersects({geometry,tpose},{geometry,tpose}) → tbool</varname></para>
-				<para><varname>tTouches(geometry,tpose) → tbool</varname></para>
-				<para><varname>tTouches(tpose,geometry) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tpose) → tbool
+tCovers(geometry,tpose) → tbool
+tDisjoint({geometry,tpose},{geometry,tpose}) → tbool
+tDwithin({geometry,tpose},{geometry,tpose},float) → tbool
+tIntersects({geometry,tpose},{geometry,tpose}) → tbool
+tTouches(geometry,tpose) → tbool
+tTouches(tpose,geometry) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tpose '[Pose(Point(1 1), 0.1)@2001-01-01,
   Pose(Point(3 3), 0.1)@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
@@ -1220,7 +1322,9 @@ SELECT tDwithin(tpose '[Pose(Point(1 1),0.3)@2001-01-01,
 			<listitem xml:id="tpose_comp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
-				<para><varname>tpose {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tpose → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tpose → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '{[Pose(Point(1 1), 0.1)@2001-01-01, 
   Pose(Point(1 1), 0.3)@2001-01-02),
@@ -1242,7 +1346,9 @@ SELECT tpose '[Pose(Point(1 1), 0.1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Comparaciones alguna vez y siempre</para>
-				<para><varname>tpose {?=, %=} tpose → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose {?=, %=} tpose → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(1 1), 0.2)@2001-01-01, 
   Pose(Point(1 1), 0.4)@2001-01-04)' ?= Pose(Point(1 1), 0.3);
@@ -1256,7 +1362,9 @@ SELECT tpose '[Pose(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tpose_tcomp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Comparaciones temporales</para>
-				<para><varname>tpose {#=, #&lt;&gt;} tpose → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose {#=, #&lt;&gt;} tpose → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(1 1), 0.2)@2001-01-01, 
   Pose(Point(1 1), 0.4)@2001-01-03)' #= pose 'Pose(Point(1 1), 0.3)';
@@ -1278,7 +1386,9 @@ SELECT tpose '[Pose(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tpose_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
-				<para><varname>tCount(tpose) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tpose) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tpose '[Pose(Point(1 1), 0.1)@2001-01-01, 
@@ -1296,7 +1406,9 @@ FROM Temp;
 			<listitem xml:id="tpose_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Conteo de ventana</para>
-				<para><varname>wCount(tpose) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tpose) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tpose '[Pose(Point(1 1), 0.1)@2001-01-01, 
@@ -1349,8 +1461,10 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poseFromGeoPose</varname></primary></indexterm>
 					<para>Convertir hacia o desde la codificación JSON de OGC GeoPose v1.0 (clase de conformidad Basic-Quaternion, Basic-YPR o Advanced)</para>
-					<para><varname>asGeoPose(pose,conformance integer=0,maxdecimaldigits integer=-1) → text</varname></para>
-					<para><varname>poseFromGeoPose(text) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPose(pose,conformance integer=0,maxdecimaldigits integer=-1) → text
+poseFromGeoPose(text) → pose
+</programlisting>
 					<para>El argumento <varname>conformance</varname> selecciona la clase de salida: <varname>0</varname> = Basic-Quaternion (predeterminado, sin pérdida), <varname>1</varname> = Basic-YPR (yaw, pitch, roll en grados, Tait-Bryan intrínseco ZYX), <varname>2</varname> = Advanced. El argumento <varname>maxdecimaldigits</varname> es el número de dígitos significativos que se conservan en los números JSON; <varname>-1</varname> utiliza el valor predeterminado sin pérdida de json-c. La función de entrada detecta automáticamente la clase de conformidad a partir de las claves JSON, donde el miembro <varname>frameSpecification</varname> implica Advanced, el miembro <varname>quaternion</varname> implica Basic-Quaternion y el miembro <varname>angles</varname> implica Basic-YPR.</para>
 					<para>Las clases Basic llevan la posición en un miembro <varname>position</varname> y dejan el marco implícito. La clase Advanced no tiene miembro de posición: nombra su marco exterior de forma explícita y la pose se sitúa en el origen de ese marco, de modo que las dos codificaciones de una misma pose se releen iguales. Todas las clases exigen un marco exterior geográfico, por lo que la pose debe ser geodésica; una pose planar se rechaza en el límite de la conversión, al igual que un SRID proyectado.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1377,7 +1491,9 @@ SELECT asEWKT(poseFromGeoPose(
 				<listitem xml:id="pose_normalize">
 					<indexterm significance="normal"><primary><varname>poseNormalize</varname></primary></indexterm>
 					<para>Devuelve una pose cuyo cuaternión de orientación se ha llevado a una norma unitaria</para>
-					<para><varname>poseNormalize(pose) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+poseNormalize(pose) → pose
+</programlisting>
 					<para>Una pose 2D se devuelve sin cambios, ya que su orientación es un único ángulo. A una pose 3D se le divide el cuaternión por su norma euclidiana, de modo que composiciones largas de SLERP (o cualquier otra vía que acumule deriva de punto flotante en <varname>|q|</varname>) pueden restaurarse al invariante <varname>|q| = 1</varname> que requiere el código de SLERP y de descomposición de Euler.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(poseNormalize(pose 'Pose(Point(1 1 1), 0.5, 0.5, 0.5, 0.5)'));
@@ -1388,7 +1504,9 @@ SELECT asText(poseNormalize(pose 'Pose(Point(1 1 1), 0.5, 0.5, 0.5, 0.5)'));
 				<listitem xml:id="pose_inverse">
 					<indexterm significance="normal"><primary><varname>poseInverse</varname></primary></indexterm>
 					<para>Devuelve la inversa de una pose</para>
-					<para><varname>poseInverse(pose) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+poseInverse(pose) → pose
+</programlisting>
 					<para>La inversa invierte la relación entre marcos: donde una pose lleva un valor del marco que nombra al marco en el que ella misma está expresada, la inversa lo lleva de vuelta. Es <varname>R_BA = R_AB^T</varname> y <varname>t_BA = −R_AB^T t_AB</varname>, de modo que componer una pose con su inversa da la identidad. Esto es lo que expresa una posición del mundo en el marco de un vehículo.</para>
 					<para>Una pose sobre un marco geográfico no tiene inversa: el marco que nombraría no es un marco del elipsoide.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1412,9 +1530,11 @@ SELECT asEWKT(round(poseInverse(pose 'Pose(Point(1 0 0), 0, 0, 0, 1)'), 6));
 					<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
 					<para>Devuelve el ángulo yaw, pitch o roll de una pose, en radianes, bajo la convención Tait-Bryan intrínseca ZYX que exige la clase de conformidad Basic-YPR de OGC GeoPose</para>
-					<para><varname>yaw(pose) → float</varname></para>
-					<para><varname>pitch(pose) → float</varname></para>
-					<para><varname>roll(pose) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+yaw(pose) → float
+pitch(pose) → float
+roll(pose) → float
+</programlisting>
 					<para>Para una pose 2D, <varname>yaw</varname> devuelve la rotación almacenada <varname>theta</varname>,por convención, el yaw del marco del cuerpo— y <varname>pitch</varname> y <varname>roll</varname> devuelven <varname>0</varname>. Para una pose 3D, los tres valores provienen de la descomposición Tait-Bryan intrínseca ZYX del cuaternión de orientación. El término de pitch <varname>asin</varname> se acota a <varname>[-1, 1]</varname> para absorber la pequeña deriva numérica que pueden introducir las composiciones largas de cuaterniones.</para>
 					<para>Sobre una pose temporal, la interpolación del resultado sigue a la dimensión. Una pose 2D interpola linealmente su ángulo almacenado y ese ángulo es su yaw, de modo que un <varname>tpose</varname> 2D lineal se proyecta en un <varname>tfloat</varname> lineal. Una pose 3D interpola mediante SLERP, cuya descomposición Tait-Bryan no es lineal en el tiempo, de modo que un <varname>tpose</varname> 3D se proyecta en un <varname>tfloat</varname> escalonado: leerlo entre dos instantes devuelve el ángulo del instante de la izquierda en lugar de un ángulo que ninguna pose contiene.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1432,7 +1552,9 @@ SELECT yaw(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475
 				<listitem xml:id="pose_ypr">
 					<indexterm significance="normal"><primary><varname>ypr</varname></primary></indexterm>
 					<para>Devuelve la orientación de una pose como una terna yaw / pitch / roll, en radianes</para>
-					<para><varname>ypr(pose) → ypr</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+ypr(pose) → ypr
+</programlisting>
 					<para>Esta es la codificación Basic-YPR de la orientación en OGC GeoPose, la contraparte de <link linkend="pose_quaternion"><varname>quaternion</varname></link>, y devuelve los tres ángulos que <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> y <varname>roll</varname> responden de uno en uno. Al igual que <varname>quaternion</varname>, está definida para ambas dimensiones: una pose 2D gira por su ángulo almacenado y no cabecea ni alabea. Los ángulos están en radianes, mientras que la codificación JSON de GeoPose los escribe en grados.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ypr(pose 'Pose(Point(1 1), 0.5)');
@@ -1449,9 +1571,11 @@ SELECT ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)');
 					<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
 					<para>Eleva los accesores de ángulos de Euler a través de una pose temporal, devolviendo un flotante temporal (radianes) por cada instante bajo la convención Tait-Bryan intrínseca ZYX</para>
-					<para><varname>yaw(tpose) → tfloat</varname></para>
-					<para><varname>pitch(tpose) → tfloat</varname></para>
-					<para><varname>roll(tpose) → tfloat</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+yaw(tpose) → tfloat
+pitch(tpose) → tfloat
+roll(tpose) → tfloat
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
   Pose(Point(1 1), 0.5)@2000-01-02]'));
@@ -1482,7 +1606,9 @@ FROM geopose_frames ORDER BY frame_id;
 				<listitem xml:id="pose_geopose_frames_fn">
 					<indexterm significance="normal"><primary><varname>geoPoseFrames</varname></primary></indexterm>
 					<para>Devuelve todos los marcos que nombran el estándar y los codificadores</para>
-					<para><varname>geoPoseFrames() &#x2192; setof record</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geoPoseFrames() &#x2192; setof record
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT count(*) FROM geoPoseFrames();
 -- 8
@@ -1494,7 +1620,9 @@ SELECT count(*) FROM geoPoseFrames();
 				<listitem xml:id="pose_geopose_frame_srid">
 					<indexterm significance="normal"><primary><varname>geoPoseFrameSRID</varname></primary></indexterm>
 					<para>Devuelve el SRID de un marco, o <varname>NULL</varname> si el marco es paramétrico (LTP, BODY)</para>
-					<para><varname>geoPoseFrameSRID(int) → int</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geoPoseFrameSRID(int) → int
+</programlisting>
 								<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoPoseFrameSRID(1), geoPoseFrameSRID(2);
 -- 4326 | 4978
@@ -1505,7 +1633,9 @@ SELECT geoPoseFrameSRID(3);
 				<listitem xml:id="pose_geopose_frame_name">
 					<indexterm significance="normal"><primary><varname>geoPoseFrameName</varname></primary></indexterm>
 					<para>Devuelve el nombre legible del marco</para>
-					<para><varname>geoPoseFrameName(int) → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geoPoseFrameName(int) → text
+</programlisting>
 								<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoPoseFrameName(1);
 -- WGS-84 geographic (lat/lon/h)
@@ -1516,7 +1646,9 @@ SELECT geoPoseFrameName(2), geoPoseFrameName(3);
 				<listitem xml:id="pose_geopose_frame_is_geographic">
 					<indexterm significance="normal"><primary><varname>geoPoseFrameIsGeographic</varname></primary></indexterm>
 					<para>Devuelve <varname>true</varname> para los marcos lat/lon/h, <varname>false</varname> para los cartesianos o proyectados</para>
-					<para><varname>geoPoseFrameIsGeographic(int) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geoPoseFrameIsGeographic(int) → boolean
+</programlisting>
 								<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoPoseFrameIsGeographic(1), geoPoseFrameIsGeographic(2);
 -- true | false
@@ -1537,9 +1669,11 @@ SELECT geoPoseFrameIsGeographic(1), geoPoseFrameIsGeographic(2);
 world = R(q) · body + p
 </programlisting>
 			<para>donde <varname>(p, q)</varname> son la posición y la orientación de la pose. La forma estática toma una única pose y una geometría estática; la forma temporal eleva la transformación rígida por instante de una <varname>tpose</varname> a lo largo de sus instantes, produciendo una trayectoria <varname>tgeompoint</varname> en el marco del mundo de la geometría del cuerpo. La forma estática admite una geometría de cuerpo de cualquier tipo y lleva su forma al marco de la pose; la forma temporal devuelve una <varname>tgeompoint</varname>, por lo que su geometría de cuerpo debe ser un punto. La pose y la geometría del cuerpo deben tener la misma dimensionalidad y deben coincidir en su SRID, adoptando el desconocido el del otro. La interpolación lineal de la trayectoria resultante es la cuerda de cada segmento, que aproxima la verdadera trayectoria de cuerpo rígido (un arco circular bajo SLERP), la misma concesión que MobilityDB ya adopta para las trayectorias espaciales.</para>
-			<para><varname>applyPose(geometry, pose) → geometry</varname></para>
-			<para><varname>applyPose(geometry, tpose) → tgeompoint</varname></para>
-			<para><varname>applyPose(pose, pose) → pose</varname></para>
+			<programlisting xml:space="preserve" format="linespecific">
+applyPose(geometry, pose) → geometry
+applyPose(geometry, tpose) → tgeompoint
+applyPose(pose, pose) → pose
+</programlisting>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- A body sensor offset 1 unit along the body X axis, traced through a
 -- tpose that ends 90 degrees yawed and translated to (10, 20).
@@ -1555,10 +1689,12 @@ SELECT ST_AsText(applyPose(ST_MakeEnvelope(-2,-1,2,1),
 -- POLYGON((8 19,8 21,12 21,12 19,8 19))
 </programlisting>
 			<para>Cualquiera de los dos marcos puede moverse. Aplicar una pose a una <varname>tpose</varname> lleva un cuerpo fijo a través de todo el movimiento de su padre, que es lo que pide un sensor montado sobre un vehículo en movimiento; aplicar una <varname>tpose</varname> a una pose lleva un cuerpo en movimiento a un marco que permanece quieto; y aplicar una <varname>tpose</varname> a una <varname>tpose</varname> compone dos marcos que ambos se mueven, sobre el tiempo que comparten. <varname>poseInverse</varname> se eleva de la misma manera, cambiando el punto de vista sobre un objeto en movimiento durante todo su movimiento.</para>
-			<para><varname>applyPose(pose, tpose) &#8594; tpose</varname></para>
-			<para><varname>applyPose(tpose, pose) &#8594; tpose</varname></para>
-			<para><varname>applyPose(tpose, tpose) &#8594; tpose</varname></para>
-			<para><varname>poseInverse(tpose) &#8594; tpose</varname></para>
+			<programlisting xml:space="preserve" format="linespecific">
+applyPose(pose, tpose) &#8594; tpose
+applyPose(tpose, pose) &#8594; tpose
+applyPose(tpose, tpose) &#8594; tpose
+poseInverse(tpose) &#8594; tpose
+</programlisting>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Un sensor una unidad delante de un cuerpo que termina girado un cuarto de
 -- vuelta en (10, 20) termina una unidad al norte de él
@@ -1592,8 +1728,10 @@ SELECT asEWKT(round(applyPose(pose 'Pose(Point(1 0 0), 1, 0, 0, 0)',
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tposeFromGeoPose</varname></primary></indexterm>
 					<para>Convierte una pose temporal hacia o desde una envoltura JSON TemporalGeoPose. Cada carga útil por instante es un documento GeoPose de clase Basic estrictamente válido según OGC más un miembro <varname>validTime</varname>; la envoltura registra la clase de conformidad, la interpolación y (para secuencias y conjuntos de secuencias) la inclusión de los límites del período. Un consumidor GeoPose ajeno a MEOS puede iterar sobre <varname>instants[]</varname> (o cada <varname>sequences[].instants[]</varname>) y consumir cada elemento como un documento GeoPose estático.</para>
-					<para><varname>asGeoPose(tpose,conformance integer=0,maxdecimaldigits integer=-1) → text</varname></para>
-					<para><varname>tposeFromGeoPose(text) → tpose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPose(tpose,conformance integer=0,maxdecimaldigits integer=-1) → text
+tposeFromGeoPose(text) → tpose
+</programlisting>
 					<para>La forma de la envoltura es</para>
 					<programlisting xml:space="preserve" format="linespecific">
 {
@@ -1626,7 +1764,9 @@ SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01,
 				<listitem xml:id="tpose_geopose_stream">
 					<indexterm significance="normal"><primary><varname>asGeoPoseStream</varname></primary></indexterm>
 					<para>Escribe una pose temporal como un Stream de OGC GeoPose</para>
-					<para><varname>asGeoPoseStream(tpose,maxdecimaldigits integer=-1) → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPoseStream(tpose,maxdecimaldigits integer=-1) → text
+</programlisting>
 					<para>Un stream lleva los marcos de una Serie Irregular sin declarar cuántas poses hay ni cuándo terminan, ya que pueden llegar más. El estándar lo escribe como un <varname>header</varname>, que contiene el modelo de transición y el marco exterior, y un arreglo <varname>streamElements</varname> con un elemento por pose. El marco exterior es el plano tangente local Este-Norte-Arriba en la posición de la primera pose, de modo que la cabecera y cada elemento hablan de un mismo punto de tangencia.</para>
 					<para>La biblioteca C también escribe los dos documentos por partes, mediante <varname>tpose_as_geopose_stream_header</varname> y <varname>tpose_as_geopose_stream_element</varname>, para un productor que emite poses a medida que llegan. Una consulta devuelve un valor que ya posee entero, que es lo que esta función escribe.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -59,8 +59,10 @@ SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '480fffffffffffff@2001-01-01'));
 			<listitem xml:id="tquadbin_tbigint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir entre un <varname>tquadbin</varname> y un <varname>tbigint</varname> (explícito, sin coste)</para>
-				<para><varname>tbigint::tquadbin</varname></para>
-				<para><varname>tquadbin::tbigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbigint::tquadbin
+tquadbin::tbigint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tbigint '5192650370358181887@2001-01-01')::tquadbin;
 -- 480fffffffffffff@2001-01-01
@@ -73,7 +75,9 @@ SELECT ((tquadbin '480fffffffffffff@2001-01-01')::tbigint)::tquadbin
 			<listitem xml:id="tquadbin_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir una celda QUADBIN temporal a un punto planar temporal (SRID 4326) de los centroides de las celdas. La conversión delega en <varname>tquadbinCellToPoint</varname>.</para>
-				<para><varname>tquadbin::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tquadbin::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tquadbin '480fffffffffffff@2001-01-01')::tgeompoint;
 </programlisting>
@@ -90,7 +94,9 @@ SELECT (tquadbin '480fffffffffffff@2001-01-01')::tgeompoint;
 			<listitem xml:id="quadbin_is_valid_index">
 				<indexterm significance="normal"><primary><varname>isValidIndex</varname></primary></indexterm>
 				<para>Devuelve si un valor es un identificador QUADBIN estructuralmente válido (etiqueta de cabecera y campo de resolución correctos)</para>
-				<para><varname>isValidIndex(quadbin) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidIndex(quadbin) → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidIndex(quadbin '480fffffffffffff');
 -- t
@@ -104,7 +110,9 @@ SELECT isValidIndex(0::bigint::quadbin);
 			<listitem xml:id="quadbin_is_valid_cell">
 				<indexterm significance="normal"><primary><varname>isValidCell</varname></primary></indexterm>
 				<para>Devuelve si un valor es una celda QUADBIN válida (un índice válido cuyas coordenadas de tesela están dentro de los límites de su resolución)</para>
-				<para><varname>isValidCell(quadbin) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidCell(quadbin) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidCell(quadbin '480fffffffffffff');
 -- true
@@ -122,8 +130,10 @@ SELECT isValidCell(quadbin '0');
 				<indexterm significance="normal"><primary><varname>startValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<para>Devuelve el primer o el último identificador de celda QUADBIN de un valor temporal</para>
-				<para><varname>startValue(tquadbin) → quadbin</varname></para>
-				<para><varname>endValue(tquadbin) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(tquadbin) → quadbin
+endValue(tquadbin) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(tquadbin '480fffffffffffff@2001-01-01');
 -- 480fffffffffffff
@@ -135,7 +145,9 @@ SELECT endValue(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01
 			<listitem xml:id="tquadbin_valueN">
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
 				<para>Devuelve el <varname>n</varname>-ésimo identificador de celda QUADBIN distinto (índice base 1). Devuelve <varname>NULL</varname> si está fuera de rango.</para>
-				<para><varname>valueN(tquadbin,integer) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueN(tquadbin,integer) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}', 1);
 -- 480fffffffffffff
@@ -149,7 +161,9 @@ SELECT valueN(tquadbin '480fffffffffffff@2001-01-01', 99);
 			<listitem xml:id="tquadbin_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Devuelve el conjunto de identificadores de celda QUADBIN distintos que toma la trayectoria</para>
-				<para><varname>getValues(tquadbin) → quadbinset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tquadbin) → quadbinset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(tquadbin '480fffffffffffff@2001-01-01');
 -- {480fffffffffffff}
@@ -163,7 +177,9 @@ SELECT getValues(tquadbin
 			<listitem xml:id="tquadbin_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el identificador de celda QUADBIN en un instante dado, usando interpolación de pasos</para>
-				<para><varname>valueAtTimestamp(tquadbin,timestamptz) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tquadbin,timestamptz) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tquadbin
   '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-05]',
@@ -181,8 +197,10 @@ SELECT valueAtTimestamp(tquadbin
 				<indexterm significance="normal"><primary><varname>quadbinGetResolution</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinGetResolution</varname></primary></indexterm>
 				<para>Devuelve el nivel de resolución (zoom) (0–26) de una celda. La forma estática devuelve un <varname>integer</varname>; la forma temporal devuelve la resolución de cada celda de una trayectoria como un <varname>tint</varname>.</para>
-				<para><varname>quadbinGetResolution(quadbin) → integer</varname></para>
-				<para><varname>tquadbinGetResolution(tquadbin) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinGetResolution(quadbin) → integer
+tquadbinGetResolution(tquadbin) → tint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinGetResolution(quadbin '480fffffffffffff');
 -- 0
@@ -194,7 +212,9 @@ SELECT tquadbinGetResolution(tquadbin '48427fffffffffff@2001-01-01');
 			<listitem xml:id="tquadbin_quadbin_is_valid_cell">
 				<indexterm significance="normal"><primary><varname>isValidCell</varname></primary></indexterm>
 				<para>Devuelve un booleano temporal que indica en cada instante si el valor es una celda QUADBIN válida</para>
-				<para><varname>isValidCell(tquadbin) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidCell(tquadbin) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidCell(tquadbin '480fffffffffffff@2001-01-01');
 -- t@2001-01-01
@@ -210,8 +230,10 @@ SELECT isValidCell(tquadbin '480fffffffffffff@2001-01-01');
 				<indexterm significance="normal"><primary><varname>quadbinCellToParent</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToParent</varname></primary></indexterm>
 				<para>Devuelve la celda padre en la resolución más gruesa dada. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el padre de cada celda de una trayectoria.</para>
-				<para><varname>quadbinCellToParent(quadbin,integer) → quadbin</varname></para>
-				<para><varname>tquadbinCellToParent(tquadbin,integer) → tquadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToParent(quadbin,integer) → quadbin
+tquadbinCellToParent(tquadbin,integer) → tquadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToParent(quadbin '48a6227affffffff', 5);
 -- 485623ffffffffff
@@ -224,7 +246,9 @@ SELECT tquadbinGetResolution(
 			<listitem xml:id="tquadbin_quadbin_cell_to_children">
 				<indexterm significance="normal"><primary><varname>quadbinCellToChildren</varname></primary></indexterm>
 				<para>Devuelve las cuatro celdas hijas en la resolución más fina solicitada como un <varname>quadbinset</varname>. Es un auxiliar estático que devuelve un conjunto sobre un único <varname>quadbin</varname>; no tiene elevación temporal (los hijos son un conjunto por instante, diferido a la espera de una primitiva <varname>tset&lt;T&gt;</varname>).</para>
-				<para><varname>quadbinCellToChildren(quadbin,integer) → quadbinset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToChildren(quadbin,integer) → quadbinset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToChildren(quadbin '480fffffffffffff', 1);
 -- {4813ffffffffffff, 4817ffffffffffff, 481bffffffffffff, 481fffffffffffff}
@@ -234,7 +258,9 @@ SELECT quadbinCellToChildren(quadbin '480fffffffffffff', 1);
 			<listitem xml:id="tquadbin_quadbin_cell_sibling">
 				<indexterm significance="normal"><primary><varname>quadbinCellSibling</varname></primary></indexterm>
 				<para>Devuelve la celda vecina en la misma resolución en la dirección dada (<varname>up</varname> / <varname>down</varname> / <varname>left</varname> / <varname>right</varname>)</para>
-				<para><varname>quadbinCellSibling(quadbin,text) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellSibling(quadbin,text) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellSibling(
   quadbinCellSibling(quadbin '48427fffffffffff', 'right'), 'left')
@@ -246,7 +272,9 @@ SELECT quadbinCellSibling(
 			<listitem xml:id="tquadbin_quadbin_grid_disk">
 				<indexterm significance="normal"><primary><varname>quadbinGridDisk</varname></primary></indexterm>
 				<para>Devuelve todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (inclusive del origen en k=0), como un <varname>quadbinset</varname>. En la cuadrícula cuadrada el disco en el paso <varname>k</varname> es el bloque cuadrado de <varname>(2k+1)</varname>×<varname>(2k+1)</varname> celdas centrado en el origen.</para>
-				<para><varname>quadbinGridDisk(quadbin,integer) → quadbinset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinGridDisk(quadbin,integer) → quadbinset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 0));  -- 1
 SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 1));  -- 9
@@ -262,7 +290,9 @@ SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 2));  -- 25
 			<listitem xml:id="tquadbin_quadbin_point_to_cell">
 				<indexterm significance="normal"><primary><varname>geoToQuadbinCell</varname></primary></indexterm>
 				<para>Devuelve la celda QUADBIN en la resolución dada que contiene una geometría de punto. La geometría debe ser un <varname>POINT</varname>; las longitudes se interpretan en SRID 4326.</para>
-				<para><varname>geoToQuadbinCell(geometry,integer) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoToQuadbinCell(geometry,integer) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
   = quadbin '48a6227affffffff';
@@ -274,8 +304,10 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 				<indexterm significance="normal"><primary><varname>quadbinCellToPoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToPoint</varname></primary></indexterm>
 				<para>Devuelve el centroide de una celda como un punto SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el centroide de cada celda de una trayectoria como un <varname>tgeompoint</varname>.</para>
-				<para><varname>quadbinCellToPoint(quadbin) → geometry</varname></para>
-				<para><varname>tquadbinCellToPoint(tquadbin) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToPoint(quadbin) → geometry
+tquadbinCellToPoint(tquadbin) → tgeompoint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(quadbinCellToPoint(quadbin '48427fffffffffff'));
 -- POINT(-101.25 48.92249926375824)
@@ -290,8 +322,10 @@ SELECT asText(tquadbinCellToPoint(tquadbin
 				<indexterm significance="normal"><primary><varname>quadbinCellToBoundary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToBoundary</varname></primary></indexterm>
 				<para>Devuelve el contorno poligonal cuadrado de una celda como una geometría SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el contorno de cada celda de una trayectoria como un <varname>tgeometry</varname>.</para>
-				<para><varname>quadbinCellToBoundary(quadbin) → geometry</varname></para>
-				<para><varname>tquadbinCellToBoundary(tquadbin) → tgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToBoundary(quadbin) → geometry
+tquadbinCellToBoundary(tquadbin) → tgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(quadbinCellToBoundary(quadbin '480fffffffffffff'));
 -- POLYGON((-180 -85.0511287798066,180 -85.0511287798066,
@@ -311,7 +345,9 @@ SELECT ST_AsText(quadbinCellToBoundary(quadbin '480fffffffffffff'));
 			<listitem xml:id="tquadbin_quadbin_tile_to_cell">
 				<indexterm significance="normal"><primary><varname>quadbinTileToCell</varname></primary></indexterm>
 				<para>Construye una celda a partir de coordenadas de tesela slippy-map: columna <varname>x</varname>, fila <varname>y</varname>, y zoom <varname>z</varname></para>
-				<para><varname>quadbinTileToCell(integer,integer,integer) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinTileToCell(integer,integer,integer) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinTileToCell(0, 0, 0) = quadbin '480fffffffffffff';
 -- true
@@ -325,7 +361,9 @@ SELECT quadbinTileToCell(524, 343, 10) = quadbin '48a6227affffffff';
 			<listitem xml:id="tquadbin_quadbin_cell_to_tile">
 				<indexterm significance="normal"><primary><varname>quadbinCellToTile</varname></primary></indexterm>
 				<para>Descompone una celda en su triple de coordenadas de tesela, devuelto como un arreglo de enteros <varname>{x, y, z}</varname>, la inversa de <varname>quadbinTileToCell</varname></para>
-				<para><varname>quadbinCellToTile(quadbin) → integer[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToTile(quadbin) → integer[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToTile(quadbin '480fffffffffffff');
 -- {0,0,0}
@@ -338,8 +376,10 @@ SELECT quadbinCellToTile(quadbin '48a6227affffffff');
 				<indexterm significance="normal"><primary><varname>quadbinCellToQuadkey</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToQuadkey</varname></primary></indexterm>
 				<para>Emite la cadena quadkey en base 4 de una celda (un dígito por nivel de zoom, primero el más significativo; la celda mundial de resolución 0 se corresponde con la cadena vacía). La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el quadkey de cada celda de una trayectoria como un <varname>ttext</varname>.</para>
-				<para><varname>quadbinCellToQuadkey(quadbin) → text</varname></para>
-				<para><varname>tquadbinCellToQuadkey(tquadbin) → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToQuadkey(quadbin) → text
+tquadbinCellToQuadkey(tquadbin) → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToQuadkey(quadbin '480fffffffffffff');
 -- (cadena vacía)
@@ -359,8 +399,10 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
 				<indexterm significance="normal"><primary><varname>quadbinCellArea</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellArea</varname></primary></indexterm>
 				<para>Devuelve el área de una celda sobre la esfera, en metros cuadrados. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el área de cada celda de una trayectoria como un <varname>tfloat</varname>. El área de la celda se reduce hacia los polos, ya que los cuadrados web-mercator cubren progresivamente menos terreno a latitudes más altas.</para>
-				<para><varname>quadbinCellArea(quadbin) → float8</varname></para>
-				<para><varname>tquadbinCellArea(tquadbin) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellArea(quadbin) → float8
+tquadbinCellArea(tquadbin) → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(quadbinCellArea(quadbin '480fffffffffffff')::numeric, 0);
 -- 508164135963886
@@ -383,7 +425,9 @@ SELECT round(quadbinCellArea(quadbin '48427fffffffffff')::numeric, 0);
 			<listitem xml:id="tquadbin_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
-				<para><varname>tCount(tquadbin) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tquadbin) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03)' UNION
@@ -398,7 +442,9 @@ FROM Temp;
 			<listitem xml:id="tquadbin_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Conteo en ventana</para>
-				<para><varname>wCount(tquadbin) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tquadbin) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03)' UNION

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -31,7 +31,9 @@ CREATE EXTENSION mobilitydb CASCADE;
 			<listitem xml:id="raster_rasterValue">
 				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
 				<para>Muestrear una banda de ráster en cada instante de una trayectoria</para>
-				<para><varname>rasterValue(tgeompoint,raster,band integer DEFAULT 1) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rasterValue(tgeompoint,raster,band integer DEFAULT 1) → tfloat
+</programlisting>
 				<para>Evalúa el píxel de la <varname>band</varname> en cada instante de <varname>traj</varname> usando muestreo bilineal-vecino más próximo (<varname>ST_Value</varname> con <varname>resample=false</varname>). Devuelve un <varname>tfloat</varname> de conjunto de instantes cuyos valores se redondean a cuatro decimales. Devuelve <varname>NULL</varname> cuando ningún instante se interseca con el ráster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Build a 3×3 synthetic elevation raster (SRID 4326, 1° pixels)
@@ -75,7 +77,9 @@ WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
 			<listitem xml:id="raster_numBands">
 				<indexterm significance="normal"><primary><varname>numBands</varname></primary></indexterm>
 				<para>Devolver el número de bandas de un ráster</para>
-				<para><varname>numBands(raster) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numBands(raster) → integer
+</programlisting>
 				<para>El número de banda que aceptan <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> y los operadores construidos sobre él va de 1 hasta este valor.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH rast1 AS (
@@ -117,7 +121,9 @@ WHERE quadbin = ANY(quadbins(traj, 8));
 			<listitem xml:id="raster_quadbins">
 				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
 				<para>Devolver las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
-				<para><varname>quadbins(tgeompoint,integer) → bigint[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbins(tgeompoint,integer) → bigint[]
+</programlisting>
 				<para>Devuelve el conjunto de celdas QUADBIN únicas (deduplicadas) cuyas envolventes de tesela Web-Mercator contienen al menos un instante de <varname>traj</varname>. El resultado es adecuado como clave de unión en la cláusula WHERE contra una tabla Raquet. El parámetro <varname>zoom</varname> debe estar en [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Three instants spanning three tiles at zoom 3
@@ -135,7 +141,10 @@ ORDER BY tile_count DESC;
 			<listitem xml:id="raster_rasterTileValueQuadbin">
 				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
 				<para>Muestrear un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
-				<para><varname>rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,boolean) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,
+  boolean) → tfloat
+</programlisting>
 				<para>Evalúa un arreglo de píxeles de banda única en orden de fila mayor en cada instante de <varname>traj</varname> (SRID 4326). La georreferenciación de la tesela (rectángulo delimitador, mapeo de píxel a coordenadas) se deriva únicamente de <varname>quadbin</varname> mediante la transformada de tesela deslizante Web-Mercator. El argumento <varname>pixtype</varname> debe ser uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Cuando <varname>has_nodata</varname> es verdadero, los instantes cuyo píxel equivale a <varname>nodata</varname> se descartan silenciosamente. Devuelve <varname>NULL</varname> cuando ningún instante sobrevive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample elevation tiles from a Raquet Parquet table
@@ -156,7 +165,9 @@ JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 			<listitem xml:id="raquet">
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construir una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
-				<para><varname>raquet(bytea,integer,integer,bigint,text,float8) → raquet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquet(bytea,integer,integer,bigint,text,float8) → raquet
+</programlisting>
 				<para>Empaqueta un arreglo de píxeles <varname>pixels</varname> de banda única en orden de fila mayor de <varname>width</varname> × <varname>height</varname> píxeles de tipo <varname>pixtype</varname> (uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>), georreferenciado por la celda <varname>quadbin</varname>, en un único valor <varname>raquet</varname> autodescriptivo. El argumento <varname>nodata</varname> es opcional; cuando se omite (<varname>NULL</varname>) la tesela no lleva valor centinela de nodata. Se genera un error cuando el arreglo <varname>pixels</varname> es menor que <varname>width</varname> × <varname>height</varname> × el tamaño del píxel. Los píxeles de más de un byte son little-endian, que es el orden de bytes que les da la especificación RaQuet sea cual sea el orden de bytes del servidor, de modo que una tesela conserva sus valores cuando se lee en otra máquina. Un <varname>raquet</varname> es un valor de longitud variable, libre de GDAL, con una representación portátil en texto Hex-WKB y binaria, distinto de y coexistente con el tipo <varname>raster</varname> de PostGIS usado por <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Empaquetar las columnas sueltas de una tabla Raquet en valores raquet
@@ -171,7 +182,9 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 			<listitem xml:id="raquetRead">
 				<indexterm significance="normal"><primary><varname>raquetRead</varname></primary></indexterm>
 				<para>Decodificar un archivo ráster en memoria en una tesela ráster Raquet mediante GDAL</para>
-				<para><varname>raquetRead(bytea,bigint) → raquet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquetRead(bytea,bigint) → raquet
+</programlisting>
 				<para>Lee los bytes de <varname>rasterfile</varname>, un ráster en cualquier formato compatible con GDAL (GeoTIFF, PNG, …), a través del sistema de archivos virtual <varname>/vsimem/</varname> de GDAL, y empaqueta su primera banda, en orden de fila mayor, en un único valor <varname>raquet</varname> autodescriptivo georreferenciado por la celda <varname>quadbin</varname>. El tipo de datos de la banda debe ser uno de <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname> o <varname>Float64</varname>; el valor de nodata de la banda, cuando está definido, se traslada a la tesela. Como el archivo se suministra como bytes, no se requiere acceso a archivos del lado del servidor. GDAL realiza la decodificación, por lo que el controlador de formato del ráster debe estar permitido por la configuración <varname>postgis.gdal_enabled_drivers</varname> de PostGIS (que deshabilita todos los controladores de forma predeterminada); habilítelo con, por ejemplo, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. Esta es la contraparte de ingesta del constructor <link linkend="raquet"><varname>raquet</varname></link>, que construye una tesela a partir de bytes de píxeles ya decodificados.</para>
 				<para>Cuando se omite <varname>quadbin</varname> o es <varname>NULL</varname>, el identificador de la tesela se deriva de la georreferenciación del ráster: el ráster debe llevar una referencia espacial <varname>EPSG:3857</varname> (Web-Mercator) y una geotransformación alineada con los ejes que describa una única tesela QUADBIN. Un ráster sin referencia espacial, uno que no esté en <varname>EPSG:3857</varname>, o una geotransformación rotada o no alineada con la cuadrícula de teselas provoca un error en lugar de ser forzado.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -187,7 +200,9 @@ FROM elevation_files;
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrear una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
-				<para><varname>rasterTileValue(tgeompoint,raquet) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rasterTileValue(tgeompoint,raquet) → tfloat
+</programlisting>
 				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Muestrear teselas raquet preempaquetadas a lo largo de trayectorias de barcos
@@ -200,7 +215,9 @@ JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
 			<listitem xml:id="raster_rasterTileValueArray">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrear un arreglo de teselas ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
-				<para><varname>rasterTileValue(tgeompoint,raquet[]) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rasterTileValue(tgeompoint,raquet[]) → tfloat
+</programlisting>
 				<para>Evalúa cada tesela de <varname>rast</varname> en cada instante de <varname>traj</varname> (SRID 4326) y devuelve los valores de píxel muestreados como un único <varname>tfloat</varname>. Una trayectoria que sale de una tesela queda cubierta por varias, y cada una aporta los instantes que caen dentro de ella. Las teselas de un mismo nivel de zoom particionan el plano, de modo que aportan instantes disjuntos. Las teselas de niveles de zoom distintos se solapan, y cuando dos de ellas muestrean el mismo instante se conserva el valor de la tesela de mayor zoom, que es la que tiene la resolución más fina. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de una tesela o sobrevive al filtrado de nodata.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Muestrear una trayectoria en todas las teselas que cruza, en un solo valor
@@ -222,7 +239,9 @@ GROUP BY t.tripid, t.trip;
 			<listitem xml:id="raquet_asBinary">
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<para>Devolver la representación Well-Known Binary (WKB) de una tesela Raquet</para>
-				<para><varname>asBinary(raquet,endianencoding text DEFAULT '') → bytea</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(raquet,endianencoding text DEFAULT '') → bytea
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8')));
@@ -233,7 +252,9 @@ SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
 			<listitem xml:id="raquet_asHexWKB">
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Devolver la representación Well-Known Binary codificada en hexadecimal ASCII (HexWKB) de una tesela Raquet</para>
-				<para><varname>asHexWKB(raquet,endianencoding text DEFAULT '') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asHexWKB(raquet,endianencoding text DEFAULT '') → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8')));
@@ -244,7 +265,9 @@ SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
 			<listitem xml:id="raquet_pixels">
 				<indexterm significance="normal"><primary><varname>pixels</varname></primary></indexterm>
 				<para>Devolver los bytes de píxeles de un mosaico Raquet</para>
-				<para><varname>pixels(raquet) → bytea</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+pixels(raquet) → bytea
+</programlisting>
 				<para>Los bytes están en orden de fila mayor y empaquetados, <varname>width</varname> × <varname>height</varname> píxeles del tamaño de <varname>pixtype</varname> cada uno, en little-endian cuando un píxel ocupa más de un byte, que es la disposición que aceptan los constructores. Por lo tanto, un mosaico se reconstruye a través de sus propios accesores.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
@@ -255,7 +278,9 @@ SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquetFromBinary">
 				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
 				<para>Devolver una tesela Raquet a partir de su representación Well-Known Binary (WKB)</para>
-				<para><varname>raquetFromBinary(bytea) → raquet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquetFromBinary(bytea) → raquet
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
   5193776270265024512, 'uint8')))
@@ -267,7 +292,9 @@ SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
 			<listitem xml:id="raquetFromHexWKB">
 				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
 				<para>Devolver una tesela Raquet a partir de su representación Well-Known Binary codificada en hexadecimal ASCII (HexWKB)</para>
-				<para><varname>raquetFromHexWKB(text) → raquet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquetFromHexWKB(text) → raquet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
   5193776270265024512, 'uint8')))
@@ -289,7 +316,9 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
 			<listitem xml:id="raquet_quadbin_accessor">
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Devolver la celda QUADBIN de una tesela Raquet</para>
-				<para><varname>quadbin(raquet) → bigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbin(raquet) → bigint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 5193776270265024512
@@ -299,7 +328,9 @@ SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_width">
 				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
 				<para>Devolver el ancho en píxeles de una tesela Raquet</para>
-				<para><varname>width(raquet) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+width(raquet) → integer
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
@@ -309,7 +340,9 @@ SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_height">
 				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
 				<para>Devolver el alto en píxeles de una tesela Raquet</para>
-				<para><varname>height(raquet) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+height(raquet) → integer
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
@@ -319,7 +352,9 @@ SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_nodata">
 				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
 				<para>Devolver el valor centinela nodata de una tesela Raquet</para>
-				<para><varname>nodata(raquet) → float8</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nodata(raquet) → float8
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nodata(raquet('\x01020304'::bytea, 2, 2,
   5193776270265024512, 'uint8', 255));
@@ -333,7 +368,9 @@ SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_pixtype">
 				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
 				<para>Devolver el nombre del tipo de dato de píxel de una tesela Raquet</para>
-				<para><varname>pixtype(raquet) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+pixtype(raquet) → text
+</programlisting>
 				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que el nombre que el ráster de PostGIS da a un tipo de píxel pasa a ellos tal cual; el nombre devuelto aquí es la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela, por lo que se compara igual a ese campo tal cual.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Leer la disposición de una tesela empaquetada
@@ -346,7 +383,9 @@ FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS 
 			<listitem xml:id="raquet_to_stbox">
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convertir una tesela Raquet en una caja espaciotemporal</para>
-				<para><varname>stbox(raquet) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stbox(raquet) → stbox
+</programlisting>
 				<para>Devuelve la huella de la tesela: la envolvente de longitud y latitud de su celda QUADBIN, en SRID 4326 y sin dimensión temporal. La huella se deriva únicamente de la celda, por lo que teselas que difieren en píxeles, dimensiones o tipo de píxel la comparten. La conversión también está disponible como conversión de tipo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The footprint of a tile covering the north-eastern quadrant at zoom 1
@@ -383,12 +422,14 @@ WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
 				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Comparar dos teselas Raquet</para>
-				<para><varname>raquet = raquet → boolean</varname></para>
-				<para><varname>raquet &lt;&gt; raquet → boolean</varname></para>
-				<para><varname>raquet &lt; raquet → boolean</varname></para>
-				<para><varname>raquet &lt;= raquet → boolean</varname></para>
-				<para><varname>raquet &gt;= raquet → boolean</varname></para>
-				<para><varname>raquet &gt; raquet → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquet = raquet → boolean
+raquet &lt;&gt; raquet → boolean
+raquet &lt; raquet → boolean
+raquet &lt;= raquet → boolean
+raquet &gt;= raquet → boolean
+raquet &gt; raquet → boolean
+</programlisting>
 				<para>Las funciones que respaldan estos operadores son <varname>eq</varname>, <varname>ne</varname>, <varname>lt</varname>, <varname>le</varname>, <varname>ge</varname> y <varname>gt</varname>, junto con <varname>cmp(raquet,raquet) → integer</varname>, que devuelve -1, 0 o 1.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Dos teselas con la misma celda, disposición y píxeles son iguales
@@ -412,7 +453,9 @@ SELECT DISTINCT tile FROM elevation_tiles;
 			<listitem xml:id="raster_atRasterValue">
 				<indexterm significance="normal"><primary><varname>atRasterValue</varname></primary></indexterm>
 				<para>Devolver los instantes de una trayectoria donde el valor ráster muestreado cae dentro de un rango de flotante</para>
-				<para><varname>atRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint
+</programlisting>
 				<para>Evalúa <varname>rasterValue</varname> en cada instante de <varname>traj</varname> y devuelve la sub-trayectoria restringida a los tiempos en que el valor del píxel está dentro de <varname>vspan</varname>. Devuelve <varname>NULL</varname> cuando ningún instante satisface la condición.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH rast AS (
@@ -434,7 +477,9 @@ FROM rast;
 			<listitem xml:id="raster_minusRasterValue">
 				<indexterm significance="normal"><primary><varname>minusRasterValue</varname></primary></indexterm>
 				<para>Devolver los instantes de una trayectoria donde el valor ráster muestreado cae fuera de un rango de flotante</para>
-				<para><varname>minusRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minusRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint
+</programlisting>
 				<para>El complemento de <varname>atRasterValue</varname>: devuelve la sub-trayectoria restringida a los tiempos en que el valor del píxel está fuera de <varname>vspan</varname>. Devuelve <varname>NULL</varname> cuando todos los instantes satisfacen la condición.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Keep only the instant whose raster value (10) is below 40
@@ -446,7 +491,9 @@ FROM trips, elevation_raster;
 			<listitem xml:id="raster_eRasterValue">
 				<indexterm significance="normal"><primary><varname>eRasterValue</varname></primary></indexterm>
 				<para>Devolver verdadero si la trayectoria alguna vez muestrea un valor de píxel ráster dentro de un rango de flotante</para>
-				<para><varname>eRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean
+</programlisting>
 				<para>Devuelve <varname>true</varname> cuando al menos un instante dentro de la extensión de <varname>traj</varname> muestrea un valor de píxel dentro de <varname>vspan</varname>, <varname>false</varname> en caso contrario. Devuelve <varname>NULL</varname> únicamente cuando la entrada es <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that ever crossed terrain above 200 m
@@ -459,7 +506,9 @@ WHERE eRasterValue(trip, elev_raster, floatspan '[200, 9999]');
 			<listitem xml:id="raster_aRasterValue">
 				<indexterm significance="normal"><primary><varname>aRasterValue</varname></primary></indexterm>
 				<para>Devolver verdadero si cada instante de la trayectoria dentro de la extensión del ráster muestrea un valor de píxel dentro de un rango de flotante</para>
-				<para><varname>aRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+aRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean
+</programlisting>
 				<para>Devuelve <varname>true</varname> cuando cada instante dentro de la extensión de <varname>traj</varname> muestrea un valor de píxel dentro de <varname>vspan</varname>, <varname>false</varname> cuando al menos uno no lo hace. Devuelve <varname>NULL</varname> únicamente cuando la entrada es <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that stayed entirely below 100 m elevation

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -55,7 +55,9 @@ SELECT trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
 			<listitem xml:id="trgeometry_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Devuelve la representación de texto conocido (Well-Known Text o WKT)</para>
-				<para><varname>asText({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.123456789),
   0.5)@2000-01-01', 6);
@@ -66,7 +68,9 @@ SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.12
 			<listitem xml:id="trgeometry_asEWKT">
 				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 				<para>Devuelve la representación extendida de texto conocido (Extended Well-Known Text o EWKT), prefijada con el SRID</para>
-				<para><varname>asEWKT({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asEWKT({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(trgeometry
   'SRID=25832;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1),0.5)@2000-01-01');
@@ -77,7 +81,9 @@ SELECT asEWKT(trgeometry
 			<listitem xml:id="trgeometry_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Devuelve la representación JSON de características móviles (Moving Features JSON o MF-JSON)</para>
-				<para><varname>asMFJSON(trgeometry [, options int=0 [, flags int=0 [, maxdecimaldigits int=15]]]) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(trgeometry [, options int=0 [, flags int=0 [, maxdecimaldigits int=15]]]) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(trgeometry
   'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2001-01-01');
@@ -89,9 +95,11 @@ SELECT asMFJSON(trgeometry
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Devuelve la representación extendida binaria conocida (Extended Well-Known Binary o EWKB)</para>
-				<para><varname>asEWKB(trgeometry [, endian text]) → bytea</varname></para>
-				<para><varname>asHexWKB(trgeometry [, endian text]) → text</varname></para>
-				<para><varname>asHexEWKB(trgeometry [, endian text]) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asEWKB(trgeometry [, endian text]) → bytea
+asHexWKB(trgeometry [, endian text]) → text
+asHexEWKB(trgeometry [, endian text]) → text
+</programlisting>
 				<para>Las funciones complementarias <varname>asHexWKB</varname> y <varname>asHexEWKB</varname> devuelven el texto codificado en hexadecimal de, respectivamente, la representación simple y la que incluye el SRID; ambas coinciden solo cuando el valor no tiene SRID, como en el ejemplo siguiente.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1),
@@ -114,11 +122,13 @@ SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry
 				<indexterm significance="normal"><primary><varname>trgeometryFromEWKT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>trgeometryFromHexEWKB</varname></primary></indexterm>
 				<para>Cada formato de salida tiene un analizador complementario:</para>
-				<para><varname>trgeometryFromText(text) → trgeometry</varname></para>
-				<para><varname>trgeometryFromEWKT(text) → trgeometry</varname></para>
-				<para><varname>trgeometryFromMFJSON(text) → trgeometry</varname></para>
-				<para><varname>trgeometryFromEWKB(bytea) → trgeometry</varname></para>
-				<para><varname>trgeometryFromHexEWKB(text) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trgeometryFromText(text) → trgeometry
+trgeometryFromEWKT(text) → trgeometry
+trgeometryFromMFJSON(text) → trgeometry
+trgeometryFromEWKB(bytea) → trgeometry
+trgeometryFromHexEWKB(text) → trgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(trgeometryFromEWKT('SRID=4326;Polygon((0 0,1 0,1 1,0 1,0 0));
   Pose(Point(1 1), 0.5)@2001-01-01'));
@@ -140,7 +150,9 @@ SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry
 			<listitem xml:id="trgeometry_constructor">
 				<indexterm significance="normal"><primary><varname>trgeometry</varname></primary></indexterm>
 				<para>Construir una geometría rígida temporal a partir de una geometría de referencia y una pose temporal</para>
-				<para><varname>trgeometry(geometry, tpose) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trgeometry(geometry, tpose) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(trgeometry(
   geometry 'Polygon((0 0,1 0,1 1,0 1,0 0))',
@@ -153,7 +165,9 @@ SELECT asText(trgeometry(
 			<listitem xml:id="trgeometry_appendInstant">
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<para>Agregar un único instante a una trgeometry existente, ampliando la trayectoria de pose subyacente</para>
-				<para><varname>appendInstant(trgeometry, trgeometry [, maxdist float [, maxt interval]]) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(trgeometry, trgeometry [, maxdist float [, maxt interval]]) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT appendInstant(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01]',
@@ -164,7 +178,9 @@ SELECT appendInstant(
 			<listitem xml:id="trgeometry_appendSequence">
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Agregar una secuencia completa a una trgeometry existente</para>
-				<para><varname>appendSequence(trgeometry, trgeometry) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendSequence(trgeometry, trgeometry) → trgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendSequence(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
@@ -187,7 +203,9 @@ SELECT asText(appendSequence(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_to_tpose">
 				<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
 				<para>Devuelve la pose temporal subyacente</para>
-				<para><varname>tpose(trgeometry) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose(trgeometry) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpose(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
   0.0)@2001-01-01, Pose(Point(10 0), 0.5)@2001-01-02]'));
@@ -198,7 +216,9 @@ SELECT asText(tpose(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
 			<listitem xml:id="trgeometry_to_tgeompoint">
 				<indexterm significance="normal"><primary><varname>tgeompoint</varname></primary></indexterm>
 				<para>Devuelve la trayectoria del centroide (antena) como un punto temporal</para>
-				<para><varname>tgeompoint(trgeometry) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tgeompoint(trgeometry) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tgeompoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
   0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
@@ -219,9 +239,11 @@ SELECT asText(tgeompoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve la geometría materializada al inicio, al final o en una marca de tiempo elegida</para>
-				<para><varname>startValue(trgeometry) → geometry</varname></para>
-				<para><varname>endValue(trgeometry) → geometry</varname></para>
-				<para><varname>valueAtTimestamp(trgeometry, timestamptz) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(trgeometry) → geometry
+endValue(trgeometry) → geometry
+valueAtTimestamp(trgeometry, timestamptz) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(startValue(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
   0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
@@ -241,9 +263,11 @@ SELECT asText(valueAtTimestamp(
 				<indexterm significance="normal"><primary><varname>numSequences</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>numTimestamps</varname></primary></indexterm>
 				<para>Devuelve el número de instantes, secuencias o marcas de tiempo distintos</para>
-				<para><varname>numInstants(trgeometry) → integer</varname></para>
-				<para><varname>numSequences(trgeometry) → integer</varname></para>
-				<para><varname>numTimestamps(trgeometry) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numInstants(trgeometry) → integer
+numSequences(trgeometry) → integer
+numTimestamps(trgeometry) → integer
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
@@ -262,9 +286,11 @@ SELECT numTimestamps(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>sequences</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>segments</varname></primary></indexterm>
 				<para>Devuelve el arreglo de instantes, secuencias o segmentos entre instantes constituyentes</para>
-				<para><varname>instants(trgeometry) → trgeometry[]</varname></para>
-				<para><varname>sequences(trgeometry) → trgeometry[]</varname></para>
-				<para><varname>segments(trgeometry) → trgeometry[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+instants(trgeometry) → trgeometry[]
+sequences(trgeometry) → trgeometry[]
+segments(trgeometry) → trgeometry[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT array_length(
   instants(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01,
@@ -277,7 +303,9 @@ SELECT array_length(
 			<listitem xml:id="trgeometry_points">
 				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
 				<para>Devuelve el conjunto de puntos del centroide (antena) distintos vistos a lo largo de la trgeometry</para>
-				<para><varname>points(trgeometry) → geomset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+points(trgeometry) → geomset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(points(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0),
   0.0)@2001-01-01, Pose(Point(5 5), 0.0)@2001-01-02, Pose(Point(0 0), 0.0)@2001-01-03}'));
@@ -290,9 +318,11 @@ SELECT asText(points(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0)
 				<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
 				<para>Devuelve el ángulo yaw, pitch o roll como un flotante temporal, en radianes, bajo la convención Tait-Bryan intrínseca ZYX que exige la clase de conformidad Basic-YPR de OGC GeoPose</para>
-				<para><varname>yaw(trgeometry) → tfloat</varname></para>
-				<para><varname>pitch(trgeometry) → tfloat</varname></para>
-				<para><varname>roll(trgeometry) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+yaw(trgeometry) → tfloat
+pitch(trgeometry) → tfloat
+roll(trgeometry) → tfloat
+</programlisting>
 				<para>Una geometría rígida lleva su orientación en sus poses, de modo que cada una de estas funciones se proyecta sobre la pose temporal y se lo pregunta, exactamente como lo hacen los accesores homónimos de <link linkend="pose_yaw_pitch_roll"><varname>tpose</varname></link>. Una geometría rígida 2D gira por el ángulo almacenado de cada pose y no cabecea ni alabea.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(yaw(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
@@ -307,7 +337,9 @@ SELECT asText(pitch(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
 			<listitem xml:id="trgeometry_geom">
 				<indexterm significance="normal"><primary><varname>geom</varname></primary></indexterm>
 				<para>Devuelve la geometría de referencia estática</para>
-				<para><varname>geom(trgeometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geom(trgeometry) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(geom(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0),
   0.5)@2001-01-01'));
@@ -326,7 +358,9 @@ SELECT ST_AsText(geom(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0)
 			<listitem xml:id="trgeometry_traversedArea_func">
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
 				<para>Devuelve el área atravesada por la geometría rígida temporal</para>
-				<para><varname>traversedArea(trgeometry, unary_union=false) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+traversedArea(trgeometry, unary_union=false) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
@@ -352,7 +386,9 @@ SELECT ST_AsText(traversedArea(
 			<listitem xml:id="trgeometry_centroid_func">
 				<indexterm significance="normal"><primary><varname>centroid</varname></primary></indexterm>
 				<para>Devuelve el centroide del cuerpo en movimiento como un punto temporal</para>
-				<para><varname>centroid(trgeometry) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+centroid(trgeometry) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(centroid(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -364,7 +400,9 @@ SELECT asText(centroid(
 			<listitem xml:id="trgeometry_convexHull_func">
 				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Devuelve la envolvente convexa del área recorrida por el cuerpo en movimiento</para>
-				<para><varname>convexHull(trgeometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+convexHull(trgeometry) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_GeometryType(convexHull(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -376,7 +414,9 @@ SELECT ST_GeometryType(convexHull(
 			<listitem xml:id="trgeometry_bodyPointTrajectory_func">
 				<indexterm significance="normal"><primary><varname>bodyPointTrajectory</varname></primary></indexterm>
 				<para>Devuelve la trayectoria en el marco del mundo de un punto del marco del cuerpo transportado por la geometría rígida en movimiento. El punto se expresa en el marco local de la forma de referencia y la pose variable en el tiempo se le aplica en cada instante.</para>
-				<para><varname>bodyPointTrajectory(trgeometry, geometry) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+bodyPointTrajectory(trgeometry, geometry) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(bodyPointTrajectory(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -398,8 +438,10 @@ SELECT asText(bodyPointTrajectory(
 				<indexterm significance="normal"><primary><varname>length</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cumulativeLength</varname></primary></indexterm>
 				<para>Devuelve la longitud total recorrida por el centroide, o su longitud acumulada a lo largo del tiempo</para>
-				<para><varname>length(trgeometry) → float</varname></para>
-				<para><varname>cumulativeLength(trgeometry) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+length(trgeometry) → float
+cumulativeLength(trgeometry) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
   Pose(Point(3 4),0)@2001-01-02]');
@@ -410,7 +452,9 @@ SELECT length(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@200
 			<listitem xml:id="trgeometry_speed">
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Devuelve la velocidad del centroide como un flotante temporal</para>
-				<para><varname>speed(trgeometry) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+speed(trgeometry) → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT speed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
@@ -421,7 +465,9 @@ SELECT speed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_angular_speed">
 				<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
 				<para>Devuelve la velocidad angular como un flotante temporal</para>
-				<para><varname>angularSpeed(trgeometry) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+angularSpeed(trgeometry) → tfloat
+</programlisting>
 				<para>La forma de una geometría rígida nunca cambia, por lo que su velocidad angular es la de la pose que la lleva, en radianes por unidad de tiempo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(angularSpeed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
@@ -433,7 +479,9 @@ SELECT asText(angularSpeed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_twcentroid">
 				<indexterm significance="normal"><primary><varname>twCentroid</varname></primary></indexterm>
 				<para>Devuelve el centroide ponderado en el tiempo de la trayectoria del centroide como una geometría</para>
-				<para><varname>twCentroid(trgeometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+twCentroid(trgeometry) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(twCentroid(trgeometry
   'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -453,7 +501,9 @@ SELECT ST_AsText(twCentroid(trgeometry
 			<listitem xml:id="trgeometry_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Redondear todos los componentes numéricos a un número dado de posiciones decimales</para>
-				<para><varname>round(trgeometry, integer) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(trgeometry, integer) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1.123456789 1.123456789),
@@ -466,7 +516,9 @@ SELECT asText(round(
 			<listitem xml:id="trgeometry_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Convertir entre interpolaciones lineal y escalonada</para>
-				<para><varname>setInterp(trgeometry, text) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(trgeometry, text) → trgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(setInterp(trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 'linear'));
@@ -481,9 +533,11 @@ SELECT asText(setInterp(trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Desplazar, escalar, o desplazar y escalar el dominio temporal de una trgeometry</para>
-				<para><varname>shiftTime(trgeometry, interval) → trgeometry</varname></para>
-				<para><varname>scaleTime(trgeometry, interval) → trgeometry</varname></para>
-				<para><varname>shiftScaleTime(trgeometry, interval, interval) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftTime(trgeometry, interval) → trgeometry
+scaleTime(trgeometry, interval) → trgeometry
+shiftScaleTime(trgeometry, interval, interval) → trgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(shiftTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),
@@ -515,8 +569,10 @@ SELECT asText(shiftScaleTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restringir una trgeometry a (el complemento de) una geometría</para>
-				<para><varname>atGeometry(trgeometry, geometry) → trgeometry</varname></para>
-				<para><varname>minusGeometry(trgeometry, geometry) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(trgeometry, geometry) → trgeometry
+minusGeometry(trgeometry, geometry) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT temporalTime(atGeometry(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
@@ -537,8 +593,10 @@ SELECT temporalTime(minusGeometry(
 				<indexterm significance="normal"><primary><varname>atStbox</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusStbox</varname></primary></indexterm>
 				<para>Restringir una trgeometry a (el complemento de) una caja espaciotemporal</para>
-				<para><varname>atStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry</varname></para>
-				<para><varname>minusStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry
+minusStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT temporalTime(atStbox(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
@@ -559,8 +617,10 @@ SELECT temporalTime(atStbox(
 				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
 				<para>Restringir una trgeometry al (complemento de) un span de elevación</para>
-				<para><varname>atElevation(trgeometry, floatspan) → trgeometry</varname></para>
-				<para><varname>minusElevation(trgeometry, floatspan) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atElevation(trgeometry, floatspan) → trgeometry
+minusElevation(trgeometry, floatspan) → trgeometry
+</programlisting>
 				<para>La elevación es la de la posición de la pose, no la del cuerpo: un cuerpo se extiende por encima y por debajo de su posición, y el span se evalúa únicamente sobre la posición. La geometría de referencia se conserva en el resultado. La geometría rígida temporal debe tener dimensión Z.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atElevation(
@@ -591,8 +651,10 @@ SELECT getTime(minusElevation(
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>
 				<para>Devuelve la distancia temporal entre dos geometrías rígidas temporales</para>
-				<para><varname>{geometry,trgeometry} &lt;-&gt; {geometry,trgeometry} → tfloat</varname></para>
-				<para><varname>tDistance({geometry,trgeometry}, {geometry,trgeometry}) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geometry,trgeometry} &lt;-&gt; {geometry,trgeometry} → tfloat
+tDistance({geometry,trgeometry}, {geometry,trgeometry}) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(maxValue(tDistance(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0), 0.0)@2001-01-01',
@@ -613,8 +675,10 @@ SELECT asText(tDistance(
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 				<para>Devuelve la distancia más pequeña entre dos geometrías rígidas temporales sobre su dominio temporal compartido</para>
-				<para><varname>{geometry,trgeometry,stbox} |=| {geometry,trgeometry,stbox} → float</varname></para>
-				<para><varname>nearestApproachDistance({geometry,trgeometry,stbox}, {geometry,trgeometry,stbox}) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geometry,trgeometry,stbox} |=| {geometry,trgeometry,stbox} → float
+nearestApproachDistance({geometry,trgeometry,stbox}, {geometry,trgeometry,stbox}) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
   Pose(Point(10 0), 0.0)@2001-01-02]'
@@ -629,7 +693,9 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01
 			<listitem xml:id="trgeometry_nai">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Devuelve el instante en el que los dos argumentos están a su menor distancia mutua</para>
-				<para><varname>nearestApproachInstant({geometry,trgeometry}, {geometry,trgeometry}) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geometry,trgeometry}, {geometry,trgeometry}) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(nearestApproachInstant(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
@@ -642,7 +708,9 @@ SELECT asText(nearestApproachInstant(
 			<listitem xml:id="trgeometry_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Devuelve la línea que conecta los dos argumentos en su aproximación más cercana</para>
-				<para><varname>shortestLine({geometry,trgeometry}, {geometry,trgeometry}) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geometry,trgeometry}, {geometry,trgeometry}) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0), 0.0)@2001-01-01',
@@ -664,9 +732,11 @@ SELECT ST_AsText(shortestLine(
 				<indexterm significance="normal"><primary><varname>frechetDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dynTimeWarpDistance</varname></primary></indexterm>
 				<para>Devuelve la distancia de Hausdorff discreta, la distancia de Fréchet discreta, o la distancia de deformación dinámica del tiempo (Dynamic Time Warp) entre dos geometrías rígidas temporales</para>
-				<para><varname>hausdorffDistance(trgeometry, trgeometry) → float</varname></para>
-				<para><varname>frechetDistance(trgeometry, trgeometry) → float</varname></para>
-				<para><varname>dynTimeWarpDistance(trgeometry, trgeometry) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+hausdorffDistance(trgeometry, trgeometry) → float
+frechetDistance(trgeometry, trgeometry) → float
+dynTimeWarpDistance(trgeometry, trgeometry) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(frechetDistance(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2000-01-01,
@@ -687,8 +757,10 @@ SELECT round(hausdorffDistance(
 				<indexterm significance="normal"><primary><varname>frechetDistancePath</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dynTimeWarpPath</varname></primary></indexterm>
 				<para>Devuelve los pares de correspondencia entre dos geometrías rígidas temporales con respecto a la distancia de Fréchet discreta o a la distancia de deformación dinámica del tiempo (Dynamic Time Warp), como un conjunto de pares de índices de instante <varname>(i,j)</varname></para>
-				<para><varname>frechetDistancePath(trgeometry, trgeometry) → {(i,j)}</varname></para>
-				<para><varname>dynTimeWarpPath(trgeometry, trgeometry) → {(i,j)}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+frechetDistancePath(trgeometry, trgeometry) → {(i,j)}
+dynTimeWarpPath(trgeometry, trgeometry) → {(i,j)}
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT frechetDistancePath(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
@@ -719,8 +791,10 @@ SELECT dynTimeWarpPath(
 				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
 				<para>Probar la (des)igualdad exacta de dos geometrías rígidas temporales</para>
-				<para><varname>trgeometry = trgeometry → boolean</varname></para>
-				<para><varname>trgeometry &lt;&gt; trgeometry → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trgeometry = trgeometry → boolean
+trgeometry &lt;&gt; trgeometry → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),
@@ -739,8 +813,10 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
 				<para>Probar si la geometría materializada es alguna vez (no) igual al operando en algún momento</para>
-				<para><varname>{geometry,trgeometry} ?= {geometry,trgeometry} → boolean</varname></para>
-				<para><varname>{geometry,trgeometry} ?&lt;&gt; {geometry,trgeometry} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geometry,trgeometry} ?= {geometry,trgeometry} → boolean
+{geometry,trgeometry} ?&lt;&gt; {geometry,trgeometry} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
   Pose(Point(5 0), 0.0)@2001-01-02]'
@@ -753,8 +829,10 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%&lt;&gt;</varname></primary></indexterm>
 				<para>Probar si la geometría materializada es siempre (no) igual al operando</para>
-				<para><varname>{geometry,trgeometry} %= {geometry,trgeometry} → boolean</varname></para>
-				<para><varname>{geometry,trgeometry} %&lt;&gt; {geometry,trgeometry} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geometry,trgeometry} %= {geometry,trgeometry} → boolean
+{geometry,trgeometry} %&lt;&gt; {geometry,trgeometry} → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),
@@ -830,9 +908,16 @@ SELECT trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
 				<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spaceTimeBoxes</varname></primary></indexterm>
 				<para>Devuelve las cajas espaciotemporales de una geometría rígida temporal dividida con respecto a una cuadrícula espacial, temporal o espaciotemporal</para>
-				<para><varname>spaceBoxes(trgeometry, xsize float [, ysize float [, zsize float]], sorigin geometry = 'Point(0 0 0)', bitmatrix boolean = true, borderInc boolean = true) → stbox[]</varname></para>
-				<para><varname>timeBoxes(trgeometry, interval, torigin timestamptz = '2000-01-03', bitmatrix boolean = true, borderInc boolean = true) → stbox[]</varname></para>
-				<para><varname>spaceTimeBoxes(trgeometry, xsize float [, ysize float [, zsize float]], interval, sorigin geometry = 'Point(0 0 0)', torigin timestamptz = '2000-01-03', bitmatrix boolean = true, borderInc boolean = true) → stbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+spaceBoxes(trgeometry, xsize float [, ysize float [, zsize float]],
+  sorigin geometry = 'Point(0 0 0)', bitmatrix boolean = true,
+  borderInc boolean = true) → stbox[]
+timeBoxes(trgeometry, interval, torigin timestamptz = '2000-01-03',
+  bitmatrix boolean = true, borderInc boolean = true) → stbox[]
+spaceTimeBoxes(trgeometry, xsize float [, ysize float [, zsize float]], interval,
+  sorigin geometry = 'Point(0 0 0)', torigin timestamptz = '2000-01-03',
+  bitmatrix boolean = true, borderInc boolean = true) → stbox[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT array_length(spaceBoxes(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -854,8 +939,10 @@ SELECT array_length(spaceBoxes(
 				<indexterm significance="normal"><primary><varname>stboxes</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
 				<para>Devuelve el arreglo de cajas espaciotemporales o lapsos de tiempo de los segmentos de una geometría rígida temporal</para>
-				<para><varname>stboxes(trgeometry) → stbox[]</varname></para>
-				<para><varname>spans(trgeometry) → tstzspan[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stboxes(trgeometry) → stbox[]
+spans(trgeometry) → tstzspan[]
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stboxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
@@ -872,10 +959,12 @@ SELECT spans(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 				<para>Devuelve las cajas espaciotemporales o los lapsos de tiempo de una geometría rígida temporal dividida en un número dado de contenedores, o con un número dado de segmentos por contenedor</para>
-				<para><varname>splitNStboxes(trgeometry, integer) → stbox[]</varname></para>
-				<para><varname>splitEachNStboxes(trgeometry, integer) → stbox[]</varname></para>
-				<para><varname>splitNSpans(trgeometry, integer) → tstzspan[]</varname></para>
-				<para><varname>splitEachNSpans(trgeometry, integer) → tstzspan[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitNStboxes(trgeometry, integer) → stbox[]
+splitEachNStboxes(trgeometry, integer) → stbox[]
+splitNSpans(trgeometry, integer) → tstzspan[]
+splitEachNSpans(trgeometry, integer) → tstzspan[]
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNStboxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 2);
@@ -895,7 +984,9 @@ SELECT splitNSpans(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Número de geometrías rígidas temporales solapadas en cada instante, equivalente a <varname>tCount</varname> sobre la tpose subyacente</para>
-				<para><varname>tCount(trgeometry) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(trgeometry) → tint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tCount(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
@@ -906,7 +997,9 @@ SELECT tCount(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Caja delimitadora agregada de una columna de geometrías rígidas temporales</para>
-				<para><varname>extent(trgeometry) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(trgeometry) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(temp) FROM tbl_trgeometry;
 </programlisting>
@@ -916,8 +1009,10 @@ SELECT extent(temp) FROM tbl_trgeometry;
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Combinar dos trgeometries con la misma geometría de referencia en un único conjunto de secuencias</para>
-				<para><varname>merge(trgeometry, trgeometry) → trgeometry</varname></para>
-				<para><varname>mergeAgg(trgeometry) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(trgeometry, trgeometry) → trgeometry
+mergeAgg(trgeometry) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,

--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -47,7 +47,9 @@
 			<listitem xml:id="geo_orientedenvelope">
 				<indexterm significance="normal"><primary><varname>orientedEnvelope</varname></primary></indexterm>
 				<para>Devuelve el rectángulo de área mínima que encierra una geometría</para>
-				<para><varname>orientedEnvelope(geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+orientedEnvelope(geometry) → geometry
+</programlisting>
 				<para>El rectángulo se orienta en el ángulo que lo hace más pequeño, que en general no es el ángulo de los ejes. Se devuelve como una línea cuando la geometría está contenida en una y como un punto cuando la geometría es uno. Una geometría que lleva un arco circular se responde sobre el arco mismo: el rectángulo se coloca contra el círculo en el que se encuentra el arco y no contra la cadena de segmentos que lo aproxima.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(round(orientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
@@ -62,7 +64,9 @@ SELECT ST_AsText(round(orientedEnvelope(geometry 'Circularstring(0 0,0.5 0.1,1 0
 			<listitem xml:id="geo_convexhull">
 				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Devuelve la geometría convexa más pequeña que encierra una geometría</para>
-				<para><varname>convexHull(geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+convexHull(geometry) → geometry
+</programlisting>
 				<para>El resultado es un polígono en el que cada esquina es un punto de la geometría, una línea cuando la geometría está contenida en una y un punto cuando la geometría es uno. Una geometría que lleva un arco circular se responde sobre el arco mismo, por lo que la envolvente está delimitada por el arco y se devuelve como una geometría curva y no como un polígono que la aproxima.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(round(convexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
@@ -77,7 +81,9 @@ SELECT ST_AsText(round(convexHull(geometry 'Circularstring(5 0,0 5,-5 0)'), 6));
 			<listitem xml:id="geo_issimple">
 				<indexterm significance="normal"><primary><varname>isSimple</varname></primary></indexterm>
 				<para>Devuelve verdadero si una geometría no tiene ningún punto en el que se cruce o se toque a sí misma</para>
-				<para><varname>isSimple(geometry) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isSimple(geometry) → boolean
+</programlisting>
 				<para>Un punto siempre es simple, un multipunto es simple cuando no repite ningún punto, una línea es simple cuando se encuentra consigo misma solo donde dos de sus segmentos se siguen y, cuando se cierra, en el punto donde se cierra, y una geometría de área es simple cuando cada uno de sus anillos lo es. Además, dos líneas de una multilínea pueden encontrarse en un punto que termina ambas. Una geometría que lleva un arco circular se encuentra consigo misma a lo largo de un arco y no en un punto, lo que la intersección de segmentos en la que esto se basa no lee, por lo que tal geometría se responde sobre la cadena de segmentos que aproxima sus arcos.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isSimple(geometry 'Linestring(0 0,10 10,10 0,0 10)');
@@ -92,7 +98,9 @@ SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(10 0,10 10))');
 			<listitem xml:id="geo_buffer">
 				<indexterm significance="normal"><primary><varname>buffer</varname></primary></indexterm>
 				<para>Devuelve la geometría que contiene todos los puntos situados a una distancia dada de una geometría</para>
-				<para><varname>buffer(geometry,float,options text='') → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+buffer(geometry,float,options text='') → geometry
+</programlisting>
 				<para>La frontera del resultado está formada por los dos desplazamientos de la geometría a la distancia dada, por la unión que rellena el lado exterior de cada giro y por el extremo que cierra cada final de una línea abierta. Una distancia negativa contrae una geometría de área y devuelve una geometría vacía para una de cualquier otra dimensión.</para>
 				<para>La cadena <varname>options</varname> lleva los estilos como pares <varname>clave=valor</varname> separados por espacios: <varname>endcap</varname> es uno de <varname>round</varname>, <varname>flat</varname> o <varname>square</varname>, <varname>join</varname> uno de <varname>round</varname>, <varname>mitre</varname> o <varname>bevel</varname>, y <varname>mitre_limit</varname> la razón a partir de la cual una unión en inglete pasa a ser biselada.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -110,7 +118,9 @@ SELECT ST_AsText(round(buffer(geometry
 			<listitem xml:id="geo_intersection">
 				<indexterm significance="normal"><primary><varname>intersection</varname></primary></indexterm>
 				<para>Devuelve la región que dos geometrías comparten</para>
-				<para><varname>intersection(geometry,geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+intersection(geometry,geometry) → geometry
+</programlisting>
 				<para>Las cuatro operaciones booleanas de esta sección responden sobre los (multi)polígonos que llevan los tipos temporales cuyos valores son regiones, y cada una toma el nombre de la función de PostGIS para la que responde sin el prefijo <varname>ST_</varname>, de modo que una consulta alcanza este motor quitando el prefijo y PostGIS conservándolo. Son planas y bidimensionales: se rechazan una geografía, una dimensión Z y una geometría que no sea un (multi)polígono. Un resultado vacío se responde como <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
@@ -128,7 +138,9 @@ SELECT intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
 			<listitem xml:id="geo_geounion">
 				<indexterm significance="normal"><primary><varname>geoUnion</varname></primary></indexterm>
 				<para>Devuelve la región que dos geometrías cubren en conjunto</para>
-				<para><varname>geoUnion(geometry,geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoUnion(geometry,geometry) → geometry
+</programlisting>
 				<para><varname>UNION</varname> es una palabra reservada de SQL, por lo que esta lleva el nombre del tipo sobre el que responde, como hacen <varname>setUnion</varname> y <varname>spanUnion</varname>. Dos geometrías que no se tocan se responden como un multipolígono.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(geoUnion(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
@@ -140,7 +152,9 @@ SELECT ST_AsText(geoUnion(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
 			<listitem xml:id="geo_difference">
 				<indexterm significance="normal"><primary><varname>difference</varname></primary></indexterm>
 				<para>Devuelve la región de la primera geometría que la segunda no cubre</para>
-				<para><varname>difference(geometry,geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+difference(geometry,geometry) → geometry
+</programlisting>
 				<para>Una segunda geometría situada dentro de la primera deja un agujero en lugar de dividirla.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
@@ -155,7 +169,9 @@ SELECT ST_AsText(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
 			<listitem xml:id="geo_symdifference">
 				<indexterm significance="normal"><primary><varname>symDifference</varname></primary></indexterm>
 				<para>Devuelve la región que cubre exactamente una de dos geometrías</para>
-				<para><varname>symDifference(geometry,geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+symDifference(geometry,geometry) → geometry
+</programlisting>
 				<para>Es la unión de las dos geometrías menos la región que comparten, por lo que una geometría contra sí misma se responde como <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(symDifference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
@@ -221,8 +237,10 @@ SELECT symDifference(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 				<para>Devuelve la representación de texto conocido (Well-Known Text o WKT) o la representación extendida de texto conocido (Extended Well-Known Text o EWKT) &Z_support; &geography_support;</para>
-				<para><varname>asText({tspatial,tspatial[],spatial[]}) → {text,text[]}</varname></para>
-				<para><varname>asEWKT({tspatial,tspatial[],spatial[]}) → {text,text[]}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({tspatial,tspatial[],spatial[]}) → {text,text[]}
+asEWKT({tspatial,tspatial[],spatial[]}) → {text,text[]}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asText(tgeompoint 'SRID=4326;[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02)');
 -- [POINT Z (0 0 0)@2001-01-01, POINT Z (1 1 1)@2001-01-02)
@@ -248,7 +266,9 @@ SELECT asEWKT(ARRAY[geometry 'SRID=5676;Point(0 0)', 'SRID=5676;Point(1 1)']);
 			<listitem xml:id="tspatial_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Devuelve la representación JSON de características móviles (Moving Features JSON o MF-JSON) &Z_support; &geography_support;</para>
-				<para><varname>asMFJSON(tspatial,options=0,flags=0,maxdecdigits=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tspatial,options=0,flags=0,maxdecdigits=15) → text
+</programlisting>
 				<para>El argumento <varname>options</varname> puede usarse para agregar BBOX y/o CRS en la salida MFJSON:</para>
 				<itemizedlist>
 					<listitem><para>0: significa que no hay opción (valor por defecto)</para></listitem>
@@ -287,9 +307,11 @@ SELECT asMFJSON(tgeompoint 'SRID=4326;
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB), la representación extendida binaria conocida (Extended Well-Known Binary o EWKB), o la representación hexadecimal extendida binaria conocida (Extended Well-Known Binary o EWKB) &Z_support; &geography_support;</para>
-				<para><varname>asBinary(tgeo,endian text='') → bytea</varname></para>
-				<para><varname>asEWKB(tgeo,endian text='') → bytea</varname></para>
-				<para><varname>asHexEWKB(tgeo,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(tgeo,endian text='') → bytea
+asEWKB(tgeo,endian text='') → bytea
+asHexEWKB(tgeo,endian text='') → text
+</programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asBinary(tgeompoint 'Point(1 2 3)@2001-01-01');
@@ -305,8 +327,10 @@ SELECT asHexEWKB(tgeompoint 'SRID=3812;Point(1 2 3)@2001-01-01');
 				<indexterm significance="normal"><primary><varname>tspatialFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tspatialFromEWKT</varname></primary></indexterm>
 				<para>Entrar a partir de la representación de texto conocido (Well-Known Text o WKT) o de la representación extendida de texto conocido (Extended Well-Known Text o EWKT) &Z_support; &geography_support;</para>
-				<para><varname>tspatialFromText(text) → tspatial</varname></para>
-				<para><varname>tspatialFromEWKT(text) → tspatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tspatialFromText(text) → tspatial
+tspatialFromEWKT(text) → tspatial
+</programlisting>
 				<para>En las funciones anteriores, <varname>tspatial</varname> reemplaza cualquier tipo espacial, como <varname>tgeompoint</varname>, <varname>tgeometry</varname> o <varname>tpose</varname></para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asEWKT(tgeompointFromText(text '[POINT(1 2)@2001-01-01, POINT(3 4)@2001-01-02]'));
@@ -328,7 +352,9 @@ SELECT asEWKT(tgeographyFromEWKT(text 'SRID=7844;[Point(1 2)@2001-01-01,
 			<listitem xml:id="tspatialFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tspatialFromMFJSON</varname></primary></indexterm>
 				<para>Entrar a partir de la representación JSON de características móviles (Moving Features JSON o MF-JSON) &Z_support; &geography_support;</para>
-				<para><varname>tspatialFromMFJSON(text) → spatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tspatialFromMFJSON(text) → spatial
+</programlisting>
 				<para>En la funcion anterior, <varname>tspatial</varname> reemplaza cualquier tipo espacial, como <varname>tgeompoint</varname>, <varname>tgeometry</varname> o <varname>tpose</varname></para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asEWKT(tgeompointFromMFJSON(text '{"type":"MovingPoint","crs":{"type":"name",
@@ -352,9 +378,11 @@ SELECT asEWKT(tgeographyFromMFJSON(text '{"type":"MovingGeometry",
 				<indexterm significance="normal"><primary><varname>tspatialFromEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tspatialFromHexEWKB</varname></primary></indexterm>
 				<para>Entrar a partir de su representación binaria conocida (WKB), de la representación extendida binaria conocida (EWKB), o de la representación hexadecimal extendida binaria conocida (HexEWKB) &Z_support; &geography_support;</para>
-				<para><varname>tspatialFromBinary(bytea) → tspatial</varname></para>
-				<para><varname>tspatialFromEWKB(bytea) → tspatial</varname></para>
-				<para><varname>tspatialFromHexEWKB(text) → tspatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tspatialFromBinary(bytea) → tspatial
+tspatialFromEWKB(bytea) → tspatial
+tspatialFromHexEWKB(text) → tspatial
+</programlisting>
 				<para>En las funciones anteriores, <varname>tspatial</varname> reemplaza cualquier tipo espacial, como <varname>tgeompoint</varname>, <varname>tgeometry</varname> o <varname>tpose</varname></para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asEWKT(tgeompointFromBinary(
@@ -378,8 +406,10 @@ SELECT asEWKT(tgeompointFromHexEWKB(
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stbox(tspatial)</varname></primary></indexterm>
 				<para>Convertir un valor espaciotemporal a un rango temporal o a un cuadro delimitador espaciotemporal</para>
-				<para><varname>tspatial::stbox</varname></para>
-				<para><varname>stbox(tspatial)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tspatial::stbox
+stbox(tspatial)
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]'::tstzspan;
 -- [2001-01-01, 2001-01-03]
@@ -393,10 +423,12 @@ SELECT tgeography '[Point(1 1 1)@2001-01-01, Point(3 3 3)@2001-01-03]'::stbox;
 			<listitem xml:id="tgeometry_tgeography">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir entre una geometría temporal y una geografía temporal</para>
-				<para><varname>tgeometry::tgeography</varname></para>
-				<para><varname>tgeography::tgeometry</varname></para>
-				<para><varname>tgeompoint::tgeogpoint</varname></para>
-				<para><varname>tgeogpoint::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tgeometry::tgeography
+tgeography::tgeometry
+tgeompoint::tgeogpoint
+tgeogpoint::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asText((tgeompoint '[Point(0 0)@2001-01-01, Point(0 1)@2001-01-02)')::tgeogpoint);
 -- [POINT(0 0)@2001-01-01, POINT(0 1)@2001-01-02)
@@ -414,8 +446,10 @@ SELECT asText((tgeography 'Linestring(0 0,1 1)@2001-01-01')::tgeometry);
 			<listitem xml:id="tgeompoint_geometry">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir entre un punto temporal y una trayectoria PostGIS</para>
-				<para><varname>tpoint::geo</varname></para>
-				<para><varname>geo::tpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpoint::geo
+geo::tpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT ST_AsText((tgeompoint 'Point(0 0)@2001-01-01')::geometry);
 -- POINT M (0 0 978307200)
@@ -455,8 +489,10 @@ SELECT asText(geometry 'GEOMETRYCOLLECTION M (LINESTRING M (0 0 978307200,1 1 97
 				<indexterm significance="normal"><primary><varname>trajectory</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
 				<para>Obtenir la trayectoria o el área atravesada &Z_support; &geography_support;</para>
-				<para><varname>trajectory(tpoint,unary_union=false) → geo</varname></para>
-				<para><varname>traversedArea(tgeo,unary_union=false) → geo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trajectory(tpoint,unary_union=false) → geo
+traversedArea(tgeo,unary_union=false) → geo
+</programlisting>
 				<para>Esta función es equivalente a <link linkend="ttype_getValues"><varname>getValues</varname></link> para los valores temporales alphanuméricos. El último argumento indica si se aplica la función PostGIS <ulink url="https://postgis.net/docs/ST_UnaryUnion.html">ST_UnaryUnion</ulink> para eliminar geometrías redundantes en el resultado. Tenga en cuenta que establecer este argumento como verdadero implica un alto consumo computacional.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(trajectory(tgeompoint '[Point(0 0)@2001-01-01, Point(0 1)@2001-01-02,
@@ -485,7 +521,9 @@ SELECT ST_AsText(traversedArea(tgeometry '[Point(1 1)@2001-01-01,
 			<listitem xml:id="tgeo_centroid">
 				<indexterm significance="normal"><primary><varname>centroid</varname></primary></indexterm>
 				<para>Devuelve el centroide como un punto temporal &geography_support;</para>
-				<para><varname>centroid(tgeo) → tpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+centroid(tgeo) → tpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(centroid(tgeometry '[Point(1 1)@2000-01-01, Linestring(1 1,3 3)@2000-01-02,
   Polygon((1 1,4 4,7 1,1 1))@2000-01-03]'));
@@ -501,9 +539,11 @@ SELECT asText(centroid(tgeography '[MultiPoint(1 1,4 4,7 1)@2000-01-01,
 				<indexterm significance="normal"><primary><varname>getY</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>getZ</varname></primary></indexterm>
 				<para>Devuelve los valores de las coordenadas X/Y/Z como un número flotante temporal &Z_support; &geography_support;</para>
-				<para><varname>getX(tpoint) → tfloat</varname></para>
-				<para><varname>getY(tpoint) → tfloat</varname></para>
-				<para><varname>getZ(tpoint) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getX(tpoint) → tfloat
+getY(tpoint) → tfloat
+getZ(tpoint) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT getX(tgeompoint '{Point(1 2)@2001-01-01, Point(3 4)@2001-01-02,
   Point(5 6)@2001-01-03}');
@@ -529,7 +569,9 @@ SELECT getZ(tgeogpoint 'Interp=Step;[Point(1 2 3)@2001-01-01, Point(4 5 6)@2001-
 			<listitem xml:id="tgeo_isSimple">
 				<indexterm significance="normal"><primary><varname>isSimple</varname></primary></indexterm>
 				<para>Devuelve verdadero si el punto temporal no se auto-intersecta espacialmente &Z_support;</para>
-				<para><varname>isSimple(tpoint) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isSimple(tpoint) → boolean
+</programlisting>
 				<para>Nótese que un punto temporal de conjunto de secuencias es simple si cada una de las secuencias que lo componen es simple.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT isSimple(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
@@ -547,7 +589,9 @@ SELECT isSimple(tgeompoint '{[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02],
 			<listitem xml:id="tgeo_length">
 				<indexterm significance="normal"><primary><varname>length</varname></primary></indexterm>
 				<para>Devuelve la longitud atravesada por el punto temporal &Z_support; &geography_support;</para>
-				<para><varname>length(tpoint) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+length(tpoint) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT length(tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02]');
 -- 1.73205080756888
@@ -563,7 +607,9 @@ SELECT length(tgeompoint 'Interp=Step;[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_cumulativeLength">
 				<indexterm significance="normal"><primary><varname>cumulativeLength</varname></primary></indexterm>
 				<para>Devuelve la longitud acumulada atravesada por el punto temporal &Z_support; &geography_support;</para>
-				<para><varname>cumulativeLength(tpoint) → tfloatSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+cumulativeLength(tpoint) → tfloatSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(cumulativeLength(tgeompoint '{[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(1 0)@2001-01-03], [Point(1 0)@2001-01-04, Point(0 0)@2001-01-05]}'), 6);
@@ -578,7 +624,9 @@ SELECT cumulativeLength(tgeompoint 'Interp=Step;[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_speed">
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Devuelve la velocidad del punto temporal en unidades por segundo &Z_support; &geography_support;</para>
-				<para><varname>speed(tpoint) → tfloatSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+speed(tpoint) → tfloatSeqSet
+</programlisting>
 				<para>El punto temporal debe tener interpolación linear</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT speed(tgeompoint '{[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
@@ -593,7 +641,9 @@ SELECT speed(tgeompoint 'Interp=Step;[Point(0 0)@2001-01-01, Point(1 1)@2001-01-
 			<listitem xml:id="tgeo_twCentroid">
 				<indexterm significance="normal"><primary><varname>twCentroid</varname></primary></indexterm>
 				<para>Devuelve el centroide ponderado en el tiempo &Z_support;</para>
-				<para><varname>twCentroid(tgeompoint) → point</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+twCentroid(tgeompoint) → point
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(twCentroid(tgeompoint '{[Point(0 0 0)@2001-01-01,
   Point(0 1 1)@2001-01-02, Point(0 1 1)@2001-01-03, Point(0 0 0)@2001-01-04)}'));
@@ -604,7 +654,9 @@ SELECT ST_AsText(twCentroid(tgeompoint '{[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_direction">
 				<indexterm significance="normal"><primary><varname>direction</varname></primary></indexterm>
 				<para>Devuelve la dirección, es decir, el acimut entre las ubicaciones inicial y final &Z_support; &geography_support;</para>
-				<para><varname>direction(tpoint) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+direction(tpoint) → float
+</programlisting>
 				<para>El resultado se expresa en radianes. Es NULL si solo hay una ubicación o si las ubicaciones inicial y final son iguales.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(degrees(direction(tgeompoint '[Point(0 0)@2001-01-01,
@@ -619,7 +671,9 @@ SELECT direction(tgeompoint '{[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_azimuth">
 				<indexterm significance="normal"><primary><varname>azimuth</varname></primary></indexterm>
 				<para>Devuelve el acimut temporal &Z_support; &geography_support;</para>
-				<para><varname>azimuth(tpoint) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+azimuth(tpoint) → tfloat
+</programlisting>
 				<para>El resultado se expresa en radianes. El azimut es indefinido cuando dos localizaciones sucesivas son iguales y en este caso se añade una brecha de tempo.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(degrees(azimuth(tgeompoint '[Point(0 0 0)@2001-01-01,
@@ -631,7 +685,9 @@ SELECT round(degrees(azimuth(tgeompoint '[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_angularDifference">
 				<indexterm significance="normal"><primary><varname>angularDifference</varname></primary></indexterm>
 				<para>Devuelve la diferencia angular temporal &geography_support;</para>
-				<para><varname>angularDifference(tpoint) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+angularDifference(tpoint) → tfloat
+</programlisting>
 				<para>El resultado se expresa en grados.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT round(angularDifference(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02,
@@ -646,7 +702,9 @@ SELECT round(degrees(angularDifference(tgeompoint '{[Point(1 1)@2001-01-01,
 			<listitem xml:id="tgeo_bearing">
 				<indexterm significance="normal"><primary><varname>bearing</varname></primary></indexterm>
 				<para>Devuelve el rumbo temporal &Z_support; &geography_support;</para>
-				<para><varname>bearing({tpoint,point},{tpoint,point}) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+bearing({tpoint,point},{tpoint,point}) → tfloat
+</programlisting>
 				<para>Nótese que esta función no acepta dos puntos geográficos temporales.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT degrees(bearing(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]',
@@ -669,7 +727,9 @@ SELECT round(degrees(bearing(tgeompoint '[Point(2 1)@2001-01-01, Point(0 1)@2001
 			<listitem xml:id="tspatial_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Redondear los valores de las coordenadas a un número de decimales &Z_support; &geography_support;</para>
-				<para><varname>round(tspatial,integer=0) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tspatial,integer=0) → tgeo
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asText(round(tgeompoint '{Point(1.12345 1.12345 1.12345)@2001-01-01,
   Point(2 2 2)@2001-01-02, Point(1.12345 1.12345 1.12345)@2001-01-03}', 2));
@@ -684,7 +744,9 @@ SELECT asText(round(tgeography 'Linestring(1.12345 1.12345,2.12345 2.12345)@2001
 			<listitem xml:id="tpoint_makeSimple">
 				<indexterm significance="normal"><primary><varname>makeSimple</varname></primary></indexterm>
 				<para>Devuelve una matriz de fragmentos del punto temporal que son simples &Z_support;</para>
-				<para><varname>makeSimple(tpoint) → tgeompoint[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+makeSimple(tpoint) → tgeompoint[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asText(makeSimple(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(0 0)@2001-01-03]'));
@@ -708,7 +770,9 @@ SELECT asText(makeSimple(tgeompoint '{[Point(0 0 0)@2001-01-01, Point(1 1 1)@200
 			<listitem xml:id="tgeo_geoMeasure">
 				<indexterm significance="normal"><primary><varname>geoMeasure</varname></primary></indexterm>
 				<para>Construir una geometría/geografía con medida M a partir de un punto temporal y un número flotante temporal &Z_support; &geography_support;</para>
-				<para><varname>geoMeasure(tpoint,tfloat,segmentize=false) → geo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoMeasure(tpoint,tfloat,segmentize=false) → geo
+</programlisting>
 				<para>El último argumento <varname>segmentize</varname> establece si el valor resultado ya sea es un <varname>Linestring M</varname> o un <varname>MultiLinestring M</varname> donde cada componente es un segmento de dos puntos.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT ST_AsText(geoMeasure(tgeompoint '{Point(1 1 1)@2001-01-01,
@@ -750,9 +814,11 @@ ramp_color('RdYlBu', scale_linear(
 			<listitem xml:id="tgeo_affine">
 				<indexterm significance="normal"><primary><varname>affine</varname></primary></indexterm>
 				<para>Devuelve la transformación afín 3D de una geometría temporal para traducirla, rotarla y/o escalarla en un solo paso &Z_support;</para>
-				<para><varname>affine(tgeo,float a,float b,float c,float d,float e,float f,float g,</varname></para>
-				<para><varname>  float h,float i,float xoff,float yoff,float zoff) → tgeo</varname></para>
-				<para><varname>affine(tgeo,float a,float b,float d,float e,float xoff,float yoff) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+affine(tgeo,float a,float b,float c,float d,float e,float f,float g,
+  float h,float i,float xoff,float yoff,float zoff) → tgeo
+affine(tgeo,float a,float b,float d,float e,float xoff,float yoff) → tgeo
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 -- Rotate a 3D temporal point 180 degrees about the z axis
 SELECT asEWKT(affine(temp, cos(pi()), -sin(pi()), 0, sin(pi()), cos(pi()), 0, 0, 0, 1,
@@ -774,9 +840,11 @@ FROM (SELECT tgeometry '[Point(1 1)@2001-01-01,
 			<listitem xml:id="tgeo_rotate">
 				<indexterm significance="normal"><primary><varname>rotate</varname></primary></indexterm>
 				<para>Devuelve el punto temporal rotado en sentido antihorario sobre el punto de origen</para>
-				<para><varname>rotate(tgeo,float radians) → tgeo</varname></para>
-				<para><varname>rotate(tgeo,float radians,float x0,float y0) → tgeo</varname></para>
-				<para><varname>rotate(tgeo,float radians,geometry pointOrigin) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rotate(tgeo,float radians) → tgeo
+rotate(tgeo,float radians,float x0,float y0) → tgeo
+rotate(tgeo,float radians,geometry pointOrigin) → tgeo
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 -- Rotate a temporal point 180 degrees
 SELECT asEWKT(rotate(tgeompoint '[Point(5 10)@2001-01-01, Point(5 5)@2001-01-02, 
@@ -798,10 +866,12 @@ FROM (SELECT tgeometry '[Point(5 10)@2001-01-01, Point(5 5)@2001-01-02,
 			<listitem xml:id="tgeo_scale">
 				<indexterm significance="normal"><primary><varname>scale</varname></primary></indexterm>
 				<para>Devuelve un punto temporal escalado por factores dados &Z_support;</para>
-				<para><varname>scale(tgeo,float Xfactor,float Yfactor,float Zfactor) → tgeo</varname></para>
-				<para><varname>scale(tgeo,float Xfactor,float Yfactor) → tgeo</varname></para>
-				<para><varname>scale(tgeo,geometry factor) → tgeo</varname></para>
-				<para><varname>scale(tgeo,geometry factor,geometry origin) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+scale(tgeo,float Xfactor,float Yfactor,float Zfactor) → tgeo
+scale(tgeo,float Xfactor,float Yfactor) → tgeo
+scale(tgeo,geometry factor) → tgeo
+scale(tgeo,geometry factor,geometry origin) → tgeo
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asEWKT(scale(tgeompoint '[Point(1 2 3)@2001-01-01, Point(1 1 1)@2001-01-02]', 
   0.5, 0.75, 0.8));
@@ -821,7 +891,9 @@ SELECT asEWKT(scale(tgeometry '[Point(1 1)@2001-01-01, Linestring(1 1,2 2)@2001-
 			<listitem xml:id="tpoint_asMVTGeom">
 				<indexterm significance="normal"><primary><varname>asMVTGeom</varname></primary></indexterm>
 				<para>Transformar un punto geométrico temporal en el espacio de coordenadas de un Mapbox Vector Tile &Z_support;</para>
-				<para><varname>asMVTGeom(tpoint,bounds,extent=4096,buffer=256,clip=true) → (geom,times)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMVTGeom(tpoint,bounds,extent=4096,buffer=256,clip=true) → (geom,times)
+</programlisting>
 				<para>El resultado es un par compuesto de un valor <varname>geometry</varname> y una matriz de valores de marca de tiempo asociados codificados como época de Unix. Los parámetros son los siguientes:</para>
 				<itemizedlist>
 					<listitem><para><varname>tpoint</varname> es el punto temporal para transformar</para></listitem>
@@ -845,7 +917,9 @@ FROM (SELECT asMVTGeom(tgeompoint '[Point(0 0)@2001-01-01, Point(100 100)@2001-0
 			<listitem xml:id="tgeo_stops">
 				<indexterm significance="normal"><primary><varname>stops</varname></primary></indexterm>
 				<para>Extraer de un punto temporal con interpolación lineal las subsecuencias donde el punto permanece dentro de un área con un tamaño máximo especificado durante al menos la duración dada &Z_support; &geography_support;</para>
-				<para><varname>stops(tpoint,maxDist=0.0,minDuration='0 minutes') → tpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stops(tpoint,maxDist=0.0,minDuration='0 minutes') → tpoint
+</programlisting>
 				<para>El tamaño del área es la mayor distancia entre dos puntos de la subsecuencia, que es la cantidad que la forma de flotante temporal de la función lee como la diferencia entre el mayor y el menor valor que toma. Si no se especifica <varname>maxDist</varname>, se asume 0.0 y, por lo tanto, la función extrae los segmentos constantes del punto temporal dado. La distancia se calcula en las unidades del sistema de coordenadas para un <varname>tgeompoint</varname> y en metros sobre el esferoide WGS84 para un <varname>tgeogpoint</varname>. Tenga en cuenta que, aunque la función acepta geometrías 3D, el cálculo siempre se realiza en 2D.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(stops(tgeompoint '[Point(1 1)@2001-01-01, Point(1 1)@2001-01-02,

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -17,8 +17,10 @@
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restringir a (al complemento de) una geometría &Z_support;</para>
-				<para><varname>atGeometry(tgeom,geometry) → tgeom</varname></para>
-				<para><varname>minusGeometry(tgeom,geometry]) → tgeom</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tgeom,geometry) → tgeom
+minusGeometry(tgeom,geometry]) → tgeom
+</programlisting>
 				<para>La geometría debe ser 2D y el cálculo con respecto a ella se realiza en 2D. El resultado conserva la dimensión Z del punto temporal, si existe.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atGeometry(tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)',
@@ -56,8 +58,10 @@ SELECT asText(minusGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01',
 				<indexterm significance="normal"><primary><varname>atStbox</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusStbox</varname></primary></indexterm>
 				<para>Restringir a (al complemento de) un <varname>stbox</varname> &Z_support;</para>
-				<para><varname>atStbox(tgeom,stbox,borderInc boolean=true) → tgeompoint</varname></para>
-				<para><varname>minusStbox(tgeom,stbox,borderInc boolean=true) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atStbox(tgeom,stbox,borderInc boolean=true) → tgeompoint
+minusStbox(tgeom,stbox,borderInc boolean=true) → tgeompoint
+</programlisting>
 				<para>El tercer argumento opcional se utiliza para mosaicos multidimensionales (ver <xref linkend="ttype_tiling"/>) para excluir el borde superior de los mosaicos cuando un valor temporal se divide en varios mosaicos, de modo que todos los fragmentos de la geometría temporal sean exclusivos.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atStbox(tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)',
@@ -92,8 +96,10 @@ SELECT asText(minusStbox(tgeometry '[Point(1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
 				<para>Restringir a (al complemento de) un rango de altitud &Z_support;</para>
-				<para><varname>atElevation(tgeom,zspan) → tgeom</varname></para>
-				<para><varname>minusElevation(tgeom,zspan) → tgeom</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atElevation(tgeom,zspan) → tgeom
+minusElevation(tgeom,zspan) → tgeom
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT astext(atElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
   Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
@@ -116,8 +122,10 @@ SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Devuelve o establece el identificador de referencia espacial &Z_support; &geography_support;</para>
-				<para><varname>SRID(tgeo) → integer</varname></para>
-				<para><varname>setSRID(tgeo) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(tgeo) → integer
+setSRID(tgeo) → tgeo
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT SRID(tgeompoint 'Point(0 0)@2001-01-01');
 -- 0
@@ -130,8 +138,10 @@ SELECT asEWKT(setSRID(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02)
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transformar a una referencia espacial diferente &Z_support; &geography_support;</para>
-				<para><varname>transform(tgeo,to_srid integer) → tgeo</varname></para>
-				<para><varname>transformPipeline(tgeo,pipeline text,to_srid integer,is_forward boolean=true) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(tgeo,to_srid integer) → tgeo
+transformPipeline(tgeo,pipeline text,to_srid integer,is_forward boolean=true) → tgeo
+</programlisting>
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el punto temporal tiene un SRID desconocido (representado por 0).</para>
 				<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
@@ -162,7 +172,9 @@ FROM test;
 			<listitem xml:id="tpoint_expandSpace">
 				<indexterm significance="normal"><primary><varname>expandSpace</varname></primary></indexterm>
 				<para>Devuelve el cuadro delimitador espaciotemporal expandido en la dimensión espacial por un valor flotante &Z_support; &geography_support;</para>
-				<para><varname>expandSpace({geo,tgeo},float) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+expandSpace({geo,tgeo},float) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT expandSpace(geography 'Linestring(0 0,1 1)', 2);
 -- SRID=4326;GEODSTBOX X((-2,-2),(3,3))
@@ -180,7 +192,9 @@ SELECT expandSpace(tgeompoint 'Point(0 0)@2001-01-01', 2);
 			<listitem xml:id="tgeo_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Devuelve la distancia más pequeña que haya existido &Z_support; &geography_support;</para>
-				<para><varname>{geo,tgeo,stbox} |=| {geo,tgeo,stbox} → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,tgeo,stbox} |=| {geo,tgeo,stbox} → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tgeompoint '[Point(0 0)@2001-01-02, Point(1 1)@2001-01-04, Point(0 0)@2001-01-06)'
   |=| geometry 'Linestring(2 2,2 1,3 1)';
@@ -211,7 +225,9 @@ SELECT ST_DistanceCPA(
 			<listitem xml:id="tgeo_nearestApproachInstant">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Devuelve el instante del primer punto temporal en el que los dos argumentos están a la distancia más cercana &Z_support; &geography_support;</para>
-				<para><varname>nearestApproachInstant({geo,tgeo},{geo,tgeo}) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geo,tgeo},{geo,tgeo}) → tgeo
+</programlisting>
 				<para>La función sólo devuelve el primer instante que encuentre si hay más de uno. El instante resultante puede tener un límite exclusivo.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asText(nearestApproachInstant(tgeompoint '(Point(1 1)@2001-01-01,
@@ -242,8 +258,10 @@ SELECT to_timestamp(ST_ClosestPointOfApproach(
 			<listitem xml:id="tgeo_minDistance">
 				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
 				<para>Devuelve la distancia espacial mínima entre dos geometrías temporales sobre la unión de sus extensiones temporales</para>
-				<para><varname>minDistance({tgeo,geo},{tgeo,geo}) → float</varname></para>
-				<para><varname>minDistance(tgeo[],tgeo[]) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minDistance({tgeo,geo},{tgeo,geo}) → float
+minDistance(tgeo[],tgeo[]) → float
+</programlisting>
 				<para><varname>minDistance(tgeo,tgeo) → float</varname> (agregado)</para>
 				<para>La forma escalar devuelve la distancia mínima alcanzada entre los dos argumentos sobre la intersección de sus extensiones temporales, equivalente al valor mínimo de la distancia temporal <varname>&lt;-&gt;</varname>. La forma de arreglo generaliza esto a dos conjuntos de geometrías temporales y devuelve el mínimo sobre todos los pares. La forma de agregado, utilizada con <varname>GROUP BY</varname>, devuelve la distancia mínima alcanzada sobre todos los pares agregados en el grupo.</para>
 				<programlisting language="sql" xml:space="preserve">
@@ -277,18 +295,20 @@ GROUP BY g;
 				<indexterm significance="normal"><primary><varname>aTouchesPairs</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouchesPairs</varname></primary></indexterm>
 				<para>Devuelve los pares de índices que cumplen la relación entre dos arreglos de geometrías temporales, generalizando las relaciones espaciales escalares a una unión espacial conjunto-conjunto</para>
-				<para><varname>eDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)</varname></para>
-				<para><varname>aDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)</varname></para>
-				<para><varname>eIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>aIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>eDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>aDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>eTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>aTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>tDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer, periods tstzspanset)</varname></para>
-				<para><varname>tIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer, periods tstzspanset)</varname></para>
-				<para><varname>tDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer, periods tstzspanset)</varname></para>
-				<para><varname>tTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer, periods tstzspanset)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)
+aDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)
+eIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer)
+aIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer)
+eDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)
+aDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)
+eTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer)
+aTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer)
+tDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer, periods tstzspanset)
+tIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer, periods tstzspanset)
+tDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer, periods tstzspanset)
+tTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer, periods tstzspanset)
+</programlisting>
 				<para>Cada función resuelve el producto cruzado podado de los dos arreglos de entrada en una sola llamada y devuelve los índices basados en uno <varname>i</varname> y <varname>j</varname> de los pares que cumplen la relación. Las funciones con prefijo <varname>e</varname> devuelven los pares para los que la relación se cumple alguna vez, las funciones con prefijo <varname>a</varname> los pares para los que se cumple siempre, y las funciones con prefijo <varname>t</varname> devuelven además los períodos durante los cuales se cumple. La caja espaciotemporal de cada entrada se usa como prefiltro de caja envolvente, de modo que la relación exacta se calcula solo sobre los pares candidatos que sobreviven, y los pares cuyas extensiones temporales no se solapan se excluyen, igual que en las relaciones escalares. Las funciones están definidas para puntos temporales y geometrías temporales tanto en el caso planar como en el geodésico, excepto la relación de toca, que está definida solo para geometrías planares. Los índices se relacionan con las identidades originales mediante un <varname>array_agg(identidad ORDER BY ...)</varname> paralelo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT i, j FROM eDwithinPairs(
@@ -310,7 +330,9 @@ SELECT i, j FROM aDisjointPairs(
 			<listitem xml:id="tgeo_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Devuelve la línea que conecta el punto de aproximación más cercano &Z_support; &geography_support;</para>
-				<para><varname>shortestLine({geo,tgeo},{geo,tgeo}) → geo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geo,tgeo},{geo,tgeo}) → geo
+</programlisting>
 				<para>La función sólo devolverá la primera línea que encuentre si hay más de una.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT ST_AsText(shortestLine(tgeompoint '(Point(1 1)@2001-01-01,
@@ -350,7 +372,9 @@ SELECT ST_CPAWithin(
 			<listitem xml:id="tgeo_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Devuelve la distancia temporal &Z_support; &geography_support;</para>
-				<para><varname>{geo,tgeo} &lt;-&gt; {geo,tgeo} → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,tgeo} &lt;-&gt; {geo,tgeo} → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)' &lt;-&gt;
   geometry 'Point(0 1)';
@@ -457,8 +481,10 @@ WHERE eIntersects(T.Trip, R.Geom)
 					<indexterm significance="normal"><primary><varname>eContains</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aContains</varname></primary></indexterm>
 					<para>Contiene alguna vez</para>
-					<para><varname>eContains(geometry,tgeom) → boolean</varname></para>
-					<para><varname>aContains(geometry,tgeom) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eContains(geometry,tgeom) → boolean
+aContains(geometry,tgeom) → boolean
+</programlisting>
 					<para>Esta función devuelve verdadero si el punto temporal está alguna vez en el interior de la geometría. Recuerde que una geometría no contiene cosas en su borde y, por lo tanto, los polígonos y las líneas no contienen líneas y puntos que se encuentran en su borde. Consulte la documentación de la función <ulink url="https://postgis.net/docs/ST_Contains.html">ST_Contains</ulink> en PostGIS.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT eContains(geometry 'Linestring(1 1,3 3)',
@@ -480,8 +506,10 @@ SELECT eContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 					<indexterm significance="normal"><primary><varname>eCovers</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aCovers</varname></primary></indexterm>
 					<para>Ever or always covers</para>
-					<para><varname>eCovers({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
-					<para><varname>aCovers({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eCovers({geometry,tgeom},{geometry,tgeom}) → boolean
+aCovers({geometry,tgeom},{geometry,tgeom}) → boolean
+</programlisting>
 					<para>Please refer to the documentation of the <ulink url="https://postgis.net/docs/ST_Contains.html">ST_Contains</ulink> and the <ulink url="https://postgis.net/docs/ST_Covers.html">ST_Covers</ulink> function in PostGIS for detailed explanations about the difference between the two functions.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eCovers(geometry 'Linestring(1 1,3 3)',
@@ -503,8 +531,10 @@ SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 					<indexterm significance="normal"><primary><varname>eDisjoint</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aDisjoint</varname></primary></indexterm>
 					<para>Está disjunto alguna vez &Z_support; &geography_support;</para>
-					<para><varname>eDisjoint({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
-					<para><varname>aDisjoint({geo,tgeo},{geo,tgeo}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eDisjoint({geometry,tgeom},{geometry,tgeom}) → boolean
+aDisjoint({geo,tgeo},{geo,tgeo}) → boolean
+</programlisting>
 						<programlisting language="sql" xml:space="preserve">
 SELECT eDisjoint(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)');
@@ -519,8 +549,10 @@ SELECT eDisjoint(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 					<indexterm significance="normal"><primary><varname>eDwithin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aDwithin</varname></primary></indexterm>
 					<para>Está alguna vez a distancia de &Z_support; &geography_support;</para>
-					<para><varname>eDwithin({geo,tgeo},{geo,tgeo},float) → boolean</varname></para>
-					<para><varname>aDwithin({geometry,tgeom},{geometry,tgeom},float) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eDwithin({geo,tgeo},{geo,tgeo},float) → boolean
+aDwithin({geometry,tgeom},{geometry,tgeom},float) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT eDwithin(geometry 'Point(1 1 1)',
   tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 0)@2001-01-02]', 1);
@@ -535,8 +567,10 @@ SELECT eDwithin(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 					<indexterm significance="normal"><primary><varname>eIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aIntersects</varname></primary></indexterm>
 					<para>Intersecta alguna vez &Z_support; &geography_support;</para>
-					<para><varname>eIntersects({geo,tgeo},{geo,tgeo}) → boolean</varname></para>
-					<para><varname>aIntersects({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eIntersects({geo,tgeo},{geo,tgeo}) → boolean
+aIntersects({geometry,tgeom},{geometry,tgeom}) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT eIntersects(geometry 'Polygon((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0))',
   tgeompoint '[Point(0 0 1)@2001-01-01, Point(1 1 1)@2001-01-03)');
@@ -551,8 +585,10 @@ SELECT eIntersects(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 					<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 					<para>Toca alguna vez</para>
-					<para><varname>eTouches({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
-					<para><varname>aTouches({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eTouches({geometry,tgeom},{geometry,tgeom}) → boolean
+aTouches({geometry,tgeom},{geometry,tgeom}) → boolean
+</programlisting>
 						<programlisting language="sql" xml:space="preserve">
 SELECT eTouches(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(0 1)@2001-01-03)');
@@ -569,7 +605,9 @@ SELECT eTouches(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
 				<listitem xml:id="tgeo_tContains">
 					<indexterm significance="normal"><primary><varname>tContains</varname></primary></indexterm>
 					<para>Contiene temporal</para>
-					<para><varname>tContains(geometry,tgeom) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tgeom) → tbool
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tContains(geometry 'Linestring(1 1,3 3)',
   tgeompoint '[Point(4 2)@2001-01-01, Point(2 4)@2001-01-02]');
@@ -589,7 +627,9 @@ SELECT tContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 				<listitem xml:id="tgeo_tDisjoint">
 					<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>
 					<para>Disjunto temporal &Z_support; &geography_support;</para>
-					<para><varname>tDisjoint({geo,tgeo},{geo,tgeo}) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tDisjoint({geo,tgeo},{geo,tgeo}) → tbool
+</programlisting>
 					<para>La función solo admite 3D o geografías para dos puntos temporales</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tDisjoint(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
@@ -604,7 +644,9 @@ SELECT tDisjoint(tgeompoint '[Point(0 3)@2001-01-01, Point(3 0)@2001-01-05)',
 				<listitem xml:id="tgeo_tDwithin">
 					<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
 					<para>Está a distancia de temporal &Z_support;</para>
-					<para><varname>tDwithin({geo,tgeo},{geo,tgeo},float) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tDwithin({geo,tgeo},{geo,tgeo},float) → tbool
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tDwithin(geometry 'Point(1 1)',
   tgeompoint '[Point(0 0)@2001-01-01, Point(2 2)@2001-01-03)', sqrt(2));
@@ -618,7 +660,9 @@ SELECT tDwithin(tgeompoint '[Point(1 0)@2001-01-01, Point(1 4)@2001-01-05]',
 				<listitem xml:id="tgeo_tIntersects">
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<para>Intersección temporal &Z_support; &geography_support;</para>
-					<para><varname>tIntersects({geo,tgeo},{geo,tgeo}) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tIntersects({geo,tgeo},{geo,tgeo}) → tbool
+</programlisting>
 					<para>La función solo admite 3D o geografías para dos puntos temporales</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tIntersects(geometry 'MultiPoint(1 1,2 2)',
@@ -634,7 +678,9 @@ SELECT tIntersects(tgeompoint '[Point(0 3)@2001-01-01, Point(3 0)@2001-01-05)',
 				<listitem xml:id="tgeo_tTouches">
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 					<para>Toca temporal</para>
-					<para><varname>tTouches({geometry,tgeom},{geometry,tgeom}) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tTouches({geometry,tgeom},{geometry,tgeom}) → tbool
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tTouches(geometry 'Polygon((1 0,1 2,2 2,2 0,1 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(3 0)@2001-01-04)');

--- a/doc/es/temporal_types_aggregation.xml
+++ b/doc/es/temporal_types_aggregation.xml
@@ -35,7 +35,9 @@
 			<listitem xml:id="ttype_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Conteo temporal</para>
-				<para><varname>tCount(ttype) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(ttype) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tCount(NoEmps) FROM Department;
 -- {[1@2001-01-01, 2@2001-02-01, 1@2001-08-01, 1@2001-10-01)}
@@ -45,7 +47,9 @@ SELECT tCount(NoEmps) FROM Department;
 			<listitem xml:id="ttype_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Extensión del cuadro delimitador</para>
-				<para><varname>extent(temp) → {tstzspan,tbox,stbox}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(temp) → {tstzspan,tbox,stbox}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT extent(noEmps) FROM Department;
 -- TBOX XT((4,12),[2001-01-01,2001-10-01])
@@ -58,8 +62,10 @@ SELECT extent(Trip) FROM Trips;
 				<indexterm significance="normal"><primary><varname>tAnd</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tOr</varname></primary></indexterm>
 				<para>Y, o temporal</para>
-				<para><varname>tAnd(tbool) → tbool</varname></para>
-				<para><varname>tOr(tbool) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tAnd(tbool) → tbool
+tOr(tbool) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tAnd(NoEmps #&gt; 6) FROM Department;
 -- {[t@2001-01-01, f@2001-04-01, f@2001-10-01)}
@@ -74,10 +80,12 @@ SELECT tOr(NoEmps #&gt; 6) FROM Department;
 				<indexterm significance="normal"><primary><varname>tSum</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tAvg</varname></primary></indexterm>
 				<para>Mínimo, máximo, suma y promedio temporal</para>
-				<para><varname>tMin(ttype) → ttype</varname></para>
-				<para><varname>tMax(ttype) → ttype</varname></para>
-				<para><varname>tSum(tnumber) → {tnumberSeq,tnumberSeqSet}</varname></para>
-				<para><varname>tAvg(tnumber) → {tfloatSeq,tfloatSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tMin(ttype) → ttype
+tMax(ttype) → ttype
+tSum(tnumber) → {tnumberSeq,tnumberSeqSet}
+tAvg(tnumber) → {tfloatSeq,tfloatSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tMin(NoEmps) FROM Department;
 -- {[10@2001-01-01, 4@2001-02-01, 6@2001-06-01, 6@2001-10-01)}
@@ -96,7 +104,9 @@ SELECT tAvg(NoEmps) FROM Department;
 			<listitem xml:id="ttype_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Conteo de ventana</para>
-				<para><varname>wCount(tnumber,interval) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tnumber,interval) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT wCount(NoEmps, interval '2 days') FROM Department;
 /* {[1@2001-01-01, 2@2001-02-01, 3@2001-04-01, 2@2001-04-03, 3@2001-06-01, 2@2001-06-03,
@@ -110,10 +120,12 @@ SELECT wCount(NoEmps, interval '2 days') FROM Department;
 				<indexterm significance="normal"><primary><varname>wSum</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>wAvg</varname></primary></indexterm>
 				<para>Mínimo, máximo, suma y promedio de ventana</para>
-				<para><varname>wMin(tnumber,interval) → {tnumberSeq,tnumberSeqSet}</varname></para>
-				<para><varname>wMax(tnumber,interval) → {tnumberSeq,tnumberSeqSet}</varname></para>
-				<para><varname>wSum(tint,interval) → {tintSeq,tintSeqSet}</varname></para>
-				<para><varname>wAvg(tint,interval) → {tfloatDiscSeq,tfloatSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wMin(tnumber,interval) → {tnumberSeq,tnumberSeqSet}
+wMax(tnumber,interval) → {tnumberSeq,tnumberSeqSet}
+wSum(tint,interval) → {tintSeq,tintSeqSet}
+wAvg(tint,interval) → {tfloatDiscSeq,tfloatSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT wMin(NoEmps, interval '2 days') FROM Department;
 -- {[10@2001-01-01, 4@2001-04-01, 6@2001-06-03, 6@2001-10-03)}
@@ -131,7 +143,9 @@ SELECT round(wAvg(NoEmps, interval '2 days'), 3) FROM Department;
 			<listitem xml:id="tpoint_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
 				<para>Centroide temporal</para>
-				<para><varname>tCentroid(tgeompoint) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCentroid(tgeompoint) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tCentroid(Trip) FROM Trips;
 /* {[POINT(0 0)@2001-01-01 08:00:00, POINT(1 0)@2001-01-01 08:05:00),

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -18,8 +18,10 @@
 				<indexterm significance="normal"><primary><varname>minDistSimplify</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minTimeDeltaSimplify</varname></primary></indexterm>
 				<para>Simplificar un flotante o un punto temporal asegurándose de que los valores consecutivos estén al menos separados por una cierta distancia o intervalo de tiempo &Z_support; &geography_support;</para>
-				<para><varname>minDistSimplify({tfloat,tpoint},mindist float) → {tfloat,tpoint}</varname></para>
-				<para><varname>minTimeDeltaSimplify({tfloat,tpoint},mint interval) → {tfloat,tpoint}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minDistSimplify({tfloat,tpoint},mindist float) → {tfloat,tpoint}
+minTimeDeltaSimplify({tfloat,tpoint},mint interval) → {tfloat,tpoint}
+</programlisting>
 				<para>En el caso de puntos temporales la distancia se especifica en las unidades del sistema de coordenadas. Observe que la simplificación se aplica sólo a secuencias temporales o conjuntos de secuencias con interpolación lineal. En todos los demás casos, se devuelve una copia del punto temporal dado.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minDistSimplify(tfloat '[1@2001-01-01,2@2001-01-02,3@2001-01-04,4@2001-01-05]', 1);
@@ -45,10 +47,12 @@ SELECT asText(minTimeDeltaSimplify(tgeogpoint '[Point(1 1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>maxDistSimplify</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>douglasPeuckerSimplify</varname></primary></indexterm>
 				<para>Simplificar un flotante o un punto temporal usando el <ulink url="https://es.wikipedia.org/wiki/Algoritmo_de_Ramer%E2%80%93Douglas%E2%80%93Peucker">algoritmo de Douglas-Peucker</ulink> &Z_support;</para>
-				<para><varname>maxDistSimplify({tfloat,tgeompoint},maxdist float,syncdist=true) →</varname></para>
-				<para><varname>  {tfloat,tgeompoint}</varname></para>
-				<para><varname>douglasPeuckerSimplify({tfloat,tgeompoint},maxdist float,syncdist=true) →</varname></para>
-				<para><varname>  {tfloat,tgeompoint}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+maxDistSimplify({tfloat,tgeompoint},maxdist float,syncdist=true) →
+  {tfloat,tgeompoint}
+douglasPeuckerSimplify({tfloat,tgeompoint},maxdist float,syncdist=true) →
+  {tfloat,tgeompoint}
+</programlisting>
 				<para>La diferencia entre las dos funciones es que <varname>maxDistSimplify</varname> usa una versión del algoritmo de un solo recorrido, mientras que <varname>douglasPeuckerSimplify</varname> usa el algoritmo recursivo estándar.</para>
 				<para>La función elimina los valores or los puntos cuya distancia es menor que la distancia pasada como segundo argumento. En el caso de puntos temporales la distancia se especifica en las unidades del sistema de coordenadas. El tercer argumento se aplica solo a puntos temporales y especifica si se utiliza la distancia espacial o la distancia  sincronizada. Observe que la simplificación se aplica sólo a secuencias temporales o conjuntos de secuencias con interpolación lineal. En todos los demás casos, se devuelve una copia del punto temporal dado.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -98,8 +102,10 @@ SELECT asText(douglasPeuckerSimplify(tgeompoint '[Point(1 1)@2001-01-01,
 			<listitem xml:id="ttype_tsample">
 				<indexterm significance="normal"><primary><varname>tsample</varname></primary></indexterm>
 				<para>Muestrear un valor temporal con respecto a un intervalo</para>
-				<para><varname>tsample(temporal,duration interval,torigin timestamptz='2000-01-03',</varname></para>
-				<para><varname>  interp='discrete') → temporal</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tsample(temporal,duration interval,torigin timestamptz='2000-01-03',
+  interp='discrete') → temporal
+</programlisting>
 				<para>Si el origen no se especifica, su valor se establece por defecto en lunes 3 de enero de 2000. El intervalo dado debe ser estrictamente mayor que cero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tsample(tbool '[true@2001-01-01,false@2001-01-02]', '12 hours', '2001-01-01',
@@ -139,8 +145,11 @@ SELECT asText(tsample(tgeompoint '{[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05
 			<listitem xml:id="ttype_tprecision">
 				<indexterm significance="normal"><primary><varname>tprecision</varname></primary></indexterm>
 				<para>Reducir la precisión temporal de un valor temporal con respecto a un intervalo calculando el promedio/centroide ponderado por el tiempo en cada intervalo de tiempo</para>
-				<para><varname>tprecision({tnumber,tgeompoint,tcbuffer,tpose,tgeo,trgeometry},duration interval,torigin timestamptz='2000-01-03')</varname></para>
-				<para><varname> → {tnumber,tgeompoint,tcbuffer,tpose,tgeo,trgeometry}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tprecision({tnumber,tgeompoint,tcbuffer,tpose,tgeo,trgeometry},duration interval,
+  torigin timestamptz='2000-01-03')
+  → {tnumber,tgeompoint,tcbuffer,tpose,tgeo,trgeometry}
+</programlisting>
 				<para>Si el origen no se especifica, su valor se establece por defecto en lunes 3 de enero de 2000. El intervalo dado debe ser estrictamente mayor que cero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tprecision(tint '[1@2001-01-01,5@2001-01-05,1@2001-01-09]','1 day',
@@ -192,11 +201,13 @@ SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-
 				<indexterm significance="normal"><primary><varname>averageHausdorffDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>lcssDistance</varname></primary></indexterm>
 				<para>Devuelve la <ulink url="https://en.wikipedia.org/wiki/Hausdorff_distance">distancia de Hausdorff</ulink> discreta, la <ulink url="https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance">distancia de Fréchet</ulink> discreta, la distancia de distorsión de tiempo dinámica (<ulink url="https://en.wikipedia.org/wiki/Dynamic_time_warping">Dynamic Time Warp</ulink> o DTW), la distancia de Hausdorff promedio, o la distancia de <ulink url="https://en.wikipedia.org/wiki/Longest_common_subsequence">subsecuencia común más larga</ulink> (Longest Common SubSequence o LCSS) entre dos valores temporales &Z_support; &geography_support;</para>
-				<para><varname>hausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
-				<para><varname>frechetDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
-				<para><varname>dynTimeWarpDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
-				<para><varname>averageHausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
-				<para><varname>lcssDistance({tnumber, tgeo}, {tnumber, tgeo}, float) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+hausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float
+frechetDistance({tnumber, tgeo}, {tnumber, tgeo}) → float
+dynTimeWarpDistance({tnumber, tgeo}, {tnumber, tgeo}) → float
+averageHausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float
+lcssDistance({tnumber, tgeo}, {tnumber, tgeo}, float) → float
+</programlisting>
 				<para>La función <varname>lcssDistance</varname> requiere un parámetro adicional que especifica el umbral de distancia por debajo del cual dos valores se consideran coincidentes.</para>
 				<para>Estas funciones tienen una complejidad de espacio lineal ya que solo dos filas de la matriz de distancia son asignadas en la memoria. Sin embargo, su complejidad de tiempo es cuadrática en el número de instantes de los valores temporales. Por lo tanto, las funciones requerien un tiempo considerable para valores temporales con gran número de instantes.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -258,8 +269,10 @@ SELECT round(lcssDistance(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01
 				<indexterm significance="normal"><primary><varname>frechetDistancePath</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dynTimeWarpPath</varname></primary></indexterm>
 				<para>Devuelve las parejas de correspondencia entre dos valores temporales con respecto a la distancia de Fréchet discreta o la distance de distorsión de tiempo dinámica (Dynamic Time Warp o DTW) &Z_support; &geography_support; &SRF;</para>
-				<para><varname>frechetDistancePath({tnumber, tgeo}, {tnumber, tgeo}) → {(i,j)}</varname></para>
-				<para><varname>dynTimeWarpPath({tnumber, tgeo}, {tnumber, tgeo}) → {(i,j)}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+frechetDistancePath({tnumber, tgeo}, {tnumber, tgeo}) → {(i,j)}
+dynTimeWarpPath({tnumber, tgeo}, {tnumber, tgeo}) → {(i,j)}
+</programlisting>
 				<para>El resultado es un conjunto de pares <varname>(i,j)</varname>. Esta función requiere ubicar en memoria una matriz de distancias cuyo tamaño es cuadrático en el número de instantes de los valores temporales. Por tanto, la función fallará para valores temporales con gran número de instantes dependiendo de la memoria disponible.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT frechetDistancePath(tfloat '[1@2001-01-01, 3@2001-01-03, 1@2001-01-06]',
@@ -308,8 +321,12 @@ SELECT dynTimeWarpPath(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03
 				<indexterm significance="normal"><primary><varname>extendedKalmanFilter</varname></primary></indexterm>
 				<para>Devolver un flotante temporal o un punto temporal suavizado, obtenido al filtrar una trayectoria ruidosa con un <ulink url="https://es.wikipedia.org/wiki/Filtro_de_Kalman">filtro de Kalman extendido</ulink> &Z_support;
 </para>
-				<para><varname>extendedKalmanFilter(tfloat, gate float, q float, variance float, to_drop boolean DEFAULT TRUE) → tfloat</varname></para>
-				<para><varname>extendedKalmanFilter(tgeompoint, gate float, q float, variance float, to_drop boolean DEFAULT TRUE) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extendedKalmanFilter(tfloat, gate float, q float, variance float,
+  to_drop boolean DEFAULT TRUE) → tfloat
+extendedKalmanFilter(tgeompoint, gate float, q float, variance float,
+  to_drop boolean DEFAULT TRUE) → tgeompoint
+</programlisting>
 				<para>El filtro modela el movimiento subyacente de un objeto móvil y lo separa del ruido de medición y de los valores atípicos ocasionales. El parámetro <varname>gate</varname> controla el rigor de la detección de atípicos, <varname>q</varname> es la escala del ruido de proceso, <varname>variance</varname> es la varianza del ruido de medición y <varname>to_drop</varname> elige si los atípicos se eliminan (<literal>true</literal>) o se reemplazan por la trayectoria predicha (<literal>false</literal>).</para>
 				<para>Estas funciones están pensadas para trayectorias con al menos tres instantes y se aplican normalmente a valores temporales con interpolación lineal.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -337,7 +354,9 @@ SELECT asEWKT(extendedKalmanFilter(tgeompoint
 			<listitem xml:id="ttype_splitNSpans">
 				<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 				<para>Devuelve una matriz de N rangos de tiempo a partir de los instantes o segmentos de un valor temporal &Z_support; &geography_support;</para>
-				<para><varname>splitNSpans(temp, integer) → tstzspan[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitNSpans(temp, integer) → tstzspan[]
+</programlisting>
 				<para>La elección entre instantes o segmentos depende de si la interpolación es discreta o continua. El último argumento especifica el número de rangos de salida. Si el número de instantes o segmentos es inferior o igual al número especificado, la matriz resultante tendrá un rango por instante o segmento del valor temporal. En caso contrario, el número de rangos especificado se obtendrá fusionando instantes o segmentos consecutivos.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(ttext '{A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-04,
@@ -366,7 +385,9 @@ SELECT splitNSpans(ttext '[A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-0
 			<listitem xml:id="ttype_splitEachNSpans">
 				<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 				<para>Devuelve una matriz de rangos de tiempo obtenida fusionando N instantes o segmentos consecutivos de un valor temporal &Z_support; &geography_support;</para>
-				<para><varname>splitEachNSpans(temp, integer) → tstzspan[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitEachNSpans(temp, integer) → tstzspan[]
+</programlisting>
 				<para>La elección entre instantes o segmentos depende de si la interpolación es discreta o continua. El último argumento especifica el número de instantes o segmentos de entrada que se fusionan para producir un rango de salida. Si el número de instantes o segmentos es inferior o igual al número especificado, la matriz resultante tendrá un único rango por secuencia. En caso contrario, el número especificado de instantes o segmentos consecutivos será fusionado en cada rango de salida. Observe que, a diferencia de la función <link linkend="ttype_splitNSpans"><varname>splitNSpans</varname></link>, el número de cuadros en el resultado depende del número de instantes o de segmentos de entrada.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNSpans(ttext '{A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-04,
@@ -391,7 +412,9 @@ SELECT splitEachNSpans(tgeogpoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-
 			<listitem xml:id="ttype_splitNTboxes">
 				<indexterm significance="normal"><primary><varname>splitNTboxes</varname></primary></indexterm>
 				<para>Devuelve una matriz de N cuadros temporales obtenida fusionando los instantes o segmentos de un número temporal</para>
-				<para><varname>splitNTboxes(tnumber, integer) → tbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitNTboxes(tnumber, integer) → tbox[]
+</programlisting>
 				<para>La elección entre instantes o segmentos depende de si la interpolación es discreta or continua. El último argumento especifica el número de cuadros de salida. Si el número de instantes o segmentos es inferior o igual al numéro especificado, la matriz resultante tendrá un cuadro por instante o segmento del número temporal. En caso contrario, En caso contrario, el número de cuadros especificado se obtendrá fusionando instantes o segmentos consecutivos.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
@@ -425,7 +448,9 @@ SELECT splitNTboxes(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-0
 			<listitem xml:id="ttype_splitEachNTboxes">
 				<indexterm significance="normal"><primary><varname>splitEachNTboxes</varname></primary></indexterm>
 				<para>Devuelve una matriz de cuadros temporales obtenida fusionando N instantes o segmentos consecutivos de un número temporal</para>
-				<para><varname>splitEachNTboxes(tnumber, integer) → tbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitEachNTboxes(tnumber, integer) → tbox[]
+</programlisting>
 				<para>La elección entre instantes o segmentos depende de si la interpolación es discreta or continua. El último argumento especifica el número de instantes o segmentos de entrada que se fusionan para producir un cuadro de salida. Si el número de instantes o segmentos es inferior o igual al número especificado, la matriz resultante tendrá un único cuadro por secuencia. En caso contrario, el número especificado de instantes o segmentos consecutivos será fusionado en cada cuadro de salida. Observe que, a diferencia de la función <link linkend="ttype_splitNTboxes"><varname>splitNTboxes</varname></link>, el número de cuadros en el resultado depende del número de instantes o de segmentos de entrada.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
@@ -456,8 +481,10 @@ SELECT splitEachNTboxes(tfloat '{[1@2000-01-01, 2@2000-01-02], [1@2000-01-03,
 			<listitem xml:id="ttype_splitNStboxes">
 				<indexterm significance="normal"><primary><varname>splitNStboxes</varname></primary></indexterm>
 				<para>Devuelve ya sea una matriz de N cuadros espaciales obtenida fusionando los segmentos de una (multi)línea o una matriz de N cuadros espaciotemporales obtenida fusionando los instantes o segmentos de un punto temporal &Z_support; &geography_support;</para>
-				<para><varname>splitNStboxes(lines, integer) → stbox[]</varname></para>
-				<para><varname>splitNStboxes(tpoint, integer) → stbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitNStboxes(lines, integer) → stbox[]
+splitNStboxes(tpoint, integer) → stbox[]
+</programlisting>
 				<para>Para puntos temporales, la elección entre instantes o segmentos depende de si la interpolación es discreta or continua. El último argumento especifica el número de cuadros de salida. Si el número de instantes o segmentos es menor que el número dado, la matriz resultante tendrá un cuadro por segmento de la (multi)línea o un cuadro por instante o segmento del punto temporal. En caso contrario, el número de cuadros especificado se obtendrá fusionando instantes o segmentos consecutivos.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 1);
@@ -505,8 +532,10 @@ SELECT splitNStboxes(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
 			<listitem xml:id="ttype_splitEachNStboxes">
 				<indexterm significance="normal"><primary><varname>splitEachNStboxes</varname></primary></indexterm>
 				<para>Devuelve ya sea una matriz de cuadros espaciales obtenida fusionando N segmentos consecutivos de una (multi)línea o una matriz de cuadros espaciotemporales obtenida fusionando N instantes o segmentos consecutivos de un punto temporal &Z_support; &geography_support;</para>
-				<para><varname>splitEachNStboxes(lines, integer) → stbox[]</varname></para>
-				<para><varname>splitEachNStboxes(tpoint, integer) → stbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitEachNStboxes(lines, integer) → stbox[]
+splitEachNStboxes(tpoint, integer) → stbox[]
+</programlisting>
 				<para>Para puntos temporales, la elección entre instantes o segmentos depende de si la interpolación es discreta or continua. El último argumento especifica el número de instantes o segmentos de entrada que se fusionan para producir un cuadro de salida. Si el número de instantes o segmentos es menor que el número dado, la matriz resultante tendrá un único cuadro por secuencia. En caso contrario, el número especificado de instantes o segmentos consecutivos será fusionado en cada cuadro de salida. Observe que, a diferencia de la función <link linkend="ttype_splitNStboxes"><varname>splitNStboxes</varname></link>, el número de cuadros en el resultado depende del número de instantes o de segmentos de entrada.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 1);
@@ -576,9 +605,11 @@ SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01
 				<listitem xml:id="setspan_bins">
 					<indexterm significance="normal"><primary><varname>bins</varname></primary></indexterm>
 					<para>Devuelve una matriz de intervalos que cubre el rango de valores o de tiempo con intervalos de la misma amplitud o duración</para>
-					<para><varname>bins(numspans,width number,origin number=0) → span[]</varname></para>
-					<para><varname>bins(datespans,duration interval,origin date='2000-01-03') → span[]</varname></para>
-					<para><varname>bins(tstzspans,duration interval,origin timestamptz='2000-01-03') → span[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+bins(numspans,width number,origin number=0) → span[]
+bins(datespans,duration interval,origin date='2000-01-03') → span[]
+bins(tstzspans,duration interval,origin timestamptz='2000-01-03') → span[]
+</programlisting>
 					<para>Si el origen no se especifica, su valor se establece por defecto en 0 para rangos de valores y en lunes 3 de enero de 2000 para rangos de tiempo.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT bins(floatspan '[-10, -1]', 2.5, -7);
@@ -605,9 +636,11 @@ FROM unnest(bins(tstzspanset '{[2001-01-15, 2001-01-17],[2001-01-22, 2001-01-25]
 				<listitem xml:id="setspan_getBin">
 					<indexterm significance="normal"><primary><varname>getBin</varname></primary></indexterm>
 					<para>Devuelve el rango que contiene un número o una marca de tiempo</para>
-					<para><varname>getBin(number,size number,origin number=0) → span</varname></para>
-					<para><varname>getBin(date,duration interval,origin date='2000-01-03') → datespan</varname></para>
-					<para><varname>getBin(timestamptz,duration interval,origin timestamptz='2000-01-03') → tstzspan</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getBin(number,size number,origin number=0) → span
+getBin(date,duration interval,origin date='2000-01-03') → datespan
+getBin(timestamptz,duration interval,origin timestamptz='2000-01-03') → tstzspan
+</programlisting>
 					<para>Si el origen no se especifica, su valor se establece por defecto en 0 para rangos de valores y en lunes 3 de enero de 2000 para rangos de tiempo.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getBin(2, 2);
@@ -632,11 +665,13 @@ SELECT getBin('2001-01-04', interval '1 week', '2001-01-07');
 					<indexterm significance="normal"><primary><varname>timeTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeTiles</varname></primary></indexterm>
 					<para>Devuelve el conjunto de mosaicos que cubre un cuadro delimitador temporal con mosaicos del mismo tamaño y/o duración &SRF;</para>
-					<para><varname>valueTiles(tbox,size float,vorigin float=0) → {(index,tile)}</varname></para>
-					<para><varname>timeTiles(tbox,duration interval,torigin timestamptz='2000-01-03') → </varname></para>
-					<para><varname>  {(index,tile)}</varname></para>
-					<para><varname>valueTimeTiles(tbox,size float,duration interval,vorigin float=0,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → {(index,tile)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+valueTiles(tbox,size float,vorigin float=0) → {(index,tile)}
+timeTiles(tbox,duration interval,torigin timestamptz='2000-01-03') → 
+  {(index,tile)}
+valueTimeTiles(tbox,size float,duration interval,vorigin float=0,
+  torigin timestamptz='2000-01-03') → {(index,tile)}
+</programlisting>
 					<para>Si el origen de la dimensión de valores y/o de tiempo no se especifica, su valor se establece por defecto en 0 y en el lunes 3 de enero de 2000, respectivamente.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (gr).index, (gr).tile
@@ -671,13 +706,15 @@ SELECT valueTimeTiles(tfloat '[15@2001-01-15, 25@2001-01-25]'::tbox, 2.0, '2 day
 					<indexterm significance="normal"><primary><varname>timeTiles</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeTiles</varname></primary></indexterm>
 					<para>Devuelve el conjunto de mosaicos que cubre un cuadro delimitador espaciotemporal con mosaicos del mismo tamaño y/o duración &Z_support; &SRF;</para>
-					<para><varname>spaceTiles(stbox,xsize float,[ysize float,zsize float,] </varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)',borderInc boolean=true) → {(index,tile)}</varname></para>
-					<para><varname>timeTiles(stbox,duration interval,torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  borderInc boolean=true) → {(index,tile)}</varname></para>
-					<para><varname>spaceTimeTiles(stbox,xsize float,[ysize float,zsize float,]duration interval,</varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  borderInc boolean=true) → {(index,tile)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spaceTiles(stbox,xsize float,[ysize float,zsize float,] 
+  sorigin geompoint='Point(0 0 0)',borderInc boolean=true) → {(index,tile)}
+timeTiles(stbox,duration interval,torigin timestamptz='2000-01-03',
+  borderInc boolean=true) → {(index,tile)}
+spaceTimeTiles(stbox,xsize float,[ysize float,zsize float,]duration interval,
+  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',
+  borderInc boolean=true) → {(index,tile)}
+</programlisting>
 					<para>Si el origen de las dimensiones espacial y/o de tiempo no se especifican, su valor se establece por defecto en <varname>'Point (0 0 0)'</varname> y en el lunes 3 de enero de 2000, respectivamente. El argumento opcional <varname>borderInc</varname> indica si se incluye el borde superior de la extensión y, por lo tanto, se generan mosaicos adicionales que contienen el borde.</para>
 					<para>En el caso de una malla espacio-temporal, <varname>ysize</varname> y <varname>zsize</varname> son opcionales, se supone que el tamaño de las dimensiones faltantes es igual a <varname>xsize</varname>. El SRID de las coordenadas de los mosaicos está determinado por el del cuadro de entrada y el tamaño se da en las unidades del SRID. Si se especifica el origen de las coordenadas espaciales, que debe ser un punto, su dimensionalidad y SRID deben ser iguales al del cuadro delimitador, de lo contrario se genera un error.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -726,11 +763,13 @@ SELECT spaceTimeTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 					<indexterm significance="normal"><primary><varname>getTboxTimeTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getValueTimeTile</varname></primary></indexterm>
 					<para>Devuelve el mosaico temporal que cubre un valor y/o una marca de tiempo</para>
-					<para><varname>getValueTile(value float,vsize float,vorigin float=0.0) → tbox</varname></para>
-					<para><varname>getTboxTimeTile(time timestamptz,duration interval,torigin timestamptz='2000-01-03')</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → tbox</varname></para>
-					<para><varname>getValueTimeTile(value float,time timestamptz,vsize float,duration interval,</varname></para>
-					<para><varname>  vorigin float=0.0,torigin timestamptz='2000-01-03') → tbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getValueTile(value float,vsize float,vorigin float=0.0) → tbox
+getTboxTimeTile(time timestamptz,duration interval,torigin timestamptz='2000-01-03')
+  torigin timestamptz='2000-01-03') → tbox
+getValueTimeTile(value float,time timestamptz,vsize float,duration interval,
+  vorigin float=0.0,torigin timestamptz='2000-01-03') → tbox
+</programlisting>
 					<para>Si el origen de las dimensiones de valores y/o de tiempo no se especifica, su valor se establece por defecto en 0 y en el lunes 3 de enero de 2000, respectivamente.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValueTile(15, 2);
@@ -749,13 +788,15 @@ SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days', 1, '2001-01-02')
 					<indexterm significance="normal"><primary><varname>getStboxTimeTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getSpaceTimeTile</varname></primary></indexterm>
 					<para>Devuelve el mosaico espaciotemporal que cubre un punto y/o una marca de tiempo &Z_support;</para>
-					<para><varname>getSpaceTile(point geometry,xsize float,[ysize float,zsize float],</varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)') → stbox</varname></para>
-					<para><varname>getStboxTimeTile(time timestamptz,duration interval,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → stbox</varname></para>
-					<para><varname>getSpaceTimeTile(point geometry,time timestamptz,xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,]duration,interval,sorigin geompoint='Point(0 0 0)',</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getSpaceTile(point geometry,xsize float,[ysize float,zsize float],
+  sorigin geompoint='Point(0 0 0)') → stbox
+getStboxTimeTile(time timestamptz,duration interval,
+  torigin timestamptz='2000-01-03') → stbox
+getSpaceTimeTile(point geometry,time timestamptz,xsize float,
+  [ysize float,zsize float,]duration,interval,sorigin geompoint='Point(0 0 0)',
+  torigin timestamptz='2000-01-03') → stbox
+</programlisting>
 					<para>Si el origen de la dimensión espacial y/o de tiempo no se especifica, su valor se establece por defecto en <varname>'Point(0 0 0)'</varname> y en el lunes 3 de enero de 2000, respectivamente.</para>
 					<para>En el caso de una malla espacio-temporal, <varname>ysize</varname> y <varname>zsize</varname> son opcionales, se supone que el tamaño de las dimensiones faltantes es igual a <varname>xsize</varname>. El SRID de las coordenadas de los mosaicos está determinado por el del cuadro de entrada y el tamaño se da en las unidades del SRID. Si se especifica el origen de las coordenadas espaciales, que debe ser un punto, su dimensionalidad y SRID deben ser iguales al del cuadro delimitador, de lo contrario se genera un error.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -781,8 +822,10 @@ SELECT getSspaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 d
 					<indexterm significance="normal"><primary><varname>valueBins</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeBins</varname></primary></indexterm>
 					<para>Devuelve una matriz de rangos de valores o de tiempo obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores o de tiempo</para>
-					<para><varname>valueBins(tnumber,vsize number,vorigin number=0) → numspan[]</varname></para>
-					<para><varname>timeBins(temp,duration interval,torigin timestamptz='2000-01-03') → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+valueBins(tnumber,vsize number,vorigin number=0) → numspan[]
+timeBins(temp,duration interval,torigin timestamptz='2000-01-03') → tstzspan[]
+</programlisting>
 					<para>La elección entre instantes o segmentos depende de si la interpolación es discreta o continua. Si no se especifica el origen de los valores, se establece por defecto en 0 para los rangos de valores y en el lunes 3 de enero de 2000 para los rangos de tiempo.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueBins(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
@@ -807,10 +850,12 @@ SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
 					<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeBoxes</varname></primary></indexterm>
 					<para>Devuelve una matriz de cuadros temporales obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores y/o tiempo</para>
-					<para><varname>valueBoxes(tnumber,size number,vorigin number=0) → tbox[]</varname></para>
-					<para><varname>timeBoxes(tnumber,duration interval,torigin timestamptz='2000-01-03') → tbox[]</varname></para>
-					<para><varname>valueTimeBoxes(tnumber,size number,duration interval,vorigin number=0,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → tbox[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+valueBoxes(tnumber,size number,vorigin number=0) → tbox[]
+timeBoxes(tnumber,duration interval,torigin timestamptz='2000-01-03') → tbox[]
+valueTimeBoxes(tnumber,size number,duration interval,vorigin number=0,
+  torigin timestamptz='2000-01-03') → tbox[]
+</programlisting>
 					<para>La elección entre instantes o segmentos depende de si la interpolación es discreta o continua. Si el origen de la dimensión de valores y/o de tiempo no se especifica, se establece por defecto en 0 y en el lunes 3 de enero de 2000, respectivamente.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueBoxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
@@ -839,16 +884,18 @@ SELECT valueTimeBoxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-
 					<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeBoxes</varname></primary></indexterm>
 					<para>Devuelve una matriz de cuadros espaciotemporales obtenidos a partir de los instantes o segmentos de un punto temporal con respecto a un mosaico espacial y/o temporal &Z_support;</para>
-					<para><varname>spaceBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,] </varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)',borderInc boolean=true) → stbox[]</varname></para>
-					<para><varname>timeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},duration interval,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  borderInc boolean=true) → stbox[]</varname></para>
-					<para><varname>spaceTimeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,]duration interval,</varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  borderInc boolean=true) → stbox[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spaceBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,
+  [ysize float,zsize float,] 
+  sorigin geompoint='Point(0 0 0)',borderInc boolean=true) → stbox[]
+timeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},duration interval,
+  torigin timestamptz='2000-01-03',
+  borderInc boolean=true) → stbox[]
+spaceTimeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,
+  [ysize float,zsize float,]duration interval,
+  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',
+  borderInc boolean=true) → stbox[]
+</programlisting>
 					<para>La elección entre instantes o segmentos depende de si la interpolación es discreta o continua. Los argumentos <varname>ysize</varname> y <varname>zsize</varname> son opcionales, se supone que el tamaño de las dimensiones faltantes es igual a <varname>xsize</varname>. El SRID de las coordenadas del mosaico se determina por el punto temporal y los tamaños se dan en las unidades del SRID. Si se proporciona el origen de las coordenadas espaciales, que debe ser un punto, su dimensionalidad y SRID deben ser iguales a los del punto temporal, de lo contrario se genera un error. Si el origen de la dimensión espacial y/o el tiempo no se especifica, su valor se establece por defecto en <varname>'Point(0 0 0)'</varname> y en el lunes 3 de enero de 2000, respectivamente. El argumento opcional <varname>borderInc</varname> indica si se incluye el borde superior de la extensión y, por lo tanto, se generan mosaicos adicionales que contienen el borde. Una pose temporal y un punto de nube de puntos temporal responden a estas funciones en el punto geométrico temporal al que se resuelve su posición, de modo que un valor con interpolación lineal se divide en mosaicos a lo largo de su trayectoria y no solo en sus instantes.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spaceBoxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
@@ -890,11 +937,13 @@ SELECT spaceBoxes(tpose '[Pose(Point(1 1),0.1)@2001-01-01,
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeSplit</varname></primary></indexterm>
 					<para>Fragmentar un número temporal con respecto a intervalos de valores y/o de tiempo &SRF;</para>
-					<para><varname>valueSplit(tnumber,width number,origin number=0) → {(number,tnumber)}</varname></para>
-					<para><varname>timeSplit(ttype,duration interval,origin timestamptz='2000-01-03') → </varname></para>
-					<para><varname>  {(time,temp)}</varname></para>
-					<para><varname>valueTimeSplit(tnumber,width number,duration interval,vorigin number=0,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → {(number,time,tnumber)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+valueSplit(tnumber,width number,origin number=0) → {(number,tnumber)}
+timeSplit(ttype,duration interval,origin timestamptz='2000-01-03') → 
+  {(time,temp)}
+valueTimeSplit(tnumber,width number,duration interval,vorigin number=0,
+  torigin timestamptz='2000-01-03') → {(number,time,tnumber)}
+</programlisting>
 					<para>El resultado es un conjunto de pares o un conjunto de triples. Si no se especifica el origen de la dimensión de valores o temporal, se establecen por defecto en 0 y en el lunes 3 de enero de 2000, respectivamente.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (sp).number, (sp).tnumber
@@ -976,17 +1025,21 @@ FROM (SELECT valueTimeSplit(tfloat '[1@2001-02-01, 10@2001-02-10)', 5.0, '5 days
 					<indexterm significance="normal"><primary><varname>spaceTimeSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Fragmentar un punto temporal con respecto a una malla espacial o espacio-temporal &SRF;</para>
-					<para><varname>spaceSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spaceSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
+  [ysize float,zsize float,]
+</programlisting>
 					<para><varname>  origin geompoint='Point(0 0 0)',bitmatrix boolean=true,borderInc boolean=true) →</varname> Una pose temporal y un punto de nube de puntos temporal responden a estas funciones en el punto geométrico temporal al que se resuelve su posición, de modo que un valor con interpolación lineal se divide en mosaicos a lo largo de su trayectoria y no solo en sus instantes. La segunda columna de una división lleva el tipo del primer argumento, de modo que dividir una pose temporal devuelve poses temporales.</para>
-					<para><varname>  {(point,tpoint)}</varname></para>
-					<para><varname>timeSplit(tgeompoint,duration interval,torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  bitmatrix boolean=true,borderInc boolean=true) → {(point,time,tpoint)}</varname></para>
-					<para><varname>spaceTimeSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,]</varname></para>
-					<para><varname>  duration interval,sorigin geompoint='Point(0 0 0)',</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03',bitmatrix boolean=true,borderInc boolean=true) →</varname></para>
-					<para><varname>  {(point,time,tpoint)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+  {(point,tpoint)}
+timeSplit(tgeompoint,duration interval,torigin timestamptz='2000-01-03',
+  bitmatrix boolean=true,borderInc boolean=true) → {(point,time,tpoint)}
+spaceTimeSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
+  [ysize float,zsize float,]
+  duration interval,sorigin geompoint='Point(0 0 0)',
+  torigin timestamptz='2000-01-03',bitmatrix boolean=true,borderInc boolean=true) →
+  {(point,time,tpoint)}
+</programlisting>
 					<para>El resultado es un conjunto de pares o un conjunto de triples. Si el origen de la dimensión espacial y/o el tiempo no se especifica, su valor se establece por defecto en <varname>'Point(0 0 0)'</varname> y en el lunes 3 de enero de 2000, respectivamente. Los argumentos <varname>ysize</varname> y <varname>zsize</varname> son opcionales, se supone que el tamaño de las dimensiones faltantes es igual a <varname>xsize</varname>. Si no se especifica el argumento <varname>bitmatrix</varname>, el cálculo utilizará una matriz de bits para acelerar el proceso. El argumento opcional <varname>borderInc</varname> indica si se incluye el borde superior de la extensión espacial y, por lo tanto, se generan mosaicos adicionales que contienen el borde.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText((sp).point) AS point, asText((sp).tpoint) AS tpoint

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -559,7 +559,9 @@ SELECT tgeogpoint 'Interp=Step;[SRID=4326;Point(0 0)@2001-01-01,
 			<listitem xml:id="ttype_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Devuelve la representación textual conocida (Well-Known Text o WKT)</para>
-				<para><varname>asText(tfloat,maxdecdigits=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText(tfloat,maxdecdigits=15) → text
+</programlisting>
 				<para>El argumento <varname>maxdecdigits</varname> puede usarse para establecer el número máximo de decimales en la salida de los valores en punto flotante (por defecto 15).</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asText(tfloat '[10.55@2001-01-01, 25.55@2001-01-02]', 0);
@@ -573,7 +575,9 @@ SELECT asText(tgeometry
 			<listitem xml:id="ttype_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Devuelve la representación JSON de características móviles (Moving Features JSON o MF-JSON)</para>
-				<para><varname>asMFJSON(ttype,options=0,flags=0,maxdecdigits=15) → bytea</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(ttype,options=0,flags=0,maxdecdigits=15) → bytea
+</programlisting>
 				<para>El argumento <varname>options</varname> puede usarse para agregar un cuadro delimitador en la salida MFJSON:</para>
 				<itemizedlist>
 						<listitem><para>0: significa que no hay opción (valor por defecto)</para></listitem>
@@ -617,8 +621,10 @@ SELECT asMFJSON(tgeometry '{[Point(1 1)@2001-01-01 18:00:00+02,
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Devuelve la representación binaria conocida (Well-Known Binary o WKB) o la representación hexadecimal binaria conocida (HexWKB)</para>
-				<para><varname>asBinary(ttype,endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB(ttype,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(ttype,endian text='') → bytea
+asHexWKB(ttype,endian text='') → text
+</programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT asBinary(tbool 'true@2001-01-01');
@@ -635,7 +641,9 @@ SELECT asHexWKB(ttext 'AAA@2001-01-01');
 			<listitem xml:id="ttypeFromMFJSON">
 				<indexterm significance="normal"><primary><varname>ttypeFromMFJSON</varname></primary></indexterm>
 				<para>Entrar a partir de la representación Moving Features JSON (MF-JSON)</para>
-				<para><varname>ttypeFromMFJSON(bytea) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeFromMFJSON(bytea) → ttype
+</programlisting>
 				<para>Hay una función por tipo temporal, el nombre de esta función tiene como prefijo el nombre del tipo, que son <varname>tbool</varname> o <varname>tint</varname> en los ejemplos a continuación</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tboolFromMFJSON(text
@@ -672,8 +680,10 @@ SELECT asText(tgeometryFromMFJSON(text
 				<indexterm significance="normal"><primary><varname>ttypeFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttypeFromHexWKB</varname></primary></indexterm>
 				<para>Entrar a partir de la representación binaria conocida (WKB) o de la representación hexadecimal binaria conocida (HexWKB)</para>
-				<para><varname>ttypeFromBinary(bytea) → ttype</varname></para>
-				<para><varname>ttypeFromHexWKB(text) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeFromBinary(bytea) → ttype
+ttypeFromHexWKB(text) → ttype
+</programlisting>
 				<para>Hay una función por tipo temporal, el nombre de la función tiene como prefijo el nombre del tipo, que son <varname>tbool</varname> o <varname>tint</varname> en los ejemplos a continuación.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tboolFromBinary('\x011a000101009c57d3c11c0000');
@@ -710,10 +720,12 @@ SELECT ttextFromHexWKB('01290001040000000000000041414100009C57D3C11C0000');
 				<indexterm significance="normal"><primary><varname>ttype</varname></primary></indexterm>
 				<para>Constructores para tipos temporales que tienen un valor constante</para>
 				<para>Estos constructores tienen dos argumentos, un tipo base y un tipo de tiempo, donde el último es un valor de <varname>timestamptz</varname>, <varname>tstzset</varname>, <varname>tstzspan</varname> o <varname>tstzspanset</varname> para construir, respectivamente, un valor de subtipo instante, una secuencia con interpolación discreta, una secuencia con interpolación linear o escalonada o un conjunto de secuencias. Las funciones para valores de secuencia o de conjunto de secuencias con tipo de base continuo tienen además un tercer argumento opcional que indica si el valor temporal resultante tiene interpolación lineal o escalonada. Se asume por defecto una interpolación lineal si el argumento no se especifica.</para>
-				<para><varname>ttype(base,timestamptz) → ttypeInst</varname></para>
-				<para><varname>ttype(base,tstzset) → ttypeDiscSeq</varname></para>
-				<para><varname>ttype(base,tstzspan,interp='linear') → ttypeContSeq</varname></para>
-				<para><varname>ttype(base,tstzspanset,interp='linear') → ttypeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttype(base,timestamptz) → ttypeInst
+ttype(base,tstzset) → ttypeDiscSeq
+ttype(base,tstzspan,interp='linear') → ttypeContSeq
+ttype(base,tstzspanset,interp='linear') → ttypeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tbool(true, timestamptz '2001-01-01');
 SELECT tint(1, timestamptz '2001-01-01');
@@ -731,8 +743,10 @@ SELECT tgeography('SRID=7844;Point(0 0)', tstzspanset '{[2001-01-01, 2001-01-02]
 				<indexterm significance="normal"><primary><varname>ttypeSeq</varname></primary></indexterm>
 				<para>Constructores para tipos temporales de subtipo secuencia</para>
 				<para>Estos constructores tienen un primer argumento obligatorio, que es una matriz de valores de los valores instantáneos correspondientes y argumentos opcionales adicionales. El segundo argumento establece la interpolación. Si no se proporciona el argumento, es por defecto escalonada para los tipos de base base discretos como los enteros y es lineal para tipos de base continuous como los flotantes. Se genera un error cuando se establece la interpolación lineal para valores temporales con tipos de base discretos. Para secuencias continuas, el tercero y el cuarto argumentos son valores booleanos que indican, respectivamente, si los límites izquierdo y derecho son inclusivos o exclusivos. Se supone que estos argumentos son verdaderos de forma predeterminada si no se especifican.</para>
-				<para><varname>ttypeSeq(ttypeInst[],interp={'step','linear'},leftInc boolean=true,</varname></para>
-        <para><varname>  rightInc boolean=true) → ttypeSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeSeq(ttypeInst[],interp={'step','linear'},leftInc boolean=true,
+  rightInc boolean=true) → ttypeSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tboolSeq(ARRAY[tbool 'true@2001-01-01 08:00:00','false@2001-01-01 08:05:00'],
   'discrete');
@@ -753,8 +767,10 @@ SELECT tgeographySeq(ARRAY[tgeography 'Point(1 1)@2001-01-01 08:00:00',
 				<indexterm significance="normal"><primary><varname>ttypeSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttypeSeqSetGaps</varname></primary></indexterm>
 				<para>Constructores para tipos temporales de subtipo conjunto de secuencias</para>
-				<para><varname>ttypeSeqSet(ttypeContSeq[]) → ttypeSeqSet</varname></para>
-				<para><varname>ttypeSeqSetGaps(ttypeInst[],maxt=NULL,maxdist=NULL,interp='linear') → ttypeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeSeqSet(ttypeContSeq[]) → ttypeSeqSet
+ttypeSeqSetGaps(ttypeInst[],maxt=NULL,maxdist=NULL,interp='linear') → ttypeSeqSet
+</programlisting>
 				<para>Un primer conjunto de constructores tiene un solo argumento, que es una matriz de valores de los valores de <emphasis>secuencia</emphasis> correspondientes. La interpolación del valor temporal resultante depende de la interpolación de las secuencias que lo componen. Se genera un error si las secuencias que componen la matriz tienen una interpolación diferente.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tboolSeqSet(ARRAY[tbool '[false@2001-01-01 08:00:00, false@2001-01-01 08:05:00)',
@@ -816,7 +832,9 @@ SELECT asText(tgeompointSeqSetGaps(ARRAY[tgeompoint 'Point(1 1)@2001-01-01',
 			<listitem xml:id="ttype_tstzspan">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convertir un valor temporal a un intervalo de marcas de tiempo</para>
-				<para><varname>ttype::tstzspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttype::tstzspan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tint '[1@2001-01-01, 2@2001-01-03]'::tstzspan;
 -- [2001-01-01, 2001-01-03]
@@ -835,7 +853,9 @@ SELECT tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]'::tstzspan;
 			<listitem xml:id="ttype_memSize">
 				<indexterm significance="normal"><primary><varname>memSize</varname></primary></indexterm>
 				<para>Devuelve el tamaño de la memoria en bytes</para>
-				<para><varname>memSize(ttype) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+memSize(ttype) → integer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT memSize(tint '{1@2001-01-01, 2@2001-01-02, 3@2001-01-03}');
 -- 176
@@ -845,7 +865,9 @@ SELECT memSize(tint '{1@2001-01-01, 2@2001-01-02, 3@2001-01-03}');
 			<listitem xml:id="ttype_tempSubtype">
 				<indexterm significance="normal"><primary><varname>tempSubtype</varname></primary></indexterm>
 				<para>Devuelve el subtipo temporal</para>
-				<para><varname>tempSubtype(ttype) → {'Instant','Sequence','SequenceSet'}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tempSubtype(ttype) → {'Instant','Sequence','SequenceSet'}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tempSubtype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 -- Sequence
@@ -855,7 +877,9 @@ SELECT tempSubtype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 			<listitem xml:id="ttype_tempBasetype">
 				<indexterm significance="normal"><primary><varname>tempBasetype</varname></primary></indexterm>
 				<para>Devuelve el tipo base</para>
-				<para><varname>tempBasetype(ttype) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tempBasetype(ttype) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tempBasetype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 -- integer
@@ -867,7 +891,9 @@ SELECT tempBasetype(tgeompoint 'Point(1 1)@2001-01-01');
 			<listitem xml:id="ttype_interp">
 				<indexterm significance="normal"><primary><varname>interp</varname></primary></indexterm>
 				<para>Devuelve la interpolación</para>
-				<para><varname>interp(ttype) → {'None','Discrete','Step','Linear'}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+interp(ttype) → {'None','Discrete','Step','Linear'}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT interp(tbool 'true@2001-01-01');
 -- None
@@ -892,8 +918,10 @@ SELECT interp(tgeometry '[Point(1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>getValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>getTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor o la marca de tiempo de un instantes</para>
-				<para><varname>getValue(ttypeInst) → base</varname></para>
-				<para><varname>getTimestamp(ttypeInst) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValue(ttypeInst) → base
+getTimestamp(ttypeInst) → timestamptz
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT getValue(tint '1@2001-01-01');
 -- 1
@@ -906,8 +934,10 @@ SELECT getTimestamp(tfloat '1@2001-01-01');
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>getTime</varname></primary></indexterm>
 				<para>Devuelve los valores o el tiempo en el que se define el valor temporal</para>
-				<para><varname>getValues(talpha) → {boolean[],spanset,textset}</varname></para>
-				<para><varname>getTime(ttype) → tstzspanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(talpha) → {boolean[],spanset,textset}
+getTime(ttype) → tstzspanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT getValues(tbool '[false@2001-01-01, true@2001-01-02, false@2001-01-03]');
 -- {f,t}
@@ -942,7 +972,9 @@ SELECT getTime(tfloat '{[1@2001-01-01, 1@2001-01-10), [12@2001-01-12, 12@2001-01
 			<listitem xml:id="ttype_timeSpan">
 				<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
 				<para>Devuelve el período delimitador en el que se define el valor temporal</para>
-				<para><varname>timeSpan(ttype) → tstzspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+timeSpan(ttype) → tstzspan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT timeSpan(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}');
 -- [2001-01-01, 2001-01-03]
@@ -956,9 +988,11 @@ SELECT timeSpan(tint '[1@2001-01-01, 1@2001-01-15)');
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
 				<para>Devuelve el valor inicial, final, o enésimo</para>
-				<para><varname>startValue(ttype) → base</varname></para>
-				<para><varname>endValue(ttype) → base</varname></para>
-				<para><varname>valueN(ttype,int) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(ttype) → base
+endValue(ttype) → base
+valueN(ttype,int) → base
+</programlisting>
 				<para>La función no tiene en cuenta si los límites son inclusivos o no.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT startValue(tfloat '(1@2001-01-01, 2@2001-01-03)');
@@ -973,7 +1007,9 @@ SELECT valueN(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01-05
 			<listitem xml:id="ttype_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Devuelve el valor en una marca de tiempo</para>
-				<para><varname>valueAtTimestamp(ttype,timestamptz) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(ttype,timestamptz) → base
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT valueAtTimestamp(tfloat '[1@2001-01-01, 4@2001-01-04)', '2001-01-02');
 -- 2
@@ -983,7 +1019,9 @@ SELECT valueAtTimestamp(tfloat '[1@2001-01-01, 4@2001-01-04)', '2001-01-02');
 			<listitem xml:id="ttype_duration">
 				<indexterm significance="normal"><primary><varname>duration</varname></primary></indexterm>
 				<para>Devuelve el intervalo de tiempo</para>
-				<para><varname>duration(ttype,boundspan=false) → interval</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+duration(ttype,boundspan=false) → interval
+</programlisting>
 				<para>Se puede poner en verdadero un parámetro adicional para calcular la duración del período limitador, ignorando así los posibles intervalos de tiempo</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT duration(tfloat '{1@2001-01-01, 2@2001-01-03, 2@2001-01-05}');
@@ -1004,8 +1042,10 @@ SELECT duration(tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-04, 2@2001-01-
 				<indexterm significance="normal"><primary><varname>lowerInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>upperInc</varname></primary></indexterm>
 				<para>¿Es el instante inicial/final inclusivo?</para>
-				<para><varname>lowerInc(ttype) → boolean</varname></para>
-				<para><varname>upperInc(ttype) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lowerInc(ttype) → boolean
+upperInc(ttype) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT lowerInc(tint '[1@2001-01-01, 2@2001-01-02)');
 -- true
@@ -1018,8 +1058,10 @@ SELECT upperInc(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 				<indexterm significance="normal"><primary><varname>numInstants</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>instants</varname></primary></indexterm>
 				<para>Devuelve el número o los instantes diferentes</para>
-				<para><varname>numInstants(ttype) → integer</varname></para>
-				<para><varname>instants(ttype) → ttypeInst[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numInstants(ttype) → integer
+instants(ttype) → ttypeInst[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT numInstants(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-03)}');
 -- 3
@@ -1033,9 +1075,11 @@ SELECT instants(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 				<indexterm significance="normal"><primary><varname>endInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>instantN</varname></primary></indexterm>
 				<para>Devuelve el instante inicial, final o enésimo</para>
-				<para><varname>startInstant(ttype) → ttypeInst</varname></para>
-				<para><varname>endInstant(ttype) → ttypeInst</varname></para>
-				<para><varname>instantN(ttype,integer) → ttypeInst</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startInstant(ttype) → ttypeInst
+endInstant(ttype) → ttypeInst
+instantN(ttype,integer) → ttypeInst
+</programlisting>
 				<para>Las funciones no tienen en cuenta si los límites son inclusivos o no.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT startInstant(tfloat '{[1@2001-01-01, 2@2001-01-02), 
@@ -1052,8 +1096,10 @@ SELECT instantN(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 				<indexterm significance="normal"><primary><varname>timestamps</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>numTimestamps</varname></primary></indexterm>
 				<para>Devuelve el número o las marcas de tiempo diferentes</para>
-				<para><varname>numTimestamps(ttype) → integer</varname></para>
-				<para><varname>timestamps(ttype) → timestamptz[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numTimestamps(ttype) → integer
+timestamps(ttype) → timestamptz[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT numTimestamps(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
@@ -1068,9 +1114,11 @@ SELECT timestamps(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-0
 				<indexterm significance="normal"><primary><varname>endTimestamp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timestampN</varname></primary></indexterm>
 				<para>Devuelve la marca de tiempo inicial, final o enésima</para>
-				<para><varname>startTimestamp(ttype) → timestamptz</varname></para>
-				<para><varname>endTimestamp(ttype) → timestamptz</varname></para>
-				<para><varname>timestampN(ttype,integer) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startTimestamp(ttype) → timestamptz
+endTimestamp(ttype) → timestamptz
+timestampN(ttype,integer) → timestamptz
+</programlisting>
 				<para>Las funciones no tienen en cuenta si los límites son inclusivos o no.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT startTimestamp(tfloat '[1@2001-01-01, 2@2001-01-03)');
@@ -1088,8 +1136,10 @@ SELECT timestampN(tfloat '{[1@2001-01-01, 2@2001-01-03),
 				<indexterm significance="normal"><primary><varname>numSequences</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>sequences</varname></primary></indexterm>
 				<para>Devuelve el número o las secuencias</para>
-				<para><varname>numSequences({ttypeContSeq,ttypeSeqSet}) → integer</varname></para>
-				<para><varname>sequences({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numSequences({ttypeContSeq,ttypeSeqSet}) → integer
+sequences({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT numSequences(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
@@ -1104,9 +1154,11 @@ SELECT sequences(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01
 				<indexterm significance="normal"><primary><varname>endSequence</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>sequenceN</varname></primary></indexterm>
 				<para>Devuelve la secuencia inicial, final, o enésima</para>
-				<para><varname>startSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq</varname></para>
-				<para><varname>endSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq</varname></para>
-				<para><varname>sequenceN({ttypeContSeq,ttypeSeqSet},integer) → ttypeContSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq
+endSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq
+sequenceN({ttypeContSeq,ttypeSeqSet},integer) → ttypeContSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT startSequence(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
@@ -1122,7 +1174,9 @@ SELECT sequenceN(tfloat '{[1@2001-01-01, 2@2001-01-03),
 			<listitem xml:id="ttype_segments">
 				<indexterm significance="normal"><primary><varname>segments</varname></primary></indexterm>
 				<para>Devuelve los segmentos</para>
-				<para><varname>segments({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+segments({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT segments(tint '{[1@2001-01-01, 3@2001-01-02, 2@2001-01-03],
   (3@2001-01-03, 5@2001-01-05]}');
@@ -1146,9 +1200,11 @@ SELECT segments(tfloat '{[1@2001-01-01, 3@2001-01-02, 2@2001-01-03],
 				<indexterm significance="normal"><primary><varname>ttypeSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttypeSeqSet</varname></primary></indexterm>
 				<para>Transformar un tipo temporal a otro subtipo</para>
-				<para><varname>ttypeInst(ttype) → ttypeInst</varname></para>
-				<para><varname>ttypeSeq(ttype) → ttypeSeq</varname></para>
-				<para><varname>ttypeSeqSet(ttype) → ttypeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeInst(ttype) → ttypeInst
+ttypeSeq(ttype) → ttypeSeq
+ttypeSeqSet(ttype) → ttypeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT tboolInst(tbool '{[true@2001-01-01]}');
 -- t@2001-01-01
@@ -1166,7 +1222,9 @@ SELECT tfloatSeqSet(tfloat '{2.5@2001-01-01, 1.5@2001-01-02, 3.5@2001-01-03}');
 			<listitem xml:id="ttype_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transformar un valor temporal a otra interpolación</para>
-				<para><varname>setInterp(ttype, interp) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(ttype, interp) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT setInterp(tbool 'true@2001-01-01','discrete');
 -- {t@2001-01-01}
@@ -1191,9 +1249,11 @@ SELECT setInterp(tgeometry '[Point(1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Desplazar y/o escalear el intervalo de tiempo de un valor temporal a uno o dos intervalos</para>
-				<para><varname>shiftTime(ttype,interval) → ttype</varname></para>
-				<para><varname>scaleTime(ttype,interval) → ttype</varname></para>
-				<para><varname>shiftScaleTime(ttype,interval,interval) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftTime(ttype,interval) → ttype
+scaleTime(ttype,interval) → ttype
+shiftScaleTime(ttype,interval,interval) → ttype
+</programlisting>
 				<para>Cuando se escalea, si el rango de valores o el intervalo de tiempo del valor temporal es cero (por ejemplo, para un instante temporal), el resultado es el valor temporal. Igualmente, el ancho o intervalo dado debe ser estrictamente mayor que cero.</para>
 				<programlisting language="sql" xml:space="preserve">
 SELECT shiftTime(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}', '1 day');
@@ -1236,8 +1296,10 @@ SELECT asText(shiftScaleTime(tgeometry '{[Point(1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>segmentMinDuration</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>segmentMaxDuration</varname></primary></indexterm>
 				<para>Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada.</para>
-				<para><varname>segmentMinDuration(temp,interval,boolean strict=true) → tbool</varname></para>
-				<para><varname>segmentMaxDuration(temp,interval,boolean strict=true) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+segmentMinDuration(temp,interval,boolean strict=true) → tbool
+segmentMaxDuration(temp,interval,boolean strict=true) → tbool
+</programlisting>
 				<para>Si el argumento <varname>strict</varname> no se especifica, se asume el valor <varname>true</varname> por defecto y, por lo tanto, la función verifica si la duración del segmento es estrictamente menor o mayor que el intervalo. Si el argumento es <varname>false</varname>, la función verifica si la duración del segmento es menor/mayor o <emphasis>igual</emphasis> que el intervalo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT segmentMinDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
@@ -1258,7 +1320,9 @@ SELECT segmentMaxDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
 			<listitem xml:id="ttype_unnest">
 				<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
 				<para>Transformar un valor temporal no lineal en un conjunto de filas, cada una es una pareja compuesta de un valor de base y un conjunto de períodos durante el cual el valor temporal tiene el valor de base &SRF;</para>
-				<para><varname>unnest(ttype) → {(value,time)}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+unnest(ttype) → {(value,time)}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT (un).value, (un).time
 FROM (SELECT unnest(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}') AS un) t;

--- a/doc/es/temporal_types_p2.xml
+++ b/doc/es/temporal_types_p2.xml
@@ -82,7 +82,9 @@
 			<listitem xml:id="ttype_insert">
 				<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
 				<para>Insertar un valor temporal en otro</para>
-				<para><varname>insert(ttype,ttype,connect=true) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+insert(ttype,ttype,connect=true) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT insert(tint '{1@2001-01-01, 3@2001-01-03, 5@2001-01-05}',
   tint '{3@2001-01-03, 7@2001-01-07}');
@@ -107,7 +109,9 @@ SELECT asText(insert(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01
 			<listitem xml:id="ttype_update">
 				<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
 				<para>Actualizar un valor temporal con otro</para>
-				<para><varname>update(ttype,ttype,connect=true) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+update(ttype,ttype,connect=true) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT update(tint '{1@2001-01-01, 3@2001-01-03, 5@2001-01-05}',
   tint '{5@2001-01-03, 7@2001-01-07}');
@@ -131,7 +135,9 @@ SELECT asText(update(
 			<listitem xml:id="ttype_deleteTime">
 				<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
 				<para>Eliminar de un valor temporal un valor de tiempo</para>
-				<para><varname>deleteTime(ttype,time,connect=true) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+deleteTime(ttype,time,connect=true) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT deleteTime(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-02', false);
 -- {[1@2001-01-01, 1@2001-01-02), (1@2001-01-02, 1@2001-01-03]}
@@ -151,8 +157,10 @@ SELECT asText(deleteTime(tgeompoint '{[Point(1 1 1)@2001-01-01,
 			<listitem xml:id="ttype_appendInstant">
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<para>Anexar un instante temporal a un valor temporal</para>
-				<para><varname>appendInstant(ttype,ttypeInst,interp=NULL) → ttype</varname></para>
-				<para><varname>appendInstant(ttypeInst,interp=NULL,maxdist=NULL,maxt=NULL) → ttypeSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(ttype,ttypeInst,interp=NULL) → ttype
+appendInstant(ttypeInst,interp=NULL,maxdist=NULL,maxt=NULL) → ttypeSeq
+</programlisting>
 				<para>La primera versión de la función devuelve el resultado de agregar el segundo argumento al primero. Si cualquiera de las entradas es NULL, se devuelve NULL.</para>
 				<para>La segunda versión de la función anterior es una función de <emphasis>agregación</emphasis> que devuelve el resultado de agregar sucesivamente un conjunto de filas de valores temporales. Esto significa que funciona de la misma manera que las funciones <varname>SUM()</varname> y <varname>AVG()</varname> y, como la mayoría de los agregados, también ignora los valores NULL. Dos argumentos opcionales establecen una distancia máxima y un intervalo de tiempo máximo de modo que se introduce una brecha de tiempo cada vez que dos instantes consecutivos tienen una distancia o un intervalo de tiempo mayor que estos valores. Para puntos temporales, la distancia se especifica en unidades del sistema de coordenadas. Si uno de estos argumentos no se dan, no se tiene en cuenta para determinar las brechas.</para>
 				<programlisting language="sql" xml:space="preserve">
@@ -220,8 +228,10 @@ SELECT asText(appendInstant(inst, NULL, sqrt(2), '1 day' ORDER BY inst)) FROM te
 			<listitem xml:id="ttype_appendSequence">
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Anexar una secuencia temporal a un valor temporal</para>
-				<para><varname>appendSequence(ttype,ttypeSeq) → {ttypeSeq, ttypeSeqSet}</varname></para>
-				<para><varname>appendSequence(ttypeSeq) → {ttypeSeq,ttypeSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendSequence(ttype,ttypeSeq) → {ttypeSeq, ttypeSeqSet}
+appendSequence(ttypeSeq) → {ttypeSeq,ttypeSeqSet}
+</programlisting>
 				<para>La primera versión de la función devuelve el resultado de agregar el segundo argumento al primero. Si cualquiera de las entradas es NULL, se devuelve NULL.</para>
 				<para>La segunda versión de la función anterior es una función de <emphasis>agregación</emphasis> que devuelve el resultado de agregar sucesivamente un conjunto de filas de valores temporales. Esto significa que funciona de la misma manera que las funciones <varname>SUM()</varname> y <varname>AVG()</varname> y, como la mayoría de los agregados, también ignora los valores NULL.</para>
 				<programlisting language="sql" xml:space="preserve">
@@ -247,9 +257,11 @@ SELECT asText(appendSequence(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001
 			<listitem xml:id="ttype_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<para>Fusionar los valores temporales</para>
-				<para><varname>merge(ttype,ttype) → ttype</varname></para>
-				<para><varname>merge(ttype[]) → ttype</varname></para>
-				<para><varname>merge(ttype) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(ttype,ttype) → ttype
+merge(ttype[]) → ttype
+merge(ttype) → ttype
+</programlisting>
 				<para>Los valores temporales solo pueden intersectar en su límite. En ese caso, para todos los tipos temporales excepto <varname>tgeometry</varname> y <varname>tgeography</varname>, sus valores de base en las marcas de tiempo comunes deben ser los mismos, de lo contrario se genera un error. Para los tipos <varname>tgeometry</varname> y <varname>tgeography</varname>, si el valor en sus marcas de tiempo comunes es diferente, el valor resultante después de la <varname>merge</varname> será la unión espacial de los valores. La razón de un comportamiento diferente para estos tipos es que son los únicos tipos temporales que no son tipos <emphasis>escalares</emphasis>, es decir, su valor en una marca de tiempo dada no es un único elemento del dominio del tipo base, sino más bien un subconjunto de su dominio.</para>
 				<para>La tercera versión de la función anterior es una función de <emphasis>agregación</emphasis> que devuelve el resultado de agregar sucesivamente un conjunto de filas de valores temporales. Esto significa que funciona de la misma manera que las funciones <varname>SUM()</varname> y <varname>AVG()</varname> y, como la mayoría de los agregados, también ignora los valores NULL.</para>
 				<programlisting language="sql" xml:space="preserve">
@@ -322,14 +334,16 @@ SELECT merge(inst) FROM temp;
 				<indexterm significance="normal"><primary><varname>atSpanset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusSpanset</varname></primary></indexterm>
 				<para>Restringir a (al complemento de) un valor o un conjunto de valores o, para un número temporal, un span o un conjunto de spans de valores</para>
-				<para><varname>atValue(ttype,value) → ttype</varname></para>
-				<para><varname>minusValue(ttype,value) → ttype</varname></para>
-				<para><varname>atValues(ttype,valueset) → ttype</varname></para>
-				<para><varname>minusValues(ttype,valueset) → ttype</varname></para>
-				<para><varname>atSpan(tnumber,span) → tnumber</varname></para>
-				<para><varname>minusSpan(tnumber,span) → tnumber</varname></para>
-				<para><varname>atSpanset(tnumber,spanset) → tnumber</varname></para>
-				<para><varname>minusSpanset(tnumber,spanset) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(ttype,value) → ttype
+minusValue(ttype,value) → ttype
+atValues(ttype,valueset) → ttype
+minusValues(ttype,valueset) → ttype
+atSpan(tnumber,span) → tnumber
+minusSpan(tnumber,span) → tnumber
+atSpanset(tnumber,spanset) → tnumber
+minusSpanset(tnumber,spanset) → tnumber
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT atValue(tint '[1@2001-01-01, 1@2001-01-15)', 1);
 -- [1@2001-01-01, 1@2001-01-15)
@@ -381,8 +395,10 @@ SELECT asText(minusValue(tgeometry '[Point(0 0)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusTime</varname></primary></indexterm>
 				<para>Restringir a (al complemento de) un valor de tiempo</para>
-				<para><varname>atTime(ttype,times) → ttype</varname></para>
-				<para><varname>minusTime(ttype,times) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atTime(ttype,times) → ttype
+minusTime(ttype,times) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT atTime(tfloat '[1@2001-01-01, 5@2001-01-05)', timestamptz '2001-01-02');
 -- 2@2001-01-02
@@ -417,8 +433,10 @@ SELECT minusTime(tint '[1@2001-01-01, 1@2001-01-15)',
 				<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
 				<para>Mantener los instantes de un valor temporal que son anteriores o posteriores a una marca de tiempo, o iguales a ella</para>
-				<para><varname>beforeTimestamp(ttype,timestamptz,strict boolean=TRUE) → ttype</varname></para>
-				<para><varname>afterTimestamp(ttype,timestamptz,strict boolean=TRUE) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+beforeTimestamp(ttype,timestamptz,strict boolean=TRUE) → ttype
+afterTimestamp(ttype,timestamptz,strict boolean=TRUE) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT beforeTimestamp(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-02');
 -- [1@2001-01-01, 1@2001-01-02)
@@ -488,7 +506,9 @@ SELECT tgeogpoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02]' =
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 					<para>Comparaciones tradicionales</para>
-					<para><varname>ttype {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} ttype → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+ttype {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} ttype → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tint '[1@2001-01-01, 1@2001-01-04)' = tint '[2@2001-01-03, 2@2001-01-05)';
 -- false
@@ -526,8 +546,10 @@ SELECT tint '[1@2001-01-01, 1@2001-01-04)' &gt;= tint '[2@2001-01-03, 2@2001-01-
 					<indexterm significance="normal"><primary><varname>?&gt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%&gt;=</varname></primary></indexterm>
 					<para>Comparaciones alguna vez y siempre</para>
-					<para><varname>{base,ttype} {?=, ?&lt;&gt;, ?&lt;, ?&gt;, ?&lt;=, ?&gt;=} {base,ttype} → boolean</varname></para>
-					<para><varname>{base,ttype} {%=, %&lt;&gt;, %&lt;, %&gt;, %&lt;=, %&gt;=} {base,ttype} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{base,ttype} {?=, ?&lt;&gt;, ?&lt;, ?&gt;, ?&lt;=, ?&gt;=} {base,ttype} → boolean
+{base,ttype} {%=, %&lt;&gt;, %&lt;, %&gt;, %&lt;=, %&gt;=} {base,ttype} → boolean
+</programlisting>
 					<para>Los operadores no tienen en cuenta si los límites son inclusivos o no.</para>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tint '[1@2001-01-01, 3@2001-01-04]' ?= 2;
@@ -596,7 +618,9 @@ SELECT ttext '{[AAA@2001-01-01, AAA@2001-01-03), [BBB@2001-01-04, BBB@2001-01-05
 					<indexterm significance="normal"><primary><varname>#&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&gt;=</varname></primary></indexterm>
 					<para>Comparaciones temporales</para>
-					<para><varname>{base,ttype} {#=, #&lt;&gt;, #&lt;, #&gt;, #&lt;=, #&gt;=} {base,ttype} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{base,ttype} {#=, #&lt;&gt;, #&lt;, #&gt;, #&lt;=, #&gt;=} {base,ttype} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tfloat '[1@2001-01-01, 2@2001-01-04)' #= 3;
 -- {[f@2001-01-01, f@2001-01-04)}
@@ -640,7 +664,9 @@ SELECT 'AAA'::text #&gt; ttext '{[AAA@2001-01-01, AAA@2001-01-03),
 			<listitem xml:id="mobilitydb_version">
 				<indexterm significance="normal"><primary><varname>mobilitydbVersion</varname></primary></indexterm>
 				<para>Versión de la extensión MobilityDB</para>
-				<para><varname>mobilitydbVersion() → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+mobilitydbVersion() → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT mobilitydbVersion();
 -- MobilityDB 1.3.0
@@ -650,7 +676,9 @@ SELECT mobilitydbVersion();
 			<listitem xml:id="mobilitydb_full_version">
 				<indexterm significance="normal"><primary><varname>mobilitydbFullVersion</varname></primary></indexterm>
 				<para>Versión de la extensión MobilityDB y de sus dependencias</para>
-				<para><varname>mobilitydbFullVersion() → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+mobilitydbFullVersion() → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve">
 /* MobilityDB 1.3.0, PostgreSQL 17.2, PostGIS 3.5.2, GEOS 3.12.0-CAPI-1.18.0, PROJ 9.2.0,
    JSON-C 0.13.1 */

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -188,7 +188,9 @@ SELECT tstzspanset '{[2001-01-01 08:00:00, 2001-01-01 08:10:00),
 			<listitem xml:id="setspan_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Return the Well-Known Text (WKT) representation</para>
-				<para><varname>asText({floatset,floatspans},maxdecdigits=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({floatset,floatspans},maxdecdigits=15) → text
+</programlisting>
 					<para>The <varname>maxdecdigits</varname> argument can be used to set the maximum number of decimal places in the output of floating point values (default 15).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(floatset '{1.123456789,2.123456789}', 3);
@@ -202,8 +204,10 @@ SELECT asText(floatspanset '{[1.55,2.55],[4,5]}',0);
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Return the Well-Known Binary (WKB) or the Hexadecimal Well-Known Binary (HexWKB) representation</para>
-				<para><varname>asBinary({set,spans},endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB({set,spans},endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary({set,spans},endian text='') → bytea
+asHexWKB({set,spans},endian text='') → text
+</programlisting>
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(dateset '{2001-01-01, 2001-01-03}');
@@ -225,8 +229,12 @@ SELECT asHexWKB(floatspanset '{[1, 2], [4, 5]}', 'XDR');
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Return the Extended Well-Known Binary (EWKB) or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation of a spatial set</para>
-				<para><varname>asEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,pcpatchset},endian text='') → bytea</varname></para>
-				<para><varname>asHexEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,pcpatchset},endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,pcpatchset},
+  endian text='') → bytea
+asHexEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,
+  pcpatchset},endian text='') → text
+</programlisting>
 				<para>For <varname>geomset</varname>, <varname>geogset</varname>, <varname>cbufferset</varname>, <varname>npointset</varname>, <varname>poseset</varname>, and <varname>posechainset</varname> the SRID (when known) is embedded once in the set header: <varname>asEWKB</varname> and <varname>asHexEWKB</varname> include it, while <varname>asBinary</varname> and <varname>asHexWKB</varname> emit the plain Well-Known Binary representation without it, matching the OGC convention and the <varname>cbuffer</varname>, <varname>npoint</varname>, and <varname>pose</varname> base-type <varname>asBinary</varname>/<varname>asHexWKB</varname>. For <varname>pcpointset</varname> and <varname>pcpatchset</varname> the schema, and its SRID, is resolved out-of-band from the <varname>pointcloud_formats</varname> catalog rather than embedded in the value, so all four functions always return the same bytes for those two types.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(geomset 'SRID=4326;{Point(1 1)}');
@@ -249,9 +257,11 @@ SELECT asHexEWKB(npointset '{"NPoint(1,0.5)"}');
 				<indexterm significance="normal"><primary><varname>spantypeFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spansettypeFromBinary</varname></primary></indexterm>
 				<para>Input from the Well-Known Binary (WKB) representation</para>
-				<para><varname>settypeFromBinary(bytea) → set</varname></para>
-				<para><varname>spantypeFromBinary(bytea) → span</varname></para>
-				<para><varname>spansettypeFromBinary(bytea) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+settypeFromBinary(bytea) → set
+spantypeFromBinary(bytea) → span
+spansettypeFromBinary(bytea) → spanset
+</programlisting>
 				<para>There is one function per set or span (set) type, the name of the function has as prefix the name of the type</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT datesetFromBinary('\x01050001020000006e01000070010000');
@@ -269,9 +279,11 @@ SELECT floatspansetFromBinary(
 				<indexterm significance="normal"><primary><varname>spantypeFromHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spansettypeFromHexWKB</varname></primary></indexterm>
 				<para>Input from the Hexadecimal Well-Known Binary (HexWKB) representation</para>
-				<para><varname>settypeFromHexWKB(text) → set</varname></para>
-				<para><varname>spantypeFromHexWKB(text) → span</varname></para>
-				<para><varname>spansettypeFromHexWKB(text) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+settypeFromHexWKB(text) → set
+spantypeFromHexWKB(text) → span
+spansettypeFromHexWKB(text) → spanset
+</programlisting>
 				<para>There is one function per set or span (set) type, the name of the function has as prefix the name of the type.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT datesetFromHexWKB('01050001020000006E01000070010000');
@@ -298,7 +310,9 @@ SELECT floatspansetFromHexWKB(
 			<listitem xml:id="set">
 				<indexterm significance="normal"><primary><varname>set</varname></primary></indexterm>
 				<para>Constructor for set types</para>
-				<para><varname>set(base[]) → set</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+set(base[]) → set
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT set(ARRAY['highway', 'primary', 'secondary']);
 -- {"highway", "primary", "secondary"}
@@ -314,7 +328,9 @@ SELECT set(ARRAY[timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00']);
 			<listitem xml:id="span">
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<para>Constructor for span types</para>
-				<para><varname>span(lower base,upper base,leftInc boolean=true,rightInc boolean=false) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+span(lower base,upper base,leftInc boolean=true,rightInc boolean=false) → span
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT span(20.5, 25);
 -- [20.5, 25)
@@ -332,7 +348,9 @@ SELECT span(timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00', false, tru
 			<listitem xml:id="spanset">
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Constructor for span set types</para>
-				<para><varname>spanset(span[]) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+spanset(span[]) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spanset(ARRAY[intspan '[10,12]', '[13,15]']);
 -- {[10, 16)}
@@ -359,10 +377,12 @@ SELECT spanset(ARRAY[tstzspan '[2001-01-01 08:00, 2001-01-01 08:10]',
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convert a base value to a set, span, or span set value</para>
-				<para><varname>base::{set,span,spanset}</varname></para>
-				<para><varname>set(base) → set</varname></para>
-				<para><varname>span(base) → span</varname></para>
-				<para><varname>spanset(base) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+base::{set,span,spanset}
+set(base) → set
+span(base) → span
+spanset(base) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT CAST(timestamptz '2001-01-01 08:00:00' AS tstzset);
 -- {2001-01-01 08:00:00}
@@ -377,8 +397,10 @@ SELECT spanset(timestamptz '2001-01-01 08:00:00');
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convert a set value to a span set value</para>
-				<para><varname>set::spanset</varname></para>
-				<para><varname>spanset(set) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+set::spanset
+spanset(set) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spanset(tstzset '{2001-01-01 08:00:00, 2001-01-01 08:15:00,
   2001-01-01 08:25:00}');
@@ -392,8 +414,10 @@ SELECT spanset(tstzset '{2001-01-01 08:00:00, 2001-01-01 08:15:00,
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<para>Convert a span value to a span set value</para>
-				<para><varname>span::spanset</varname></para>
-				<para><varname>spanset(span) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+span::spanset
+spanset(span) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floatspan '[1.5,2.5]'::floatspanset;
 -- {[1.5, 2.5]}
@@ -405,8 +429,10 @@ SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-01 08:30:00)'::tstzspanset;
 			<listitem xml:id="setspan_span">
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<para>Convert a set or a span set into a span, ignoring the potential time gaps</para>
-				<para><varname>{set,spanset}::span</varname></para>
-				<para><varname>span({set,spanset}) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{set,spanset}::span
+span({set,spanset}) → span
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT span(dateset '{2001-01-01, 2001-01-03, 2001-01-05}');
 -- [2001-01-01, 2001-01-06)
@@ -420,10 +446,12 @@ SELECT span(tstzspanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>range</varname></primary></indexterm>
 				<para>Convert a span value to and from a PostgreSQL range value</para>
-				<para><varname>span::range</varname></para>
-				<para><varname>range::span</varname></para>
-				<para><varname>range(span) → range</varname></para>
-				<para><varname>span(range) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+span::range
+range::span
+range(span) → range
+span(range) → span
+</programlisting>
 				<para>Notice that PostgreSQL range values accept empty ranges and ranges with infinite values, which are not allowed as span values in MobilityDB</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[10, 20)'::int4range;
@@ -446,10 +474,12 @@ SELECT tstzrange '[2001-01-01 08:00:00, 2001-01-01 08:30:00)'::tstzspan;
 				<indexterm significance="normal"><primary><varname>spanset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>multirange</varname></primary></indexterm>
 				<para>Convert a span set value to and from a PostgreSQL multirange value</para>
-				<para><varname>spanset::multirange</varname></para>
-				<para><varname>multirange::spanset</varname></para>
-				<para><varname>multirange(spanset) → multirange</varname></para>
-				<para><varname>spanset(multirange) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+spanset::multirange
+multirange::spanset
+multirange(spanset) → multirange
+spanset(multirange) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspanset '{[1,2],[4,5]}'::int4multirange;
 -- {[1,3),[4,6)}
@@ -471,7 +501,9 @@ SELECT tstzmultirange '{[2001-01-01,2001-01-02],[2001-01-04,2001-01-05]}'::tstzs
 			<listitem xml:id="setspan_memSize">
 				<indexterm significance="normal"><primary><varname>memSize</varname></primary></indexterm>
 				<para>Return the memory size in bytes</para>
-				<para><varname>memSize({set,spanset}) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+memSize({set,spanset}) → integer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT memSize(tstzset '{2001-01-01, 2001-01-02, 2001-01-03}');
 -- 48
@@ -485,8 +517,10 @@ SELECT memSize(tstzspanset '{[2001-01-01, 2001-01-02], [2001-01-03, 2001-01-04],
 				<indexterm significance="normal"><primary><varname>lower</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>upper</varname></primary></indexterm>
 				<para>Return the lower or upper bound</para>
-				<para><varname>lower(spans) → base</varname></para>
-				<para><varname>upper(spans) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lower(spans) → base
+upper(spans) → base
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lower(tstzspan '[2001-01-01, 2001-01-05)');
 -- 2001-01-01
@@ -515,8 +549,10 @@ SELECT upper(tstzspan '[2001-01-01, 2001-01-05)');
 				<indexterm significance="normal"><primary><varname>lowerInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>upperInc</varname></primary></indexterm>
 				<para>Is the lower or upper bound inclusive?</para>
-				<para><varname>lowerInc(spans) → boolean</varname></para>
-				<para><varname>upperInc(spans) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lowerInc(spans) → boolean
+upperInc(spans) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lowerInc(datespan '[2001-01-01, 2001-01-05)');
 -- true
@@ -534,8 +570,10 @@ SELECT upperInc(tstzspan '[2001-01-01, 2001-01-05)');
 			<listitem xml:id="setspan_width">
 				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
 				<para>Return the width of the span as a float</para>
-				<para><varname>width(numspan) → float</varname></para>
-				<para><varname>width(numspanset,boundspan=false) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+width(numspan) → float
+width(numspanset,boundspan=false) → float
+</programlisting>
 				<para>An additional parameter can be set to true to compute the width of the bounding span, thus ignoring the potential value gaps</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT width(floatspan '[1, 3)');
@@ -550,8 +588,10 @@ SELECT width(intspanset '{[1,3),[5,7)}', true);
 			<listitem xml:id="setspan_duration">
 				<indexterm significance="normal"><primary><varname>duration</varname></primary></indexterm>
 				<para>Return the duration</para>
-				<para><varname>duration({datespan,tstzspan}) → interval</varname></para>
-				<para><varname>duration({datespanset,tstzspanset},boundspan boolean=false) → interval</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+duration({datespan,tstzspan}) → interval
+duration({datespanset,tstzspanset},boundspan boolean=false) → interval
+</programlisting>
 				<para>An additional parameter can be set to true to compute the duration of the bounding time span, thus ignoring the potential time gaps</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT duration(datespan '[2001-01-01, 2001-01-03)');
@@ -567,8 +607,10 @@ SELECT duration(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-05)
 				<indexterm significance="normal"><primary><varname>numValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Return the (number of) values</para>
-				<para><varname>numValues(set) → integer</varname></para>
-				<para><varname>getValues(set) → base[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numValues(set) → integer
+getValues(set) → base[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(intset '{1,3,5,7}');
 -- 4
@@ -582,9 +624,11 @@ SELECT getValues(tstzset '{2001-01-01, 2001-01-03, 2001-01-05, 2001-01-07}');
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th value</para>
-				<para><varname>startValue(set) → base</varname></para>
-				<para><varname>endValue(set) → base</varname></para>
-				<para><varname>valueN(set,integer) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(set) → base
+endValue(set) → base
+valueN(set,integer) → base
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(intset '{1,3,5,7}');
 -- 1
@@ -599,8 +643,10 @@ SELECT valueN(floatset '{1,3,5,7}',2);
 				<indexterm significance="normal"><primary><varname>numSpans</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
 				<para>Return the (number of) spans</para>
-				<para><varname>numSpans(spanset) → integer</varname></para>
-				<para><varname>spans(spanset) → span[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numSpans(spanset) → integer
+spans(spanset) → span[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSpans(intspanset '{[1,3),[4,5),[6,7)}');
 -- 3
@@ -622,9 +668,11 @@ SELECT spans(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-04],
 				<indexterm significance="normal"><primary><varname>endSpan</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spanN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th span</para>
-				<para><varname>startSpan(spanset) → span</varname></para>
-				<para><varname>endSpan(spanset) → span</varname></para>
-				<para><varname>spanN(spanset,integer) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startSpan(spanset) → span
+endSpan(spanset) → span
+spanN(spanset,integer) → span
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startSpan(intspanset '{[1,3),[4,5),[6,7)}');
 -- [1,3)
@@ -652,8 +700,10 @@ SELECT spanN(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-04],
 				<indexterm significance="normal"><primary><varname>numDates</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dates</varname></primary></indexterm>
 				<para>Return the (number of) different dates</para>
-				<para><varname>numDates(datespanset) → integer</varname></para>
-				<para><varname>dates(datespanset) → dateset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numDates(datespanset) → integer
+dates(datespanset) → dateset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numDates(datespanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
 -- 4
@@ -667,9 +717,11 @@ SELECT dates(datespanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}')
 				<indexterm significance="normal"><primary><varname>endDate</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dateN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th date</para>
-				<para><varname>startDate(datespanset) → date</varname></para>
-				<para><varname>endDate(datespanset) → date</varname></para>
-				<para><varname>dateN(datespanset,integer) → date</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startDate(datespanset) → date
+endDate(datespanset) → date
+dateN(datespanset,integer) → date
+</programlisting>
 				<para>The functions do not take into account whether the bounds are inclusive or not.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startDate(datespanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
@@ -685,8 +737,10 @@ SELECT dateN(datespanset '{[2001-01-01, 2001-01-03), (2001-01-03, 2001-01-05)}',
 				<indexterm significance="normal"><primary><varname>numTimestamps</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timestamps</varname></primary></indexterm>
 				<para>Return the (number of) different timestamps</para>
-				<para><varname>numTimestamps(tstzspanset) → integer</varname></para>
-				<para><varname>timestamps(tstzspanset) → tstzset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numTimestamps(tstzspanset) → integer
+timestamps(tstzspanset) → tstzset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numTimestamps(tstzspanset '{[2001-01-01, 2001-01-03), (2001-01-03, 2001-01-05)}');
 -- 3
@@ -700,9 +754,11 @@ SELECT timestamps(tstzspanset '{[2001-01-01, 2001-01-03), (2001-01-03, 2001-01-0
 				<indexterm significance="normal"><primary><varname>endTimestamp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timestampN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th timestamp</para>
-				<para><varname>startTimestamp(tstzspanset) → timestamptz</varname></para>
-				<para><varname>endTimestamp(tstzspanset) → timestamptz</varname></para>
-				<para><varname>timestampN(tstzspanset,integer) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startTimestamp(tstzspanset) → timestamptz
+endTimestamp(tstzspanset) → timestamptz
+timestampN(tstzspanset,integer) → timestamptz
+</programlisting>
 				<para>The functions do not take into account whether the bounds are inclusive or not.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startTimestamp(tstzspanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
@@ -722,8 +778,10 @@ SELECT timestampN(tstzspanset '{[2001-01-01, 2001-01-03), (2001-01-03, 2001-01-0
 			<listitem xml:id="setspan_expand">
 				<indexterm significance="normal"><primary><varname>expand</varname></primary></indexterm>
 				<para>Expand or shrink the bounds by a value or an interval</para>
-				<para><varname>expand(numspan,base) → numspan</varname></para>
-				<para><varname>expand(tstzspan,interval) → tstzspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+expand(numspan,base) → numspan
+expand(tstzspan,interval) → tstzspan
+</programlisting>
 				<para>The function returns NULL if the value or interval given as second argument is negative and the span resulting from shifting the bounds with the argument is empty.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expand(floatspan '[1, 3]', 1);
@@ -744,9 +802,11 @@ SELECT expand(tstzspan '[2001-01-01, 2001-01-03]', interval '-2 day');
 			<listitem xml:id="setspan_shift">
 				<indexterm significance="normal"><primary><varname>shift</varname></primary></indexterm>
 				<para>Shift by a value or interval</para>
-				<para><varname>shift(numbers,base) → numbers</varname></para>
-				<para><varname>shift(dates,integer) → dates</varname></para>
-				<para><varname>shift(times,interval) → times</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shift(numbers,base) → numbers
+shift(dates,integer) → dates
+shift(times,interval) → times
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shift(dateset '{2001-01-01, 2001-01-03, 2001-01-05}', 1);
 -- {2001-01-02, 2001-01-04, 2001-01-06}
@@ -765,9 +825,11 @@ SELECT shift(tstzspanset '{[2001-01-01, 2001-01-03], [2001-01-04, 2001-01-05]}',
 			<listitem xml:id="setspan_scale">
 				<indexterm significance="normal"><primary><varname>scale</varname></primary></indexterm>
 				<para>Scale by a value or interval</para>
-				<para><varname>scale(numbers,base) → numbers</varname></para>
-				<para><varname>scale(dates,integer) → dates</varname></para>
-				<para><varname>scale(times,interval) → times</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+scale(numbers,base) → numbers
+scale(dates,integer) → dates
+scale(times,interval) → times
+</programlisting>
 				<para>If the width or time span of the input value is zero (for example, for a singleton timestamp set), the result is the input value. The given value or interval must be strictly greater than zero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT scale(tstzset '{2001-01-01}', '1 day');
@@ -793,9 +855,11 @@ SELECT scale(tstzset '{2001-01-01}', '-1 day');
 			<listitem xml:id="setspan_shiftScale">
 				<indexterm significance="normal"><primary><varname>shiftScale</varname></primary></indexterm>
 				<para>Shift and scale by the values or intervals</para>
-				<para><varname>shiftScale(numbers,base,base) → numbers</varname></para>
-				<para><varname>shiftScale(dates,integer,integer) → dates</varname></para>
-				<para><varname>shiftScale(times,interval,interval) → times</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftScale(numbers,base,base) → numbers
+shiftScale(dates,integer,integer) → dates
+shiftScale(times,interval,interval) → times
+</programlisting>
 				<para>This function combines the functions <link linkend="setspan_shift"><varname>shift</varname></link> and <link linkend="setspan_scale"><varname>scale</varname></link>.</para>
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftScale(tstzset '{2001-01-01}', '1 day', '1 day');
@@ -821,8 +885,10 @@ SELECT shiftScale(tstzspanset '{[2001-01-01, 2001-01-03], [2001-01-04, 2001-01-0
 				<indexterm significance="normal"><primary><varname>floor</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ceil</varname></primary></indexterm>
 				<para>Round down or up to the nearest integer</para>
-				<para><varname>floor({floatset,floatspans}) → {floatset,floatspans}</varname></para>
-				<para><varname>ceil({floatset,floatspans}) → {floatset,floatspans}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+floor({floatset,floatspans}) → {floatset,floatspans}
+ceil({floatset,floatspans}) → {floatset,floatspans}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floor(floatset '{1.5,2.5}');
 -- {1, 2}
@@ -838,7 +904,9 @@ SELECT ceil(floatspanset '{[1.5, 2.5],[3.5,4.5]}');
 			<listitem xml:id="floatsetspan_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Round to a number of decimal places</para>
-				<para><varname>round({floatset,floatspans},integer=0) → {floatset,floatspans}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round({floatset,floatspans},integer=0) → {floatset,floatspans}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(floatset '{1.123456789,2.123456789}', 3);
 -- {1.123, 2.123}
@@ -855,8 +923,10 @@ SELECT round(floatspanset '{[1.123456789, 2.123456789],[3.123456789,4.123456789]
 				<indexterm significance="normal"><primary><varname>degrees</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>radians</varname></primary></indexterm>
 				<para>Convert to degrees or radians</para>
-				<para><varname>degrees({floatset,floatspans}, normalize=false) → {floatset,floatspans}</varname></para>
-				<para><varname>radians({floatset,floatspans}) → {floatset,floatspans}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+degrees({floatset,floatspans}, normalize=false) → {floatset,floatspans}
+radians({floatset,floatspans}) → {floatset,floatspans}
+</programlisting>
 				<para>The additional parameter in the <varname>degrees</varname> function can be used to normalize the values between 0 and 360 degrees.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(degrees(floatset '{0, 0.5, 0.7, 1.0}', true), 3);
@@ -871,9 +941,11 @@ SELECT round(radians(floatspanset '{[0, 45], [90, 135]}'), 3);
 				<indexterm significance="normal"><primary><varname>upper</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>initcap</varname></primary></indexterm>
 				<para>Transform to lowercase, uppercase, or initcap</para>
-				<para><varname>lower(textset) → textset</varname></para>
-				<para><varname>upper(textset) → textset</varname></para>
-				<para><varname>initcap(textset) → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lower(textset) → textset
+upper(textset) → textset
+initcap(textset) → textset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lower(textset '{"AAA", "BBB", "CCC"}');
 -- {"aaa", "bbb", "ccc"}
@@ -887,7 +959,9 @@ SELECT initcap(textset '{"aaa", "bbb", "ccc"}');
 			<listitem xml:id="textset_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
 				<para>Text concatenation</para>
-				<para><varname>{text,textset} || {text,textset} → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{text,textset} || {text,textset} → textset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT textset '{aaa, bbb}' || text 'XX';
 -- {"aaaXX", "bbbXX"}
@@ -899,7 +973,9 @@ SELECT text 'XX' || textset '{aaa, bbb}';
 			<listitem xml:id="time_tprecision">
 				<indexterm significance="normal"><primary><varname>tprecision</varname></primary></indexterm>
 				<para>Set the temporal precision of the time value to the interval with respect to the origin</para>
-				<para><varname>tprecision(times,interval,origin timestamptz=’2000-01-03’) → times</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tprecision(times,interval,origin timestamptz=’2000-01-03’) → times
+</programlisting>
 				<para>If the origin is not specified, it is set by default to Monday, January 3, 2000</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tprecision(timestamptz '2001-12-03', '30 days');
@@ -932,8 +1008,10 @@ SELECT tprecision(tstzspanset '{[2001-12-01 08:00, 2001-12-01 09:00],
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Return or set the spatial reference identifier</para>
-				<para><varname>SRID(spatialset) → integer</varname></para>
-				<para><varname>setSRID(spatialset) → spatialset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(spatialset) → integer
+setSRID(spatialset) → spatialset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(geomset '{"Point(1 1)", "Point(2 2)"}');
 -- 0
@@ -958,9 +1036,11 @@ SELECT asEWKT(setSRID(cbufferset '{"Cbuffer(Point(1 1),0.5)",
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transform to a spatial reference identifier</para>
-				<para><varname>transform(spatialset,to_srid integer) → spatialset</varname></para>
-				<para><varname>transformPipeline(spatialset,pipeline text,to_srid integer,is_forward boolean=true) →</varname></para>
-				<para><varname>  spatialset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(spatialset,to_srid integer) → spatialset
+transformPipeline(spatialset,pipeline text,to_srid integer,is_forward boolean=true) →
+  spatialset
+</programlisting>
 				<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input set has an unknown SRID (represented by 0). The <varname>transformPipeline</varname> function specifies the transformation with a coordinate transformation pipeline in the following format:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
 				<para>The SRID of the input set is ignored, and the SRID of the output set will be set to zero unless a value is provided via the optional <varname>to_srid</varname> parameter. As stated by the last parameter, the pipeline is executed by default in a forward direction; by setting the parameter to false, the pipeline is executed in the inverse direction.</para>
@@ -992,8 +1072,10 @@ FROM test;
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 				<para>Union, difference, or intersection of sets or spans</para>
-				<para><varname>set {+, -, *} set → set</varname></para>
-				<para><varname>spans {+, -, *} spans → spans</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+set {+, -, *} set → set
+spans {+, -, *} spans → spans
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT dateset '{2001-01-01, 2001-01-03, 2001-01-05}' +
   dateset '{2001-01-03, 2001-01-06}';
@@ -1049,7 +1131,9 @@ SELECT tstzspan '[2001-01-01, 2001-01-05)' * tstzspan '[2001-01-03, 2001-01-07)'
 				<listitem xml:id="setspan_overlaps">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 					<para>Do the values overlap (have values in common)?</para>
-					<para><varname>{set,spans} &amp;&amp; {set,spans} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{set,spans} &amp;&amp; {set,spans} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intset '{1, 3}' &amp;&amp; intset '{2, 3, 4}';
 -- true
@@ -1064,7 +1148,9 @@ SELECT floatspanset '{[1, 5),[6, 8)}' &amp;&amp; floatspan '[1, 6)';
 				<listitem xml:id="setspan_contains">
 					<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
 					<para>Does the first value contain the second one?</para>
-					<para><varname>{set,spans} @&gt; {base,set,spans} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{set,spans} @&gt; {base,set,spans} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floatset '{1.5, 2.5}' @&gt; 2.5;
 -- true
@@ -1078,7 +1164,9 @@ SELECT floatspanset '{[1, 2),(2, 3)}' @&gt; 2.0;
 				<listitem xml:id="setspan_containedby">
 					<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
 					<para>Is the first value contained by the second one?</para>
-					<para><varname>{base,set,spans} &lt;@ {set,spans} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{base,set,spans} &lt;@ {set,spans} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timestamptz '2001-01-10' &lt;@ tstzspan '[2001-01-01, 2001-05-01)';
 -- true
@@ -1094,7 +1182,9 @@ SELECT floatspanset '{[1,2],[3,4]}' &lt;@ floatspan '[1, 6]';
 				<listitem xml:id="setspan_adjacent">
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 					<para>Is the first value adjacent to the second one? Two values are adjacent when they touch without overlapping, that is, when they share a boundary and have no value in common inside it. For the continuous base types <varname>float</varname> and <varname>timestamptz</varname> a shared bound is such a touch. For the discrete base types <varname>int</varname>, <varname>bigint</varname> and <varname>date</varname>, whose spans are stored in normal form, it means consecutive values.</para>
-					<para><varname>spans -|- spans → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spans -|- spans → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[2, 6)' -|- intspan '[6, 7)';
 -- true
@@ -1135,8 +1225,10 @@ SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 12;
 					<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
 					<para>Is the first value strictly left of the second one?</para>
-					<para><varname>numbers &lt;&lt; numbers → boolean</varname></para>
-					<para><varname>times &lt;&lt;# times → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numbers &lt;&lt; numbers → boolean
+times &lt;&lt;# times → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[15, 20)' &lt;&lt; 20;
 -- true
@@ -1153,8 +1245,10 @@ SELECT dateset '{2001-01-01, 2001-01-02}' &lt;&lt;# dateset '{2001-01-03, 2001-0
 					<indexterm significance="normal"><primary><varname>&gt;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
 					<para>Is the first value strictly to the right of the second one?</para>
-					<para><varname>numbers &gt;&gt; numbers → boolean</varname></para>
-					<para><varname>times #&gt;&gt; times → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numbers &gt;&gt; numbers → boolean
+times #&gt;&gt; times → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[15, 20)' &gt;&gt; 10;
 -- true
@@ -1172,8 +1266,10 @@ SELECT tstzspan '[2001-01-04, 2001-01-05)' #&gt;&gt;
 					<indexterm significance="normal"><primary><varname>&amp;&lt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&amp;&lt;#</varname></primary></indexterm>
 					<para>Is the first value not to the right of the second one?</para>
-					<para><varname>numbers &amp;&lt; numbers → boolean</varname></para>
-					<para><varname>times &amp;&lt;# times → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numbers &amp;&lt; numbers → boolean
+times &amp;&lt;# times → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[15, 20)' &amp;&lt; 18;
 -- false
@@ -1190,8 +1286,10 @@ SELECT dateset '{2001-01-02, 2001-01-05}' &amp;&lt;# dateset '{2001-01-01, 2001-
 					<indexterm significance="normal"><primary><varname>&amp;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&amp;&gt;</varname></primary></indexterm>
 					<para>Is the first value not to the left of the second one?</para>
-					<para><varname>numbers &amp;&gt; numbers → boolean</varname></para>
-					<para><varname>times #&amp;&gt; times → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numbers &amp;&gt; numbers → boolean
+times #&amp;&gt; times → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[15, 20)' &amp;&gt; 30;
 -- true
@@ -1217,8 +1315,10 @@ SELECT timestamp '2001-01-01' #&amp;&gt; tstzspan '[2001-01-01, 2001-01-05)';
 				<listitem xml:id="setspan_splitNSpans">
 					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 					<para>Return an array of N spans obtained by merging the elements of a set or the spans of a spanset</para>
-					<para><varname>splitNSpans(set, integer) → span[]</varname></para>
-					<para><varname>splitNSpans(spanset, integer) → span[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+splitNSpans(set, integer) → span[]
+splitNSpans(spanset, integer) → span[]
+</programlisting>
 					<para>The last argument specifies the number of output spans. If the number of input elements or spans is less than the given number, the resulting array will have one span per input element or span. Otherwise, the given number of output spans will be obtained by merging several consecutive input elements or spans.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
@@ -1244,8 +1344,10 @@ SELECT splitNSpans(datespanset '{[2000-01-01, 2000-01-04), [2000-01-05, 2000-01-
 				<listitem xml:id="setspan_splitEachNSpans">
 					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 					<para>Return an array of spans obtained by merging N consecutive elements of a set or N consecutive spans of a spanset</para>
-					<para><varname>splitEachNSpans(set, integer) → span[]</varname></para>
-					<para><varname>splitEachNSpans(spanset, integer) → span[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+splitEachNSpans(set, integer) → span[]
+splitEachNSpans(spanset, integer) → span[]
+</programlisting>
 					<para>The last argument specifies the number of input elements that are merged to produce an output span. If the number of input elements is less than the given number, the resulting array will have one output span per element. Otherwise, the given number of consecutive input elements will be merged into a single output span in the answer. Notice that, contrary to the <link linkend="setspan_splitNSpans"><varname>splitNSpans</varname></link> function, the number of spans in the result depends on the number of input elements or spans.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
@@ -1272,9 +1374,11 @@ SELECT splitEachNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 12);
 			<listitem xml:id="smallest_distance_time">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Return the smallest distance ever</para>
-				<para><varname>numbers &lt;-&gt; numbers → base</varname></para>
-				<para><varname>dates &lt;-&gt; dates → integer</varname></para>
-				<para><varname>times &lt;-&gt; times → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numbers &lt;-&gt; numbers → base
+dates &lt;-&gt; dates → integer
+times &lt;-&gt; times → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT 3 &lt;-&gt; intspan '[6, 8)';
 -- 3
@@ -1309,11 +1413,13 @@ SELECT dateset '{2001-01-01, 2001-01-03, 2001-01-05}' &lt;-&gt;
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
-				<para><varname>set {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} set → boolean</varname></para>
-				<para><varname>spans {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} spans → boolean</varname></para>
-				<para><varname>cmp(set,set) → int</varname></para>
-				<para><varname>cmp(span,span) → int</varname></para>
-				<para><varname>cmp(spanset,spanset) → int</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+set {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} set → boolean
+spans {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} spans → boolean
+cmp(set,set) → int
+cmp(span,span) → int
+cmp(spanset,spanset) → int
+</programlisting>
 				<para>Functions <varname>cmp</varname>, <varname>cmp</varname>, and <varname>cmp</varname> return -1, 0, or 1 depending on whether the first argument is, respectively, less than, equal to, or greater than the second one.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[1,3]' = intspan '[1,4)';
@@ -1363,7 +1469,9 @@ SELECT cmp(intspanset '{[1, 4)}', intspanset '{[1, 5), [6, 7)}');
 			<listitem xml:id="setspan_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Bounding span</para>
-				<para><varname>extent({set,spans}) → span</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent({set,spans}) → span
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH spans(r) AS (
   SELECT floatspan '[1, 4)' UNION SELECT floatspan '(5, 8)' UNION 
@@ -1390,9 +1498,11 @@ SELECT extent(ps) FROM periods;
 				<indexterm significance="normal"><primary><varname>spanUnion</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spansetUnion</varname></primary></indexterm>
 				<para>Aggregate union</para>
-				<para><varname>setUnion({value,set}) → set</varname></para>
-				<para><varname>spanUnion(spans) → spanset</varname></para>
-					<para><varname>spansetUnion(spansets) → spanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setUnion({value,set}) → set
+spanUnion(spans) → spanset
+spansetUnion(spansets) → spanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH times(ts) AS (
   SELECT tstzset '{2001-01-01, 2001-01-03, 2001-01-05}' UNION
@@ -1412,7 +1522,9 @@ SELECT spansetUnion(ps) FROM periods;
 			<listitem xml:id="setspan_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
-				<para><varname>tCount(times) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(times) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH times(ts) AS (
   SELECT tstzset '{2001-01-01, 2001-01-03, 2001-01-05}' UNION

--- a/doc/temporal_alpha.xml
+++ b/doc/temporal_alpha.xml
@@ -50,10 +50,12 @@
 				<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tbox</varname></primary></indexterm>
 				<para>Convert a temporal number to a span or to a temporal bounding box</para>
-				<para><varname>tnumber::{span,tbox}</varname></para>
-				<para><varname>valueSpan(tnumber) → numspan</varname></para>
-				<para><varname>timeSpan(tnumber) → tstzspan</varname></para>
-				<para><varname>tbox(tnumber) → tbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnumber::{span,tbox}
+valueSpan(tnumber) → numspan
+timeSpan(tnumber) → tstzspan
+tbox(tnumber) → tbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 2@2001-01-03]'::intspan;
 -- [1, 3)
@@ -75,7 +77,9 @@ SELECT tfloat '(1@2001-01-01, 3@2001-01-03, 2@2001-01-05]'::tbox;
 			<listitem xml:id="talpha_valueSpan">
 				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
 				<para>Return the span of values, ignoring any gaps</para>
-				<para><varname>valueSpan(tnumber) → numspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueSpan(tnumber) → numspan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueSpan(tint '{1@2001-01-01, 5@2001-01-02, 3@2001-01-03}');
 -- [1, 6)
@@ -89,8 +93,10 @@ SELECT valueSpan(tfloat '[1.5@2001-01-01, 4.5@2001-01-03]');
 				<indexterm significance="normal"><primary><varname>tint(tbool)</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tint</varname></primary></indexterm>
 				<para>Convert between a temporal Boolean and a temporal integer</para>
-				<para><varname>tbool::tint</varname></para>
-				<para><varname>tint(tbool) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbool::tint
+tint(tbool) → tint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
 -- [1@2001-01-01, 0@2001-01-03]
@@ -101,8 +107,10 @@ SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tnumber(tnumber)</varname></primary></indexterm>
 				<para>Convert between temporal integers, temporal big integers, and temporal floats</para>
-				<para><varname>tnumber::tnumber</varname></para>
-				<para><varname>tnumber(tnumber) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnumber::tnumber
+tnumber(tnumber) → tnumber
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 2@2001-01-03]'::tfloat;
 -- Interp=Step;[1@2001-01-01, 2@2001-01-03]
@@ -123,7 +131,9 @@ SELECT tint(tfloat '[1.5@2001-01-01, 2.5@2001-01-03]');
 			<listitem xml:id="talpha_valueSet">
 				<indexterm significance="normal"><primary><varname>valueSet</varname></primary></indexterm>
 				<para>Return the values of a temporal number as a set</para>
-				<para><varname>valueSet(tnumber) → numset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueSet(tnumber) → numset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueSet(tint '[1@2001-01-01, 2@2001-01-03]');
 -- {1, 2}
@@ -137,9 +147,11 @@ SELECT valueSet(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 4@2001-01-
 				<indexterm significance="normal"><primary><varname>maxValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>avgValue</varname></primary></indexterm>
 				<para>Return the minimum, maximum, or average value</para>
-				<para><varname>minValue(torder) → base</varname></para>
-				<para><varname>maxValue(torder) → base</varname></para>
-				<para><varname>avgValue(tnumber) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minValue(torder) → base
+maxValue(torder) → base
+avgValue(tnumber) → base
+</programlisting>
 				<para>The functions do not take into account whether the bounds are inclusive or not.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minValue(tfloat '{1@2001-01-01, 2@2001-01-03, 3@2001-01-05}');
@@ -161,8 +173,10 @@ SELECT maxValue(ttext '{[A@2001-01-01, B@2001-01-02], [C@2001-01-03, E@2001-01-0
 				<indexterm significance="normal"><primary><varname>minInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>maxInstant</varname></primary></indexterm>
 				<para>Return the instant with the minimum or maximum value</para>
-				<para><varname>minInstant(torder) → base</varname></para>
-				<para><varname>maxInstant(torder) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minInstant(torder) → base
+maxInstant(torder) → base
+</programlisting>
 				<para>The function does not take into account whether the bounds are inclusive or not. If several instants have the minimum value, the first one is returned.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minInstant(tfloat '{1@2001-01-01, 2@2001-01-03, 3@2001-01-05}');
@@ -182,9 +196,11 @@ SELECT maxInstant(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-0
 				<indexterm significance="normal"><primary><varname>scaleValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleValue</varname></primary></indexterm>
 				<para>Shift and/or the value span of a temporal number by one or two numbers</para>
-				<para><varname>shiftValue(tnumber,base) → tnumber</varname></para>
-				<para><varname>scaleValue(tnumber,width) → tnumber</varname></para>
-				<para><varname>shiftScaleValue(tnumber,base,base) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftValue(tnumber,base) → tnumber
+scaleValue(tnumber,width) → tnumber
+shiftScaleValue(tnumber,base,base) → tnumber
+</programlisting>
 				<para>For scaling, if the value span of the temporal value is a single value (for example, for a temporal instant), the result is the temporal value. Furthermore, the given width must be strictly greater than zero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftValue(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}', 1);
@@ -208,7 +224,9 @@ SELECT shiftScaleValue(tfloat '{[1@2001-01-01,2@2001-01-02],[3@2001-01-03,4@2001
 			<listitem xml:id="tnumber_stops">
 				<indexterm significance="normal"><primary><varname>stops</varname></primary></indexterm>
 				<para>Extract from a temporal float with linear interpolation the subsequences where the values stay within a span of a given width for at least a given duration</para>
-				<para><varname>stops(tfloat,maxDist=0.0,minDuration='0 minutes') → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stops(tfloat,maxDist=0.0,minDuration='0 minutes') → tfloat
+</programlisting>
 				<para>If <varname>maxDist</varname> is not given, a value 0.0 is assumed by default and thus, the function extracts the constant segments of the temporal float.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stops(tfloat '[1@2001-01-01, 1@2001-01-02, 2@2001-01-03]');
@@ -229,10 +247,12 @@ SELECT stops(tfloat '[1@2001-01-01, 1@2001-01-02, 2@2001-01-03]', 0.0, '2 days')
 				<indexterm significance="normal"><primary><varname>minusMin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusMax</varname></primary></indexterm>
 				<para>Restrict to (the complement of) the minimum or maximum value</para>
-				<para><varname>atMin(torder) → torder</varname></para>
-				<para><varname>atMax(torder) → torder</varname></para>
-				<para><varname>minusMin(torder) → torder</varname></para>
-				<para><varname>minusMax(torder) → torder</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atMin(torder) → torder
+atMax(torder) → torder
+minusMin(torder) → torder
+minusMax(torder) → torder
+</programlisting>
 				<para>The functions returns a NULL value if the minimum value only happens at exclusive bounds.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atMin(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}');
@@ -279,8 +299,10 @@ SELECT minusMax(tfloat '{[1@2001-01-01, 3@2001-01-03), (3@2001-01-03, 1@2001-01-
 				<indexterm significance="normal"><primary><varname>atTbox</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusTbox</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a <varname>tbox</varname></para>
-				<para><varname>atTbox(tnumber,tbox) → tnumber</varname></para>
-				<para><varname>minusTbox(tnumber,tbox) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atTbox(tnumber,tbox) → tnumber
+minusTbox(tnumber,tbox) → tnumber
+</programlisting>
 				<para>Cuando el cuadro delimitador tiene dimensiones tanto de valores como temporales, las funciones restringen el número temporal con respecto al valor <emphasis>y</emphasis> las extensiones temporales del cuadro.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atTbox(tfloat '[0@2001-01-01, 3@2001-01-04)',
@@ -308,7 +330,9 @@ SELECT minusSpan(minusTime(temp, box::tstzspan), box::floatspan) FROM temp;
 				<indexterm significance="normal"><primary><varname>&amp;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>|</varname></primary></indexterm>
 				<para>Temporal and, temporal or</para>
-				<para><varname>{boolean,tbool} {&amp;, |} {boolean,tbool} → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{boolean,tbool} {&amp;, |} {boolean,tbool} → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool '[true@2001-01-03, true@2001-01-05)' &amp;
   tbool '[false@2001-01-03, false@2001-01-05)';
@@ -326,7 +350,9 @@ SELECT tbool '[true@2001-01-03, true@2001-01-05)' |
 			<listitem xml:id="tbool_not">
 				<indexterm significance="normal"><primary><varname>~</varname></primary></indexterm>
 				<para>Temporal not</para>
-				<para><varname>~tbool → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+~tbool → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ~tbool '[true@2001-01-03, true@2001-01-05)';
 -- [f@2001-01-03, f@2001-01-05)
@@ -336,7 +362,9 @@ SELECT ~tbool '[true@2001-01-03, true@2001-01-05)';
 			<listitem xml:id="tbool_whenTrue">
 				<indexterm significance="normal"><primary><varname>whenTrue</varname></primary></indexterm>
 				<para>Return the time when a temporal Boolean takes the value true</para>
-				<para><varname>whenTrue(tbool) → tstzspanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+whenTrue(tbool) → tstzspanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT whenTrue(tfloat '[1@2001-01-01, 4@2001-01-04, 1@2001-01-07]' #&gt; 2);
 -- {(2001-01-02, 2001-01-06)}
@@ -358,7 +386,9 @@ SELECT whenTrue(tdwithin(tgeompoint '[Point(1 1)@2001-01-01, Point(4 4)@2001-01-
 				<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>/</varname></primary></indexterm>
 				<para>Temporal addition, subtraction, multiplication, and division</para>
-				<para><varname>{number,tnumber} {+, -, *, /} {number,tnumber} → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{number,tnumber} {+, -, *, /} {number,tnumber} → tnumber
+</programlisting>
 				<para>The temporal division will raise an error if the denominator is ever equal to zero during the common timespan of the arguments.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[2@2001-01-01, 2@2001-01-04)' + 1;
@@ -401,7 +431,9 @@ SELECT tfloat '[-1@2001-01-04, 1@2001-01-05]' / tfloat '[-1@2001-01-01, 1@2001-0
 			<listitem xml:id="tnumber_abs">
 				<indexterm significance="normal"><primary><varname>abs</varname></primary></indexterm>
 				<para>Return the absolute value of the temporal number</para>
-				<para><varname>abs(tnumber) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+abs(tnumber) → tnumber
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT abs(tfloat '[1@2001-01-01, -1@2001-01-03, 1@2001-01-05]');
 -- [1@2001-01-01, 0@2001-01-02, 1@2001-01-03, 0@2001-01-04, 1@2001-01-05]
@@ -414,8 +446,10 @@ SELECT abs(tint '[1@2001-01-01, -1@2001-01-03, 1@2001-01-05]');
 				<indexterm significance="normal"><primary><varname>floor</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ceil</varname></primary></indexterm>
 				<para>Round up or down to the neareast integer</para>
-				<para><varname>floor(tfloat) → tfloat</varname></para>
-				<para><varname>ceil(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+floor(tfloat) → tfloat
+ceil(tfloat) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floor(tfloat '[0.5@2001-01-01, 1.5@2001-01-02]');
 -- [0@2001-01-01, 1@2001-01-02]
@@ -427,7 +461,9 @@ SELECT ceil(tfloat '[0.5@2001-01-01, 0.6@2001-01-02, 0.7@2001-01-03]');
 			<listitem xml:id="tnumber_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Round to a number of decimal places</para>
-				<para><varname>round(tfloat,integer=0) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tfloat,integer=0) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tfloat '[0.785398163397448@2001-01-01, 2.356194490192345@2001-01-02]', 2);
 -- [0.79@2001-01-01, 2.36@2001-01-02]
@@ -438,8 +474,10 @@ SELECT round(tfloat '[0.785398163397448@2001-01-01, 2.356194490192345@2001-01-02
 				<indexterm significance="normal"><primary><varname>degrees</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>radians</varname></primary></indexterm>
 				<para>Convert to degrees or radians</para>
-				<para><varname>degrees({float,tfloat},normalize=false) → tfloat</varname></para>
-				<para><varname>radians(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+degrees({float,tfloat},normalize=false) → tfloat
+radians(tfloat) → tfloat
+</programlisting>
 				<para>The additional parameter in the <varname>degrees</varname> function can be used to normalize the values between 0 and 360 degrees.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT degrees(pi() * 5);
@@ -457,7 +495,9 @@ SELECT radians(tfloat '[45@2001-01-01, 135@2001-01-02]');
 			<listitem xml:id="tnumber_deltaValue">
 				<indexterm significance="normal"><primary><varname>deltaValue</varname></primary></indexterm>
 				<para>Return the value difference between consecutive instants of the temporal number</para>
-				<para><varname>deltaValue(tnumber) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+deltaValue(tnumber) → tnumber
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT deltaValue(tint '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03]');
 -- [1@2001-01-01, -1@2001-01-02, -1@2001-01-03)
@@ -471,7 +511,9 @@ SELECT deltaValue(tfloat '{[1.5@2001-01-01, 2@2001-01-02, 1@2001-01-03],
 			<listitem xml:id="tfloat_trend">
 				<indexterm significance="normal"><primary><varname>trend</varname></primary></indexterm>
 				<para>Return the trend of a temporal float with linear interpolation, which states whether its value is increasing, constant, or decreasing, represented, respectively, by 1, 0, and -1.</para>
-				<para><varname>trend(tfloat) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trend(tfloat) → tint
+</programlisting>
 				<para>Note that the trend is NULL for instantaneous sequences.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trend(tfloat '[1@2001-01-01, 2@2001-01-02, 4@2001-01-03, 4@2001-01-04,
@@ -485,7 +527,9 @@ SELECT trend(tfloat '[1@2001-01-01]');
 			<listitem xml:id="tnumber_derivative">
 				<indexterm significance="normal"><primary><varname>derivative</varname></primary></indexterm>
 				<para>Return the derivative over time of a temporal float in units per second</para>
-				<para><varname>derivative(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+derivative(tfloat) → tfloat
+</programlisting>
 				<para>The temporal float must have linear interpolation. Note that this function corresponds to the <link linkend="tgeo_speed"><varname>speed</varname></link> function for temporal points.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT derivative(tfloat '{[0@2001-01-01, 10@2001-01-02, 5@2001-01-03],
@@ -500,7 +544,9 @@ SELECT derivative(tfloat 'Interp=Step;[0@2001-01-01, 10@2001-01-02, 5@2001-01-03
 			<listitem xml:id="tnumber_integral">
 				<indexterm significance="normal"><primary><varname>integral</varname></primary></indexterm>
 				<para>Return the area under the curve</para>
-				<para><varname>integral(tnumber) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+integral(tnumber) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT  integral(tint '[1@2001-01-01,2@2001-01-02]') / (24 * 3600 * 1e6);
 -- 1
@@ -512,7 +558,9 @@ SELECT integral(tfloat '[1@2001-01-01,2@2001-01-02]') / (24 * 3600 * 1e6);
 			<listitem xml:id="tnumber_twAvg">
 				<indexterm significance="normal"><primary><varname>twAvg</varname></primary></indexterm>
 				<para>Return the time-weighted average</para>
-				<para><varname>twAvg(tnumber) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+twAvg(tnumber) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT twAvg(tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-04, 2@2001-01-06)}');
 -- 1.75
@@ -523,8 +571,10 @@ SELECT twAvg(tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-04, 2@2001-01-06)
 				<indexterm significance="normal"><primary><varname>ln</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>log10</varname></primary></indexterm>
 				<para>Return the natural logarithm and the base 10 logarithm of a temporal float</para>
-				<para><varname>ln(tfloat) → tfloat</varname></para>
-				<para><varname>log10(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ln(tfloat) → tfloat
+log10(tfloat) → tfloat
+</programlisting>
 				<para>The temporal float cannot be zero or negative</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ln(tfloat '{[1@2001-01-01, 10@2001-01-02, 5@2001-01-03],
@@ -539,7 +589,9 @@ SELECT log10(tfloat 'Interp=Step;[-10@2001-01-01, 10@2001-01-02]');
 			<listitem xml:id="tnumber_exp">
 				<indexterm significance="normal"><primary><varname>exp</varname></primary></indexterm>
 				<para>Return the exponential (e raised to the given power) of a temporal float</para>
-				<para><varname>exp(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+exp(tfloat) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT exp(tfloat '{[1@2001-01-01, 10@2001-01-02],
   [1@2001-01-04, 1@2001-01-05]}');
@@ -555,9 +607,11 @@ SELECT exp(tfloat '{-10@2001-01-01, 0@2001-01-02, 10@2001-01-03}');
 				<indexterm significance="normal"><primary><varname>cos</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tan</varname></primary></indexterm>
 				<para>Return the sine, cosine, or tangent of a temporal float (argument in radians)</para>
-				<para><varname>sin(tfloat) → tfloat</varname></para>
-				<para><varname>cos(tfloat) → tfloat</varname></para>
-				<para><varname>tan(tfloat) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+sin(tfloat) → tfloat
+cos(tfloat) → tfloat
+tan(tfloat) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(sin(tfloat '[0@2001-01-01, 6.283185307@2001-01-02]'), 6);
 -- [0@2001-01-01, -0.000000@2001-01-02]
@@ -577,7 +631,9 @@ SELECT round(tan(tfloat '{0@2001-01-01, 0.785398163@2001-01-02}'), 6);
 			<listitem xml:id="ttext_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
 				<para>Text concatenation</para>
-				<para><varname>{text,ttext} || {text,ttext} → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{text,ttext} || {text,ttext} → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '[AA@2001-01-01, AA@2001-01-04)' || text 'B';
 -- ["AAB"@2001-01-01, "AAB"@2001-01-04)
@@ -594,9 +650,11 @@ SELECT ttext '[A@2001-01-01, B@2001-01-03, C@2001-01-04]' ||
 				<indexterm significance="normal"><primary><varname>upper</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>initcap</varname></primary></indexterm>
 				<para>Transform in lowercase, uppercase, or initcap</para>
-				<para><varname>upper(ttext) → ttext</varname></para>
-				<para><varname>lower(ttext) → ttext</varname></para>
-				<para><varname>initcap(ttext) → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+upper(ttext) → ttext
+lower(ttext) → ttext
+initcap(ttext) → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lower(ttext '[AA@2001-01-01, bb@2001-01-02]');
 -- ["aa"@2001-01-01, "bb"@2001-01-02]

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -54,8 +54,10 @@ SELECT cbuffer 'Cbuffer(Point(1 1), -2.0)';
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>asText({cbuffer,cbuffer[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({cbuffer,cbuffer[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({cbuffer,cbuffer[]}) → {text,text[]}
+asEWKT({cbuffer,cbuffer[]}) → {text,text[]}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(cbuffer 'Cbuffer(Point(1 1), 0.5)');
 -- Cbuffer(POINT(1 1),0.5)
@@ -75,10 +77,12 @@ SELECT asEWKT(ARRAY[cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.2)',
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 					<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB), the Hexadecimal Well-Known Binary (HexWKB), or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-					<para><varname>asBinary(cbuffer,endian text='') → bytea</varname></para>
-					<para><varname>asEWKB(cbuffer,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(cbuffer,endian text='') → text</varname></para>
-					<para><varname>asHexEWKB(cbuffer,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(cbuffer,endian text='') → bytea
+asEWKB(cbuffer,endian text='') → bytea
+asHexWKB(cbuffer,endian text='') → text
+asHexEWKB(cbuffer,endian text='') → text
+</programlisting>
 					<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used. A circular buffer takes its SRID from its underlying point: <varname>asEWKB</varname> and <varname>asHexEWKB</varname> embed it, while the plain <varname>asBinary</varname> and <varname>asHexWKB</varname> forms omit it.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
@@ -96,8 +100,10 @@ SELECT asHexEWKB(cbuffer 'Cbuffer(SRID=5676;Point(1 1),0.5)');
 					<indexterm significance="normal"><primary><varname>cbufferFromText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>cbufferFromEWKT</varname></primary></indexterm>
 					<para>Input from the Well-Known Text (WKT) or from the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>cbufferFromText(text) → cbuffer</varname></para>
-					<para><varname>cbufferFromEWKT(text) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+cbufferFromText(text) → cbuffer
+cbufferFromEWKT(text) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(cbufferFromText(text 'Cbuffer(Point(1 1),0.5)'));
 -- Cbuffer(POINT(1 1),0.5)
@@ -111,9 +117,11 @@ SELECT asEWKT(cbufferFromEWKT(text 'SRID=5676;Cbuffer(Point(1 1),0.5)'));
 					<indexterm significance="normal"><primary><varname>cbufferFromEWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>cbufferFromHexEWKB</varname></primary></indexterm>
 					<para>Input from the Well-Known Binary (WKB), from the Extended Well-Known Binary (EWKB), or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-					<para><varname>cbufferFromBinary(bytea) → cbuffer</varname></para>
-					<para><varname>cbufferFromEWKB(bytea) → cbuffer</varname></para>
-					<para><varname>cbufferFromHexEWKB(text) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+cbufferFromBinary(bytea) → cbuffer
+cbufferFromEWKB(bytea) → cbuffer
+cbufferFromHexEWKB(text) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(cbufferFromBinary(
   '\x0100000000000000f03f000000000000f03f000000000000e03f'));
@@ -135,7 +143,9 @@ SELECT asEWKT(cbufferFromHexEWKB(
 				<listitem xml:id="cbuffer">
 					<indexterm significance="normal"><primary><varname>cbuffer</varname></primary></indexterm>
 					<para>Constructor for circular buffers</para>
-					<para><varname>cbuffer(geompoint,float) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+cbuffer(geompoint,float) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(cbuffer(ST_Point(1,1), 0.3));
 -- Cbuffer(POINT(1 1),0.3)
@@ -151,8 +161,10 @@ SELECT asText(cbuffer(ST_Point(1,1), 0.3));
 				<listitem xml:id="cbuffer_geometry">
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Convert between a circular buffer and a geometry</para>
-					<para><varname>geometry::cbuffer</varname></para>
-					<para><varname>cbuffer::geometry</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geometry::cbuffer
+cbuffer::geometry
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(cbuffer(ST_Point(1,1), 1)::geometry);
 -- CURVEPOLYGON(CIRCULARSTRING(0 1,2 1,0 1))
@@ -166,8 +178,10 @@ SELECT asText(geometry 'SRID=5676;LINESTRING(0 0,2 2)'::cbuffer);
 			<listitem xml:id="cbuffer_stbox">
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convert a circular buffer and, optionally, a timestamp or a period, to a spatiotemporal box</para>
-				<para><varname>stbox(cbuffer) → stbox</varname></para>
-				<para><varname>stbox(cbuffer,{timestamptz,tstzspan}) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stbox(cbuffer) → stbox
+stbox(cbuffer,{timestamptz,tstzspan}) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(cbuffer 'SRID=5676;Cbuffer(Point(1 1),0.3)');
 -- SRID=5676;STBOX X((0.7,0.7),(1.3,1.3))
@@ -186,7 +200,9 @@ SELECT stbox(cbuffer 'Cbuffer(Point(1 1),0.3)', tstzspan '[2001-01-01,2001-01-02
 				<listitem xml:id="cbuffer_point">
 					<indexterm significance="normal"><primary><varname>point</varname></primary></indexterm>
 					<para>Return the point</para>
-					<para><varname>point(cbuffer) → geompoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+point(cbuffer) → geompoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(point(cbuffer 'Cbuffer(Point(1 1), 0.3)'));
 -- Point(1 1)
@@ -196,7 +212,9 @@ SELECT ST_AsText(point(cbuffer 'Cbuffer(Point(1 1), 0.3)'));
 				<listitem xml:id="cbuffer_radius">
 					<indexterm significance="normal"><primary><varname>radius</varname></primary></indexterm>
 					<para>Return the radius</para>
-					<para><varname>radius(cbuffer) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+radius(cbuffer) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT radius(cbuffer 'Cbuffer(Point(1 1), 0.3)');
 -- 0.3
@@ -211,7 +229,9 @@ SELECT radius(cbuffer 'Cbuffer(Point(1 1), 0.3)');
 				<listitem xml:id="cbuffer_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Round the point and the radius of the circular buffer to the number of decimal places</para>
-					<para><varname>round(cbuffer,integer=0) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(cbuffer,integer=0) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(cbuffer(ST_Point(1.123456789,1.123456789), 0.123456789), 6));
 -- Cbuffer(POINT(1.123457 1.123457),0.123457)
@@ -228,8 +248,10 @@ SELECT asText(round(cbuffer(ST_Point(1.123456789,1.123456789), 0.123456789), 6))
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Return or set the spatial reference identifier</para>
-					<para><varname>SRID(cbuffer) → integer</varname></para>
-					<para><varname>setSRID(cbuffer) → cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(cbuffer) → integer
+setSRID(cbuffer) → cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(cbuffer 'Cbuffer(SRID=5676;Point(1 1), 0.3)');
 -- 5676
@@ -242,9 +264,11 @@ SELECT asEWKT(setSRID(cbuffer 'Cbuffer(Point(0 0),1)', 4326));
 					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transform to a spatial reference identifier</para>
-					<para><varname>transform(cbuffer,integer) → cbuffer</varname></para>
-					<para><varname>transformPipeline(cbuffer,pipeline text,to_srid integer,is_forward boolean=true) → </varname></para>
-					<para><varname>  cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+transform(cbuffer,integer) → cbuffer
+transformPipeline(cbuffer,pipeline text,to_srid integer,is_forward boolean=true) → 
+  cbuffer
+</programlisting>
 					<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input circular buffer has an unknown SRID (represented by 0).</para>
 					<para>The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
@@ -280,7 +304,9 @@ FROM test;
 					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Traditional comparisons</para>
-					<para><varname>cbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} cbuffer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+cbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} cbuffer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT cbuffer 'Cbuffer(Point(3 3), 0.5)' = cbuffer 'Cbuffer(Point(3 3), 0.5)';
 -- true
@@ -360,8 +386,10 @@ SELECT tcbuffer 'Point(0 0)@2001-01-01 08:05:00';
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 				<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
-				<para><varname>asText({tcbuffer,tcbuffer[],cbuffer[]}) → {text,text[]}</varname></para>
-				<para><varname>asEWKT({tcbuffer,tcbuffer[],cbuffer[]}) → {text,text[]}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({tcbuffer,tcbuffer[],cbuffer[]}) → {text,text[]}
+asEWKT({tcbuffer,tcbuffer[],cbuffer[]}) → {text,text[]}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbuffer 'SRID=4326;[Cbuffer(Point(0 0),1)@2001-01-01, 
   Cbuffer(Point(1 1),2)@2001-01-02)');
@@ -380,7 +408,9 @@ SELECT asEWKT(ARRAY[cbuffer 'Cbuffer(SRID=5676;Point(0 0),1)',
 			<listitem xml:id="tcbuffer_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Return the Moving Features JSON (MF-JSON) representation</para>
-				<para><varname>asMFJSON(tcbuffer) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tcbuffer) → text
+</programlisting>
 				<para>A circular buffer is always planar 2D. Each value is an object with a <varname>point</varname> member, an <varname>[x, y]</varname> coordinate array, and a numeric <varname>radius</varname> member, mirroring the <varname>point</varname> and <varname>radius</varname> accessors.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tcbuffer 'Cbuffer(Point(1 2),0.5)@2001-01-01', 3);
@@ -407,10 +437,12 @@ SELECT asMFJSON(tcbuffer 'SRID=4326;[Cbuffer(Point(1 1),0.2)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB) representation, the Hexadecimal Well-Known Binary (HexWKB) representation, or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-				<para><varname>asBinary(tcbuffer,endian text='') → bytea</varname></para>
-				<para><varname>asEWKB(tcbuffer,endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB(tcbuffer,endian text='') → text</varname></para>
-				<para><varname>asHexEWKB(tcbuffer,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(tcbuffer,endian text='') → bytea
+asEWKB(tcbuffer,endian text='') → bytea
+asHexWKB(tcbuffer,endian text='') → text
+asHexEWKB(tcbuffer,endian text='') → text
+</programlisting>
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tcbuffer 'Cbuffer(Point(1 2),1)@2001-01-01');
@@ -428,8 +460,10 @@ SELECT asHexEWKB(tcbuffer 'SRID=3812;Cbuffer(Point(1 2),1)@2001-01-01');
 				<indexterm significance="normal"><primary><varname>tcbufferFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferFromEWKT</varname></primary></indexterm>
 				<para>Input from the Well-Known Text (WKT) representation or from the Extended Well-Known Text (EWKT) representation</para>
-				<para><varname>tcbufferFromText(text) → tcbuffer</varname></para>
-				<para><varname>tcbufferFromEWKT(text) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferFromText(text) → tcbuffer
+tcbufferFromEWKT(text) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tcbufferFromText(text '[Cbuffer(Point(1 2),1)@2001-01-01, 
   Cbuffer(Point(3 4),2)@2001-01-02]'));
@@ -443,7 +477,9 @@ SELECT asEWKT(tcbufferFromEWKT(text 'SRID=3812;[Cbuffer(Point(1 2),1)@2001-01-01
 			<listitem xml:id="tcbufferFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tcbufferFromMFJSON</varname></primary></indexterm>
 				<para>Input from the Moving Features JSON (MF-JSON) representation</para>
-				<para><varname>tcbufferFromMFJSON(text) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferFromMFJSON(text) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tcbufferFromMFJSON(asMFJSON(tcbuffer
   'SRID=3812;Cbuffer(Point(1 2),0.5)@2001-01-01', 3)));
@@ -459,9 +495,11 @@ SELECT asEWKT(tcbufferFromMFJSON(asMFJSON(tcbuffer
 				<indexterm significance="normal"><primary><varname>tcbufferFromEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferFromHexEWKB</varname></primary></indexterm>
 				<para>Input from the Well-Known Binary (WKB) representation, from the Extended Well-Known Binary (EWKB) representation, or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-				<para><varname>tcbufferFromBinary(bytea) → tcbuffer</varname></para>
-				<para><varname>tcbufferFromEWKB(bytea) → tcbuffer</varname></para>
-				<para><varname>tcbufferFromHexEWKB(text) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferFromBinary(bytea) → tcbuffer
+tcbufferFromEWKB(bytea) → tcbuffer
+tcbufferFromHexEWKB(text) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tcbufferFromBinary(
   '\x013b0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000'));
@@ -484,10 +522,12 @@ SELECT asEWKT(tcbufferFromHexEWKB(
 			<listitem xml:id="tcbuffer_const">
 				<indexterm significance="normal"><primary><varname>tcbuffer</varname></primary></indexterm>
 				<para>Constructor for temporal circular buffers having a constant value</para>
-				<para><varname>tcbuffer(cbuffer,timestamptz) → tcbufferInst</varname></para>
-				<para><varname>tcbuffer(cbuffer,tstzset) → tcbufferDiscSeq</varname></para>
-				<para><varname>tcbuffer(cbuffer,tstzspan,interp='linear') → tcbufferContSeq</varname></para>
-				<para><varname>tcbuffer(cbuffer,tstzspanset,interp='linear') → tcbufferSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer(cbuffer,timestamptz) → tcbufferInst
+tcbuffer(cbuffer,tstzset) → tcbufferDiscSeq
+tcbuffer(cbuffer,tstzspan,interp='linear') → tcbufferContSeq
+tcbuffer(cbuffer,tstzspanset,interp='linear') → tcbufferSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.5)', timestamptz '2001-01-01'));
 -- Cbuffer(Point(1 1),0.5)@2001-01-01
@@ -507,8 +547,10 @@ SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.2)',
 			<listitem xml:id="tcbufferSeq">
 				<indexterm significance="normal"><primary><varname>tcbufferSeq</varname></primary></indexterm>
 				<para>Constructor for temporal circular buffers of sequence subtype</para>
-				<para><varname>tcbufferSeq(tcbufferInst[],interp='linear',leftInc boolean=true,</varname></para>
-				<para><varname>  rightInc boolean=true) →tcbufferSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferSeq(tcbufferInst[],interp='linear',leftInc boolean=true,
+  rightInc boolean=true) →tcbufferSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.3)@2001-01-01',
   'Cbuffer(Point(2 2), 0.5)@2001-01-02', 'Cbuffer(Point(1 1), 0.5)@2001-01-03']));
@@ -530,9 +572,11 @@ SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.2)@2001-01-01',
 				<indexterm significance="normal"><primary><varname>tcbufferSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor for temporal circular buffers of sequence set subtype</para>
-				<para><varname>tcbufferSeqSet(tcbuffer[]) → tcbufferSeqSet</varname></para>
-				<para><varname>tcbufferSeqSetGaps(tcbufferInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
-				<para><varname>  tcbufferSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferSeqSet(tcbuffer[]) → tcbufferSeqSet
+tcbufferSeqSetGaps(tcbufferInst[],maxt=NULL,maxdist=NULL,interp='linear') →
+  tcbufferSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeqSet(ARRAY[tcbuffer 
   '[Cbuffer(Point(1 1),0.2)@2001-01-01, Cbuffer(Point(2 2),0.4)@2001-01-02]', 
@@ -549,7 +593,9 @@ SELECT asText(tcbufferSeqSetGaps(ARRAY[tcbuffer 'Cbuffer(Point(1 1),0.1)@2001-01
 			<listitem xml:id="tgeompoint_tfloat_tcbuffer">
 				<indexterm significance="normal"><primary><varname>tcbuffer</varname></primary></indexterm>
 				<para>Construct a temporal circular buffer from a temporal geometry point and a temporal float</para>
-				<para><varname>tcbuffer(tgeompoint, tfloat) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer(tgeompoint, tfloat) → tcbuffer
+</programlisting>
 				<para>The time frame of the result is the intersection of the time frames of the temporal point and the temporal float. If they do not intersect, a null value is returned</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbuffer(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02)',
@@ -570,7 +616,9 @@ SELECT asText(tcbuffer(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02
 			<listitem xml:id="tcbuffer_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert a temporal circular buffer to a temporal geometry point</para>
-				<para><varname>tcbuffer::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
   Cbuffer(Point(1 1), 0.3)@2001-01-02)')::tgeompoint);
@@ -581,7 +629,9 @@ SELECT asText((tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tcbuffer_tfloat">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert a temporal circular buffer to a temporal float</para>
-				<para><varname>tcbuffer::tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer::tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
   Cbuffer(Point(1 1), 0.3)@2001-01-02)')::tfloat;
@@ -597,7 +647,9 @@ SELECT (tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tcbuffer_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Return the values</para>
-				<para><varname>getValues(tcbuffer) → cbufferset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tcbuffer) → cbufferset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(getValues(tcbuffer '{[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02)}'));
@@ -612,8 +664,10 @@ SELECT asEWKT(getValues(tcbuffer 'SRID=5676;{[Cbuffer(Point(1 1), 0.3)@2001-01-0
 				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>radius</varname></primary></indexterm>
 				<para>Return the points or the radii</para>
-				<para><varname>points(tcbuffer) → geomset</varname></para>
-				<para><varname>radius(tcbuffer) → floatset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+points(tcbuffer) → geomset
+radius(tcbuffer) → floatset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(points(tcbuffer 'SRID=5676;{Cbuffer(Point(3 3), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02}'));
@@ -627,7 +681,9 @@ SELECT radius(tcbuffer 'SRID=5676;{Cbuffer(Point(3 3), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(tcbuffer,timestamptz) → cbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tcbuffer,timestamptz) → cbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(valueAtTimestamp(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(3 3), 0.5)@2001-01-03)', '2001-01-02'));
@@ -645,9 +701,11 @@ SELECT asText(valueAtTimestamp(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tcbufferSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tcbufferSeqSet</varname></primary></indexterm>
 				<para>Transform a temporal circular buffer to another subtype</para>
-				<para><varname>tcbufferInst(tcbuffer) → tcbufferInst</varname></para>
-				<para><varname>tcbufferSeq(tcbuffer) → tcbufferSeq</varname></para>
-				<para><varname>tcbufferSeqSet(tcbuffer) → tcbufferSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbufferInst(tcbuffer) → tcbufferInst
+tcbufferSeq(tcbuffer) → tcbufferSeq
+tcbufferSeqSet(tcbuffer) → tcbufferSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeq(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2001-01-01', 'discrete'));
 -- {Cbuffer(Point(1 1),0.5)@2001-01-01}
@@ -661,7 +719,9 @@ SELECT asText(tcbufferSeqSet(tcbuffer 'Cbuffer(Point(1 1), 0.5)@2001-01-01'));
 			<listitem xml:id="tcbuffer_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transform a temporal circular buffer to another interpolation</para>
-				<para><varname>setInterp(tcbuffer, interp) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(tcbuffer, interp) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(setInterp(tcbuffer 'Cbuffer(Point(1 1),0.2)@2001-01-01','linear'));
 -- [Cbuffer(Point(1 1),0.2)@2001-01-01]
@@ -674,7 +734,9 @@ SELECT asText(setInterp(tcbuffer '{[Cbuffer(Point(1 1),0.1)@2001-01-01],
 			<listitem xml:id="tcbuffer_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Round the points and the radii of the temporal circular buffer to the number of decimal places</para>
-				<para><varname>round(tcbuffer,integer) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tcbuffer,integer) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(tcbuffer '{[Cbuffer(Point(1 1.123456789),0.123456789)@2001-01-01, 
   Cbuffer(Point(1 1),0.5)@2001-01-02)}', 3));
@@ -691,8 +753,10 @@ SELECT asText(round(tcbuffer '{[Cbuffer(Point(1 1.123456789),0.123456789)@2001-0
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Append a temporal instant or a temporal sequence</para>
-				<para><varname>appendInstant(tcbuffer,tcbufferInst) → tcbuffer</varname></para>
-				<para><varname>appendSequence(tcbuffer,tcbufferSeq) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tcbuffer,tcbufferInst) → tcbuffer
+appendSequence(tcbuffer,tcbufferSeq) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendInstant(tcbuffer 'Cbuffer(Point(1 1), 0.1)@2001-01-01',
   'Cbuffer(Point(2 2), 0.2)@2001-01-02'));
@@ -707,9 +771,11 @@ SELECT asText(appendSequence(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01]',
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Merge the temporal circular buffers</para>
-				<para><varname>merge(tcbuffer,tcbuffer) → tcbuffer</varname></para>
-				<para><varname>merge(tcbuffer[]) → tcbuffer</varname></para>
-				<para><varname>mergeAgg(tcbuffer) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(tcbuffer,tcbuffer) → tcbuffer
+merge(tcbuffer[]) → tcbuffer
+mergeAgg(tcbuffer) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1),
   0.3)@2001-01-03]',
@@ -736,8 +802,10 @@ SELECT asText(mergeAgg(inst)) FROM temp;
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Return or set the spatial reference identifier</para>
-				<para><varname>SRID(tcbuffer) → integer</varname></para>
-				<para><varname>setSRID(tcbuffer) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(tcbuffer) → integer
+setSRID(tcbuffer) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tcbuffer 'SRID=5676;[Cbuffer(Point(0 0),1)@2001-01-01, 
   Cbuffer(Point(1 1),2)@2001-01-02)');
@@ -752,9 +820,11 @@ SELECT asEWKT(setSRID(tcbuffer '[Cbuffer(Point(0 0),1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transform to a spatial reference identifier</para>
-				<para><varname>transform(tcbuffer,integer) → tcbuffer</varname></para>
-				<para><varname>transformPipeline(tcbuffer,pipeline text,to_srid integer,is_forward boolean=true) →</varname></para>
-				<para><varname>  tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(tcbuffer,integer) → tcbuffer
+transformPipeline(tcbuffer,pipeline text,to_srid integer,is_forward boolean=true) →
+  tcbuffer
+</programlisting>
 				<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input temporal circular buffer has an unknown SRID (represented by 0).</para>
 				<para>The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format: <varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname>. The SRID of the input temporal circular buffer is ignored, and the SRID of the output temporal circular buffer will be set to zero unless a value is provided via the optional <varname>to_srid</varname> parameter. As stated by the last parameter, the pipeline is executed by default in a forward direction; by setting the parameter to false, the pipeline is executed in the inverse direction.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -778,7 +848,9 @@ FROM test;
 			<listitem xml:id="tcbuffer_traversedArea">
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
 				<para>Return the area traversed by the temporal circular buffer</para>
-				<para><varname>traversedArea(tcbuffer, unary_union=false) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+traversedArea(tcbuffer, unary_union=false) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]'));
@@ -789,7 +861,9 @@ SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_centroid">
 				<indexterm significance="normal"><primary><varname>centroid</varname></primary></indexterm>
 				<para>Return the temporal geometric point given by the centers of a temporal circular buffer</para>
-				<para><varname>centroid(tcbuffer) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+centroid(tcbuffer) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
   Cbuffer(Point(3 3), 0.5)@2001-01-03]'));
@@ -800,7 +874,9 @@ SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
 			<listitem xml:id="tcbuffer_convexHull">
 				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Return the convex hull of the area traversed by the temporal circular buffer</para>
-				<para><varname>convexHull(tcbuffer) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+convexHull(tcbuffer) → geometry
+</programlisting>
 				<para>The convex hull is computed on the linearized traversed area: the circular arcs bounding the swept region are first stroked into straight segments and the hull is then computed with GEOS. The result is therefore a linear <varname>POLYGON</varname> that approximates the circular boundary, not a curved <varname>CURVEDPOLYGON</varname>. Use <varname>traversedArea</varname> to obtain the exact curved swept region.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_GeometryType(convexHull(tcbuffer
@@ -825,7 +901,9 @@ SELECT round(ST_Area(convexHull(tcbuffer
 			<listitem xml:id="tcbuffer_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Return the smallest distance ever</para>
-				<para><varname>{geo,cbuffer,tcbuffer,stbox} |=| {geo,cbuffer,tcbuffer,stbox} → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,cbuffer,tcbuffer,stbox} |=| {geo,cbuffer,tcbuffer,stbox} → float
+</programlisting>
 				<para>The operator <varname>|=|</varname> that can be used for doing nearest neightbor searches using a GiST or an SP-GiST index (see <xref linkend="ttype_indexing"/>).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
@@ -840,7 +918,9 @@ SELECT tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_nearestApproachInstant">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Return the instant of the first temporal circular buffer at which the two arguments are at the nearest distance</para>
-				<para><varname>nearestApproachInstant({geo,cbuffer,tcbuffer},{geo,cbuffer,tcbuffer}) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geo,cbuffer,tcbuffer},{geo,cbuffer,tcbuffer}) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nearestApproachInstant(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
   Cbuffer(Point(2 2), 0.7)@2001-01-02]', geometry 'Linestring(50 50,55 55)');
@@ -854,7 +934,9 @@ SELECT nearestApproachInstant(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Return the line connecting the nearest approach point between the two arguments</para>
-				<para><varname>shortestLine({geo,cbuffer,tcbuffer},{geo,cbuffer,tcbuffer}) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geo,cbuffer,tcbuffer},{geo,cbuffer,tcbuffer}) → geometry
+</programlisting>
 				<para>The function will only return the first line that it finds if there are more than one</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
@@ -869,7 +951,9 @@ SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Return the temporal distance</para>
-				<para><varname>{geo,cbuffer,tcbuffer} &lt;-&gt; {geo,cbuffer,tcbuffer} → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,cbuffer,tcbuffer} &lt;-&gt; {geo,cbuffer,tcbuffer} → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt; cbuffer 'Cbuffer(Point(1 1), 0.2)';
@@ -887,7 +971,9 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_minDistance">
 				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
 				<para>Return the minimum spatial distance, ignoring time</para>
-				<para><varname>minDistance(tcbuffer,{geo,cbuffer}) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minDistance(tcbuffer,{geo,cbuffer}) → float
+</programlisting>
 				<para><varname>minDistance(tcbuffer,tcbuffer) → float</varname> (aggregate)</para>
 				<para>The result is the spatial distance between the areas swept by the two arguments over their whole lifespans, equal to <varname>ST_Distance(traversedArea(...), traversedArea(...))</varname>. The two-argument temporal-circular-buffer form is an aggregate so that a cross join grouped by a key yields the minimum over every pair in the group.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -915,10 +1001,12 @@ GROUP BY t1.ShipTypeLabel, t2.ShipTypeLabel;
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a value or a set of values</para>
-				<para><varname>atValue(tcbuffer,value) → tcbuffer</varname></para>
-				<para><varname>minusValue(tcbuffer,value) → tcbuffer</varname></para>
-				<para><varname>atValues(tcbuffer,valueset) → tcbuffer</varname></para>
-				<para><varname>minusValues(tcbuffer,valueset) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(tcbuffer,value) → tcbuffer
+minusValue(tcbuffer,value) → tcbuffer
+atValues(tcbuffer,valueset) → tcbuffer
+minusValues(tcbuffer,valueset) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atValue(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
   Cbuffer(Point(2 2), 0.7)@2001-01-03]', cbuffer 'Cbuffer(Point(2 2), 0.5)'));
@@ -934,8 +1022,10 @@ SELECT asText(minusValue(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a geometry</para>
-				<para><varname>atGeometry(tcbuffer,geometry) → tcbuffer</varname></para>
-				<para><varname>minusGeometry(tcbuffer,geometry) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tcbuffer,geometry) → tcbuffer
+minusGeometry(tcbuffer,geometry) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atGeometry(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01, 
   Cbuffer(Point(2 2), 0.7)@2001-01-03]', 'Polygon((0 0,0 2,2 2,2 0,0 0))'));
@@ -951,8 +1041,10 @@ SELECT asText(minusGeometry(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atStbox</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusStbox</varname></primary></indexterm>
 				<para>Restrict a temporal circular buffer to (the complement of) a spatiotemporal box</para>
-				<para><varname>atStbox(tcbuffer,stbox,borderInc boolean=true) → tcbuffer</varname></para>
-				<para><varname>minusStbox(tcbuffer,stbox,borderInc boolean=true) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atStbox(tcbuffer,stbox,borderInc boolean=true) → tcbuffer
+minusStbox(tcbuffer,stbox,borderInc boolean=true) → tcbuffer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2000-01-01,
   Cbuffer(Point(3 3), 0.5)@2000-01-03]', stbox 'STBOX X((0,0),(2,2))'));
@@ -973,7 +1065,9 @@ SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2000-01-01,
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
-				<para><varname>tcbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tcbuffer → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tcbuffer → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.1)@2001-01-01, 
   Cbuffer(Point(1 1), 0.3)@2001-01-02),
@@ -995,7 +1089,9 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Ever and always comparisons</para>
-				<para><varname>{tcbuffer,cbuffer} {?=, %=} {tcbuffer,cbuffer} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tcbuffer,cbuffer} {?=, %=} {tcbuffer,cbuffer} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01, 
   Cbuffer(Point(1 1), 0.4)@2001-01-03)' ?= cbuffer 'Cbuffer(Point(1 1), 0.3)';
@@ -1013,7 +1109,9 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tcbuffer_tcomp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Temporal comparisons</para>
-				<para><varname>tcbuffer {#=, #&lt;&gt;} tcbuffer → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tcbuffer {#=, #&lt;&gt;} tcbuffer → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01, 
   Cbuffer(Point(1 1), 0.4)@2001-01-03)' #= cbuffer 'Cbuffer(Point(1 1), 0.3)';
@@ -1037,7 +1135,9 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Topological operators</para>
-				<para><varname>{tstzspan,stbox,tcbuffer} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tcbuffer} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tstzspan,stbox,tcbuffer} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tcbuffer} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &amp;&amp; cbuffer 'Cbuffer(Point(1 1), 0.5)';
@@ -1059,9 +1159,11 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_pos">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Position operators</para>
-				<para><varname>{stbox,tcbuffer} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tcbuffer} → boolean</varname></para>
-				<para><varname>{stbox,tcbuffer} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tcbuffer} → boolean</varname></para>
-				<para><varname>{tstzspan,stbox,tcbuffer} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tcbuffer} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{stbox,tcbuffer} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tcbuffer} → boolean
+{stbox,tcbuffer} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tcbuffer} → boolean
+{tstzspan,stbox,tcbuffer} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tcbuffer} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt; cbuffer 'Cbuffer(Point(1 1), 0.2)'
@@ -1098,18 +1200,20 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 				<para>The <emphasis>ever</emphasis> and <emphasis>always</emphasis> relationships determine whether the topological or distance relationship is ever or always satisfied (see <xref linkend="ever_always_comparison"/>) and return a <varname>boolean</varname>. Examples are the <varname>eIntersects</varname> and <varname>aIntersects</varname> functions.</para>
-				<para><varname>eContains(geometry,tcbuffer) → boolean</varname></para>
-				<para><varname>aContains(geometry,tcbuffer) → boolean</varname></para>
-				<para><varname>eCovers({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>aCovers({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>eDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>aDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>eDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean</varname></para>
-				<para><varname>aDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean</varname></para>
-				<para><varname>eIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>aIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>eTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>aTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eContains(geometry,tcbuffer) → boolean
+aContains(geometry,tcbuffer) → boolean
+eCovers({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+aCovers({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+eDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+aDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+eDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean
+aDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean
+eIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+aIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+eTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+aTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
   tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.3)@2001-01-03)');
@@ -1131,11 +1235,13 @@ SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 				<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. Examples are the <varname>tIntersects</varname> and <varname>tDwithin</varname> functions.</para>
-				<para><varname>tContains(geometry,tcbuffer) → boolean</varname></para>
-				<para><varname>tDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>tDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean</varname></para>
-				<para><varname>tIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
-				<para><varname>tTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tcbuffer) → boolean
+tDisjoint({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+tDwithin({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer},float) → boolean
+tIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+tTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tDisjoint(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
   tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.3)@2001-01-03)');
@@ -1159,7 +1265,9 @@ SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tcbuffer_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
-				<para><varname>tCount(tcbuffer) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tcbuffer) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, 
@@ -1177,7 +1285,9 @@ FROM Temp;
 			<listitem xml:id="tcbuffer_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Window count</para>
-				<para><varname>wCount(tcbuffer) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tcbuffer) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, 
@@ -1196,7 +1306,9 @@ FROM Temp;
 			<listitem xml:id="tcbuffer_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
 				<para>Aggregate the centres of a set of temporal circular buffers into their temporal centroid, by casting to <varname>tgeompoint</varname></para>
-				<para><varname>tCentroid(tcbuffer::tgeompoint) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCentroid(tcbuffer::tgeompoint) → tgeompoint
+</programlisting>
 				<para>The aggregate belongs to the <varname>tgeompoint</varname> type: a circular buffer's centre trajectory is a temporal point, so the cast reaches the aggregate rather than the buffer type carrying its own copy of it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
@@ -1218,8 +1330,10 @@ SELECT asText(tCentroid(temp::tgeompoint)) FROM Temp;
 				<indexterm significance="normal"><primary><varname>minDistSimplify</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minTimeDeltaSimplify</varname></primary></indexterm>
 				<para>Return a temporal circular buffer simplified ensuring that consecutive centers are at least a certain distance or time interval apart</para>
-				<para><varname>minDistSimplify(tcbuffer,mindist float) → tcbuffer</varname></para>
-				<para><varname>minTimeDeltaSimplify(tcbuffer,mint interval) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minDistSimplify(tcbuffer,mindist float) → tcbuffer
+minTimeDeltaSimplify(tcbuffer,mint interval) → tcbuffer
+</programlisting>
 				<para>The simplification operates on the center trajectory of the temporal circular buffer and preserves the radius at each surviving instant. Simplification applies only to temporal sequences or sequence sets with linear interpolation. In all other cases, a copy of the given value is returned.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(minDistSimplify(tcbuffer
@@ -1242,8 +1356,10 @@ SELECT asText(minTimeDeltaSimplify(tcbuffer
 				<indexterm significance="normal"><primary><varname>maxDistSimplify</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>douglasPeuckerSimplify</varname></primary></indexterm>
 				<para>Return a temporal circular buffer simplified using the <ulink url="https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm">Douglas-Peucker algorithm</ulink></para>
-				<para><varname>maxDistSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer</varname></para>
-				<para><varname>douglasPeuckerSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+maxDistSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer
+douglasPeuckerSimplify(tcbuffer,maxdist float,syncdist=true) → tcbuffer
+</programlisting>
 				<para>The difference between the two functions is that <varname>maxDistSimplify</varname> uses a single-pass version of the algorithm whereas <varname>douglasPeuckerSimplify</varname> uses the standard recursive algorithm. As for the functions above, the simplification operates on the center trajectory and preserves the radius at each surviving instant.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(douglasPeuckerSimplify(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01,

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -52,8 +52,10 @@ SELECT th3indexFromHexWKB(asHexWKB(th3index '831c02fffffffff@2001-01-01'));
 			<listitem xml:id="th3_tbigint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert between a <varname>th3index</varname> and a <varname>tbigint</varname> (explicit, zero-cost)</para>
-				<para><varname>tbigint::th3index</varname></para>
-				<para><varname>th3index::tbigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbigint::th3index
+th3index::tbigint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tbigint '590464338553208831@2001-01-01')::th3index;
 -- 831c02fffffffff@2001-01-01
@@ -66,8 +68,10 @@ SELECT ((th3index '831c02fffffffff@2001-01-01')::tbigint)::th3index
 			<listitem xml:id="th3_tgeogpoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Cast a temporal H3 cell to a temporal geodetic / planar point of cell centroids. The two overloads give the caller a choice between the geodetic (<varname>tgeogpoint</varname>) and SRID-4326 planar (<varname>tgeompoint</varname>) representations.</para>
-				<para><varname>th3index::tgeogpoint</varname></para>
-				<para><varname>th3index::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index::tgeogpoint
+th3index::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeogpoint;
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint;
@@ -85,7 +89,9 @@ SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint;
 			<listitem xml:id="th3_geoToH3Cell">
 				<indexterm significance="normal"><primary><varname>geoToH3Cell</varname></primary></indexterm>
 				<para>Return the H3 cell that contains a point geometry at the given resolution. The geometry must be a <varname>POINT</varname>.</para>
-				<para><varname>geoToH3Cell(geometry,integer) → h3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoToH3Cell(geometry,integer) → h3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3Cell(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- 871fa4418ffffff
@@ -95,7 +101,9 @@ SELECT geoToH3Cell(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 			<listitem xml:id="th3_geoToH3IndexSet">
 				<indexterm significance="normal"><primary><varname>geoToH3IndexSet</varname></primary></indexterm>
 				<para>Return the set of H3 cells covering a geometry at the given resolution. Every geometry type is supported: a <varname>POINT</varname> yields a single cell, a <varname>LINESTRING</varname> samples its segments, a <varname>POLYGON</varname> fills its interior, and <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> values return the union of their components.</para>
-				<para><varname>geoToH3IndexSet(geometry,integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoToH3IndexSet(geometry,integer) → h3indexset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- {"871fa4418ffffff"}
@@ -105,8 +113,10 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 			<listitem xml:id="th3_ever_eq_set">
 				<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 				<para>Return whether a temporal H3 trajectory ever takes one of the cells in a cell set. Combined with <varname>geoToH3IndexSet</varname> it answers whether a trip ever passes through a region, without materialising the trajectory geometry, the sound, conservative prefilter for the exact <varname>eIntersects(geometry,th3index)</varname>.</para>
-				<para><varname>eEq(h3indexset,th3index) → boolean</varname></para>
-				<para><varname>h3indexset ?= th3index → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eEq(h3indexset,th3index) → boolean
+h3indexset ?= th3index → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
   th3index '871fa4418ffffff@2001-01-01';
@@ -123,8 +133,10 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
 				<indexterm significance="normal"><primary><varname>startValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<para>Return the first or last H3 cell identifier of a temporal value</para>
-				<para><varname>startValue(th3index) → h3index</varname></para>
-				<para><varname>endValue(th3index) → h3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(th3index) → h3index
+endValue(th3index) → h3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(th3index '831c02fffffffff@2001-01-01');
 -- 831c02fffffffff
@@ -136,7 +148,9 @@ SELECT endValue(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-0
 			<listitem xml:id="th3_valueN">
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
 				<para>Return the <varname>n</varname>th distinct H3 cell identifier (1-indexed). Returns <varname>NULL</varname> if out of range.</para>
-				<para><varname>valueN(th3index,integer) → h3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueN(th3index,integer) → h3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}', 1);
 -- 831c02fffffffff
@@ -150,7 +164,9 @@ SELECT valueN(th3index '831c02fffffffff@2001-01-01', 99);
 			<listitem xml:id="th3_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Return the set of distinct H3 cell identifiers the trajectory takes</para>
-				<para><varname>getValues(th3index) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(th3index) → h3indexset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(th3index '831c02fffffffff@2001-01-01');
 -- {831c02fffffffff}
@@ -164,7 +180,9 @@ SELECT getValues(th3index
 			<listitem xml:id="th3_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the H3 cell identifier at a given timestamp, using step interpolation</para>
-				<para><varname>valueAtTimestamp(th3index,timestamptz) → h3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(th3index,timestamptz) → h3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(th3index
   '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-05]',
@@ -181,7 +199,9 @@ SELECT valueAtTimestamp(th3index
 			<listitem xml:id="th3_h3_get_resolution">
 				<indexterm significance="normal"><primary><varname>th3GetResolution</varname></primary></indexterm>
 				<para>Return the temporal resolution level (0–15) of each cell in a trajectory</para>
-				<para><varname>th3GetResolution(th3index) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3GetResolution(th3index) → tint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(th3index '831c02fffffffff@2001-01-01');
 -- 3@2001-01-01
@@ -193,7 +213,9 @@ SELECT th3GetResolution(th3index '880326b885fffff@2001-01-01');
 			<listitem xml:id="th3_h3_get_base_cell_number">
 				<indexterm significance="normal"><primary><varname>th3GetBaseCellNumber</varname></primary></indexterm>
 				<para>Return the temporal base-cell number (0–121) of each cell in a trajectory</para>
-				<para><varname>th3GetBaseCellNumber(th3index) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3GetBaseCellNumber(th3index) → tint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetBaseCellNumber(th3index '831c02fffffffff@2001-01-01');
 </programlisting>
@@ -202,7 +224,9 @@ SELECT th3GetBaseCellNumber(th3index '831c02fffffffff@2001-01-01');
 			<listitem xml:id="th3_h3_is_valid_cell">
 				<indexterm significance="normal"><primary><varname>isValidCell</varname></primary></indexterm>
 				<para>Return a temporal boolean stating at each instant whether the value is a valid H3 cell</para>
-				<para><varname>isValidCell(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidCell(th3index) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidCell(th3index '831c02fffffffff@2001-01-01');
 -- t@2001-01-01
@@ -214,7 +238,9 @@ SELECT isValidCell(th3index '0@2001-01-01');
 			<listitem xml:id="th3_h3_is_res_class_iii">
 				<indexterm significance="normal"><primary><varname>th3IsResClassIii</varname></primary></indexterm>
 				<para>Return a temporal boolean stating whether each cell has Class-III orientation. Class III alternates with resolution: odd resolutions are class III, even are class II.</para>
-				<para><varname>th3IsResClassIii(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3IsResClassIii(th3index) → tbool
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3IsResClassIii(th3index '871fa44a8ffffff@2001-01-01');
 -- t@2001-01-01
@@ -224,7 +250,9 @@ SELECT th3IsResClassIii(th3index '871fa44a8ffffff@2001-01-01');
 			<listitem xml:id="th3_h3_is_pentagon">
 				<indexterm significance="normal"><primary><varname>th3IsPentagon</varname></primary></indexterm>
 				<para>Return a temporal boolean stating whether each cell is a pentagon (12 cells per resolution are pentagons, the remaining 110 at each base cell descend as hexagons)</para>
-				<para><varname>th3IsPentagon(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3IsPentagon(th3index) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3IsPentagon(th3index '831c00fffffffff@2001-01-01');
 -- t@2001-01-01
@@ -241,8 +269,10 @@ SELECT th3IsPentagon(th3index '831c02fffffffff@2001-01-01');
 			<listitem xml:id="th3_h3_cell_to_parent">
 				<indexterm significance="normal"><primary><varname>th3CellToParent</varname></primary></indexterm>
 				<para>Return the temporal parent cell at the given resolution. The no-argument form drops to the next-coarser resolution.</para>
-				<para><varname>th3CellToParent(th3index,integer) → th3index</varname></para>
-				<para><varname>th3CellToParent(th3index) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToParent(th3index,integer) → th3index
+th3CellToParent(th3index) → th3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(
   th3CellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
@@ -253,8 +283,10 @@ SELECT th3GetResolution(
 			<listitem xml:id="th3_h3_cell_to_center_child">
 				<indexterm significance="normal"><primary><varname>th3CellToCenterChild</varname></primary></indexterm>
 				<para>Return the temporal center-child cell at the given resolution. The no-argument form drops to the next-finer resolution.</para>
-				<para><varname>th3CellToCenterChild(th3index,integer) → th3index</varname></para>
-				<para><varname>th3CellToCenterChild(th3index) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToCenterChild(th3index,integer) → th3index
+th3CellToCenterChild(th3index) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01', 8);
 -- 881fa44a81fffff@2001-01-01
@@ -267,7 +299,9 @@ SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01');
 			<listitem xml:id="th3_h3_cell_to_child_pos">
 				<indexterm significance="normal"><primary><varname>th3CellToChildPos</varname></primary></indexterm>
 				<para>Return the ordinal position (0-based) of each cell among the children of its parent at the given resolution</para>
-				<para><varname>th3CellToChildPos(th3index,integer) → tbigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToChildPos(th3index,integer) → tbigint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellToChildPos(th3index '871fa44a8ffffff@2001-01-01', 6);
 -- 0@2001-01-01
@@ -277,7 +311,9 @@ SELECT th3CellToChildPos(th3index '871fa44a8ffffff@2001-01-01', 6);
 			<listitem xml:id="th3_h3_child_pos_to_cell">
 				<indexterm significance="normal"><primary><varname>th3ChildPosToCell</varname></primary></indexterm>
 				<para>Return the temporal child cell at a given ordinal position of the given parent, at the given child resolution. The two temporal operands are synchronised over their shared time axis.</para>
-				<para><varname>th3ChildPosToCell(tbigint,th3index,integer) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3ChildPosToCell(tbigint,th3index,integer) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3ChildPosToCell(tbigint '0@2001-01-01', th3index '871fa44a8ffffff@2001-01-01',
   8);
@@ -293,8 +329,10 @@ SELECT th3ChildPosToCell(tbigint '0@2001-01-01', th3index '871fa44a8ffffff@2001-
 			<listitem xml:id="th3_tgeompoint_to_th3">
 				<indexterm significance="normal"><primary><varname>th3index</varname></primary></indexterm>
 				<para>Return the temporal H3 cell at the given resolution that contains each point in a temporal geodetic or planar point (SRID must be 4326 for the <varname>tgeompoint</varname> overload)</para>
-				<para><varname>th3index(tgeogpoint,integer) → th3index</varname></para>
-				<para><varname>th3index(tgeompoint,integer) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index(tgeogpoint,integer) → th3index
+th3index(tgeompoint,integer) → th3index
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(th3index(
   tgeogpoint 'POINT(-73.96 40.78)@2001-01-01', 9));
@@ -309,8 +347,10 @@ SELECT th3GetResolution(th3index(
 				<indexterm significance="normal"><primary><varname>th3CellToLatlng</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3CellToLatlngTgeompoint</varname></primary></indexterm>
 				<para>Return the temporal geodetic centroid of each cell in a trajectory. A planar (SRID 4326) overload is available under the name <varname>th3CellToLatlngTgeompoint</varname>.</para>
-				<para><varname>th3CellToLatlng(th3index) → tgeogpoint</varname></para>
-				<para><varname>th3CellToLatlngTgeompoint(th3index) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToLatlng(th3index) → tgeogpoint
+th3CellToLatlngTgeompoint(th3index) → tgeompoint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3CellToLatlng(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
@@ -322,7 +362,9 @@ SELECT asText(th3CellToLatlngTgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 
 			<listitem xml:id="th3_h3_cell_to_boundary">
 				<indexterm significance="normal"><primary><varname>th3CellToBoundary</varname></primary></indexterm>
 				<para>Return the temporal polygon boundary of each cell in a trajectory, as a temporal geography</para>
-				<para><varname>th3CellToBoundary(th3index) → tgeography</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToBoundary(th3index) → tgeography
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_GeometryType(getValue(th3CellToBoundary(th3index
   '871fa44a8ffffff@2001-01-01'))::geometry);
@@ -343,7 +385,9 @@ SELECT ST_NPoints(getValue(th3CellToBoundary(th3index
 			<listitem xml:id="th3_h3_are_neighbor_cells">
 				<indexterm significance="normal"><primary><varname>th3AreNeighborCells</varname></primary></indexterm>
 				<para>Return a temporal boolean stating whether two temporal cells are grid neighbours at each instant. The two operands are synchronised.</para>
-				<para><varname>th3AreNeighborCells(th3index,th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3AreNeighborCells(th3index,th3index) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3AreNeighborCells(
   th3index '880326b885fffff@2001-01-01',
@@ -355,7 +399,9 @@ SELECT th3AreNeighborCells(
 			<listitem xml:id="th3_h3_cells_to_directed_edge">
 				<indexterm significance="normal"><primary><varname>th3CellsToDirectedEdge</varname></primary></indexterm>
 				<para>Return a temporal directed-edge identifier from an origin/destination pair of temporal cells</para>
-				<para><varname>th3CellsToDirectedEdge(th3index,th3index) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellsToDirectedEdge(th3index,th3index) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
     th3index '871fa44aeffffff@2001-01-01');
@@ -366,7 +412,9 @@ SELECT th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
 			<listitem xml:id="th3_h3_is_valid_directed_edge">
 				<indexterm significance="normal"><primary><varname>isValidDirectedEdge</varname></primary></indexterm>
 				<para>Return a temporal boolean stating at each instant whether the value is a valid H3 directed edge</para>
-				<para><varname>isValidDirectedEdge(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidDirectedEdge(th3index) → tbool
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidDirectedEdge(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
     th3index '871fa44aeffffff@2001-01-01'));
@@ -380,8 +428,10 @@ SELECT isValidDirectedEdge(th3index '871fa44a8ffffff@2001-01-01');
 				<indexterm significance="normal"><primary><varname>th3GetDirectedEdgeOrigin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3GetDirectedEdgeDestination</varname></primary></indexterm>
 				<para>Return the temporal origin or destination cell of a temporal directed edge</para>
-				<para><varname>th3GetDirectedEdgeOrigin(th3index) → th3index</varname></para>
-				<para><varname>th3GetDirectedEdgeDestination(th3index) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3GetDirectedEdgeOrigin(th3index) → th3index
+th3GetDirectedEdgeDestination(th3index) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetDirectedEdgeOrigin(th3CellsToDirectedEdge(th3index
   '871fa44a8ffffff@2001-01-01',
@@ -397,7 +447,9 @@ SELECT th3GetDirectedEdgeDestination(th3CellsToDirectedEdge(th3index
 			<listitem xml:id="th3_h3_directed_edge_to_boundary">
 				<indexterm significance="normal"><primary><varname>th3DirectedEdgeToBoundary</varname></primary></indexterm>
 				<para>Return the temporal polygon boundary of each directed edge in a trajectory, as a temporal geography</para>
-				<para><varname>th3DirectedEdgeToBoundary(th3index) → tgeography</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3DirectedEdgeToBoundary(th3index) → tgeography
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_NPoints(getValue(th3DirectedEdgeToBoundary(
   th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
@@ -414,7 +466,9 @@ SELECT ST_NPoints(getValue(th3DirectedEdgeToBoundary(
 			<listitem xml:id="th3_h3_cell_to_vertex">
 				<indexterm significance="normal"><primary><varname>th3CellToVertex</varname></primary></indexterm>
 				<para>Return the temporal H3 vertex at the given vertex number (0–5 for hexagons, 0–4 for pentagons)</para>
-				<para><varname>th3CellToVertex(th3index,integer) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToVertex(th3index,integer) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0);
 -- 2071fa44a8ffffff@2001-01-01
@@ -424,7 +478,9 @@ SELECT th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0);
 			<listitem xml:id="th3_h3_vertex_to_latlng">
 				<indexterm significance="normal"><primary><varname>th3VertexToLatlng</varname></primary></indexterm>
 				<para>Return the temporal geodetic coordinates of each vertex in a trajectory</para>
-				<para><varname>th3VertexToLatlng(th3index) → tgeogpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3VertexToLatlng(th3index) → tgeogpoint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3VertexToLatlng(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01',
   0)), 6);
@@ -435,7 +491,9 @@ SELECT asText(th3VertexToLatlng(th3CellToVertex(th3index '871fa44a8ffffff@2001-0
 			<listitem xml:id="th3_h3_is_valid_vertex">
 				<indexterm significance="normal"><primary><varname>isValidVertex</varname></primary></indexterm>
 				<para>Return a temporal boolean stating at each instant whether the value is a valid H3 vertex</para>
-				<para><varname>isValidVertex(th3index) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidVertex(th3index) → tbool
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
 -- t@2001-01-01
@@ -451,8 +509,10 @@ SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
 				<indexterm significance="normal"><primary><varname>th3GridDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Return the temporal grid-hop distance (number of single-cell steps) between two temporal cells. Equivalently, the <varname>&lt;-&gt;</varname> operator returns the same distance. The two operands are synchronised over their shared time axis.</para>
-				<para><varname>th3GridDistance(th3index,th3index) → tbigint</varname></para>
-				<para><varname>th3index &lt;-&gt; th3index → tbigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3GridDistance(th3index,th3index) → tbigint
+th3index &lt;-&gt; th3index → tbigint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '880326b885fffff@2001-01-01'
    &lt;-&gt; th3index '880326b88dfffff@2001-01-01';
@@ -464,8 +524,10 @@ SELECT th3index '880326b885fffff@2001-01-01'
 				<indexterm significance="normal"><primary><varname>th3CellToLocalIj</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3LocalIjToCell</varname></primary></indexterm>
 				<para>Convert between a temporal cell and a temporal local (I, J) coordinate pair relative to an origin temporal cell. The local coordinate is exposed as a <varname>tgeompoint</varname> with the I axis in the <varname>x</varname> slot and J in <varname>y</varname>.</para>
-				<para><varname>th3CellToLocalIj(th3index,th3index) → tgeompoint</varname></para>
-				<para><varname>th3LocalIjToCell(th3index,tgeompoint) → th3index</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellToLocalIj(th3index,th3index) → tgeompoint
+th3LocalIjToCell(th3index,tgeompoint) → th3index
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3CellToLocalIj(th3index '871fa44a8ffffff@2001-01-01',
   th3index '871fa44aeffffff@2001-01-01'));
@@ -487,7 +549,9 @@ SELECT th3LocalIjToCell(th3index '871fa44a8ffffff@2001-01-01',
 			<listitem xml:id="th3_h3_cell_area">
 				<indexterm significance="normal"><primary><varname>th3CellArea</varname></primary></indexterm>
 				<para>Return the temporal area of each cell in a trajectory, in the requested unit</para>
-				<para><varname>th3CellArea(th3index,text='km2') → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3CellArea(th3index,text='km2') → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellArea(th3index '871fa44a8ffffff@2001-01-01');
 -- 4.441914270110932@2001-01-01
@@ -499,7 +563,9 @@ SELECT th3CellArea(th3index '871fa44a8ffffff@2001-01-01', 'm2');
 			<listitem xml:id="th3_h3_edge_length">
 				<indexterm significance="normal"><primary><varname>th3EdgeLength</varname></primary></indexterm>
 				<para>Return the temporal length of each directed edge in a trajectory, in the requested unit</para>
-				<para><varname>th3EdgeLength(th3index,text='km') → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3EdgeLength(th3index,text='km') → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
     th3index '871fa44aeffffff@2001-01-01'));
@@ -510,7 +576,9 @@ SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01
 			<listitem xml:id="th3_h3_great_circle_distance">
 				<indexterm significance="normal"><primary><varname>greatCircleDistance</varname></primary></indexterm>
 				<para>Return the temporal great-circle distance between two temporal geodetic points (not between cells). The two operands are synchronised.</para>
-				<para><varname>greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
   tgeogpoint 'Point(1 0)@2001-01-01');
@@ -532,10 +600,12 @@ SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
 					<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 					<para>Return <varname>true</varname> if a temporal H3 cell is ever equal to the probe at at least one instant</para>
-					<para><varname>eEq({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>eEq(th3index,h3index) → boolean</varname></para>
-					<para><varname>{h3index,th3index} ?= th3index</varname></para>
-					<para><varname>th3index ?= h3index</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eEq({h3index,th3index},th3index) → boolean
+eEq(th3index,h3index) → boolean
+{h3index,th3index} ?= th3index
+th3index ?= h3index
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index
   '[831c02fffffffff@2001-01-01, 880326b885fffff@2001-01-05]'
@@ -548,10 +618,12 @@ SELECT th3index
 					<indexterm significance="normal"><primary><varname>aEq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 					<para>Return <varname>true</varname> if a temporal H3 cell is always equal to the probe across its entire time axis</para>
-					<para><varname>aEq({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>aEq(th3index,h3index) → boolean</varname></para>
-					<para><varname>{h3index,th3index} %= th3index</varname></para>
-					<para><varname>th3index %= h3index</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+aEq({h3index,th3index},th3index) → boolean
+aEq(th3index,h3index) → boolean
+{h3index,th3index} %= th3index
+th3index %= h3index
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT aEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 -- t
@@ -562,10 +634,12 @@ SELECT aEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 					<indexterm significance="normal"><primary><varname>eNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
 					<para>Return <varname>true</varname> if a temporal H3 cell is ever different from the probe</para>
-					<para><varname>eNe({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>eNe(th3index,h3index) → boolean</varname></para>
-					<para><varname>{h3index,th3index} ?&lt;&gt; th3index</varname></para>
-					<para><varname>th3index ?&lt;&gt; h3index</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eNe({h3index,th3index},th3index) → boolean
+eNe(th3index,h3index) → boolean
+{h3index,th3index} ?&lt;&gt; th3index
+th3index ?&lt;&gt; h3index
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 -- t
@@ -576,10 +650,12 @@ SELECT eNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 					<indexterm significance="normal"><primary><varname>aNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%&lt;&gt;</varname></primary></indexterm>
 					<para>Return <varname>true</varname> if a temporal H3 cell is always different from the probe</para>
-					<para><varname>aNe({h3index,th3index},th3index) → boolean</varname></para>
-					<para><varname>aNe(th3index,h3index) → boolean</varname></para>
-					<para><varname>{h3index,th3index} %&lt;&gt; th3index</varname></para>
-					<para><varname>th3index %&lt;&gt; h3index</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+aNe({h3index,th3index},th3index) → boolean
+aNe(th3index,h3index) → boolean
+{h3index,th3index} %&lt;&gt; th3index
+th3index %&lt;&gt; h3index
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT aNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 -- t
@@ -597,14 +673,16 @@ SELECT aNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 					<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&lt;&gt;</varname></primary></indexterm>
 					<para>Return a temporal boolean giving the per-instant equality (or inequality) between a temporal H3 cell and a probe</para>
-					<para><varname>tEq({h3index,th3index},th3index) → tbool</varname></para>
-					<para><varname>tEq(th3index,h3index) → tbool</varname></para>
-					<para><varname>tNe({h3index,th3index},th3index) → tbool</varname></para>
-					<para><varname>tNe(th3index,h3index) → tbool</varname></para>
-					<para><varname>{h3index,th3index} #= th3index</varname></para>
-					<para><varname>th3index #= h3index</varname></para>
-					<para><varname>{h3index,th3index} #&lt;&gt; th3index</varname></para>
-					<para><varname>th3index #&lt;&gt; h3index</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tEq({h3index,th3index},th3index) → tbool
+tEq(th3index,h3index) → tbool
+tNe({h3index,th3index},th3index) → tbool
+tNe(th3index,h3index) → tbool
+{h3index,th3index} #= th3index
+th3index #= h3index
+{h3index,th3index} #&lt;&gt; th3index
+th3index #&lt;&gt; h3index
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 -- t@2001-01-01
@@ -632,11 +710,13 @@ SELECT tNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Bounding-box overlap, contains, contained-by, same, and adjacent</para>
-				<para><varname>th3index &amp;&amp; {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index @&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &lt;@ {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index ~= {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index -|- {tstzspan,stbox,th3index} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index &amp;&amp; {tstzspan,stbox,th3index} → boolean
+th3index @&gt; {tstzspan,stbox,th3index} → boolean
+th3index &lt;@ {tstzspan,stbox,th3index} → boolean
+th3index ~= {tstzspan,stbox,th3index} → boolean
+th3index -|- {tstzspan,stbox,th3index} → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '871fa44a8ffffff@2001-01-01' &amp;&amp; tstzspan '[2001-01-01, 2001-01-02]';
 -- t
@@ -655,14 +735,16 @@ SELECT th3index '871fa44a8ffffff@2001-01-01' ~= th3index '871fa44a8ffffff@2001-0
 				<indexterm significance="normal"><primary><varname>|&amp;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>|&gt;&gt;</varname></primary></indexterm>
 				<para>Relative position along the spatial axes (strictly-left, overlaps-left, overlaps-right, strictly-right; strictly-below, overlaps-below, overlaps-above, strictly-above)</para>
-				<para><varname>th3index &lt;&lt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &amp;&lt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &amp;&gt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &gt;&gt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &lt;&lt;| {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &amp;&lt;| {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index |&amp;&gt; {stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index |&gt;&gt; {stbox,th3index} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index &lt;&lt; {stbox,th3index} → boolean
+th3index &amp;&lt; {stbox,th3index} → boolean
+th3index &amp;&gt; {stbox,th3index} → boolean
+th3index &gt;&gt; {stbox,th3index} → boolean
+th3index &lt;&lt;| {stbox,th3index} → boolean
+th3index &amp;&lt;| {stbox,th3index} → boolean
+th3index |&amp;&gt; {stbox,th3index} → boolean
+th3index |&gt;&gt; {stbox,th3index} → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;
   th3index '871fa44aeffffff@2001-01-01';
@@ -676,10 +758,12 @@ SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;
 				<indexterm significance="normal"><primary><varname>#&gt;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>#&amp;&gt;</varname></primary></indexterm>
 				<para>Relative position along the time axis (strictly-before, overlaps-before, strictly-after, overlaps-after)</para>
-				<para><varname>th3index &lt;&lt;# {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index &amp;&lt;# {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index #&gt;&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
-				<para><varname>th3index #&amp;&gt; {tstzspan,stbox,th3index} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+th3index &lt;&lt;# {tstzspan,stbox,th3index} → boolean
+th3index &amp;&lt;# {tstzspan,stbox,th3index} → boolean
+th3index #&gt;&gt; {tstzspan,stbox,th3index} → boolean
+th3index #&amp;&gt; {tstzspan,stbox,th3index} → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '871fa44a8ffffff@2001-01-01' &lt;&lt;#
   th3index '871fa44aeffffff@2001-01-05';
@@ -700,7 +784,9 @@ SELECT th3index '871fa44a8ffffff@2001-01-01' #&gt;&gt;
 			<listitem xml:id="th3_h3_grid_disk">
 				<indexterm significance="normal"><primary><varname>h3GridDisk</varname></primary></indexterm>
 				<para>All cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0).</para>
-				<para><varname>h3GridDisk(h3index, integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3GridDisk(h3index, integer) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GridDisk(h3index '871fa44a8ffffff', 1);
 -- {"871fa44a8ffffff", "871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff",
@@ -711,7 +797,9 @@ SELECT h3GridDisk(h3index '871fa44a8ffffff', 1);
 			<listitem xml:id="th3_h3_grid_ring">
 				<indexterm significance="normal"><primary><varname>h3GridRing</varname></primary></indexterm>
 				<para>The cells at <emphasis>exactly</emphasis> <varname>k</varname> grid steps from the origin. Fails near pentagons.</para>
-				<para><varname>h3GridRing(h3index, integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3GridRing(h3index, integer) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
 -- {"871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff", "871fa44acffffff",
@@ -722,7 +810,9 @@ SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
 			<listitem xml:id="th3_h3_grid_path_cells">
 				<indexterm significance="normal"><primary><varname>h3GridPathCells</varname></primary></indexterm>
 				<para>The inclusive path of cells between two cells of the same resolution.</para>
-				<para><varname>h3GridPathCells(h3index, h3index) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3GridPathCells(h3index, h3index) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GridPathCells(h3index '871fa44a8ffffff', h3index '871fa44b1ffffff');
 -- {"871fa4484ffffff", "871fa44a3ffffff", "871fa44a8ffffff", "871fa44aeffffff",
@@ -733,7 +823,9 @@ SELECT h3GridPathCells(h3index '871fa44a8ffffff', h3index '871fa44b1ffffff');
 			<listitem xml:id="th3_h3_cell_to_children">
 				<indexterm significance="normal"><primary><varname>h3CellToChildren</varname></primary></indexterm>
 				<para>All children of a cell at the given target resolution.</para>
-				<para><varname>h3CellToChildren(h3index, integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3CellToChildren(h3index, integer) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3CellToChildren(h3index '831c02fffffffff', 4);
 -- {"841c021ffffffff", "841c023ffffffff", "841c025ffffffff", "841c027ffffffff",
@@ -744,7 +836,9 @@ SELECT h3CellToChildren(h3index '831c02fffffffff', 4);
 			<listitem xml:id="th3_h3_compact_cells">
 				<indexterm significance="normal"><primary><varname>h3CompactCells</varname></primary></indexterm>
 				<para>Compacted representation of a cell set, finer cells are merged into their parent whenever a full hexagonal set of siblings is present.</para>
-				<para><varname>h3CompactCells(h3indexset) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3CompactCells(h3indexset) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4));
 -- {"831c02fffffffff"}
@@ -754,7 +848,9 @@ SELECT h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4));
 			<listitem xml:id="th3_h3_uncompact_cells">
 				<indexterm significance="normal"><primary><varname>h3UncompactCells</varname></primary></indexterm>
 				<para>Uncompacted representation at the given resolution, the inverse of <varname>h3CompactCells</varname>.</para>
-				<para><varname>h3UncompactCells(h3indexset, integer) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3UncompactCells(h3indexset, integer) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(h3UncompactCells(
   h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4)), 4));
@@ -765,7 +861,9 @@ SELECT numValues(h3UncompactCells(
 			<listitem xml:id="th3_h3_origin_to_directed_edges">
 				<indexterm significance="normal"><primary><varname>h3OriginToDirectedEdges</varname></primary></indexterm>
 				<para>All outgoing directed edges of a cell (6 for hexagons, 5 for pentagons).</para>
-				<para><varname>h3OriginToDirectedEdges(h3index) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3OriginToDirectedEdges(h3index) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3OriginToDirectedEdges(h3index '871fa44a8ffffff');
 -- {"1171fa44a8ffffff", "1271fa44a8ffffff", "1371fa44a8ffffff",
@@ -776,7 +874,9 @@ SELECT h3OriginToDirectedEdges(h3index '871fa44a8ffffff');
 			<listitem xml:id="th3_h3_cell_to_vertexes">
 				<indexterm significance="normal"><primary><varname>h3CellToVertexes</varname></primary></indexterm>
 				<para>All vertexes of a cell (6 for hexagons, 5 for pentagons).</para>
-				<para><varname>h3CellToVertexes(h3index) → h3indexset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3CellToVertexes(h3index) → h3indexset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3CellToVertexes(h3index '871fa44a8ffffff');
 -- {"2071fa44a8ffffff", "2171fa44a8ffffff", "2271fa44a8ffffff",
@@ -787,7 +887,9 @@ SELECT h3CellToVertexes(h3index '871fa44a8ffffff');
 			<listitem xml:id="th3_h3_get_icosahedron_faces">
 				<indexterm significance="normal"><primary><varname>h3GetIcosahedronFaces</varname></primary></indexterm>
 				<para>The icosahedron face indexes (0..19) intersected by a cell.</para>
-				<para><varname>h3GetIcosahedronFaces(h3index) → intset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+h3GetIcosahedronFaces(h3index) → intset
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GetIcosahedronFaces(h3index '831c02fffffffff');
 -- {6, 11}
@@ -807,7 +909,9 @@ SELECT h3GetIcosahedronFaces(h3index '831c02fffffffff');
 				<indexterm significance="normal"><primary><varname>aContains</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tContains</varname></primary></indexterm>
 				<para>Whether one footprint contains the other (interiors only)</para>
-				<para><varname>eContains, aContains, tContains</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eContains, aContains, tContains
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'SRID=4326;Polygon((-123 37,-123 38,-122 38,-122 37,-123 37))',
   th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]');
@@ -822,7 +926,9 @@ SELECT tContains(geometry 'SRID=4326;Polygon((-123 37,-123 38,-122 38,-122 37,-1
 				<indexterm significance="normal"><primary><varname>aCovers</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tCovers</varname></primary></indexterm>
 				<para>Whether one footprint covers the other (boundary included)</para>
-				<para><varname>eCovers, aCovers, tCovers</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eCovers, aCovers, tCovers
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eCovers(geometry 'SRID=4326;Polygon((-123 37,-123 38,-122 38,-122 37,-123 37))',
   th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]');
@@ -837,7 +943,9 @@ SELECT tCovers(geometry 'SRID=4326;Polygon((-123 37,-123 38,-122 38,-122 37,-123
 				<indexterm significance="normal"><primary><varname>aDisjoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>
 				<para>Whether the footprints share no point</para>
-				<para><varname>eDisjoint, aDisjoint, tDisjoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eDisjoint, aDisjoint, tDisjoint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eDisjoint(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]',
   th3index '[88283082b3fffff@2001-01-01, 88283082b1fffff@2001-01-02]');
@@ -852,7 +960,9 @@ SELECT tDisjoint(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-
 				<indexterm significance="normal"><primary><varname>aIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 				<para>Whether the footprints share at least one point</para>
-				<para><varname>eIntersects, aIntersects, tIntersects</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eIntersects, aIntersects, tIntersects
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eIntersects(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]',
   th3index '[8828308281fffff@2001-01-01, 88283082b1fffff@2001-01-02]');
@@ -867,7 +977,9 @@ SELECT tIntersects(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-0
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 				<para>Whether the footprints share a boundary point but no interior point</para>
-				<para><varname>eTouches, aTouches, tTouches</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eTouches, aTouches, tTouches
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eTouches(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]',
   th3index '[8828308283fffff@2001-01-01, 8828308285fffff@2001-01-02]');
@@ -882,7 +994,9 @@ SELECT tTouches(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-0
 				<indexterm significance="normal"><primary><varname>aDwithin</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
 				<para>Whether the footprints lie within a given distance, passed as the third argument</para>
-				<para><varname>eDwithin, aDwithin, tDwithin (…, dist float)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eDwithin, aDwithin, tDwithin (…, dist float)
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eDwithin(th3index '[8828308281fffff@2001-01-01, 8828308283fffff@2001-01-02]',
   th3index '[88283082b3fffff@2001-01-01, 88283082b1fffff@2001-01-02]', 5000);
@@ -911,7 +1025,9 @@ SELECT eContains(
 			<listitem xml:id="th3_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
-				<para><varname>tCount(th3index) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(th3index) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION
@@ -926,7 +1042,9 @@ FROM Temp;
 			<listitem xml:id="th3_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Window count</para>
-				<para><varname>wCount(th3index) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(th3index) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT th3index '[831c02fffffffff@2001-01-01, 831c02fffffffff@2001-01-03)' UNION

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -46,10 +46,12 @@ SELECT tjsonb '[{"unit": "km", "speed": 10}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>jsonbsetObjectField</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetObjectFieldText</varname></primary></indexterm>
 				<para>Extract a JSON object field specified by a key</para>
-				<para><varname>{textset,jsonbset} -> text → {textset,jsonbset}</varname></para>
-				<para><varname>jsonbset ->> text → textset</varname></para>
-				<para><varname>jsonbsetObjectField(jsonbset,text,null_handle text='use_json_null') → jsonbset</varname></para>
-				<para><varname>jsonbsetObjectFieldText(jsonbset,text,null_handle text='use_json_null') → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{textset,jsonbset} -> text → {textset,jsonbset}
+jsonbset ->> text → textset
+jsonbsetObjectField(jsonbset,text,null_handle text='use_json_null') → jsonbset
+jsonbsetObjectFieldText(jsonbset,text,null_handle text='use_json_null') → textset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT textset '{[{"unit": "km", "speed": 10}, 
   {"unit": "km", "speed": 20}]}' -> text 'speed';
@@ -88,9 +90,11 @@ SELECT jsonbsetObjectField(textset '{[{"unit": "km", "speed": 10},
 				<indexterm significance="normal"><primary><varname>jsonbsetExtractPath</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetExtractPathText</varname></primary></indexterm>
 				<para>Extract a JSON object field specified by a path</para>
-				<para><varname>{textset,jsonbset} #> text[] → {textset,jsonbset}</varname></para>
-				<para><varname>jsonbsetExtractPath(jsonbset,text[],null_handle text='use_json_null') → jsonbset</varname></para>
-				<para><varname>jsonbsetExtractPathText(jsonbset,text[],null_handle text='use_json_null') → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{textset,jsonbset} #> text[] → {textset,jsonbset}
+jsonbsetExtractPath(jsonbset,text[],null_handle text='use_json_null') → jsonbset
+jsonbsetExtractPathText(jsonbset,text[],null_handle text='use_json_null') → textset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT textset '[{"speed": {"unit": "km", "value": 10}}, 
   {"speed": {"unit": "km", "value": 20}}]' #> ARRAY[text 'speed', 'value'];
@@ -106,8 +110,10 @@ SELECT jsonbset '[{"position":"Point(1 1)", "PoIs":["Grand Place", "La Bourse"]}
 				<indexterm significance="normal"><primary><varname>jsonbsetArrayElement</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetArrayElementText</varname></primary></indexterm>
 				<para>Extract an element from a JSON array</para>
-				<para><varname>jsonbsetArrayElement(jsonbset,integer,null_handle text='use_json_null') → jsonbset</varname></para>
-				<para><varname>jsonbsetArrayElementText(jsonbset,integer,null_handle text='use_json_null') → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetArrayElement(jsonbset,integer,null_handle text='use_json_null') → jsonbset
+jsonbsetArrayElementText(jsonbset,integer,null_handle text='use_json_null') → jsonbset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetArrayElement(textset '[["Grand Place", "La Bourse"],
   ["Palais Royal", "Manneken Pis"]]', 0);
@@ -123,9 +129,11 @@ SELECT jsonbsetArrayElement(jsonbset '[["Grand Place", "La Bourse"],
 				<indexterm significance="normal"><primary><varname>floatset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>textset</varname></primary></indexterm>
 				<para>Extract a alphanumeric value from a JSONB set given by a key</para>
-				<para><varname>intset(jsonbset,text,null_handle text='raise_exception') → tint</varname></para>
-				<para><varname>floatset(jsonbset,text,null_handle text='raise_exception') → tfloat</varname></para>
-				<para><varname>textset(jsonbset,text,null_handle text='raise_exception') → textset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+intset(jsonbset,text,null_handle text='raise_exception') → tint
+floatset(jsonbset,text,null_handle text='raise_exception') → tfloat
+textset(jsonbset,text,null_handle text='raise_exception') → textset
+</programlisting>
 				<para>Note that the value <varname>use_json_null</varname> cannot be used for the above functions and thus the default value <varname>'raise_exception'</varname> is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intset(jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}",
@@ -143,7 +151,9 @@ SELECT textset(jsonbset '{"{\"road\": \"Bvd Gén. Jacques\", \"category\": \"pri
 			<listitem xml:id="jsonbset_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
 				<para>Temporal JSONB concatenation</para>
-				<para><varname>jsonbset || {jsonb,jsonbset} → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset || {jsonb,jsonbset} → jsonbset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbset '{[{"speed":10}, {"speed":20}]}' ||
   '{"unit":"km"}'::jsonb;
@@ -158,8 +168,10 @@ SELECT jsonbset '{[{"speed":10}, {"speed":20}]}' ||
 			<listitem xml:id="jsonbset_delete">
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
 				<para>Temporal JSONB deletion</para>
-				<para><varname>jsonbset - {int,text,text[]} → jsonbset</varname></para>
-				<para><varname>jsonbset #- text[] → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset - {int,text,text[]} → jsonbset
+jsonbset #- text[] → jsonbset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbset '{[{"unit": "km", "speed": 10},
   {"unit": "km", "speed": 20}]}' - 'unit';
@@ -195,9 +207,11 @@ SELECT minusValues(jsonbset '[["Grand Place", "La Bourse"],
 			<listitem xml:id="jsonbset_exists">
 				<indexterm significance="normal"><primary><varname>?</varname></primary></indexterm>
 				<para>JSONB set exists</para>
-				<para><varname>jsonbset ? text → boolean[]</varname></para>
-				<para><varname>jsonbset ?| text[] → boolean[]</varname></para>
-				<para><varname>jsonbset ?&amp; text[] → boolean[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset ? text → boolean[]
+jsonbset ?| text[] → boolean[]
+jsonbset ?&amp; text[] → boolean[]
+</programlisting>
 				<para>As in PostgreSQL, the operators <varname>?|</varname> and <varname>?&amp;</varname> test, respectively, whether <emphasis>any</emphasis> or <emphasis>all</emphasis> of the strings in the text array exist as top-level keys or array elements.</para>
 				<para>The result is a Boolean for every value of the set, in the order of the values of the set.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -220,8 +234,11 @@ SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}'
 				<indexterm significance="normal"><primary><varname>jsonbsetSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetSetLax</varname></primary></indexterm>
 				<para>Temporal JSONB set</para>
-				<para><varname>jsonbsetSet(jsonbset,path text[],jsonb,create boolean=true) → jsonbset</varname></para>
-				<para><varname>jsonbsetSetLax(jsonbset,path text[],jsonb,create boolean=true,handle_null text) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetSet(jsonbset,path text[],jsonb,create boolean=true) → jsonbset
+jsonbsetSetLax(jsonbset,path text[],jsonb,create boolean=true,
+  handle_null text) → jsonbset
+</programlisting>
 				<para>Return the <varname>jsonbset</varname> value with the item specified by path replaced by <varname>jsonb</varname>, or added if <varname>create</varname> is true and the item does not exist. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, and create_if_missing is true, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive.
         </para>
 				<para>Function <varname>jsonbsetSetLax</varname> behaves identically to <varname>jsonbsetSet</varname> if the given value is not NULL, Otherwise, it behaves according to the value of <varname>handle_null</varname>, which must be one of <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname>, or <varname>'return_source'</varname>. As stated above, we kept PostgreSQL behavior for this function enabling the value <varname>'return_source'</varname> whereas for all other <emphasis>query</emphasis> operations, this value has been replaced with <varname>'return_null'</varname>.</para>
@@ -244,7 +261,9 @@ SELECT jsonbsetSetLax(jsonbset '[{"speed": 10, "units": "km/h"},
 			<listitem xml:id="jsonbset_insert">
 				<indexterm significance="normal"><primary><varname>jsonbsetInsert</varname></primary></indexterm>
 				<para>Temporal JSONB insert</para>
-				<para><varname>jsonbsetInsert(jsonbset,path text[],jsonb,after boolean=false) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetInsert(jsonbset,path text[],jsonb,after boolean=false) → jsonbset
+</programlisting>
 				<para>Return the <varname>jsonbset</varname> value with <varname>jsonb</varname> inserted. If the item specified by the path is an array element, the new value will be inserted before that item if <varname>after</varname> is false, or after it otherwise. If the item specified by the path is an object field, the new value will be inserted only if the object does not already contain that key. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetInsert(jsonbset '[{"speed":10}, {"speed":20}]',
@@ -262,7 +281,9 @@ SELECT jsonbsetInsert(jsonbset '[{"speed": 10, "units": "km/h"},
 			<listitem xml:id="jsonbset_strip_nulls">
 				<indexterm significance="normal"><primary><varname>jsonbsetStripNulls</varname></primary></indexterm>
 				<para>Return a JSONB set without nulls</para>
-				<para><varname>jsonbsetStripNulls(jsonbset,strip_in_arrays boolean=false) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetStripNulls(jsonbset,strip_in_arrays boolean=false) → jsonbset
+</programlisting>
 				<para>The last argument states whether null array elements are also stripped. Bare null values are never stripped.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetStripNulls(textset '[{"speed": 10, "lights": null},
@@ -300,9 +321,11 @@ SELECT minusValues(textset '[{"speed": 10}, null,
 				<indexterm significance="normal"><primary><varname>jsonbsetPathExists</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetPathExistsTz</varname></primary></indexterm>
 				<para>Does the JSON path return any item for the specified JSONB set?</para>
-				<para><varname>jsonbset @? jsonpath → boolean[]</varname></para>
-				<para><varname>jsonbsetPathExists(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
-				<para><varname>jsonbsetPathExistsTz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset @? jsonpath → boolean[]
+jsonbsetPathExists(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]
+jsonbsetPathExistsTz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]
+</programlisting>
 				<para>The operator <varname>@?</varname> suppresses the following errors: missing object field or array element, unexpected JSON item type, datetime and numeric errors. The above functions can also suppress these types of errors by setting the last argument to true. This behavior might be helpful when searching JSON document collections of varying structure.</para>
 				<para>The result is a Boolean for every value of the set, in the order of the values of the set.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -323,9 +346,11 @@ SELECT jsonbsetPathExists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20,
 				<indexterm significance="normal"><primary><varname>jsonbsetPathMatch</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetPathMatchTz</varname></primary></indexterm>
 				<para>Return the result of a JSON path predicate check for a JSONB set</para>
-				<para><varname>jsonbset @@ jsonpath → boolean[]</varname></para>
-				<para><varname>jsonbsetPathMatch(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
-				<para><varname>jsonbsetPathMatchTz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbset @@ jsonpath → boolean[]
+jsonbsetPathMatch(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]
+jsonbsetPathMatchTz(jsonbset,vars jsonb='{}',silent boolean=false) → boolean[]
+</programlisting>
 				<para>The operator <varname>@@</varname> suppresses the following errors: missing object field or array element, unexpected JSON item type, datetime and numeric errors. The above functions can also suppress these types of errors by setting the last argument to true. This behavior might be helpful when searching JSON document collections of varying structure.</para>
 				<para>The result is a Boolean for every value of the set, in the order of the values of the set.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -345,8 +370,10 @@ SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20,
 				<indexterm significance="normal"><primary><varname>jsonbsetPathQueryArray</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetPathQueryArrayTz</varname></primary></indexterm>
 				<para>Return all items returned by a JSON path from a JSONB set, as a JSON array</para>
-				<para><varname>jsonbsetPathQueryArray(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset</varname></para>
-				<para><varname>jsonbsetPathQueryArrayTz(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetPathQueryArray(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset
+jsonbsetPathQueryArrayTz(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset
+</programlisting>
 				<para>The above function can suppress the following errors by setting the last argument to true: missing object field or array element, unexpected JSON item type, datetime and numeric errors. This behavior might be helpful when searching JSON document collections of varying structure.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetPathQueryArray(jsonbset 
@@ -367,8 +394,10 @@ SELECT jsonbsetPathQueryArrayTz(jsonbset
 				<indexterm significance="normal"><primary><varname>jsonbsetPathQueryFirst</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetPathQueryFirstTz</varname></primary></indexterm>
 				<para>Return the fist item returned by a JSON path from a JSONB set</para>
-				<para><varname>jsonbsetPathQueryFirst(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset</varname></para>
-				<para><varname>jsonbsetPathQueryFirstTz(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+jsonbsetPathQueryFirst(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset
+jsonbsetPathQueryFirstTz(jsonbset,vars jsonb='{}',silent boolean=false) → jsonbset
+</programlisting>
 				<para>The above functions can suppress the following errors by setting the last argument to true: missing object field or array element, unexpected JSON item type, datetime and numeric errors. This behavior might be helpful when searching JSON document collections of varying structure.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetPathQueryFirst(jsonbset 
@@ -455,7 +484,9 @@ SELECT tjsonb 'Point(0 0)@2001-01-01 08:05:00';
 			<listitem xml:id="tjsonb_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Return the Well-Known Text (WKT) representation</para>
-				<para><varname>asText({tjsonb,tjsonb[]}) → {text,text[]}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({tjsonb,tjsonb[]}) → {text,text[]}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]');
@@ -473,8 +504,10 @@ SELECT asText(ARRAY[tjsonb '"{\"vehicleId\":1, \"location\": \"Point(1 1)\"}"@20
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Return the Well-Known Binary (WKB) or the Hexadecimal Extended Well-Known Binary (HexWKB) representation</para>
-				<para><varname>asBinary(tjsonb,endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB(tjsonb,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(tjsonb,endian text='') → bytea
+asHexWKB(tjsonb,endian text='') → text
+</programlisting>
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tjsonb '"{\"vehicleId\": 1, \"location\": \"Point(1 2)\"}"@2001-01-01');
@@ -487,7 +520,9 @@ SELECT asHexWKB(tjsonb '"{\"vehicleId\": 1, \"location\": \"Point(1 2)\"}"@2001-
 			<listitem xml:id="tjsonb_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Return the Moving Features JSON (MF-JSON) representation</para>
-				<para><varname>asMFJSON(text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(text) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tjsonb '[{"Position": "Point(1 1)"}@2001-01-01,
   {"Position": "Point(2 2)"}@2001-01-02]');
@@ -500,7 +535,9 @@ SELECT asMFJSON(tjsonb '[{"Position": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonbFromText">
 				<indexterm significance="normal"><primary><varname>tjsonbFromText</varname></primary></indexterm>
 				<para>Input from the Well-Known Text (WKT) representation</para>
-				<para><varname>tjsonbFromText(text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbFromText(text) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbFromText(text
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -514,8 +551,10 @@ SELECT tjsonbFromText(text
 				<indexterm significance="normal"><primary><varname>tjsonbFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbFromHexWKB</varname></primary></indexterm>
 				<para>Input from the Well-Known Binary (WKB) or from the Hexadecimal Well-Known Binary (HexWKB) representation</para>
-				<para><varname>tjsonbFromBinary(bytea) → tjsonb</varname></para>
-				<para><varname>tjsonbFromHexWKB(text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbFromBinary(bytea) → tjsonb
+tjsonbFromHexWKB(text) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbFromBinary(asBinary(
   tjsonb '[{"vehicleId": 1, "location": "Point(1 2)"}@2001-01-01]'));
@@ -529,7 +568,9 @@ SELECT tjsonbFromHexWKB(asHexWKB(
 			<listitem xml:id="tjsonbFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tjsonbFromMFJSON</varname></primary></indexterm>
 				<para>Input from the Moving Features JSON (MF-JSON) representation</para>
-				<para><varname>tjsonbFromMFJSON(text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbFromMFJSON(text) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbFromMFJSON('{"type": "MovingJsonb", "interpolation": "Step",
   "values": [{"Position": "Point(1 1)"}, {"Position": "Point(2 2)"}],
@@ -548,10 +589,12 @@ SELECT tjsonbFromMFJSON('{"type": "MovingJsonb", "interpolation": "Step",
 			<listitem xml:id="tjsonb_const">
 				<indexterm significance="normal"><primary><varname>tjsonb</varname></primary></indexterm>
 				<para>Constructor for temporal JSONB values having a constant value</para>
-				<para><varname>tjsonb(jsonb,timestamptz) → tjsonbInst</varname></para>
-				<para><varname>tjsonb(jsonb,tstzset) → tjsonbDiscSeq</varname></para>
-				<para><varname>tjsonb(jsonb,tstzspan) → tjsonbContSeq</varname></para>
-				<para><varname>tjsonb(jsonb,tstzspanset) → tjsonbSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb(jsonb,timestamptz) → tjsonbInst
+tjsonb(jsonb,tstzset) → tjsonbDiscSeq
+tjsonb(jsonb,tstzspan) → tjsonbContSeq
+tjsonb(jsonb,tstzspanset) → tjsonbSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb('{"vehicleId": 1, "location": "Point(1 1)"}', timestamptz '2001-01-01');
 -- {"location": "Point(1 1)", "vehicleId": 1}@2001-01-01
@@ -576,7 +619,9 @@ SELECT tjsonb('{"vehicleId": 1, "location": "Point(1 1)"}',
 			<listitem xml:id="tjsonbSeq">
 				<indexterm significance="normal"><primary><varname>tjsonbSeq</varname></primary></indexterm>
 				<para>Constructor for temporal JSONB values of sequence subtype</para>
-				<para><varname>tjsonbSeq(tjsonbInst[]},leftInc boolean=true,rightInc boolean=true) →tjsonbSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbSeq(tjsonbInst[]},leftInc boolean=true,rightInc boolean=true) →tjsonbSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeq(ARRAY[tjsonb
   '"{\"vehicleId\": 1, \"location\": \"Point(1 1)\"}"@2001-01-01',
@@ -592,8 +637,10 @@ SELECT tjsonbSeq(ARRAY[tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor for temporal JSONB values of sequence set subtype</para>
-				<para><varname>tjsonbSeqSet(tjsonb[]) → tjsonbSeqSet</varname></para>
-				<para><varname>tjsonbSeqSetGaps(tjsonbInst[],maxt=NULL,maxdist=NULL) → tjsonbSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbSeqSet(tjsonb[]) → tjsonbSeqSet
+tjsonbSeqSetGaps(tjsonbInst[],maxt=NULL,maxdist=NULL) → tjsonbSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeqSet(ARRAY[tjsonb
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -622,7 +669,9 @@ SELECT tjsonbSeqSetGaps(ARRAY[tjsonb
 			<listitem xml:id="tjsonb_tstzspan">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert a temporal JSONB to a <varname>tstzspan</varname></para>
-				<para><varname>tjsonb::tstzpan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb::tstzpan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]'::tstzspan;
@@ -633,8 +682,10 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_text">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert between a temporal JSONB and a text</para>
-				<para><varname>tjsonb::text</varname></para>
-				<para><varname>text::tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb::text
+text::tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (text '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]')::jsonb;
@@ -649,8 +700,10 @@ SELECT pg_typeof(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_ttext">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert between a temporal JSONB and a temporal text</para>
-				<para><varname>tjsonb::ttext</varname></para>
-				<para><varname>ttext::tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb::ttext
+ttext::tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (ttext '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]')::tjsonb;
@@ -670,7 +723,9 @@ SELECT pg_typeof(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Return the values</para>
-				<para><varname>getValues(tjsonb) → jsonbset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tjsonb) → jsonbset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(tjsonb
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -682,7 +737,9 @@ SELECT getValues(tjsonb
 			<listitem xml:id="tjsonb_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(tjsonb,timestamptz) → jsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tjsonb,timestamptz) → jsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tjsonb
   '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -701,9 +758,11 @@ SELECT valueAtTimestamp(tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbSeqSet</varname></primary></indexterm>
 				<para>Transform a temporal JSONB to another subtype</para>
-				<para><varname>tjsonbInst(tjsonb) → tjsonbInst</varname></para>
-				<para><varname>tjsonbSeq(tjsonb,interp='step') → tjsonbSeq</varname></para>
-				<para><varname>tjsonbSeqSet(tjsonb) → tjsonbSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbInst(tjsonb) → tjsonbInst
+tjsonbSeq(tjsonb,interp='step') → tjsonbSeq
+tjsonbSeqSet(tjsonb) → tjsonbSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeq(tjsonb '"{\"vehicleId\": 1, \"location\": \"Point(1 1)\"}"@2001-01-01');
 -- [{"location": "Point(1 1)", "vehicleId": 1}@2001-01-01]
@@ -718,7 +777,9 @@ SELECT tjsonbSeqSet(tjsonb '"{\"vehicleId\": 1,\"location\":\"Point(1 1)\"}"@200
 			<listitem xml:id="tjsonb_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transform a temporal JSONB value to another interpolation</para>
-				<para><varname>setInterp(tjsonb,interp) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(tjsonb,interp) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT setInterp(tjsonb
   '"{\"vehicleId\": 1,\"location\": \"Point(1 1)\"}"@2001-01-01','step');
@@ -764,11 +825,13 @@ SELECT tjsonb '{[{"unit": "km", "speed": 10}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tjsonbObjectField</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbObjectFieldText</varname></primary></indexterm>
 				<para>Extract a temporal JSON object field specified by a key</para>
-				<para><varname>{ttext,tjsonb} -> text → {ttext,tjsonb}</varname></para>
-				<para><varname>tjsonb ->> text → ttext</varname></para>
-				<para><varname>tjsonObjectField(ttext,text,null_handle text='use_json_null') → ttext</varname></para>
-				<para><varname>tjsonbObjectField(tjsonb,text,null_handle text='use_json_null') → tjsonb</varname></para>
-				<para><varname>tjsonbObjectFieldText(tjsonb,text,null_handle text='use_json_null') → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{ttext,tjsonb} -> text → {ttext,tjsonb}
+tjsonb ->> text → ttext
+tjsonObjectField(ttext,text,null_handle text='use_json_null') → ttext
+tjsonbObjectField(tjsonb,text,null_handle text='use_json_null') → tjsonb
+tjsonbObjectFieldText(tjsonb,text,null_handle text='use_json_null') → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '{[{"unit": "km", "speed": 10}@2001-01-01, 
   {"unit": "km", "speed": 20}@2001-01-02]}' -> text 'speed';
@@ -808,10 +871,12 @@ SELECT tjsonObjectField(ttext '{[{"unit": "km", "speed": 10}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tjsonbExtractPath</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbExtractPathText</varname></primary></indexterm>
 				<para>Extract a temporal JSON object field specified by a path</para>
-				<para><varname>{ttext,tjsonb} #> text[] → {ttext,tjsonb}</varname></para>
-				<para><varname>tjsonExtractPath(ttext,text[],null_handle text='use_json_null') → ttext</varname></para>
-				<para><varname>tjsonbExtractPath(tjsonb,text[],null_handle text='use_json_null') → tjsonb</varname></para>
-				<para><varname>tjsonbExtractPathText(tjsonb,text[],null_handle text='use_json_null') → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{ttext,tjsonb} #> text[] → {ttext,tjsonb}
+tjsonExtractPath(ttext,text[],null_handle text='use_json_null') → ttext
+tjsonbExtractPath(tjsonb,text[],null_handle text='use_json_null') → tjsonb
+tjsonbExtractPathText(tjsonb,text[],null_handle text='use_json_null') → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '[{"speed": {"unit": "km", "value": 10}}@2001-01-01, 
   {"speed": {"unit": "km", "value": 20}}@2001-01-02]' #> ARRAY[text 'speed', 'value'];
@@ -829,9 +894,11 @@ SELECT tjsonb '[{"position":"Point(1 1)", "PoIs":["Grand Place",
 				<indexterm significance="normal"><primary><varname>tjsonbArrayElement</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbArrayElementText</varname></primary></indexterm>
 				<para>Extract an element from a temporal JSON array</para>
-				<para><varname>tjsonArrayElement(tjsonb,integer,null_handle text='use_json_null') → tjsonb</varname></para>
-				<para><varname>tjsonbArrayElement(tjsonb,integer,null_handle text='use_json_null') → tjsonb</varname></para>
-				<para><varname>tjsonbArrayElementText(tjsonb,integer,null_handle text='use_json_null') → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonArrayElement(tjsonb,integer,null_handle text='use_json_null') → tjsonb
+tjsonbArrayElement(tjsonb,integer,null_handle text='use_json_null') → tjsonb
+tjsonbArrayElementText(tjsonb,integer,null_handle text='use_json_null') → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonArrayElement(ttext '[["Grand Place", "La Bourse"]@2001-01-01,
   ["Palais Royal", "Manneken Pis"]@2001-01-02]', 0);
@@ -848,10 +915,12 @@ SELECT tjsonbArrayElement(tjsonb '[["Grand Place", "La Bourse"]@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tfloat</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttext</varname></primary></indexterm>
 				<para>Extract a temporal alphanumeric value from a temporal JSONB value given by a key</para>
-				<para><varname>tbool(tjsonb,text,null_handle text='raise_exception') → tbool</varname></para>
-				<para><varname>tint(tjsonb,text,null_handle text='raise_exception') → tint</varname></para>
-				<para><varname>tfloat(tjsonb,text,interp='linear',null_handle text='raise_exception') → tfloat</varname></para>
-				<para><varname>ttext(tjsonb,text, null_handle text='raise_exception') → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbool(tjsonb,text,null_handle text='raise_exception') → tbool
+tint(tjsonb,text,null_handle text='raise_exception') → tint
+tfloat(tjsonb,text,interp='linear',null_handle text='raise_exception') → tfloat
+ttext(tjsonb,text, null_handle text='raise_exception') → ttext
+</programlisting>
 				<para>Note that the value <varname>use_json_null</varname> cannot be used for the above functions and thus the default value <varname>'raise_exception'</varname> is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool(tjsonb '[{"speed": 10, "lights": "on"}@2001-01-01,
@@ -874,7 +943,9 @@ SELECT ttext(tjsonb '[{"road": "Bvd Gén. Jacques", "category": "primary"}@2001-
 			<listitem xml:id="tjsonb_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
 				<para>Temporal JSONB concatenation</para>
-				<para><varname>tjsonb || {jsonb,tjsonb} → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb || {jsonb,tjsonb} → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '{[{"speed":10}@2001-01-01, {"speed":20}@2001-01-02]}' ||
   '{"unit":"km"}'::jsonb;
@@ -889,8 +960,10 @@ SELECT tjsonb '{[{"speed":10}@2001-01-01, {"speed":20}@2001-01-03]}' ||
 			<listitem xml:id="tjsonb_delete">
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
 				<para>Temporal JSONB deletion</para>
-				<para><varname>tjsonb - {int,text,text[]} → tjsonb</varname></para>
-				<para><varname>tjsonb #- text[] → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb - {int,text,text[]} → tjsonb
+tjsonb #- text[] → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '{[{"unit": "km", "speed": 10}@2001-01-01,
   {"unit": "km", "speed": 20}@2001-01-02]}' - 'unit';
@@ -926,9 +999,11 @@ SELECT minusValues(tjsonb '[["Grand Place", "La Bourse"]@2001-01-01,
 			<listitem xml:id="tjsonb_exists">
 				<indexterm significance="normal"><primary><varname>?</varname></primary></indexterm>
 				<para>Temporal JSONB exists</para>
-				<para><varname>tjsonb ? jsonb → tbool</varname></para>
-				<para><varname>tjsonb ?| jsonb[] → tbool</varname></para>
-				<para><varname>tjsonb ?&amp; jsonb[] → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb ? jsonb → tbool
+tjsonb ?| jsonb[] → tbool
+tjsonb ?&amp; jsonb[] → tbool
+</programlisting>
 				<para>As in PostgreSQL, the operators <varname>?|</varname> and <varname>?&amp;</varname> test, respectively, whether <emphasis>any</emphasis> or <emphasis>all</emphasis> of the strings in the text array exist as top-level keys or array elements.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2001-01-01' ? text 'geom';
@@ -946,8 +1021,10 @@ SELECT tjsonb '[{"speed": 10, "units": "km/h"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
 				<para>Temporal JSONB contains/contained</para>
-				<para><varname>{tjsonb,jsonb} @&gt; {tjsonb,jsonb} → tbool</varname></para>
-				<para><varname>{tjsonb,jsonb} &lt;@ {tjsonb,jsonb} → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tjsonb,jsonb} @&gt; {tjsonb,jsonb} → tbool
+{tjsonb,jsonb} &lt;@ {tjsonb,jsonb} → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2001-01-01' @&gt; jsonb '{"geom": "Point(1 1)"}';
 -- t@2001-01-01
@@ -965,8 +1042,10 @@ SELECT jsonb '{"geom": "Point(1 1)"}' &lt;@ tjsonb '{[{"geom": "Point(1 1)"}@200
 				<indexterm significance="normal"><primary><varname>tjsonbSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbSetLax</varname></primary></indexterm>
 				<para>Temporal JSONB set</para>
-				<para><varname>tjsonbSet(tjsonb,path text[],jsonb,create boolean=true) → tjsonb</varname></para>
-				<para><varname>tjsonbSetLax(tjsonb,path text[],jsonb,create boolean=true,handle_null text) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbSet(tjsonb,path text[],jsonb,create boolean=true) → tjsonb
+tjsonbSetLax(tjsonb,path text[],jsonb,create boolean=true,handle_null text) → tjsonb
+</programlisting>
 				<para>Return the <varname>tjsonb</varname> value with the item specified by path replaced by <varname>jsonb</varname>, or added if <varname>create</varname> is true and the item does not exist. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, and create_if_missing is true, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive.
         </para>
 				<para>Function <varname>tjsonbSetLax</varname> behaves identically to <varname>tjsonbSet</varname> if the given value is not NULL, Otherwise, it behaves according to the value of <varname>handle_null</varname>, which must be one of <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname>, or <varname>'return_source'</varname>. As stated above, we kept PostgreSQL behavior for this function enabling the value <varname>'return_source'</varname> whereas for all other <emphasis>query</emphasis> operations, this value has been replaced with <varname>'return_null'</varname>.</para>
@@ -989,7 +1068,9 @@ SELECT tjsonbSetLax(tjsonb '[{"speed": 10, "units": "km/h"}@2001-01-01,
 			<listitem xml:id="tjsonb_insert">
 				<indexterm significance="normal"><primary><varname>tjsonbInsert</varname></primary></indexterm>
 				<para>Temporal JSONB insert</para>
-				<para><varname>tjsonbInsert(tjsonb,path text[],jsonb,after boolean=false) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbInsert(tjsonb,path text[],jsonb,after boolean=false) → tjsonb
+</programlisting>
 				<para>Return the <varname>tjsonb</varname> value with <varname>jsonb</varname> inserted. If the item specified by the path is an array element, the new value will be inserted before that item if <varname>after</varname> is false, or after it otherwise. If the item specified by the path is an object field, the new value will be inserted only if the object does not already contain that key. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbInsert(tjsonb '[{"speed":10}@2001-01-01, {"speed":20}@2001-01-02]',
@@ -1008,8 +1089,10 @@ SELECT tjsonbInsert(tjsonb '[{"speed": 10, "units": "km/h"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tjsonStripNulls</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbStripNulls</varname></primary></indexterm>
 				<para>Return a temporal JSON value without nulls</para>
-				<para><varname>tjsonStripNulls(ttext,strip_in_arrays boolean=false) → ttext</varname></para>
-				<para><varname>tjsonbStripNulls(tjsonb,strip_in_arrays boolean=false) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonStripNulls(ttext,strip_in_arrays boolean=false) → ttext
+tjsonbStripNulls(tjsonb,strip_in_arrays boolean=false) → tjsonb
+</programlisting>
 				<para>The last argument states whether null array elements are also stripped. Bare null values are never stripped.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonStripNulls(ttext '[{"speed": 10, "lights": null}@2001-01-01,
@@ -1047,9 +1130,11 @@ SELECT minusValues(ttext '[{"speed": 10}@2001-01-01, null@2001-01-02,
 				<indexterm significance="normal"><primary><varname>tjsonbPathExists</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbPathExistsTz</varname></primary></indexterm>
 				<para>Does the JSON path return any item for the specified temporal JSONB value?</para>
-				<para><varname>tjsonb @? jsonpath → tbool</varname></para>
-				<para><varname>tjsonbPathExists(tjsonb,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
-				<para><varname>tjsonbPathExistsTz(tjsonb,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb @? jsonpath → tbool
+tjsonbPathExists(tjsonb,vars jsonb='{}',silent boolean=false) → tbool
+tjsonbPathExistsTz(tjsonb,vars jsonb='{}',silent boolean=false) → tbool
+</programlisting>
 				<para>The operator <varname>@?</varname> suppresses the following errors: missing object field or array element, unexpected JSON item type, datetime and numeric errors. The above functions can also suppress these types of errors by setting the last argument to true. This behavior might be helpful when searching JSON document collections of varying structure.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"speed":10}@2001-01-01, {"speed": 20, "units": "km/h"}@2001-01-02]' @?
@@ -1075,9 +1160,11 @@ SELECT tjsonbPathExistsTz(tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbPathMatch</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbPathMatchTz</varname></primary></indexterm>
 				<para>Return the result of a JSON path predicate check for a temporal JSONB value</para>
-				<para><varname>tjsonb @@ jsonpath → tbool</varname></para>
-				<para><varname>tjsonbPathMatch(tjsonb,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
-				<para><varname>tjsonbPathMatchTz(tjsonb,vars jsonb='{}',silent boolean=false) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb @@ jsonpath → tbool
+tjsonbPathMatch(tjsonb,vars jsonb='{}',silent boolean=false) → tbool
+tjsonbPathMatchTz(tjsonb,vars jsonb='{}',silent boolean=false) → tbool
+</programlisting>
 				<para>The operator <varname>@@</varname> suppresses the following errors: missing object field or array element, unexpected JSON item type, datetime and numeric errors. The above functions can also suppress these types of errors by setting the last argument to true. This behavior might be helpful when searching JSON document collections of varying structure.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"speed":10}@2001-01-01, {"speed": 20, "units": "km/h"}@2001-01-02]' @@
@@ -1102,8 +1189,10 @@ SELECT tjsonbPathMatchTz(tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbPathQueryArray</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbPathQueryArrayTz</varname></primary></indexterm>
 				<para>Return all items returned by a JSON path from a temporal JSONB value, as a JSON array</para>
-				<para><varname>tjsonbPathQueryArray(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb</varname></para>
-				<para><varname>tjsonbPathQueryArrayTz(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbPathQueryArray(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb
+tjsonbPathQueryArrayTz(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb
+</programlisting>
 				<para>The above function can suppress the following errors by setting the last argument to true: missing object field or array element, unexpected JSON item type, datetime and numeric errors. This behavior might be helpful when searching JSON document collections of varying structure.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbPathQueryArray(tjsonb 
@@ -1124,8 +1213,10 @@ SELECT tjsonbPathQueryArrayTz(tjsonb
 				<indexterm significance="normal"><primary><varname>tjsonbPathQueryFirst</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tjsonbPathQueryFirstTz</varname></primary></indexterm>
 				<para>Return the fist item returned by a JSON path from a temporal JSONB value</para>
-				<para><varname>tjsonbPathQueryFirst(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb</varname></para>
-				<para><varname>tjsonbPathQueryFirstTz(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonbPathQueryFirst(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb
+tjsonbPathQueryFirstTz(tjsonb,vars jsonb='{}',silent boolean=false) → tjsonb
+</programlisting>
 				<para>The above functions can suppress the following errors by setting the last argument to true: missing object field or array element, unexpected JSON item type, datetime and numeric errors. This behavior might be helpful when searching JSON document collections of varying structure.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbPathQueryFirst(tjsonb 
@@ -1154,10 +1245,12 @@ SELECT tjsonbPathQueryArrayTz(tjsonb
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a value or a set of values</para>
-				<para><varname>atValue(tjsonb,value) → tjsonb</varname></para>
-				<para><varname>minusValue(tjsonb,value) → tjsonb</varname></para>
-				<para><varname>atValues(tjsonb,valueset) → tjsonb</varname></para>
-				<para><varname>minusValues(tjsonb,valueset) → tjsonb</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(tjsonb,value) → tjsonb
+minusValue(tjsonb,value) → tjsonb
+atValues(tjsonb,valueset) → tjsonb
+minusValues(tjsonb,valueset) → tjsonb
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atValue(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-03]',
@@ -1184,7 +1277,9 @@ SELECT minusValue(tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
-				<para><varname>tjsonb {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tjsonb → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tjsonb {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tjsonb → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '{[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(1 1)"}@2001-01-02),
@@ -1210,7 +1305,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Ever and always comparisons</para>
-				<para><varname>{jsonb,tjsonb} {?=, %=} {jsonb,tjsonb} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{jsonb,tjsonb} {?=, %=} {jsonb,tjsonb} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]' ?=
@@ -1226,7 +1323,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_tcomp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Temporal comparisons</para>
-				<para><varname>{jsonb,tjsonb} {#=, #&lt;&gt;} {jsonb,tjsonb} → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{jsonb,tjsonb} {#=, #&lt;&gt;} {jsonb,tjsonb} → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
   {"vehicleId": 1, "location": "Point(1 1)"}@2001-01-03)' #=
@@ -1252,7 +1351,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Topological operators</para>
-				<para><varname>{tjsonb,tstzspan} {&amp;&amp;, &lt;@#, #@&gt;, ~=, -|-} {tjsonb,tstzspan} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tjsonb,tstzspan} {&amp;&amp;, &lt;@#, #@&gt;, ~=, -|-} {tjsonb,tstzspan} → boolean
+</programlisting>
 				<para>The temporal contains and contained operator are marked with a <varname>#</varname> to distinguish them from the corresponding JSONB operators.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -1274,7 +1375,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
 			<listitem xml:id="tjsonb_pos">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Position operators</para>
-				<para><varname>{tjsonb,tstzspan} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tjsonb,tstzspan} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tjsonb,tstzspan} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tjsonb,tstzspan} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
     {"vehicleId": 1, "location": "Point(2 2)"}@2001-01-02]' &lt;&lt;#
@@ -1302,7 +1405,9 @@ SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-02,
 			<listitem xml:id="tjsonb_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
-				<para><varname>tCount(tjsonb) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tjsonb) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,
@@ -1318,7 +1423,9 @@ FROM Temp;
 			<listitem xml:id="tjsonb_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Window count</para>
-				<para><varname>wCount(tjsonb) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tjsonb) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tjsonb '[{"vehicleId": 1, "location": "Point(1 1)"}@2001-01-01,

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -94,8 +94,10 @@ SELECT npoint 'Npoint(99999999, 1.0)';
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>asText({npoint,npoint[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({npoint,npoint[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({npoint,npoint[]}) → {text,text[]}
+asEWKT({npoint,npoint[]}) → {text,text[]}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(npoint 'SRID=5676;Npoint(1,0.5)');
 -- NPoint(1,0.5)
@@ -114,10 +116,12 @@ SELECT asEWKT(ARRAY[npoint 'SRID=5676;Npoint(1,0.2)', 'SRID=5676;Npoint(1,0.5)']
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 					<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB), the Hexadecimal Well-Known Binary (HexWKB), or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-					<para><varname>asBinary(npoint,endian text='') → bytea</varname></para>
-					<para><varname>asEWKB(npoint,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(npoint,endian text='') → text</varname></para>
-					<para><varname>asHexEWKB(npoint,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(npoint,endian text='') → bytea
+asEWKB(npoint,endian text='') → bytea
+asHexWKB(npoint,endian text='') → text
+asHexEWKB(npoint,endian text='') → text
+</programlisting>
 					<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used. A network point takes its SRID from the underlying route network: <varname>asEWKB</varname> and <varname>asHexEWKB</varname> embed it, while the plain <varname>asBinary</varname> and <varname>asHexWKB</varname> forms omit it.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(npoint 'SRID=5676;Npoint(1,0.5)');
@@ -135,8 +139,10 @@ SELECT asHexEWKB(npoint 'SRID=5676;Npoint(1,0.5)');
 					<indexterm significance="normal"><primary><varname>npointFromText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>npointFromEWKT</varname></primary></indexterm>
 					<para>Input from the Well-Known Text (WKT) or from the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>npointFromText(text) → npoint</varname></para>
-					<para><varname>npointFromEWKT(text) → npoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+npointFromText(text) → npoint
+npointFromEWKT(text) → npoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(npointFromText(text 'Npoint(1,0.5)'));
 -- SRID=5676;NPoint(1,0.5)
@@ -150,9 +156,11 @@ SELECT asEWKT(npointFromEWKT(text 'SRID=5676;Npoint(1,0.5)'));
 					<indexterm significance="normal"><primary><varname>npointFromEWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>npointFromHexEWKB</varname></primary></indexterm>
 					<para>Input from the Well-Known Binary (WKB), from the Extended Well-Known Binary (EWKB), or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-					<para><varname>npointFromBinary(bytea) → npoint</varname></para>
-					<para><varname>npointFromEWKB(bytea) → npoint</varname></para>
-					<para><varname>npointFromHexEWKB(text) → npoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+npointFromBinary(bytea) → npoint
+npointFromEWKB(bytea) → npoint
+npointFromHexEWKB(text) → npoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(npointFromEWKB(
   '\x01412c1600000100000000000000000000000000e03f'));
@@ -173,8 +181,10 @@ SELECT asEWKT(npointFromHexEWKB(
 					<indexterm significance="normal"><primary><varname>npoint</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>nsegment</varname></primary></indexterm>
 					<para>Constructors for network points and network segments</para>
-					<para><varname>npoint(bigint,float) → npoint</varname></para>
-					<para><varname>nsegment(bigint,float,float) → nsegment</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+npoint(bigint,float) → npoint
+nsegment(bigint,float,float) → nsegment
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT npoint(76, 0.3);
 SELECT nsegment(76, 0.3, 0.5);
@@ -190,8 +200,10 @@ SELECT nsegment(76, 0.3, 0.5);
 				<listitem xml:id="npoint_geometry">
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Convert between a network point or segment and a geometry</para>
-					<para><varname>{npoint,nsegment}::geometry</varname></para>
-					<para><varname>geometry::{npoint,nsegment}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{npoint,nsegment}::geometry
+geometry::{npoint,nsegment}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(npoint(76, 0.33)::geometry);
 -- POINT(21.6338731332283 50.0545869554067)
@@ -216,8 +228,10 @@ SELECT geometry 'SRID=5676;LINESTRING(406.7 702.6,383.6 845.1)'::nsegment;
 				<listitem xml:id="npoint_stbox">
 					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 					<para>Construct a spatiotemporal box from a network point and, optionally, a timestamp or a period</para>
-					<para><varname>stbox(npoint) → stbox</varname></para>
-					<para><varname>stbox(npoint,{timestamptz,tstzspan}) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+stbox(npoint) → stbox
+stbox(npoint,{timestamptz,tstzspan}) → stbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(npoint 'NPoint(1,0.3)');
 -- SRID=5676;STBOX X((62.786633,80.143556),(62.786633,80.143556))
@@ -238,7 +252,9 @@ SELECT stbox(npoint 'NPoint(1,0.3)', tstzspan '[2001-01-01,2001-01-02]');
 				<listitem xml:id="npoint_route">
 					<indexterm significance="normal"><primary><varname>route</varname></primary></indexterm>
 					<para>Return the route identifier</para>
-					<para><varname>route({npoint,nsegment}) → bigint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+route({npoint,nsegment}) → bigint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT route(npoint 'Npoint(63, 0.3)');
 -- 63
@@ -250,7 +266,9 @@ SELECT route(nsegment 'Nsegment(76, 0.3, 0.3)');
 				<listitem xml:id="npoint_getPosition">
 					<indexterm significance="normal"><primary><varname>getPosition</varname></primary></indexterm>
 					<para>Return the position</para>
-					<para><varname>getPosition(npoint) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getPosition(npoint) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getPosition(npoint 'Npoint(63, 0.3)');
 -- 0.3
@@ -261,8 +279,10 @@ SELECT getPosition(npoint 'Npoint(63, 0.3)');
 					<indexterm significance="normal"><primary><varname>startPosition</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>endPosition</varname></primary></indexterm>
 					<para>Return the start/end position</para>
-					<para><varname>startPosition(nsegment) → float</varname></para>
-					<para><varname>endPosition(nsegment) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+startPosition(nsegment) → float
+endPosition(nsegment) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startPosition(nsegment 'Nsegment(76, 0.3, 0.5)');
 -- 0.3
@@ -279,7 +299,9 @@ SELECT endPosition(nsegment 'Nsegment(76, 0.3, 0.5)');
 				<listitem xml:id="npoint_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Round the position(s) of the network point or the network segment to the number of decimal places</para>
-					<para><varname>round({npoint,nsegment},integer=0) → {npoint,nsegment}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round({npoint,nsegment},integer=0) → {npoint,nsegment}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(npoint(76, 0.123456789), 6);
 --  NPoint(76,0.123457)
@@ -296,7 +318,9 @@ SELECT round(nsegment(76, 0.123456789, 0.223456789), 6);
 				<listitem xml:id="npoint_srid">
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<para>Return the spatial reference identifier</para>
-					<para><varname>SRID({npoint,nsegment}) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID({npoint,nsegment}) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(npoint 'Npoint(76, 0.3)');
 -- 5676
@@ -311,7 +335,9 @@ SELECT SRID(nsegment 'Nsegment(76, 0.3, 0.5)');
 				<listitem xml:id="npoint_same">
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Spatial similarity</para>
-					<para><varname>equals(npoint, npoint)::Boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+equals(npoint, npoint)::Boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH inter(geom) AS (
   SELECT st_intersection(t1.the_geom, t2.the_geom)
@@ -339,8 +365,10 @@ SELECT equals(npoint(1, f1), npoint(2, f2)) FROM fractions;
 					<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Traditional comparisons</para>
-					<para><varname>npoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} npoint</varname></para>
-					<para><varname>nsegment {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} nsegment</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+npoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} npoint
+nsegment {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} nsegment
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT npoint 'Npoint(3, 0.5)' = npoint 'Npoint(3, 0.5)';
 -- true
@@ -423,10 +451,12 @@ SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01 09:00:00, Npoint(2, 0.2)@2001-01-01 0
 					<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
 					<para>Constructor for temporal network points having a constant value</para>
-					<para><varname>tnpoint(npoint,timestamptz) → tnpointInst</varname></para>
-					<para><varname>tnpoint(npoint,tstzset) → tnpointDiscSeq</varname></para>
-					<para><varname>tnpoint(npoint,tstzspan,interp='linear') → tnpointContSeq</varname></para>
-					<para><varname>tnpoint(npoint,tstzspanset,interp='linear') → tnpointSeqSet</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tnpoint(npoint,timestamptz) → tnpointInst
+tnpoint(npoint,tstzset) → tnpointDiscSeq
+tnpoint(npoint,tstzspan,interp='linear') → tnpointContSeq
+tnpoint(npoint,tstzspanset,interp='linear') → tnpointSeqSet
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint('Npoint(1, 0.5)', timestamptz '2001-01-01');
 -- NPoint(1,0.5)@2001-01-01
@@ -442,8 +472,10 @@ SELECT tnpointSeqSet('Npoint(1, 0.2)', tstzspanset '{[2001-01-01, 2001-01-03]}',
 				<listitem xml:id="tnpointSeq">
 					<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 					<para>Constructor for temporal network points of sequence subtype</para>
-					<para><varname>tnpointSeq(tnpointInst[],interp={'step','linear'},leftInc boolean=true,</varname></para>
-					<para><varname>  rightInc boolean=true) →tnpointSeq</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tnpointSeq(tnpointInst[],interp={'step','linear'},leftInc boolean=true,
+  rightInc boolean=true) →tnpointSeq
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.3)@2001-01-01',
   'Npoint(1, 0.5)@2001-01-02', 'Npoint(1, 0.5)@2001-01-03']);
@@ -458,9 +490,11 @@ SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.2)@2001-01-01',
 					<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tnpointSeqSetGaps</varname></primary></indexterm>
 					<para>Constructor for temporal network points of sequence set subtype</para>
-					<para><varname>tnpointSeqSet(tnpoint[]) → tnpointSeqSet</varname></para>
-					<para><varname>tnpointSeqSetGaps(tnpointInst[],maxt=NULL,maxdist=NULL,interp='linear') →</varname></para>
-					<para><varname>  tnpointSeqSet</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tnpointSeqSet(tnpoint[]) → tnpointSeqSet
+tnpointSeqSetGaps(tnpointInst[],maxt=NULL,maxdist=NULL,interp='linear') →
+  tnpointSeqSet
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointSeqSet(ARRAY[tnpoint '[Npoint(1,0.2)@2001-01-01, Npoint(1,0.4)@2001-01-02,
   Npoint(1,0.5)@2001-01-03]', '[Npoint(2,0.6)@2001-01-04, Npoint(2,0.6)@2001-01-05]']);
@@ -482,8 +516,10 @@ SELECT tnpointSeqSetGaps(ARRAY[tnpoint 'NPoint(1,0.1)@2001-01-01',
 			<listitem xml:id="tnpoint_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert between a temporal network point and a temporal geometry point</para>
-				<para><varname>tnpoint::tgeompoint</varname></para>
-				<para><varname>tgeompoint::tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpoint::tgeompoint
+tgeompoint::tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tnpoint '[NPoint(1, 0.2)@2001-01-01,
   NPoint(1, 0.3)@2001-01-02)')::tgeompoint);
@@ -509,8 +545,10 @@ SELECT tgeompoint '[POINT(23.057077727326 28.7666335767956)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tnpointFromMFJSON</varname></primary></indexterm>
 				<para>Output a temporal network point as MF-JSON and read it back; the round trip is lossless. The output takes the options, flags, and decimal-digits arguments shared with the other temporal types.</para>
-				<para><varname>asMFJSON(tnpoint,integer,integer,integer) → text</varname></para>
-				<para><varname>tnpointFromMFJSON(text) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tnpoint,integer,integer,integer) → text
+tnpointFromMFJSON(text) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointFromMFJSON(asMFJSON(tnpoint 'NPoint(1, 0.5)@2001-01-01'))
   = tnpoint 'NPoint(1, 0.5)@2001-01-01';
@@ -527,7 +565,9 @@ SELECT tnpointFromMFJSON(asMFJSON(tnpoint 'NPoint(1, 0.5)@2001-01-01'))
 			<listitem xml:id="tnpoint_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Return the values</para>
-				<para><varname>getValues(tnpoint) → npointset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tnpoint) → npointset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02)}');
 -- {"NPoint(1,0.3)","NPoint(1,0.5)"}
@@ -539,7 +579,9 @@ SELECT getValues(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.3)@2001-01-02
 			<listitem xml:id="tnpoint_routes">
 				<indexterm significance="normal"><primary><varname>routes</varname></primary></indexterm>
 				<para>Return the road identifiers</para>
-				<para><varname>routes(tnpoint) → bigintset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+routes(tnpoint) → bigintset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT routes(tnpoint '{NPoint(3, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02}');
 -- {1, 3}
@@ -549,7 +591,9 @@ SELECT routes(tnpoint '{NPoint(3, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02}');
 			<listitem xml:id="tnpoint_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(tnpoint,timestamptz) → npoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tnpoint,timestamptz) → npoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03)',
   '2001-01-02');
@@ -560,7 +604,9 @@ SELECT valueAtTimestamp(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001
 			<listitem xml:id="tnpoint_length">
 				<indexterm significance="normal"><primary><varname>length</varname></primary></indexterm>
 				<para>Return the length traversed by the temporal network point</para>
-				<para><varname>length(tnpoint) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+length(tnpoint) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]');
 -- 54.3757408468784
@@ -570,7 +616,9 @@ SELECT length(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]');
 			<listitem xml:id="tnpoint_cumulativeLength">
 				<indexterm significance="normal"><primary><varname>cumulativeLength</varname></primary></indexterm>
 				<para>Return the cumulative length traversed by the temporal network point</para>
-				<para><varname>cumulativeLength(tnpoint) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+cumulativeLength(tnpoint) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT cumulativeLength(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02,
   NPoint(1, 0.5)@2001-01-03], [NPoint(1, 0.6)@2001-01-04, NPoint(1, 0.7)@2001-01-05]}');
@@ -582,7 +630,9 @@ SELECT cumulativeLength(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@200
 			<listitem xml:id="tnpoint_speed">
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Return the speed of the temporal network point in units per second</para>
-				<para><varname>speed({tnpointSeq, tnpointSeqSet}) → tfloatSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+speed({tnpointSeq, tnpointSeqSet}) → tfloatSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT speed(tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.4)@2001-01-02,
   NPoint(1, 0.6)@2001-01-03]') * 3600 * 24;
@@ -601,9 +651,11 @@ SELECT speed(tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.4)@2001-01-02,
 				<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tnpointSeqSet</varname></primary></indexterm>
 				<para>Transform a temporal network point to another subtype</para>
-				<para><varname>tnpointInst(tnpoint) → tnpointInst</varname></para>
-				<para><varname>tnpointSeq(tnpoint) → tnpointSeq</varname></para>
-				<para><varname>tnpointSeqSet(tnpoint) → tnpointSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpointInst(tnpoint) → tnpointInst
+tnpointSeq(tnpoint) → tnpointSeq
+tnpointSeqSet(tnpoint) → tnpointSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointSeq(tnpoint 'NPoint(1, 0.5)@2001-01-01', 'discrete');
 -- {NPoint(1,0.5)@2001-01-01}
@@ -617,7 +669,9 @@ SELECT tnpointSeqSet(tnpoint 'NPoint(1, 0.5)@2001-01-01');
 			<listitem xml:id="tnpoint_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transform a temporal network point to another interpolation</para>
-				<para><varname>setInterp(tnpoint, interp) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(tnpoint, interp) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT setInterp(tnpoint 'NPoint(1,0.2)@2001-01-01','linear');
 -- [NPoint(1,0.2)@2001-01-01]
@@ -630,7 +684,9 @@ SELECT setInterp(tnpoint '{[NPoint(1,0.1)@2001-01-01], [NPoint(1,0.2)@2001-01-02
 			<listitem xml:id="tnpoint_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Round the fraction of the temporal network point to the number of decimal places</para>
-				<para><varname>round(tnpoint,integer) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tnpoint,integer) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tnpoint '{[NPoint(1,0.123456789)@2001-01-01, NPoint(1,0.5)@2001-01-02)}', 6);
 -- {[NPoint(1,0.123457)@2001-01-01, NPoint(1,0.5)@2001-01-02)}
@@ -646,8 +702,10 @@ SELECT round(tnpoint '{[NPoint(1,0.123456789)@2001-01-01, NPoint(1,0.5)@2001-01-
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Append a temporal instant or a temporal sequence</para>
-				<para><varname>appendInstant(tnpoint,tnpointInst) → tnpoint</varname></para>
-				<para><varname>appendSequence(tnpoint,tnpointSeq) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tnpoint,tnpointInst) → tnpoint
+appendSequence(tnpoint,tnpointSeq) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendInstant(tnpoint 'Npoint(1, 0.1)@2001-01-01',
   'Npoint(1, 0.2)@2001-01-02'));
@@ -662,9 +720,11 @@ SELECT asText(appendSequence(tnpoint '[Npoint(1, 0.1)@2001-01-01]',
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Merge the temporal network points</para>
-				<para><varname>merge(tnpoint,tnpoint) → tnpoint</varname></para>
-				<para><varname>merge(tnpoint[]) → tnpoint</varname></para>
-				<para><varname>mergeAgg(tnpoint) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(tnpoint,tnpoint) → tnpoint
+merge(tnpoint[]) → tnpoint
+mergeAgg(tnpoint) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]',
   '[Npoint(1, 0.3)@2001-01-03, Npoint(1, 0.5)@2001-01-05]'));
@@ -693,10 +753,12 @@ SELECT asText(mergeAgg(inst)) FROM temp;
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a value or a set of values</para>
-				<para><varname>atValue(tnpoint,value) → tnpoint</varname></para>
-				<para><varname>minusValue(tnpoint,value) → tnpoint</varname></para>
-				<para><varname>atValues(tnpoint,valueset) → tnpoint</varname></para>
-				<para><varname>minusValues(tnpoint,valueset) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(tnpoint,value) → tnpoint
+minusValue(tnpoint,value) → tnpoint
+atValues(tnpoint,valueset) → tnpoint
+minusValues(tnpoint,valueset) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atValue(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03]',
   'NPoint(2, 0.5)');
@@ -712,8 +774,10 @@ SELECT minusValue(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a geometry</para>
-				<para><varname>atGeometry(tnpoint,geometry) → tnpoint</varname></para>
-				<para><varname>minusGeometry(tnpoint,geometry) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tnpoint,geometry) → tnpoint
+minusGeometry(tnpoint,geometry) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03]',
   'Polygon((40 40,40 50,50 50,50 40,40 40))');
@@ -732,7 +796,9 @@ SELECT minusGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01
 			<listitem xml:id="tnpoint_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Return the smallest distance ever</para>
-				<para><varname>{geo,npoint,tnpoint,stbox} |=| {geo,npoint,tnpoint,stbox} → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,npoint,tnpoint,stbox} |=| {geo,npoint,tnpoint,stbox} → float
+</programlisting>
 				<para>The operator <varname>|=|</varname> can be used for doing nearest neightbor searches using a GiST or an SP-GiST index (see <xref linkend="ttype_indexing"/>).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-02]' |=|
@@ -750,7 +816,9 @@ SELECT tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-02]' |=|
 			<listitem xml:id="tnpoint_nearestApproachInstant">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Return the instant of the first temporal network point at which the two arguments are at the nearest distance</para>
-				<para><varname>nearestApproachInstant({geo,npoint,tnpoint},{geo,npoint,tnpoint}) → tnpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geo,npoint,tnpoint},{geo,npoint,tnpoint}) → tnpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nearestApproachInstant(tnpoint '[NPoint(2, 0.3)@2001-01-01,
   NPoint(2, 0.7)@2001-01-02]', geometry 'Linestring(50 50,55 55)');
@@ -764,7 +832,9 @@ SELECT nearestApproachInstant(tnpoint '[NPoint(2, 0.3)@2001-01-01,
 			<listitem xml:id="tnpoint_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Return the line connecting the nearest approach point between the two arguments</para>
-				<para><varname>shortestLine({geo,npoint,tpoint},{geo,npoint,tpoint}) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geo,npoint,tpoint},{geo,npoint,tpoint}) → geometry
+</programlisting>
 				<para>The function will only return the first line that it finds if there are more than one</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(tnpoint '[NPoint(2, 0.3)@2001-01-01,
@@ -779,7 +849,9 @@ SELECT ST_AsText(shortestLine(tnpoint '[NPoint(2, 0.3)@2001-01-01,
 			<listitem xml:id="tnpoint_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Return the temporal distance</para>
-				<para><varname>tnpoint &lt;-&gt; tnpoint → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpoint &lt;-&gt; tnpoint → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;-&gt;
   npoint 'NPoint(1, 0.2)';
@@ -801,7 +873,9 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;-&gt
 			<listitem xml:id="tnpoint_twCentroid">
 				<indexterm significance="normal"><primary><varname>twCentroid</varname></primary></indexterm>
 				<para>Return the time-weighted centroid</para>
-				<para><varname>twCentroid(tnpoint) → geometry(Point)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+twCentroid(tnpoint) → geometry(Point)
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(twCentroid(tnpoint '{[NPoint(1, 0.3)@2001-01-01,
   NPoint(1, 0.5)@2001-01-02, NPoint(1, 0.5)@2001-01-03, NPoint(1, 0.7)@2001-01-04)}'));
@@ -820,7 +894,10 @@ SELECT ST_AsText(twCentroid(tnpoint '{[NPoint(1, 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>@@</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>@=</varname></primary></indexterm>
 				<para>Route operators, which compare the route identifiers a temporal network point visits: contained in, contains, overlaps, and equal</para>
-				<para><varname>{bigint,bigintset,npoint,tnpoint} {?@, @?, @@, @=} {bigint,bigintset,npoint,tnpoint} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{bigint,bigintset,npoint,tnpoint} {?@, @?, @@, @=} {bigint,bigintset,npoint,
+  tnpoint} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT bigint '1' ?@ tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]';
 -- true
@@ -845,7 +922,9 @@ SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01, NPoint(3, 0.5)@2001-01-02}' @=
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Topological operators</para>
-				<para><varname>{tstzspan,stbox,tnpoint} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tnpoint} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tstzspan,stbox,tnpoint} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tnpoint} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]' &amp;&amp;
   tstzspan '[2001-01-02,2001-01-03]';
@@ -863,9 +942,11 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' ~=
 			<listitem xml:id="tnpoint_pos">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Position operators</para>
-				<para><varname>{stbox,tnpoint} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tnpoint} → boolean</varname></para>
-				<para><varname>{stbox,tnpoint} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tnpoint} → boolean</varname></para>
-				<para><varname>{tstzspan,stbox,tnpoint} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tnpoint} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{stbox,tnpoint} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tnpoint} → boolean
+{stbox,tnpoint} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tnpoint} → boolean
+{tstzspan,stbox,tnpoint} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tnpoint} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]' &lt;&lt;
   stbox(npoint 'NPoint(1, 0.2)');
@@ -905,20 +986,22 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-03, NPoint(1, 0.3)@2001-01-05]' #&gt;&gt
 				<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 				<para>The <emphasis>ever</emphasis> and <emphasis>always</emphasis> relationships determine whether the topological or distance relationship is ever or always satisfied and result in a <varname>boolean</varname>. A temporal network point answers them at the position its route and fraction resolve to, so a sequence with linear interpolation is answered along its route rather than at its instants alone. The temporal network point declares the relationships a moving point answers: <varname>eContains</varname>, <varname>aContains</varname>, <varname>eCovers</varname> and <varname>aCovers</varname> take the geometry first only, and <varname>eTouches</varname> and <varname>aTouches</varname> have no direction between two temporal network points, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
-				<para><varname>eContains(geometry,tnpoint) &#8594; boolean</varname></para>
-				<para><varname>eCovers(geometry,tnpoint) &#8594; boolean</varname></para>
-				<para><varname>eDisjoint({geometry,tnpoint},{geometry,tnpoint}) &#8594; boolean</varname></para>
-				<para><varname>eDwithin({geometry,tnpoint},{geometry,tnpoint},float) &#8594; boolean</varname></para>
-				<para><varname>eIntersects({geometry,tnpoint},{geometry,tnpoint}) &#8594; boolean</varname></para>
-				<para><varname>eTouches(geometry,tnpoint) &#8594; boolean</varname></para>
-				<para><varname>eTouches(tnpoint,geometry) &#8594; boolean</varname></para>
-				<para><varname>aContains(geometry,tnpoint) &#8594; boolean</varname></para>
-				<para><varname>aCovers(geometry,tnpoint) &#8594; boolean</varname></para>
-				<para><varname>aDisjoint({geometry,tnpoint},{geometry,tnpoint}) &#8594; boolean</varname></para>
-				<para><varname>aDwithin({geometry,tnpoint},{geometry,tnpoint},float) &#8594; boolean</varname></para>
-				<para><varname>aIntersects({geometry,tnpoint},{geometry,tnpoint}) &#8594; boolean</varname></para>
-				<para><varname>aTouches(geometry,tnpoint) &#8594; boolean</varname></para>
-				<para><varname>aTouches(tnpoint,geometry) &#8594; boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eContains(geometry,tnpoint) &#8594; boolean
+eCovers(geometry,tnpoint) &#8594; boolean
+eDisjoint({geometry,tnpoint},{geometry,tnpoint}) &#8594; boolean
+eDwithin({geometry,tnpoint},{geometry,tnpoint},float) &#8594; boolean
+eIntersects({geometry,tnpoint},{geometry,tnpoint}) &#8594; boolean
+eTouches(geometry,tnpoint) &#8594; boolean
+eTouches(tnpoint,geometry) &#8594; boolean
+aContains(geometry,tnpoint) &#8594; boolean
+aCovers(geometry,tnpoint) &#8594; boolean
+aDisjoint({geometry,tnpoint},{geometry,tnpoint}) &#8594; boolean
+aDwithin({geometry,tnpoint},{geometry,tnpoint},float) &#8594; boolean
+aIntersects({geometry,tnpoint},{geometry,tnpoint}) &#8594; boolean
+aTouches(geometry,tnpoint) &#8594; boolean
+aTouches(tnpoint,geometry) &#8594; boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
   tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
@@ -949,13 +1032,15 @@ SELECT aDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]'
 				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 				<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal network point answers them at the position its route and fraction resolve to. The temporal network point declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two temporal network points, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
-				<para><varname>tContains(geometry,tnpoint) &#8594; tbool</varname></para>
-				<para><varname>tCovers(geometry,tnpoint) &#8594; tbool</varname></para>
-				<para><varname>tDisjoint({geometry,tnpoint},{geometry,tnpoint}) &#8594; tbool</varname></para>
-				<para><varname>tDwithin({geometry,tnpoint},{geometry,tnpoint},float) &#8594; tbool</varname></para>
-				<para><varname>tIntersects({geometry,tnpoint},{geometry,tnpoint}) &#8594; tbool</varname></para>
-				<para><varname>tTouches(geometry,tnpoint) &#8594; tbool</varname></para>
-				<para><varname>tTouches(tnpoint,geometry) &#8594; tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tnpoint) &#8594; tbool
+tCovers(geometry,tnpoint) &#8594; tbool
+tDisjoint({geometry,tnpoint},{geometry,tnpoint}) &#8594; tbool
+tDwithin({geometry,tnpoint},{geometry,tnpoint},float) &#8594; tbool
+tIntersects({geometry,tnpoint},{geometry,tnpoint}) &#8594; tbool
+tTouches(geometry,tnpoint) &#8594; tbool
+tTouches(tnpoint,geometry) &#8594; tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
   tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
@@ -988,7 +1073,9 @@ SELECT tDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]'
 			<listitem xml:id="tnpoint_comp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
-				<para><varname>tnpoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tnpoint → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tnpoint → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '{[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-02),
   [NPoint(1, 0.3)@2001-01-02, NPoint(1, 0.5)@2001-01-03]}' =
@@ -1007,7 +1094,9 @@ SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Ever and always comparisons</para>
-				<para><varname>{npoint,tnpoint} {?=, %=} {npoint,tnpoint} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{npoint,tnpoint} {?=, %=} {npoint,tnpoint} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.4)@2001-01-04)' ?= Npoint(1, 0.3);
 -- true
@@ -1019,7 +1108,9 @@ SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.2)@2001-01-04)' &amp;= N
 			<listitem xml:id="tnpoint_tcomp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Temporal comparisons</para>
-				<para><varname>{npoint,tnpoint} {#=, #&lt;&gt;} {npoint,tnpoint} → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{npoint,tnpoint} {#=, #&lt;&gt;} {npoint,tnpoint} → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.4)@2001-01-03)' #=
   npoint 'NPoint(1, 0.3)';
@@ -1041,7 +1132,9 @@ SELECT tnpoint '[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.8)@2001-01-03)' #&lt;&gt
 			<listitem xml:id="tnpoint_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
-				<para><varname>tCount(tnpoint) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tnpoint) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
@@ -1056,7 +1149,9 @@ FROM Temp;
 			<listitem xml:id="tnpoint_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Window count</para>
-				<para><varname>wCount(tnpoint) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tnpoint) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
@@ -1072,7 +1167,9 @@ FROM Temp;
 			<listitem xml:id="tnpoint_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
 				<para>Temporal centroid</para>
-				<para><varname>tCentroid(tnpoint) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCentroid(tnpoint) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
 SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
@@ -1117,7 +1214,9 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 			<listitem xml:id="tnpoint_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Return the spatiotemporal bounding box covering every materialised position in a set of network points. The aggregate is polymorphic with the <varname>extent</varname> aggregates on the other spatial temporal types, so one query can compute a single box across a heterogeneous set of <varname>tgeompoint</varname>, <varname>tgeometry</varname>, and <varname>tnpoint</varname> columns. Each instant's spatial extent is resolved through the ways registry, which dominates the cost over a large input.</para>
-				<para><varname>extent(tnpoint) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(tnpoint) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(temp) FROM tbl_tnpoint;
 </programlisting>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -48,7 +48,9 @@ INSERT INTO pointcloud_dimensions
 				<listitem xml:id="pointcloud_schema_srid">
 					<indexterm significance="normal"><primary><varname>pointCloudSchemaSRID</varname></primary></indexterm>
 					<para>Return the spatial reference system every value of a schema is expressed in</para>
-					<para><varname>pointCloudSchemaSRID(integer) &#x2192; integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pointCloudSchemaSRID(integer) &#x2192; integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pointCloudSchemaSRID(1);
 -- 4326
@@ -57,7 +59,9 @@ SELECT pointCloudSchemaSRID(1);
 				<listitem xml:id="pointcloud_schema_compression">
 					<indexterm significance="normal"><primary><varname>pointCloudSchemaCompression</varname></primary></indexterm>
 					<para>Return how a patch of a schema is stored</para>
-					<para><varname>pointCloudSchemaCompression(integer) &#x2192; text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pointCloudSchemaCompression(integer) &#x2192; text
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pointCloudSchemaCompression(1);
 -- none
@@ -66,7 +70,9 @@ SELECT pointCloudSchemaCompression(1);
 				<listitem xml:id="pointcloud_schema_ndims">
 					<indexterm significance="normal"><primary><varname>pointCloudSchemaNDims</varname></primary></indexterm>
 					<para>Return how many dimensions of a schema hold values</para>
-					<para><varname>pointCloudSchemaNDims(integer) &#x2192; integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pointCloudSchemaNDims(integer) &#x2192; integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pointCloudSchemaNDims(1);
 -- 3
@@ -190,8 +196,10 @@ SELECT id, numPoints(full_scan) FROM scans;
 				<listitem xml:id="pcpoint_xy_xyz">
 					<indexterm significance="normal"><primary><varname>pcpoint</varname></primary></indexterm>
 					<para>Build a 2D or 3D pcpoint directly from x/y(/z) coordinates</para>
-					<para><varname>pcpoint(pcid integer, x float, y float) → pcpoint</varname></para>
-					<para><varname>pcpoint(pcid integer, x float, y float, z float) → pcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpoint(pcid integer, x float, y float) → pcpoint
+pcpoint(pcid integer, x float, y float, z float) → pcpoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcpoint(1, 10.0, 20.0, 30.0);
 -- equivalent to PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]::float[])
@@ -201,7 +209,9 @@ SELECT pcpoint(1, 10.0, 20.0, 30.0);
 				<listitem xml:id="pcpoint_coordinates">
 					<indexterm significance="normal"><primary><varname>pcpoint</varname></primary></indexterm>
 					<para>Build a pcpoint from the coordinates of every dimension of the layout of the schema, inactive dimensions included, which is how a schema of more dimensions than the overloads above reach is given its values. That count is the one <varname>PC_MakePoint</varname> takes and is NOT the count of active dimensions that <varname>pointCloudSchemaNDims</varname> reports</para>
-					<para><varname>pcpoint(pcid integer, coordinates float[]) → pcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpoint(pcid integer, coordinates float[]) → pcpoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcpoint(1, ARRAY[10.0, 20.0, 30.0]::float[]);
 </programlisting>
@@ -210,7 +220,9 @@ SELECT pcpoint(1, ARRAY[10.0, 20.0, 30.0]::float[]);
 				<listitem xml:id="pcpatch_coordinates">
 					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
 					<para>Build a pcpatch from the coordinates of its points, one point after another, every dimension of the layout of the schema given for each point, inactive dimensions included. That count is the one <varname>PC_MakePatch</varname> takes and is NOT the count of active dimensions that <varname>pointCloudSchemaNDims</varname> reports; a count that divides evenly by the wrong one of the two builds a patch of the wrong points rather than reporting an error. A patch built this way states the schema itself, there being no point to read it from</para>
-					<para><varname>pcpatch(pcid integer, coordinates float[]) → pcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpatch(pcid integer, coordinates float[]) → pcpatch
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcpatch(1, ARRAY[1.0, 1.0, 1.0, 2.0, 2.0, 2.0]::float[]);
 </programlisting>
@@ -219,7 +231,9 @@ SELECT pcpatch(1, ARRAY[1.0, 1.0, 1.0, 2.0, 2.0, 2.0]::float[]);
 				<listitem xml:id="pcpatch_variadic">
 					<indexterm significance="normal"><primary><varname>pcpatch</varname></primary></indexterm>
 					<para>Build a pcpatch from a variadic list of pcpoints sharing the same pcid</para>
-					<para><varname>pcpatch(VARIADIC points pcpoint[]) → pcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpatch(VARIADIC points pcpoint[]) → pcpatch
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
 -- equivalent to PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]),
@@ -236,8 +250,10 @@ SELECT pcpatch(pcpoint(1, 1.0, 1.0, 1.0), pcpoint(1, 2.0, 2.0, 2.0));
 				<listitem xml:id="pcpoint_pcid">
 					<indexterm significance="normal"><primary><varname>pcid</varname></primary></indexterm>
 					<para>Return the schema id of a pcpoint or pcpatch</para>
-					<para><varname>pcid(pcpoint) → integer</varname></para>
-					<para><varname>pcid(pcpatch) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcid(pcpoint) → integer
+pcid(pcpatch) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcid(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 -- 1
@@ -249,9 +265,11 @@ SELECT pcid(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 					<indexterm significance="normal"><primary><varname>getY</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getZ</varname></primary></indexterm>
 					<para>Return a coordinate of a pcpoint, NULL if the dimension is absent from the schema</para>
-					<para><varname>getX(pcpoint) → float</varname></para>
-					<para><varname>getY(pcpoint) → float</varname></para>
-					<para><varname>getZ(pcpoint) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getX(pcpoint) → float
+getY(pcpoint) → float
+getZ(pcpoint) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH pt AS (SELECT PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]) p)
   SELECT getX(p), getY(p), getZ(p) FROM pt;
@@ -262,7 +280,9 @@ WITH pt AS (SELECT PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]) p)
 				<listitem xml:id="pcpoint_getDim">
 					<indexterm significance="normal"><primary><varname>getDim</varname></primary></indexterm>
 					<para>Return any named dimension of a pcpoint, NULL if the name is unknown for the schema</para>
-					<para><varname>getDim(pcpoint,text) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getDim(pcpoint,text) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getDim(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), 'X');
 -- 10
@@ -272,8 +292,10 @@ SELECT getDim(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), 'X');
 				<listitem xml:id="pcpoint_SRID">
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<para>Return the spatial reference identifier (inherited from the schema)</para>
-					<para><varname>SRID(pcpoint) → integer</varname></para>
-					<para><varname>SRID(pcpatch) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(pcpoint) → integer
+SRID(pcpatch) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 -- 0
@@ -286,7 +308,9 @@ SELECT SRID(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), PC_MakePoin
 				<listitem xml:id="pcpatch_geometry">
 					<indexterm significance="normal"><primary><varname>geometry</varname></primary></indexterm>
 					<para>Return the multipoint of the positions the points of a patch occupy. The schema the <varname>pcid</varname> names decides the SRID and whether the result carries a Z dimension</para>
-					<para><varname>geometry(pcpatch) &#8594; geometry</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geometry(pcpatch) &#8594; geometry
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(geometry(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 -- MULTIPOINT Z ((1 1 1),(2 2 2))
@@ -309,8 +333,10 @@ SELECT ST_AsText(geometry(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2))));
 				<listitem xml:id="pcpointset_set">
 					<indexterm significance="normal"><primary><varname>set</varname></primary></indexterm>
 					<para>Construct a set from an array of values, all of which must share the same pcid</para>
-					<para><varname>set(pcpoint[]) → pcpointset</varname></para>
-					<para><varname>set(pcpatch[]) → pcpatchset</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+set(pcpoint[]) → pcpointset
+set(pcpatch[]) → pcpatchset
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(set(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
   PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),  -- duplicate, deduped
@@ -339,11 +365,13 @@ SELECT numValues(set(ARRAY[PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 					<indexterm significance="normal"><primary><varname>tpcbox_xt</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcbox_zt</varname></primary></indexterm>
 					<para>Construct a tpcbox from explicit X/Y/Z/T bounds and a pcid</para>
-					<para><varname>tpcbox(xmin,ymin,xmax,ymax,pcid,srid=0) → tpcbox</varname></para>
-					<para><varname>tpcbox_z(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid=0) → tpcbox</varname></para>
-					<para><varname>tpcbox_t(period,pcid) → tpcbox</varname></para>
-					<para><varname>tpcbox_xt(xmin,ymin,xmax,ymax,period,pcid,srid=0) → tpcbox</varname></para>
-					<para><varname>tpcbox_zt(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid=0) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox(xmin,ymin,xmax,ymax,pcid,srid=0) → tpcbox
+tpcbox_z(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid=0) → tpcbox
+tpcbox_t(period,pcid) → tpcbox
+tpcbox_xt(xmin,ymin,xmax,ymax,period,pcid,srid=0) → tpcbox
+tpcbox_zt(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid=0) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 10, 10, 1, 0);
 -- TPCBOX(X((0,0),(10,10)), 1)
@@ -360,7 +388,9 @@ SELECT tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0)
 				<listitem xml:id="tpcbox_pcpoint_to_tpcbox">
 					<indexterm significance="normal"><primary><varname>tpcbox</varname></primary></indexterm>
 					<para>Convert a pcpoint to a degenerate (zero-extent) tpcbox; SRID and pcid come from the schema</para>
-					<para><varname>tpcbox(pcpoint) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox(pcpoint) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 -- TPCBOX(Z((10,20,30),(10,20,30)), 1)
@@ -370,8 +400,10 @@ SELECT tpcbox(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]));
 				<listitem xml:id="tpcbox_pcpatch_to_tpcbox">
 					<indexterm significance="normal"><primary><varname>tpcbox</varname></primary></indexterm>
 					<para>Convert a pcpatch to a tpcbox using the patch's embedded 2D PCBOUNDS; the second form takes an explicit SRID instead of looking it up from the schema</para>
-					<para><varname>tpcbox(pcpatch) → tpcbox</varname></para>
-					<para><varname>tpcbox(pcpatch,integer) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox(pcpatch) → tpcbox
+tpcbox(pcpatch,integer) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])));
 </programlisting>
@@ -387,9 +419,11 @@ SELECT tpcbox(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])));
 					<indexterm significance="normal"><primary><varname>hasZ</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>hasT</varname></primary></indexterm>
 					<para>Return whether a tpcbox has the X/Y, Z, or T dimensions set</para>
-					<para><varname>hasX(tpcbox) → boolean</varname></para>
-					<para><varname>hasZ(tpcbox) → boolean</varname></para>
-					<para><varname>hasT(tpcbox) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+hasX(tpcbox) → boolean
+hasZ(tpcbox) → boolean
+hasT(tpcbox) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
   SELECT hasX(b), hasZ(b) FROM b;
@@ -405,12 +439,14 @@ WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
 					<indexterm significance="normal"><primary><varname>zmin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>zmax</varname></primary></indexterm>
 					<para>Return a coordinate bound, NULL if the corresponding dimension is absent</para>
-					<para><varname>xmin(tpcbox) → float</varname></para>
-					<para><varname>xmax(tpcbox) → float</varname></para>
-					<para><varname>ymin(tpcbox) → float</varname></para>
-					<para><varname>ymax(tpcbox) → float</varname></para>
-					<para><varname>zmin(tpcbox) → float</varname></para>
-					<para><varname>zmax(tpcbox) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+xmin(tpcbox) → float
+xmax(tpcbox) → float
+ymin(tpcbox) → float
+ymax(tpcbox) → float
+zmin(tpcbox) → float
+zmax(tpcbox) → float
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
   SELECT xmin(b), xmax(b) FROM b;
@@ -422,8 +458,10 @@ WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
 					<indexterm significance="normal"><primary><varname>tmin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tmax</varname></primary></indexterm>
 					<para>Return a temporal bound, NULL if the box has no T dimension</para>
-					<para><varname>tmin(tpcbox) → timestamptz</varname></para>
-					<para><varname>tmax(tpcbox) → timestamptz</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tmin(tpcbox) → timestamptz
+tmax(tpcbox) → timestamptz
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tmin(tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1));
 -- 2024-01-01
@@ -434,8 +472,10 @@ SELECT tmin(tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1));
 					<indexterm significance="normal"><primary><varname>pcid</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<para>Return the schema id and SRID</para>
-					<para><varname>pcid(tpcbox) → integer</varname></para>
-					<para><varname>SRID(tpcbox) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcid(tpcbox) → integer
+SRID(tpcbox) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH b AS (SELECT tpcbox(0, 0, 10, 10, 7, 4326) AS b)
   SELECT pcid(b), SRID(b) FROM b;
@@ -451,7 +491,9 @@ WITH b AS (SELECT tpcbox(0, 0, 10, 10, 7, 4326) AS b)
 				<listitem xml:id="tpcbox_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Return a tpcbox with coordinates rounded to a given number of decimal digits</para>
-					<para><varname>round(tpcbox,integer=0) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(tpcbox,integer=0) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tpcbox(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
 -- TPCBOX(X((0.12,1.23),(2.35,3.46)), 1)
@@ -461,7 +503,9 @@ SELECT round(tpcbox(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
 				<listitem xml:id="tpcbox_setSRID">
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Return a tpcbox with the SRID overwritten. Does not reproject coordinates, for that, project the underlying tpcpoint first and take the bbox of the result</para>
-					<para><varname>setSRID(tpcbox,integer) → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+setSRID(tpcbox,integer) → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(setSRID(tpcbox(0, 0, 10, 10, 1, 0), 4326));
 -- 4326
@@ -476,8 +520,10 @@ SELECT SRID(setSRID(tpcbox(0, 0, 10, 10, 1, 0), 4326));
 				<listitem xml:id="tpcbox_union">
 					<indexterm significance="normal"><primary><varname>tpcbox_union</varname></primary></indexterm>
 					<para>Return the union of two tpcboxes; both must share the same pcid</para>
-					<para><varname>tpcbox_union(tpcbox,tpcbox) → tpcbox</varname></para>
-					<para><varname>tpcbox + tpcbox → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox_union(tpcbox,tpcbox) → tpcbox
+tpcbox + tpcbox → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
 -- TPCBOX(X((0,0),(10,10)), 1)
@@ -487,8 +533,10 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
 				<listitem xml:id="tpcbox_intersection">
 					<indexterm significance="normal"><primary><varname>tpcbox_intersection</varname></primary></indexterm>
 					<para>Return the intersection of two tpcboxes, NULL if disjoint or pcid mismatch</para>
-					<para><varname>tpcbox_intersection(tpcbox,tpcbox) → tpcbox</varname></para>
-					<para><varname>tpcbox * tpcbox → tpcbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox_intersection(tpcbox,tpcbox) → tpcbox
+tpcbox * tpcbox → tpcbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
 -- TPCBOX(X((3,3),(5,5)), 1)
@@ -505,7 +553,9 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
 				<listitem xml:id="tpcbox_contains">
 					<indexterm significance="normal"><primary><varname>@&gt;</varname></primary></indexterm>
 					<para>Return true if the first tpcbox contains the second</para>
-					<para><varname>tpcbox @&gt; tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox @&gt; tpcbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 10, 10, 1, 0) @&gt; tpcbox(2, 2, 8, 8, 1, 0);
 -- t
@@ -515,7 +565,9 @@ SELECT tpcbox(0, 0, 10, 10, 1, 0) @&gt; tpcbox(2, 2, 8, 8, 1, 0);
 				<listitem xml:id="tpcbox_contained">
 					<indexterm significance="normal"><primary><varname>&lt;@</varname></primary></indexterm>
 					<para>Return true if the first tpcbox is contained in the second</para>
-					<para><varname>tpcbox &lt;@ tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox &lt;@ tpcbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(2, 2, 8, 8, 1, 0) &lt;@ tpcbox(0, 0, 10, 10, 1, 0);
 -- t
@@ -525,7 +577,9 @@ SELECT tpcbox(2, 2, 8, 8, 1, 0) &lt;@ tpcbox(0, 0, 10, 10, 1, 0);
 				<listitem xml:id="tpcbox_overlaps">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 					<para>Return true if two tpcboxes overlap</para>
-					<para><varname>tpcbox &amp;&amp; tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox &amp;&amp; tpcbox → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(3, 3, 10, 10, 1, 0);  -- t
 SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);
@@ -536,7 +590,9 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);
 				<listitem xml:id="tpcbox_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Return true if two tpcboxes are equal in the dimensions they share</para>
-					<para><varname>tpcbox ~= tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox ~= tpcbox → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 2, 2) ~= tpcbox(0, 0, 2, 2);
 -- t
@@ -546,7 +602,9 @@ SELECT tpcbox(0, 0, 2, 2) ~= tpcbox(0, 0, 2, 2);
 				<listitem xml:id="tpcbox_adjacent">
 					<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 					<para>Return true if two tpcboxes are adjacent (share a boundary)</para>
-					<para><varname>tpcbox -|- tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox -|- tpcbox → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 2, 2) -|- tpcbox(5, 5, 7, 7);
 -- f
@@ -638,12 +696,14 @@ SELECT tpcbox(0, 0, 2, 2) &lt;&lt;# tpcbox(5, 5, 7, 7);
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 					<para>Compare two tpcboxes; total order over the canonical encoding (pcid, srid, flags, period, then spatial bounds in XYZ-min/max order)</para>
-					<para><varname>tpcbox = tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &lt;&gt; tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &lt; tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &lt;= tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &gt; tpcbox → boolean</varname></para>
-					<para><varname>tpcbox &gt;= tpcbox → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcbox = tpcbox → boolean
+tpcbox &lt;&gt; tpcbox → boolean
+tpcbox &lt; tpcbox → boolean
+tpcbox &lt;= tpcbox → boolean
+tpcbox &gt; tpcbox → boolean
+tpcbox &gt;= tpcbox → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(0, 0, 2, 2) = tpcbox(0, 0, 2, 2);
 -- t
@@ -683,7 +743,9 @@ INSERT INTO scans VALUES (1,
 				<listitem xml:id="tpcpoint_inst">
 					<indexterm significance="normal"><primary><varname>tpcpoint</varname></primary></indexterm>
 					<para>Construct a temporal pcpoint of instant subtype</para>
-					<para><varname>tpcpoint(pcpoint,timestamptz) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpoint(pcpoint,timestamptz) → tpcpoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), '2024-01-01 12:00+00');
 </programlisting>
@@ -692,8 +754,10 @@ SELECT tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]), '2024-01-01 12:00+00')
 				<listitem xml:id="tpcpoint_seq">
 					<indexterm significance="normal"><primary><varname>tpcpointSeq</varname></primary></indexterm>
 					<para>Construct a temporal pcpoint of sequence subtype from an array of instants. The interpolation is one of <varname>'discrete'</varname>, <varname>'step'</varname>; <varname>'step'</varname> is the default for tpcpoint since pcpoints carry heterogeneous dimensions that do not interpolate linearly</para>
-					<para><varname>tpcpointSeq(tpcpoint[]) → tpcpoint</varname></para>
-					<para><varname>tpcpointSeq(tpcpoint[],text) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpointSeq(tpcpoint[]) → tpcpoint
+tpcpointSeq(tpcpoint[],text) → tpcpoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 2.0, 3.0]),
   '2024-01-01'::timestamptz),
@@ -704,7 +768,9 @@ SELECT tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 2.0, 3.0]),
 				<listitem xml:id="tpcpoint_seqset">
 					<indexterm significance="normal"><primary><varname>tpcpointSeqSet</varname></primary></indexterm>
 					<para>Construct a temporal pcpoint of sequence-set subtype from an array of sequences</para>
-					<para><varname>tpcpointSeqSet(tpcpoint[]) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpointSeqSet(tpcpoint[]) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSequences(tpcpointSeqSet(ARRAY[tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -726,7 +792,9 @@ SELECT numInstants(tpcpointSeqSet(ARRAY[tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_pcid">
 					<indexterm significance="normal"><primary><varname>pcid</varname></primary></indexterm>
 					<para>Return the pgPointCloud schema id shared by all instants</para>
-					<para><varname>pcid(tpcpoint) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcid(tpcpoint) → integer
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pcid(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 -- 1
@@ -736,8 +804,10 @@ SELECT pcid(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 				<listitem xml:id="tpcpoint_SRID">
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<para>Return the SRID inherited from the schema</para>
-					<para><varname>SRID(tpcpoint) → integer</varname></para>
-					<para><varname>SRID(tpcpatch) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(tpcpoint) → integer
+SRID(tpcpatch) → integer
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The SRID is that of the schema registered for the pcid.
 SELECT SRID(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
@@ -758,9 +828,11 @@ SELECT SRID(tpcpatch(PC_Patch(ARRAY[pcpoint(1, 1, 1, 1)]),
 					<indexterm significance="normal"><primary><varname>getY</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getZ</varname></primary></indexterm>
 					<para>Project a tpcpoint onto a spatial dimension, yielding a tfloat</para>
-					<para><varname>getX(tpcpoint) → tfloat</varname></para>
-					<para><varname>getY(tpcpoint) → tfloat</varname></para>
-					<para><varname>getZ(tpcpoint) → tfloat</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getX(tpcpoint) → tfloat
+getY(tpcpoint) → tfloat
+getZ(tpcpoint) → tfloat
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(getX(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
   '2024-01-01'::timestamptz)));
@@ -771,7 +843,9 @@ SELECT startValue(getX(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 				<listitem xml:id="tpcpoint_getDim">
 					<indexterm significance="normal"><primary><varname>getDim</varname></primary></indexterm>
 					<para>Project a tpcpoint onto any named schema dimension, yielding a tfloat</para>
-					<para><varname>getDim(tpcpoint,text) → tfloat</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getDim(tpcpoint,text) → tfloat
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getDim(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -789,7 +863,9 @@ SELECT getDim(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Cast a tpcpoint to a temporal geometry point, projecting away every non-spatial dimension while preserving timestamps. The result has the same SRID as the schema; its dimensionality (2D vs. 3D) follows the presence of Z in the schema. A reverse cast is not provided: reconstructing a pcpoint requires a target schema that the temporal value alone cannot supply</para>
 					<para><varname>tgeompoint::tpcpoint</varname> is not defined</para>
-					<para><varname>tpcpoint::tgeompoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpoint::tgeompoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
   '2024-01-01'::timestamptz)::tgeompoint));
@@ -808,9 +884,11 @@ SELECT ST_AsText(startValue(tpcpoint(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]),
 					<indexterm significance="normal"><primary><varname>tpcpointSeq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcpointSeqSet</varname></primary></indexterm>
 					<para>Transform a tpcpoint to another subtype</para>
-					<para><varname>tpcpointInst(tpcpoint) → tpcpoint</varname></para>
-					<para><varname>tpcpointSeq(tpcpoint,interp='step') → tpcpoint</varname></para>
-					<para><varname>tpcpointSeqSet(tpcpoint) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpointInst(tpcpoint) → tpcpoint
+tpcpointSeq(tpcpoint,interp='step') → tpcpoint
+tpcpointSeqSet(tpcpoint) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(tpcpointInst(tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz)));
@@ -824,7 +902,9 @@ SELECT numInstants(tpcpointSeq(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_setInterp">
 					<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 					<para>Transform a tpcpoint to another interpolation</para>
-					<para><varname>setInterp(tpcpoint,interp) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+setInterp(tpcpoint,interp) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- A tpcpoint carries step interpolation.
 SELECT interp(tpcpointSeq(ARRAY[
@@ -851,12 +931,14 @@ SELECT interp(setInterp(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 					<para>Compare two tpcpoints lexicographically over their canonical encodings</para>
-					<para><varname>tpcpoint = tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &lt;&gt; tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &lt; tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &lt;= tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &gt; tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint &gt;= tpcpoint → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpoint = tpcpoint → boolean
+tpcpoint &lt;&gt; tpcpoint → boolean
+tpcpoint &lt; tpcpoint → boolean
+tpcpoint &lt;= tpcpoint → boolean
+tpcpoint &gt; tpcpoint → boolean
+tpcpoint &gt;= tpcpoint → boolean
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz) = tpcpoint(pcpoint(1, 1,
   1, 1), '2001-01-01'::timestamptz);
@@ -878,13 +960,17 @@ SELECT tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz) &lt; tpcpoint(pc
 					<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 					<para>Test whether the value at any (ever) or every (always) instant equals, or differs from, a pcpoint or another tpcpoint</para>
-					<para><varname>eEq(pcpoint,tpcpoint) → boolean</varname></para>
-					<para><varname>eEq(tpcpoint,pcpoint) → boolean</varname></para>
-					<para><varname>eEq(tpcpoint,tpcpoint) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eEq(pcpoint,tpcpoint) → boolean
+eEq(tpcpoint,pcpoint) → boolean
+eEq(tpcpoint,tpcpoint) → boolean
+</programlisting>
 					<para><varname>aEq</varname>, <varname>eNe</varname> and <varname>aNe</varname> take the same three argument pairs</para>
-					<para><varname>pcpoint ?= tpcpoint → boolean</varname></para>
-					<para><varname>tpcpoint ?= pcpoint → boolean</varname></para>
-					<para><varname>tpcpoint ?= tpcpoint → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpoint ?= tpcpoint → boolean
+tpcpoint ?= pcpoint → boolean
+tpcpoint ?= tpcpoint → boolean
+</programlisting>
 					<para>The operators <varname>%=</varname>, <varname>?&lt;&gt;</varname> and <varname>%&lt;&gt;</varname> take the same three operand pairs</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eEq(pcpoint(1, 1, 1, 1), tpcpointSeq(ARRAY[
@@ -905,13 +991,17 @@ SELECT aEq(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#=</varname></primary></indexterm>
 					<para>Return the temporal equality or inequality of a tpcpoint with a pcpoint or with another tpcpoint, as a tbool</para>
-					<para><varname>tEq(pcpoint,tpcpoint) → tbool</varname></para>
-					<para><varname>tEq(tpcpoint,pcpoint) → tbool</varname></para>
-					<para><varname>tEq(tpcpoint,tpcpoint) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tEq(pcpoint,tpcpoint) → tbool
+tEq(tpcpoint,pcpoint) → tbool
+tEq(tpcpoint,tpcpoint) → tbool
+</programlisting>
 					<para><varname>tNe</varname> takes the same three argument pairs</para>
-					<para><varname>pcpoint #= tpcpoint → tbool</varname></para>
-					<para><varname>tpcpoint #= pcpoint → tbool</varname></para>
-					<para><varname>tpcpoint #= tpcpoint → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpoint #= tpcpoint → tbool
+tpcpoint #= pcpoint → tbool
+tpcpoint #= tpcpoint → tbool
+</programlisting>
 					<para>The operator <varname>#&lt;&gt;</varname> takes the same three operand pairs</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(tpcpointSeq(ARRAY[
@@ -933,10 +1023,12 @@ SELECT tEq(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 					<para>Restrict a tpcpoint to (the complement of) a pcpoint value or a set of pcpoint values</para>
-					<para><varname>atValue(tpcpoint,pcpoint) → tpcpoint</varname></para>
-					<para><varname>minusValue(tpcpoint,pcpoint) → tpcpoint</varname></para>
-					<para><varname>atValues(tpcpoint,pcpointset) → tpcpoint</varname></para>
-					<para><varname>minusValues(tpcpoint,pcpointset) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atValue(tpcpoint,pcpoint) → tpcpoint
+minusValue(tpcpoint,pcpoint) → tpcpoint
+atValues(tpcpoint,pcpointset) → tpcpoint
+minusValues(tpcpoint,pcpointset) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- With step interpolation the matching value is held on
 -- [2001-01-01, 2001-01-02); its closing bound is stored as a second instant.
@@ -957,14 +1049,16 @@ SELECT numInstants(minusValue(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTime</varname></primary></indexterm>
 					<para>Restrict a tpcpoint to a time selector (timestamp, period, set, or spanset), or remove it</para>
-					<para><varname>atTime(tpcpoint,timestamptz) → tpcpoint</varname></para>
-					<para><varname>atTime(tpcpoint,tstzspan) → tpcpoint</varname></para>
-					<para><varname>atTime(tpcpoint,tstzset) → tpcpoint</varname></para>
-					<para><varname>atTime(tpcpoint,tstzspanset) → tpcpoint</varname></para>
-					<para><varname>minusTime(tpcpoint,timestamptz) → tpcpoint</varname></para>
-					<para><varname>minusTime(tpcpoint,tstzspan) → tpcpoint</varname></para>
-					<para><varname>minusTime(tpcpoint,tstzset) → tpcpoint</varname></para>
-					<para><varname>minusTime(tpcpoint,tstzspanset) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTime(tpcpoint,timestamptz) → tpcpoint
+atTime(tpcpoint,tstzspan) → tpcpoint
+atTime(tpcpoint,tstzset) → tpcpoint
+atTime(tpcpoint,tstzspanset) → tpcpoint
+minusTime(tpcpoint,timestamptz) → tpcpoint
+minusTime(tpcpoint,tstzspan) → tpcpoint
+minusTime(tpcpoint,tstzset) → tpcpoint
+minusTime(tpcpoint,tstzspanset) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTime(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -984,8 +1078,10 @@ SELECT numInstants(atTime(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTpcbox</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTpcbox</varname></primary></indexterm>
 					<para>Restrict a tpcpoint to the spatial / temporal extent of a tpcbox, or remove it. Returns NULL when the tpcbox's pcid does not match the tpcpoint's. Internally projects to a tgeompoint via the schema cache, restricts the projection by the equivalent stbox, and lifts the result's time span back onto the original tpcpoint to preserve the full pcpoint values</para>
-					<para><varname>atTpcbox(tpcpoint,tpcbox,border_inc boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>minusTpcbox(tpcpoint,tpcbox,border_inc boolean=TRUE) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTpcbox(tpcpoint,tpcbox,border_inc boolean=TRUE) → tpcpoint
+minusTpcbox(tpcpoint,tpcbox,border_inc boolean=TRUE) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1007,8 +1103,10 @@ SELECT numInstants(minusTpcbox(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
 					<para>Restrict a tpcpoint to the instants before or after a timestamp. The strict flag excludes the instant at the timestamp itself</para>
-					<para><varname>beforeTimestamp(tpcpoint,timestamptz,strict boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>afterTimestamp(tpcpoint,timestamptz,strict boolean=TRUE) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+beforeTimestamp(tpcpoint,timestamptz,strict boolean=TRUE) → tpcpoint
+afterTimestamp(tpcpoint,timestamptz,strict boolean=TRUE) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeSpan(beforeTimestamp(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1032,8 +1130,10 @@ SELECT timeSpan(afterTimestamp(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
 					<para>Insert a tpcpoint into another one, or update another one with it</para>
-					<para><varname>insert(tpcpoint,tpcpoint,connect boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>update(tpcpoint,tpcpoint,connect boolean=TRUE) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+insert(tpcpoint,tpcpoint,connect boolean=TRUE) → tpcpoint
+update(tpcpoint,tpcpoint,connect boolean=TRUE) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(insert(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1047,10 +1147,12 @@ SELECT numInstants(insert(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_deleteTime">
 					<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
 					<para>Delete a time selector (timestamp, set, period, or spanset) from a tpcpoint</para>
-					<para><varname>deleteTime(tpcpoint,timestamptz,connect boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>deleteTime(tpcpoint,tstzset,connect boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>deleteTime(tpcpoint,tstzspan,connect boolean=TRUE) → tpcpoint</varname></para>
-					<para><varname>deleteTime(tpcpoint,tstzspanset,connect boolean=TRUE) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+deleteTime(tpcpoint,timestamptz,connect boolean=TRUE) → tpcpoint
+deleteTime(tpcpoint,tstzset,connect boolean=TRUE) → tpcpoint
+deleteTime(tpcpoint,tstzspan,connect boolean=TRUE) → tpcpoint
+deleteTime(tpcpoint,tstzspanset,connect boolean=TRUE) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Deleting the middle instant splits the sequence into
 -- {[2001-01-01, 2001-01-02), (2001-01-02, 2001-01-03]}; each half stores
@@ -1067,8 +1169,10 @@ SELECT numInstants(deleteTime(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 					<para>Append an instant or a sequence to a tpcpoint</para>
-					<para><varname>appendInstant(tpcpoint,tpcpoint) → tpcpoint</varname></para>
-					<para><varname>appendSequence(tpcpoint,tpcpoint) → tpcpoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tpcpoint,tpcpoint) → tpcpoint
+appendSequence(tpcpoint,tpcpoint) → tpcpoint
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(appendInstant(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1086,7 +1190,9 @@ SELECT numInstants(appendInstant(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_unnest">
 					<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
 					<para>Return the distinct values of a tpcpoint with the span set on which each of them is taken</para>
-					<para><varname>unnest(tpcpoint) → {(value,time)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+unnest(tpcpoint) → {(value,time)}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (un).time
 FROM (SELECT unnest(tpcpointSeq(ARRAY[
@@ -1101,7 +1207,10 @@ FROM (SELECT unnest(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_timeSplit">
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Split a tpcpoint into fragments, one per time bin</para>
-					<para><varname>timeSplit(tpcpoint,bin_width interval,origin timestamptz='2000-01-03') → {(time,tpcpoint)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+timeSplit(tpcpoint,bin_width interval,
+  origin timestamptz='2000-01-03') → {(time,tpcpoint)}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (ts).time, numInstants((ts).temp)
 FROM (SELECT timeSplit(tpcpointSeq(ARRAY[
@@ -1118,7 +1227,9 @@ FROM (SELECT timeSplit(tpcpointSeq(ARRAY[
 				<listitem xml:id="tpcpoint_spans">
 					<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
 					<para>Return the array of time spans of a tpcpoint's segments</para>
-					<para><varname>spans(tpcpoint) → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spans(tpcpoint) → tstzspan[]
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spans(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
@@ -1132,8 +1243,10 @@ SELECT spans(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 					<para>Return the time spans of a tpcpoint split into a given number of bins, or with a given number of segments per bin</para>
-					<para><varname>splitNSpans(tpcpoint, integer) → tstzspan[]</varname></para>
-					<para><varname>splitEachNSpans(tpcpoint, integer) → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+splitNSpans(tpcpoint, integer) → tstzspan[]
+splitEachNSpans(tpcpoint, integer) → tstzspan[]
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2024-01-01'::timestamptz),
@@ -1200,8 +1313,10 @@ SELECT tpcbox 'TPCBOX(ZT(((0,0,0),(1,1,1)),[2024-01-01, 2024-01-02]), 1)' &lt;&l
 					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 					<para>Nearest-approach distance, KNN-orderable through the GiST opclass: <varname>SELECT … ORDER BY temp |=| query LIMIT N</varname> is index-accelerated. Pcid mismatch yields infinity.</para>
-					<para><varname>nearestApproachDistance(tpcpoint,tpcbox) → float</varname></para>
-					<para><varname>nearestApproachDistance(tpcpoint,tpcpoint) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+nearestApproachDistance(tpcpoint,tpcbox) → float
+nearestApproachDistance(tpcpoint,tpcpoint) → float
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(nearestApproachDistance(
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1254,10 +1369,12 @@ SELECT round((tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz) |=|
 					<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 					<para>Ever / always contains, covers and touches</para>
-					<para><varname>{eContains,aContains}(geometry,tpcpoint) &#8594; boolean</varname></para>
-					<para><varname>{eCovers,aCovers}(geometry,tpcpoint) &#8594; boolean</varname></para>
-					<para><varname>{eTouches,aTouches}(geometry,tpcpoint) &#8594; boolean</varname></para>
-					<para><varname>{eTouches,aTouches}(tpcpoint,geometry) &#8594; boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{eContains,aContains}(geometry,tpcpoint) &#8594; boolean
+{eCovers,aCovers}(geometry,tpcpoint) &#8594; boolean
+{eTouches,aTouches}(geometry,tpcpoint) &#8594; boolean
+{eTouches,aTouches}(tpcpoint,geometry) &#8594; boolean
+</programlisting>
 					<para>A moving point neither contains nor covers a geometry and two moving points do not touch, so these take the geometry first only, apart from <varname>eTouches</varname> and <varname>aTouches</varname>, which read either order. They are planar relationships: a point whose schema states a Z dimension is refused.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))',
@@ -1348,13 +1465,15 @@ SELECT aDwithin(tpcpointSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 					<para>Temporal spatial relationships</para>
-					<para><varname>tDisjoint({geometry,tpcpoint},{geometry,tpcpoint}) &#8594; tbool</varname></para>
-					<para><varname>tDwithin({geometry,tpcpoint},{geometry,tpcpoint},float) &#8594; tbool</varname></para>
-					<para><varname>tIntersects({geometry,tpcpoint},{geometry,tpcpoint}) &#8594; tbool</varname></para>
-					<para><varname>tContains(geometry,tpcpoint) &#8594; tbool</varname></para>
-					<para><varname>tCovers(geometry,tpcpoint) &#8594; tbool</varname></para>
-					<para><varname>tTouches(geometry,tpcpoint) &#8594; tbool</varname></para>
-					<para><varname>tTouches(tpcpoint,geometry) &#8594; tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tDisjoint({geometry,tpcpoint},{geometry,tpcpoint}) &#8594; tbool
+tDwithin({geometry,tpcpoint},{geometry,tpcpoint},float) &#8594; tbool
+tIntersects({geometry,tpcpoint},{geometry,tpcpoint}) &#8594; tbool
+tContains(geometry,tpcpoint) &#8594; tbool
+tCovers(geometry,tpcpoint) &#8594; tbool
+tTouches(geometry,tpcpoint) &#8594; tbool
+tTouches(tpcpoint,geometry) &#8594; tbool
+</programlisting>
 					<para>A temporal point cloud point declares the relationships its cast target declares, so <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only and <varname>tTouches</varname> has no direction between two point cloud points. The three are planar relationships: a schema whose dimensions do not include Z answers them, and one carrying Z meets the refusal <varname>The tgeompoint cannot have Z dimension</varname>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1392,7 +1511,9 @@ SELECT tDwithin(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
 				<listitem xml:id="tpcpatch_inst">
 					<indexterm significance="normal"><primary><varname>tpcpatch</varname></primary></indexterm>
 					<para>Construct a temporal pcpatch of instant subtype</para>
-					<para><varname>tpcpatch(pcpatch,timestamptz) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpatch(pcpatch,timestamptz) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tempSubtype(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz));
@@ -1403,8 +1524,10 @@ SELECT tempSubtype(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
 				<listitem xml:id="tpcpatch_seq">
 					<indexterm significance="normal"><primary><varname>tpcpatchSeq</varname></primary></indexterm>
 					<para>Construct a temporal pcpatch of sequence subtype</para>
-					<para><varname>tpcpatchSeq(tpcpatch[]) → tpcpatch</varname></para>
-					<para><varname>tpcpatchSeq(tpcpatch[],text) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpatchSeq(tpcpatch[]) → tpcpatch
+tpcpatchSeq(tpcpatch[],text) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1422,7 +1545,9 @@ SELECT numInstants(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_seqset">
 					<indexterm significance="normal"><primary><varname>tpcpatchSeqSet</varname></primary></indexterm>
 					<para>Construct a temporal pcpatch of sequence-set subtype</para>
-					<para><varname>tpcpatchSeqSet(tpcpatch[]) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpatchSeqSet(tpcpatch[]) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSequences(tpcpatchSeqSet(ARRAY[tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1443,8 +1568,10 @@ SELECT numSequences(tpcpatchSeqSet(ARRAY[tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>startNumPoints</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>endNumPoints</varname></primary></indexterm>
 					<para>Return the number of points in the patch carried by the first or last instant</para>
-					<para><varname>startNumPoints(tpcpatch) → integer</varname></para>
-					<para><varname>endNumPoints(tpcpatch) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+startNumPoints(tpcpatch) → integer
+endNumPoints(tpcpatch) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startNumPoints(tpcpatch(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])),
   '2024-02-01'::timestamptz));
@@ -1455,7 +1582,9 @@ SELECT startNumPoints(tpcpatch(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])
 				<listitem xml:id="tpcpatch_total_numpoints">
 					<indexterm significance="normal"><primary><varname>numPoints</varname></primary></indexterm>
 					<para>Return the total number of points across every instant's patch. Read directly from each patch's header, no decompression.</para>
-					<para><varname>numPoints(tpcpatch) → bigint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numPoints(tpcpatch) → bigint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numPoints(tpcpatchSeq(ARRAY[
   tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
@@ -1470,7 +1599,9 @@ SELECT numPoints(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_points">
 					<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
 					<para>Set-returning function: emits one row per (instant timestamp, point) by walking each instant's patch and decomposing it through pgPointCloud's in-memory C API. Useful for joining a tpcpatch column against per-point predicates that the bbox-level operators can't express. Cost is O(total points), one per-instant decompression plus one row emission per point.</para>
-					<para><varname>points(tpcpatch) → setof (t timestamptz, point pcpoint)</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+points(tpcpatch) → setof (t timestamptz, point pcpoint)
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT t, point FROM points(tpcpatch(
   PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]),
@@ -1495,9 +1626,11 @@ SELECT t, point FROM points(tpcpatch(
 					<indexterm significance="normal"><primary><varname>tpcpatchSeq</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcpatchSeqSet</varname></primary></indexterm>
 					<para>Transform a tpcpatch to another subtype</para>
-					<para><varname>tpcpatchInst(tpcpatch) → tpcpatch</varname></para>
-					<para><varname>tpcpatchSeq(tpcpatch,interp='step') → tpcpatch</varname></para>
-					<para><varname>tpcpatchSeqSet(tpcpatch) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpcpatchInst(tpcpatch) → tpcpatch
+tpcpatchSeq(tpcpatch,interp='step') → tpcpatch
+tpcpatchSeqSet(tpcpatch) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2,
   2)), '2001-01-01'::timestamptz)));
@@ -1507,7 +1640,9 @@ SELECT tempSubtype(tpcpatchSeq(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 
 				<listitem xml:id="tpcpatch_setInterp">
 					<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 					<para>Transform a tpcpatch to another interpolation</para>
-					<para><varname>setInterp(tpcpatch,interp) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+setInterp(tpcpatch,interp) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT interp(setInterp(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1529,10 +1664,12 @@ SELECT interp(setInterp(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 					<para>Restrict a tpcpatch to (the complement of) a pcpatch value or a set of pcpatch values</para>
-					<para><varname>atValue(tpcpatch,pcpatch) → tpcpatch</varname></para>
-					<para><varname>minusValue(tpcpatch,pcpatch) → tpcpatch</varname></para>
-					<para><varname>atValues(tpcpatch,pcpatchset) → tpcpatch</varname></para>
-					<para><varname>minusValues(tpcpatch,pcpatchset) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atValue(tpcpatch,pcpatch) → tpcpatch
+minusValue(tpcpatch,pcpatch) → tpcpatch
+atValues(tpcpatch,pcpatchset) → tpcpatch
+minusValues(tpcpatch,pcpatchset) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The matching value is held up to the next instant; the closing bound
 -- is stored as a second instant.
@@ -1557,8 +1694,10 @@ SELECT numInstants(minusValue(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTpcbox</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTpcbox</varname></primary></indexterm>
 					<para>Restrict a tpcpatch to the instants whose patch passes a coarse PCBOUNDS overlap test against the tpcbox, or remove them. Granularity is patch-level: each surviving instant keeps its pcpatch payload verbatim, with no per-point decompression. Because pgPointCloud's <varname>PCBOUNDS</varname> is 2D, the Z dimension of the box is ignored at this granularity. Returns NULL when the tpcbox's pcid does not match.</para>
-					<para><varname>atTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>minusTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch
+minusTpcbox(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1582,8 +1721,10 @@ SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTpcboxFine</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusTpcboxFine</varname></primary></indexterm>
 					<para>Per-point variant of the previous: each surviving instant carries a freshly-built pcpatch holding only the points inside (or outside, for minus) the tpcbox in 2D, and 3D when the box has a Z dimension. Instants whose patch filters to zero points are dropped. Slower than the coarse variant because every patch is decompressed and rebuilt; use when you need point-level fidelity.</para>
-					<para><varname>atTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>minusTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch
+minusTpcboxFine(tpcpatch,tpcbox,border_inc boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1598,8 +1739,10 @@ SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 					<para>Restrict a tpcpatch to the points whose XY projection intersects (or does not intersect, for minus) a 2D geometry. Z is ignored. SRID compatibility between the patch schema and the geometry must be ensured by the caller.</para>
-					<para><varname>atGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
-					<para><varname>minusGeometry(tpcpatch,geometry) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tpcpatch,geometry) → tpcpatch
+minusGeometry(tpcpatch,geometry) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The polygon boundary touches the point (3 3) of the patch at
 -- 2001-01-02, so that patch survives both the at and the minus side.
@@ -1624,8 +1767,10 @@ SELECT numInstants(minusGeometry(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
 					<para>Restrict a tpcpatch to the instants before or after a timestamp. The strict flag excludes the instant at the timestamp itself</para>
-					<para><varname>beforeTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>afterTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+beforeTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch
+afterTimestamp(tpcpatch,timestamptz,strict boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeSpan(beforeTimestamp(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1655,8 +1800,10 @@ SELECT timeSpan(afterTimestamp(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
 					<para>Insert a tpcpatch into another one, or update another one with it</para>
-					<para><varname>insert(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>update(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+insert(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch
+update(tpcpatch,tpcpatch,connect boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(insert(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1673,10 +1820,12 @@ SELECT numInstants(insert(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_deleteTime">
 					<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
 					<para>Delete a time selector (timestamp, set, period, or spanset) from a tpcpatch</para>
-					<para><varname>deleteTime(tpcpatch,timestamptz,connect boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>deleteTime(tpcpatch,tstzset,connect boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>deleteTime(tpcpatch,tstzspan,connect boolean=TRUE) → tpcpatch</varname></para>
-					<para><varname>deleteTime(tpcpatch,tstzspanset,connect boolean=TRUE) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+deleteTime(tpcpatch,timestamptz,connect boolean=TRUE) → tpcpatch
+deleteTime(tpcpatch,tstzset,connect boolean=TRUE) → tpcpatch
+deleteTime(tpcpatch,tstzspan,connect boolean=TRUE) → tpcpatch
+deleteTime(tpcpatch,tstzspanset,connect boolean=TRUE) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Deleting the middle instant splits the sequence into
 -- {[2001-01-01, 2001-01-02), (2001-01-02, 2001-01-03]}; each half stores
@@ -1696,8 +1845,10 @@ SELECT numInstants(deleteTime(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 					<para>Append an instant or a sequence to a tpcpatch</para>
-					<para><varname>appendInstant(tpcpatch,tpcpatch) → tpcpatch</varname></para>
-					<para><varname>appendSequence(tpcpatch,tpcpatch) → tpcpatch</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tpcpatch,tpcpatch) → tpcpatch
+appendSequence(tpcpatch,tpcpatch) → tpcpatch
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(appendInstant(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1717,7 +1868,9 @@ SELECT numInstants(appendInstant(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_unnest">
 					<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
 					<para>Return the distinct values of a tpcpatch with the span set on which each of them is taken</para>
-					<para><varname>unnest(tpcpatch) → {(value,time)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+unnest(tpcpatch) → {(value,time)}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (un).time
 FROM (SELECT unnest(tpcpatchSeq(ARRAY[
@@ -1735,7 +1888,10 @@ FROM (SELECT unnest(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_timeSplit">
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Split a tpcpatch into fragments, one per time bin</para>
-					<para><varname>timeSplit(tpcpatch,bin_width interval,origin timestamptz='2000-01-03') → {(time,tpcpatch)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+timeSplit(tpcpatch,bin_width interval,
+  origin timestamptz='2000-01-03') → {(time,tpcpatch)}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (ts).time, numInstants((ts).temp)
 FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
@@ -1755,7 +1911,9 @@ FROM (SELECT timeSplit(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_spans">
 					<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
 					<para>Return the array of time spans of a tpcpatch's segments</para>
-					<para><varname>spans(tpcpatch) → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spans(tpcpatch) → tstzspan[]
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spans(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1772,8 +1930,10 @@ SELECT spans(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 					<para>Return the time spans of a tpcpatch split into a given number of bins, or with a given number of segments per bin</para>
-					<para><varname>splitNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
-					<para><varname>splitEachNSpans(tpcpatch, integer) → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+splitNSpans(tpcpatch, integer) → tstzspan[]
+splitEachNSpans(tpcpatch, integer) → tstzspan[]
+</programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(tpcpatchSeq(ARRAY[
   tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -1805,7 +1965,9 @@ SELECT splitNSpans(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>eDwithin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aDwithin</varname></primary></indexterm>
 					<para>Return true iff at least one point in any of the tpcpatch's instants intersects the geometry (XY only).</para>
-					<para><varname>eIntersects(tpcpatch,geometry) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eIntersects(tpcpatch,geometry) → boolean
+</programlisting>
 					<para>The ever and always relationships cover the same matrix: <varname>eContains</varname>, <varname>eCovers</varname>, <varname>eDisjoint</varname>, <varname>eIntersects</varname>, <varname>eTouches</varname> and <varname>eDwithin</varname>, each in the three argument orders, and their always twins. <varname>eIntersects(tpcpatch,geometry)</varname> is the one the type answers natively, walking the points of each instant and stopping at the first hit; the rest convert the patch to the temporal geometry of its multipoints.</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eIntersects(tpcpatchSeq(ARRAY[
@@ -1825,7 +1987,9 @@ SELECT eIntersects(tpcpatchSeq(ARRAY[
 				<listitem xml:id="tpcpatch_tgeometry">
 					<indexterm significance="normal"><primary><varname>tgeometry</varname></primary></indexterm>
 					<para>Convert a temporal patch into the temporal geometry of the multipoints its patches occupy. Each instant's patch becomes the multipoint of the positions its points occupy, read through the schema its <varname>pcid</varname> names</para>
-					<para><varname>tgeometry(tpcpatch) &#8594; tgeometry</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tgeometry(tpcpatch) &#8594; tgeometry
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz)::tgeometry);
@@ -1847,12 +2011,14 @@ SELECT asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 					<para>Temporal spatial relationships</para>
-					<para><varname>tDisjoint({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
-					<para><varname>tDwithin({geometry,tpcpatch},{geometry,tpcpatch},float) &#8594; tbool</varname></para>
-					<para><varname>tIntersects({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
-					<para><varname>tContains({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
-					<para><varname>tCovers({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
-					<para><varname>tTouches({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tDisjoint({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+tDwithin({geometry,tpcpatch},{geometry,tpcpatch},float) &#8594; tbool
+tIntersects({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+tContains({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+tCovers({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+tTouches({geometry,tpcpatch},{geometry,tpcpatch}) &#8594; tbool
+</programlisting>
 					<para>A patch reaches the geometry engine as the multipoint of the positions its points occupy, so it declares the matrix that temporal geometry declares: every predicate in every direction. The planar ones answer for a schema whose dimensions do not include Z, and a schema carrying Z meets the refusal <varname>The tgeometry cannot have Z dimension</varname>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 9, 9, 9)),
@@ -1890,8 +2056,10 @@ SELECT tIntersects(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 					<para>Nearest-approach distance (<varname>|=|</varname>) is KNN-orderable through the GiST opclass.</para>
-					<para><varname>nearestApproachDistance(tpcpatch,tpcbox) → float</varname></para>
-					<para><varname>nearestApproachDistance(tpcpatch,tpcpatch) → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+nearestApproachDistance(tpcpatch,tpcbox) → float
+nearestApproachDistance(tpcpatch,tpcpatch) → float
+</programlisting>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -1907,13 +2075,17 @@ SELECT tIntersects(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 					<para>Test whether the value at any (ever) or every (always) instant equals, or differs from, a pcpatch or another tpcpatch</para>
-					<para><varname>eEq(pcpatch,tpcpatch) → boolean</varname></para>
-					<para><varname>eEq(tpcpatch,pcpatch) → boolean</varname></para>
-					<para><varname>eEq(tpcpatch,tpcpatch) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eEq(pcpatch,tpcpatch) → boolean
+eEq(tpcpatch,pcpatch) → boolean
+eEq(tpcpatch,tpcpatch) → boolean
+</programlisting>
 					<para><varname>aEq</varname>, <varname>eNe</varname> and <varname>aNe</varname> take the same three argument pairs</para>
-					<para><varname>pcpatch ?= tpcpatch → boolean</varname></para>
-					<para><varname>tpcpatch ?= pcpatch → boolean</varname></para>
-					<para><varname>tpcpatch ?= tpcpatch → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpatch ?= tpcpatch → boolean
+tpcpatch ?= pcpatch → boolean
+tpcpatch ?= tpcpatch → boolean
+</programlisting>
 					<para>The operators <varname>%=</varname>, <varname>?&lt;&gt;</varname> and <varname>%&lt;&gt;</varname> take the same three operand pairs</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eEq(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)), tpcpatchSeq(ARRAY[
@@ -1936,13 +2108,17 @@ SELECT aEq(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#=</varname></primary></indexterm>
 					<para>Return the temporal equality or inequality of a tpcpatch with a pcpatch or with another tpcpatch, as a tbool</para>
-					<para><varname>tEq(pcpatch,tpcpatch) → tbool</varname></para>
-					<para><varname>tEq(tpcpatch,pcpatch) → tbool</varname></para>
-					<para><varname>tEq(tpcpatch,tpcpatch) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tEq(pcpatch,tpcpatch) → tbool
+tEq(tpcpatch,pcpatch) → tbool
+tEq(tpcpatch,tpcpatch) → tbool
+</programlisting>
 					<para><varname>tNe</varname> takes the same three argument pairs</para>
-					<para><varname>pcpatch #= tpcpatch → tbool</varname></para>
-					<para><varname>tpcpatch #= pcpatch → tbool</varname></para>
-					<para><varname>tpcpatch #= tpcpatch → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pcpatch #= tpcpatch → tbool
+tpcpatch #= pcpatch → tbool
+tpcpatch #= tpcpatch → tbool
+</programlisting>
 					<para>The operator <varname>#&lt;&gt;</varname> takes the same three operand pairs</para>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(tpcpatchSeq(ARRAY[
@@ -2024,9 +2200,11 @@ CREATE INDEX ON my_table USING spgist(my_tpcpoint_column tpcpoint_kdtree_ops);
 			<listitem xml:id="tpcpoint_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Bounding-box aggregate over a column of tpcpoint, tpcpatch, or tpcbox values. Returns the smallest tpcbox containing every input. Aggregating across distinct pcids raises an error, the bbox would be uninterpretable since dimensions are pcid-relative.</para>
-				<para><varname>extent(tpcpoint) → tpcbox</varname></para>
-				<para><varname>extent(tpcpatch) → tpcbox</varname></para>
-				<para><varname>extent(tpcbox) → tpcbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(tpcpoint) → tpcbox
+extent(tpcpatch) → tpcbox
+extent(tpcbox) → tpcbox
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(v) FROM (VALUES
   (tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz)),
@@ -2056,7 +2234,9 @@ SELECT wCount(v, interval '1 day') FROM (VALUES
 			<listitem xml:id="tpcpatch_tnpoints">
 				<indexterm significance="normal"><primary><varname>tnpoints</varname></primary></indexterm>
 				<para>Per-instant pcpatch point count, summed across rows. Distinct from <varname>tCount(tpcpatch)</varname>, which counts the number of patches (always 1 per instant). <varname>tnpoints</varname> reads as "how many points were in the cloud at time t", the natural primitive for ingest-QC and density-over-time dashboards.</para>
-				<para><varname>tnpoints(tpcpatch) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tnpoints(tpcpatch) → tint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoints(v) FROM (VALUES
   (tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -2070,7 +2250,9 @@ SELECT tnpoints(v) FROM (VALUES
 			<listitem xml:id="tpcpatch_tdensity">
 				<indexterm significance="normal"><primary><varname>tdensity</varname></primary></indexterm>
 				<para>Per-instant point density (<varname>numPoints / xy-bbox-area</varname>) summed across rows. Each pcpatch carries the inline <varname>PCBOUNDS</varname> (xmin / xmax / ymin / ymax) so the bbox-area term is read directly, no recomputation. A 1-point or co-linear patch yields <varname>+Infinity</varname> for that instant; filter with <varname>isfinite()</varname> in downstream queries if needed.</para>
-				<para><varname>tdensity(tpcpatch) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tdensity(tpcpatch) → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Each patch holds 2 points over a 1x1 xy-bbox.
 SELECT tdensity(v) FROM (VALUES
@@ -2135,9 +2317,11 @@ SELECT numInstants(appendInstant(v ORDER BY startTimestamp(v))) FROM (VALUES
 			<listitem xml:id="tpcpoint_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Return the text representation of a tpcpoint, or of an array of them, and cast a tpcpoint to text</para>
-				<para><varname>asText(tpcpoint) → text</varname></para>
-				<para><varname>asText(tpcpoint[]) → text[]</varname></para>
-				<para><varname>tpcpoint::text → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText(tpcpoint) → text
+asText(tpcpoint[]) → text[]
+tpcpoint::text → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The pcpoint payload renders as hex-encoded WKB.
 SELECT asText(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
@@ -2147,9 +2331,11 @@ SELECT asText(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 			<listitem xml:id="tpcpatch_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Return the text representation of a tpcpatch, or of an array of them, and cast a tpcpatch to text</para>
-				<para><varname>asText(tpcpatch) → text</varname></para>
-				<para><varname>asText(tpcpatch[]) → text[]</varname></para>
-				<para><varname>tpcpatch::text → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText(tpcpatch) → text
+asText(tpcpatch[]) → text[]
+tpcpatch::text → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The pcpatch payload renders as hex-encoded WKB.
 SELECT left(asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
@@ -2170,7 +2356,9 @@ SELECT left(asText(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
 			<listitem xml:id="tpcpoint_mfjson">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>For <varname>tpcpoint</varname>, the temporal type is emitted as <varname>{"type":"MovingPCPoint", … "coordinates":[[X,Y,Z], …], "datetimes":[…]}</varname>. X/Y/[Z] are extracted from each instant's <varname>pcpoint</varname> via the schema cache; if the schema lacks X/Y the coordinate array is empty for that instant.</para>
-				<para><varname>asMFJSON(tpcpoint, options int=0, flags int=0, maxdecimaldigits int=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tpcpoint, options int=0, flags int=0, maxdecimaldigits int=15) → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 -- {"type":"MovingPCPoint","coordinates":[[1,1,1]],
@@ -2180,7 +2368,9 @@ SELECT asMFJSON(tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz));
 			<listitem xml:id="tpcpatch_mfjson">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>For <varname>tpcpatch</varname>, the type tag is <varname>"MovingPCPatch"</varname> and each instant emits a small object <varname>{"pcid":N, "npoints":N, "bounds":[xmin,xmax,ymin,ymax]}</varname>. The compressed point payload is intentionally not in the JSON, use <varname>asBinary</varname> / <varname>asHexWKB</varname> for round-trip.</para>
-				<para><varname>asMFJSON(tpcpatch, options int=0, flags int=0, maxdecimaldigits int=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tpcpatch, options int=0, flags int=0, maxdecimaldigits int=15) → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tpcpatch(pcpatch(pcpoint(1, 1, 1, 1), pcpoint(1, 2, 2, 2)),
   '2001-01-01'::timestamptz));

--- a/doc/temporal_pose_chains.xml
+++ b/doc/temporal_pose_chains.xml
@@ -29,8 +29,10 @@
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>asText({posechain,posechain[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({posechain,posechain[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({posechain,posechain[]}) → {text,text[]}
+asEWKT({posechain,posechain[]}) → {text,text[]}
+</programlisting>
 					<para>The outer link is written as a pose carrying the frame of the chain, and every later link is written without one.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(posechain 'PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),1))');
@@ -49,10 +51,12 @@ SELECT asEWKT(posechain 'SRID=3812;PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 					<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB), the Hexadecimal Well-Known Binary (HexWKB), or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-					<para><varname>asBinary(posechain,endian text='') → bytea</varname></para>
-					<para><varname>asEWKB(posechain,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(posechain,endian text='') → text</varname></para>
-					<para><varname>asHexEWKB(posechain,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(posechain,endian text='') → bytea
+asEWKB(posechain,endian text='') → bytea
+asHexWKB(posechain,endian text='') → text
+asHexEWKB(posechain,endian text='') → text
+</programlisting>
 					<para>The chain writes its flags and its one SRID once, then the number of links, then the values of every link in order. The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(posechain 'PoseChain(Pose(Point(1 2),1))');
@@ -68,8 +72,10 @@ SELECT asHexEWKB(posechain 'SRID=3812;PoseChain(Pose(Point(1 2),1))');
 					<indexterm significance="normal"><primary><varname>posechainFromText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>posechainFromEWKT</varname></primary></indexterm>
 					<para>Input from the Well-Known Text (WKT) or from the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>posechainFromText(text) → posechain</varname></para>
-					<para><varname>posechainFromEWKT(text) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechainFromText(text) → posechain
+posechainFromEWKT(text) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(posechainFromText('PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),1))'));
 -- PoseChain(Pose(POINT(0 0),0),Pose(POINT(1 0),1))
@@ -83,9 +89,11 @@ SELECT asEWKT(posechainFromEWKT('SRID=3812;PoseChain(Pose(Point(0 0),0))'));
 					<indexterm significance="normal"><primary><varname>posechainFromEWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>posechainFromHexEWKB</varname></primary></indexterm>
 					<para>Input from the Well-Known Binary (WKB), from the Extended Well-Known Binary (EWKB), or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-					<para><varname>posechainFromBinary(bytea) → posechain</varname></para>
-					<para><varname>posechainFromEWKB(bytea) → posechain</varname></para>
-					<para><varname>posechainFromHexEWKB(text) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechainFromBinary(bytea) → posechain
+posechainFromEWKB(bytea) → posechain
+posechainFromHexEWKB(text) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT posechainFromBinary(asBinary(posechain 'PoseChain(Pose(Point(1 2),0.5))')) =
   posechain 'PoseChain(Pose(Point(1 2),0.5))';
@@ -105,7 +113,9 @@ SELECT posechainFromHexEWKB(asHexEWKB(
 				<listitem xml:id="posechain_constructor">
 					<indexterm significance="normal"><primary><varname>posechain</varname></primary></indexterm>
 					<para>Construct a pose chain from an array of poses ordered from the outermost frame inwards</para>
-					<para><varname>posechain(pose[]) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechain(pose[]) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(posechain(ARRAY[pose 'Pose(Point(0 0),0)', pose 'Pose(Point(1 0),0)']));
 -- PoseChain(Pose(POINT(0 0),0),Pose(POINT(1 0),0))
@@ -115,7 +125,9 @@ SELECT asEWKT(posechain(ARRAY[pose 'Pose(Point(0 0),0)', pose 'Pose(Point(1 0),0
 				<listitem xml:id="posechain_appendPose">
 					<indexterm significance="normal"><primary><varname>appendPose</varname></primary></indexterm>
 					<para>Return a pose chain with a pose appended as its innermost link</para>
-					<para><varname>appendPose(posechain,pose) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendPose(posechain,pose) → posechain
+</programlisting>
 					<para>The pose is read in the frame the last link of the chain defines, so it carries neither an SRID nor the geodetic marker.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(appendPose(posechain 'PoseChain(Pose(Point(0 0),0))',
@@ -132,7 +144,9 @@ SELECT asEWKT(appendPose(posechain 'PoseChain(Pose(Point(0 0),0))',
 				<listitem xml:id="pose_to_posechain">
 					<indexterm significance="normal"><primary><varname>posechain</varname></primary></indexterm>
 					<para>Convert a pose into a pose chain of a single link</para>
-					<para><varname>posechain(pose) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechain(pose) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(posechain(pose 'SRID=3812;Pose(Point(1 2),0.5)'));
 -- SRID=3812;PoseChain(Pose(POINT(1 2),0.5))
@@ -142,8 +156,10 @@ SELECT asEWKT(posechain(pose 'SRID=3812;Pose(Point(1 2),0.5)'));
 				<listitem xml:id="posechain_to_pose">
 					<indexterm significance="normal"><primary><varname>pose</varname></primary></indexterm>
 					<para>Return the pose of a frame the chain defines, read in the outer frame of the chain</para>
-					<para><varname>pose(posechain) → pose</varname></para>
-					<para><varname>pose(posechain,integer) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose(posechain) → pose
+pose(posechain,integer) → pose
+</programlisting>
 					<para>With one argument the whole chain is composed, giving the pose of its innermost frame. With two the first <varname>n</varname> links are composed, giving the pose of the frame the <varname>n</varname>-th link defines, that is, where that joint of the chain sits.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(pose(posechain
@@ -158,7 +174,9 @@ SELECT asEWKT(pose(posechain
 				<listitem xml:id="posechain_to_point">
 					<indexterm significance="normal"><primary><varname>point</varname></primary></indexterm>
 					<para>Convert a pose chain into the geometry point of its innermost frame</para>
-					<para><varname>point(posechain) → geometry</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+point(posechain) → geometry
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(point(posechain
   'PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),0))'));
@@ -169,7 +187,9 @@ SELECT ST_AsText(point(posechain
 				<listitem xml:id="posechain_to_stbox">
 					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 					<para>Convert a pose chain into a spatiotemporal box</para>
-					<para><varname>stbox(posechain) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+stbox(posechain) → stbox
+</programlisting>
 					<para>The box covers the composed position of every prefix of the chain, not only of the whole of it: every joint is a place, and a query window that meets the elbow but not the hand still meets the chain.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(posechain
@@ -186,7 +206,9 @@ SELECT stbox(posechain
 				<listitem xml:id="posechain_numPoses">
 					<indexterm significance="normal"><primary><varname>numPoses</varname></primary></indexterm>
 					<para>Return the number of links of a pose chain</para>
-					<para><varname>numPoses(posechain) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numPoses(posechain) → integer
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numPoses(posechain
   'PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),0),Pose(Point(2 0),0))');
@@ -200,10 +222,12 @@ SELECT numPoses(posechain
 					<indexterm significance="normal"><primary><varname>poseN</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poses</varname></primary></indexterm>
 					<para>Return the links of a pose chain</para>
-					<para><varname>startPose(posechain) → pose</varname></para>
-					<para><varname>endPose(posechain) → pose</varname></para>
-					<para><varname>poseN(posechain,integer) → pose</varname></para>
-					<para><varname>poses(posechain) → pose[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+startPose(posechain) → pose
+endPose(posechain) → pose
+poseN(posechain,integer) → pose
+poses(posechain) → pose[]
+</programlisting>
 					<para>A link is returned as it is stored, that is, in the frame the link before it defines. Where that frame sits in the outer frame of the chain is what <varname>pose(posechain,integer)</varname> answers. The function <varname>poseN</varname> returns <varname>NULL</varname> if the chain has fewer links than the number given.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(startPose(posechain
@@ -227,7 +251,9 @@ SELECT asEWKT(poses(posechain 'PoseChain(Pose(Point(0 0),0),Pose(Point(1 0),0))'
 				<listitem xml:id="posechain_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Round the values of the links of a pose chain to a number of decimal places</para>
-					<para><varname>round(posechain,integer=0) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(posechain,integer=0) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(round(posechain
   'PoseChain(Pose(Point(1.123456789 2.123456789),0.123456789))', 3));
@@ -244,8 +270,10 @@ SELECT asEWKT(round(posechain
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Return or set the spatial reference identifier of the outer frame of a pose chain</para>
-					<para><varname>SRID(posechain) → integer</varname></para>
-					<para><varname>setSRID(posechain,integer) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(posechain) → integer
+setSRID(posechain,integer) → posechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(posechain 'SRID=3812;PoseChain(Pose(Point(1 2),0))');
 -- 3812
@@ -258,8 +286,11 @@ SELECT asEWKT(setSRID(posechain 'PoseChain(Pose(Point(1 2),0))', 3812));
 					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transform to a spatial reference identifier</para>
-					<para><varname>transform(posechain,integer) → posechain</varname></para>
-					<para><varname>transformPipeline(posechain,pipeline text,to_srid integer,is_forward boolean=true) → posechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+transform(posechain,integer) → posechain
+transformPipeline(posechain,pipeline text,to_srid integer,
+  is_forward boolean=true) → posechain
+</programlisting>
 					<para>Only the outer link names a frame, so only the outer link is transformed: every other link is a rigid transform read in the axes of its parent, and a change of the outer frame leaves those axes as they were. An error is raised when the input chain has an unknown SRID (represented by 0).</para>
 					<para>For a three-dimensional chain over a geographic frame the outer link's orientation is re-expressed in the basis of the target frame at its point, exactly as it is for a pose. For a two-dimensional chain the angle is intrinsic to the source projection and is passed through unchanged.</para>
 					<para>The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format:</para>
@@ -289,7 +320,9 @@ SELECT asEWKT(round(transformPipeline(posechain
 					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Traditional comparison operators</para>
-					<para><varname>{posechain} {=,&lt;&gt;,&lt;,&gt;,&lt;=,&gt;=} {posechain} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{posechain} {=,&lt;&gt;,&lt;,&gt;,&lt;=,&gt;=} {posechain} → boolean
+</programlisting>
 					<para>The ordering compares the dimension, then the SRID, then the links in order, and last the number of links, so a chain precedes every chain that extends it.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT posechain 'PoseChain(Pose(Point(0 0),0))' =
@@ -304,7 +337,9 @@ SELECT posechain 'PoseChain(Pose(Point(0 0),0))' &lt;
 				<listitem xml:id="posechain_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Return true if two pose chains are equal up to the tolerance of the comparison of floating-point values</para>
-					<para><varname>posechain ~= posechain → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+posechain ~= posechain → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT posechain 'PoseChain(Pose(Point(0 0),0))' ~=
   posechain 'PoseChain(Pose(Point(0 0),0))';
@@ -375,8 +410,10 @@ SELECT tposechain(Sequence) 'PoseChain(Pose(Point(1 1), 0.2))@2001-01-01';
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>asText({tposechain,tposechain[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({tposechain,tposechain[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({tposechain,tposechain[]}) → {text,text[]}
+asEWKT({tposechain,tposechain[]}) → {text,text[]}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01');
 -- PoseChain(Pose(POINT(1 1),0.5))@2001-01-01
@@ -388,9 +425,11 @@ SELECT asText(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01');
 					<indexterm significance="normal"><primary><varname>tposechainFromBinary</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tposechainFromHexEWKB</varname></primary></indexterm>
 					<para>Return a temporal pose chain from its text or binary representation</para>
-					<para><varname>tposechainFromText(text) → tposechain</varname></para>
-					<para><varname>tposechainFromBinary(bytea) → tposechain</varname></para>
-					<para><varname>tposechainFromHexEWKB(text) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tposechainFromText(text) → tposechain
+tposechainFromBinary(bytea) → tposechain
+tposechainFromHexEWKB(text) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposechainFromText('SRID=5676;PoseChain(Pose(Point(1 1),0.5))@2001-01-01'));
 -- SRID=5676;PoseChain(Pose(POINT(1 1),0.5))@2001-01-01
@@ -406,7 +445,9 @@ SELECT asEWKT(tposechainFromHexEWKB(asHexEWKB(tposechain
 				<listitem xml:id="tposechain_asMFJSON">
 					<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 					<para>Return the Moving Features JSON representation</para>
-					<para><varname>asMFJSON(tposechain) → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tposechain) → text
+</programlisting>
 					<para>A chain is written as the array of its links, in the order that says in whose frame each of them is read.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01');
@@ -423,10 +464,12 @@ SELECT asMFJSON(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01');
 				<listitem xml:id="tposechain_constructor">
 					<indexterm significance="normal"><primary><varname>tposechain</varname></primary></indexterm>
 					<para>Construct a temporal pose chain from a pose chain and a time value</para>
-					<para><varname>tposechain(posechain, timestamptz) → tposechain</varname></para>
-					<para><varname>tposechain(posechain, tstzset) → tposechain</varname></para>
-					<para><varname>tposechain(posechain, tstzspan, text DEFAULT 'linear') → tposechain</varname></para>
-					<para><varname>tposechain(posechain, tstzspanset, text DEFAULT 'linear') → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tposechain(posechain, timestamptz) → tposechain
+tposechain(posechain, tstzset) → tposechain
+tposechain(posechain, tstzspan, text DEFAULT 'linear') → tposechain
+tposechain(posechain, tstzspanset, text DEFAULT 'linear') → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposechain(posechain 'PoseChain(Pose(Point(1 1), 0.5))',
   timestamptz '2001-01-01'));
@@ -450,7 +493,9 @@ SELECT asEWKT(tposechain(posechain 'PoseChain(Pose(Point(1 1), 0.5))',
 				<listitem xml:id="tposechain_to_tpose">
 					<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
 					<para>Convert a temporal pose chain into a temporal pose</para>
-					<para><varname>tpose(tposechain) → tpose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tpose(tposechain) → tpose
+</programlisting>
 					<para>Every instant holds the pose the whole chain composes to, which is where its innermost frame sits in the frame of the chain. The result is a step function: composing a chain multiplies the rotations of its links, so the pose of the chain interpolated between two instants is not the pose interpolated between the two composed poses, and a linear result would answer a pose the chain never holds. A chain of one link composes to itself, and there the interpolation of the argument carries over unchanged.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(round(tpose(tposechain
@@ -473,7 +518,9 @@ SELECT asEWKT(round((tposechain
 				<listitem xml:id="tposechain_numPoses">
 					<indexterm significance="normal"><primary><varname>numPoses</varname></primary></indexterm>
 					<para>Return the number of links every value of a temporal pose chain holds</para>
-					<para><varname>numPoses(tposechain) → integer</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+numPoses(tposechain) → integer
+</programlisting>
 					<para>The number is the same at every instant, so one instant answers for the whole value.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numPoses(tposechain
@@ -487,9 +534,11 @@ SELECT numPoses(tposechain
 					<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
 					<para>Return the value of a temporal instant, the set of values, or the time span</para>
-					<para><varname>getValue(tposechain) → posechain</varname></para>
-					<para><varname>getValues(tposechain) → posechainset</varname></para>
-					<para><varname>timeSpan(tposechain) → tstzspan</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getValue(tposechain) → posechain
+getValues(tposechain) → posechainset
+timeSpan(tposechain) → tstzspan
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(getValue(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01'));
 -- PoseChain(Pose(POINT(1 1),0.5))
@@ -505,7 +554,9 @@ SELECT timeSpan(tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 				<listitem xml:id="tposechain_stbox">
 					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 					<para>Return the spatiotemporal box of a temporal pose chain</para>
-					<para><varname>stbox(tposechain) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+stbox(tposechain) → stbox
+</programlisting>
 					<para>The box spans the composed position of every prefix of the chain, that is, of every one of its joints, and not only the position its links store.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(stbox(tposechain
@@ -524,8 +575,10 @@ SELECT round(stbox(tposechain
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>shiftTime</varname></primary></indexterm>
 					<para>Round the coordinates to a number of decimal places, or shift the time</para>
-					<para><varname>round(tposechain, integer DEFAULT 0) → tposechain</varname></para>
-					<para><varname>shiftTime(tposechain, interval) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(tposechain, integer DEFAULT 0) → tposechain
+shiftTime(tposechain, interval) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(round(tposechain
   'PoseChain(Pose(Point(1.123456789 2.123456789), 0.5))@2001-01-01', 3));
@@ -545,8 +598,10 @@ SELECT asEWKT(shiftTime(tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01'
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Return or set the spatial reference identifier of the outer frame of a temporal pose chain</para>
-					<para><varname>SRID(tposechain) &#8594; integer</varname></para>
-					<para><varname>setSRID(tposechain,integer) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(tposechain) &#8594; integer
+setSRID(tposechain,integer) &#8594; tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tposechain 'SRID=3812;{PoseChain(Pose(Point(1 2),0),
   Pose(Point(3 0),0.5))@2001-01-01, PoseChain(Pose(Point(2 3),0),
@@ -563,8 +618,11 @@ SELECT asEWKT(setSRID(tposechain '{PoseChain(Pose(Point(1 2),0))@2001-01-01,
 					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transform to a spatial reference identifier</para>
-					<para><varname>transform(tposechain,integer) &#8594; tposechain</varname></para>
-					<para><varname>transformPipeline(tposechain,pipeline text,to_srid integer,is_forward boolean=true) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+transform(tposechain,integer) &#8594; tposechain
+transformPipeline(tposechain,pipeline text,to_srid integer,
+  is_forward boolean=true) &#8594; tposechain
+</programlisting>
 					<para>The chain of every instant is transformed as the corresponding static chain is, which is to say that only the outer link is transformed, as described for <link linkend="posechain_transform"><varname>transform</varname></link>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(round(transform(tposechain 'SRID=4326;PoseChain(
@@ -587,8 +645,10 @@ SELECT asEWKT(round(transformPipeline(tposechain
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tposechainFromGeoPose</varname></primary></indexterm>
 					<para>Write or read an OGC GeoPose Composite Chain document</para>
-					<para><varname>asGeoPose(tposechain,maxdecimaldigits integer=-1) &#8594; text</varname></para>
-					<para><varname>tposechainFromGeoPose(text) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPose(tposechain,maxdecimaldigits integer=-1) &#8594; text
+tposechainFromGeoPose(text) &#8594; tposechain
+</programlisting>
 					<para>A Chain document is an outer frame and a sequence of transformations reaching a final innermost frame, which is what a pose chain holds. The document names the LTP-ENU frame tangent at the outer link's position and one transformation per link: the first takes that tangent frame to the outer link's own frame, and each later one is the link as it is stored, read in the axes of its parent.</para>
 					<para>The document carries one valid time, so it is written from a single instant; <link linkend="tposechain_atTime"><varname>atTime</varname></link> obtains one from a longer value. Its frame chain holds at least two frames, so a chain of one link has no Chain document.</para>
 					<para>The Chain class names its two frames <varname>/Extrinsic/LTP-ENU</varname> and <varname>/Intrinsic/Translate-Rotate</varname>, where the Advanced, Series and Stream classes name the same two frames <varname>LTP-ENU</varname> and <varname>RotateTranslate</varname>. A document is written with the pair its own class uses, and either pair is accepted on reading.</para>
@@ -614,7 +674,9 @@ SELECT asGeoPose(tposechain 'SRID=4326;PoseChain(
 				<listitem xml:id="tposechainarr_asGeoPose">
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<para>Write an OGC GeoPose Composite Graph document</para>
-					<para><varname>asGeoPose(tposechain[],maxdecimaldigits integer=-1) &#8594; text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPose(tposechain[],maxdecimaldigits integer=-1) &#8594; text
+</programlisting>
 					<para>A Graph document is a set of frames and the transformations between them, which several pose chains sharing their outermost frame hold. The frame list names the LTP-ENU frame tangent at that outermost link followed by the links of every chain, and the transform list names the parent and the child of each edge by their position in that list. The edges carry no transformation of their own; it lives in the frames they name.</para>
 					<para>The document carries one valid time, so it is written from chains read at one and the same instant; <link linkend="tposechain_atTime"><varname>atTime</varname></link> obtains them from longer values. Its frame list holds at least two frames, which one link of one chain already gives beside the tangent frame.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -649,8 +711,10 @@ SELECT asGeoPose(ARRAY[
 					<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
 					<para>Restrict a temporal pose chain to a time or to a value</para>
-					<para><varname>atTime(tposechain, time) → tposechain</varname></para>
-					<para><varname>atValue(tposechain, posechain) → tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+atTime(tposechain, time) → tposechain
+atValue(tposechain, posechain) → tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(atTime(tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
   PoseChain(Pose(Point(2 2), 0.5))@2001-01-03]', timestamptz '2001-01-02'));
@@ -670,8 +734,10 @@ SELECT asEWKT(atValue(tposechain '{PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 				<listitem xml:id="tposechain_eq">
 					<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
 					<para>Compare two temporal pose chains, or a temporal pose chain and a pose chain</para>
-					<para><varname>tposechain operator tposechain → boolean</varname></para>
-					<para><varname>eEq(tposechain, posechain) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tposechain operator tposechain → boolean
+eEq(tposechain, posechain) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01' =
   tposechain 'PoseChain(Pose(Point(1 1), 0.5))@2001-01-01';
@@ -692,7 +758,9 @@ SELECT eEq(tposechain '{PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;&lt;#</varname></primary></indexterm>
 					<para>Compare the bounding box of a temporal pose chain with another bounding box</para>
-					<para><varname>tposechain op {stbox,tposechain} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tposechain op {stbox,tposechain} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
   PoseChain(Pose(Point(2 2), 0.5))@2001-01-02]' &amp;&amp; stbox 'STBOX X((1,1),(2,2))';
@@ -716,13 +784,15 @@ SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.5))@2001-01-01,
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 					<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal pose chain answers them at the position its composed pose occupies, so a chain with linear interpolation is answered along its trajectory rather than at its instants alone. The chain declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two chains, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
-					<para><varname>tContains(geometry,tposechain) &#8594; tbool</varname></para>
-					<para><varname>tCovers(geometry,tposechain) &#8594; tbool</varname></para>
-					<para><varname>tDisjoint({geometry,tposechain},{geometry,tposechain}) &#8594; tbool</varname></para>
-					<para><varname>tDwithin({geometry,tposechain},{geometry,tposechain},float) &#8594; tbool</varname></para>
-					<para><varname>tIntersects({geometry,tposechain},{geometry,tposechain}) &#8594; tbool</varname></para>
-					<para><varname>tTouches(geometry,tposechain) &#8594; tbool</varname></para>
-					<para><varname>tTouches(tposechain,geometry) &#8594; tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tposechain) &#8594; tbool
+tCovers(geometry,tposechain) &#8594; tbool
+tDisjoint({geometry,tposechain},{geometry,tposechain}) &#8594; tbool
+tDwithin({geometry,tposechain},{geometry,tposechain},float) &#8594; tbool
+tIntersects({geometry,tposechain},{geometry,tposechain}) &#8594; tbool
+tTouches(geometry,tposechain) &#8594; tbool
+tTouches(tposechain,geometry) &#8594; tbool
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tposechain '{PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
   PoseChain(Pose(Point(3 3), 0.1))@2001-01-03}',
@@ -752,7 +822,9 @@ SELECT tDwithin(tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01',
 				<listitem xml:id="tposechain_tCount">
 					<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 					<para>Temporal count</para>
-					<para><varname>tCount(tposechain) &#8594; {tintSeq,tintSeqSet}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tCount(tposechain) &#8594; {tintSeq,tintSeqSet}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
@@ -770,7 +842,9 @@ FROM Temp;
 				<listitem xml:id="tposechain_wCount">
 					<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 					<para>Window count</para>
-					<para><varname>wCount(tposechain, interval) &#8594; {tintSeq,tintSeqSet}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+wCount(tposechain, interval) &#8594; {tintSeq,tintSeqSet}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01,
@@ -787,7 +861,9 @@ FROM Temp;
 				<listitem xml:id="tposechain_extent">
 					<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 					<para>Bounding box extent</para>
-					<para><varname>extent(tposechain) &#8594; stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+extent(tposechain) &#8594; stbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(temp) FROM ( VALUES
   (NULL::tposechain),
@@ -801,7 +877,9 @@ SELECT extent(temp) FROM ( VALUES
 				<listitem xml:id="tposechain_mergeAgg">
 					<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 					<para>Merge the aggregated temporal pose chains. The name <varname>merge</varname> denotes the same aggregate</para>
-					<para><varname>mergeAgg(tposechain) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+mergeAgg(tposechain) &#8594; tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(mergeAgg(temp)) FROM (VALUES
   (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
@@ -814,7 +892,9 @@ SELECT asText(mergeAgg(temp)) FROM (VALUES
 				<listitem xml:id="tposechain_appendInstantAgg">
 					<indexterm significance="normal"><primary><varname>appendInstantAgg</varname></primary></indexterm>
 					<para>Append the aggregated instants into a sequence. The name <varname>appendInstant</varname> denotes the same aggregate</para>
-					<para><varname>appendInstantAgg(tposechain) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendInstantAgg(tposechain) &#8594; tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendInstantAgg(inst)) FROM (VALUES
   (tposechain 'PoseChain(Pose(Point(1 1), 0.1))@2001-01-01'),
@@ -827,7 +907,9 @@ SELECT asText(appendInstantAgg(inst)) FROM (VALUES
 				<listitem xml:id="tposechain_appendSequenceAgg">
 					<indexterm significance="normal"><primary><varname>appendSequenceAgg</varname></primary></indexterm>
 					<para>Append the aggregated sequences into a sequence set. The name <varname>appendSequence</varname> denotes the same aggregate</para>
-					<para><varname>appendSequenceAgg(tposechain) &#8594; tposechain</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+appendSequenceAgg(tposechain) &#8594; tposechain
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendSequenceAgg(seq)) FROM (VALUES
   (tposechain '[PoseChain(Pose(Point(1 1), 0.1))@2001-01-01]'),

--- a/doc/temporal_poses.xml
+++ b/doc/temporal_poses.xml
@@ -106,8 +106,10 @@ SELECT pose 'Pose(Point Z(1 1 1), 1.0)';
 					<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 					<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>asText({pose,pose[]}) → {text,text[]}</varname></para>
-					<para><varname>asEWKT({pose,pose[]}) → {text,text[]}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asText({pose,pose[]}) → {text,text[]}
+asEWKT({pose,pose[]}) → {text,text[]}
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(pose 'SRID=4326;Pose(Point(0 0),1)');
 -- Pose(POINT(0 0),1)
@@ -126,10 +128,12 @@ SELECT asEWKT(ARRAY[pose 'Pose(SRID=5676;Point(0 0),1)', 'Pose(SRID=5676;Point(1
 					<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 					<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB), the Hexadecimal Well-Known Binary (HexWKB), or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-					<para><varname>asBinary(pose,endian text='') → bytea</varname></para>
-					<para><varname>asEWKB(pose,endian text='') → bytea</varname></para>
-					<para><varname>asHexWKB(pose,endian text='') → text</varname></para>
-					<para><varname>asHexEWKB(pose,endian text='') → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asBinary(pose,endian text='') → bytea
+asEWKB(pose,endian text='') → bytea
+asHexWKB(pose,endian text='') → text
+asHexEWKB(pose,endian text='') → text
+</programlisting>
 					<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(pose 'Pose(Point(1 2),1)');
@@ -147,8 +151,10 @@ SELECT asHexEWKB(pose 'SRID=3812;Pose(Point(1 2),1)');
 					<indexterm significance="normal"><primary><varname>poseFromText</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poseFromEWKT</varname></primary></indexterm>
 					<para>Input from the Well-Known Text (WKT) or from the Extended Well-Known Text (EWKT) representation</para>
-					<para><varname>poseFromText(text) → pose</varname></para>
-					<para><varname>poseFromEWKT(text) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+poseFromText(text) → pose
+poseFromEWKT(text) → pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(poseFromText(text 'Pose(Point(1 2),1)'));
 -- Pose(POINT(1 2),1)
@@ -162,9 +168,11 @@ SELECT asEWKT(poseFromEWKT(text 'SRID=3812;Pose(Point(1 2),1)'));
 					<indexterm significance="normal"><primary><varname>poseFromEWKB</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poseFromHexEWKB</varname></primary></indexterm>
 					<para>Input from the Well-Known Binary (WKB), from the Extended Well-Known Binary (EWKB), or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-					<para><varname>poseFromBinary(bytea) → pose</varname></para>
-					<para><varname>poseFromEWKB(bytea) → pose</varname></para>
-					<para><varname>poseFromHexEWKB(text) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+poseFromBinary(bytea) → pose
+poseFromEWKB(bytea) → pose
+poseFromHexEWKB(text) → pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(poseFromBinary(
   '\x0101000000000000f03f0000000000000040000000000000f03f'));
@@ -186,9 +194,11 @@ SELECT asEWKT(poseFromHexEWKB(
 				<listitem xml:id="pose">
 					<indexterm significance="normal"><primary><varname>pose</varname></primary></indexterm>
 					<para>Constructor for poses</para>
-					<para><varname>pose(geompoint2D,float) → pose</varname></para>
-					<para><varname>pose(geompoint3D,float,float,float,float) → pose</varname></para>
-					<para><varname>pose(geompoint3D,yaw float,pitch float,roll float) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose(geompoint2D,float) → pose
+pose(geompoint3D,float,float,float,float) → pose
+pose(geompoint3D,yaw float,pitch float,roll float) → pose
+</programlisting>
 					<para>The three-angle form takes the orientation in the other encoding the OGC GeoPose v1.0 standard prescribes, a yaw / pitch / roll triple in radians under the ZYX intrinsic Tait-Bryan convention, and stores the quaternion it denotes. It is the inverse of <link linkend="pose_ypr"><varname>ypr</varname></link>.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(pose(ST_Point(1,1), radians(45)), 6);
@@ -212,9 +222,11 @@ SELECT asText(pose(ST_PointZ(1,1,1), radians(90), 0, 0), 6);
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 					<para>Convert a pose and, optionally, a timestamp or a period, into a spatiotemporal box</para>
-					<para><varname>pose::stbox</varname></para>
-					<para><varname>stbox(pose) → stbox</varname></para>
-					<para><varname>stbox(pose,{timestamptz,tstzspan}) → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose::stbox
+stbox(pose) → stbox
+stbox(pose,{timestamptz,tstzspan}) → stbox
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox(pose 'SRID=5676;Pose(Point(1 1),0.3)');
 -- SRID=5676;STBOX X((1,1),(1,1))
@@ -228,7 +240,9 @@ SELECT stbox(pose 'Pose(Point(1 1),0.3)', tstzspan '[2001-01-01,2001-01-02]');
 				<listitem xml:id="pose_geometry">
 					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 					<para>Convert a pose into geometry point</para>
-					<para><varname>pose::geompoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose::geompoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(pose(ST_Point(1, 1), 1)::geometry);
 -- Point(1 1)
@@ -245,7 +259,9 @@ SELECT ST_AsEWKT(pose(ST_PointZ(1, 1, 1, 5676), 1, 0, 0, 0)::geometry);
 				<listitem xml:id="pose_point">
 					<indexterm significance="normal"><primary><varname>point</varname></primary></indexterm>
 					<para>Return the point</para>
-					<para><varname>point(pose) → geompoint</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+point(pose) → geompoint
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(point(pose 'Pose(Point(1 1), 0.3)'));
 -- Point(1 1)
@@ -255,7 +271,9 @@ SELECT ST_AsText(point(pose 'Pose(Point(1 1), 0.3)'));
 				<listitem xml:id="pose_quaternion">
 					<indexterm significance="normal"><primary><varname>quaternion</varname></primary></indexterm>
 					<para>Return the orientation quaternion of a pose</para>
-					<para><varname>quaternion(pose) → quaternion</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+quaternion(pose) → quaternion
+</programlisting>
 					<para>The components are returned in the order <varname>W</varname>, <varname>X</varname>, <varname>Y</varname>, <varname>Z</varname>, the Hamilton convention in which a 3D pose stores them. This is one of the two orientation encodings the OGC GeoPose v1.0 standard prescribes; the other, yaw / pitch / roll, is given by <link linkend="pose_ypr"><varname>ypr</varname></link>. Both are defined for both dimensions: the orientation of a 2D pose is a turn about the local vertical by its stored angle, so it puts half that angle in <varname>W</varname> and <varname>Z</varname> and leaves <varname>X</varname> and <varname>Y</varname> at zero. This is the quaternion a GeoPose Basic-Quaternion document carries for a planar pose.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quaternion(pose 'Pose(Point Z(1 1 1), 0, 0, 0, 1)');
@@ -273,7 +291,9 @@ SELECT quaternion(pose 'Pose(Point(1 1), 0)');
 				<listitem xml:id="pose_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Round the point and the orientation of the pose to the number of decimal places</para>
-					<para><varname>round(pose,integer=0) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+round(pose,integer=0) → pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(pose(ST_Point(1.123456789,1.123456789), 0.123456789), 6));
 -- Pose(POINT(1.123457 1.123457),0.123457)
@@ -290,8 +310,10 @@ SELECT asText(round(pose(ST_Point(1.123456789,1.123456789), 0.123456789), 6));
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 					<para>Return or set the spatial reference identifier</para>
-					<para><varname>SRID(pose) → integer</varname></para>
-					<para><varname>setSRID(pose) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+SRID(pose) → integer
+setSRID(pose) → pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(pose 'Pose(SRID=5676;Point(1 1), 0.3)');
 -- 5676
@@ -304,8 +326,10 @@ SELECT asEWKT(setSRID(pose 'Pose(Point(0 0),1)', 4326));
 					<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 					<para>Transform to a spatial reference identifier</para>
-					<para><varname>transform(pose,integer) → pose</varname></para>
-					<para><varname>transformPipeline(pose,pipeline text,to_srid integer,is_forward boolean=true) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+transform(pose,integer) → pose
+transformPipeline(pose,pipeline text,to_srid integer,is_forward boolean=true) → pose
+</programlisting>
 					<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input pose has an unknown SRID (represented by 0).</para>
 					<para>For a 3D pose the orientation is re-expressed in the basis of the target frame at the pose's point. The correction is defined for the canonical OGC GeoPose pair, WGS-84 geographic (EPSG:4326) ↔ WGS-84 ECEF (EPSG:4978), and takes the standard East-North-Up basis at the geographic point as the rotation pivot. For any other pair of SRIDs, <varname>transform</varname> emits a <varname>NOTICE</varname> and passes the orientation through unchanged. For a 2D pose the angle is intrinsic to the source projection and is passed through unchanged.</para>
 					<para>The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format:</para>
@@ -348,9 +372,11 @@ FROM test;
 				<listitem xml:id="pose_distance_op">
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Return the distance</para>
-					<para><varname>distance({geo,stbox,pose},pose) → float</varname></para>
-					<para><varname>distance(pose,{geo,stbox,pose}) → float</varname></para>
-					<para><varname>{geo,stbox,pose} &lt;-&gt; pose → float</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+distance({geo,stbox,pose},pose) → float
+distance(pose,{geo,stbox,pose}) → float
+{geo,stbox,pose} &lt;-&gt; pose → float
+</programlisting>
 					<para>Only the point component of the pose is taken into account, the orientation is ignored. The distance is computed in two dimensions, even when the arguments are three-dimensional. The result is <varname>NULL</varname> when the geometry is empty.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
@@ -383,7 +409,9 @@ SELECT round(geometry 'Point empty' &lt;-&gt; pose 'Pose(Point(4 0),0)', 6);
 					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Traditional comparisons</para>
-					<para><varname>pose {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} pose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pose 'Pose(Point(3 3), 0.5)' = pose 'Pose(Point(3 3), 0.5)';
 -- true
@@ -404,7 +432,9 @@ SELECT pose 'Pose(Point(1 1), 0.6)' &gt;= pose 'Pose(Point(1 1), 0.5)';
 				<listitem xml:id="pose_same">
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Are the poses approximately equal with respect to an epsilon value?</para>
-					<para><varname>pose ~= pose → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+pose ~= pose → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pose 'Pose(SRID=5676;Point(1 1), 0.3)' ~=
   pose 'Pose(SRID=5676;Point(1 1.0000001), 0.30000001)';
@@ -475,8 +505,10 @@ SELECT tpose 'Point(0 0)@2001-01-01 08:05:00';
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 				<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation</para>
-				<para><varname>asText({tpose,tpose[]}) → {text,text[]}</varname></para>
-				<para><varname>asEWKT({tpose,tpose[]}) → {text,text[]}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({tpose,tpose[]}) → {text,text[]}
+asEWKT({tpose,tpose[]}) → {text,text[]}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpose 'SRID=4326;[Pose(Point(0 0),1)@2001-01-01, 
   Pose(Point(1 1),2)@2001-01-02)');
@@ -495,7 +527,9 @@ SELECT asEWKT(ARRAY[pose 'Pose(SRID=5676;Point(0 0),1)',
 			<listitem xml:id="tpose_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Return the Moving Features JSON (MF-JSON) representation</para>
-				<para><varname>asMFJSON(tpose) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tpose) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tpose 'Pose(Point(1 2),0.5)@2001-01-01', 3);
 /* {"type":"MovingPose","bbox":[[1,2],[1,2]],"period":{"begin":"2001-01-01T00:00:00",
@@ -517,10 +551,12 @@ SELECT asMFJSON(tpose 'Pose(Point Z(1 2 3),1,0,0,0)@2001-01-01', 3);
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB) representation, the Hexadecimal Well-Known Binary (HexWKB) representation, or the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-				<para><varname>asBinary(tpose,endian text='') → bytea</varname></para>
-				<para><varname>asEWKB(tpose,endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB(tpose,endian text='') → text</varname></para>
-				<para><varname>asHexEWKB(tpose,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(tpose,endian text='') → bytea
+asEWKB(tpose,endian text='') → bytea
+asHexWKB(tpose,endian text='') → text
+asHexEWKB(tpose,endian text='') → text
+</programlisting>
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tpose 'Pose(Point(1 2),1)@2001-01-01');
@@ -538,8 +574,10 @@ SELECT asHexEWKB(tpose 'SRID=3812;Pose(Point(1 2),1)@2001-01-01');
 				<indexterm significance="normal"><primary><varname>tposeFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeFromEWKT</varname></primary></indexterm>
 				<para>Input from the Well-Known Text (WKT) representation or from the Extended Well-Known Text (EWKT) representation</para>
-				<para><varname>tposeFromText(text) → tpose</varname></para>
-				<para><varname>tposeFromEWKT(text) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeFromText(text) → tpose
+tposeFromEWKT(text) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposeFromText(text '[Pose(Point(1 2),1)@2001-01-01, 
   Pose(Point(3 4),2)@2001-01-02]'));
@@ -553,7 +591,9 @@ SELECT asEWKT(tposeFromEWKT(text 'SRID=3812;[Pose(Point(1 2),1)@2001-01-01,
 			<listitem xml:id="tposeFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tposeFromMFJSON</varname></primary></indexterm>
 				<para>Input from the Moving Features JSON (MF-JSON) representation</para>
-				<para><varname>tposeFromMFJSON(bytea) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeFromMFJSON(bytea) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose 
   'SRID=3812;Pose(Point(1 2),0.5)@2001-01-01', 3)));
@@ -569,9 +609,11 @@ SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose
 				<indexterm significance="normal"><primary><varname>tposeFromEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeFromHexEWKB</varname></primary></indexterm>
 				<para>Input from the Well-Known Binary (WKB) representation, from the Extended Well-Known Binary (EWKB) representation, or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-				<para><varname>tposeFromBinary(bytea) → tpose</varname></para>
-				<para><varname>tposeFromEWKB(bytea) → tpose</varname></para>
-				<para><varname>tposeFromHexEWKB(text) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeFromBinary(bytea) → tpose
+tposeFromEWKB(bytea) → tpose
+tposeFromHexEWKB(text) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposeFromBinary(
   '\x013a0001000000000000f03f0000000000000040000000000000f03f009c57d3c11c0000'));
@@ -594,10 +636,12 @@ SELECT asEWKT(tposeFromHexEWKB(
 			<listitem xml:id="tpose_const">
 				<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
 				<para>Constructor for temporal poses having a constant value</para>
-				<para><varname>tpose(pose,timestamptz) → tposeInst</varname></para>
-				<para><varname>tpose(pose,tstzset) → tposeDiscSeq</varname></para>
-				<para><varname>tpose(pose,tstzspan,interp='linear') → tposeContSeq</varname></para>
-				<para><varname>tpose(pose,tstzspanset,interp='linear') → tposeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose(pose,timestamptz) → tposeInst
+tpose(pose,tstzset) → tposeDiscSeq
+tpose(pose,tstzspan,interp='linear') → tposeContSeq
+tpose(pose,tstzspanset,interp='linear') → tposeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpose('Pose(Point(1 1), 0.5)', timestamptz '2001-01-01'));
 -- Pose(Point(1 1),0.5)@2001-01-01
@@ -617,8 +661,10 @@ SELECT asText(tpose('Pose(Point(1 1), 0.2)',
 			<listitem xml:id="tposeSeq">
 				<indexterm significance="normal"><primary><varname>tposeSeq</varname></primary></indexterm>
 				<para>Constructor for temporal poses of sequence subtype</para>
-				<para><varname>tposeSeq(tposeInst[],interp={'step','linear'},leftInc boolean=true,</varname></para>
-				<para><varname>  rightInc boolean=true) → tposeSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeSeq(tposeInst[],interp={'step','linear'},leftInc boolean=true,
+  rightInc boolean=true) → tposeSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.3)@2001-01-01',
   'Pose(Point(2 2), 0.5)@2001-01-02', 'Pose(Point(1 1), 0.5)@2001-01-03']));
@@ -635,8 +681,10 @@ SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.2)@2001-01-01',
 				<indexterm significance="normal"><primary><varname>tposeSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeSeqSetGaps</varname></primary></indexterm>
 				<para>Constructor for temporal poses of sequence set subtype</para>
-				<para><varname>tposeSeqSet(tpose[]) → tposeSeqSet</varname></para>
-				<para><varname>tposeSeqSetGaps(tposeInst[],maxt=NULL,maxdist=NULL,interp='linear') → tposeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeSeqSet(tpose[]) → tposeSeqSet
+tposeSeqSetGaps(tposeInst[],maxt=NULL,maxdist=NULL,interp='linear') → tposeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposeSeqSet(ARRAY[tpose 
   '[Pose(Point(1 1),0.2)@2001-01-01, Pose(Point(2 2),0.4)@2001-01-02]', 
@@ -653,7 +701,9 @@ SELECT asText(tposeSeqSetGaps(ARRAY[tpose 'Pose(Point(1 1),0.1)@2001-01-01',
 			<listitem xml:id="tgeompoint_tfloat_tpose">
 				<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
 				<para>Construct a 2D temporal pose from a temporal geometry point and a temporal float</para>
-				<para><varname>tpose(tgeompoint, tfloat) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose(tgeompoint, tfloat) → tpose
+</programlisting>
 				<para>The time frame of the result is the intersection of the time frames of the temporal point and the temporal float. If they do not intersect, a null value is returned</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpose(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02)',
@@ -674,7 +724,9 @@ SELECT asText(tpose(tgeompoint '[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02)',
 			<listitem xml:id="tpose_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert a temporal pose into a temporal geometry point</para>
-				<para><varname>tpose::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tpose '[Pose(Point(1 1), 0.2)@2001-01-01,
   Pose(Point(1 1), 0.3)@2001-01-02)')::tgeompoint);
@@ -688,7 +740,9 @@ SELECT asEWKT((tpose '[Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)@2001-01-01,
 			<listitem xml:id="tpose_tgeogpoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert a geodetic temporal pose into a temporal geography point</para>
-				<para><varname>tpose::tgeogpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose::tgeogpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tpose '[GeodPose(Point(1 1), 0.2)@2001-01-01,
   GeodPose(Point(1 1), 0.3)@2001-01-02)')::tgeogpoint);
@@ -704,7 +758,9 @@ SELECT asText((tpose '[GeodPose(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tpose_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Return the values</para>
-				<para><varname>getValues(tpose) → poseset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tpose) → poseset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(getValues(tpose '{[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-02)}'));
@@ -718,7 +774,9 @@ SELECT asEWKT(getValues(tpose 'SRID=5676;{[Pose(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_points">
 				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
 				<para>Return the points</para>
-				<para><varname>points(tpose) → geomset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+points(tpose) → geomset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(points(tpose 'SRID=5676;{Pose(Point(3 3), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-02}'));
@@ -729,7 +787,9 @@ SELECT asEWKT(points(tpose 'SRID=5676;{Pose(Point(3 3), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_trajectory">
 				<indexterm significance="normal"><primary><varname>trajectory</varname></primary></indexterm>
 				<para>Return the trajectory</para>
-				<para><varname>trajectory(tpose) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trajectory(tpose) → geometry
+</programlisting>
 				<para>A pose has a position and an orientation but no extent, so the geometry it covers over time is the trajectory of its position, as for a temporal point. A pose that interpolates moves along the line between two consecutive positions; one that does not stands at each of them and covers nothing between them.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(trajectory(tpose '[Pose(Point(1 1),0.5)@2000-01-01, 
@@ -744,7 +804,9 @@ SELECT ST_AsText(trajectory(tpose 'Interp=Step;[Pose(Point(1 1),0.5)@2000-01-01,
 			<listitem xml:id="tpose_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(tpose,timestamptz) → pose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tpose,timestamptz) → pose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(valueAtTimestamp(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(3 3), 0.5)@2001-01-03)', '2001-01-02'));
@@ -759,7 +821,9 @@ SELECT asText(valueAtTimestamp(tpose
 			<listitem xml:id="tpose_speed">
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Return the speed of a temporal pose as a temporal float, the magnitude of the position-component velocity (distance travelled per unit time)</para>
-				<para><varname>speed(tpose) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+speed(tpose) → tfloat
+</programlisting>
 				<para>The orientation is not considered; for angular velocity see <varname>angularSpeed</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01 08:00,
@@ -772,7 +836,9 @@ SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01 08:00,
 			<listitem xml:id="tpose_angular_speed">
 				<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
 				<para>Return the angular speed of a temporal pose as a step-interpolated temporal float (radians per unit time)</para>
-				<para><varname>angularSpeed(tpose) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+angularSpeed(tpose) → tfloat
+</programlisting>
 				<para>For 2D poses this is the per-segment shortest-arc theta delta divided by the segment duration; for 3D poses it is the SLERP arc angle <varname>2 · acos(|q1 · q2|)</varname> divided by the segment duration. SLERP is by construction constant-angular-velocity along a segment, so the result is piecewise-constant.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- 90-degree yaw rotation over one day -> pi/2 rad / 86400 s
@@ -793,9 +859,11 @@ SELECT asText(angularSpeed(tpose
 				<indexterm significance="normal"><primary><varname>tposeSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tposeSeqSet</varname></primary></indexterm>
 				<para>Transform to another subtype</para>
-				<para><varname>tposeInst(tpose) → tposeInst</varname></para>
-				<para><varname>tposeSeq(tpose) → tposeSeq</varname></para>
-				<para><varname>tposeSeqSet(tpose) → tposeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tposeInst(tpose) → tposeInst
+tposeSeq(tpose) → tposeSeq
+tposeSeqSet(tpose) → tposeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposeSeq(tpose 'Pose(Point(1 1), 0.5)@2001-01-01', 'discrete'));
 -- {Pose(Point(1 1),0.5)@2001-01-01}
@@ -809,7 +877,9 @@ SELECT asText(tposeSeqSet(tpose 'Pose(PointZ(1 1 1), 0.5, 0.5, 0.5, 0.5)@2001-01
 			<listitem xml:id="tpose_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transform to another interpolation</para>
-				<para><varname>setInterp(tpose, interp) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(tpose, interp) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(setInterp(tpose 'Pose(Point(1 1),0.2)@2001-01-01','linear'));
 -- [Pose(Point(1 1),0.2)@2001-01-01]
@@ -822,7 +892,9 @@ SELECT asText(setInterp(tpose '{[Pose(Point Z(1 1 1),1,0,0,0)@2001-01-01],
 			<listitem xml:id="tpose_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Round the points and the orientations of the temporal pose to the number of decimal places</para>
-				<para><varname>round(tpose,integer=0) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tpose,integer=0) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(tpose '{[Pose(Point(1 1.123456789),0.123456789)@2001-01-01, 
   Pose(Point(1 1),0.5)@2001-01-02)}', 3));
@@ -839,8 +911,10 @@ SELECT asText(round(tpose '{[Pose(Point(1 1.123456789),0.123456789)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Append a temporal instant or a temporal sequence</para>
-				<para><varname>appendInstant(tpose,tposeInst) → tpose</varname></para>
-				<para><varname>appendSequence(tpose,tposeSeq) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(tpose,tposeInst) → tpose
+appendSequence(tpose,tposeSeq) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendInstant(tpose 'Pose(Point(1 1), 0.5)@2001-01-01',
   'Pose(Point(2 2), 1)@2001-01-02'));
@@ -855,10 +929,12 @@ SELECT asText(appendSequence(tpose '[Pose(Point(1 1), 0.5)@2001-01-01]',
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Merge the temporal poses</para>
-				<para><varname>merge(tpose,tpose) → tpose</varname></para>
-				<para><varname>merge(tpose[]) → tpose</varname></para>
-				<para><varname>merge(tpose) → tpose</varname></para>
-				<para><varname>mergeAgg(tpose) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(tpose,tpose) → tpose
+merge(tpose[]) → tpose
+merge(tpose) → tpose
+mergeAgg(tpose) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(tpose
   '[Pose(Point(1 1 1),1,0,0,0)@2001-01-01, Pose(Point(2 2 2),0,1,0,0)@2001-01-02]',
@@ -892,10 +968,12 @@ SELECT asText(merge(inst)) FROM temp;
 				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a value or a set of values</para>
-				<para><varname>atValue(tpose,value) → tpose</varname></para>
-				<para><varname>minusValue(tpose,value) → tpose</varname></para>
-				<para><varname>atValues(tpose,valueset) → tpose</varname></para>
-				<para><varname>minusValues(tpose,valueset) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(tpose,value) → tpose
+minusValue(tpose,value) → tpose
+atValues(tpose,valueset) → tpose
+minusValues(tpose,valueset) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atValue(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
   Pose(Point(2 2), 0.7)@2001-01-03]', 'Pose(Point(2 2), 0.5)');
@@ -911,8 +989,10 @@ SELECT minusValue(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a geometry</para>
-				<para><varname>atGeometry(tpose,geometry) → tpose</varname></para>
-				<para><varname>minusGeometry(tpose,geometry) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tpose,geometry) → tpose
+minusGeometry(tpose,geometry) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atGeometry(tpose '[Pose(Point(2 2), 0.3)@2001-01-01, 
   Pose(Point(2 2), 0.7)@2001-01-03]',
@@ -929,8 +1009,10 @@ SELECT minusGeometry(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
 				<para>Restrict to (the complement of) an elevation span</para>
-				<para><varname>atElevation(tpose,floatspan) → tpose</varname></para>
-				<para><varname>minusElevation(tpose,floatspan) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atElevation(tpose,floatspan) → tpose
+minusElevation(tpose,floatspan) → tpose
+</programlisting>
 				<para>The elevation of a pose is the elevation of its position, so the restriction keeps the times at which that position lies within the span. The temporal pose must have Z dimension.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
@@ -955,8 +1037,10 @@ SELECT asText(minusElevation(tpose '[Pose(Point(0 0 0),1,0,0,0)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Return or set the spatial reference identifier</para>
-				<para><varname>SRID(tpose) → integer</varname></para>
-				<para><varname>setSRID(tpose) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(tpose) → integer
+setSRID(tpose) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tpose 'SRID=5676;[Pose(Point(0 0),1)@2001-01-01, 
   Pose(Point(1 1),2)@2001-01-02)'));
@@ -971,8 +1055,10 @@ SELECT asEWKT(setSRID(tpose '[Pose(Point(0 0),1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transform to a spatial reference identifier</para>
-				<para><varname>transform(tpose,integer) → tpose</varname></para>
-				<para><varname>transformPipeline(tpose,pipeline text,to_srid integer,is_forward boolean=true) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(tpose,integer) → tpose
+transformPipeline(tpose,pipeline text,to_srid integer,is_forward boolean=true) → tpose
+</programlisting>
 				<para>Each instant's pose is transformed as the corresponding static pose is, orientation correction included, as described for <link linkend="pose_transform"><varname>transform</varname></link>. The same holds for a <varname>poseset</varname>. A <varname>trgeometry</varname> pairs its poses with a reference geometry that shares their frame, and transformation to another SRID is not supported for it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(tpose 'SRID=4326;Pose(Point(4.35 50.85),1)@2001-01-01', 
@@ -1004,7 +1090,9 @@ FROM test;
 				<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>-|-</varname></primary></indexterm>
 				<para>Topological operators</para>
-				<para><varname>{tstzspan,stbox,tpose} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tpose} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{tstzspan,stbox,tpose} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tpose} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-03]' &amp;&amp; tstzspan '[2001-01-02,2001-01-04]';
@@ -1022,10 +1110,12 @@ SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_pos">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Position operators</para>
-				<para><varname>{stbox,tpose} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tpose}  → boolean</varname></para>
-				<para><varname>{stbox,tpose} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tpose}  → boolean</varname></para>
-				<para><varname>{stbox,tpose} {&lt;&lt;/, &amp;&lt;/, /&gt;&gt;, /&amp;&gt;} {stbox,tpose}  → boolean</varname></para>
-				<para><varname>{tstzspan,stbox,tpose} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tpose} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{stbox,tpose} {&lt;&lt;, &amp;&lt;, &gt;&gt;, &amp;&gt;} {stbox,tpose}  → boolean
+{stbox,tpose} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tpose}  → boolean
+{stbox,tpose} {&lt;&lt;/, &amp;&lt;/, /&gt;&gt;, /&amp;&gt;} {stbox,tpose}  → boolean
+{tstzspan,stbox,tpose} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tpose} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-02]' &lt;&lt; stbox(pose 'Pose(Point(2 2), 0.5)');
@@ -1057,7 +1147,9 @@ SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-03,
 			<listitem xml:id="tpose_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Return the smallest distance ever</para>
-				<para><varname>{geo,pose,tpose,stbox} |=| {geo,pose,tpose,stbox} → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,pose,tpose,stbox} |=| {geo,pose,tpose,stbox} → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(2 2), 0.3)@2001-01-01, Pose(Point(2 2), 0.7)@2001-01-02]' |=|
   geometry 'Linestring(50 50,55 55)';
@@ -1078,7 +1170,9 @@ SELECT tpose '[Pose(Point(1 1), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_nearestApproachInstant">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Return the instant of the first temporal pose at which the two arguments are at the nearest distance</para>
-				<para><varname>nearestApproachInstant({geo,pose,tpose},{geo,pose,tpose}) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geo,pose,tpose},{geo,pose,tpose}) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(nearestApproachInstant(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
   Pose(Point(2 2), 0.7)@2001-01-02]', geometry 'Linestring(50 50,55 55)'));
@@ -1092,7 +1186,9 @@ SELECT asText(nearestApproachInstant(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Return the line connecting the nearest approach point</para>
-				<para><varname>shortestLine({geo,pose,tpose},{geo,pose,tpose}) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geo,pose,tpose},{geo,pose,tpose}) → geometry
+</programlisting>
 				<para>The function will only return the first line that it finds if there are more than one.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
@@ -1107,7 +1203,9 @@ SELECT ST_AsText(shortestLine(tpose '[Pose(Point(2 2), 0.3)@2001-01-01,
 			<listitem xml:id="tpose_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Return the temporal distance</para>
-				<para><varname>tpose &lt;-&gt; tpose → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose &lt;-&gt; tpose → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tpose '[Pose(Point(1 1), 0.3)@2001-01-01, 
   Pose(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt; pose 'Pose(Point(2 2), 0.2)', 6);
@@ -1145,20 +1243,22 @@ SELECT round(tpose '[Pose(Point(1 1), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 				<para>The <emphasis>ever</emphasis> and <emphasis>always</emphasis> relationships determine whether the topological or distance relationship is ever or always satisfied and result in a <varname>boolean</varname>. A temporal pose answers them at the position it occupies, so a value with linear interpolation is answered along its trajectory rather than at its instants alone. The temporal pose declares the relationships a moving point answers: <varname>eContains</varname>, <varname>aContains</varname>, <varname>eCovers</varname> and <varname>aCovers</varname> take the geometry first only, and <varname>eTouches</varname> and <varname>aTouches</varname> have no direction between two temporal poses, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
-				<para><varname>eContains(geometry,tpose) &#8594; boolean</varname></para>
-				<para><varname>eCovers(geometry,tpose) &#8594; boolean</varname></para>
-				<para><varname>eDisjoint({geometry,tpose},{geometry,tpose}) &#8594; boolean</varname></para>
-				<para><varname>eDwithin({geometry,tpose},{geometry,tpose},float) &#8594; boolean</varname></para>
-				<para><varname>eIntersects({geometry,tpose},{geometry,tpose}) &#8594; boolean</varname></para>
-				<para><varname>eTouches(geometry,tpose) &#8594; boolean</varname></para>
-				<para><varname>eTouches(tpose,geometry) &#8594; boolean</varname></para>
-				<para><varname>aContains(geometry,tpose) &#8594; boolean</varname></para>
-				<para><varname>aCovers(geometry,tpose) &#8594; boolean</varname></para>
-				<para><varname>aDisjoint({geometry,tpose},{geometry,tpose}) &#8594; boolean</varname></para>
-				<para><varname>aDwithin({geometry,tpose},{geometry,tpose},float) &#8594; boolean</varname></para>
-				<para><varname>aIntersects({geometry,tpose},{geometry,tpose}) &#8594; boolean</varname></para>
-				<para><varname>aTouches(geometry,tpose) &#8594; boolean</varname></para>
-				<para><varname>aTouches(tpose,geometry) &#8594; boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eContains(geometry,tpose) &#8594; boolean
+eCovers(geometry,tpose) &#8594; boolean
+eDisjoint({geometry,tpose},{geometry,tpose}) &#8594; boolean
+eDwithin({geometry,tpose},{geometry,tpose},float) &#8594; boolean
+eIntersects({geometry,tpose},{geometry,tpose}) &#8594; boolean
+eTouches(geometry,tpose) &#8594; boolean
+eTouches(tpose,geometry) &#8594; boolean
+aContains(geometry,tpose) &#8594; boolean
+aCovers(geometry,tpose) &#8594; boolean
+aDisjoint({geometry,tpose},{geometry,tpose}) &#8594; boolean
+aDwithin({geometry,tpose},{geometry,tpose},float) &#8594; boolean
+aIntersects({geometry,tpose},{geometry,tpose}) &#8594; boolean
+aTouches(geometry,tpose) &#8594; boolean
+aTouches(tpose,geometry) &#8594; boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
   tpose '[Pose(Point(1 1),0.1)@2001-01-01, Pose(Point(3 3),0.3)@2001-01-03]');
@@ -1190,13 +1290,15 @@ SELECT aDwithin(tpose '[Pose(Point(1 1),0.1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 				<para>The <emphasis>temporal</emphasis> relationships compute the topological or distance relationship at each instant and result in a <varname>tbool</varname>. A temporal pose answers them at the position it occupies, so a value with linear interpolation is answered along its trajectory rather than at its instants alone. The temporal pose declares the relationships a moving point answers: <varname>tContains</varname> and <varname>tCovers</varname> take the geometry first only, and <varname>tTouches</varname> has no direction between two temporal poses, since a moving point neither contains nor covers a geometry and two moving points do not touch.</para>
-				<para><varname>tContains(geometry,tpose) &#8594; tbool</varname></para>
-				<para><varname>tCovers(geometry,tpose) &#8594; tbool</varname></para>
-				<para><varname>tDisjoint({geometry,tpose},{geometry,tpose}) &#8594; tbool</varname></para>
-				<para><varname>tDwithin({geometry,tpose},{geometry,tpose},float) &#8594; tbool</varname></para>
-				<para><varname>tIntersects({geometry,tpose},{geometry,tpose}) &#8594; tbool</varname></para>
-				<para><varname>tTouches(geometry,tpose) &#8594; tbool</varname></para>
-				<para><varname>tTouches(tpose,geometry) &#8594; tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tpose) &#8594; tbool
+tCovers(geometry,tpose) &#8594; tbool
+tDisjoint({geometry,tpose},{geometry,tpose}) &#8594; tbool
+tDwithin({geometry,tpose},{geometry,tpose},float) &#8594; tbool
+tIntersects({geometry,tpose},{geometry,tpose}) &#8594; tbool
+tTouches(geometry,tpose) &#8594; tbool
+tTouches(tpose,geometry) &#8594; tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(tpose '[Pose(Point(1 1), 0.1)@2001-01-01,
   Pose(Point(3 3), 0.1)@2001-01-03]', geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))');
@@ -1229,7 +1331,9 @@ SELECT tDwithin(tpose '[Pose(Point(1 1),0.3)@2001-01-01,
 			<listitem xml:id="tpose_comp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Traditional comparisons</para>
-				<para><varname>tpose {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tpose → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tpose → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '{[Pose(Point(1 1), 0.1)@2001-01-01, 
   Pose(Point(1 1), 0.3)@2001-01-02),
@@ -1251,7 +1355,9 @@ SELECT tpose '[Pose(Point(1 1), 0.1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<para>Ever and always comparisons</para>
-				<para><varname>tpose {?=, %=} tpose → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose {?=, %=} tpose → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(1 1), 0.2)@2001-01-01, 
   Pose(Point(1 1), 0.4)@2001-01-04)' ?= Pose(Point(1 1), 0.3);
@@ -1265,7 +1371,9 @@ SELECT tpose '[Pose(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tpose_tcomp">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Temporal comparisons</para>
-				<para><varname>tpose {#=, #&lt;&gt;} tpose → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose {#=, #&lt;&gt;} tpose → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpose '[Pose(Point(1 1), 0.2)@2001-01-01, 
   Pose(Point(1 1), 0.4)@2001-01-03)' #= pose 'Pose(Point(1 1), 0.3)';
@@ -1287,7 +1395,9 @@ SELECT tpose '[Pose(Point(1 1), 0.2)@2001-01-01,
 			<listitem xml:id="tpose_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
-				<para><varname>tCount(tpose) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tpose) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tpose '[Pose(Point(1 1), 0.1)@2001-01-01, 
@@ -1305,7 +1415,9 @@ FROM Temp;
 			<listitem xml:id="tpose_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Window count</para>
-				<para><varname>wCount(tpose) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tpose) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tpose '[Pose(Point(1 1), 0.1)@2001-01-01, 
@@ -1358,8 +1470,10 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>poseFromGeoPose</varname></primary></indexterm>
 					<para>Convert to or from the OGC GeoPose v1.0 JSON encoding (Basic-Quaternion, Basic-YPR or Advanced conformance class)</para>
-					<para><varname>asGeoPose(pose,conformance integer=0,maxdecimaldigits integer=-1) → text</varname></para>
-					<para><varname>poseFromGeoPose(text) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPose(pose,conformance integer=0,maxdecimaldigits integer=-1) → text
+poseFromGeoPose(text) → pose
+</programlisting>
 					<para>The <varname>conformance</varname> argument selects the output class: <varname>0</varname> = Basic-Quaternion (default, lossless), <varname>1</varname> = Basic-YPR (yaw, pitch, roll in degrees, ZYX intrinsic Tait-Bryan), <varname>2</varname> = Advanced. The <varname>maxdecimaldigits</varname> argument is the number of significant digits to keep in the JSON numbers; <varname>-1</varname> uses json-c's lossless default. The input function auto-detects the conformance class from the JSON keys, where a <varname>frameSpecification</varname> member implies Advanced, a <varname>quaternion</varname> member implies Basic-Quaternion, and an <varname>angles</varname> member implies Basic-YPR.</para>
 					<para>The Basic classes carry the position in a <varname>position</varname> member and leave the frame implicit. The Advanced class has no position member: it names its outer frame explicitly, and the pose sits at the origin of that frame, so the two encodings of one pose read back equal. Every class mandates a geographic outer frame, so the pose must be geodetic; a planar pose is rejected at the conversion boundary, as is a projected SRID.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1386,7 +1500,9 @@ SELECT asEWKT(poseFromGeoPose(
 				<listitem xml:id="pose_normalize">
 					<indexterm significance="normal"><primary><varname>poseNormalize</varname></primary></indexterm>
 					<para>Return a pose whose orientation quaternion has been transformed to a unit norm</para>
-					<para><varname>poseNormalize(pose) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+poseNormalize(pose) → pose
+</programlisting>
 					<para>A 2D pose is returned unchanged since its orientation is a single angle. A 3D pose has its quaternion divided by its Euclidean norm, so long compositions of SLERPs (or any other path that accumulates floating-point drift in <varname>|q|</varname>) can be brought back to the <varname>|q| = 1</varname> invariant required by the SLERP and Euler-decomposition code.</para>
 
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1398,7 +1514,9 @@ SELECT asText(poseNormalize(pose 'Pose(Point(1 1 1), 0.5, 0.5, 0.5, 0.5)'));
 				<listitem xml:id="pose_inverse">
 					<indexterm significance="normal"><primary><varname>poseInverse</varname></primary></indexterm>
 					<para>Return the inverse of a pose</para>
-					<para><varname>poseInverse(pose) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+poseInverse(pose) → pose
+</programlisting>
 					<para>The inverse reverses the frame relationship: where a pose carries a value from the frame it names into the frame it is expressed in, the inverse carries it back. It is <varname>R_BA = R_AB^T</varname> and <varname>t_BA = −R_AB^T t_AB</varname>, so composing a pose with its inverse gives the identity. This is what expresses a world position in the frame of a vehicle.</para>
 					<para>A pose over a geographic frame has no inverse: the frame it would name is not a frame of the ellipsoid.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1422,9 +1540,11 @@ SELECT asEWKT(round(poseInverse(pose 'Pose(Point(1 0 0), 0, 0, 0, 1)'), 6));
 					<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
 					<para>Return the yaw, pitch, or roll angle of a (temporal) pose, in radians, under the ZYX intrinsic Tait-Bryan convention required by the OGC GeoPose Basic-YPR conformance class</para>
-					<para><varname>yaw({pose,tpose}) → {float,tfloat}</varname></para>
-					<para><varname>pitch({pose,tpose}) → {float,tfloat}</varname></para>
-					<para><varname>roll({pose,tpose}) → {float,tfloat}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+yaw({pose,tpose}) → {float,tfloat}
+pitch({pose,tpose}) → {float,tfloat}
+roll({pose,tpose}) → {float,tfloat}
+</programlisting>
 					<para>For a 2D pose <varname>yaw</varname> returns the stored rotation <varname>theta</varname>, by convention the yaw of the body frame, and <varname>pitch</varname> and <varname>roll</varname> return <varname>0</varname>. For a 3D pose the three values come from the ZYX intrinsic Tait-Bryan decomposition of the orientation quaternion. The <varname>asin</varname> pitch term is clamped to <varname>[-1, 1]</varname> to absorb the small numeric drift that long quaternion compositions can introduce.</para>
 					<para>On a temporal pose the interpolation of the result follows the dimension. A 2D pose interpolates its stored angle linearly and that angle is its yaw, so a linear 2D <varname>tpose</varname> projects to a linear <varname>tfloat</varname>. A 3D pose interpolates by SLERP, whose Tait-Bryan decomposition is not linear in time, so a 3D <varname>tpose</varname> projects to a step <varname>tfloat</varname>: reading it between two instants answers the angle of the instant on the left rather than an angle no pose holds.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1447,7 +1567,9 @@ SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
 				<listitem xml:id="pose_ypr">
 					<indexterm significance="normal"><primary><varname>ypr</varname></primary></indexterm>
 					<para>Return the orientation of a pose as a yaw / pitch / roll triple, in radians</para>
-					<para><varname>ypr(pose) → ypr</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+ypr(pose) → ypr
+</programlisting>
 					<para>This is the OGC GeoPose Basic-YPR encoding of the orientation, the counterpart of <link linkend="pose_quaternion"><varname>quaternion</varname></link>, and it returns the three angles <link linkend="pose_yaw_pitch_roll"><varname>yaw</varname></link>, <varname>pitch</varname> and <varname>roll</varname> answer one at a time. Like <varname>quaternion</varname>, it is defined for both dimensions: a 2D pose yaws by its stored angle and neither pitches nor rolls. The angles are in radians, where the GeoPose JSON encoding writes them in degrees.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ypr(pose 'Pose(Point(1 1), 0.5)');
@@ -1464,9 +1586,11 @@ SELECT ypr(pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)');
 					<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
 					<para>Lift the Euler angle accessors over a temporal pose, returning a temporal float in radians</para>
-					<para><varname>yaw(tpose) → tfloat</varname></para>
-					<para><varname>pitch(tpose) → tfloat</varname></para>
-					<para><varname>roll(tpose) → tfloat</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+yaw(tpose) → tfloat
+pitch(tpose) → tfloat
+roll(tpose) → tfloat
+</programlisting>
 					<para>The result carries step interpolation, since an angle read from a rotation does not vary linearly between two poses.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(yaw(tpose '[Pose(Point(0 0),0.5)@2001-01-01,
@@ -1500,7 +1624,9 @@ FROM geopose_frames ORDER BY frame_id;
 				<listitem xml:id="pose_geopose_frames_fn">
 					<indexterm significance="normal"><primary><varname>geoPoseFrames</varname></primary></indexterm>
 					<para>Return every frame the standard and the encoders name</para>
-					<para><varname>geoPoseFrames() &#x2192; setof record</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geoPoseFrames() &#x2192; setof record
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT count(*) FROM geoPoseFrames();
 -- 8
@@ -1512,7 +1638,9 @@ SELECT count(*) FROM geoPoseFrames();
 				<listitem xml:id="pose_geopose_frame_srid">
 					<indexterm significance="normal"><primary><varname>geoPoseFrameSRID</varname></primary></indexterm>
 					<para>Return the SRID for a frame, or <varname>NULL</varname> if the frame is parametric (LTP, BODY)</para>
-					<para><varname>geoPoseFrameSRID(int) → int</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geoPoseFrameSRID(int) → int
+</programlisting>
 								<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoPoseFrameSRID(1), geoPoseFrameSRID(2);
 -- 4326 | 4978
@@ -1523,7 +1651,9 @@ SELECT geoPoseFrameSRID(3);
 				<listitem xml:id="pose_geopose_frame_name">
 					<indexterm significance="normal"><primary><varname>geoPoseFrameName</varname></primary></indexterm>
 					<para>Return the human-readable name of a frame</para>
-					<para><varname>geoPoseFrameName(int) → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geoPoseFrameName(int) → text
+</programlisting>
 								<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoPoseFrameName(1);
 -- WGS-84 geographic (lat/lon/h)
@@ -1534,7 +1664,9 @@ SELECT geoPoseFrameName(2), geoPoseFrameName(3);
 				<listitem xml:id="pose_geopose_frame_is_geographic">
 					<indexterm significance="normal"><primary><varname>geoPoseFrameIsGeographic</varname></primary></indexterm>
 					<para>Return <varname>true</varname> for lat/lon/h frames, <varname>false</varname> for Cartesian or projected</para>
-					<para><varname>geoPoseFrameIsGeographic(int) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+geoPoseFrameIsGeographic(int) → boolean
+</programlisting>
 								<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoPoseFrameIsGeographic(1), geoPoseFrameIsGeographic(2);
 -- true | false
@@ -1550,9 +1682,11 @@ SELECT geoPoseFrameIsGeographic(1), geoPoseFrameIsGeographic(2);
 				<listitem xml:id="pose_applyPose">
 					<indexterm significance="normal"><primary><varname>applyPose</varname></primary></indexterm>
 					<para>Applies the rigid-body transform encoded by a pose (the OGC GeoPose <emphasis>body to world</emphasis> mapping) to a body-frame geometry, producing the corresponding world-frame geometry</para>
-					<para><varname>applyPose(geometry, pose) → geometry</varname></para>
-					<para><varname>applyPose(geometry, tpose) → tgeompoint</varname></para>
-					<para><varname>applyPose(pose, pose) → pose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+applyPose(geometry, pose) → geometry
+applyPose(geometry, tpose) → tgeompoint
+applyPose(pose, pose) → pose
+</programlisting>
 					<para>The transform is</para>
 					<programlisting xml:space="preserve" format="linespecific">
 world = R(q) · body + p
@@ -1573,10 +1707,12 @@ SELECT ST_AsText(applyPose(ST_MakeEnvelope(-2,-1,2,1),
 -- POLYGON((8 19,8 21,12 21,12 19,8 19))
 </programlisting>
 					<para>Either frame may move. Applying a pose to a <varname>tpose</varname> carries a fixed body through the whole movement of its parent, which is what a sensor mounted on a moving vehicle asks for; applying a <varname>tpose</varname> to a pose carries a moving body into a frame that stands still; and applying a <varname>tpose</varname> to a <varname>tpose</varname> composes two frames that both move, over the time they share. <varname>poseInverse</varname> lifts the same way, changing the point of view onto a moving object for the whole of its movement.</para>
-					<para><varname>applyPose(pose, tpose) &#8594; tpose</varname></para>
-					<para><varname>applyPose(tpose, pose) &#8594; tpose</varname></para>
-					<para><varname>applyPose(tpose, tpose) &#8594; tpose</varname></para>
-					<para><varname>poseInverse(tpose) &#8594; tpose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+applyPose(pose, tpose) &#8594; tpose
+applyPose(tpose, pose) &#8594; tpose
+applyPose(tpose, tpose) &#8594; tpose
+poseInverse(tpose) &#8594; tpose
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- A sensor one unit ahead of a body that ends yawed a quarter turn at
 -- (10, 20) ends one unit north of it
@@ -1610,8 +1746,10 @@ SELECT asEWKT(round(applyPose(pose 'Pose(Point(1 0 0), 1, 0, 0, 0)',
 					<indexterm significance="normal"><primary><varname>asGeoPose</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tposeFromGeoPose</varname></primary></indexterm>
 					<para>Convert a temporal pose to or from its OGC GeoPose v1.0 encoding</para>
-					<para><varname>asGeoPose(tpose,conformance integer=0,maxdecimaldigits integer=-1) → text</varname></para>
-					<para><varname>tposeFromGeoPose(text) → tpose</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPose(tpose,conformance integer=0,maxdecimaldigits integer=-1) → text
+tposeFromGeoPose(text) → tpose
+</programlisting>
 					<para>The conformance class follows from the value. A single instant is a Basic document carrying its <varname>validTime</varname>; a sequence or sequence set is a Composite Sequence Series, of the Regular class when the instants are equally spaced by a whole number of milliseconds and of the Irregular class otherwise. The <varname>conformance</varname> argument chooses the orientation encoding of a Basic document, as it does for a <varname>pose</varname>, and has no effect on a Series, whose inner frames carry a quaternion and offer no such choice.</para>
 					<para>A Series states its outer frame once, as the local tangent plane East-North-Up frame at the position of the first pose, and gives each pose as an inner frame holding its translation from that tangent point, in metres, and its rotation relative to that frame's basis. Times are <varname>GeoPose_Instant</varname> values, that is Unix time in integer milliseconds, which is what the standard requires of every time position it defines. Sub-millisecond sampling is therefore not carried; the MF-JSON encoding, which the standard behind it types as a datetime string, does carry it.</para>
 					<para>The transition model reports the interpolation. Linear interpolation is the standard's <varname>interpolate</varname> model and step and discrete interpolation are its <varname>none</varname> model; since those two identifiers cannot tell step from discrete apart, the model's <varname>parameters</varname> name the interpolation with the same words the MF-JSON encoding uses.</para>
@@ -1698,7 +1836,9 @@ SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01,
 				<listitem xml:id="tpose_geopose_stream">
 					<indexterm significance="normal"><primary><varname>asGeoPoseStream</varname></primary></indexterm>
 					<para>Write a temporal pose as an OGC GeoPose Stream</para>
-					<para><varname>asGeoPoseStream(tpose,maxdecimaldigits integer=-1) → text</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+asGeoPoseStream(tpose,maxdecimaldigits integer=-1) → text
+</programlisting>
 					<para>A stream carries the frames of an Irregular Series while stating neither how many poses there are nor when they end, since more may arrive. The standard writes it as a <varname>header</varname>, holding the transition model and the outer frame, and a <varname>streamElements</varname> array holding one element per pose. The outer frame is the local tangent plane East-North-Up frame at the position of the first pose, so the header and every element speak of one tangent point.</para>
 					<para>The C library also writes the two documents a piece at a time, through <varname>tpose_as_geopose_stream_header</varname> and <varname>tpose_as_geopose_stream_element</varname>, for a producer emitting poses as they arrive. A query returns a value it already holds whole, which is what this writes.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -59,8 +59,10 @@ SELECT tquadbinFromMFJSON(asMFJSON(tquadbin '480fffffffffffff@2001-01-01'));
 			<listitem xml:id="tquadbin_tbigint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert between a <varname>tquadbin</varname> and a <varname>tbigint</varname> (explicit, zero-cost)</para>
-				<para><varname>tbigint::tquadbin</varname></para>
-				<para><varname>tquadbin::tbigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tbigint::tquadbin
+tquadbin::tbigint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tbigint '5192650370358181887@2001-01-01')::tquadbin;
 -- 480fffffffffffff@2001-01-01
@@ -73,7 +75,9 @@ SELECT ((tquadbin '480fffffffffffff@2001-01-01')::tbigint)::tquadbin
 			<listitem xml:id="tquadbin_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Cast a temporal QUADBIN cell to a temporal planar (SRID 4326) point of cell centroids. The cast delegates to <varname>tquadbinCellToPoint</varname>.</para>
-				<para><varname>tquadbin::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tquadbin::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tquadbin '480fffffffffffff@2001-01-01')::tgeompoint;
 </programlisting>
@@ -90,7 +94,9 @@ SELECT (tquadbin '480fffffffffffff@2001-01-01')::tgeompoint;
 			<listitem xml:id="quadbin_is_valid_index">
 				<indexterm significance="normal"><primary><varname>isValidIndex</varname></primary></indexterm>
 				<para>Return whether a value is a structurally valid QUADBIN identifier (correct header tag and resolution field)</para>
-				<para><varname>isValidIndex(quadbin) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidIndex(quadbin) → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidIndex(quadbin '480fffffffffffff');
 -- t
@@ -104,7 +110,9 @@ SELECT isValidIndex(0::bigint::quadbin);
 			<listitem xml:id="quadbin_is_valid_cell">
 				<indexterm significance="normal"><primary><varname>isValidCell</varname></primary></indexterm>
 				<para>Return whether a value is a valid QUADBIN cell (a valid index whose tile coordinates fall within the bounds of its resolution)</para>
-				<para><varname>isValidCell(quadbin) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidCell(quadbin) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidCell(quadbin '480fffffffffffff');
 -- true
@@ -122,8 +130,10 @@ SELECT isValidCell(quadbin '0');
 				<indexterm significance="normal"><primary><varname>startValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<para>Return the first or last QUADBIN cell identifier of a temporal value</para>
-				<para><varname>startValue(tquadbin) → quadbin</varname></para>
-				<para><varname>endValue(tquadbin) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(tquadbin) → quadbin
+endValue(tquadbin) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(tquadbin '480fffffffffffff@2001-01-01');
 -- 480fffffffffffff
@@ -135,7 +145,9 @@ SELECT endValue(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01
 			<listitem xml:id="tquadbin_valueN">
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
 				<para>Return the <varname>n</varname>th distinct QUADBIN cell identifier (1-indexed). Returns <varname>NULL</varname> if out of range.</para>
-				<para><varname>valueN(tquadbin,integer) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueN(tquadbin,integer) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}', 1);
 -- 480fffffffffffff
@@ -149,7 +161,9 @@ SELECT valueN(tquadbin '480fffffffffffff@2001-01-01', 99);
 			<listitem xml:id="tquadbin_getValues">
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<para>Return the set of distinct QUADBIN cell identifiers the trajectory takes</para>
-				<para><varname>getValues(tquadbin) → quadbinset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(tquadbin) → quadbinset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(tquadbin '480fffffffffffff@2001-01-01');
 -- {480fffffffffffff}
@@ -163,7 +177,9 @@ SELECT getValues(tquadbin
 			<listitem xml:id="tquadbin_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the QUADBIN cell identifier at a given timestamp, using step interpolation</para>
-				<para><varname>valueAtTimestamp(tquadbin,timestamptz) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(tquadbin,timestamptz) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tquadbin
   '[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-05]',
@@ -181,8 +197,10 @@ SELECT valueAtTimestamp(tquadbin
 				<indexterm significance="normal"><primary><varname>quadbinGetResolution</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinGetResolution</varname></primary></indexterm>
 				<para>Return the resolution (zoom) level (0–26) of a cell. The static form returns an <varname>integer</varname>; the temporal form returns the resolution of each cell in a trajectory as a <varname>tint</varname>.</para>
-				<para><varname>quadbinGetResolution(quadbin) → integer</varname></para>
-				<para><varname>tquadbinGetResolution(tquadbin) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinGetResolution(quadbin) → integer
+tquadbinGetResolution(tquadbin) → tint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinGetResolution(quadbin '480fffffffffffff');
 -- 0
@@ -194,7 +212,9 @@ SELECT tquadbinGetResolution(tquadbin '48427fffffffffff@2001-01-01');
 			<listitem xml:id="tquadbin_quadbin_is_valid_cell">
 				<indexterm significance="normal"><primary><varname>isValidCell</varname></primary></indexterm>
 				<para>Return a temporal boolean stating at each instant whether the value is a valid QUADBIN cell</para>
-				<para><varname>isValidCell(tquadbin) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isValidCell(tquadbin) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isValidCell(tquadbin '480fffffffffffff@2001-01-01');
 -- t@2001-01-01
@@ -210,8 +230,10 @@ SELECT isValidCell(tquadbin '480fffffffffffff@2001-01-01');
 				<indexterm significance="normal"><primary><varname>quadbinCellToParent</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToParent</varname></primary></indexterm>
 				<para>Return the parent cell at the given coarser resolution. The static form takes a single <varname>quadbin</varname>; the temporal form returns the parent of each cell in a trajectory.</para>
-				<para><varname>quadbinCellToParent(quadbin,integer) → quadbin</varname></para>
-				<para><varname>tquadbinCellToParent(tquadbin,integer) → tquadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToParent(quadbin,integer) → quadbin
+tquadbinCellToParent(tquadbin,integer) → tquadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToParent(quadbin '48a6227affffffff', 5);
 -- 485623ffffffffff
@@ -224,7 +246,9 @@ SELECT tquadbinGetResolution(
 			<listitem xml:id="tquadbin_quadbin_cell_to_children">
 				<indexterm significance="normal"><primary><varname>quadbinCellToChildren</varname></primary></indexterm>
 				<para>Return the four child cells at the requested finer resolution as a <varname>quadbinset</varname>. This is a static set-returning helper on a single <varname>quadbin</varname>; it has no temporal lift (children are a per-instant set, deferred pending a <varname>tset&lt;T&gt;</varname> primitive).</para>
-				<para><varname>quadbinCellToChildren(quadbin,integer) → quadbinset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToChildren(quadbin,integer) → quadbinset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToChildren(quadbin '480fffffffffffff', 1);
 -- {4813ffffffffffff, 4817ffffffffffff, 481bffffffffffff, 481fffffffffffff}
@@ -234,7 +258,9 @@ SELECT quadbinCellToChildren(quadbin '480fffffffffffff', 1);
 			<listitem xml:id="tquadbin_quadbin_cell_sibling">
 				<indexterm significance="normal"><primary><varname>quadbinCellSibling</varname></primary></indexterm>
 				<para>Return the neighbouring cell at the same resolution in the given direction (<varname>up</varname> / <varname>down</varname> / <varname>left</varname> / <varname>right</varname>)</para>
-				<para><varname>quadbinCellSibling(quadbin,text) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellSibling(quadbin,text) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellSibling(
   quadbinCellSibling(quadbin '48427fffffffffff', 'right'), 'left')
@@ -246,7 +272,9 @@ SELECT quadbinCellSibling(
 			<listitem xml:id="tquadbin_quadbin_grid_disk">
 				<indexterm significance="normal"><primary><varname>quadbinGridDisk</varname></primary></indexterm>
 				<para>Return all cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0), as a <varname>quadbinset</varname>. On the square grid the disk at step <varname>k</varname> is the <varname>(2k+1)</varname>×<varname>(2k+1)</varname> square block of cells centred on the origin.</para>
-				<para><varname>quadbinGridDisk(quadbin,integer) → quadbinset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinGridDisk(quadbin,integer) → quadbinset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 0));  -- 1
 SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 1));  -- 9
@@ -262,7 +290,9 @@ SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 2));  -- 25
 			<listitem xml:id="tquadbin_quadbin_point_to_cell">
 				<indexterm significance="normal"><primary><varname>geoToQuadbinCell</varname></primary></indexterm>
 				<para>Return the QUADBIN cell at the given resolution that contains a point geometry. The geometry must be a <varname>POINT</varname>; longitudes are interpreted in SRID 4326.</para>
-				<para><varname>geoToQuadbinCell(geometry,integer) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoToQuadbinCell(geometry,integer) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
   = quadbin '48a6227affffffff';
@@ -274,8 +304,10 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 				<indexterm significance="normal"><primary><varname>quadbinCellToPoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToPoint</varname></primary></indexterm>
 				<para>Return the centroid of a cell as an SRID-4326 point. The static form takes a single <varname>quadbin</varname>; the temporal form returns the centroid of each cell in a trajectory as a <varname>tgeompoint</varname>.</para>
-				<para><varname>quadbinCellToPoint(quadbin) → geometry</varname></para>
-				<para><varname>tquadbinCellToPoint(tquadbin) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToPoint(quadbin) → geometry
+tquadbinCellToPoint(tquadbin) → tgeompoint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(quadbinCellToPoint(quadbin '48427fffffffffff'));
 -- POINT(-101.25 48.92249926375824)
@@ -290,8 +322,10 @@ SELECT asText(tquadbinCellToPoint(tquadbin
 				<indexterm significance="normal"><primary><varname>quadbinCellToBoundary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToBoundary</varname></primary></indexterm>
 				<para>Return the square polygon boundary of a cell as an SRID-4326 geometry. The static form takes a single <varname>quadbin</varname>; the temporal form returns the boundary of each cell in a trajectory as a <varname>tgeometry</varname>.</para>
-				<para><varname>quadbinCellToBoundary(quadbin) → geometry</varname></para>
-				<para><varname>tquadbinCellToBoundary(tquadbin) → tgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToBoundary(quadbin) → geometry
+tquadbinCellToBoundary(tquadbin) → tgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(quadbinCellToBoundary(quadbin '480fffffffffffff'));
 -- POLYGON((-180 -85.0511287798066,180 -85.0511287798066,
@@ -311,7 +345,9 @@ SELECT ST_AsText(quadbinCellToBoundary(quadbin '480fffffffffffff'));
 			<listitem xml:id="tquadbin_quadbin_tile_to_cell">
 				<indexterm significance="normal"><primary><varname>quadbinTileToCell</varname></primary></indexterm>
 				<para>Build a cell from slippy-map tile coordinates: column <varname>x</varname>, row <varname>y</varname>, and zoom <varname>z</varname></para>
-				<para><varname>quadbinTileToCell(integer,integer,integer) → quadbin</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinTileToCell(integer,integer,integer) → quadbin
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinTileToCell(0, 0, 0) = quadbin '480fffffffffffff';
 -- true
@@ -325,7 +361,9 @@ SELECT quadbinTileToCell(524, 343, 10) = quadbin '48a6227affffffff';
 			<listitem xml:id="tquadbin_quadbin_cell_to_tile">
 				<indexterm significance="normal"><primary><varname>quadbinCellToTile</varname></primary></indexterm>
 				<para>Decompose a cell back into its tile coordinate triple, returned as an integer array <varname>{x, y, z}</varname>, the inverse of <varname>quadbinTileToCell</varname></para>
-				<para><varname>quadbinCellToTile(quadbin) → integer[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToTile(quadbin) → integer[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToTile(quadbin '480fffffffffffff');
 -- {0,0,0}
@@ -338,8 +376,10 @@ SELECT quadbinCellToTile(quadbin '48a6227affffffff');
 				<indexterm significance="normal"><primary><varname>quadbinCellToQuadkey</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToQuadkey</varname></primary></indexterm>
 				<para>Emit the base-4 slippy-tile quadkey string of a cell (one digit per zoom level, MSB-first; the resolution-0 world cell maps to the empty string). The static form takes a single <varname>quadbin</varname>; the temporal form returns the quadkey of each cell in a trajectory as a <varname>ttext</varname>.</para>
-				<para><varname>quadbinCellToQuadkey(quadbin) → text</varname></para>
-				<para><varname>tquadbinCellToQuadkey(tquadbin) → ttext</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellToQuadkey(quadbin) → text
+tquadbinCellToQuadkey(tquadbin) → ttext
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToQuadkey(quadbin '480fffffffffffff');
 -- (empty string)
@@ -359,8 +399,10 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
 				<indexterm significance="normal"><primary><varname>quadbinCellArea</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellArea</varname></primary></indexterm>
 				<para>Return the area of a cell on the sphere, in square metres. The static form takes a single <varname>quadbin</varname>; the temporal form returns the area of each cell in a trajectory as a <varname>tfloat</varname>. Cell area shrinks toward the poles, as web-mercator squares cover progressively less ground at higher latitudes.</para>
-				<para><varname>quadbinCellArea(quadbin) → float8</varname></para>
-				<para><varname>tquadbinCellArea(tquadbin) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbinCellArea(quadbin) → float8
+tquadbinCellArea(tquadbin) → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(quadbinCellArea(quadbin '480fffffffffffff')::numeric, 0);
 -- 508164135963886
@@ -383,7 +425,9 @@ SELECT round(quadbinCellArea(quadbin '48427fffffffffff')::numeric, 0);
 			<listitem xml:id="tquadbin_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
-				<para><varname>tCount(tquadbin) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(tquadbin) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03)' UNION
@@ -398,7 +442,9 @@ FROM Temp;
 			<listitem xml:id="tquadbin_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Window count</para>
-				<para><varname>wCount(tquadbin) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tquadbin) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
   SELECT tquadbin '[480fffffffffffff@2001-01-01, 480fffffffffffff@2001-01-03)' UNION

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -31,7 +31,9 @@ CREATE EXTENSION mobilitydb CASCADE;
 			<listitem xml:id="raster_rasterValue">
 				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
 				<para>Sample a raster band at each instant of a trajectory</para>
-				<para><varname>rasterValue(tgeompoint,raster,band integer DEFAULT 1) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rasterValue(tgeompoint,raster,band integer DEFAULT 1) → tfloat
+</programlisting>
 				<para>Evaluates pixel <varname>band</varname> at every instant of <varname>traj</varname> using bilinear-nearest sampling (<varname>ST_Value</varname> with <varname>resample=false</varname>). Returns an instant-set <varname>tfloat</varname> whose values are rounded to four decimal places. Returns <varname>NULL</varname> when no instant intersects the raster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
@@ -74,7 +76,9 @@ WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
 			<listitem xml:id="raster_numBands">
 				<indexterm significance="normal"><primary><varname>numBands</varname></primary></indexterm>
 				<para>Return the number of bands of a raster</para>
-				<para><varname>numBands(raster) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numBands(raster) → integer
+</programlisting>
 				<para>The band number accepted by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> and by the operators built on it ranges from 1 to this value.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH rast1 AS (
@@ -116,7 +120,9 @@ WHERE quadbin = ANY(quadbins(traj, 8));
 			<listitem xml:id="raster_quadbins">
 				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
 				<para>Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
-				<para><varname>quadbins(tgeompoint,integer) → bigint[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbins(tgeompoint,integer) → bigint[]
+</programlisting>
 				<para>Returns the set of unique QUADBIN cells (deduplicated) whose Web-Mercator tile envelopes contain at least one instant of <varname>traj</varname>. The result is suitable as a WHERE-clause join key against a Raquet table. <varname>zoom</varname> must be in [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Three instants spanning three tiles at zoom 3
@@ -134,7 +140,10 @@ ORDER BY tile_count DESC;
 			<listitem xml:id="raster_rasterTileValueQuadbin">
 				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
 				<para>Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
-				<para><varname>rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,boolean) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,
+  boolean) → tfloat
+</programlisting>
 				<para>Evaluates a row-major single-band pixel array at each instant of <varname>traj</varname> (SRID 4326). The tile georeferencing (bounding box, pixel-to-coordinate mapping) is derived from <varname>quadbin</varname> alone via the Web-Mercator slippy-tile transform. The <varname>pixtype</varname> argument must be one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. When <varname>has_nodata</varname> is true, instants whose pixel equals <varname>nodata</varname> are silently dropped. Returns <varname>NULL</varname> when no instant survives.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample elevation tiles from a Raquet Parquet table
@@ -155,7 +164,9 @@ JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 			<listitem xml:id="raquet">
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
-				<para><varname>raquet(bytea,integer,integer,bigint,text,float8) → raquet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquet(bytea,integer,integer,bigint,text,float8) → raquet
+</programlisting>
 				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. Pixels of more than one byte are little-endian, which is the byte order the RaQuet specification gives them whatever the byte order of the server, so that a tile keeps its values when it is read on another machine. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Package the loose tile columns of a Raquet table into raquet values
@@ -170,7 +181,9 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 			<listitem xml:id="raquetRead">
 				<indexterm significance="normal"><primary><varname>raquetRead</varname></primary></indexterm>
 				<para>Decode an in-memory raster file into a Raquet raster tile via GDAL</para>
-				<para><varname>raquetRead(bytea,bigint) → raquet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquetRead(bytea,bigint) → raquet
+</programlisting>
 				<para>Reads the bytes of <varname>rasterfile</varname>, a raster in any format GDAL supports (GeoTIFF, PNG, …), through GDAL's <varname>/vsimem/</varname> virtual filesystem, and packs its first band, row-major, into a single self-describing <varname>raquet</varname> value georeferenced by the <varname>quadbin</varname> cell. The band data type must be one of <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname>, or <varname>Float64</varname>; the band nodata value, when set, is carried into the tile. Because the file is supplied as bytes, no server-side file access is required. GDAL performs the decode, so the raster's format driver must be permitted by PostGIS's <varname>postgis.gdal_enabled_drivers</varname> setting (which disables all drivers by default); enable it with, for example, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. This is the ingest counterpart of the <link linkend="raquet"><varname>raquet</varname></link> constructor, which builds a tile from already-decoded pixel bytes.</para>
 				<para>When <varname>quadbin</varname> is omitted or <varname>NULL</varname>, the tile identifier is derived from the raster's georeferencing: the raster must carry an <varname>EPSG:3857</varname> (Web-Mercator) spatial reference and an axis-aligned geotransform describing a single QUADBIN tile. A raster with no spatial reference, one that is not in <varname>EPSG:3857</varname>, or a geotransform that is rotated or not aligned to the tile grid raises an error rather than being coerced.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -186,7 +199,9 @@ FROM elevation_files;
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>
-				<para><varname>rasterTileValue(tgeompoint,raquet) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rasterTileValue(tgeompoint,raquet) → tfloat
+</programlisting>
 				<para>Evaluates the tile at each instant of <varname>traj</varname> (SRID 4326), returning the sampled pixel values as a <varname>tfloat</varname>. This is the typed equivalent of <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: the dimensions, QUADBIN cell, pixel type and nodata handling are taken from the <varname>raquet</varname> value instead of from separate arguments. Returns <varname>NULL</varname> when no instant falls inside the tile or survives nodata filtering.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample pre-packaged raquet tiles along ship trajectories
@@ -198,7 +213,9 @@ FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
 			<listitem xml:id="raster_rasterTileValueArray">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample an array of <varname>raquet</varname> raster tiles along a trajectory</para>
-				<para><varname>rasterTileValue(tgeompoint,raquet[]) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rasterTileValue(tgeompoint,raquet[]) → tfloat
+</programlisting>
 				<para>Evaluates every tile of <varname>rast</varname> at each instant of <varname>traj</varname> (SRID 4326) and returns the sampled pixel values as a single <varname>tfloat</varname>. A trajectory that leaves one tile is covered by several of them, each contributing the instants that fall inside it. Tiles of one zoom level partition the plane, so they contribute disjoint instants. Tiles of different zoom levels overlap, and where two of them sample the same instant the value of the tile of higher zoom is kept, that being the one carrying the finer resolution. Returns <varname>NULL</varname> when no instant falls inside a tile or survives nodata filtering.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample a trajectory across every tile it crosses, in one value
@@ -220,7 +237,9 @@ GROUP BY t.tripid, t.trip;
 			<listitem xml:id="raquet_asBinary">
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<para>Return the Well-Known Binary (WKB) representation of a Raquet tile</para>
-				<para><varname>asBinary(raquet,endianencoding text DEFAULT '') → bytea</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(raquet,endianencoding text DEFAULT '') → bytea
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8')));
@@ -231,7 +250,9 @@ SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
 			<listitem xml:id="raquet_asHexWKB">
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Return the ASCII hex-encoded Well-Known Binary (HexWKB) representation of a Raquet tile</para>
-				<para><varname>asHexWKB(raquet,endianencoding text DEFAULT '') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asHexWKB(raquet,endianencoding text DEFAULT '') → text
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8')));
@@ -242,7 +263,9 @@ SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
 			<listitem xml:id="raquetFromBinary">
 				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
 				<para>Return a Raquet tile from its Well-Known Binary (WKB) representation</para>
-				<para><varname>raquetFromBinary(bytea) → raquet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquetFromBinary(bytea) → raquet
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
   5193776270265024512, 'uint8')))
@@ -254,7 +277,9 @@ SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
 			<listitem xml:id="raquetFromHexWKB">
 				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
 				<para>Return a Raquet tile from its ASCII hex-encoded Well-Known Binary (HexWKB) representation</para>
-				<para><varname>raquetFromHexWKB(text) → raquet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquetFromHexWKB(text) → raquet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
   5193776270265024512, 'uint8')))
@@ -276,7 +301,9 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
 			<listitem xml:id="raquet_quadbin_accessor">
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Return the QUADBIN cell of a Raquet tile</para>
-				<para><varname>quadbin(raquet) → bigint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+quadbin(raquet) → bigint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 5193776270265024512
@@ -286,7 +313,9 @@ SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_width">
 				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
 				<para>Return the width in pixels of a Raquet tile</para>
-				<para><varname>width(raquet) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+width(raquet) → integer
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
@@ -296,7 +325,9 @@ SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_height">
 				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
 				<para>Return the height in pixels of a Raquet tile</para>
-				<para><varname>height(raquet) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+height(raquet) → integer
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
@@ -306,7 +337,9 @@ SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_nodata">
 				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
 				<para>Return the nodata sentinel value of a Raquet tile</para>
-				<para><varname>nodata(raquet) → float8</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nodata(raquet) → float8
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nodata(raquet('\x01020304'::bytea, 2, 2,
   5193776270265024512, 'uint8', 255));
@@ -320,7 +353,9 @@ SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_pixtype">
 				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
 				<para>Return the name of the pixel data type of a Raquet tile</para>
-				<para><varname>pixtype(raquet) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+pixtype(raquet) → text
+</programlisting>
 				<para>The returned name is the one the constructors accept, that is, one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. The constructors read the name without regard to case, so the name PostGIS raster gives a pixel type carries into them as it stands; the name returned here is the lower-case spelling the RaQuet specification gives a tile's <varname>type</varname> field, so it compares equal to that field as it stands.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Read back the layout of a packaged tile
@@ -333,7 +368,9 @@ FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS 
 			<listitem xml:id="raquet_pixels">
 				<indexterm significance="normal"><primary><varname>pixels</varname></primary></indexterm>
 				<para>Return the pixel bytes of a Raquet tile</para>
-				<para><varname>pixels(raquet) → bytea</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+pixels(raquet) → bytea
+</programlisting>
 				<para>The bytes are row-major and packed, <varname>width</varname> × <varname>height</varname> pixels of the size of <varname>pixtype</varname> each, little-endian when a pixel is wider than one byte, which is the layout the constructors accept. A tile therefore round trips through its own accessors.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
@@ -344,7 +381,9 @@ SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			<listitem xml:id="raquet_to_stbox">
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convert a Raquet tile into a spatiotemporal box</para>
-				<para><varname>stbox(raquet) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stbox(raquet) → stbox
+</programlisting>
 				<para>Returns the tile footprint: the longitude and latitude envelope of its QUADBIN cell, in SRID 4326 and without a time dimension. The footprint follows from the cell alone, so tiles differing in pixels, dimensions or pixel type share it. The conversion is also available as a cast.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- The footprint of a tile covering the north-eastern quadrant at zoom 1
@@ -381,12 +420,14 @@ WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
 				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 				<para>Compare two Raquet tiles</para>
-				<para><varname>raquet = raquet → boolean</varname></para>
-				<para><varname>raquet &lt;&gt; raquet → boolean</varname></para>
-				<para><varname>raquet &lt; raquet → boolean</varname></para>
-				<para><varname>raquet &lt;= raquet → boolean</varname></para>
-				<para><varname>raquet &gt;= raquet → boolean</varname></para>
-				<para><varname>raquet &gt; raquet → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+raquet = raquet → boolean
+raquet &lt;&gt; raquet → boolean
+raquet &lt; raquet → boolean
+raquet &lt;= raquet → boolean
+raquet &gt;= raquet → boolean
+raquet &gt; raquet → boolean
+</programlisting>
 				<para>The functions backing these operators are <varname>eq</varname>, <varname>ne</varname>, <varname>lt</varname>, <varname>le</varname>, <varname>ge</varname> and <varname>gt</varname>, together with <varname>cmp(raquet,raquet) → integer</varname>, which returns -1, 0, or 1.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Two tiles with the same cell, layout and pixels are equal
@@ -410,7 +451,9 @@ SELECT DISTINCT tile FROM elevation_tiles;
 			<listitem xml:id="raster_atRasterValue">
 				<indexterm significance="normal"><primary><varname>atRasterValue</varname></primary></indexterm>
 				<para>Return the instants of a trajectory where the sampled raster value falls inside a float range</para>
-				<para><varname>atRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint
+</programlisting>
 				<para>Evaluates <varname>rasterValue</varname> at every instant of <varname>traj</varname> and returns the sub-trajectory restricted to the times when the pixel value lies within <varname>vspan</varname>. Returns <varname>NULL</varname> when no instant satisfies the condition.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH rast AS (
@@ -433,7 +476,9 @@ FROM rast;
 			<listitem xml:id="raster_minusRasterValue">
 				<indexterm significance="normal"><primary><varname>minusRasterValue</varname></primary></indexterm>
 				<para>Return the instants of a trajectory where the sampled raster value falls outside a float range</para>
-				<para><varname>minusRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minusRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → tgeompoint
+</programlisting>
 				<para>The complement of <varname>atRasterValue</varname>: returns the sub-trajectory restricted to the times when the pixel value lies outside <varname>vspan</varname>. Returns <varname>NULL</varname> when every instant satisfies the condition.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Keep only the instant whose raster value (10) is below 40
@@ -445,7 +490,9 @@ FROM trips, elevation_raster;
 			<listitem xml:id="raster_eRasterValue">
 				<indexterm significance="normal"><primary><varname>eRasterValue</varname></primary></indexterm>
 				<para>Return true if the trajectory ever samples a raster pixel value inside a float range</para>
-				<para><varname>eRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean
+</programlisting>
 				<para>Returns <varname>true</varname> when at least one in-extent instant of <varname>traj</varname> samples a pixel value within <varname>vspan</varname>, <varname>false</varname> otherwise. Returns <varname>NULL</varname> only when the input is <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that ever crossed terrain above 200 m
@@ -458,7 +505,9 @@ WHERE eRasterValue(trip, elev_raster, floatspan '[200, 9999]');
 			<listitem xml:id="raster_aRasterValue">
 				<indexterm significance="normal"><primary><varname>aRasterValue</varname></primary></indexterm>
 				<para>Return true if every in-raster-extent instant of the trajectory samples a pixel value inside a float range</para>
-				<para><varname>aRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+aRasterValue(tgeompoint,raster,floatspan,band integer DEFAULT 1) → boolean
+</programlisting>
 				<para>Returns <varname>true</varname> when every in-extent instant of <varname>traj</varname> samples a pixel value within <varname>vspan</varname>, <varname>false</varname> when at least one does not. Returns <varname>NULL</varname> only when the input is <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that stayed entirely below 100 m elevation

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -55,7 +55,9 @@ SELECT trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
 			<listitem xml:id="trgeometry_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Return the Well-Known Text (WKT) representation</para>
-				<para><varname>asText({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.123456789),
   0.5)@2000-01-01', 6);
@@ -66,7 +68,9 @@ SELECT asText(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1.123456789 1.12
 			<listitem xml:id="trgeometry_asEWKT">
 				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 				<para>Return the Extended Well-Known Text (EWKT) representation, prefixed with the SRID</para>
-				<para><varname>asEWKT({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asEWKT({trgeometry,trgeometry[]} [, maxdecimaldigits int=15]) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(trgeometry
   'SRID=25832;Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1),0.5)@2000-01-01');
@@ -77,7 +81,9 @@ SELECT asEWKT(trgeometry
 			<listitem xml:id="trgeometry_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Return the Moving Features JSON representation</para>
-				<para><varname>asMFJSON(trgeometry [, options int=0 [, flags int=0 [, maxdecimaldigits int=15]]]) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(trgeometry [, options int=0 [, flags int=0 [, maxdecimaldigits int=15]]]) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(trgeometry
   'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0),0)@2001-01-01');
@@ -89,9 +95,11 @@ SELECT asMFJSON(trgeometry
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Return the Extended Well-Known Binary (EWKB) representation</para>
-				<para><varname>asEWKB(trgeometry [, endian text]) → bytea</varname></para>
-				<para><varname>asHexWKB(trgeometry [, endian text]) → text</varname></para>
-				<para><varname>asHexEWKB(trgeometry [, endian text]) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asEWKB(trgeometry [, endian text]) → bytea
+asHexWKB(trgeometry [, endian text]) → text
+asHexEWKB(trgeometry [, endian text]) → text
+</programlisting>
 				<para>Companion <varname>asHexWKB</varname> and <varname>asHexEWKB</varname> return the hex-encoded text of, respectively, the plain and the SRID-carrying representation; the two coincide only when the value has no SRID, as in the example below.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asEWKB(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1 1),
@@ -114,11 +122,13 @@ SELECT asText(trgeometryFromHexEWKB(asHexWKB(trgeometry
 				<indexterm significance="normal"><primary><varname>trgeometryFromEWKT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>trgeometryFromHexEWKB</varname></primary></indexterm>
 				<para>Each output format has a companion parser:</para>
-				<para><varname>trgeometryFromText(text) → trgeometry</varname></para>
-				<para><varname>trgeometryFromEWKT(text) → trgeometry</varname></para>
-				<para><varname>trgeometryFromMFJSON(text) → trgeometry</varname></para>
-				<para><varname>trgeometryFromEWKB(bytea) → trgeometry</varname></para>
-				<para><varname>trgeometryFromHexEWKB(text) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trgeometryFromText(text) → trgeometry
+trgeometryFromEWKT(text) → trgeometry
+trgeometryFromMFJSON(text) → trgeometry
+trgeometryFromEWKB(bytea) → trgeometry
+trgeometryFromHexEWKB(text) → trgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(trgeometryFromEWKT('SRID=4326;Polygon((0 0,1 0,1 1,0 1,0 0));
   Pose(Point(1 1), 0.5)@2001-01-01'));
@@ -140,7 +150,9 @@ SELECT asText(trgeometryFromHexEWKB(asHexEWKB(trgeometry
 			<listitem xml:id="trgeometry_constructor">
 				<indexterm significance="normal"><primary><varname>trgeometry</varname></primary></indexterm>
 				<para>Construct a temporal rigid geometry from a reference geometry and a temporal pose</para>
-				<para><varname>trgeometry(geometry, tpose) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trgeometry(geometry, tpose) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(trgeometry(
   geometry 'Polygon((0 0,1 0,1 1,0 1,0 0))',
@@ -153,7 +165,9 @@ SELECT asText(trgeometry(
 			<listitem xml:id="trgeometry_appendInstant">
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<para>Append a single instant to an existing trgeometry, growing the underlying pose path</para>
-				<para><varname>appendInstant(trgeometry, trgeometry [, maxdist float [, maxt interval]]) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(trgeometry, trgeometry [, maxdist float [, maxt interval]]) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT appendInstant(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01]',
@@ -164,7 +178,9 @@ SELECT appendInstant(
 			<listitem xml:id="trgeometry_appendSequence">
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Append an entire sequence to an existing trgeometry</para>
-				<para><varname>appendSequence(trgeometry, trgeometry) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendSequence(trgeometry, trgeometry) → trgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(appendSequence(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]',
@@ -187,7 +203,9 @@ SELECT asText(appendSequence(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_to_tpose">
 				<indexterm significance="normal"><primary><varname>tpose</varname></primary></indexterm>
 				<para>Return the underlying temporal pose</para>
-				<para><varname>tpose(trgeometry) → tpose</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpose(trgeometry) → tpose
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tpose(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
   0.0)@2001-01-01, Pose(Point(10 0), 0.5)@2001-01-02]'));
@@ -198,7 +216,9 @@ SELECT asText(tpose(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
 			<listitem xml:id="trgeometry_to_tgeompoint">
 				<indexterm significance="normal"><primary><varname>tgeompoint</varname></primary></indexterm>
 				<para>Return the centroid (antenna) trajectory as a temporal point</para>
-				<para><varname>tgeompoint(trgeometry) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tgeompoint(trgeometry) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tgeompoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
   0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
@@ -219,9 +239,11 @@ SELECT asText(tgeompoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the materialised geometry at the start, end, or a chosen timestamp</para>
-				<para><varname>startValue(trgeometry) → geometry</varname></para>
-				<para><varname>endValue(trgeometry) → geometry</varname></para>
-				<para><varname>valueAtTimestamp(trgeometry, timestamptz) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(trgeometry) → geometry
+endValue(trgeometry) → geometry
+valueAtTimestamp(trgeometry, timestamptz) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(startValue(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
   0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]'));
@@ -241,9 +263,11 @@ SELECT asText(valueAtTimestamp(
 				<indexterm significance="normal"><primary><varname>numSequences</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>numTimestamps</varname></primary></indexterm>
 				<para>Return the number of distinct instants, sequences, or timestamps</para>
-				<para><varname>numInstants(trgeometry) → integer</varname></para>
-				<para><varname>numSequences(trgeometry) → integer</varname></para>
-				<para><varname>numTimestamps(trgeometry) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numInstants(trgeometry) → integer
+numSequences(trgeometry) → integer
+numTimestamps(trgeometry) → integer
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
@@ -262,9 +286,11 @@ SELECT numTimestamps(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>sequences</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>segments</varname></primary></indexterm>
 				<para>Return the array of constituent instants, sequences, or inter-instant segments</para>
-				<para><varname>instants(trgeometry) → trgeometry[]</varname></para>
-				<para><varname>sequences(trgeometry) → trgeometry[]</varname></para>
-				<para><varname>segments(trgeometry) → trgeometry[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+instants(trgeometry) → trgeometry[]
+sequences(trgeometry) → trgeometry[]
+segments(trgeometry) → trgeometry[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT array_length(
   instants(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01,
@@ -277,7 +303,9 @@ SELECT array_length(
 			<listitem xml:id="trgeometry_points">
 				<indexterm significance="normal"><primary><varname>points</varname></primary></indexterm>
 				<para>Return the set of distinct centroid (antenna) points seen along the trgeometry</para>
-				<para><varname>points(trgeometry) → geomset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+points(trgeometry) → geomset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(points(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0),
   0.0)@2001-01-01, Pose(Point(5 5), 0.0)@2001-01-02, Pose(Point(0 0), 0.0)@2001-01-03}'));
@@ -290,9 +318,11 @@ SELECT asText(points(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0)
 				<indexterm significance="normal"><primary><varname>pitch</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>roll</varname></primary></indexterm>
 				<para>Return the yaw, pitch, or roll angle as a temporal float, in radians, under the ZYX intrinsic Tait-Bryan convention required by the OGC GeoPose Basic-YPR conformance class</para>
-				<para><varname>yaw(trgeometry) → tfloat</varname></para>
-				<para><varname>pitch(trgeometry) → tfloat</varname></para>
-				<para><varname>roll(trgeometry) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+yaw(trgeometry) → tfloat
+pitch(trgeometry) → tfloat
+roll(trgeometry) → tfloat
+</programlisting>
 				<para>A rigid geometry carries its orientation in its poses, so each of these projects onto the temporal pose and asks it, exactly as the <link linkend="pose_yaw_pitch_roll"><varname>tpose</varname></link> accessors of the same name do. A 2D rigid geometry yaws by the stored angle of each pose and neither pitches nor rolls.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(yaw(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
@@ -307,7 +337,9 @@ SELECT asText(pitch(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),
 			<listitem xml:id="trgeometry_geom">
 				<indexterm significance="normal"><primary><varname>geom</varname></primary></indexterm>
 				<para>Return the static reference geometry</para>
-				<para><varname>geom(trgeometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geom(trgeometry) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(geom(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0),
   0.5)@2001-01-01'));
@@ -326,7 +358,9 @@ SELECT ST_AsText(geom(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(5 0)
 			<listitem xml:id="trgeometry_traversedArea_func">
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
 				<para>Return the area traversed by the temporal rigid geometry</para>
-				<para><varname>traversedArea(trgeometry, unary_union=false) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+traversedArea(trgeometry, unary_union=false) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
@@ -352,7 +386,9 @@ SELECT ST_AsText(traversedArea(
 			<listitem xml:id="trgeometry_centroid_func">
 				<indexterm significance="normal"><primary><varname>centroid</varname></primary></indexterm>
 				<para>Return the centroid of the moving body as a temporal point</para>
-				<para><varname>centroid(trgeometry) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+centroid(trgeometry) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(centroid(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -364,7 +400,9 @@ SELECT asText(centroid(
 			<listitem xml:id="trgeometry_convexHull_func">
 				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Return the convex hull of the area traversed by the moving body</para>
-				<para><varname>convexHull(trgeometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+convexHull(trgeometry) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_GeometryType(convexHull(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -376,7 +414,9 @@ SELECT ST_GeometryType(convexHull(
 			<listitem xml:id="trgeometry_bodyPointTrajectory_func">
 				<indexterm significance="normal"><primary><varname>bodyPointTrajectory</varname></primary></indexterm>
 				<para>Return the world-frame trajectory of a body-frame point carried by the moving rigid geometry. The point is expressed in the reference shape's local frame and the time-varying pose is applied to it at each instant.</para>
-				<para><varname>bodyPointTrajectory(trgeometry, geometry) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+bodyPointTrajectory(trgeometry, geometry) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(bodyPointTrajectory(
   trgeometry 'Polygon((0 0, 1 0, 1 1, 0 1, 0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -398,8 +438,10 @@ SELECT asText(bodyPointTrajectory(
 				<indexterm significance="normal"><primary><varname>length</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>cumulativeLength</varname></primary></indexterm>
 				<para>Return the total length traversed by the centroid, or its cumulative length over time</para>
-				<para><varname>length(trgeometry) → float</varname></para>
-				<para><varname>cumulativeLength(trgeometry) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+length(trgeometry) → float
+cumulativeLength(trgeometry) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
   Pose(Point(3 4),0)@2001-01-02]');
@@ -410,7 +452,9 @@ SELECT length(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@200
 			<listitem xml:id="trgeometry_speed">
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Return the speed of the centroid as a temporal float</para>
-				<para><varname>speed(trgeometry) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+speed(trgeometry) → tfloat
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT speed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
@@ -421,7 +465,9 @@ SELECT speed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_angular_speed">
 				<indexterm significance="normal"><primary><varname>angularSpeed</varname></primary></indexterm>
 				<para>Return the angular speed as a temporal float</para>
-				<para><varname>angularSpeed(trgeometry) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+angularSpeed(trgeometry) → tfloat
+</programlisting>
 				<para>The shape of a rigid geometry never changes, so its angular speed is the angular speed of the pose that carries it, in radians per unit time.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(angularSpeed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
@@ -433,7 +479,9 @@ SELECT asText(angularSpeed(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_twcentroid">
 				<indexterm significance="normal"><primary><varname>twCentroid</varname></primary></indexterm>
 				<para>Return the time-weighted centroid of the centroid trajectory as a geometry</para>
-				<para><varname>twCentroid(trgeometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+twCentroid(trgeometry) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(twCentroid(trgeometry
   'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -453,7 +501,9 @@ SELECT ST_AsText(twCentroid(trgeometry
 			<listitem xml:id="trgeometry_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Round all numeric components to a given number of decimal places</para>
-				<para><varname>round(trgeometry, integer) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(trgeometry, integer) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(1.123456789 1.123456789),
@@ -466,7 +516,9 @@ SELECT asText(round(
 			<listitem xml:id="trgeometry_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Convert between linear and step interpolations</para>
-				<para><varname>setInterp(trgeometry, text) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(trgeometry, text) → trgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(setInterp(trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 'linear'));
@@ -481,9 +533,11 @@ SELECT asText(setInterp(trgeometry 'Interp=Step;Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Shift, scale, or both shift and scale the time domain of a trgeometry</para>
-				<para><varname>shiftTime(trgeometry, interval) → trgeometry</varname></para>
-				<para><varname>scaleTime(trgeometry, interval) → trgeometry</varname></para>
-				<para><varname>shiftScaleTime(trgeometry, interval, interval) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftTime(trgeometry, interval) → trgeometry
+scaleTime(trgeometry, interval) → trgeometry
+shiftScaleTime(trgeometry, interval, interval) → trgeometry
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(shiftTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),
@@ -515,8 +569,10 @@ SELECT asText(shiftScaleTime(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restrict a trgeometry to (the complement of) a geometry</para>
-				<para><varname>atGeometry(trgeometry, geometry) → trgeometry</varname></para>
-				<para><varname>minusGeometry(trgeometry, geometry) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(trgeometry, geometry) → trgeometry
+minusGeometry(trgeometry, geometry) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT temporalTime(atGeometry(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
@@ -537,8 +593,10 @@ SELECT temporalTime(minusGeometry(
 				<indexterm significance="normal"><primary><varname>atStbox</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusStbox</varname></primary></indexterm>
 				<para>Restrict a trgeometry to (the complement of) a spatiotemporal box</para>
-				<para><varname>atStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry</varname></para>
-				<para><varname>minusStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry
+minusStbox(trgeometry, stbox [, border_inc boolean = true]) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT temporalTime(atStbox(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
@@ -559,8 +617,10 @@ SELECT temporalTime(atStbox(
 				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
 				<para>Restrict a trgeometry to (the complement of) an elevation span</para>
-				<para><varname>atElevation(trgeometry, floatspan) → trgeometry</varname></para>
-				<para><varname>minusElevation(trgeometry, floatspan) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atElevation(trgeometry, floatspan) → trgeometry
+minusElevation(trgeometry, floatspan) → trgeometry
+</programlisting>
 				<para>The elevation is that of the position of the pose, not that of the body: a body extends above and below its position, and the span is tested against the position alone. The reference geometry is carried over to the result. The temporal rigid geometry must have Z dimension.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atElevation(
@@ -591,8 +651,10 @@ SELECT getTime(minusElevation(
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>
 				<para>Return the temporal distance between two temporal rigid geometries</para>
-				<para><varname>{geometry,trgeometry} &lt;-&gt; {geometry,trgeometry} → tfloat</varname></para>
-				<para><varname>tDistance({geometry,trgeometry}, {geometry,trgeometry}) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geometry,trgeometry} &lt;-&gt; {geometry,trgeometry} → tfloat
+tDistance({geometry,trgeometry}, {geometry,trgeometry}) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(maxValue(tDistance(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0), 0.0)@2001-01-01',
@@ -613,8 +675,10 @@ SELECT asText(tDistance(
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 				<para>Return the smallest distance between two temporal rigid geometries over their shared time domain</para>
-				<para><varname>{geometry,trgeometry,stbox} |=| {geometry,trgeometry,stbox} → float</varname></para>
-				<para><varname>nearestApproachDistance({geometry,trgeometry,stbox}, {geometry,trgeometry,stbox}) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geometry,trgeometry,stbox} |=| {geometry,trgeometry,stbox} → float
+nearestApproachDistance({geometry,trgeometry,stbox}, {geometry,trgeometry,stbox}) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
   Pose(Point(10 0), 0.0)@2001-01-02]'
@@ -629,7 +693,9 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01
 			<listitem xml:id="trgeometry_nai">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Return the instant at which the two arguments are at their smallest mutual distance</para>
-				<para><varname>nearestApproachInstant({geometry,trgeometry}, {geometry,trgeometry}) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geometry,trgeometry}, {geometry,trgeometry}) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(nearestApproachInstant(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
@@ -642,7 +708,9 @@ SELECT asText(nearestApproachInstant(
 			<listitem xml:id="trgeometry_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Return the line connecting the two arguments at their nearest approach</para>
-				<para><varname>shortestLine({geometry,trgeometry}, {geometry,trgeometry}) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geometry,trgeometry}, {geometry,trgeometry}) → geometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));Pose(Point(0 0), 0.0)@2001-01-01',
@@ -664,9 +732,11 @@ SELECT ST_AsText(shortestLine(
 				<indexterm significance="normal"><primary><varname>frechetDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dynTimeWarpDistance</varname></primary></indexterm>
 				<para>Return the discrete Hausdorff distance, the discrete Fréchet distance, or the Dynamic Time Warp distance between two temporal rigid geometries</para>
-				<para><varname>hausdorffDistance(trgeometry, trgeometry) → float</varname></para>
-				<para><varname>frechetDistance(trgeometry, trgeometry) → float</varname></para>
-				<para><varname>dynTimeWarpDistance(trgeometry, trgeometry) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+hausdorffDistance(trgeometry, trgeometry) → float
+frechetDistance(trgeometry, trgeometry) → float
+dynTimeWarpDistance(trgeometry, trgeometry) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(frechetDistance(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2000-01-01,
@@ -687,8 +757,10 @@ SELECT round(hausdorffDistance(
 				<indexterm significance="normal"><primary><varname>frechetDistancePath</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>dynTimeWarpPath</varname></primary></indexterm>
 				<para>Return the correspondence pairs between two temporal rigid geometries with respect to the discrete Fréchet distance or the Dynamic Time Warp distance, as a set of <varname>(i,j)</varname> instant-index pairs</para>
-				<para><varname>frechetDistancePath(trgeometry, trgeometry) → {(i,j)}</varname></para>
-				<para><varname>dynTimeWarpPath(trgeometry, trgeometry) → {(i,j)}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+frechetDistancePath(trgeometry, trgeometry) → {(i,j)}
+dynTimeWarpPath(trgeometry, trgeometry) → {(i,j)}
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT frechetDistancePath(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
@@ -719,8 +791,10 @@ SELECT dynTimeWarpPath(
 				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
 				<para>Test exact (in)equality of two temporal rigid geometries</para>
-				<para><varname>trgeometry = trgeometry → boolean</varname></para>
-				<para><varname>trgeometry &lt;&gt; trgeometry → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trgeometry = trgeometry → boolean
+trgeometry &lt;&gt; trgeometry → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),
@@ -739,8 +813,10 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
 				<para>Test whether the materialised geometry is ever (not) equal to the operand at any time</para>
-				<para><varname>{geometry,trgeometry} ?= {geometry,trgeometry} → boolean</varname></para>
-				<para><varname>{geometry,trgeometry} ?&lt;&gt; {geometry,trgeometry} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geometry,trgeometry} ?= {geometry,trgeometry} → boolean
+{geometry,trgeometry} ?&lt;&gt; {geometry,trgeometry} → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,
   Pose(Point(5 0), 0.0)@2001-01-02]'
@@ -753,8 +829,10 @@ SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01
 				<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>%&lt;&gt;</varname></primary></indexterm>
 				<para>Test whether the materialised geometry is always (not) equal to the operand</para>
-				<para><varname>{geometry,trgeometry} %= {geometry,trgeometry} → boolean</varname></para>
-				<para><varname>{geometry,trgeometry} %&lt;&gt; {geometry,trgeometry} → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geometry,trgeometry} %= {geometry,trgeometry} → boolean
+{geometry,trgeometry} %&lt;&gt; {geometry,trgeometry} → boolean
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),
@@ -830,9 +908,16 @@ SELECT trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));
 				<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spaceTimeBoxes</varname></primary></indexterm>
 				<para>Return the spatiotemporal boxes of a temporal rigid geometry split with respect to a spatial, temporal, or spatiotemporal grid</para>
-				<para><varname>spaceBoxes(trgeometry, xsize float [, ysize float [, zsize float]], sorigin geometry = 'Point(0 0 0)', bitmatrix boolean = true, borderInc boolean = true) → stbox[]</varname></para>
-				<para><varname>timeBoxes(trgeometry, interval, torigin timestamptz = '2000-01-03', bitmatrix boolean = true, borderInc boolean = true) → stbox[]</varname></para>
-				<para><varname>spaceTimeBoxes(trgeometry, xsize float [, ysize float [, zsize float]], interval, sorigin geometry = 'Point(0 0 0)', torigin timestamptz = '2000-01-03', bitmatrix boolean = true, borderInc boolean = true) → stbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+spaceBoxes(trgeometry, xsize float [, ysize float [, zsize float]],
+  sorigin geometry = 'Point(0 0 0)', bitmatrix boolean = true,
+  borderInc boolean = true) → stbox[]
+timeBoxes(trgeometry, interval, torigin timestamptz = '2000-01-03',
+  bitmatrix boolean = true, borderInc boolean = true) → stbox[]
+spaceTimeBoxes(trgeometry, xsize float [, ysize float [, zsize float]], interval,
+  sorigin geometry = 'Point(0 0 0)', torigin timestamptz = '2000-01-03',
+  bitmatrix boolean = true, borderInc boolean = true) → stbox[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT array_length(spaceBoxes(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01,
@@ -854,8 +939,10 @@ SELECT array_length(spaceBoxes(
 				<indexterm significance="normal"><primary><varname>stboxes</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>spans</varname></primary></indexterm>
 				<para>Return the array of spatiotemporal boxes or time spans of the segments of a temporal rigid geometry</para>
-				<para><varname>stboxes(trgeometry) → stbox[]</varname></para>
-				<para><varname>spans(trgeometry) → tstzspan[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stboxes(trgeometry) → stbox[]
+spans(trgeometry) → tstzspan[]
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stboxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
@@ -872,10 +959,12 @@ SELECT spans(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 				<indexterm significance="normal"><primary><varname>splitNSpans</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>splitEachNSpans</varname></primary></indexterm>
 				<para>Return the spatiotemporal boxes or time spans of a temporal rigid geometry split into a given number of bins, or with a given number of segments per bin</para>
-				<para><varname>splitNStboxes(trgeometry, integer) → stbox[]</varname></para>
-				<para><varname>splitEachNStboxes(trgeometry, integer) → stbox[]</varname></para>
-				<para><varname>splitNSpans(trgeometry, integer) → tstzspan[]</varname></para>
-				<para><varname>splitEachNSpans(trgeometry, integer) → tstzspan[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitNStboxes(trgeometry, integer) → stbox[]
+splitEachNStboxes(trgeometry, integer) → stbox[]
+splitNSpans(trgeometry, integer) → tstzspan[]
+splitEachNSpans(trgeometry, integer) → tstzspan[]
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNStboxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]', 2);
@@ -895,7 +984,9 @@ SELECT splitNSpans(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Number of overlapping temporal rigid geometries at each instant, equivalent to <varname>tCount</varname> on the underlying tpose</para>
-				<para><varname>tCount(trgeometry) → tint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(trgeometry) → tint
+</programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tCount(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
   [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]');
@@ -906,7 +997,9 @@ SELECT tCount(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 			<listitem xml:id="trgeometry_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Aggregate bounding box of a column of temporal rigid geometries</para>
-				<para><varname>extent(trgeometry) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(trgeometry) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(temp) FROM tbl_trgeometry;
 </programlisting>
@@ -916,8 +1009,10 @@ SELECT extent(temp) FROM tbl_trgeometry;
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>mergeAgg</varname></primary></indexterm>
 				<para>Combine two trgeometries with the same reference geometry into a single sequence-set</para>
-				<para><varname>merge(trgeometry, trgeometry) → trgeometry</varname></para>
-				<para><varname>mergeAgg(trgeometry) → trgeometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(trgeometry, trgeometry) → trgeometry
+mergeAgg(trgeometry) → trgeometry
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(merge(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01,

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -47,7 +47,9 @@
 			<listitem xml:id="geo_orientedenvelope">
 				<indexterm significance="normal"><primary><varname>orientedEnvelope</varname></primary></indexterm>
 				<para>Return the rectangle of minimum area enclosing a geometry</para>
-				<para><varname>orientedEnvelope(geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+orientedEnvelope(geometry) → geometry
+</programlisting>
 				<para>The rectangle is at the angle that makes it smallest, which is not in general the angle of the axes. It is answered as a line when the geometry is contained in one and as a point when the geometry is one. A geometry carrying a circular arc is answered on the arc itself, the rectangle being placed against the circle the arc lies on rather than against the chain of segments approximating it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(round(orientedEnvelope(geometry 'Polygon((0 0,3 4,-1 7,-4 3,0 0))'), 6));
@@ -62,7 +64,9 @@ SELECT ST_AsText(round(orientedEnvelope(geometry 'Circularstring(0 0,0.5 0.1,1 0
 			<listitem xml:id="geo_convexhull">
 				<indexterm significance="normal"><primary><varname>convexHull</varname></primary></indexterm>
 				<para>Return the smallest convex geometry enclosing a geometry</para>
-				<para><varname>convexHull(geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+convexHull(geometry) → geometry
+</programlisting>
 				<para>The result is a polygon whose every corner is a point of the geometry, a line when the geometry is contained in one, and a point when the geometry is one. A geometry carrying a circular arc is answered on the arc itself, so the hull is bounded by the arc and is returned as a curved geometry rather than as a polygon approximating it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(round(convexHull(geometry 'Multipoint(0 0,10 0,10 10,0 10,5 5)'), 6));
@@ -77,7 +81,9 @@ SELECT ST_AsText(round(convexHull(geometry 'Circularstring(5 0,0 5,-5 0)'), 6));
 			<listitem xml:id="geo_issimple">
 				<indexterm significance="normal"><primary><varname>isSimple</varname></primary></indexterm>
 				<para>Return true if a geometry has no point at which it crosses or touches itself</para>
-				<para><varname>isSimple(geometry) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isSimple(geometry) → boolean
+</programlisting>
 				<para>A point is always simple, a multipoint is simple when it repeats no point, a line is simple when it meets itself only where two of its segments follow one another and, when it closes, at the point where it closes, and an areal geometry is simple when each of its rings is. Two lines of a multiline may additionally meet at a point that ends both. A geometry carrying a circular arc meets itself along an arc rather than at a point, which the segment intersection this rests on does not read, so such a geometry is answered on the chain of segments approximating its arcs.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isSimple(geometry 'Linestring(0 0,10 10,10 0,0 10)');
@@ -92,7 +98,9 @@ SELECT isSimple(geometry 'Multilinestring((0 0,10 0),(10 0,10 10))');
 			<listitem xml:id="geo_buffer">
 				<indexterm significance="normal"><primary><varname>buffer</varname></primary></indexterm>
 				<para>Return the geometry holding every point within a distance of a geometry</para>
-				<para><varname>buffer(geometry,float,options text='') → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+buffer(geometry,float,options text='') → geometry
+</programlisting>
 				<para>The boundary of the result is made of the two offsets of the geometry at the given distance, of the join filling the outer side of each turn, and of the cap closing each end of an open line. A negative distance shrinks an areal geometry and answers an empty geometry for one of any other dimension.</para>
 				<para>The <varname>options</varname> string carries the styles as space-separated <varname>key=value</varname> pairs: <varname>endcap</varname> is one of <varname>round</varname>, <varname>flat</varname> or <varname>square</varname>, <varname>join</varname> one of <varname>round</varname>, <varname>mitre</varname> or <varname>bevel</varname>, and <varname>mitre_limit</varname> the ratio at which a mitre join falls back to a bevel.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -110,7 +118,9 @@ SELECT ST_AsText(round(buffer(geometry
 			<listitem xml:id="geo_intersection">
 				<indexterm significance="normal"><primary><varname>intersection</varname></primary></indexterm>
 				<para>Return the region two geometries share</para>
-				<para><varname>intersection(geometry,geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+intersection(geometry,geometry) → geometry
+</programlisting>
 				<para>The four Boolean operations of this section answer over the (multi)polygons the temporal types whose values are regions carry, and each takes the name of the PostGIS function it answers for without the <varname>ST_</varname> prefix, so a query reaches this engine by dropping the prefix and PostGIS by keeping it. They are planar and two-dimensional: a geography, a Z dimension and a geometry that is not a (multi)polygon are refused. An empty result is answered as <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(intersection(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
@@ -128,7 +138,9 @@ SELECT intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
 			<listitem xml:id="geo_geounion">
 				<indexterm significance="normal"><primary><varname>geoUnion</varname></primary></indexterm>
 				<para>Return the region two geometries cover together</para>
-				<para><varname>geoUnion(geometry,geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoUnion(geometry,geometry) → geometry
+</programlisting>
 				<para><varname>UNION</varname> is a reserved word of SQL, so this one carries the name of the type it answers over, as <varname>setUnion</varname> and <varname>spanUnion</varname> do. Two geometries that do not meet are answered as a multipolygon.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(geoUnion(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
@@ -140,7 +152,9 @@ SELECT ST_AsText(geoUnion(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
 			<listitem xml:id="geo_difference">
 				<indexterm significance="normal"><primary><varname>difference</varname></primary></indexterm>
 				<para>Return the region of the first geometry that the second does not cover</para>
-				<para><varname>difference(geometry,geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+difference(geometry,geometry) → geometry
+</programlisting>
 				<para>A second geometry lying inside the first leaves a hole rather than dividing it.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
@@ -155,7 +169,9 @@ SELECT ST_AsText(difference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
 			<listitem xml:id="geo_symdifference">
 				<indexterm significance="normal"><primary><varname>symDifference</varname></primary></indexterm>
 				<para>Return the region exactly one of two geometries covers</para>
-				<para><varname>symDifference(geometry,geometry) → geometry</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+symDifference(geometry,geometry) → geometry
+</programlisting>
 				<para>It is the union of the two geometries less the region they share, so a geometry against itself is answered as <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(symDifference(geometry 'Polygon((1 1,1 5,5 5,5 1,1 1))',
@@ -221,8 +237,10 @@ SELECT symDifference(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asEWKT</varname></primary></indexterm>
 				<para>Return the Well-Known Text (WKT) or the Extended Well-Known Text (EWKT) representation &Z_support; &geography_support;</para>
-				<para><varname>asText({tspatial,tspatial[],spatial[]}) → {text,text[]}</varname></para>
-				<para><varname>asEWKT({tspatial,tspatial[],spatial[]}) → {text,text[]}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText({tspatial,tspatial[],spatial[]}) → {text,text[]}
+asEWKT({tspatial,tspatial[],spatial[]}) → {text,text[]}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tgeompoint 'SRID=4326;[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02)');
 -- [POINT Z (0 0 0)@2001-01-01, POINT Z (1 1 1)@2001-01-02)
@@ -248,7 +266,9 @@ SELECT asEWKT(ARRAY[geometry 'SRID=5676;Point(0 0)', 'SRID=5676;Point(1 1)']);
 			<listitem xml:id="tspatial_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Return the Moving Features JSON representation &Z_support; &geography_support;</para>
-				<para><varname>asMFJSON(tspatial,options=0,flags=0,maxdecdigits=15) → bytea</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(tspatial,options=0,flags=0,maxdecdigits=15) → bytea
+</programlisting>
 				<para>The <varname>options</varname> argument can be used to add BBOX and/or CRS in MFJSON output:</para>
 				<itemizedlist>
 					<listitem><para>0: means no option (default value)</para></listitem>
@@ -287,9 +307,11 @@ SELECT asMFJSON(tgeompoint 'SRID=4326;
 				<indexterm significance="normal"><primary><varname>asEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexEWKB</varname></primary></indexterm>
 				<para>Return the Well-Known Binary (WKB), the Extended Well-Known Binary (EWKB) representation, or the Hexadecimal Extended Well-Known Binary (EWKB) representation &Z_support; &geography_support;</para>
-				<para><varname>asBinary(tspatial,endian text='') → bytea</varname></para>
-				<para><varname>asEWKB(tspatial,endian text='') → bytea</varname></para>
-				<para><varname>asHexEWKB(tspatial,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(tspatial,endian text='') → bytea
+asEWKB(tspatial,endian text='') → bytea
+asHexEWKB(tspatial,endian text='') → text
+</programlisting>
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tgeompoint 'Point(1 2 3)@2001-01-01');
@@ -305,8 +327,10 @@ SELECT asHexEWKB(tgeompoint 'SRID=3812;Point(1 2 3)@2001-01-01');
 				<indexterm significance="normal"><primary><varname>tspatialFromText</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tspatialFromEWKT</varname></primary></indexterm>
 				<para>Input from the Well-Known Text (WKT) or from the Extended Well-Known Text (EWKT) representation &Z_support; &geography_support;</para>
-				<para><varname>tspatialFromText(text) → tspatial</varname></para>
-				<para><varname>tspatialFromEWKT(text) → tspatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tspatialFromText(text) → tspatial
+tspatialFromEWKT(text) → tspatial
+</programlisting>
 				<para>In the above functions, <varname>tspatial</varname> replaces any spatial type, such as <varname>tgeompoint</varname>, <varname>tgeometry</varname>, or <varname>tpose</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tgeompointFromText(text '[POINT(1 2)@2001-01-01, POINT(3 4)@2001-01-02]'));
@@ -328,7 +352,9 @@ SELECT asEWKT(tgeographyFromEWKT(text 'SRID=7844;[Point(1 2)@2001-01-01,
 			<listitem xml:id="tspatialFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tspatialFromMFJSON</varname></primary></indexterm>
 				<para>Input from the Moving Features JSON representation &Z_support; &geography_support;</para>
-				<para><varname>tspatialFromMFJSON(text) → tspatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tspatialFromMFJSON(text) → tspatial
+</programlisting>
 				<para>In the above function, <varname>tspatial</varname> replaces any spatiotemporal type, for example, <varname>tgeompoint</varname>, <varname>tgeometry</varname>, or <varname>tpose</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tgeompointFromMFJSON(text '{"type":"MovingPoint","crs":{"type":"name",
@@ -352,9 +378,11 @@ SELECT asEWKT(tgeographyFromMFJSON(text '{"type":"MovingGeometry",
 				<indexterm significance="normal"><primary><varname>tspatialFromEWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tspatialFromHexEWKB</varname></primary></indexterm>
 				<para>Input from the Well-Known Binary (WKB), from the Extended Well-Known Binary (EWKB), or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation &Z_support; &geography_support;</para>
-				<para><varname>tspatialFromBinary(bytea) → tspatial</varname></para>
-				<para><varname>tspatialFromEWKB(bytea) → tspatial</varname></para>
-				<para><varname>tspatialFromHexEWKB(text) → tspatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tspatialFromBinary(bytea) → tspatial
+tspatialFromEWKB(bytea) → tspatial
+tspatialFromHexEWKB(text) → tspatial
+</programlisting>
 				<para>In the previous functions, <varname>tspatial</varname> replaces any spatiotemporal type, for example, <varname>tgeompoint</varname>, <varname>tgeometry</varname>, or <varname>tpose</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tgeompointFromBinary(
@@ -378,8 +406,10 @@ SELECT asEWKT(tgeompointFromHexEWKB(
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stbox(tspatial)</varname></primary></indexterm>
 				<para>Convert a spatiotemporal value to a spatiotemporal box</para>
-				<para><varname>tspatial::stbox</varname></para>
-				<para><varname>stbox(tspatial)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tspatial::stbox
+stbox(tspatial)
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]'::stbox;
 -- STBOX XT(((1,1),(3,3)),[2001-01-01, 2001-01-03])
@@ -391,10 +421,12 @@ SELECT tgeography '[Point(1 1 1)@2001-01-01, Point(3 3 3)@2001-01-03]'::stbox;
 			<listitem xml:id="tgeometry_tgeography">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert between a temporal geometry and a temporal geography</para>
-				<para><varname>tgeometry::tgeography</varname></para>
-				<para><varname>tgeography::tgeometry</varname></para>
-				<para><varname>tgeompoint::tgeogpoint</varname></para>
-				<para><varname>tgeogpoint::tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tgeometry::tgeography
+tgeography::tgeometry
+tgeompoint::tgeogpoint
+tgeogpoint::tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tgeompoint '[Point(0 0)@2001-01-01, Point(0 1)@2001-01-02)')::tgeogpoint);
 -- [POINT(0 0)@2001-01-01, POINT(0 1)@2001-01-02)
@@ -412,8 +444,10 @@ SELECT asText((tgeography 'Linestring(0 0,1 1)@2001-01-01')::tgeometry);
 			<listitem xml:id="tgeompoint_geometry">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert between a temporal point and a PostGIS trajectory</para>
-				<para><varname>tpoint::geo</varname></para>
-				<para><varname>geo::tpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tpoint::geo
+geo::tpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText((tgeompoint 'Point(0 0)@2001-01-01')::geometry);
 -- POINT M (0 0 978307200)
@@ -453,8 +487,10 @@ SELECT asText(geometry 'GEOMETRYCOLLECTION M (LINESTRING M (0 0 978307200,1 1 97
 				<indexterm significance="normal"><primary><varname>trajectory</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>traversedArea</varname></primary></indexterm>
 				<para>Return the trajectory or the traversed area &Z_support; &geography_support;</para>
-				<para><varname>trajectory(tpoint,unary_union=false) → geo</varname></para>
-				<para><varname>traversedArea(tgeo,unary_union=false) → geo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+trajectory(tpoint,unary_union=false) → geo
+traversedArea(tgeo,unary_union=false) → geo
+</programlisting>
 				<para>This function is equivalent to <link linkend="ttype_getValues"><varname>getValues</varname></link> for temporal alphanumeric values. The last argument states whether the PostGIS function <ulink url="https://postgis.net/docs/ST_UnaryUnion.html">ST_UnaryUnion</ulink> is applied to remove redundant geometries in the result. Notice that setting this argument to true is computationally expensive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(trajectory(tgeompoint '[Point(0 0)@2001-01-01, Point(0 1)@2001-01-02,
@@ -483,7 +519,9 @@ SELECT ST_AsText(traversedArea(tgeometry '[Point(1 1)@2001-01-01,
 			<listitem xml:id="tgeo_centroid">
 				<indexterm significance="normal"><primary><varname>centroid</varname></primary></indexterm>
 				<para>Return the centroid as a temporal point &geography_support;</para>
-				<para><varname>centroid(tgeo) → tpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+centroid(tgeo) → tpoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(centroid(tgeometry '[Point(1 1)@2000-01-01, Linestring(1 1,3 3)@2000-01-02,
   Polygon((1 1,4 4,7 1,1 1))@2000-01-03]'));
@@ -499,9 +537,11 @@ SELECT asText(centroid(tgeography '[MultiPoint(1 1,4 4,7 1)@2000-01-01,
 				<indexterm significance="normal"><primary><varname>getY</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>getZ</varname></primary></indexterm>
 				<para>Return the X/Y/Z coordinate values as a temporal float &Z_support; &geography_support;</para>
-				<para><varname>getX(tpoint) → tfloat</varname></para>
-				<para><varname>getY(tpoint) → tfloat</varname></para>
-				<para><varname>getZ(tpoint) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getX(tpoint) → tfloat
+getY(tpoint) → tfloat
+getZ(tpoint) → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getX(tgeompoint '{Point(1 2)@2001-01-01, Point(3 4)@2001-01-02,
   Point(5 6)@2001-01-03}');
@@ -527,7 +567,9 @@ SELECT getZ(tgeogpoint 'Interp=Step;[Point(1 2 3)@2001-01-01, Point(4 5 6)@2001-
 			<listitem xml:id="tgeo_isSimple">
 				<indexterm significance="normal"><primary><varname>isSimple</varname></primary></indexterm>
 				<para>Return true if the temporal point does not spatially self-intersect &Z_support;</para>
-				<para><varname>isSimple(tpoint) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+isSimple(tpoint) → boolean
+</programlisting>
 				<para>Notice that a temporal sequence set point is simple if every composing sequence is simple.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isSimple(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
@@ -545,7 +587,9 @@ SELECT isSimple(tgeompoint '{[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02],
 			<listitem xml:id="tgeo_length">
 				<indexterm significance="normal"><primary><varname>length</varname></primary></indexterm>
 				<para>Return the length traversed by the temporal point &Z_support; &geography_support;</para>
-				<para><varname>length(tpoint) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+length(tpoint) → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02]');
 -- 1.73205080756888
@@ -561,7 +605,9 @@ SELECT length(tgeompoint 'Interp=Step;[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_cumulativeLength">
 				<indexterm significance="normal"><primary><varname>cumulativeLength</varname></primary></indexterm>
 				<para>Return the cumulative length traversed by the temporal point &Z_support; &geography_support;</para>
-				<para><varname>cumulativeLength(tpoint) → tfloatSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+cumulativeLength(tpoint) → tfloatSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(cumulativeLength(tgeompoint '{[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(1 0)@2001-01-03], [Point(1 0)@2001-01-04, Point(0 0)@2001-01-05]}'), 6);
@@ -576,7 +622,9 @@ SELECT cumulativeLength(tgeompoint 'Interp=Step;[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_speed">
 				<indexterm significance="normal"><primary><varname>speed</varname></primary></indexterm>
 				<para>Return the speed of the temporal point in units per second &Z_support; &geography_support;</para>
-				<para><varname>speed(tpoint) → tfloatSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+speed(tpoint) → tfloatSeqSet
+</programlisting>
 				<para>The temporal point must have linear interpolation</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT speed(tgeompoint '{[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
@@ -592,7 +640,9 @@ SELECT speed(tgeompoint 'Interp=Step;[Point(0 0)@2001-01-01, Point(1 1)@2001-01-
 			<listitem xml:id="tgeo_twCentroid">
 				<indexterm significance="normal"><primary><varname>twCentroid</varname></primary></indexterm>
 				<para>Return the time-weighted centroid &Z_support;</para>
-				<para><varname>twCentroid(tgeompoint) → point</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+twCentroid(tgeompoint) → point
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(twCentroid(tgeompoint '{[Point(0 0 0)@2001-01-01,
   Point(0 1 1)@2001-01-02, Point(0 1 1)@2001-01-03, Point(0 0 0)@2001-01-04)}'));
@@ -603,7 +653,9 @@ SELECT ST_AsText(twCentroid(tgeompoint '{[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_direction">
 				<indexterm significance="normal"><primary><varname>direction</varname></primary></indexterm>
 				<para>Return the direction, that is, the azimuth between the start and end locations &Z_support; &geography_support;</para>
-				<para><varname>direction(tpoint) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+direction(tpoint) → float
+</programlisting>
 				<para>The result is expressed in radians. It is NULL if there is only one location or if the start and end locations are equal.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(degrees(direction(tgeompoint '[Point(0 0)@2001-01-01,
@@ -618,7 +670,9 @@ SELECT direction(tgeompoint '{[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_azimuth">
 				<indexterm significance="normal"><primary><varname>azimuth</varname></primary></indexterm>
 				<para>Return the temporal azimuth &Z_support; &geography_support;</para>
-				<para><varname>azimuth(tpoint) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+azimuth(tpoint) → tfloat
+</programlisting>
 				<para>The result is expressed in radians. The azimut is undefined when two succesive locations are equal and in this case a temporal gap is added.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(degrees(azimuth(tgeompoint '[Point(0 0 0)@2001-01-01,
@@ -630,7 +684,9 @@ SELECT round(degrees(azimuth(tgeompoint '[Point(0 0 0)@2001-01-01,
 			<listitem xml:id="tgeo_angularDifference">
 				<indexterm significance="normal"><primary><varname>angularDifference</varname></primary></indexterm>
 				<para>Return the temporal angular difference &geography_support;</para>
-				<para><varname>angularDifference(tpoint) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+angularDifference(tpoint) → tfloat
+</programlisting>
 				<para>The result is expressed in degrees.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(angularDifference(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02,
@@ -645,7 +701,9 @@ SELECT round(degrees(angularDifference(tgeompoint '{[Point(1 1)@2001-01-01,
 			<listitem xml:id="tgeo_bearing">
 				<indexterm significance="normal"><primary><varname>bearing</varname></primary></indexterm>
 				<para>Return the temporal bearing &Z_support; &geography_support;</para>
-				<para><varname>bearing({tpoint,point},{tpoint,point}) → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+bearing({tpoint,point},{tpoint,point}) → tfloat
+</programlisting>
 				<para>Notice that this function does not accept two temporal geographic points.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT degrees(bearing(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]',
@@ -668,7 +726,9 @@ SELECT round(degrees(bearing(tgeompoint '[Point(2 1)@2001-01-01, Point(0 1)@2001
 			<listitem xml:id="tspatial_round">
 				<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 				<para>Round the coordinate values to a number of decimal places &Z_support; &geography_support;</para>
-				<para><varname>round(tspatial,integer=0) → tspatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+round(tspatial,integer=0) → tspatial
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(tgeompoint '{Point(1.12345 1.12345 1.12345)@2001-01-01,
   Point(2 2 2)@2001-01-02, Point(1.12345 1.12345 1.12345)@2001-01-03}', 2));
@@ -683,7 +743,9 @@ SELECT asText(round(tgeography 'Linestring(1.12345 1.12345,2.12345 2.12345)@2001
 			<listitem xml:id="tpoint_makeSimple">
 				<indexterm significance="normal"><primary><varname>makeSimple</varname></primary></indexterm>
 				<para>Return an array of fragments of the temporal point which are simple &Z_support;</para>
-				<para><varname>makeSimple(tpoint) → tgeompoint[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+makeSimple(tpoint) → tgeompoint[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(makeSimple(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(0 0)@2001-01-03]'));
@@ -707,7 +769,9 @@ SELECT asText(makeSimple(tgeompoint '{[Point(0 0 0)@2001-01-01, Point(1 1 1)@200
 			<listitem xml:id="tgeo_geoMeasure">
 				<indexterm significance="normal"><primary><varname>geoMeasure</varname></primary></indexterm>
 				<para>Construct a geometry/geography with M measure from a temporal point and a temporal float &Z_support; &geography_support;</para>
-				<para><varname>geoMeasure(tpoint,tfloat,segmentize=false) → geo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+geoMeasure(tpoint,tfloat,segmentize=false) → geo
+</programlisting>
 				<para>The last argument <varname>segmentize</varname> states whether the resulting value is a either <varname>Linestring M</varname> or a <varname>MultiLinestring M</varname> where each component is a segment of two points.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(geoMeasure(tgeompoint '{Point(1 1 1)@2001-01-01,
@@ -749,9 +813,11 @@ ramp_color('RdYlBu', scale_linear(
 			<listitem xml:id="tgeo_affine">
 				<indexterm significance="normal"><primary><varname>affine</varname></primary></indexterm>
 				<para>Return the 3D affine transform of a temporal geometry to translate, rotate, and/or scale it in a single step &Z_support;</para>
-				<para><varname>affine(tgeo,float a,float b,float c,float d,float e,float f,float g,</varname></para>
-				<para><varname>  float h,float i,float xoff,float yoff,float zoff) → tgeo</varname></para>
-				<para><varname>affine(tgeo,float a,float b,float d,float e,float xoff,float yoff) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+affine(tgeo,float a,float b,float c,float d,float e,float f,float g,
+  float h,float i,float xoff,float yoff,float zoff) → tgeo
+affine(tgeo,float a,float b,float d,float e,float xoff,float yoff) → tgeo
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Rotate a 3D temporal point 180 degrees about the z axis
 SELECT asEWKT(affine(temp, cos(pi()), -sin(pi()), 0, sin(pi()), cos(pi()), 0, 0, 0, 1,
@@ -773,9 +839,11 @@ FROM (SELECT tgeometry '[Point(1 1)@2001-01-01,
 			<listitem xml:id="tgeo_rotate">
 				<indexterm significance="normal"><primary><varname>rotate</varname></primary></indexterm>
 				<para>Return the temporal point rotated counter-clockwise about the origin point</para>
-				<para><varname>rotate(tgeo,float radians) → tgeo</varname></para>
-				<para><varname>rotate(tgeo,float radians,float x0,float y0) → tgeo</varname></para>
-				<para><varname>rotate(tgeo,float radians,geometry origin) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+rotate(tgeo,float radians) → tgeo
+rotate(tgeo,float radians,float x0,float y0) → tgeo
+rotate(tgeo,float radians,geometry origin) → tgeo
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Rotate a temporal point 180 degrees
 SELECT asEWKT(rotate(tgeompoint '[Point(5 10)@2001-01-01, Point(5 5)@2001-01-02, 
@@ -797,10 +865,12 @@ FROM (SELECT tgeometry '[Point(5 10)@2001-01-01, Point(5 5)@2001-01-02,
 			<listitem xml:id="tgeo_scale">
 				<indexterm significance="normal"><primary><varname>scale</varname></primary></indexterm>
 				<para>Return a temporal point scaled by given factors &Z_support;</para>
-				<para><varname>scale(tgeo,float Xfactor,float Yfactor,float Zfactor) → tgeo</varname></para>
-				<para><varname>scale(tgeo,float Xfactor,float Yfactor) → tgeo</varname></para>
-				<para><varname>scale(tgeo,geometry factor) → tgeo</varname></para>
-				<para><varname>scale(tgeo,geometry factor,geometry origin) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+scale(tgeo,float Xfactor,float Yfactor,float Zfactor) → tgeo
+scale(tgeo,float Xfactor,float Yfactor) → tgeo
+scale(tgeo,geometry factor) → tgeo
+scale(tgeo,geometry factor,geometry origin) → tgeo
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(scale(tgeompoint '[Point(1 2 3)@2001-01-01, Point(1 1 1)@2001-01-02]', 
   0.5, 0.75, 0.8));
@@ -820,7 +890,9 @@ SELECT asEWKT(scale(tgeometry '[Point(1 1)@2001-01-01, Linestring(1 1,2 2)@2001-
 			<listitem xml:id="tpoint_asMVTGeom">
 				<indexterm significance="normal"><primary><varname>asMVTGeom</varname></primary></indexterm>
 				<para>Transform a temporal geometric point into the coordinate space of a Mapbox Vector Tile &Z_support;</para>
-				<para><varname>asMVTGeom(tpoint,bounds,extent=4096,buffer=256,clip=true) → (geom,times)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMVTGeom(tpoint,bounds,extent=4096,buffer=256,clip=true) → (geom,times)
+</programlisting>
 				<para>The result is a couple composed of a <varname>geometry</varname> value and an array of associated timestamp values encoded as Unix epoch. The parameters are as follows:</para>
 				<itemizedlist>
 					<listitem><para><varname>tpoint</varname> is the temporal point to transform</para></listitem>
@@ -844,7 +916,9 @@ FROM (SELECT asMVTGeom(tgeompoint '[Point(0 0)@2001-01-01, Point(100 100)@2001-0
 			<listitem xml:id="tgeo_stops">
 				<indexterm significance="normal"><primary><varname>stops</varname></primary></indexterm>
 				<para>Extract from a temporal point with linear interpolation the subsequences where the point stays within an area with a specified maximum size for at least the given duration &Z_support; &geography_support;</para>
-				<para><varname>stops(tpoint,maxDist=0.0,minDuration='0 minutes') → tpoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+stops(tpoint,maxDist=0.0,minDuration='0 minutes') → tpoint
+</programlisting>
 				<para>The size of the area is the greatest distance between two points of the subsequence, which is the quantity the temporal float form of the function reads as the difference between the greatest and the least value it takes. If <varname>maxDist</varname> is not given it is assumed 0.0 and thus, the function extracts the constant segments of the given temporal point. The distance is computed in the units of the coordinate system for a <varname>tgeompoint</varname> and in meters on the WGS84 spheroid for a <varname>tgeogpoint</varname>. Note that even though the function accepts 3D geometries, the computation is always performed in 2D.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(stops(tgeompoint '[Point(1 1)@2001-01-01, Point(1 1)@2001-01-02,

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -17,8 +17,10 @@
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a geometry &Z_support;</para>
-				<para><varname>atGeometry(tgeom,geometry) → tgeom</varname></para>
-				<para><varname>minusGeometry(tgeom,geometry) → tgeom</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atGeometry(tgeom,geometry) → tgeom
+minusGeometry(tgeom,geometry) → tgeom
+</programlisting>
 				<para>The geometry must be in 2D and the computation with respect to it is done in 2D. The result preserves the Z dimension of the temporal point, if it exists.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atGeometry(tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)',
@@ -56,8 +58,10 @@ SELECT asText(minusGeometry(tgeometry 'Linestring(1 1,10 1)@2001-01-01',
 				<indexterm significance="normal"><primary><varname>atStbox</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusStbox</varname></primary></indexterm>
 				<para>Restrict to (the complement of) an <varname>stbox</varname> &Z_support;</para>
-				<para><varname>atStbox(tgeom,stbox,borderInc boolean=true) → tgeompoint</varname></para>
-				<para><varname>minusStbox(tgeom,stbox,borderInc boolean=true) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atStbox(tgeom,stbox,borderInc boolean=true) → tgeompoint
+minusStbox(tgeom,stbox,borderInc boolean=true) → tgeompoint
+</programlisting>
 				<para>The third optional argument is used for multidimensional tiling (see <xref linkend="ttype_tiling"/>) to exclude the upper border of the tiles when a temporal value is split in multiple tiles, so that all fragments of the temporal geometry are exclusive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(atStbox(tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)',
@@ -92,8 +96,10 @@ SELECT asText(minusStbox(tgeometry '[Point(1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atElevation</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusElevation</varname></primary></indexterm>
 				<para>Restrict to (the complement of) an elevation span &Z_support;</para>
-				<para><varname>atElevation(tgeom,zspan) → tgeom</varname></para>
-				<para><varname>minusElevation(tgeom,zspan) → tgeom</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atElevation(tgeom,zspan) → tgeom
+minusElevation(tgeom,zspan) → tgeom
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT astext(atElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
   Point(4 4 4)@2001-01-04, Point(1 1 1)@2001-01-07]', floatspan '[2,3]'));
@@ -115,8 +121,10 @@ SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Return or set the spatial reference identifier &Z_support; &geography_support;</para>
-				<para><varname>SRID(tspatial) → integer</varname></para>
-				<para><varname>setSRID(tspatial) → tspatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+SRID(tspatial) → integer
+setSRID(tspatial) → tspatial
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tgeompoint 'Point(0 0)@2001-01-01');
 -- 0
@@ -129,8 +137,11 @@ SELECT asEWKT(setSRID(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02)
 				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transform to a spatial reference identifier &Z_support; &geography_support;</para>
-				<para><varname>transform(tspatial,integer) → tspatial</varname></para>
-				<para><varname>transformPipeline(tspatial,pipeline text,to_srid integer,is_forward boolean=true) → tspatial</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+transform(tspatial,integer) → tspatial
+transformPipeline(tspatial,pipeline text,to_srid integer,
+  is_forward boolean=true) → tspatial
+</programlisting>
 				<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input temporal point has an unknown SRID (represented by 0).</para>
 				<para>The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
@@ -161,7 +172,9 @@ FROM test;
 			<listitem xml:id="tpoint_expandSpace">
 				<indexterm significance="normal"><primary><varname>expandSpace</varname></primary></indexterm>
 				<para>Return the spatiotemporal bounding box expanded in the spatial dimension by a float value &Z_support; &geography_support;</para>
-				<para><varname>expandSpace({spatial,tspatial},float) → stbox</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+expandSpace({spatial,tspatial},float) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expandSpace(geography 'Linestring(0 0,1 1)', 2);
 -- SRID=4326;GEODSTBOX X((-2,-2),(3,3))
@@ -179,7 +192,9 @@ SELECT expandSpace(tgeompoint 'Point(0 0)@2001-01-01', 2);
 			<listitem xml:id="tgeo_nearestApproachDistance">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 				<para>Return the smallest distance ever &Z_support; &geography_support;</para>
-				<para><varname>{geo,tgeo,stbox} |=| {geo,tgeo,stbox} → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,tgeo,stbox} |=| {geo,tgeo,stbox} → float
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[Point(0 0)@2001-01-02, Point(1 1)@2001-01-04, Point(0 0)@2001-01-06)'
   |=| geometry 'Linestring(2 2,2 1,3 1)';
@@ -210,7 +225,9 @@ SELECT ST_DistanceCPA(
 			<listitem xml:id="tgeo_nearestApproachInstant">
 				<indexterm significance="normal"><primary><varname>nearestApproachInstant</varname></primary></indexterm>
 				<para>Return the instant of the first temporal point at which the two arguments are at the nearest distance &Z_support; &geography_support;</para>
-				<para><varname>nearestApproachInstant({geo,tgeo},{geo,tgeo}) → tgeo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+nearestApproachInstant({geo,tgeo},{geo,tgeo}) → tgeo
+</programlisting>
 				<para>The function will only return the first instant that it finds if there are more than one. The resulting instant may be at an exclusive bound.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(nearestApproachInstant(tgeompoint '(Point(1 1)@2001-01-01,
@@ -241,8 +258,10 @@ SELECT to_timestamp(ST_ClosestPointOfApproach(
 			<listitem xml:id="tgeo_minDistance">
 				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
 				<para>Return the minimum spatial distance between two temporal geometries over the union of their temporal extents</para>
-				<para><varname>minDistance({tgeo,geo},{tgeo,geo}) → float</varname></para>
-				<para><varname>minDistance(tgeo[],tgeo[]) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minDistance({tgeo,geo},{tgeo,geo}) → float
+minDistance(tgeo[],tgeo[]) → float
+</programlisting>
 				<para><varname>minDistance(tgeo,tgeo) → float</varname> (aggregate)</para>
 				<para>The scalar form returns the minimum distance reached between the two arguments over the intersection of their temporal extents, equivalent to the minimum value of the temporal distance <varname>&lt;-&gt;</varname>. The array form generalises this to two sets of temporal geometries and returns the minimum across all pairs. The aggregate form, used with <varname>GROUP BY</varname>, returns the minimum distance reached over all aggregated pairs in the group.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -276,18 +295,20 @@ GROUP BY g;
 				<indexterm significance="normal"><primary><varname>aTouchesPairs</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tTouchesPairs</varname></primary></indexterm>
 				<para>Return the qualifying index pairs of two arrays of temporal geometries, generalising the scalar spatial relationships to a set-set spatial join</para>
-				<para><varname>eDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)</varname></para>
-				<para><varname>aDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)</varname></para>
-				<para><varname>eIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>aIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>eDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>aDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>eTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>aTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer)</varname></para>
-				<para><varname>tDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer, periods tstzspanset)</varname></para>
-				<para><varname>tIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer, periods tstzspanset)</varname></para>
-				<para><varname>tDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer, periods tstzspanset)</varname></para>
-				<para><varname>tTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer, periods tstzspanset)</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+eDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)
+aDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer)
+eIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer)
+aIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer)
+eDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)
+aDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer)
+eTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer)
+aTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer)
+tDwithinPairs(tgeo[],tgeo[],float) → setof(i integer, j integer, periods tstzspanset)
+tIntersectsPairs(tgeo[],tgeo[]) → setof(i integer, j integer, periods tstzspanset)
+tDisjointPairs(tgeo[],tgeo[]) → setof(i integer, j integer, periods tstzspanset)
+tTouchesPairs(tgeometry[],tgeometry[]) → setof(i integer, j integer, periods tstzspanset)
+</programlisting>
 				<para>Each function resolves the pruned cross product of the two input arrays inside a single call and returns the one-based indexes <varname>i</varname> and <varname>j</varname> of the qualifying pairs. The <varname>e</varname>-prefixed functions return the pairs for which the relationship ever holds, the <varname>a</varname>-prefixed functions the pairs for which it always holds, and the <varname>t</varname>-prefixed functions additionally return the periods during which it holds. Each input's spatiotemporal box is used as a bounding-box prefilter so that the exact relationship is computed only on the surviving candidate pairs, and pairs whose temporal extents do not overlap are excluded, matching the scalar relationships. The functions are defined for temporal points and temporal geometries in both the planar and geodetic cases, except the touches relationship, which is defined for planar geometries only. The indexes map back to the original identities through a parallel <varname>array_agg(identity ORDER BY ...)</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT i, j FROM eDwithinPairs(
@@ -309,7 +330,9 @@ SELECT i, j FROM aDisjointPairs(
 			<listitem xml:id="tgeo_shortestLine">
 				<indexterm significance="normal"><primary><varname>shortestLine</varname></primary></indexterm>
 				<para>Return the line connecting the nearest approach point &Z_support; &geography_support;</para>
-				<para><varname>shortestLine({geo,tgeo},{geo,tgeo}) → geo</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shortestLine({geo,tgeo},{geo,tgeo}) → geo
+</programlisting>
 				<para>The function will only return the first line that it finds if there are more than one.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(tgeompoint '(Point(1 1)@2001-01-01,
@@ -349,7 +372,9 @@ SELECT ST_CPAWithin(
 			<listitem xml:id="tgeo_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Return the temporal distance &Z_support; &geography_support;</para>
-				<para><varname>{geo,tgeo} &lt;-&gt; {geo,tgeo} → tfloat</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+{geo,tgeo} &lt;-&gt; {geo,tgeo} → tfloat
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)' &lt;-&gt;
   geometry 'Point(0 1)';
@@ -458,8 +483,10 @@ WHERE eIntersects(T.Trip, R.Geom)
 					<indexterm significance="normal"><primary><varname>eContains</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aContains</varname></primary></indexterm>
 					<para>Ever or always contains</para>
-					<para><varname>eContains({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
-					<para><varname>aContains({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eContains({geometry,tgeom},{geometry,tgeom}) → boolean
+aContains({geometry,tgeom},{geometry,tgeom}) → boolean
+</programlisting>
 					<para>This function returns true if the temporal geometry and the geometry ever or always intersect at their interior. Recall that a geometry does not contain things in its boundary and thus, polygons and lines do not contain lines and points lying in their boundary. Please refer to the documentation of the <ulink url="https://postgis.net/docs/ST_Contains.html">ST_Contains</ulink> function in PostGIS.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Linestring(1 1,3 3)',
@@ -481,8 +508,10 @@ SELECT eContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 					<indexterm significance="normal"><primary><varname>eCovers</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aCovers</varname></primary></indexterm>
 					<para>Ever or always covers</para>
-					<para><varname>eCovers({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
-					<para><varname>aCovers({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eCovers({geometry,tgeom},{geometry,tgeom}) → boolean
+aCovers({geometry,tgeom},{geometry,tgeom}) → boolean
+</programlisting>
 					<para>Please refer to the documentation of the <ulink url="https://postgis.net/docs/ST_Contains.html">ST_Contains</ulink> and the <ulink url="https://postgis.net/docs/ST_Covers.html">ST_Covers</ulink> function in PostGIS for detailed explanations about the difference between the two functions.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eCovers(geometry 'Linestring(1 1,3 3)',
@@ -504,8 +533,10 @@ SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 					<indexterm significance="normal"><primary><varname>eDisjoint</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aDisjoint</varname></primary></indexterm>
 					<para>Is ever or always disjoint &Z_support; &geography_support;</para>
-					<para><varname>eDisjoint({geo,tgeo},{geo,tgeo}) → boolean</varname></para>
-					<para><varname>aDisjoint({geo,tgeo},{geo,tgeo}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eDisjoint({geo,tgeo},{geo,tgeo}) → boolean
+aDisjoint({geo,tgeo},{geo,tgeo}) → boolean
+</programlisting>
 						<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eDisjoint(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)');
@@ -520,8 +551,10 @@ SELECT eDisjoint(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 					<indexterm significance="normal"><primary><varname>eDwithin</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aDwithin</varname></primary></indexterm>
 					<para>Is ever or always at distance within &Z_support; &geography_support;</para>
-					<para><varname>eDwithin({geo,tgeo},{geo,tgeo},float) → boolean</varname></para>
-					<para><varname>aDwithin({geometry,tgeom},{geometry,tgeom},float) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eDwithin({geo,tgeo},{geo,tgeo},float) → boolean
+aDwithin({geometry,tgeom},{geometry,tgeom},float) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eDwithin(geometry 'Point(1 1 1)',
   tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 0)@2001-01-02]', 1);
@@ -536,8 +569,10 @@ SELECT eDwithin(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 					<indexterm significance="normal"><primary><varname>eIntersects</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aIntersects</varname></primary></indexterm>
 					<para>Ever or always intersects &Z_support; &geography_support;</para>
-					<para><varname>eIntersects({geo,tgeo},{geo,tgeo}) → boolean</varname></para>
-					<para><varname>aIntersects({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eIntersects({geo,tgeo},{geo,tgeo}) → boolean
+aIntersects({geometry,tgeom},{geometry,tgeom}) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eIntersects(geometry 'Polygon((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0))',
   tgeompoint '[Point(0 0 1)@2001-01-01, Point(1 1 1)@2001-01-03)');
@@ -552,8 +587,10 @@ SELECT eIntersects(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 					<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
 					<para>Ever or always touches</para>
-					<para><varname>eTouches({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
-					<para><varname>aTouches({geometry,tgeom},{geometry,tgeom}) → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+eTouches({geometry,tgeom},{geometry,tgeom}) → boolean
+aTouches({geometry,tgeom},{geometry,tgeom}) → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eTouches(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(0 1)@2001-01-03)');
@@ -571,7 +608,9 @@ SELECT eTouches(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
 				<listitem xml:id="tgeo_tContains">
 					<indexterm significance="normal"><primary><varname>tContains</varname></primary></indexterm>
 					<para>Temporal contains</para>
-					<para><varname>tContains(geometry,tgeom) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tContains(geometry,tgeom) → tbool
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tContains(geometry 'Linestring(1 1,3 3)',
   tgeompoint '[Point(4 2)@2001-01-01, Point(2 4)@2001-01-02]');
@@ -591,7 +630,9 @@ SELECT tContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 				<listitem xml:id="tgeo_tDisjoint">
 					<indexterm significance="normal"><primary><varname>tDisjoint</varname></primary></indexterm>
 					<para>Temporal disjoint &Z_support; &geography_support;</para>
-					<para><varname>tDisjoint({geo,tgeo},{geo,tgeo}) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tDisjoint({geo,tgeo},{geo,tgeo}) → tbool
+</programlisting>
 					<para>The function only supports 3D or geographies for two temporal points</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tDisjoint(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
@@ -606,7 +647,9 @@ SELECT tDisjoint(tgeompoint '[Point(0 3)@2001-01-01, Point(3 0)@2001-01-05)',
 				<listitem xml:id="tgeo_tDwithin">
 					<indexterm significance="normal"><primary><varname>tDwithin</varname></primary></indexterm>
 					<para>Temporal distance within &Z_support;</para>
-					<para><varname>tDwithin({geo,tgeo},{geo,tgeo},float) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tDwithin({geo,tgeo},{geo,tgeo},float) → tbool
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tDwithin(geometry 'Point(1 1)',
   tgeompoint '[Point(0 0)@2001-01-01, Point(2 2)@2001-01-03)', sqrt(2));
@@ -620,7 +663,9 @@ SELECT tDwithin(tgeompoint '[Point(1 0)@2001-01-01, Point(1 4)@2001-01-05]',
 				<listitem xml:id="tgeo_tIntersects">
 					<indexterm significance="normal"><primary><varname>tIntersects</varname></primary></indexterm>
 					<para>Temporal intersects &Z_support; &geography_support;</para>
-					<para><varname>tIntersects({geo,tgeo},{geo,tgeo}) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tIntersects({geo,tgeo},{geo,tgeo}) → tbool
+</programlisting>
 					<para>The function only supports 3D or geographies for two temporal points</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(geometry 'MultiPoint(1 1,2 2)',
@@ -636,7 +681,9 @@ SELECT tIntersects(tgeompoint '[Point(0 3)@2001-01-01, Point(3 0)@2001-01-05)',
 				<listitem xml:id="tgeo_tTouches">
 					<indexterm significance="normal"><primary><varname>tTouches</varname></primary></indexterm>
 					<para>Temporal touches</para>
-					<para><varname>tTouches({geometry,tgeom},{geometry,tgeom}) → tbool</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+tTouches({geometry,tgeom},{geometry,tgeom}) → tbool
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tTouches(geometry 'Polygon((1 0,1 2,2 2,2 0,1 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(3 0)@2001-01-04)');

--- a/doc/temporal_types_aggregation.xml
+++ b/doc/temporal_types_aggregation.xml
@@ -35,7 +35,9 @@
 			<listitem xml:id="ttype_tCount">
 				<indexterm significance="normal"><primary><varname>tCount</varname></primary></indexterm>
 				<para>Temporal count</para>
-				<para><varname>tCount(ttype) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCount(ttype) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tCount(NoEmps) FROM Department;
 -- {[1@2001-01-01, 2@2001-02-01, 1@2001-08-01, 1@2001-10-01)}
@@ -45,7 +47,9 @@ SELECT tCount(NoEmps) FROM Department;
 			<listitem xml:id="ttype_extent">
 				<indexterm significance="normal"><primary><varname>extent</varname></primary></indexterm>
 				<para>Bounding box extent</para>
-				<para><varname>extent(temp) → {tstzspan,tbox,stbox}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extent(temp) → {tstzspan,tbox,stbox}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(noEmps) FROM Department;
 -- TBOX XT((4,12),[2001-01-01,2001-10-01])
@@ -58,8 +62,10 @@ SELECT extent(Trip) FROM Trips;
 				<indexterm significance="normal"><primary><varname>tAnd</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tOr</varname></primary></indexterm>
 				<para>Temporal and, temporal or</para>
-				<para><varname>tOr(tbool) → tbool</varname></para>
-				<para><varname>tAnd(tbool) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tOr(tbool) → tbool
+tAnd(tbool) → tbool
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tAnd(NoEmps #&gt; 6) FROM Department;
 -- {[t@2001-01-01, f@2001-04-01, f@2001-10-01)}
@@ -74,10 +80,12 @@ SELECT tOr(NoEmps #&gt; 6) FROM Department;
 				<indexterm significance="normal"><primary><varname>tSum</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tAvg</varname></primary></indexterm>
 				<para>Temporal minimum, maximum, sum, and average</para>
-				<para><varname>tMin(ttype) → ttype</varname></para>
-				<para><varname>tMax(ttype) → ttype</varname></para>
-				<para><varname>tSum(tnumber) → {tnumberSeq,tnumberSeqSet}</varname></para>
-				<para><varname>tAvg(tnumber) → {tfloatSeq,tfloatSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tMin(ttype) → ttype
+tMax(ttype) → ttype
+tSum(tnumber) → {tnumberSeq,tnumberSeqSet}
+tAvg(tnumber) → {tfloatSeq,tfloatSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tMin(NoEmps) FROM Department;
 -- {[10@2001-01-01, 4@2001-02-01, 6@2001-06-01, 6@2001-10-01)}
@@ -96,7 +104,9 @@ SELECT tAvg(NoEmps) FROM Department;
 			<listitem xml:id="ttype_wCount">
 				<indexterm significance="normal"><primary><varname>wCount</varname></primary></indexterm>
 				<para>Window count</para>
-				<para><varname>wCount(tnumber,interval) → {tintSeq,tintSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wCount(tnumber,interval) → {tintSeq,tintSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT wCount(NoEmps, interval '2 days') FROM Department;
 /* {[1@2001-01-01, 2@2001-02-01, 3@2001-04-01, 2@2001-04-03, 3@2001-06-01, 2@2001-06-03,
@@ -110,10 +120,12 @@ SELECT wCount(NoEmps, interval '2 days') FROM Department;
 				<indexterm significance="normal"><primary><varname>wSum</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>wAvg</varname></primary></indexterm>
 				<para>Window minimum, maximum, sum, and average</para>
-				<para><varname>wMin(tnumber,interval) → {tnumberSeq,tnumberSeqSet}</varname></para>
-				<para><varname>wMax(tnumber,interval) → {tnumberDiscSeq,tnumberSeqSet}</varname></para>
-				<para><varname>wSum(tint,interval) → {tintSeq,tintSeqSet}</varname></para>
-				<para><varname>wAvg(tint,interval) → {tfloatSeq,tfloatSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+wMin(tnumber,interval) → {tnumberSeq,tnumberSeqSet}
+wMax(tnumber,interval) → {tnumberDiscSeq,tnumberSeqSet}
+wSum(tint,interval) → {tintSeq,tintSeqSet}
+wAvg(tint,interval) → {tfloatSeq,tfloatSeqSet}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT wMin(NoEmps, interval '2 days') FROM Department;
 -- {[10@2001-01-01, 4@2001-04-01, 6@2001-06-03, 6@2001-10-03)}
@@ -131,7 +143,9 @@ SELECT round(wAvg(NoEmps, interval '2 days'), 3) FROM Department;
 			<listitem xml:id="tpoint_tCentroid">
 				<indexterm significance="normal"><primary><varname>tCentroid</varname></primary></indexterm>
 				<para>Temporal centroid</para>
-				<para><varname>tCentroid(tgeompoint) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tCentroid(tgeompoint) → tgeompoint
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tCentroid(Trip) FROM Trips;
 /* {[POINT(0 0)@2001-01-01 08:00:00, POINT(1 0)@2001-01-01 08:05:00),

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -19,8 +19,10 @@
 				<indexterm significance="normal"><primary><varname>minTimeDeltaSimplify</varname></primary></indexterm>
 				<para>Return a temporal float or a temporal point simplified ensuring that consecutive values are at least a certain distance or time interval apart &Z_support; &geography_support;
 </para>
-				<para><varname>minDistSimplify({tfloat,tpoint},mindist float) → {tfloat,tpoint}</varname></para>
-				<para><varname>minTimeDeltaSimplify({tfloat,tpoint},mint interval) → {tfloat,tpoint}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+minDistSimplify({tfloat,tpoint},mindist float) → {tfloat,tpoint}
+minTimeDeltaSimplify({tfloat,tpoint},mint interval) → {tfloat,tpoint}
+</programlisting>
 				<para>In the case of temporal points, the distance is specified in the units of the coordinate system. Notice that simplification applies only to temporal sequences or sequence sets with linear interpolation. In all other cases, a copy of the given temporal value is returned.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minDistSimplify(tfloat '[1@2001-01-01,2@2001-01-02,3@2001-01-04,4@2001-01-05]', 1);
@@ -46,10 +48,12 @@ SELECT asText(minTimeDeltaSimplify(tgeogpoint '[Point(1 1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>maxDistSimplify</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>douglasPeuckerSimplify</varname></primary></indexterm>
 				<para>Return a temporal float or a temporal point simplified using the <ulink url="https://en.wikipedia.org/wiki/Ramer%E2%80%93Douglas%E2%80%93Peucker_algorithm">Douglas-Peucker algorithm</ulink> &Z_support;</para>
-				<para><varname>maxDistSimplify({tfloat,tgeompoint},maxdist float,syncdist=true) →</varname></para>
-				<para><varname>  {tfloat,tgeompoint}</varname></para>
-				<para><varname>douglasPeuckerSimplify({tfloat,tgeompoint},maxdist float,syncdist=true) →</varname></para>
-				<para><varname>  {tfloat,tgeompoint}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+maxDistSimplify({tfloat,tgeompoint},maxdist float,syncdist=true) →
+  {tfloat,tgeompoint}
+douglasPeuckerSimplify({tfloat,tgeompoint},maxdist float,syncdist=true) →
+  {tfloat,tgeompoint}
+</programlisting>
 				<para>The difference between the two functions is that <varname>maxDistSimplify</varname> uses a single-pass version of the algorithm whereas <varname>douglasPeuckerSimplify</varname> uses the standard recursive algorithm.</para>
 				<para>The function removes values or points that are less than or equal to the distance passed as second argument. In the case of temporal points, the distance is specified in the units of the coordinate system. The third argument applies only for temporal points and specifies whether the spatial or the synchronized distance is used. Notice that simplification applies only to temporal sequences or sequence sets with linear interpolation. In all other cases, a copy of the given temporal value is returned.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -99,8 +103,10 @@ SELECT asText(douglasPeuckerSimplify(tgeompoint '[Point(1 1)@2001-01-01,
 			<listitem xml:id="ttype_tsample">
 				<indexterm significance="normal"><primary><varname>tsample</varname></primary></indexterm>
 				<para>Sample a temporal value with respect to an interval</para>
-				<para><varname>tsample(temporal,duration interval,torigin timestamptz='2000-01-03',</varname></para>
-				<para><varname>  interp='discrete') → temporal</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tsample(temporal,duration interval,torigin timestamptz='2000-01-03',
+  interp='discrete') → temporal
+</programlisting>
 				<para>If the origin is not specified, it is set by default to Monday, January 3, 2000. The given interval must be strictly greater than zero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tsample(tbool '[true@2001-01-01,false@2001-01-02]', '12 hours', '2001-01-01',
@@ -140,8 +146,11 @@ SELECT asText(tsample(tgeompoint '{[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05
 			<listitem xml:id="ttype_tprecision">
 				<indexterm significance="normal"><primary><varname>tprecision</varname></primary></indexterm>
 				<para>Reduce the temporal precision of a temporal value with respect to an interval computing the time-weighted average/centroid in each time bin</para>
-				<para><varname>tprecision({tnumber,tgeompoint,tcbuffer,tpose,tgeo,trgeometry},duration interval,torigin timestamptz='2000-01-03')</varname></para>
-				<para><varname> → {tnumber,tpoint,tcbuffer,tpose,tgeo,trgeometry}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tprecision({tnumber,tgeompoint,tcbuffer,tpose,tgeo,trgeometry},duration interval,
+  torigin timestamptz='2000-01-03')
+  → {tnumber,tpoint,tcbuffer,tpose,tgeo,trgeometry}
+</programlisting>
 				<para>If the origin is not specified, it is set by default to Monday, January 3, 2000. The given interval must be strictly greater than zero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tprecision(tint '[1@2001-01-01,5@2001-01-05,1@2001-01-09]','1 day',
@@ -194,11 +203,13 @@ SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-
 				<indexterm significance="normal"><primary><varname>lcssDistance</varname></primary></indexterm>
 				<para>Return the discrete <ulink url="https://en.wikipedia.org/wiki/Hausdorff_distance">Hausdorff distance</ulink>, the discrete <ulink url="https://en.wikipedia.org/wiki/Fr%C3%A9chet_distance">Fréchet distance</ulink>, the <ulink url="https://en.wikipedia.org/wiki/Dynamic_time_warping">Dynamic Time Warp</ulink> (DTW) distance, the average Hausdorff distance, or the <ulink url="https://en.wikipedia.org/wiki/Longest_common_subsequence">Longest Common SubSequence</ulink> (LCSS) distance between two temporal values &Z_support; &geography_support;
 </para>
-				<para><varname>hausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
-				<para><varname>frechetDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
-				<para><varname>dynTimeWarpDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
-				<para><varname>averageHausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float</varname></para>
-				<para><varname>lcssDistance({tnumber, tgeo}, {tnumber, tgeo}, float) → float</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+hausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float
+frechetDistance({tnumber, tgeo}, {tnumber, tgeo}) → float
+dynTimeWarpDistance({tnumber, tgeo}, {tnumber, tgeo}) → float
+averageHausdorffDistance({tnumber, tgeo}, {tnumber, tgeo}) → float
+lcssDistance({tnumber, tgeo}, {tnumber, tgeo}, float) → float
+</programlisting>
 				<para>The <varname>lcssDistance</varname> function requires an additional parameter that specifies the distance threshold under which two values are considered to match.</para>
 				<para>These functions have a linear space complexity since only two rows of the distance matrix are allocated in memory. Nevertheless, their time complexity is quadratic in the number of instants of the temporal values. Therefore, the functions require considerable time for temporal values with large number of instants.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -262,8 +273,10 @@ SELECT round(lcssDistance(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01
 				<para>Return the correspondence pairs between two temporal values with respect to the discrete Fréchet distance or the Dynamic Time Warp Distance &Z_support;
  &geography_support; &SRF;
 </para>
-				<para><varname>frechetDistancePath({tnumber, tgeo}, {tnumber, tgeo}) → {(i,j)}</varname></para>
-				<para><varname>dynTimeWarpPath({tnumber, tgeo}, {tnumber, tgeo}) → {(i,j)}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+frechetDistancePath({tnumber, tgeo}, {tnumber, tgeo}) → {(i,j)}
+dynTimeWarpPath({tnumber, tgeo}, {tnumber, tgeo}) → {(i,j)}
+</programlisting>
 				<para>The result is a set of pairs <varname>(i,j)</varname>. This function requires to allocate in memory a distance matrix whose size is quadratic in the number of instants of the temporal values. Therefore, the function will fail for temporal values with large number of instants depending on the available memory.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT frechetDistancePath(tfloat '[1@2001-01-01, 3@2001-01-03, 1@2001-01-06]',
@@ -312,8 +325,12 @@ SELECT dynTimeWarpPath(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03
 				<indexterm significance="normal"><primary><varname>extendedKalmanFilter</varname></primary></indexterm>
 				<para>Return a smoothed temporal float or temporal point obtained by filtering a noisy trajectory with an <ulink url="https://en.wikipedia.org/wiki/Kalman_filter">Extended Kalman Filter</ulink> &Z_support;
 </para>
-				<para><varname>extendedKalmanFilter(tfloat, gate float, q float, variance float, to_drop boolean DEFAULT TRUE) → tfloat</varname></para>
-				<para><varname>extendedKalmanFilter(tgeompoint, gate float, q float, variance float, to_drop boolean DEFAULT TRUE) → tgeompoint</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+extendedKalmanFilter(tfloat, gate float, q float, variance float,
+  to_drop boolean DEFAULT TRUE) → tfloat
+extendedKalmanFilter(tgeompoint, gate float, q float, variance float,
+  to_drop boolean DEFAULT TRUE) → tgeompoint
+</programlisting>
 				<para>The filter models the underlying motion of a moving object and separates it from measurement noise and occasional outliers. The <varname>gate</varname> parameter controls how strict the outlier detection is, <varname>q</varname> is the process-noise scale, <varname>variance</varname> is the measurement-noise variance, and <varname>to_drop</varname> chooses whether outliers are removed (<literal>true</literal>) or replaced by the predicted trajectory (<literal>false</literal>).</para>
 				<para>These functions are intended for trajectories with at least three instants and are typically applied to temporal values with linear interpolation.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -347,7 +364,9 @@ SELECT asEWKT(extendedKalmanFilter(tgeompoint
 				<para>Return an array of N time spans obtained by merging the instants or segments of a temporal value &Z_support;
  &geography_support;
 </para>
-				<para><varname>splitNSpans(temp, integer) → tstzspan[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitNSpans(temp, integer) → tstzspan[]
+</programlisting>
 				<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. The last argument specifies the number of output spans. If the number of instants or segments is less than or equal to the given number, the resulting array will have one span per instant or segment of the temporal value. Otherwise, the given number of spans will be obtained by merging consecutive instants or segments.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(ttext '{A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-04,
@@ -378,7 +397,9 @@ SELECT splitNSpans(ttext '[A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-0
 				<para>Return an array of time spans obtained by merging N consecutive instants or segments of a temporal value &Z_support;
  &geography_support;
 </para>
-				<para><varname>splitEachNSpans(temp, integer) → tstzspan[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitEachNSpans(temp, integer) → tstzspan[]
+</programlisting>
 				<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. The last argument specifies the number of input instants or segments that are merged to produce an output span. If the number of input elements is less than or equal to the given number, the resulting array will have a single span per sequence. Otherwise, the given number of consecutive instants or segments will be merged into each output span. Notice that, contrary to the <link linkend="ttype_splitNSpans"><varname>splitNSpans</varname></link> function, the number of spans in the result depends on the number of input instants or segments.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNSpans(ttext '{A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-04,
@@ -403,7 +424,9 @@ SELECT splitEachNSpans(tgeogpoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-
 			<listitem xml:id="ttype_splitNTboxes">
 				<indexterm significance="normal"><primary><varname>splitNTboxes</varname></primary></indexterm>
 				<para>Return an array of N temporal boxes obtained by merging the instants or segments of a temporal number</para>
-				<para><varname>splitNTboxes(tnumber, integer) → tbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitNTboxes(tnumber, integer) → tbox[]
+</programlisting>
 				<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. The last argument specifies the number of output boxes. If the number of input instants or segments is less than or equal to the given number, the resulting array will have one box per instant or segment of the temporal number. Otherwise, the specified number of boxes will be obtained by merging consecutive instants or segments.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
@@ -437,7 +460,9 @@ SELECT splitNTboxes(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-0
 			<listitem xml:id="ttype_splitEachNTboxes">
 				<indexterm significance="normal"><primary><varname>splitEachNTboxes</varname></primary></indexterm>
 				<para>Return an array of temporal boxes obtained by merging N consecutive instants or segments of a temporal number</para>
-				<para><varname>splitEachNTboxes(tnumber, integer) → tbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitEachNTboxes(tnumber, integer) → tbox[]
+</programlisting>
 				<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. The last argument specifies the number of input instants or segments that are merged to produce an output box. If the number of input instants or segments is less than or equal to the given number, the resulting array will have a single box per sequence. Otherwise, the specified number of consecutive instants or segments will be merged into each output box. Notice that, contrary to the <link linkend="ttype_splitNTboxes"><varname>splitNTboxes</varname></link> function, the number of boxes in the result depends on the number of input instants or segments.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
@@ -470,8 +495,10 @@ SELECT splitEachNTboxes(tfloat '{[1@2000-01-01, 2@2000-01-02], [1@2000-01-03,
 				<para>Return either an array of N spatial boxes obtained by merging the segments of a (multi)line or an array of N spatiotemporal boxes obtained by merging the instants or segments of a temporal point &Z_support;
  &geography_support;
 </para>
-				<para><varname>splitNStboxes(lines, integer) → stbox[]</varname></para>
-				<para><varname>splitNStboxes(tpoint, integer) → stbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitNStboxes(lines, integer) → stbox[]
+splitNStboxes(tpoint, integer) → stbox[]
+</programlisting>
 				<para>For temporal points, the choice between instants or segments depends on whether the interpolation is discrete or continuous. The last argument specifies the number of output boxes. If the number of instants or segments is less than or equal to the given number, the resulting array will have either one box per segment of the (multi)line or one box per instant or segment of the temporal point. Otherwise, the specified number of boxes will be obtained by merging consecutive instants or segments.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 1);
@@ -521,8 +548,10 @@ SELECT splitNStboxes(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
 				<para>Return either an array of spatial boxes obtained by merging N consecutive segments of a (multi)line or an array of spatiotemporal boxes obtained by merging N consecutive instants or segments of a temporal point &Z_support;
  &geography_support;
 </para>
-				<para><varname>splitEachNStboxes(lines, integer) → stbox[]</varname></para>
-				<para><varname>splitEachNStboxes(tpoint, integer) → stbox[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+splitEachNStboxes(lines, integer) → stbox[]
+splitEachNStboxes(tpoint, integer) → stbox[]
+</programlisting>
 				<para>For temporal points, the choice between instants or segments depends on whether the interpolation is discrete or continuous. The last argument specifies the number of input instants or segments that are merged to produce an output box. If the number of instants or segments is less than or equal to the given number, the resulting array will have a single box per sequence. Otherwise, the specified number of consecutive instants or segments will be merged into each output box. Notice that, contrary to the <link linkend="ttype_splitNStboxes"><varname>splitNStboxes</varname></link> function, the number of boxes in the result depends on the number of input instants or segments.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 1);
@@ -595,9 +624,11 @@ SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01
 					<indexterm significance="normal"><primary><varname>bins</varname></primary></indexterm>
 					<para>Return an array of bins that cover a value or time span with bins of the same size or duration
 </para>
-					<para><varname>bins(numspans,size number,origin number=0) → span[]</varname></para>
-					<para><varname>bins(datespans,duration interval,origin date='2000-01-03') → span[]</varname></para>
-					<para><varname>bins(tstzspans,duration interval,origin timestamptz='2000-01-03') → span[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+bins(numspans,size number,origin number=0) → span[]
+bins(datespans,duration interval,origin date='2000-01-03') → span[]
+bins(tstzspans,duration interval,origin timestamptz='2000-01-03') → span[]
+</programlisting>
 					<para>If the origin is not specified, it is set by default to 0 for value spans and Monday, January 3, 2000 for time spans.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT bins(floatspan '[-10, -1]', 2.5, -7);
@@ -624,9 +655,11 @@ FROM unnest(bins(tstzspanset '{[2001-01-15, 2001-01-17],[2001-01-22, 2001-01-25]
 				<listitem xml:id="setspan_getBin">
 					<indexterm significance="normal"><primary><varname>getBin</varname></primary></indexterm>
 					<para>Return the bin that contains a number or a timestamp</para>
-					<para><varname>getBin(number,size number,origin number=0) → span</varname></para>
-					<para><varname>getBin(date,duration interval,origin date='2000-01-03') → datespan</varname></para>
-					<para><varname>getBin(timestamptz,duration interval,origin timestamptz='2000-01-03') → tstzspan</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getBin(number,size number,origin number=0) → span
+getBin(date,duration interval,origin date='2000-01-03') → datespan
+getBin(timestamptz,duration interval,origin timestamptz='2000-01-03') → tstzspan
+</programlisting>
 					<para>If the origin is not specified, it is set by default to 0 for value bins and to Monday, January 3, 2000 for time bins.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getBin(2, 2);
@@ -652,11 +685,13 @@ SELECT getBin('2001-01-04', interval '1 week', '2001-01-07');
 					<indexterm significance="normal"><primary><varname>valueTimeTiles</varname></primary></indexterm>
 					<para>Return the set of tiles that covers a temporal box with tiles of the same size and/or duration &SRF;
 </para>
-					<para><varname>valueTiles(tbox,vsize float,vorigin float=0) → {(index,tile)}</varname></para>
-					<para><varname>timeTiles(tbox,duration interval,torigin timestamptz='2000-01-03')  →</varname></para>
-					<para><varname> {(index,tile)}</varname></para>
-					<para><varname>valueTimeTiles(tbox,vsize float,duration interval,vorigin float=0,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → {(index,tile)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+valueTiles(tbox,vsize float,vorigin float=0) → {(index,tile)}
+timeTiles(tbox,duration interval,torigin timestamptz='2000-01-03')  →
+  {(index,tile)}
+valueTimeTiles(tbox,vsize float,duration interval,vorigin float=0,
+  torigin timestamptz='2000-01-03') → {(index,tile)}
+</programlisting>
 					<para>The result is a set of pairs <varname>(index,tile)</varname>. If the origin of the value and/or time dimension is not specified, it is set by default to 0 and to Monday, January 3, 2000, respectively.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (gr).index, (gr).tile
@@ -693,13 +728,15 @@ SELECT valueTimeTiles(tfloat '[15@2001-01-15,25@2001-01-25]'::tbox, 2.0, '2 days
 					<para>Return the set of tiles that covers a spatiotemporal box with tiles of the same size and/or duration &Z_support;
  &SRF;
 </para>
-					<para><varname>spaceTiles({stbox,tgeompoint},xsize float,[ysize float,zsize float,]</varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)',borderInc boolean=true) → {(index,tile)}</varname></para>
-					<para><varname>timeTiles({stbox,tgeompoint},duration interval,torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  borderInc boolean=true) → {(index,tile)}</varname></para>
-					<para><varname>spaceTimeTiles({stbox,tgeompoint},xsize float,[ysize float,zsize float,]duration interval,</varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  borderInc boolean=true) → {(index,tile)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spaceTiles({stbox,tgeompoint},xsize float,[ysize float,zsize float,]
+  sorigin geompoint='Point(0 0 0)',borderInc boolean=true) → {(index,tile)}
+timeTiles({stbox,tgeompoint},duration interval,torigin timestamptz='2000-01-03',
+  borderInc boolean=true) → {(index,tile)}
+spaceTimeTiles({stbox,tgeompoint},xsize float,[ysize float,zsize float,]duration interval,
+  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',
+  borderInc boolean=true) → {(index,tile)}
+</programlisting>
 					<para>The result is a set of pairs <varname>(index,tile)</varname>. If the origin of the space and/or time dimension is not specified, it is set by default to <varname>'Point(0 0 0)'</varname> and to Monday, January 3, 2000, respectively. The optional argument <varname>borderInc</varname> states whether the upper border of the extent is included and thus, extra tiles containing the border are generated. When the first argument is a <varname>tgeompoint</varname>, the bounding spatiotemporal box is derived implicitly via <varname>stbox(temp)</varname>.</para>
 					<para>In the case of a spatiotemporal grid, <varname>ysize</varname> and <varname>zsize</varname> are optional, the size for the missing dimensions is assumed to be equal to <varname>xsize</varname>. The SRID of the tile coordinates is determined by the input box and the sizes are given in the units of the SRID. If the origin for the spatial coordinates is given, which must be a point, its dimensionality and SRID should be equal to the one of box, otherwise an error is raised.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -749,11 +786,13 @@ SELECT spaceTimeTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 					<indexterm significance="normal"><primary><varname>getValueTimeTile</varname></primary></indexterm>
 					<para>Return the temporal tile that covers a value and/or a timestamp &Z_support;
 </para>
-					<para><varname>getValueTile(value float,vsize float,vorigin float=0.0,) → tbox</varname></para>
-					<para><varname>getTboxTimeTile(time timestamptz,duration interval,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → tbox</varname></para>
-					<para><varname>getValueTimeTile(value float,time timestamptz,size float,duration interval,</varname></para>
-					<para><varname>  vorigin float=0.0,torigin timestamptz='2000-01-03') → tbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getValueTile(value float,vsize float,vorigin float=0.0,) → tbox
+getTboxTimeTile(time timestamptz,duration interval,
+  torigin timestamptz='2000-01-03') → tbox
+getValueTimeTile(value float,time timestamptz,size float,duration interval,
+  vorigin float=0.0,torigin timestamptz='2000-01-03') → tbox
+</programlisting>
 					<para>If the origin of the value and/or time dimension is not specified, it is set by default to 0 and to Monday, January 3, 2000, respectively.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValueTile(15, 2);
@@ -773,13 +812,15 @@ SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days', 1, '2001-01-02')
 					<indexterm significance="normal"><primary><varname>getSpaceTimeTile</varname></primary></indexterm>
 					<para>Return the spatiotemporal tile that covers a point and/or a timestamp &Z_support;
 </para>
-					<para><varname>getSpaceTile(point geometry,xsize float,[ysize float,zsize float],</varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)') → stbox</varname></para>
-					<para><varname>getStboxTimeTile(time timestamptz,duration interval,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → stbox</varname></para>
-					<para><varname>getSpaceTimeTile(point geometry,time timestamptz,xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,]duration,interval,sorigin geompoint='Point(0 0 0)',</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → stbox</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+getSpaceTile(point geometry,xsize float,[ysize float,zsize float],
+  sorigin geompoint='Point(0 0 0)') → stbox
+getStboxTimeTile(time timestamptz,duration interval,
+  torigin timestamptz='2000-01-03') → stbox
+getSpaceTimeTile(point geometry,time timestamptz,xsize float,
+  [ysize float,zsize float,]duration,interval,sorigin geompoint='Point(0 0 0)',
+  torigin timestamptz='2000-01-03') → stbox
+</programlisting>
 					<para>If the origin of the space and/or time dimension is not specified, it is set by default to <varname>Point(0 0 0)</varname> and to Monday, January 3, 2000, respectively.</para>
 					<para>In the case of a spatiotemporal grid, <varname>ysize</varname> and <varname>zsize</varname> are optional, the size for the missing dimensions is assumed to be equal to <varname>xsize</varname>. The SRID of the tile coordinates is determined by the input point and the sizes are given in the units of the SRID. If the origin for the spatial coordinates is given, which must be a point, its dimensionality and SRID should be equal to the one of box, otherwise an error is raised.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -805,8 +846,10 @@ SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 da
 					<indexterm significance="normal"><primary><varname>valueBins</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeBins</varname></primary></indexterm>
 					<para>Return an array of value or time spans obtained from the instants or segments of a temporal number with respect to a value or time grid</para>
-					<para><varname>valueBins(tnumber,vsize number,vorigin number=0) → numspan[]</varname></para>
-					<para><varname>timeBins(temp,duration interval,torigin timestamptz='2000-01-03') → tstzspan[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+valueBins(tnumber,vsize number,vorigin number=0) → numspan[]
+timeBins(temp,duration interval,torigin timestamptz='2000-01-03') → tstzspan[]
+</programlisting>
 					<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. If the origin of values or time is not specified, it is set by default to 0 for value spans or to Monday, January 3, 2000 for time spans.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueBins(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
@@ -831,10 +874,12 @@ SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
 					<indexterm significance="normal"><primary><varname>timeBoxes</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeBoxes</varname></primary></indexterm>
 					<para>Return an array of temporal boxes obtained from the instants or segments of a temporal number with respect to a value and/or time grid</para>
-					<para><varname>valueBoxes(tnumber,size number,vorigin number=0) → tbox[]</varname></para>
-					<para><varname>timeBoxes(tnumber,duration interval,torigin timestamptz='2000-01-03') → tbox[]</varname></para>
-					<para><varname>valueTimeBoxes(tnumber,size number,duration interval,vorigin number=0,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → tbox[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+valueBoxes(tnumber,size number,vorigin number=0) → tbox[]
+timeBoxes(tnumber,duration interval,torigin timestamptz='2000-01-03') → tbox[]
+valueTimeBoxes(tnumber,size number,duration interval,vorigin number=0,
+  torigin timestamptz='2000-01-03') → tbox[]
+</programlisting>
 					<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. If the origin of value and/or time dimension is not specified, it is set by default to 0 and to Monday, January 3, 2000, respectively.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueBoxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
@@ -864,16 +909,18 @@ SELECT valueTimeBoxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-
 					<indexterm significance="normal"><primary><varname>spaceTimeBoxes</varname></primary></indexterm>
 					<para>Return an array of spatiotemporal boxes obtained from the instants or segments of a temporal point with respect to a space and/or time grid &Z_support;
 </para>
-					<para><varname>spaceBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,] </varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)',borderInc boolean=true) → stbox[]</varname></para>
-					<para><varname>timeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},duration interval,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  borderInc boolean=true) → stbox[]</varname></para>
-					<para><varname>spaceTimeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,]duration interval,</varname></para>
-					<para><varname>  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',</varname></para>
-					<para><varname>  borderInc boolean=true) → stbox[]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spaceBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,
+  [ysize float,zsize float,] 
+  sorigin geompoint='Point(0 0 0)',borderInc boolean=true) → stbox[]
+timeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},duration interval,
+  torigin timestamptz='2000-01-03',
+  borderInc boolean=true) → stbox[]
+spaceTimeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,
+  [ysize float,zsize float,]duration interval,
+  sorigin geompoint='Point(0 0 0)',torigin timestamptz='2000-01-03',
+  borderInc boolean=true) → stbox[]
+</programlisting>
 					<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. The arguments <varname>ysize</varname> and <varname>zsize</varname> are optional, the size for the missing dimensions is assumed to be equal to <varname>xsize</varname>. The SRID of the tile coordinates is determined by the temporal point and the sizes are given in the units of the SRID. If the origin for the spatial coordinates is given, which must be a point, its dimensionality and SRID should be equal to the one of temporal point, otherwise an error is raised. If the origin of space and/or time dimension is not specified, it is set by default to <varname>'Point(0 0 0)'</varname> and to Monday, January 3, 2000, respectively. The optional argument <varname>borderInc</varname> states whether the upper border of the extent is included and thus, extra tiles containing the border are generated. A temporal pose and a temporal point cloud point answer these at the temporal geometry point their position resolves to, so a value carrying linear interpolation is tiled along its trajectory rather than at its instants alone.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spaceBoxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
@@ -915,11 +962,13 @@ SELECT spaceBoxes(tpose '[Pose(Point(1 1),0.1)@2001-01-01,
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>valueTimeSplit</varname></primary></indexterm>
 					<para>Split a temporal number with respect to value and/or time bins &SRF;</para>
-					<para><varname>valueSplit(tnumber,size number,origin number=0) → {(number,tnumber)}</varname></para>
-					<para><varname>timeSplit(ttype,duration interval,origin timestamptz='2000-01-03') → </varname></para>
-					<para><varname>  {(time,temp)}</varname></para>
-					<para><varname>valueTimeSplit(tnumber,size number,duration interval,vorigin number=0,</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03') → {(number,time,tnumber}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+valueSplit(tnumber,size number,origin number=0) → {(number,tnumber)}
+timeSplit(ttype,duration interval,origin timestamptz='2000-01-03') → 
+  {(time,temp)}
+valueTimeSplit(tnumber,size number,duration interval,vorigin number=0,
+  torigin timestamptz='2000-01-03') → {(number,time,tnumber}
+</programlisting>
 					<para>The result is a set of pairs or a set of triples. If the origin of the value and/or the time dimension is not specified, they are set by default to 0 and to Monday, January 3, 2000, respectively.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (sp).number, (sp).tnumber
@@ -1003,16 +1052,20 @@ FROM (SELECT valueTimeSplit(tfloat '[1@2001-02-01, 10@2001-02-10)', 5.0, '5 days
 					<para>Split a temporal point with respect to a spatial grid &Z_support;
  &SRF;
 </para>
-					<para><varname>spaceSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,]</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+spaceSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
+  [ysize float,zsize float,]
+</programlisting>
 					<para><varname>  origin geompoint='Point(0 0 0)',bitmatrix boolean=true,borderInc boolean=true) →</varname> A temporal pose and a temporal point cloud point answer these at the temporal geometry point their position resolves to, so a value carrying linear interpolation is tiled along its trajectory rather than at its instants alone. The second column of a split carries the type of the first argument, so splitting a temporal pose returns temporal poses.</para>
-					<para><varname>  {(point,tpoint)}</varname></para>
-					<para><varname>timeSplit(tpoint,duration interval,torigin timestamptz='2000-01-03') → {(time,tpoint)}</varname></para>
-					<para><varname>spaceTimeSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,</varname></para>
-					<para><varname>  [ysize float,zsize float,]</varname></para>
-					<para><varname>  duration interval,sorigin geompoint='Point(0 0 0)',</varname></para>
-					<para><varname>  torigin timestamptz='2000-01-03',bitmatrix boolean=true,borderInc boolean=true) →</varname></para>
-					<para><varname>  {(point,time,tpoint)}</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+  {(point,tpoint)}
+timeSplit(tpoint,duration interval,torigin timestamptz='2000-01-03') → {(time,tpoint)}
+spaceTimeSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
+  [ysize float,zsize float,]
+  duration interval,sorigin geompoint='Point(0 0 0)',
+  torigin timestamptz='2000-01-03',bitmatrix boolean=true,borderInc boolean=true) →
+  {(point,time,tpoint)}
+</programlisting>
 					<para>The result is a set of pairs or a set of triples. If the origin of the space and/or time dimension is not specified, it is set by default to <varname>'Point(0 0 0)'</varname> and to Monday, January 3, 2000, respectively. The arguments <varname>ysize</varname> and <varname>zsize</varname> are optional, the size for the missing dimensions is assumed to be equal to <varname>xsize</varname>. If the argument <varname>bitmatrix</varname> is not specified, then the computation will use a bit matrix to speed up the process. The optional argument <varname>borderInc</varname> states whether the upper border of the extent is included and thus extra tiles containing the border are generated.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText((sp).point) AS point, astext((sp).tpoint) AS tpoint

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -550,7 +550,9 @@ SELECT tgeogpoint 'Interp=Step;[SRID=4326;Point(0 0)@2001-01-01,
 			<listitem xml:id="ttype_asText">
 				<indexterm significance="normal"><primary><varname>asText</varname></primary></indexterm>
 				<para>Return the Well-Known Text (WKT) representation</para>
-				<para><varname>asText(ttype,maxdecdigits=15) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asText(ttype,maxdecdigits=15) → text
+</programlisting>
 					<para>The <varname>maxdecdigits</varname> argument can be used to set the maximum number of decimal places in the output of floating point values (default 15).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tfloat '[10.55@2001-01-01, 25.55@2001-01-02]', 0);
@@ -564,7 +566,9 @@ SELECT asText(tgeometry
 			<listitem xml:id="ttype_asMFJSON">
 				<indexterm significance="normal"><primary><varname>asMFJSON</varname></primary></indexterm>
 				<para>Return the Moving Features JSON (MF-JSON) representation</para>
-				<para><varname>asMFJSON(ttype,options=0,flags=0,maxdecdigits=15) → bytea</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asMFJSON(ttype,options=0,flags=0,maxdecdigits=15) → bytea
+</programlisting>
 				<para>The <varname>options</varname> argument can be used to add a bounding box in the MFJSON output:</para>
 				<itemizedlist>
 					<listitem><para>0: means no option (default value)</para></listitem>
@@ -608,8 +612,10 @@ SELECT asMFJSON(tgeometry '{[Point(1 1)@2001-01-01 18:00:00+02,
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Return the Well-Known Binary (WKB) or the Hexadecimal Well-Known Binary (WKB) representation</para>
-				<para><varname>asBinary(ttype,endian text='') → bytea</varname></para>
-				<para><varname>asHexWKB(ttype,endian text='') → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+asBinary(ttype,endian text='') → bytea
+asHexWKB(ttype,endian text='') → text
+</programlisting>
 				<para>The result is encoded using either the little-endian (NDR) or the big-endian (XDR) encoding. If no encoding is specified, then the encoding of the machine is used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tbool 'true@2001-01-01');
@@ -626,7 +632,9 @@ SELECT asHexWKB(ttext 'AAA@2001-01-01');
 			<listitem xml:id="ttypeFromMFJSON">
 				<indexterm significance="normal"><primary><varname>ttypeFromMFJSON</varname></primary></indexterm>
 				<para>Input from the Moving Features JSON (MF-JSON) representation</para>
-				<para><varname>ttypeFromMFJSON(bytea) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeFromMFJSON(bytea) → ttype
+</programlisting>
 				<para>There is one function per temporal type, the name of the function has as prefix the name of the type, which is <varname>tbool</varname> or <varname>tint</varname> in the examples below.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolFromMFJSON(text
@@ -663,8 +671,10 @@ SELECT asText(tgeometryFromMFJSON(text
 				<indexterm significance="normal"><primary><varname>ttypeFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttypeFromHexWKB</varname></primary></indexterm>
 				<para>Input from the Well-Known Binary (WKB) or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>
-				<para><varname>ttypeFromBinary(bytea) → ttype</varname></para>
-				<para><varname>ttypeFromHexWKB(text) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeFromBinary(bytea) → ttype
+ttypeFromHexWKB(text) → ttype
+</programlisting>
 				<para>There is one function per temporal type, the name of the function has as prefix the name of the type, which is <varname>tbool</varname> or <varname>tint</varname> in the examples below.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolFromBinary('\x011a000101009c57d3c11c0000');
@@ -700,10 +710,12 @@ SELECT ttextFromHexWKB('01290001040000000000000041414100009C57D3C11C0000');
 				<indexterm significance="normal"><primary><varname>ttype</varname></primary></indexterm>
 				<para>Constructors for temporal types having a constant value</para>
 				<para>These contructors have two arguments, a base type and a time value, where the latter is a <varname>timestamptz</varname>, a <varname>tstzset</varname>, a <varname>tstzspan</varname>, or a <varname>tstzspanset</varname> value for constructing, respectively, an instant, a sequence with discrete interpolation, a sequence with linear or step interpolation, or a sequence set value. The functions for sequence or sequence set values with continuous base type have an optional third argument stating whether the resulting temporal value has linear or step interpolation. Linear interpolation is assumed by default if the argument is not specified.</para>
-				<para><varname>ttype(base,timestamptz) → ttypeInst</varname></para>
-				<para><varname>ttype(base,tstzset) → ttypeDiscSeq</varname></para>
-				<para><varname>ttype(base,tstzspan,interp='linear') → ttypeContSeq</varname></para>
-				<para><varname>ttype(base,tstzspanset,interp='linear') → ttypeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttype(base,timestamptz) → ttypeInst
+ttype(base,tstzset) → ttypeDiscSeq
+ttype(base,tstzspan,interp='linear') → ttypeContSeq
+ttype(base,tstzspanset,interp='linear') → ttypeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool(true, timestamptz '2001-01-01');
 SELECT tint(1, timestamptz '2001-01-01');
@@ -721,8 +733,10 @@ SELECT tgeography('SRID=7844;Point(0 0)', tstzspanset '{[2001-01-01, 2001-01-02]
 				<indexterm significance="normal"><primary><varname>ttypeSeq</varname></primary></indexterm>
 				<para>Constructors for temporal types of sequence subtype</para>
 				<para>These contructors have a first mandatory argument, which is an array of values of the corresponding instant values and additional optional arguments. The second argument states the interpolation. If the argument is not given, it is by default step for discrete base types such as integer, and linear for continuous base types such as float. An error is raised when linear interpolation is stated for temporal values with discrete base types. For continuous sequences, the third and fourth arguments are Boolean values stating, respectively, whether the left and right bounds are inclusive or exclusive. These arguments are assumed to be true by default if they are not specified.</para>
-				<para><varname>ttypeSeq(ttypeInst[],interp={'step','linear'},leftInc boolean=true,</varname></para>
-        <para><varname>  rightInc boolean=true) → ttypeSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeSeq(ttypeInst[],interp={'step','linear'},leftInc boolean=true,
+  rightInc boolean=true) → ttypeSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolSeq(ARRAY[tbool 'true@2001-01-01 08:00:00','false@2001-01-01 08:05:00'],
   'discrete');
@@ -743,8 +757,10 @@ SELECT tgeographySeq(ARRAY[tgeography 'Point(1 1)@2001-01-01 08:00:00',
 				<indexterm significance="normal"><primary><varname>ttypeSeqSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttypeSeqSetGaps</varname></primary></indexterm>
 				<para>Constructors for temporal types of sequence set subtype</para>
-				<para><varname>ttypeSeqSet(ttypeContSeq[]) → ttypeSeqSet</varname></para>
-				<para><varname>ttypeSeqSetGaps(ttypeInst[],maxt=NULL,maxdist=NULL,interp='linear') → ttypeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeSeqSet(ttypeContSeq[]) → ttypeSeqSet
+ttypeSeqSetGaps(ttypeInst[],maxt=NULL,maxdist=NULL,interp='linear') → ttypeSeqSet
+</programlisting>
 				<para>A first set of contructors have a single argument, which is an array of values of the corresponding <emphasis>sequence</emphasis> values. The interpolation of the resulting temporal value depends on the interpolation of the composing sequences. An error is raised if the sequences composing the array have different interpolation.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolSeqSet(ARRAY[tbool '[false@2001-01-01 08:00:00, false@2001-01-01 08:05:00)',
@@ -806,7 +822,9 @@ SELECT asText(tgeompointSeqSetGaps(ARRAY[tgeompoint 'Point(1 1)@2001-01-01',
 			<listitem xml:id="ttype_tstzspan">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<para>Convert a temporal value to a timestamptz span</para>
-				<para><varname>ttype::tstzspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttype::tstzspan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 2@2001-01-03]'::tstzspan;
 -- [2001-01-01, 2001-01-03]
@@ -826,7 +844,9 @@ SELECT tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]'::tstzspan;
 			<listitem xml:id="ttype_memSize">
 				<indexterm significance="normal"><primary><varname>memSize</varname></primary></indexterm>
 				<para>Return the memory size in bytes</para>
-				<para><varname>memSize(ttype) → integer</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+memSize(ttype) → integer
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT memSize(tint '{1@2001-01-01, 2@2001-01-02, 3@2001-01-03}');
 -- 176
@@ -836,7 +856,9 @@ SELECT memSize(tint '{1@2001-01-01, 2@2001-01-02, 3@2001-01-03}');
 			<listitem xml:id="ttype_tempSubtype">
 				<indexterm significance="normal"><primary><varname>tempSubtype</varname></primary></indexterm>
 				<para>Return the temporal type</para>
-				<para><varname>tempSubtype(ttype) → {'Instant','Sequence','SequenceSet'}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tempSubtype(ttype) → {'Instant','Sequence','SequenceSet'}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tempSubtype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 -- Sequence
@@ -846,7 +868,9 @@ SELECT tempSubtype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 			<listitem xml:id="ttype_tempBasetype">
 				<indexterm significance="normal"><primary><varname>tempBasetype</varname></primary></indexterm>
 				<para>Return the base type</para>
-				<para><varname>tempBasetype(ttype) → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+tempBasetype(ttype) → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tempBasetype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 -- integer
@@ -858,7 +882,9 @@ SELECT tempBasetype(tgeompoint 'Point(1 1)@2001-01-01');
 			<listitem xml:id="ttype_interp">
 				<indexterm significance="normal"><primary><varname>interp</varname></primary></indexterm>
 				<para>Return the interpolation</para>
-				<para><varname>interp(ttype) → {'None','Discrete','Step','Linear'}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+interp(ttype) → {'None','Discrete','Step','Linear'}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT interp(tbool 'true@2001-01-01');
 -- None
@@ -883,8 +909,10 @@ SELECT interp(tgeometry '[Point(1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>getValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>getTimestamp</varname></primary></indexterm>
 				<para>Return the value or the timestamp of an instant</para>
-				<para><varname>getValue(ttypeInst) → base</varname></para>
-				<para><varname>getTimestamp(ttypeInst) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValue(ttypeInst) → base
+getTimestamp(ttypeInst) → timestamptz
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValue(tint '1@2001-01-01');
 -- 1
@@ -897,8 +925,10 @@ SELECT getTimestamp(tfloat '1@2001-01-01');
 				<indexterm significance="normal"><primary><varname>getValues</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>getTime</varname></primary></indexterm>
 				<para>Return the values or the time on which a temporal value is defined</para>
-				<para><varname>getValues(ttype) → baseset</varname></para>
-				<para><varname>getTime(ttype) → tstzspanset</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+getValues(ttype) → baseset
+getTime(ttype) → tstzspanset
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(tbool '[false@2001-01-01, true@2001-01-02, false@2001-01-03]');
 -- {f,t}
@@ -933,7 +963,9 @@ SELECT getTime(tfloat '{[1@2001-01-01, 1@2001-01-10), [12@2001-01-12, 12@2001-01
 			<listitem xml:id="ttype_timeSpan">
 				<indexterm significance="normal"><primary><varname>timeSpan</varname></primary></indexterm>
 				<para>Return the bounding period on which a temporal value is defined</para>
-				<para><varname>timeSpan(ttype) → tstzspan</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+timeSpan(ttype) → tstzspan
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeSpan(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}');
 -- [2001-01-01, 2001-01-03]
@@ -947,9 +979,11 @@ SELECT timeSpan(tint '[1@2001-01-01, 1@2001-01-15)');
 				<indexterm significance="normal"><primary><varname>endValue</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th  value</para>
-				<para><varname>startValue(ttype) → base</varname></para>
-				<para><varname>endValue(ttype) → base</varname></para>
-				<para><varname>valueN(ttype,int) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startValue(ttype) → base
+endValue(ttype) → base
+valueN(ttype,int) → base
+</programlisting>
 				<para>The functions do not take into account whether the bounds are inclusive or not.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(tfloat '(1@2001-01-01, 2@2001-01-03)');
@@ -964,7 +998,9 @@ SELECT valueN(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01-05
 			<listitem xml:id="ttype_valueAtTimestamp">
 				<indexterm significance="normal"><primary><varname>valueAtTimestamp</varname></primary></indexterm>
 				<para>Return the value at a timestamp</para>
-				<para><varname>valueAtTimestamp(ttype,timestamptz) → base</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+valueAtTimestamp(ttype,timestamptz) → base
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tfloat '[1@2001-01-01, 4@2001-01-04)', '2001-01-02');
 -- 2
@@ -974,7 +1010,9 @@ SELECT valueAtTimestamp(tfloat '[1@2001-01-01, 4@2001-01-04)', '2001-01-02');
 			<listitem xml:id="ttype_duration">
 				<indexterm significance="normal"><primary><varname>duration</varname></primary></indexterm>
 				<para>Return the time interval</para>
-				<para><varname>duration(ttype,boundspan=false) → interval</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+duration(ttype,boundspan=false) → interval
+</programlisting>
 				<para>An additional parameter can be set to true to compute the duration of the bounding time span, thus ignoring the potential time gaps</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT duration(tfloat '{1@2001-01-01, 2@2001-01-03, 2@2001-01-05}');
@@ -995,8 +1033,10 @@ SELECT duration(tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-04, 2@2001-01-
 				<indexterm significance="normal"><primary><varname>lowerInc</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>upperInc</varname></primary></indexterm>
 				<para>Is the start/end instant inclusive?</para>
-				<para><varname>lowerInc(ttype) → boolean</varname></para>
-				<para><varname>upperInc(ttype) → boolean</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+lowerInc(ttype) → boolean
+upperInc(ttype) → boolean
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lowerInc(tint '[1@2001-01-01, 2@2001-01-02)');
 -- true
@@ -1009,8 +1049,10 @@ SELECT upperInc(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 				<indexterm significance="normal"><primary><varname>numInstants</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>instants</varname></primary></indexterm>
 				<para>Return the (number of) different instants</para>
-				<para><varname>numInstants(ttype) → integer</varname></para>
-				<para><varname>instants(ttype) → ttypeInst[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numInstants(ttype) → integer
+instants(ttype) → ttypeInst[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-03)}');
 -- 3
@@ -1024,9 +1066,11 @@ SELECT instants(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 				<indexterm significance="normal"><primary><varname>endInstant</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>instantN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th instant</para>
-				<para><varname>startInstant(ttype) → ttypeInst</varname></para>
-				<para><varname>endInstant(ttype) → ttypeInst</varname></para>
-				<para><varname>instantN(ttype,integer) → ttypeInst</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startInstant(ttype) → ttypeInst
+endInstant(ttype) → ttypeInst
+instantN(ttype,integer) → ttypeInst
+</programlisting>
 				<para>The functions do not take into account whether the bounds are inclusive or not.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startInstant(tfloat '{[1@2001-01-01, 2@2001-01-02),
@@ -1043,8 +1087,10 @@ SELECT instantN(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 				<indexterm significance="normal"><primary><varname>numTimestamps</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timestamps</varname></primary></indexterm>
 				<para>Return the (number of) different timestamps</para>
-				<para><varname>numTimestamps(ttype) → integer</varname></para>
-				<para><varname>timestamps(ttype) → timestamptz[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numTimestamps(ttype) → integer
+timestamps(ttype) → timestamptz[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numTimestamps(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
@@ -1059,9 +1105,11 @@ SELECT timestamps(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-0
 				<indexterm significance="normal"><primary><varname>endTimestamp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>timestampN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th timestamp</para>
-				<para><varname>startTimestamp(ttype) → timestamptz</varname></para>
-				<para><varname>endTimestamp(ttype) → timestamptz</varname></para>
-				<para><varname>timestampN(ttype,integer) → timestamptz</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startTimestamp(ttype) → timestamptz
+endTimestamp(ttype) → timestamptz
+timestampN(ttype,integer) → timestamptz
+</programlisting>
 				<para>The functions do not take into account whether the bounds are inclusive or not.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startTimestamp(tfloat '[1@2001-01-01, 2@2001-01-03)');
@@ -1079,8 +1127,10 @@ SELECT timestampN(tfloat '{[1@2001-01-01, 2@2001-01-03),
 				<indexterm significance="normal"><primary><varname>numSequences</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>sequences</varname></primary></indexterm>
 				<para>Return the (number of) sequences</para>
-				<para><varname>numSequences({ttypeContSeq,ttypeSeqSet}) → integer</varname></para>
-				<para><varname>sequences({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+numSequences({ttypeContSeq,ttypeSeqSet}) → integer
+sequences({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSequences(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
@@ -1095,9 +1145,11 @@ SELECT sequences(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01
 				<indexterm significance="normal"><primary><varname>endSequence</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>sequenceN</varname></primary></indexterm>
 				<para>Return the start, end, or n-th sequence</para>
-				<para><varname>startSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq</varname></para>
-				<para><varname>endSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq</varname></para>
-				<para><varname>sequenceN({ttypeContSeq,ttypeSeqSet},integer) → ttypeContSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+startSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq
+endSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq
+sequenceN({ttypeContSeq,ttypeSeqSet},integer) → ttypeContSeq
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startSequence(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
@@ -1113,7 +1165,9 @@ SELECT sequenceN(tfloat '{[1@2001-01-01, 2@2001-01-03),
 			<listitem xml:id="ttype_segments">
 				<indexterm significance="normal"><primary><varname>segments</varname></primary></indexterm>
 				<para>Return the segments</para>
-				<para><varname>segments({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+segments({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT segments(tint '{[1@2001-01-01, 3@2001-01-02, 2@2001-01-03],
   (3@2001-01-03, 5@2001-01-05]}');
@@ -1137,9 +1191,11 @@ SELECT segments(tfloat '{[1@2001-01-01, 3@2001-01-02, 2@2001-01-03],
 				<indexterm significance="normal"><primary><varname>ttypeSeq</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>ttypeSeqSet</varname></primary></indexterm>
 				<para>Transform a temporal value to another subtype</para>
-				<para><varname>ttypeInst(ttype) → ttypeInst</varname></para>
-				<para><varname>ttypeSeq(ttype) → ttypeSeq</varname></para>
-				<para><varname>ttypeSeqSet(ttype) → ttypeSeqSet</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+ttypeInst(ttype) → ttypeInst
+ttypeSeq(ttype) → ttypeSeq
+ttypeSeqSet(ttype) → ttypeSeqSet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolInst(tbool '{[true@2001-01-01]}');
 -- t@2001-01-01
@@ -1157,7 +1213,9 @@ SELECT tfloatSeqSet(tfloat '{2.5@2001-01-01, 1.5@2001-01-02, 3.5@2001-01-03}');
 			<listitem xml:id="ttype_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transform a temporal value to another interpolation</para>
-				<para><varname>setInterp(ttype, interp) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+setInterp(ttype, interp) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT setInterp(tbool 'true@2001-01-01','discrete');
 -- {t@2001-01-01}
@@ -1181,8 +1239,10 @@ SELECT setInterp(tgeometry '[Point(1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>segmentMinDuration</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>segmentMaxDuration</varname></primary></indexterm>
 				<para>Return a temporal boolean stating whether each segment of a continuous temporal sequence (set) has, respectively, at least or at most a given duration</para>
-				<para><varname>segmentMinDuration(temp,interval,boolean strict=true) → tbool</varname></para>
-				<para><varname>segmentMaxDuration(temp,interval,boolean strict=true) → tbool</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+segmentMinDuration(temp,interval,boolean strict=true) → tbool
+segmentMaxDuration(temp,interval,boolean strict=true) → tbool
+</programlisting>
 				<para>If <varname>strict</varname> is not specified, the value <varname>true</varname> is assumed by default, and therefore the function checks whether the segment duration is strictly less than or greater than the interval. If the argument is set to <varname>false</varname>, the function checks whether the segment duration is less/greater than or <emphasis>equal to</emphasis> the interval.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT segmentMinDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
@@ -1206,9 +1266,11 @@ SELECT segmentMaxDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Shift and/or scale the time span of a temporal value by one or two intervals</para>
 				<para>The given intervals must be strictly greater than zero. If the time span of the temporal value is zero (for example, for a temporal instant), the result of a scale operation is the temporal value.</para>
-				<para><varname>shiftTime(ttype,interval) → ttype</varname></para>
-				<para><varname>scaleTime(ttype,interval) → ttype</varname></para>
-				<para><varname>shiftScaleTime(ttype,interval,interval) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+shiftTime(ttype,interval) → ttype
+scaleTime(ttype,interval) → ttype
+shiftScaleTime(ttype,interval,interval) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftTime(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}', '1 day');
 -- {1@2001-01-02, 2@2001-01-04, 1@2001-01-06}
@@ -1250,7 +1312,9 @@ SELECT asText(shiftScaleTime(tgeometry '{[Point(1 1)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
 				<para>Transform a nonlinear temporal value into a set of rows, each one is a pair composed of a base value and a period set during which the temporal value has the base value &SRF;
 </para>
-				<para><varname>unnest(ttype) → {(value,time)}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+unnest(ttype) → {(value,time)}
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (un).value, (un).time
 FROM (SELECT unnest(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}') AS un) t;

--- a/doc/temporal_types_p2.xml
+++ b/doc/temporal_types_p2.xml
@@ -82,7 +82,9 @@
 			<listitem xml:id="ttype_insert">
 				<indexterm significance="normal"><primary><varname>insert</varname></primary></indexterm>
 				<para>Insert a temporal value into another one</para>
-				<para><varname>insert(ttype,ttype,connect=true) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+insert(ttype,ttype,connect=true) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT insert(tint '{1@2001-01-01, 3@2001-01-03, 5@2001-01-05}',
   tint '{3@2001-01-03, 7@2001-01-07}');
@@ -107,7 +109,9 @@ SELECT asText(insert(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01
 			<listitem xml:id="ttype_update">
 				<indexterm significance="normal"><primary><varname>update</varname></primary></indexterm>
 				<para>Update a temporal value with another one</para>
-				<para><varname>update(ttype,ttype,connect=true) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+update(ttype,ttype,connect=true) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT update(tint '{1@2001-01-01, 3@2001-01-03, 5@2001-01-05}',
   tint '{5@2001-01-03, 7@2001-01-07}');
@@ -131,7 +135,9 @@ SELECT asText(update(
 			<listitem xml:id="ttype_deleteTime">
 				<indexterm significance="normal"><primary><varname>deleteTime</varname></primary></indexterm>
 				<para>Delete the instants of a temporal value that intersect a time value</para>
-				<para><varname>deleteTime(ttype,time,connect=true) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+deleteTime(ttype,time,connect=true) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT deleteTime(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-02', false);
 -- {[1@2001-01-01, 1@2001-01-02), (1@2001-01-02, 1@2001-01-03]}
@@ -151,8 +157,10 @@ SELECT asText(deleteTime(tgeompoint '{[Point(1 1 1)@2001-01-01,
 			<listitem xml:id="ttype_appendInstant">
 				<indexterm significance="normal"><primary><varname>appendInstant</varname></primary></indexterm>
 				<para>Append a temporal instant to a temporal value</para>
-				<para><varname>appendInstant(ttype,ttypeInst,interp=NULL) → ttype</varname></para>
-				<para><varname>appendInstant(ttypeInst,interp=NULL,maxdist=NULL,maxt=NULL) → ttypeSeq</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendInstant(ttype,ttypeInst,interp=NULL) → ttype
+appendInstant(ttypeInst,interp=NULL,maxdist=NULL,maxt=NULL) → ttypeSeq
+</programlisting>
 				<para>The first version of the function returns the result of appending the second argument to the first one. If either input is NULL, then NULL is returned.</para>
 				<para>The second version of the function above is an <emphasis>aggregate</emphasis> function that returns the result of successively appending a set of rows of temporal values. This means that it operates in the same way the <varname>SUM()</varname> and <varname>AVG()</varname> functions do and like most aggregates, it also ignores NULL values. Two optional arguments state a maximum distance and a maximum time interval such that a gap is introduced whenever two consecutive instants have a distance or a time gap greater than these values. For temporal points the distance is specified in units of the coordinate system. If one of the arguments are not given, it is not taken into account for determining the gaps.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -220,8 +228,10 @@ SELECT asText(appendInstant(inst, NULL, sqrt(2), '1 day' ORDER BY inst)) FROM te
 			<listitem xml:id="ttype_appendSequence">
 				<indexterm significance="normal"><primary><varname>appendSequence</varname></primary></indexterm>
 				<para>Append a temporal sequence to a temporal value</para>
-				<para><varname>appendSequence(ttype,ttypeSeq) → {ttypeSeq,ttypeSeqSet}</varname></para>
-				<para><varname>appendSequence(ttypeSeq) → {ttypeSeq,ttypeSeqSet}</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+appendSequence(ttype,ttypeSeq) → {ttypeSeq,ttypeSeqSet}
+appendSequence(ttypeSeq) → {ttypeSeq,ttypeSeqSet}
+</programlisting>
 				<para>The first version of the function returns the result of appending the second argument to the first one. If either input is NULL, then NULL is returned.</para>
 				<para>The second version of the function above is an <emphasis>aggregate</emphasis> function that returns the result of successively appending a set of rows of temporal values. This means that it operates in the same way the <varname>SUM()</varname> and <varname>AVG()</varname> functions do and like most aggregates, it also ignores NULL values.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -247,9 +257,11 @@ SELECT asText(appendSequence(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001
 			<listitem xml:id="ttype_merge">
 				<indexterm significance="normal"><primary><varname>merge</varname></primary></indexterm>
 				<para>Merge the temporal values</para>
-				<para><varname>merge(ttype,ttype) → ttype</varname></para>
-				<para><varname>merge(ttype[]) → ttype</varname></para>
-				<para><varname>merge(ttype) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+merge(ttype,ttype) → ttype
+merge(ttype[]) → ttype
+merge(ttype) → ttype
+</programlisting>
 				<para>The temporal values may only intersect at their boundary. In that case, for all temporal types excepted <varname>tgeometry</varname> and <varname>tgeography</varname>, their base values at the common timestamps must be the same, otherwise an error is raised. For the <varname>tgeometry</varname> and <varname>tgeography</varname> types, if the value at their common timestamps is different, the resulting value after the <varname>merge</varname> will be the spatial union of the values. The reason for a different behaviour for these types is that they are the only temporal types that are not <emphasis>scalar</emphasis> types, that is, their value at a given timestamp is not a single element of the domain of the base type, but rather a subset of their domain.</para>
         <para>The third version of the function above is an <emphasis>aggregate</emphasis> function that returns the result of successively appending a set of rows of temporal values. This means that it operates in the same way the <varname>SUM()</varname> and <varname>AVG()</varname> functions do and like most aggregates, it also ignores NULL values.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -325,14 +337,16 @@ SELECT merge(inst) FROM temp;
 				<indexterm significance="normal"><primary><varname>atSpanset</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusSpanset</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a value or a set of values, or, for a temporal number, a span or a span set of values</para>
-				<para><varname>atValue(ttype,value) → ttype</varname></para>
-				<para><varname>minusValue(ttype,value) → ttype</varname></para>
-				<para><varname>atValues(ttype,valueset) → ttype</varname></para>
-				<para><varname>minusValues(ttype,valueset) → ttype</varname></para>
-				<para><varname>atSpan(tnumber,span) → tnumber</varname></para>
-				<para><varname>minusSpan(tnumber,span) → tnumber</varname></para>
-				<para><varname>atSpanset(tnumber,spanset) → tnumber</varname></para>
-				<para><varname>minusSpanset(tnumber,spanset) → tnumber</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atValue(ttype,value) → ttype
+minusValue(ttype,value) → ttype
+atValues(ttype,valueset) → ttype
+minusValues(ttype,valueset) → ttype
+atSpan(tnumber,span) → tnumber
+minusSpan(tnumber,span) → tnumber
+atSpanset(tnumber,spanset) → tnumber
+minusSpanset(tnumber,spanset) → tnumber
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atValue(tint '[1@2001-01-01, 1@2001-01-15)', 1);
 -- [1@2001-01-01, 1@2001-01-15)
@@ -384,8 +398,10 @@ SELECT asText(minusValue(tgeometry '[Point(0 0)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>atTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusTime</varname></primary></indexterm>
 				<para>Restrict to (the complement of) a time value</para>
-				<para><varname>atTime(ttype,times) → ttype</varname></para>
-				<para><varname>minusTime(ttype,times) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+atTime(ttype,times) → ttype
+minusTime(ttype,times) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atTime(tfloat '[1@2001-01-01, 5@2001-01-05)', timestamptz '2001-01-02');
 -- 2@2001-01-02
@@ -420,8 +436,10 @@ SELECT minusTime(tint '[1@2001-01-01, 1@2001-01-15)',
 				<indexterm significance="normal"><primary><varname>beforeTimestamp</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>afterTimestamp</varname></primary></indexterm>
 				<para>Keep the instants of a temporal value that are before/after or equal a timestamp</para>
-				<para><varname>beforeTimestamp(ttype,timestamptz,strict boolean=TRUE) → ttype</varname></para>
-				<para><varname>afterTimestamp(ttype,timestamptz,strict boolean=TRUE) → ttype</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+beforeTimestamp(ttype,timestamptz,strict boolean=TRUE) → ttype
+afterTimestamp(ttype,timestamptz,strict boolean=TRUE) → ttype
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT beforeTimestamp(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-02');
 -- [1@2001-01-01, 1@2001-01-02)
@@ -491,8 +509,10 @@ SELECT tgeography '[Point(1 1)@2001-01-01, Linestring(1 1,2 2)@2001-01-02]' =
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>cmp</varname></primary></indexterm>
 					<para>Traditional comparisons</para>
-					<para><varname>ttype {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} ttype → boolean</varname></para>
-				<para><varname>cmp(ttype,ttype) → int</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+ttype {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} ttype → boolean
+cmp(ttype,ttype) → int
+</programlisting>
 				<para>Function <varname>cmp</varname> returns -1, 0, or 1 depending on whether the first argument is, respectively, less than, equal to, or greater than the second one.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 1@2001-01-04)' = tint '[2@2001-01-03, 2@2001-01-05)';
@@ -534,8 +554,10 @@ SELECT cmp(tfloat '[1@2001-01-01, 1@2001-01-04)', '[2@2001-01-03, 2@2001-01-05)'
 					<indexterm significance="normal"><primary><varname>?&gt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>%&gt;=</varname></primary></indexterm>
 					<para>Ever and always comparisons</para>
-					<para><varname>{base,ttype} {?=, ?&lt;&gt;, ?&lt;, ?&gt;, ?&lt;=, ?&gt;=} {base,ttype} → boolean</varname></para>
-					<para><varname>{base,ttype} {%=, %&lt;&gt;, %&lt;, %&gt;, %&lt;=, %&gt;=} {base,ttype} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{base,ttype} {?=, ?&lt;&gt;, ?&lt;, ?&gt;, ?&lt;=, ?&gt;=} {base,ttype} → boolean
+{base,ttype} {%=, %&lt;&gt;, %&lt;, %&gt;, %&lt;=, %&gt;=} {base,ttype} → boolean
+</programlisting>
 					<para>The operators do not take into account whether the bounds are inclusive or not.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 3@2001-01-04]' ?= 2;
@@ -604,7 +626,9 @@ SELECT ttext '{[AAA@2001-01-01, AAA@2001-01-03), [BBB@2001-01-04, BBB@2001-01-05
 					<indexterm significance="normal"><primary><varname>#&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>#&gt;=</varname></primary></indexterm>
 					<para>Temporal comparisons</para>
-					<para><varname>{base,ttype} {#=, #&lt;&gt;, #&lt;, #&gt;, #&lt;=, #&gt;=} {base,ttype} → boolean</varname></para>
+					<programlisting xml:space="preserve" format="linespecific">
+{base,ttype} {#=, #&lt;&gt;, #&lt;, #&gt;, #&lt;=, #&gt;=} {base,ttype} → boolean
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat '[1@2001-01-01, 2@2001-01-04)' #= 3;
 -- {[f@2001-01-01, f@2001-01-04)}
@@ -648,7 +672,9 @@ SELECT 'AAA'::text #&gt; ttext '{[AAA@2001-01-01, AAA@2001-01-03),
 			<listitem xml:id="mobilitydb_version">
 				<indexterm significance="normal"><primary><varname>mobilitydbVersion</varname></primary></indexterm>
 				<para>Version of the MobilityDB extension</para>
-				<para><varname>mobilitydbVersion() → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+mobilitydbVersion() → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT mobilitydbVersion();
 -- MobilityDB 1.3.0
@@ -658,7 +684,9 @@ SELECT mobilitydbVersion();
 			<listitem xml:id="mobilitydb_full_version">
 				<indexterm significance="normal"><primary><varname>mobilitydbFullVersion</varname></primary></indexterm>
 				<para>Versions of the MobilityDB extension and its dependencies</para>
-				<para><varname>mobilitydbFullVersion() → text</varname></para>
+				<programlisting xml:space="preserve" format="linespecific">
+mobilitydbFullVersion() → text
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT mobilitydbFullVersion();
 /* MobilityDB 1.3.0, PostgreSQL 17.2, PostGIS 3.5.2, GEOS 3.12.0-CAPI-1.18.0, PROJ 9.2.0,


### PR DESCRIPTION
Every manual entry states its syntax in the same verbatim environment as its examples, so the signatures of an overloaded function read as one block and a signature too long for the line keeps the two-space indent of its continuation, which a paragraph collapses to a single space. Each block holds the lines the entry already stated, folded at the manual's ninety-column listing width, in both manuals.