### PR TITLE
Read the edges a boundary is split at out of an index

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -6038,9 +6038,20 @@ relate_union_edges(const LWGEOM *geom)
   int nall = (int) all->count;
   int maxparams = 2 * nall + 2;
   double *params = palloc(sizeof(double) * maxparams);
+  /* Every edge is asked against every other, so the walk costs the SQUARE of
+   * the array while indexing it costs one pass. Two edges that meet have
+   * boxes that meet, so the index answers the pairs the walk would split at
+   * and leaves out the ones it would only reject */
+  Edge **edges = palloc(sizeof(Edge *) * Max(nall, 1));
+  for (int i = 0; i < nall; i++)
+    edges[i] = (Edge *) meos_array_get(all, i);
+  RelateEdges re;
+  relate_edges_init(&re, edges, nall,
+    (int64) nall * (int64) nall >= RELATE_INDEX_MIN_PAIRS);
+  MeosArray *candidates = re.index ? meos_array_create(sizeof(int64)) : NULL;
   for (int i = 0; i < nall; i++)
   {
-    Edge *e = (Edge *) meos_array_get(all, i);
+    Edge *e = edges[i];
     if (! relate_area_boundary_edge(e))
     {
       /* An edge of another dimension bounds no area of the union */
@@ -6051,9 +6062,21 @@ relate_union_edges(const LWGEOM *geom)
     int nparams = 0;
     params[nparams++] = 0.0;
     params[nparams++] = 1.0;
-    for (int j = 0; j < nall; j++)
+    /* The query is grown by the widest tolerance the array asks for, which is
+     * what makes it admit every edge the walk would have solved against */
+    int ncand = nall;
+    if (re.index)
     {
-      Edge *other = (Edge *) meos_array_get(all, j);
+      STBox query;
+      double pad = fmax(re.tol, e->tol);
+      stbox_set(true, false, false, 0, e->xmin - pad, e->xmax + pad,
+        e->ymin - pad, e->ymax + pad, 0, 0, NULL, &query);
+      ncand = rtree_search(re.index, INDEX_OVERLAPS, &query, candidates);
+    }
+    for (int c = 0; c < ncand; c++)
+    {
+      int j = candidates ? (int) *(int64 *) meos_array_get(candidates, c) : c;
+      const Edge *other = edges[j];
       if (j == i || ! relate_area_boundary_edge(other))
         continue;
       double ix[2], iy[2];
@@ -6113,6 +6136,10 @@ relate_union_edges(const LWGEOM *geom)
     }
   }
   pfree(params);
+  if (candidates)
+    meos_array_destroy(candidates);
+  relate_edges_clear(&re);
+  pfree(edges);
 
   relate_comps_free(comps, ncomp);
   meos_array_destroy(all);


### PR DESCRIPTION
The edges of a multi-surface are read as those of the union of its members, which splits every boundary edge at its intersections with the others. The split asks each edge against every other, so it costs the square of the array, and it holds no witness to stop at: an edge is split wherever any other meets it, so the walk runs to the end whatever it finds. Two real protected areas carry 11203 and 13503 edges, and every one of 20 profile samples over that corpus falls inside this extraction rather than in the matrix it feeds.

Two edges that meet have bounding boxes that meet, so the pairs whose boxes stand apart are the ones the walk spends itself on. The matrix already builds an index over an edge array once the work it saves reaches a threshold, and reads the edges each of its cells needs out of it. Building one here in the same shape asks the intersection only of the pairs whose boxes meet, the query grown by the widest tolerance the array asks for so that it admits every pair the walk would have solved, and the array is read whole below the size the index is worth.

Over ten real protected-area pairs of 30 to 120 KB, interleaved with a build of master in three rounds, the four relationships read 216.3, 211.6 and 209.4 times the cost of GEOS against 294.6, 251.0 and 308.1, and TOUCHES 85.8, 81.4 and 81.5 against 104.9, 105.2 and 110.8.

The matrix is unchanged over 14580 geometry pairs — 12880 mixed pairs carrying circular arcs, 1444 small areal pairs and 202 real trajectory pairs — every one of the nine cells reads exactly as it reads on master, as it does over 54 adversarial pairs and the ten real protected-area pairs.
