### PR TITLE
Find the feature nearest a boundary point through an index

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -6008,8 +6008,51 @@ relate_edge_distance(double x, double y, const Edge *e)
  * reading the neighbourhood of that edge alone
  */
 static double
-relate_clearance(double x, double y, const RelateComp *comps, int ncomp)
+relate_clearance(double x, double y, const RelateComp *comps, int ncomp,
+  double seed)
 {
+  /* The nearest feature is found by growing a box about the point until one
+   * falls inside it. An edge whose box stands outside a box of half-width r
+   * has every one of its points outside it, so it lies further than r, and a
+   * feature found no further than r is therefore the nearest there is. Where
+   * a component carries no index the walk below answers, and it answers if
+   * the growth ever runs out, so the two paths agree by construction */
+  bool indexed = (ncomp > 0);
+  for (int i = 0; i < ncomp && indexed; i++)
+    indexed = (comps[i].re.index != NULL);
+  if (indexed)
+  {
+    MeosArray *candidates = meos_array_create(sizeof(int64));
+    double r = seed > MEOS_GEOM_TOLERANCE ? seed : MEOS_GEOM_TOLERANCE;
+    for (int round = 0; round < 64; round++)
+    {
+      double best = -1;
+      for (int i = 0; i < ncomp; i++)
+      {
+        STBox query;
+        stbox_set(true, false, false, 0, x - r, x + r, y - r, y + r, 0, 0,
+          NULL, &query);
+        int nc = rtree_search(comps[i].re.index, INDEX_OVERLAPS, &query,
+          candidates);
+        for (int c = 0; c < nc; c++)
+        {
+          int j = (int) *(int64 *) meos_array_get(candidates, c);
+          double d = relate_edge_distance(x, y, comps[i].edges[j]);
+          if (d <= MEOS_GEOM_TOLERANCE)
+            continue;
+          if (best < 0 || d < best)
+            best = d;
+        }
+      }
+      if (best >= 0 && best <= r)
+      {
+        meos_array_destroy(candidates);
+        return best;
+      }
+      r *= 4;
+    }
+    meos_array_destroy(candidates);
+  }
   double result = -1;
   for (int i = 0; i < ncomp; i++)
     for (int j = 0; j < comps[i].nedges; j++)
@@ -6061,7 +6104,11 @@ relate_portion_inside_union(const Edge *e, double t, const RelateComp *comps,
 {
   double x, y;
   relate_area_edge_point(e, t, &x, &y);
-  double delta = relate_clearance(x, y, comps, ncomp);
+  /* The portion's own edge sets the scale the search starts at: the feature
+   * nearest a point of a boundary is normally the next one along it */
+  double delta = relate_clearance(x, y, comps, ncomp,
+    e->etype == EDGE_POLYARC || e->etype == EDGE_LINEARC ?
+      e->radius : e->length);
   if (delta <= 0)
     return false;
   delta *= 0.5;

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -5891,6 +5891,9 @@ typedef struct
   MeosArray *arr;  /**< Edges of the component, owning their memory */
   Edge **edges;    /**< Pointers into the array above */
   int nedges;      /**< Number of edges */
+  RelateEdges re;  /**< The same edges, with what reading them selectively
+                        needs, so a point is located against a component
+                        without walking it whole */
 } RelateComp;
 
 /**
@@ -5901,7 +5904,7 @@ typedef struct
  */
 static void
 relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
-  int *maxcomp)
+  int *maxcomp, bool index)
 {
   if (! geom || lwgeom_is_empty(geom))
     return;
@@ -5915,7 +5918,7 @@ relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
     {
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       for (uint32_t i = 0; i < col->ngeoms; i++)
-        relate_area_comps_iter(col->geoms[i], comps, ncomp, maxcomp);
+        relate_area_comps_iter(col->geoms[i], comps, ncomp, maxcomp, index);
       return;
     }
     case POLYGONTYPE:
@@ -5936,6 +5939,7 @@ relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
   c->edges = palloc(sizeof(Edge *) * Max(c->nedges, 1));
   for (int i = 0; i < c->nedges; i++)
     c->edges[i] = (Edge *) meos_array_get(c->arr, i);
+  relate_edges_init(&c->re, c->edges, c->nedges, index);
   return;
 }
 
