### PR TITLE
Say that the tcbuffer convex hull is the exact curved hull

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -876,19 +876,16 @@ SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
 				<programlisting xml:space="preserve" format="linespecific">
 convexHull(tcbuffer) → geometry
 </programlisting>
-				<para>La envolvente convexa se calcula sobre el área atravesada linealizada: los arcos circulares que delimitan la región barrida se convierten primero en segmentos rectos y la envolvente se calcula luego con GEOS. Por lo tanto, el resultado es un <varname>POLYGON</varname> lineal que aproxima el contorno circular, no un <varname>CURVEDPOLYGON</varname> curvo. Utilice <varname>traversedArea</varname> para obtener la región barrida curva exacta.</para>
+				<para>La envolvente convexa se calcula sobre el área atravesada exacta, arcos incluidos: un arco alcanza más allá de los puntos que lo definen, por lo que aporta a la envolvente el trozo de su círculo que ninguna otra característica del área alcanza. Por lo tanto, el resultado es un <varname>CURVEPOLYGON</varname> curvo delimitado por un <varname>COMPOUNDCURVE</varname> de arcos circulares y segmentos rectos, tan exacto como la región que devuelve <varname>traversedArea</varname>. La envolvente es lineal solo cuando el búfer mantiene un radio cero, ya que el área atravesada no lleva entonces ningún arco.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_GeometryType(convexHull(tcbuffer
-  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'));
--- ST_Polygon
-SELECT ST_NPoints(convexHull(tcbuffer
-  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'));
--- 131
-SELECT round(ST_Area(convexHull(tcbuffer
-  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'))::numeric, 3);
--- 11.140
--- The exact swept region has area pi + 8 = 11.1416; the stroked hull is
--- slightly smaller because the arcs are replaced by chords.
+SELECT ST_AsText(convexHull(tcbuffer
+  '[Cbuffer(Point(1 1), 0.5)@2001-01-01, Cbuffer(Point(1 3), 0.5)@2001-01-02]'));
+-- CURVEPOLYGON(COMPOUNDCURVE((1.5 3,1.5 1),CIRCULARSTRING(1.5 1,1 0.5,0.5 1),
+--   (0.5 1,0.5 3),CIRCULARSTRING(0.5 3,1 3.5,1.5 3)))
+SELECT ST_AsText(convexHull(tcbuffer
+  '[Cbuffer(Point(1 1), 0)@2001-01-01, Cbuffer(Point(1 3), 0)@2001-01-02,
+  Cbuffer(Point(3 3), 0)@2001-01-03]'));
+-- POLYGON((1 1,1 3,3 3,1 1))
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -877,19 +877,16 @@ SELECT asText(centroid(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
 				<programlisting xml:space="preserve" format="linespecific">
 convexHull(tcbuffer) → geometry
 </programlisting>
-				<para>The convex hull is computed on the linearized traversed area: the circular arcs bounding the swept region are first stroked into straight segments and the hull is then computed with GEOS. The result is therefore a linear <varname>POLYGON</varname> that approximates the circular boundary, not a curved <varname>CURVEDPOLYGON</varname>. Use <varname>traversedArea</varname> to obtain the exact curved swept region.</para>
+				<para>The convex hull is computed on the exact traversed area, arcs included: an arc reaches past the points that define it, so it contributes to the hull the piece of its circle that no other feature of the area reaches past. The result is therefore a curved <varname>CURVEPOLYGON</varname> bounded by a <varname>COMPOUNDCURVE</varname> of circular arcs and straight segments, as exact as the region returned by <varname>traversedArea</varname>. The hull is linear only when the buffer keeps a zero radius, since the traversed area then carries no arc.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_GeometryType(convexHull(tcbuffer
-  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'));
--- ST_Polygon
-SELECT ST_NPoints(convexHull(tcbuffer
-  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'));
--- 131
-SELECT round(ST_Area(convexHull(tcbuffer
-  '[Cbuffer(Point(0 0), 1)@2001-01-01, Cbuffer(Point(4 0), 1)@2001-01-02]'))::numeric, 3);
--- 11.140
--- The exact swept region has area pi + 8 = 11.1416; the stroked hull is
--- slightly smaller because the arcs are replaced by chords.
+SELECT ST_AsText(convexHull(tcbuffer
+  '[Cbuffer(Point(1 1), 0.5)@2001-01-01, Cbuffer(Point(1 3), 0.5)@2001-01-02]'));
+-- CURVEPOLYGON(COMPOUNDCURVE((1.5 3,1.5 1),CIRCULARSTRING(1.5 1,1 0.5,0.5 1),
+--   (0.5 1,0.5 3),CIRCULARSTRING(0.5 3,1 3.5,1.5 3)))
+SELECT ST_AsText(convexHull(tcbuffer
+  '[Cbuffer(Point(1 1), 0)@2001-01-01, Cbuffer(Point(1 3), 0)@2001-01-02,
+  Cbuffer(Point(3 3), 0)@2001-01-03]'));
+-- POLYGON((1 1,1 3,3 3,1 1))
 </programlisting>
 			</listitem>
 		</itemizedlist>


### PR DESCRIPTION
The convex hull of a temporal circular buffer is computed on the exact traversed area: an arc reaches past the points that define it and contributes to the hull the piece of its circle that no other feature of the area reaches past, so the result is a CURVEPOLYGON bounded by a COMPOUNDCURVE of circular arcs and straight segments, and it is linear only for a buffer that keeps a zero radius. The examples show the hull of a moving buffer of constant radius and the linear hull of a zero-radius one, in the English and the Spanish manual.