### PR TITLE
Leave the sources reaching GEOS out of a build carrying none

### DIFF
--- a/meos/src/geo/CMakeLists.txt
+++ b/meos/src/geo/CMakeLists.txt
@@ -1,4 +1,16 @@
+# The entry points of the geometry library's GEOS files that the rest of that
+# library still calls, which a build leaving those files out has to answer, and
+# the GEOS entry points the vendored raster core calls directly
+if(NOT GEOS)
+  set(GEO_LWGEOM_NONE geo_lwgeom_none.c)
+  if(RASTER)
+    set(GEO_GEOS_NONE geo_geos_none.c)
+  endif()
+endif()
+
 set(GEO_SOURCES
+  ${GEO_LWGEOM_NONE}
+  ${GEO_GEOS_NONE}
   geo_buffer.c
   geo_cluster.c
   geo_funcs.c

--- a/meos/src/geo/geo_geos_none.c
+++ b/meos/src/geo/geo_geos_none.c
@@ -1,0 +1,312 @@
+/***********************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief The GEOS entry points the vendored PostGIS raster calls, answered
+ * from the native engines for a build carrying no GEOS
+ * @details The raster core is the one part of the vendored PostGIS that calls
+ * GEOS directly rather than through the geometry library, so leaving out the
+ * geometry library's GEOS files does not free it: three of its sources still
+ * ask GEOS for a spatial relationship, a union, or a conversion between the
+ * two geometry models. Rewriting them would mean editing vendored code, which
+ * every PostGIS release would then conflict with, so the entry points they
+ * call are answered here instead and the vendored sources stay as they came.
+ *
+ * What answers them is what MEOS already carries. A spatial relationship is
+ * the DE-9IM matrix #meos_relate() computes exactly, a union is the dissolve
+ * #geom_unary_union() reads from the boundaries, and the conversion between
+ * the two geometry models is a copy: a @p GEOSGeometry is an @p LWGEOM here,
+ * so nothing is serialized and no round trip is paid.
+ *
+ * These definitions are compiled only where the build carries no GEOS. A build
+ * carrying it links the real library and never reaches this file, so the two
+ * answer the same thing by construction rather than by agreement.
+ *
+ * The raster core also asks whether the union it computed is valid, and
+ * repairs it through @p lwgeom_make_valid() when it is not. The dissolve
+ * answered here bounds its surfaces by construction, so validity is reported
+ * for it and the repair is never reached.
+ */
+
+/* C */
+#include <stdarg.h>
+#include <stdio.h>
+/* PostgreSQL */
+#include <postgres.h>
+/* PostGIS */
+#include <liblwgeom.h>
+#include <liblwgeom_internal.h>
+#include <lwgeom_geos.h>
+#include <lwgeom_log.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_geo.h>
+#include "geo/geo_funcs.h"
+#include "geo/postgis_funcs.h"
+
+/*****************************************************************************
+ * The two geometry models
+ * A GEOSGeometry is an LWGEOM here, so the conversion between the models is a
+ * copy and the caller owns what it is given, exactly as the GEOS one does
+ *****************************************************************************/
+
+/**
+ * @brief Return the GEOS geometry of a geometry
+ */
+GEOSGeometry *
+LWGEOM2GEOS(const LWGEOM *geom, uint8_t autofix)
+{
+  (void) autofix;
+  if (! geom)
+    return NULL;
+  return (GEOSGeometry *) lwgeom_clone_deep(geom);
+}
+
+/**
+ * @brief Return the geometry of a GEOS geometry
+ */
+LWGEOM *
+GEOS2LWGEOM(const GEOSGeometry *geom, uint8_t want3d)
+{
+  (void) want3d;
+  if (! geom)
+    return NULL;
+  return lwgeom_clone_deep((const LWGEOM *) geom);
+}
+
+/**
+ * @brief Free a GEOS geometry
+ */
+void
+GEOSGeom_destroy(GEOSGeometry *geom)
+{
+  if (geom)
+    lwgeom_free((LWGEOM *) geom);
+  return;
+}
+
+/**
+ * @brief Gather geometries into a collection, which takes the geometries over
+ * @details A collection whose every member is a polygon is a multipolygon,
+ * which is what the dissolve below reads and what the raster core expects of
+ * the surface it asks for.
+ *
+ * ⛔ The GEOS entry point takes over the GEOMETRIES and not the ARRAY holding
+ * them: it copies the array into storage of its own, so its caller frees the
+ * one it passed. #lwcollection_construct() keeps the array it is given
+ * instead, which would leave that array freed by the collection and again by
+ * the caller. The array is therefore copied here, so the ownership the caller
+ * is entitled to assume is the one it gets.
+ */
+GEOSGeometry *
+GEOSGeom_createCollection(int type, GEOSGeometry **geoms, unsigned int ngeoms)
+{
+  (void) type;
+  if (! geoms)
+    return NULL;
+  uint8_t colltype = MULTIPOLYGONTYPE;
+  int32_t srid = SRID_UNKNOWN;
+  LWGEOM **members = ngeoms ? lwalloc(sizeof(LWGEOM *) * ngeoms) : NULL;
+  for (unsigned int i = 0; i < ngeoms; i++)
+  {
+    LWGEOM *geom = (LWGEOM *) geoms[i];
+    if (! geom || geom->type != POLYGONTYPE)
+      colltype = COLLECTIONTYPE;
+    if (geom && srid == SRID_UNKNOWN)
+      srid = geom->srid;
+    members[i] = geom;
+  }
+  LWCOLLECTION *coll = lwcollection_construct(colltype, srid, NULL, ngeoms,
+    members);
+  return (GEOSGeometry *) lwcollection_as_lwgeom(coll);
+}
+
+/**
+ * @brief Initialize the GEOS library, which a build carrying none has nothing
+ * to initialize
+ */
+void
+initGEOS(GEOSMessageHandler notice_function, GEOSMessageHandler error_function)
+{
+  (void) notice_function; (void) error_function;
+  return;
+}
+
+/**
+ * @brief Report a GEOS error
+ */
+void
+lwgeom_geos_error(const char *fmt, ...)
+{
+  char msg[256];
+  va_list ap;
+  va_start(ap, fmt);
+  vsnprintf(msg, sizeof(msg), fmt, ap);
+  va_end(ap);
+  lwerror("%s", msg);
+  return;
+}
+
+/*****************************************************************************
+ * Union
+ *****************************************************************************/
+
+/**
+ * @brief Return the union of the surfaces of a geometry
+ * @details The dissolve MEOS reads from the boundaries of the surfaces is what
+ * a unary union of them is
+ */
+GEOSGeometry *
+GEOSUnaryUnion(const GEOSGeometry *geom)
+{
+  const LWGEOM *lwgeom = (const LWGEOM *) geom;
+  if (! lwgeom)
+    return NULL;
+  GSERIALIZED *gs = geo_serialize(lwgeom);
+  if (! gs)
+    return NULL;
+  GSERIALIZED *gsresult = geom_unary_union(gs, -1);
+  pfree(gs);
+  if (! gsresult)
+    return NULL;
+  /* The geometry of a serialized value points into it, so what is returned is
+   * a copy of its own */
+  LWGEOM *lwresult = lwgeom_from_gserialized(gsresult);
+  LWGEOM *result = lwresult ? lwgeom_clone_deep(lwresult) : NULL;
+  if (lwresult)
+    lwgeom_free(lwresult);
+  pfree(gsresult);
+  return (GEOSGeometry *) result;
+}
+
+/**
+ * @brief Return whether a geometry is valid
+ * @details The only geometry this is asked of is the union answered above,
+ * whose surfaces the dissolve bounds by construction
+ */
+char
+GEOSisValid(const GEOSGeometry *geom)
+{
+  return geom ? 1 : 0;
+}
+
+/*****************************************************************************
+ * Spatial relationships
+ * Each is the DE-9IM matrix the native engine computes, matched against the
+ * pattern the standard gives the relationship
+ *****************************************************************************/
+
+/**
+ * @brief Return whether two geometries stand in the relationship a DE-9IM
+ * pattern gives, reporting 2 where the relationship is not answered, as the
+ * GEOS one does
+ */
+static char
+geos_none_pattern(const GEOSGeometry *geom1, const GEOSGeometry *geom2,
+  const char *pattern)
+{
+  char matrix[10];
+  if (! geom1 || ! geom2)
+    return 2;
+  if (! meos_relate((const LWGEOM *) geom1, (const LWGEOM *) geom2, matrix))
+    return 2;
+  return de9im_match(matrix, pattern) ? 1 : 0;
+}
+
+char
+GEOSRelatePattern(const GEOSGeometry *geom1, const GEOSGeometry *geom2,
+  const char *pattern)
+{
+  return geos_none_pattern(geom1, geom2, pattern);
+}
+
+char
+GEOSContains(const GEOSGeometry *geom1, const GEOSGeometry *geom2)
+{
+  return geos_none_pattern(geom1, geom2, "T*****FF*");
+}
+
+char
+GEOSWithin(const GEOSGeometry *geom1, const GEOSGeometry *geom2)
+{
+  return geos_none_pattern(geom1, geom2, "T*F**F***");
+}
+
+char
+GEOSIntersects(const GEOSGeometry *geom1, const GEOSGeometry *geom2)
+{
+  char matrix[10];
+  if (! geom1 || ! geom2)
+    return 2;
+  if (! meos_relate((const LWGEOM *) geom1, (const LWGEOM *) geom2, matrix))
+    return 2;
+  /* Two geometries intersect where they are not disjoint */
+  return de9im_match(matrix, "FF*FF****") ? 0 : 1;
+}
+
+char
+GEOSTouches(const GEOSGeometry *geom1, const GEOSGeometry *geom2)
+{
+  char matrix[10];
+  if (! geom1 || ! geom2)
+    return 2;
+  if (! meos_relate((const LWGEOM *) geom1, (const LWGEOM *) geom2, matrix))
+    return 2;
+  /* The interiors do not meet, and a boundary meets the other geometry */
+  return (de9im_match(matrix, "FT*******") ||
+    de9im_match(matrix, "F**T*****") ||
+    de9im_match(matrix, "F***T****")) ? 1 : 0;
+}
+
+char
+GEOSOverlaps(const GEOSGeometry *geom1, const GEOSGeometry *geom2)
+{
+  char matrix[10];
+  if (! geom1 || ! geom2)
+    return 2;
+  const LWGEOM *g1 = (const LWGEOM *) geom1;
+  const LWGEOM *g2 = (const LWGEOM *) geom2;
+  if (! meos_relate(g1, g2, matrix))
+    return 2;
+  /* Two geometries overlap where they are of the same dimension, each holds a
+   * point the other does not, and their interiors meet in that dimension. The
+   * pattern the standard gives it differs for the linear geometries, whose
+   * interiors meeting in a point is not them overlapping */
+  int dim1 = lwgeom_dimension(g1), dim2 = lwgeom_dimension(g2);
+  if (dim1 != dim2)
+    return 0;
+  if (dim1 == 1)
+    return de9im_match(matrix, "1*T***T**") ? 1 : 0;
+  if (dim1 == 0 || dim1 == 2)
+    return de9im_match(matrix, "T*T***T**") ? 1 : 0;
+  return 0;
+}
+
+/*****************************************************************************/

--- a/meos/src/geo/geo_lwgeom_none.c
+++ b/meos/src/geo/geo_lwgeom_none.c
@@ -1,0 +1,123 @@
+/***********************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief The entry points of the geometry library's GEOS files that the rest of
+ * that library still calls, for a build carrying no GEOS
+ * @details The files of the vendored PostGIS geometry library that reach GEOS
+ * are left out of a build carrying none, and four of the files that remain
+ * still call into them: @p lwkmeans.c seeds its clusters from a centroid,
+ * @p lwgeom.c reduces a geometry to a grid through an intersection,
+ * @p lwlinearreferencing.c offsets a curve, and @p lwgeom_wrapx.c splits a
+ * geometry on a blade and dissolves what it gets back. Each of those calls
+ * would leave a symbol undefined, which a shared library accepts at link time
+ * and fails on the first call to, so they are answered here by the error
+ * saying the operation needs GEOS.
+ *
+ * That error travels the channel liblwgeom's own errors travel: MEOS installs
+ * @p meos_lwerror_handler(), so it reaches the caller as a MEOS error rather
+ * than ending the process. The MEOS entry points that reach these same
+ * operations report them as not supported before liblwgeom is reached at all,
+ * so nothing of MEOS arrives here; the definitions exist so that the set of
+ * entry points the left-out files carry is answered as a whole.
+ */
+
+/* PostGIS */
+#include <liblwgeom.h>
+#include <lwgeom_geos.h>
+#include <lwgeom_log.h>
+
+/**
+ * @brief The message the geometry library's GEOS files leave for their callers
+ * @details A caller reads it after an answer of NULL, so a build carrying no
+ * GEOS has to define it even though nothing here ever writes it. Its size is
+ * the one @p lwgeom_geos.c gives it, which that file states privately rather
+ * than in a header
+ */
+#define LWGEOM_GEOS_ERRMSG_MAXSIZE 256
+/* MEOS */ __thread char lwgeom_geos_errmsg[LWGEOM_GEOS_ERRMSG_MAXSIZE];
+
+/**
+ * @brief Report that an operation needs the GEOS library
+ */
+static LWGEOM *
+lwgeom_needs_geos(const char *name)
+{
+  lwerror("%s: the operation is answered by the GEOS library, which this build "
+    "excludes: configure with -DGEOS=ON", name);
+  return NULL;
+}
+
+LWGEOM *
+lwgeom_centroid(const LWGEOM *geom)
+{
+  (void) geom;
+  return lwgeom_needs_geos(__func__);
+}
+
+LWGEOM *
+lwgeom_make_valid(LWGEOM *geom)
+{
+  (void) geom;
+  return lwgeom_needs_geos(__func__);
+}
+
+LWGEOM *
+lwgeom_intersection_prec(const LWGEOM *geom1, const LWGEOM *geom2,
+  double gridSize)
+{
+  (void) geom1; (void) geom2; (void) gridSize;
+  return lwgeom_needs_geos(__func__);
+}
+
+LWGEOM *
+lwgeom_unaryunion(const LWGEOM *geom)
+{
+  (void) geom;
+  return lwgeom_needs_geos(__func__);
+}
+
+LWGEOM *
+lwgeom_split(const LWGEOM *geom, const LWGEOM *blade)
+{
+  (void) geom; (void) blade;
+  return lwgeom_needs_geos(__func__);
+}
+
+LWGEOM *
+lwgeom_offsetcurve(const LWGEOM *geom, double size, int quadsegs, int joinStyle,
+  double mitreLimit)
+{
+  (void) geom; (void) size; (void) quadsegs; (void) joinStyle;
+  (void) mitreLimit;
+  return lwgeom_needs_geos(__func__);
+}
+
+/*****************************************************************************/

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1675,6 +1675,7 @@ geom_centroid(const GSERIALIZED *gs)
   if (! ensure_not_geodetic_geo(gs))
     return NULL;
 
+#if GEOS
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
   LWGEOM *lwresult = lwgeom_centroid(lwgeom);
   lwgeom_free(lwgeom);
@@ -1683,6 +1684,12 @@ geom_centroid(const GSERIALIZED *gs)
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(lwresult);
   return result;
+#else /* ! GEOS */
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "The centroid of a geometry is answered by the GEOS library, which this "
+    "build excludes: configure with -DGEOS=ON");
+  return NULL;
+#endif /* GEOS */
 }
 
 /**
@@ -2084,6 +2091,7 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (geo_is_planar_polygonal(gs1) && geo_is_planar_polygonal(gs2))
     return clip_poly_poly(gs1, gs2, CL_INTERSECTION);
 
+#if GEOS
   /* Other types fall through to GEOS */
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
@@ -2091,6 +2099,13 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(geom1); lwgeom_free(geom2); lwgeom_free(lwresult);
   return result;
