### PR TITLE
Report the operations a build carrying no GEOS cannot answer

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1675,6 +1675,7 @@ geom_centroid(const GSERIALIZED *gs)
   if (! ensure_not_geodetic_geo(gs))
     return NULL;
 
+#if GEOS
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
   LWGEOM *lwresult = lwgeom_centroid(lwgeom);
   lwgeom_free(lwgeom);
@@ -1683,6 +1684,12 @@ geom_centroid(const GSERIALIZED *gs)
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(lwresult);
   return result;
+#else /* ! GEOS */
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "The centroid of a geometry is answered by the GEOS library, which this "
+    "build excludes: configure with -DGEOS=ON");
+  return NULL;
+#endif /* GEOS */
 }
 
 /**
@@ -2084,6 +2091,7 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (geo_is_planar_polygonal(gs1) && geo_is_planar_polygonal(gs2))
     return clip_poly_poly(gs1, gs2, CL_INTERSECTION);
 
+#if GEOS
   /* Other types fall through to GEOS */
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
@@ -2091,6 +2099,13 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(geom1); lwgeom_free(geom2); lwgeom_free(lwresult);
   return result;
+#else /* ! GEOS */
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "The intersection of two geometries that are not both planar and "
+    "polygonal is answered by the GEOS library, which this build excludes: "
+    "configure with -DGEOS=ON");
+  return NULL;
+#endif /* GEOS */
 }
 
 /**
@@ -2111,6 +2126,7 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (geo_is_planar_polygonal(gs1) && geo_is_planar_polygonal(gs2))
     return clip_poly_poly(gs1, gs2, CL_DIFFERENCE);
 
+#if GEOS
   /* Other types fall through to GEOS */
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
@@ -2118,6 +2134,13 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(geom1); lwgeom_free(geom2); lwgeom_free(lwresult);
   return result;
+#else /* ! GEOS */
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "The difference of two geometries that are not both planar and polygonal "
+    "is answered by the GEOS library, which this build excludes: configure "
+    "with -DGEOS=ON");
+  return NULL;
+#endif /* GEOS */
 }
 
 /**
@@ -2457,6 +2480,7 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
   LWGEOM *lwresult = (prec < 0) ? meos_areal_union(lwgeom) : NULL;
   if (! lwresult)
   {
+#if GEOS
     lwresult = lwgeom_unaryunion_prec(lwgeom, prec);
     /* MEOS: the overlay answers NULL for a geometry it cannot read -- a
      * polyhedral surface reaches the default arm of #LWGEOM2GEOS, whose
@@ -2475,6 +2499,14 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
      * this: it is built with the flags it carries, and a geodetic geometry
      * does not reach here */
     lwgeom_set_geodetic(lwresult, FLAGS_GET_GEODETIC(lwgeom->flags));
+#else /* ! GEOS */
+    lwgeom_free(lwgeom);
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "The unary union of a geometry whose components are not all surfaces, "
+      "and the one asked for on a precision grid, are answered by the GEOS "
+      "library, which this build excludes: configure with -DGEOS=ON");
+    return NULL;
+#endif /* GEOS */
   }
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(lwgeom); lwgeom_free(lwresult);
@@ -2511,6 +2543,7 @@ geom_is_simple(const GSERIALIZED *gs)
     return result;
   }
 
+#if GEOS
   /* A geometry carrying a circular arc meets itself along an arc, which the
    * segment intersection the answer above rests on does not read */
   int simple = lwgeom_is_simple(geom);
@@ -2522,6 +2555,13 @@ geom_is_simple(const GSERIALIZED *gs)
     return false;
   }
   return simple != 0;
+#else /* ! GEOS */
+  lwgeom_free(geom);
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "Whether a geometry carrying a circular arc is simple is answered by the "
+    "GEOS library, which this build excludes: configure with -DGEOS=ON");
+  return false;
+#endif /* GEOS */
 }
 
 /*****************************************************************************/

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -145,11 +145,21 @@ geoarr_merge(GSERIALIZED **gsarr, int count)
    */
   if (gserialized_get_type(result) == MULTILINETYPE)
   {
+#if GEOS
     LWGEOM *geom = lwgeom_from_gserialized(result);
     LWGEOM *geom1 = lwgeom_linemerge_directed(geom, 0);
     GSERIALIZED *tmp = gserialized_from_lwgeom(geom1, NULL);
     pfree(result);
     result = tmp;
+#else /* ! GEOS */
+    /* Answering the union without sewing its lines is a different geometry,
+     * not the same one built differently, so it is reported rather than given */
+    pfree(result);
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "Sewing the lines of a merged geometry is answered by the GEOS library, "
+      "which this build excludes: configure with -DGEOS=ON");
+    return NULL;
+#endif /* GEOS */
   }
   return result;
 }


### PR DESCRIPTION
The `GEOS` option says that with it off, an operation no native implementation
covers reports that it is not supported. Five entry points did not honour it.

Each reaches GEOS *through* the vendored geometry library rather than by naming a
GEOS entry point, so it is invisible at the call site and counting the GEOS
symbols a source file references does not report it. The library the option
excluded is loaded anyway by another dependency, so nothing announces the
mismatch: the answers are right, they are simply not the ones that configuration
asked for.

### Measured, on a build configured `-DMEOS=ON -DGEOS=OFF -DALL=ON`

A probe drives each entry against an isolated prefix; `gcc -H` names only that
prefix's headers and `ldd` only its `libmeos.so`. A `gdb` breakpoint on the GEOS
entry points records which are reached — `set breakpoint pending on` is needed,
since the symbols are not defined until the library enters the load closure.

| entry | before | GEOS entry point reached |
|---|---|---|
| `geom_centroid` | answers `POINT(2 2)` | `GEOSGetCentroid_r` |
| `geom_intersection2d`, two lines | answers `POINT(2 2)` | `GEOSIntersection_r` |
| `geom_difference2d`, two lines | answers a `MULTILINESTRING` | `GEOSDifference_r` |
| `geom_unary_union`, a self-crossing line | answers a `MULTILINESTRING` | `GEOSUnaryUnion_r` |
| `geom_is_simple`, a `CIRCULARSTRING` | answers `t` | `GEOSisSimple_r` |

After this change each reports the operation as not supported (`errno` 13,
`MEOS_ERR_FEATURE_NOT_SUPPORTED`), and the same breakpoints record **no** GEOS
entry point being reached. The wording is the one `geom_array_union` already
uses for the same situation.

The sewing of merged linework joins them. `geoarr_merge` unions an array of
geometries — which is answered natively — and then sews the lines of the result
through the geometry library, which answers with GEOS. A union whose lines are
left unsewn is a different geometry rather than the same one built differently,
and the tree carries no native sewing, so it is reported rather than given.

### The build carrying GEOS is untouched

The same probe against a `-DGEOS=ON` build of this branch answers exactly as it
does on master: `POINT(2 2)`, `POINT(2 2)`, the two multilinestrings, `t`. Every
guard is a `#if GEOS` around the arm that was already there.
