### PR TITLE
Answer the traversed area of a growing circular buffer with its bigger disc

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -854,7 +854,7 @@ traversedArea(tcbuffer, unary_union=false) → geometry
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02]'));
--- CURVEPOLYGON(CIRCULARSTRING(0.7 1,1.3 1,0.7 1))
+-- CURVEPOLYGON(CIRCULARSTRING(0.5 1,1.5 1,0.5 1))
 </programlisting>
 			</listitem>
 			<listitem xml:id="tcbuffer_centroid">

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -854,7 +854,7 @@ traversedArea(tcbuffer, unary_union=false) → geometry
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]'));
--- CURVEPOLYGON(CIRCULARSTRING(0.7 1,1.3 1,0.7 1))
+-- CURVEPOLYGON(CIRCULARSTRING(0.5 1,1.5 1,0.5 1))
 </programlisting>
 			</listitem>
 

--- a/meos/src/cbuffer/tcbuffer_spatialfuncs.c
+++ b/meos/src/cbuffer/tcbuffer_spatialfuncs.c
@@ -383,11 +383,11 @@ tcbuffersegm_traversed_area(const TInstant *inst1, const TInstant *inst2)
   const POINT2D *p2 = cbuffer_point2d_p(cb_max);
   int32_t srid = cbuffer_srid(cb_min);
 
-  /* If the two points are equal compute the traversed area of the circular
-   * buffer with the bigger radius */
+  /* If the two points are equal the buffer of the smaller radius is covered
+   * by the one of the bigger radius, which is the area traversed */
   if (p1->x == p2->x && p1->y == p2->y)
   {
-    return (cb_min->radius <= cb_max->radius) ?
+    return (cb_min->radius >= cb_max->radius) ?
       cbuffer_traversed_area(cb_min) : cbuffer_traversed_area(cb_max);
   }
 

--- a/mobilitydb/test/cbuffer/expected/205_tcbuffer_spatialfuncs.test.out
+++ b/mobilitydb/test/cbuffer/expected/205_tcbuffer_spatialfuncs.test.out
@@ -13,7 +13,13 @@ SELECT ST_AsText(traversedArea(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01'));
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1),0.3)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]'));
                     st_astext                    
 -------------------------------------------------
- CURVEPOLYGON(CIRCULARSTRING(0.7 1,1.3 1,0.7 1))
+ CURVEPOLYGON(CIRCULARSTRING(0.5 1,1.5 1,0.5 1))
+(1 row)
+
+SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.3)@2000-01-02]'));
+                    st_astext                    
+-------------------------------------------------
+ CURVEPOLYGON(CIRCULARSTRING(0.5 1,1.5 1,0.5 1))
 (1 row)
 
 SELECT atGeometry(NULL::tcbuffer, geometry 'Point(1 1)');

--- a/mobilitydb/test/cbuffer/queries/205_tcbuffer_spatialfuncs.test.sql
+++ b/mobilitydb/test/cbuffer/queries/205_tcbuffer_spatialfuncs.test.sql
@@ -34,6 +34,7 @@
 SELECT traversedArea(NULL::tcbuffer);
 SELECT ST_AsText(traversedArea(tcbuffer 'Cbuffer(Point(1 1),0.5)@2000-01-01'));
 SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1),0.3)@2000-01-01, Cbuffer(Point(1 1),0.5)@2000-01-02]'));
+SELECT ST_AsText(traversedArea(tcbuffer '[Cbuffer(Point(1 1),0.5)@2000-01-01, Cbuffer(Point(1 1),0.3)@2000-01-02]'));
 
 -------------------------------------------------------------------------------
 -- Restriction to a geometry (atGeometry / minusGeometry)


### PR DESCRIPTION
A segment of a temporal circular buffer whose two centres coincide covers the disc of the bigger of the two radii, since the buffer of the smaller radius lies inside it. The segment orders its two buffers by comparing the centre and then the radius, so the smaller radius is always the first of the pair and asking for it returned the smaller disc; the bigger radius is the one answered. The test asks the area in both orders and the manuals show the disc of radius 0.5 the example traverses.