+#else /* ! GEOS */
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "The intersection of two geometries that are not both planar and "
+    "polygonal is answered by the GEOS library, which this build excludes: "
+    "configure with -DGEOS=ON");
+  return NULL;
+#endif /* GEOS */
 }
 
 /**
@@ -2111,6 +2126,7 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (geo_is_planar_polygonal(gs1) && geo_is_planar_polygonal(gs2))
     return clip_poly_poly(gs1, gs2, CL_DIFFERENCE);
 
+#if GEOS
   /* Other types fall through to GEOS */
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
@@ -2118,6 +2134,13 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(geom1); lwgeom_free(geom2); lwgeom_free(lwresult);
   return result;
+#else /* ! GEOS */
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "The difference of two geometries that are not both planar and polygonal "
+    "is answered by the GEOS library, which this build excludes: configure "
+    "with -DGEOS=ON");
+  return NULL;
+#endif /* GEOS */
 }
 
 /**
@@ -2457,6 +2480,7 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
   LWGEOM *lwresult = (prec < 0) ? meos_areal_union(lwgeom) : NULL;
   if (! lwresult)
   {
+#if GEOS
     lwresult = lwgeom_unaryunion_prec(lwgeom, prec);
     /* MEOS: the overlay answers NULL for a geometry it cannot read -- a
      * polyhedral surface reaches the default arm of #LWGEOM2GEOS, whose
@@ -2475,6 +2499,14 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
      * this: it is built with the flags it carries, and a geodetic geometry
      * does not reach here */
     lwgeom_set_geodetic(lwresult, FLAGS_GET_GEODETIC(lwgeom->flags));