@@ -5947,6 +5951,7 @@ relate_comps_free(RelateComp *comps, int ncomp)
 {
   for (int i = 0; i < ncomp; i++)
   {
+    relate_edges_clear(&comps[i].re);
     pfree(comps[i].edges);
     meos_array_destroy(comps[i].arr);
   }
@@ -5962,7 +5967,7 @@ static bool
 relate_in_area_union(double x, double y, const RelateComp *comps, int ncomp)
 {
   for (int i = 0; i < ncomp; i++)
-    if (relate_point_in_area(x, y, comps[i].edges, comps[i].nedges) != 2)
+    if (relate_point_in_area_index(x, y, &comps[i].re) != 2)
       return true;
   return false;
 }
@@ -6105,11 +6110,17 @@ relate_same_portion(const Edge *a, const Edge *b)
 static MeosArray *
 relate_union_edges(const LWGEOM *geom)
 {
+  MeosArray *all = geom_extract_edges(geom);
+  int nall = (int) all->count;
+  /* Every edge is located against every component, so a component is read
+   * once for each edge and the two indexes below are worth what the same
+   * threshold is worth anywhere else in this file */
+  bool index = ((int64) nall * (int64) nall >= RELATE_INDEX_MIN_PAIRS);
+
   int ncomp = 0, maxcomp = 8;
   RelateComp *comps = palloc(sizeof(RelateComp) * maxcomp);
-  relate_area_comps_iter(geom, &comps, &ncomp, &maxcomp);
+  relate_area_comps_iter(geom, &comps, &ncomp, &maxcomp, index);
 
-  MeosArray *all = geom_extract_edges(geom);
   /* A collection holding at most one surface has no overlap to resolve */
   if (ncomp < 2)
   {
@@ -6118,7 +6129,6 @@ relate_union_edges(const LWGEOM *geom)
   }
 
   MeosArray *result = meos_array_create(sizeof(Edge));
-  int nall = (int) all->count;
   int maxparams = 2 * nall + 2;
   double *params = palloc(sizeof(double) * maxparams);
   /* Every edge is asked against every other, so the walk costs the SQUARE of
@@ -6129,8 +6139,7 @@ relate_union_edges(const LWGEOM *geom)
   for (int i = 0; i < nall; i++)
     edges[i] = (Edge *) meos_array_get(all, i);
   RelateEdges re;
-  relate_edges_init(&re, edges, nall,
-    (int64) nall * (int64) nall >= RELATE_INDEX_MIN_PAIRS);
+  relate_edges_init(&re, edges, nall, index);
   MeosArray *candidates = re.index ? meos_array_create(sizeof(int64)) : NULL;
   for (int i = 0; i < nall; i++)
   {
@@ -6496,7 +6505,7 @@ relate_stratum(const LWGEOM *geom, int dim, int ncomps, const LWGEOM *area,
     int nareal = 0, maxareal = 8;
     RelateComp *areal = palloc(sizeof(RelateComp) * maxareal);
     if (area)
-      relate_area_comps_iter(area, &areal, &nareal, &maxareal);
+      relate_area_comps_iter(area, &areal, &nareal, &maxareal, false);
     MeosArray *larr = line ? geom_extract_edges(line) : NULL;
     int nledges = larr ? (int) larr->count : 0;
     Edge **ledges = palloc(sizeof(Edge *) * Max(nledges, 1));


### PR DESCRIPTION
Telling the two sides of a boundary portion apart places a point off it, and how far off is how far the point can move before it reaches a feature it does not already lie on. That distance is read by measuring every edge of every component, once per portion, and the portions of a multi-surface are as many as its edges, so the extraction is quadratic in the size of the geometry a third time. With the two other walks answered from the index, it is what the profile then names.

An edge whose bounding box stands outside a box of half-width r about the point has every one of its points outside that box, so it lies further than r. Growing a box about the point until a feature falls inside it therefore finds the nearest one, the first feature no further than the half-width that found it being the nearest there is. The search starts at the scale of the portion's own edge, since the feature nearest a point of a boundary is normally the next one along that boundary, and it falls back to the measurement of every edge where a component carries no index or the growth runs out, so the two paths agree by construction.

Over two real protected-area pairs, interleaved with a build of master in two rounds, TOUCHES reads 1760 and 1765 ms against 4416 and 4396, CONTAINS 1714 and 1738 against 4418 and 4454, COVERS 1734 and 1699 against 4419 and 4354, and INTERSECTS 1717 and 1563 against 4342 and 4464. A relate call on that pair falls from about 4.4 to about 1.7 seconds. Each arm holds to under one percent between its two rounds, while the ratio against GEOS moves by a fifth on the same pairs, so the native side is the figure quoted.

The answers are unchanged over 14590 geometry pairs -- 12880 mixed pairs carrying circular arcs, 1444 small areal pairs, 202 real trajectory pairs, 54 adversarial pairs and ten real protected-area pairs, 4258 of them holding a relationship that answers true. Every one of the nine DE-9IM cells and every one of the four relationships reads on this branch exactly as it reads on master, and on the 1444 areal pairs both agree with the matrix that corpus records for each pair.

The branch holds the commit of `geo/union-point-index` below its own, and needs it: the expanding-box search reads the per-component index that branch adds.
