### PR TITLE
Read the upper border of a box out of a rigid geometry restriction

### DIFF
--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -201,10 +201,51 @@ restrict_double_cmp(const void *a, const void *b)
  * @param[in] lwtarget LWGEOM view of @p target (for the clip primitive)
  * @return true on success, false if the error handler returned (error set)
  */
+/**
+ * @brief Return true where a body meets a box only along the borders the box
+ * leaves out
+ * @details A box of a grid is half-open, `[xmin,xmax) x [ymin,ymax)`, so the
+ * tiles either side of a grid line claim a value lying on that line exactly
+ * once. The overlap of two geometries is a closed test and answers true for a
+ * body that merely touches, so a body every point of which stands at or beyond
+ * one of the two upper borders meets the closed box while meeting no point of
+ * the half-open one
+ * @param[in] body Body, already placed in the world
+ * @param[in] box Box whose upper borders are left out
+ * @note A body reaching past an upper border and back is admitted, so this
+ * decides exactly the case where the contact is confined to a border and never
+ * withholds a box the body genuinely reaches
+ */
+static bool
+body_on_excluded_border(const GSERIALIZED *body, const STBox *box)
+{
+  STBox bbox;
+  if (! geo_set_stbox(body, &bbox))
+    return false;
+  return (bbox.xmin >= box->xmax) || (bbox.ymin >= box->ymax);
+}
+
+/**
+ * @brief Return whether a body meets a target, leaving out the upper borders
+ * of @p excl where it is given
+ * @param[in] body Body, already placed in the world
+ * @param[in] target Target geometry
+ * @param[in] excl Box whose upper borders are left out, NULL to meet the
+ * target as a closed region
+ */
+static bool
+body_meets_target(const GSERIALIZED *body, const GSERIALIZED *target,
+  const STBox *excl)
+{
+  if (! geom_intersects2d(body, target))
+    return false;
+  return excl ? ! body_on_excluded_border(body, excl) : true;
+}
+
 static bool
 segment_overlap_spans(const GSERIALIZED *ref, const Pose *pose1,
   const Pose *pose2, TimestampTz t1, TimestampTz t2,
-  const GSERIALIZED *target, const LWGEOM *lwtarget,
+  const GSERIALIZED *target, const LWGEOM *lwtarget, const STBox *excl,
   Span **spans, int *nspans, int *spancap)
 {
   /* Pure translation: orientation is fixed over the segment (the caller has
@@ -245,7 +286,7 @@ segment_overlap_spans(const GSERIALIZED *ref, const Pose *pose1,
     double tm = 0.5 * (ta + tb);
     Pose *posem = posesegm_interpolate(pose1, pose2, tm);
     GSERIALIZED *bodym = pose_apply_geo(posem, ref);
-    bool ov = geom_intersects2d(bodym, target);
+    bool ov = body_meets_target(bodym, target, excl);
     pfree(bodym);
     pfree(posem);
     if (ov && ! prev_overlap)
@@ -294,10 +335,11 @@ segment_overlap_spans(const GSERIALIZED *ref, const Pose *pose1,
  */
 static void
 instant_overlap_span(const GSERIALIZED *ref, const Pose *pose, TimestampTz t,
-  const GSERIALIZED *target, Span **spans, int *nspans, int *spancap)
+  const GSERIALIZED *target, const STBox *excl, Span **spans, int *nspans,
+  int *spancap)
 {
   GSERIALIZED *body = pose_apply_geo(pose, ref);
-  bool ov = geom_intersects2d(body, target);
+  bool ov = body_meets_target(body, target, excl);
   pfree(body);
   if (! ov)
     return;
@@ -324,7 +366,7 @@ instant_overlap_span(const GSERIALIZED *ref, const Pose *pose, TimestampTz t,
  */
 static SpanSet *
 trgeo_overlap_spanset(const Temporal *temp, const GSERIALIZED *gs,
-  const LWGEOM *lwgs, bool *err)
+  const LWGEOM *lwgs, const STBox *excl, bool *err)
 {
   *err = false;
   const GSERIALIZED *ref = trgeo_geom_p(temp);
@@ -335,7 +377,7 @@ trgeo_overlap_spanset(const Temporal *temp, const GSERIALIZED *gs,
   {
     const TInstant *inst = (const TInstant *) temp;
     instant_overlap_span(ref, DatumGetPoseP(tinstant_value_p(inst)),
-      inst->t, gs, &spans, &nspans, &spancap);
+      inst->t, gs, excl, &spans, &nspans, &spancap);
   }
   else
   {
@@ -365,7 +407,7 @@ trgeo_overlap_spanset(const Temporal *temp, const GSERIALIZED *gs,
       {
         const TInstant *inst = TSEQUENCE_INST_N(seq, 0);
         instant_overlap_span(ref, DatumGetPoseP(tinstant_value_p(inst)),
-          inst->t, gs, &spans, &nspans, &spancap);
+          inst->t, gs, excl, &spans, &nspans, &spancap);
         continue;
       }
       if (! linear)
@@ -378,7 +420,7 @@ trgeo_overlap_spanset(const Temporal *temp, const GSERIALIZED *gs,
           const TInstant *inst = TSEQUENCE_INST_N(seq, i);
           const Pose *pose = DatumGetPoseP(tinstant_value_p(inst));
           GSERIALIZED *body = pose_apply_geo(pose, ref);
-          bool ov = geom_intersects2d(body, gs);
+          bool ov = body_meets_target(body, gs, excl);
           pfree(body);
           if (! ov)
             continue;
@@ -415,7 +457,7 @@ trgeo_overlap_spanset(const Temporal *temp, const GSERIALIZED *gs,
           return NULL;
         }
         if (! segment_overlap_spans(ref, pose1, pose2, inst1->t, inst2->t,
-            gs, lwgs, &spans, &nspans, &spancap))
+            gs, lwgs, excl, &spans, &nspans, &spancap))
         {
           pfree(spans);
           if (temp->subtype == TSEQUENCESET)
@@ -505,7 +547,9 @@ trgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc)
   }
 
   bool err;
-  SpanSet *ss = trgeo_overlap_spanset(temp, gs, lwgs, &err);
+  /* A geometry is met as a closed region: only a box of a grid leaves its
+   * upper borders out */
+  SpanSet *ss = trgeo_overlap_spanset(temp, gs, lwgs, NULL, &err);
   lwgeom_free(lwgs);
   if (err)
     return NULL;
@@ -560,10 +604,12 @@ trgeometry_minus_geom(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] box Spatiotemporal box
  * @param[in] border_inc True when the box contains the upper border
  * @param[in] atfunc True if the restriction is `at`, false for `minus`
- * @note @p border_inc governs the temporal upper border (carried in the box
- * period). The spatial footprint is the closed box region: an area body
- * overlaps it on a positive-measure set of times, so border-only spatial
- * contact (a measure-zero boundary touch) does not change the result.
+ * @note @p border_inc governs the upper border of BOTH dimensions. The time
+ * span carries it directly. On the spatial side the box is closed where the
+ * upper border is asked for and half-open where it is not, so a body meeting
+ * the box only along an upper border stands outside it -- which is what lets
+ * the tiles either side of a grid line claim a body lying on that line once
+ * rather than twice.
  */
 Temporal *
 trgeo_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
@@ -575,9 +621,11 @@ trgeo_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
 
   bool hasx = MEOS_FLAGS_GET_X(box->flags);
   bool hast = MEOS_FLAGS_GET_T(box->flags);
-  /* The box period already encodes its temporal-border inclusivity; the
-   * spatial overlap is an exact closed-region area test (see @note). */
-  (void) border_inc;
+  /* The box period already carries its temporal-border inclusivity. On the
+   * spatial side the box is closed where the upper border is asked for, and
+   * half-open where it is not, so that the tiles either side of a grid line
+   * claim a body lying on that line exactly once */
+  const STBox *excl = border_inc ? NULL : box;
 
   /* Spatial overlap spans (whole time domain if the box has no X bounds). */
   SpanSet *spatial = NULL;
@@ -586,7 +634,7 @@ trgeo_restrict_stbox(const Temporal *temp, const STBox *box, bool border_inc,
     GSERIALIZED *geo = stbox_geo(box);
     LWGEOM *lwgeo = lwgeom_from_gserialized(geo);
     bool err;
-    spatial = trgeo_overlap_spanset(temp, geo, lwgeo, &err);
+    spatial = trgeo_overlap_spanset(temp, geo, lwgeo, excl, &err);
     lwgeom_free(lwgeo);
     pfree(geo);
     if (err)

--- a/mobilitydb/test/rgeo/expected/167_trgeo_restrict_exact.test.out
+++ b/mobilitydb/test/rgeo/expected/167_trgeo_restrict_exact.test.out
@@ -161,3 +161,59 @@ SELECT asText(atStbox(
  POLYGON((0 0,1 0,1 1,0 1,0 0));{[Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST, Pose(POINT(3 0),0)@Thu Jan 04 00:00:00 2001 PST]}
 (1 row)
 
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((-2, 0), (0, 2))', false));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((0, -2), (2, 0))', false));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((-2, -2), (0, 0))', false));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((-2, 0), (0, 2))', true));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST}
+(1 row)
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((0, -2), (2, 0))', true));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST}
+(1 row)
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((0, 0), (2, 2))', false));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST}
+(1 row)
+
+SELECT asText(minusStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((-2, 0), (0, 2))', false));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST}
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/167_trgeo_restrict_exact.test.sql
+++ b/mobilitydb/test/rgeo/queries/167_trgeo_restrict_exact.test.sql
@@ -213,3 +213,44 @@ SELECT asText(atStbox(
   stbox 'STBOX X((1, -1), (3, 1))'));
 
 -------------------------------------------------------------------------------
+-- A box asked for without its upper border is half-open, so a body standing
+-- entirely at or beyond that border meets the closed box and no point of the
+-- half-open one. This is what lets the tiles either side of a grid line claim
+-- a body lying on that line once rather than twice. The body below occupies
+-- [0,1] x [0,1], so it touches each of the three boxes along a border only.
+-------------------------------------------------------------------------------
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((-2, 0), (0, 2))', false));
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((0, -2), (2, 0))', false));
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((-2, -2), (0, 0))', false));
+
+-- Asked for WITH the upper border the same three boxes hold the body, which is
+-- what separates the border being honoured from the box being smaller.
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((-2, 0), (0, 2))', true));
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((0, -2), (2, 0))', true));
+
+-- A box the body genuinely enters answers the same either way.
+
+SELECT asText(atStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((0, 0), (2, 2))', false));
+
+SELECT asText(minusStbox(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
+  stbox 'STBOX X((-2, 0), (0, 2))', false));
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
A spatiotemporal box carries whether its upper border belongs to it, and the spatial restriction of a temporal rigid geometry spends that on the time span alone: the footprint is the closed box whatever is asked for. The note above the function records the reasoning -- a boundary touch has measure zero, so it cannot change which times the body overlaps a box -- and that holds for the times while missing what the border decides, which is which of two adjacent boxes a body lying between them belongs to.

It is a grid that asks. Tiles are half-open, `[xmin,xmax) x [ymin,ymax)`, so that the tiles either side of a grid line claim a body lying on that line exactly once. Under a closed footprint both of them claim it, and a body whose edge lies on a grid line is answered twice.

The overlap of two geometries is a closed test, so the restriction leaves out a body every point of which stands at or beyond one of the two upper borders: such a body meets the closed box and no point of the half-open one. A body reaching past an upper border and back is admitted, so this decides exactly the case where the contact is confined to a border, and it never withholds a box the body genuinely reaches.

A unit square held at the origin covers `[0,1] x [0,1]`, so it meets the boxes `((-2,0),(0,2))`, `((0,-2),(2,0))` and `((-2,-2),(0,0))` along a border alone. Asked for without the upper border each answers nothing, and `minusStbox` answers the whole value; asked for with it each holds the body, which is what separates the border being read from the box being smaller. A box the body enters answers the same either way. Seven queries covering those readings join `167_trgeo_restrict_exact`, which carries no case standing on a border until now.

Every other expected output is unchanged: the rgeo suites pass as they stand, so what moves is the reading of a border and nothing else.