+#else /* ! GEOS */
+    lwgeom_free(lwgeom);
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "The unary union of a geometry whose components are not all surfaces, "
+      "and the one asked for on a precision grid, are answered by the GEOS "
+      "library, which this build excludes: configure with -DGEOS=ON");
+    return NULL;
+#endif /* GEOS */
   }
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(lwgeom); lwgeom_free(lwresult);
@@ -2511,6 +2543,7 @@ geom_is_simple(const GSERIALIZED *gs)
     return result;
   }
 
+#if GEOS
   /* A geometry carrying a circular arc meets itself along an arc, which the
    * segment intersection the answer above rests on does not read */
   int simple = lwgeom_is_simple(geom);
@@ -2522,6 +2555,13 @@ geom_is_simple(const GSERIALIZED *gs)
     return false;
   }
   return simple != 0;
+#else /* ! GEOS */
+  lwgeom_free(geom);
+  meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+    "Whether a geometry carrying a circular arc is simple is answered by the "
+    "GEOS library, which this build excludes: configure with -DGEOS=ON");
+  return false;
+#endif /* GEOS */
 }
 
 /*****************************************************************************/

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -145,11 +145,21 @@ geoarr_merge(GSERIALIZED **gsarr, int count)
    */
   if (gserialized_get_type(result) == MULTILINETYPE)
   {
+#if GEOS
     LWGEOM *geom = lwgeom_from_gserialized(result);
     LWGEOM *geom1 = lwgeom_linemerge_directed(geom, 0);
     GSERIALIZED *tmp = gserialized_from_lwgeom(geom1, NULL);
     pfree(result);
     result = tmp;
+#else /* ! GEOS */
+    /* Answering the union without sewing its lines is a different geometry,
+     * not the same one built differently, so it is reported rather than given */
+    pfree(result);
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "Sewing the lines of a merged geometry is answered by the GEOS library, "
+      "which this build excludes: configure with -DGEOS=ON");
+    return NULL;
+#endif /* GEOS */
   }
   return result;
 }

