### PR TITLE
Tile a temporal rigid geometry over the region its body covers

### DIFF
--- a/meos/include/geo/tgeo_tile.h
+++ b/meos/include/geo/tgeo_tile.h
@@ -98,6 +98,18 @@ extern STboxGridState *stbox_tile_state_make(const Temporal *temp,
 extern void stbox_tile_state_next(STboxGridState *state);
 extern bool stbox_tile_state_get(STboxGridState *state, STBox *box);
 
+/**
+ * @brief Restriction of a temporal value to a spatiotemporal box, which is the
+ * one step of the tiling that differs between families
+ */
+typedef Temporal *(*TileRestrictFn)(const Temporal *temp, const STBox *box,
+  bool border_inc, bool atfunc);
+
+extern STBox *tspatial_space_time_boxes(const Temporal *temp, double xsize,
+  double ysize, double zsize, const Interval *duration,
+  const GSERIALIZED *sorigin, TimestampTz torigin, bool bitmatrix,
+  bool border_inc, TileRestrictFn restrfn, int *count);
+
 extern STboxGridState *tgeo_space_time_tile_init(const Temporal *temp,
   double xsize, double ysize, double zsize, const Interval *duration,
   const GSERIALIZED *sorigin, TimestampTz torigin, bool bitmatrix, 

--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -304,6 +304,7 @@ extern bool tpoint_type(MeosType type);
 extern bool ensure_tpoint_type(MeosType type);
 extern bool tgeo_type(MeosType type);
 extern bool ensure_tgeo_type(MeosType type);
+extern bool tspatial_body_type(MeosType type);
 extern bool tgeo_type_all(MeosType type);
 extern bool ensure_tgeo_type_all(MeosType type);
 extern bool tgeometry_type(MeosType type);

--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -951,39 +951,31 @@ stbox_get_time_tile(TimestampTz t, const Interval *duration,
  *****************************************************************************/
 
 /**
- * @ingroup meos_geo_bbox_split
- * @brief Return the spatiotemporal boxes of a temporal point split with
- * respect to a space and possibly a time grid
- * @param[in] temp Temporal point
+ * @brief Return the spatiotemporal boxes of a temporal value with a spatial
+ * bounding box, split with respect to a space and possibly a time grid
+ * @details Every family lays its values on the grid the same way and differs
+ * only in how a value is read against one tile, so the restriction is the
+ * parameter: a temporal geo passes #tgeo_restrict_stbox, a temporal rigid
+ * geometry the restriction that reads its body. A family whose values cover a
+ * region MUST NOT pass a restriction reading a point, since the boxes would
+ * then answer where the point goes instead of where the value is
+ * @param[in] temp Temporal value
  * @param[in] xsize,ysize,zsize Size of the corresponding dimension
  * @param[in] duration Size of the time dimension as an interval, may be `NULL`
  * @param[in] sorigin Origin for the space dimension, may be `NULL`
  * @param[in] torigin Origin for the time dimension
  * @param[in] bitmatrix True when using a bitmatrix to speed up the computation
- * @param[in] border_inc True when the box contains the upper border, otherwise
- * the upper border is assumed as outside of the box.
+ * @param[in] border_inc True when the box contains the upper border
+ * @param[in] restrfn Restriction of the value to one tile
  * @param[out] count Number of elements in the output array
- * @csqlfn #Tgeo_space_time_boxes()
  */
 STBox *
-tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
+tspatial_space_time_boxes(const Temporal *temp, double xsize, double ysize,
   double zsize, const Interval *duration, const GSERIALIZED *sorigin,
-  TimestampTz torigin, bool bitmatrix, bool border_inc, int *count)
+  TimestampTz torigin, bool bitmatrix, bool border_inc,
+  TileRestrictFn restrfn, int *count)
 {
-  /* The out parameter is defined even when a later check fails */
-  *count = 0;
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(count, NULL); VALIDATE_TGEO(temp, NULL);
-  if ((xsize > 0 && ! ensure_not_null((void *) sorigin)) ||
-      (xsize > 0 && ! ensure_positive_datum(xsize, T_FLOAT8)) ||
-      (xsize > 0 && ! ensure_positive_datum(ysize, T_FLOAT8)) ||
-      (xsize > 0 && MEOS_FLAGS_GET_Z(temp->flags) &&
-        ! ensure_positive_datum(zsize, T_FLOAT8)) ||
-      (duration && ! ensure_positive_duration(duration)) ||
-      /* Generic 3D geometries cannot be tiled */
-      (tgeo_type(temp->temptype) &&
-      ! ensure_has_not_Z(temp->temptype, temp->flags)))
-    return NULL;
+  assert(temp); assert(restrfn); assert(count);
 
   /* Initialize state */
   int ntiles;
@@ -1020,15 +1012,11 @@ tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
     }
     stbox_tile_state_next(state);
 
-    /* Restrict the temporal point to the box and compute its bounding box */
-    Temporal *atstbox = tgeo_restrict_stbox(state->temp, &box, BORDER_EXC,
-      REST_AT);
+    /* Restrict the value to the box and compute its bounding box */
+    Temporal *atstbox = restrfn(state->temp, &box, BORDER_EXC, REST_AT);
     if (atstbox == NULL)
       continue;
     tspatial_set_stbox(atstbox, &box);
-    /* If only space grid */
-    // if (! duration)
-      // MEOS_FLAGS_SET_T(box.flags, false);
     pfree(atstbox);
 
     /* Copy the box to the result */
@@ -1036,6 +1024,45 @@ tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
   }
   *count = i;
   return result;
+}
+
+/**
+ * @ingroup meos_geo_bbox_split
+ * @brief Return the spatiotemporal boxes of a temporal point split with
+ * respect to a space and possibly a time grid
+ * @param[in] temp Temporal point
+ * @param[in] xsize,ysize,zsize Size of the corresponding dimension
+ * @param[in] duration Size of the time dimension as an interval, may be `NULL`
+ * @param[in] sorigin Origin for the space dimension, may be `NULL`
+ * @param[in] torigin Origin for the time dimension
+ * @param[in] bitmatrix True when using a bitmatrix to speed up the computation
+ * @param[in] border_inc True when the box contains the upper border, otherwise
+ * the upper border is assumed as outside of the box.
+ * @param[out] count Number of elements in the output array
+ * @csqlfn #Tgeo_space_time_boxes()
+ */
+STBox *
+tgeo_space_time_boxes(const Temporal *temp, double xsize, double ysize,
+  double zsize, const Interval *duration, const GSERIALIZED *sorigin,
+  TimestampTz torigin, bool bitmatrix, bool border_inc, int *count)
+{
+  /* The out parameter is defined even when a later check fails */
+  *count = 0;
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(count, NULL); VALIDATE_TGEO(temp, NULL);
+  if ((xsize > 0 && ! ensure_not_null((void *) sorigin)) ||
+      (xsize > 0 && ! ensure_positive_datum(xsize, T_FLOAT8)) ||
+      (xsize > 0 && ! ensure_positive_datum(ysize, T_FLOAT8)) ||
+      (xsize > 0 && MEOS_FLAGS_GET_Z(temp->flags) &&
+        ! ensure_positive_datum(zsize, T_FLOAT8)) ||
+      (duration && ! ensure_positive_duration(duration)) ||
+      /* Generic 3D geometries cannot be tiled */
+      (tgeo_type(temp->temptype) &&
+      ! ensure_has_not_Z(temp->temptype, temp->flags)))
+    return NULL;
+
+  return tspatial_space_time_boxes(temp, xsize, ysize, zsize, duration,
+    sorigin, torigin, bitmatrix, border_inc, &tgeo_restrict_stbox, count);
 }
 
 /**
@@ -1285,7 +1312,10 @@ tgeo_space_time_tile_init(const Temporal *temp, double xsize, double ysize,
   /* The out parameter is defined even when a later check fails */
   *ntiles = 0;
   /* Ensure parameter validity */
-  VALIDATE_NOT_NULL(ntiles, NULL); VALIDATE_TGEO(temp, NULL);
+  /* Every value with a spatial bounding box can be laid on a spatial grid;
+   * what differs between the families is which restriction reads the value,
+   * which is the caller's to supply */
+  VALIDATE_NOT_NULL(ntiles, NULL); VALIDATE_TSPATIAL(temp, NULL);
   if ((xsize && ! ensure_positive_datum(Float8GetDatum(xsize), T_FLOAT8)) ||
       (xsize && ! ensure_positive_datum(Float8GetDatum(ysize), T_FLOAT8)) ||
       (xsize && ! ensure_positive_datum(Float8GetDatum(zsize), T_FLOAT8)) ||
@@ -1308,8 +1338,11 @@ tgeo_space_time_tile_init(const Temporal *temp, double xsize, double ysize,
   }
 
   /* Disable the usage of bitmatrix for instantaneous temporal values, for
-   * time only bins, or for temporal geos */
-  if (! xsize || temporal_num_instants(temp) == 1 || tgeo_type(temp->temptype))
+   * time only bins, or for a value covering a region: the matrix is filled
+   * from the segments a POINT traverses, which is not what such a value
+   * occupies */
+  if (! xsize || temporal_num_instants(temp) == 1 ||
+      tspatial_body_type(temp->temptype))
       bitmatrix = false;
 
   /* Zero-init at declaration: when xsize == 0 the if-block below is

--- a/meos/src/rgeo/trgeo_tile.c
+++ b/meos/src/rgeo/trgeo_tile.c
@@ -31,9 +31,16 @@
  * @file
  * @brief Spatial and spatiotemporal grid tiling for temporal rigid geometries
  *
- * The boxes are computed on the temporal centroid trajectory
- * (`trgeometry_to_tgeompoint`) and thus reuse the `tgeo` tiling kernel, keeping the
- * trgeometry tiling surface aligned with the temporal geometry one.
+ * A rigid geometry occupies the region its body covers, so the tiles are the
+ * ones that body reaches, which #trgeo_restrict_stbox answers by solving for
+ * the times the body meets a box. The grid itself is the `tgeo` one, reached
+ * through #tspatial_space_time_boxes, so the two families lay values on the
+ * same grid and differ only in how a value is read against one tile.
+ *
+ * Reading the centroid trajectory instead answers the tiles a POINT visits:
+ * a value holding one placement of a 4 by 4 square answers a single box of
+ * zero extent, and a square carried past four grid columns answers none of
+ * them.
  */
 
 /* PostgreSQL */
@@ -42,7 +49,9 @@
 #include <meos.h>
 #include <meos_geo.h>
 #include <meos_rgeo.h>
+#include "geo/tgeo_tile.h"
 #include "rgeo/trgeo.h"
+#include "rgeo/trgeo_spatialfuncs.h"
 
 /*****************************************************************************
  * Boxes functions
@@ -71,11 +80,8 @@ trgeometry_space_boxes(const Temporal *temp, double xsize, double ysize,
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
-  STBox *result = tgeo_space_time_boxes(tpoint, xsize, ysize, zsize, NULL,
-    sorigin, 0, bitmatrix, border_inc, count);
-  pfree(tpoint);
-  return result;
+  return tspatial_space_time_boxes(temp, xsize, ysize, zsize, NULL, sorigin,
+    0, bitmatrix, border_inc, &trgeo_restrict_stbox, count);
 }
 
 /**
@@ -103,11 +109,8 @@ trgeometry_space_time_boxes(const Temporal *temp, double xsize, double ysize,
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
 
-  Temporal *tpoint = trgeometry_to_tgeompoint(temp);
-  STBox *result = tgeo_space_time_boxes(tpoint, xsize, ysize, zsize, duration,
-    sorigin, torigin, bitmatrix, border_inc, count);
-  pfree(tpoint);
-  return result;
+  return tspatial_space_time_boxes(temp, xsize, ysize, zsize, duration,
+    sorigin, torigin, bitmatrix, border_inc, &trgeo_restrict_stbox, count);
 }
 
 /*****************************************************************************/

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -1431,6 +1431,25 @@ ensure_tgeo_type(MeosType type)
 #endif /* MEOS */
 
 /**
+ * @brief Return true if a type is a temporal spatial type whose values cover a
+ * region rather than standing at a point
+ * @details A point has no extent, so what such a value occupies is the path
+ * its point follows; a value of one of these types occupies the region its
+ * body covers, which is what a question about the space it takes up has to
+ * read
+ */
+bool
+tspatial_body_type(MeosType type)
+{
+  return (type == T_TGEOMETRY || type == T_TGEOGRAPHY ||
+    type == T_TRGEOMETRY || type == T_TCBUFFER
+#if POINTCLOUD
+    || type == T_TPCPATCH
+#endif
+    );
+}
+
+/**
  * @brief Return true if a type is a temporal type with geometry/geography as
  * base type
  */

--- a/mobilitydb/test/rgeo/expected/158_trgeo_tile.test.out
+++ b/mobilitydb/test/rgeo/expected/158_trgeo_tile.test.out
@@ -25,18 +25,45 @@ SELECT array_length(timeBoxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(P
 SELECT array_length(spaceTimeBoxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-05]', 2.0, interval '1 day'), 1);
  array_length 
 --------------
-            9
+           12
 (1 row)
 
 SELECT array_length(spaceTimeBoxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-05]', 2.0, 2.0, interval '1 day'), 1);
  array_length 
 --------------
-            9
+           12
 (1 row)
 
 SELECT array_length(spaceTimeBoxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-05]', 2.0, 2.0, 2.0, interval '1 day'), 1);
  array_length 
 --------------
+           12
+(1 row)
+
+SELECT array_length(spaceBoxes(
+  trgeometry 'Polygon((-2 -2,2 -2,2 2,-2 2,-2 -2));{Pose(Point(0 0),0)@2001-01-01}',
+  2.0), 1);
+ array_length 
+--------------
             9
+(1 row)
+
+SELECT min(xMin(b)), max(xMax(b)), min(yMin(b)), max(yMax(b))
+FROM unnest(spaceBoxes(
+  trgeometry 'Polygon((-2 -2,2 -2,2 2,-2 2,-2 -2));{Pose(Point(0 0),0)@2001-01-01}',
+  2.0)) b;
+ min | max | min | max 
+-----+-----+-----+-----
+  -2 |   2 |  -2 |   2
+(1 row)
+
+SELECT round(min(xMin(b))::numeric, 6), round(max(xMax(b))::numeric, 6),
+  round(min(yMin(b))::numeric, 6), round(max(yMax(b))::numeric, 6)
+FROM unnest(spaceBoxes(
+  trgeometry 'Polygon((-2 -2,2 -2,2 2,-2 2,-2 -2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(12 0),0)@2001-01-02]',
+  2.0)) b;
+   round   |   round   |   round   |  round   
+-----------+-----------+-----------+----------
+ -2.828427 | 14.828427 | -2.828427 | 2.828427
 (1 row)
 

--- a/mobilitydb/test/rgeo/queries/158_trgeo_tile.test.sql
+++ b/mobilitydb/test/rgeo/queries/158_trgeo_tile.test.sql
@@ -13,3 +13,29 @@ SELECT array_length(spaceTimeBoxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[P
 SELECT array_length(spaceTimeBoxes(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-05]', 2.0, 2.0, 2.0, interval '1 day'), 1);
 
 -------------------------------------------------------------------------------
+-- The tiles of a rigid geometry are the ones its BODY reaches, not the ones
+-- the trajectory of its reference point visits. The body below is a 4 by 4
+-- square, so a value holding a single placement of it covers [-2,2] x [-2,2]
+-- and reaches nine tiles of a grid of size 2; reading the reference point
+-- alone answers one tile of no extent.
+-------------------------------------------------------------------------------
+
+SELECT array_length(spaceBoxes(
+  trgeometry 'Polygon((-2 -2,2 -2,2 2,-2 2,-2 -2));{Pose(Point(0 0),0)@2001-01-01}',
+  2.0), 1);
+
+SELECT min(xMin(b)), max(xMax(b)), min(yMin(b)), max(yMax(b))
+FROM unnest(spaceBoxes(
+  trgeometry 'Polygon((-2 -2,2 -2,2 2,-2 2,-2 -2));{Pose(Point(0 0),0)@2001-01-01}',
+  2.0)) b;
+
+-- Carried between two placements the body also covers the columns between
+-- them, which the reference point reaches with no width at all.
+
+SELECT round(min(xMin(b))::numeric, 6), round(max(xMax(b))::numeric, 6),
+  round(min(yMin(b))::numeric, 6), round(max(yMax(b))::numeric, 6)
+FROM unnest(spaceBoxes(
+  trgeometry 'Polygon((-2 -2,2 -2,2 2,-2 2,-2 -2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(12 0),0)@2001-01-02]',
+  2.0)) b;
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
The spatial tiles of a temporal rigid geometry are computed on the trajectory of its reference point, so they answer the tiles a point visits rather than the ones the body reaches. A value holding one placement of a 4 by 4 square answers a single box of zero extent where the body covers `[-2,2] x [-2,2]`, and a square carried from `(0 0)` to `(12 0)` answers none of the four grid columns standing between its two placements.

A rigid geometry occupies the region its body covers, and `trgeo_restrict_stbox` already answers the times that body meets a box, so the tiles are the ones it finds. The grid is unchanged: both families lay their values on the same grid and differ only in how a value is read against one tile, so the loop over the tiles moves into `tspatial_space_time_boxes`, which takes that reading as a parameter. A temporal geo passes `tgeo_restrict_stbox`, a temporal rigid geometry the restriction that reads its body, and neither family reaches into the other -- `RGEO` is a family a build may leave out.

Two supporting changes carry that. The grid is initialised for any value with a spatial bounding box rather than for a temporal geo alone, since a bounding box is all it reads. And the bitmatrix, which is filled from the segments a point traverses, is disabled for every value covering a region rather than for temporal geos alone: `tspatial_body_type` names that class, holding tgeometry, tgeography, trgeometry, tcbuffer and tpcpatch.

Measured against the bounding box the engine itself gives the value, the tiles now reach it exactly where they fall short of it by the size of the body. One placement of a 4 by 4 square covers `[-2,2] x [-2,2]` against a box of zero extent, and a square carried from `(0 0)` to `(12 0)` covers every grid column between, where the columns between the two placements carry no tile. Three queries reading the extent of the boxes rather than counting them join `158_trgeo_tile`, which carries only counts and cannot see the difference: the count of that file's own fixture stands at 6 either way, since its body is small beside the grid.

One reading narrows. `trgeo_restrict_stbox` answers an honest `FEATURE_NOT_SUPPORTED` for a segment that rotates, the limitation `atStbox` and `minusStbox` already carry, so `spaceBoxes` of a rotating rigid geometry refuses where reading the reference point alone answers boxes that do not cover its body.

The half-open tile is what keeps a body lying on a grid line from being answered twice, so the boxes here rest on the restriction reading the upper border of the box, which master carries.