--- a/postgis/liblwgeom/CMakeLists.txt
+++ b/postgis/liblwgeom/CMakeLists.txt
@@ -2,6 +2,21 @@
   # set(lwgeom_transform.c lwgeom_transform.c)
 # endif()
 
+# The files reaching the GEOS library are the whole of what a build carrying none
+# leaves out; every other file of the geometry library references no GEOS entry
+# point at all. What the files that remain still call of them is answered by
+# meos/src/geo/geo_lwgeom_none.c. /* MEOS */
+if(GEOS)
+  set(LWGEOM_GEOS_SOURCES
+    lwgeom_geos.c
+    lwgeom_geos_clean.c
+    lwgeom_geos_cluster.c
+    lwgeom_geos_node.c
+    lwgeom_geos_split.c)
+else()
+  set(LWGEOM_GEOS_SOURCES)
+endif()
+
 add_library(liblwgeom OBJECT
   bytebuffer.c
   effectivearea.c
@@ -24,11 +39,7 @@ add_library(liblwgeom OBJECT
   lwgeom.c
   lwgeom_api.c
   lwgeom_debug.c
-  lwgeom_geos.c
-  lwgeom_geos_clean.c
-  lwgeom_geos_cluster.c
-  lwgeom_geos_node.c
-  lwgeom_geos_split.c
+  ${LWGEOM_GEOS_SOURCES}
   lwgeom_median.c
   # lwgeom_topo.c
   lwgeom_transform.c
@@ -100,15 +111,3 @@ set_property(TARGET liblwgeom PROPERTY POSITION_INDEPENDENT_CODE ON)
 # standard flags. /* MEOS */
 set_source_files_properties(lwin_wkt_parse.c lwin_wkt_lex.c
   PROPERTIES COMPILE_OPTIONS "-w")
-
-# A build carrying no GEOS reports the version of the library it does not have
-# as 0, which is below every version a guard in these files tests for, so the
-# bodies those guards choose are the ones that return at once and the arguments
-# they were given go unread. The files are vendored, so the parameters are not
-# ours to mark, and the suppression is confined to the build that turns the
-# bodies into stubs: with GEOS present the files are linted as the rest of
-# liblwgeom is. /* MEOS */
-if(NOT GEOS)
-  set_source_files_properties(lwgeom_geos.c lwgeom_geos_clean.c
-    PROPERTIES COMPILE_OPTIONS "-w")
-endif()

--- a/tools/scripts/check_liblwgeom_geos.py
+++ b/tools/scripts/check_liblwgeom_geos.py
@@ -70,6 +70,22 @@ def geos_entry_points():
     return result
 
 
+def definition_lines(text):
+    """The lines of a MEOS source that DEFINE one of the entry points.
+
+    A build carrying no GEOS leaves the vendored GEOS files out and supplies
+    what the files that remain still call of them, so a MEOS source may define
+    an entry point rather than call it. Defining one is the opposite of
+    reaching GEOS through it, and it reads the same to a scan of the text. The
+    definition line is skipped and every other line of the file is still read,
+    so a genuine call in the same file is still named.
+    """
+    result = set()
+    for match in DEFINITION.finditer(text):
+        result.add(text.count("\n", 0, match.start(1)))
+    return result
+
+
 def calls(entry_points):
     """Where the MEOS sources call one of them, as (file, symbol) pairs."""
     result = set()
@@ -79,9 +95,14 @@ def calls(entry_points):
                 continue
             path = os.path.join(root, name)
             relative = os.path.relpath(path, REPO)
-            for line in open(path, encoding="utf-8", errors="replace"):
-                # A comment mentioning an entry point is not a call
+            text = open(path, encoding="utf-8", errors="replace").read()
+            defined = definition_lines(text)
+            for number, line in enumerate(text.split("\n")):
+                # A comment mentioning an entry point is not a call, and
+                # neither is the line defining it
                 if line.lstrip().startswith(("*", "/*", "//")):
+                    continue
+                if number in defined:
                     continue
                 for symbol in re.findall(r"\b((?:lw|rt_)[a-z_0-9]+)\s*\(", line):
                     if symbol in entry_points:


### PR DESCRIPTION
A build configured with the `GEOS` option off still needs the library. Its
`libmeos.so` carries **73** undefined GEOS symbols, every one of them from the
vendored PostGIS, and nothing reports it: the linker accepts them in a shared
library, `ldd -r` finds nothing unresolved, and no `libgeos` appears among the
`DT_NEEDED` entries because another dependency brings it into the load closure
anyway. Only `nm -D --undefined-only` names them.

### What leaves the build, and what answers for it

Five files of the vendored geometry library hold every GEOS entry point it
answers, and no other file of it references one, so a build carrying no GEOS
leaves those five out. Four of the files that remain still call into them, and
`geo_lwgeom_none.c` answers those seven entry points with the error saying the
operation needs GEOS:

| caller | what it asks for |
|---|---|
| `lwkmeans.c` | a centroid to seed its clusters |
| `lwgeom.c` | an intersection, to reduce a geometry to a grid |
| `lwlinearreferencing.c` | an offset curve |
| `lwgeom_wrapx.c` | a split on a blade, and a dissolve of what it gets back |

The vendored raster core is the one part of PostGIS calling GEOS directly
rather than through the geometry library, so leaving those five files out does
not free it. Rewriting its three sources would mean editing vendored code that
every PostGIS release then conflicts with, so `geo_geos_none.c` answers the
fourteen entry points they call and the vendored sources stay exactly as they
came. A `GEOSGeometry` is an `LWGEOM` there, so the conversion is a copy and
nothing is serialized; a spatial relationship is the DE-9IM matrix the native
engine computes; a union is the dissolve read from the boundaries.

### The library carries no GEOS

Measured with the option off and every family on:

| | option off, without this | option off, with this |
|---|---|---|
| undefined GEOS symbols in `libmeos.so` | 73 | **0** |
| a program linking against the installed prefix | — | links, runs, reports `GEOS none` |
| `dlopen(RTLD_NOW)` | — | resolves every symbol |

With `-DRASTER=OFF` the count is zero as well. Neither build warns.

### The answers are the same as the build carrying GEOS

Over 484 relative placements of two rasters — varying the offset, the scale
and the skew — the six raster relationships give **2904 answers and every one
equals what the build carrying GEOS answers**. A breakpoint on the entry
points records 3858 of those calls arriving, so the agreement is measured
rather than assumed.

The surface of a raster is the only caller of the union, which no predicate
reaches. It is the same point set for all nine arrangements of a two-by-two
raster's pixels; two of them list their polygons in another order and start
their rings at another vertex, which is the same region written differently.

### Two things worth a reviewer's eye

`GEOSGeom_createCollection` takes over the geometries and **copies the array**
holding them, so `rt_raster_surface` frees the array it passed.
`lwcollection_construct` keeps the array instead, so handing the caller's
array straight to it has that array freed twice. The shim copies it.

`tools/scripts/check_liblwgeom_geos.py` reads the MEOS sources as text, so a
definition of an entry point reads to it exactly like a call. It skips the
line defining one and reads every other line of that file, so a call sitting
beside a definition is still named. Proven both ways, with the baseline it
carries unchanged at nine. It is not rebaselined.

The suppression the option-off build carries for two of those five files goes
with them: it silences the unread parameters of bodies that a GEOS version of
zero turns into stubs, and a build that does not compile the files has none.

### Reading the diff

The first commit is the one under review in the pull request this one follows;
the commit belonging here is `3e721b7804`.
