### PR TITLE
State one sentence in the one-liner of every H3 and QUADBIN entry

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2882,7 +2882,7 @@
 					<para><link linkend="th3_tbigint"><varname>::</varname></link>: Convertir entre un <varname>th3index</varname> y un <varname>tbigint</varname> (explícita, sin coste)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_tgeogpoint"><varname>::</varname></link>: Convertir una celda H3 temporal en un punto temporal geodésico o planar de los centroides de las celdas. Las dos sobrecargas dan al usuario una elección entre la representación geodésica (<varname>tgeogpoint</varname>) y la planar SRID 4326 (<varname>tgeompoint</varname>).</para>
+					<para><link linkend="th3_tgeogpoint"><varname>::</varname></link>: Convertir una celda H3 temporal en un punto temporal geodésico o planar de los centroides de las celdas</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2890,13 +2890,13 @@
 			<title>Cobertura de Geometrías Estáticas</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_geoToH3Cell"><varname>geoToH3Cell</varname></link>: Devuelve la celda H3 que contiene una geometría de punto a la resolución dada. La geometría debe ser un <varname>POINT</varname>.</para>
+					<para><link linkend="th3_geoToH3Cell"><varname>geoToH3Cell</varname></link>: Devuelve la celda H3 que contiene una geometría de punto a la resolución dada</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_geoToH3IndexSet"><varname>geoToH3IndexSet</varname></link>: Devuelve el conjunto de celdas H3 que cubren una geometría a la resolución dada. Se admiten todos los tipos de geometría: un <varname>POINT</varname> produce una sola celda, una <varname>LINESTRING</varname> muestrea sus segmentos, un <varname>POLYGON</varname> rellena su interior, y los valores <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> devuelven la unión de sus componentes.</para>
+					<para><link linkend="th3_geoToH3IndexSet"><varname>geoToH3IndexSet</varname></link>: Devuelve el conjunto de celdas H3 que cubren una geometría a la resolución dada</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_ever_eq_set"><varname>eEq</varname></link>: Devuelve si una trayectoria H3 temporal toma alguna vez una de las celdas de un conjunto de celdas. Combinada con <varname>geoToH3IndexSet</varname> responde si un viaje pasa alguna vez por una región, sin materializar la geometría de la trayectoria, el prefiltro robusto y conservador para el predicado exacto <varname>eIntersects(geometry,th3index)</varname>.</para>
+					<para><link linkend="th3_ever_eq_set"><varname>eEq</varname></link>: Devuelve si una trayectoria H3 temporal toma alguna vez una de las celdas de un conjunto de celdas</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2907,7 +2907,7 @@
 					<para><link linkend="th3_startValue"><varname>startValue</varname>, <varname>endValue</varname></link>: Devolver el primer o el último identificador de celda H3 de un valor temporal</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_valueN"><varname>valueN</varname></link>: Devolver el <varname>n</varname>-ésimo identificador de celda H3 distinto (indexado desde 1). Devuelve <varname>NULL</varname> si está fuera del rango.</para>
+					<para><link linkend="th3_valueN"><varname>valueN</varname></link>: Devolver el <varname>n</varname>-ésimo identificador de celda H3 distinto (indexado desde 1)</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_getValues"><varname>getValues</varname></link>: Devolver el conjunto de identificadores de celda H3 distintos que toma la trayectoria</para>
@@ -2930,7 +2930,7 @@
 					<para><link linkend="th3_h3_is_valid_cell"><varname>isValidCell</varname></link>: Devolver un booleano temporal que indica en cada instante si el valor es una celda H3 válida</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_is_res_class_iii"><varname>th3IsResClassIii</varname></link>: Devolver un booleano temporal que indica si cada celda tiene orientación de Clase III. La Clase III se alterna con la resolución: las resoluciones impares son de clase III, las pares son de clase II.</para>
+					<para><link linkend="th3_h3_is_res_class_iii"><varname>th3IsResClassIii</varname></link>: Devolver un booleano temporal que indica si cada celda tiene orientación de Clase III</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_is_pentagon"><varname>th3IsPentagon</varname></link>: Devolver un booleano temporal que indica si cada celda es un pentágono (12 celdas por resolución son pentágonos; las restantes 110 en cada celda base descienden como hexágonos)</para>
@@ -2941,16 +2941,16 @@
 			<title>Jerarquía</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_parent"><varname>th3CellToParent</varname></link>: Devolver la celda padre temporal en la resolución dada. La forma sin argumento desciende a la siguiente resolución más gruesa.</para>
+					<para><link linkend="th3_h3_cell_to_parent"><varname>th3CellToParent</varname></link>: Devolver la celda padre temporal en la resolución dada</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_center_child"><varname>th3CellToCenterChild</varname></link>: Devolver la celda hijo central temporal en la resolución dada. La forma sin argumento desciende a la siguiente resolución más fina.</para>
+					<para><link linkend="th3_h3_cell_to_center_child"><varname>th3CellToCenterChild</varname></link>: Devolver la celda hijo central temporal en la resolución dada</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_cell_to_child_pos"><varname>th3CellToChildPos</varname></link>: Devolver la posición ordinal (basada en 0) de cada celda entre los hijos de su padre en la resolución dada</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_child_pos_to_cell"><varname>th3ChildPosToCell</varname></link>: Devolver la celda hijo temporal en una posición ordinal dada del padre dado, en la resolución de hijo dada. Los dos operandos temporales se sincronizan sobre su eje de tiempo compartido.</para>
+					<para><link linkend="th3_h3_child_pos_to_cell"><varname>th3ChildPosToCell</varname></link>: Devolver la celda hijo temporal en una posición ordinal dada del padre dado, en la resolución de hijo dada</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2961,7 +2961,7 @@
 					<para><link linkend="th3_tgeompoint_to_th3"><varname>th3index</varname></link>: Devolver la celda H3 temporal en la resolución dada que contiene cada punto de un punto temporal geodésico o planar (el SRID debe ser 4326 para la sobrecarga de <varname>tgeompoint</varname>)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_latlng"><varname>th3CellToLatlng</varname>, <varname>th3CellToLatlngTgeompoint</varname></link>: Devolver el centroide geodésico temporal de cada celda en una trayectoria. Una sobrecarga planar (SRID 4326) está disponible bajo el nombre <varname>th3CellToLatlngTgeompoint</varname>.</para>
+					<para><link linkend="th3_h3_cell_to_latlng"><varname>th3CellToLatlng</varname>, <varname>th3CellToLatlngTgeompoint</varname></link>: Devolver el centroide geodésico temporal de cada celda en una trayectoria</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_cell_to_boundary"><varname>th3CellToBoundary</varname></link>: Devolver el límite poligonal temporal de cada celda en una trayectoria, como una geografía temporal</para>
@@ -2972,7 +2972,7 @@
 			<title>Aristas Dirigidas</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_are_neighbor_cells"><varname>th3AreNeighborCells</varname></link>: Devolver un booleano temporal que indica si dos celdas temporales son vecinas en la cuadrícula en cada instante. Los dos operandos se sincronizan.</para>
+					<para><link linkend="th3_h3_are_neighbor_cells"><varname>th3AreNeighborCells</varname></link>: Devolver un booleano temporal que indica si dos celdas temporales son vecinas en la cuadrícula en cada instante</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_cells_to_directed_edge"><varname>th3CellsToDirectedEdge</varname></link>: Devolver un identificador de arista dirigida temporal a partir de un par de celdas temporales origen/destino</para>
@@ -3006,10 +3006,10 @@
 			<title>Recorrido de la Cuadrícula</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_grid_distance"><varname>th3GridDistance</varname>, <varname>&lt;-&gt;</varname></link>: Devolver la distancia temporal de saltos en la cuadrícula (número de pasos de una sola celda) entre dos celdas temporales. De forma equivalente, el operador <varname>&lt;-&gt;</varname> devuelve la misma distancia. Los dos operandos se sincronizan sobre su eje de tiempo compartido.</para>
+					<para><link linkend="th3_h3_grid_distance"><varname>th3GridDistance</varname>, <varname>&lt;-&gt;</varname></link>: Devolver la distancia temporal de saltos en la cuadrícula (número de pasos de una sola celda) entre dos celdas temporales</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_local_ij"><varname>th3CellToLocalIj</varname>, <varname>th3LocalIjToCell</varname></link>: Convertir entre una celda temporal y un par de coordenadas locales (I, J) temporales relativas a una celda temporal de origen. La coordenada local se expone como un <varname>tgeompoint</varname> con el eje I en el slot <varname>x</varname> y J en <varname>y</varname>.</para>
+					<para><link linkend="th3_h3_cell_to_local_ij"><varname>th3CellToLocalIj</varname>, <varname>th3LocalIjToCell</varname></link>: Convertir entre una celda temporal y un par de coordenadas locales (I, J) temporales relativas a una celda temporal de origen</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3023,7 +3023,7 @@
 					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLength</varname></link>: Devolver la longitud temporal de cada arista dirigida en una trayectoria, en la unidad solicitada</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistance</varname></link>: Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas). Los dos operandos se sincronizan.</para>
+					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistance</varname></link>: Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas)</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3073,31 +3073,31 @@
 			<title>Funciones que devuelven conjuntos</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_grid_disk"><varname>h3GridDisk</varname></link>: Todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (incluyendo el origen cuando k=0).</para>
+					<para><link linkend="th3_h3_grid_disk"><varname>h3GridDisk</varname></link>: Todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (incluyendo el origen cuando k=0)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_grid_ring"><varname>h3GridRing</varname></link>: Las celdas a <emphasis>exactamente</emphasis> <varname>k</varname> pasos de cuadrícula del origen. Falla cerca de pentágonos.</para>
+					<para><link linkend="th3_h3_grid_ring"><varname>h3GridRing</varname></link>: Las celdas a <emphasis>exactamente</emphasis> <varname>k</varname> pasos de cuadrícula del origen</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_grid_path_cells"><varname>h3GridPathCells</varname></link>: El camino inclusivo de celdas entre dos celdas de la misma resolución.</para>
+					<para><link linkend="th3_h3_grid_path_cells"><varname>h3GridPathCells</varname></link>: El camino inclusivo de celdas entre dos celdas de la misma resolución</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_children"><varname>h3CellToChildren</varname></link>: Todas las celdas hijas de una celda en la resolución objetivo.</para>
+					<para><link linkend="th3_h3_cell_to_children"><varname>h3CellToChildren</varname></link>: Todas las celdas hijas de una celda en la resolución objetivo</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_compact_cells"><varname>h3CompactCells</varname></link>: Representación compactada de un conjunto de celdas, las celdas más finas se fusionan en su padre cuando el conjunto hexagonal completo de hermanas está presente.</para>
+					<para><link linkend="th3_h3_compact_cells"><varname>h3CompactCells</varname></link>: Representación compactada de un conjunto de celdas, las celdas más finas se fusionan en su padre cuando el conjunto hexagonal completo de hermanas está presente</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_uncompact_cells"><varname>h3UncompactCells</varname></link>: Representación descompactada a la resolución dada, la inversa de <varname>h3CompactCells</varname>.</para>
+					<para><link linkend="th3_h3_uncompact_cells"><varname>h3UncompactCells</varname></link>: Representación descompactada a la resolución dada, la inversa de <varname>h3CompactCells</varname></para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_origin_to_directed_edges"><varname>h3OriginToDirectedEdges</varname></link>: Todas las aristas dirigidas salientes de una celda (6 para hexágonos, 5 para pentágonos).</para>
+					<para><link linkend="th3_h3_origin_to_directed_edges"><varname>h3OriginToDirectedEdges</varname></link>: Todas las aristas dirigidas salientes de una celda (6 para hexágonos, 5 para pentágonos)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_vertexes"><varname>h3CellToVertexes</varname></link>: Todos los vértices de una celda (6 para hexágonos, 5 para pentágonos).</para>
+					<para><link linkend="th3_h3_cell_to_vertexes"><varname>h3CellToVertexes</varname></link>: Todos los vértices de una celda (6 para hexágonos, 5 para pentágonos)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_get_icosahedron_faces"><varname>h3GetIcosahedronFaces</varname></link>: Los índices de caras del icosaedro (0..19) intersectadas por una celda.</para>
+					<para><link linkend="th3_h3_get_icosahedron_faces"><varname>h3GetIcosahedronFaces</varname></link>: Los índices de caras del icosaedro (0..19) intersectadas por una celda</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3139,10 +3139,10 @@
 			<title>Indexación</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_rtree_ops"><varname>th3_rtree_ops</varname></link>: Clase de operadores GiST para celdas H3 temporales. Indexa una caja envolvente espaciotemporal <varname>stbox</varname> por fila (la extensión geodésica de los límites de las celdas junto con el período temporal).</para>
+					<para><link linkend="th3_rtree_ops"><varname>th3_rtree_ops</varname></link>: Clase de operadores GiST para celdas H3 temporales</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_quadtree_ops"><varname>th3_quadtree_ops</varname>, <varname>th3_kdtree_ops</varname></link>: Clases de operadores SP-GiST para celdas H3 temporales, indexadas por la caja envolvente espaciotemporal <varname>stbox</varname>. <varname>th3_quadtree_ops</varname> es la predeterminada (partición por quadtree); <varname>th3_kdtree_ops</varname> utiliza partición por árbol k-d y debe ser nombrada explícitamente.</para>
+					<para><link linkend="th3_quadtree_ops"><varname>th3_quadtree_ops</varname>, <varname>th3_kdtree_ops</varname></link>: Clases de operadores SP-GiST para celdas H3 temporales, indexadas por la caja envolvente espaciotemporal <varname>stbox</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3157,7 +3157,7 @@
 					<para><link linkend="tquadbin_tbigint"><varname>::</varname></link>: Convertir entre un <varname>tquadbin</varname> y un <varname>tbigint</varname> (explícito, sin coste)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_tgeompoint"><varname>::</varname></link>: Convertir una celda QUADBIN temporal a un punto planar temporal (SRID 4326) de los centroides de las celdas. La conversión delega en <varname>tquadbinCellToPoint</varname>.</para>
+					<para><link linkend="tquadbin_tgeompoint"><varname>::</varname></link>: Convertir una celda QUADBIN temporal a un punto planar temporal (SRID 4326) de los centroides de las celdas</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3179,7 +3179,7 @@
 					<para><link linkend="tquadbin_startValue"><varname>startValue</varname>, <varname>endValue</varname></link>: Devuelve el primer o el último identificador de celda QUADBIN de un valor temporal</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_valueN"><varname>valueN</varname></link>: Devuelve el <varname>n</varname>-ésimo identificador de celda QUADBIN distinto (índice base 1). Devuelve <varname>NULL</varname> si está fuera de rango.</para>
+					<para><link linkend="tquadbin_valueN"><varname>valueN</varname></link>: Devuelve el <varname>n</varname>-ésimo identificador de celda QUADBIN distinto (índice base 1)</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tquadbin_getValues"><varname>getValues</varname></link>: Devuelve el conjunto de identificadores de celda QUADBIN distintos que toma la trayectoria</para>
@@ -3193,7 +3193,7 @@
 			<title>Inspección del Índice</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_get_resolution"><varname>quadbinGetResolution</varname>, <varname>tquadbinGetResolution</varname></link>: Devuelve el nivel de resolución (zoom) (0–26) de una celda. La forma estática devuelve un <varname>integer</varname>; la forma temporal devuelve la resolución de cada celda de una trayectoria como un <varname>tint</varname>.</para>
+					<para><link linkend="tquadbin_quadbin_get_resolution"><varname>quadbinGetResolution</varname>, <varname>tquadbinGetResolution</varname></link>: Devuelve el nivel de resolución (zoom) (0–26) de una celda</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tquadbin_quadbin_is_valid_cell"><varname>isValidCell</varname></link>: Devuelve un booleano temporal que indica en cada instante si el valor es una celda QUADBIN válida</para>
@@ -3204,16 +3204,16 @@
 			<title>Jerarquía</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_parent"><varname>quadbinCellToParent</varname>, <varname>tquadbinCellToParent</varname></link>: Devuelve la celda padre en la resolución más gruesa dada. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el padre de cada celda de una trayectoria.</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_parent"><varname>quadbinCellToParent</varname>, <varname>tquadbinCellToParent</varname></link>: Devuelve la celda padre en la resolución más gruesa dada</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_children"><varname>quadbinCellToChildren</varname></link>: Devuelve las cuatro celdas hijas en la resolución más fina solicitada como un <varname>quadbinset</varname>. Es un auxiliar estático que devuelve un conjunto sobre un único <varname>quadbin</varname>; no tiene elevación temporal (los hijos son un conjunto por instante, diferido a la espera de una primitiva <varname>tset&lt;T&gt;</varname>).</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_children"><varname>quadbinCellToChildren</varname></link>: Devuelve las cuatro celdas hijas en la resolución más fina solicitada como un <varname>quadbinset</varname></para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tquadbin_quadbin_cell_sibling"><varname>quadbinCellSibling</varname></link>: Devuelve la celda vecina en la misma resolución en la dirección dada (<varname>up</varname> / <varname>down</varname> / <varname>left</varname> / <varname>right</varname>)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_grid_disk"><varname>quadbinGridDisk</varname></link>: Devuelve todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (inclusive del origen en k=0), como un <varname>quadbinset</varname>. En la cuadrícula cuadrada el disco en el paso <varname>k</varname> es el bloque cuadrado de <varname>(2k+1)</varname>×<varname>(2k+1)</varname> celdas centrado en el origen.</para>
+					<para><link linkend="tquadbin_quadbin_grid_disk"><varname>quadbinGridDisk</varname></link>: Devuelve todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (inclusive del origen en k=0), como un <varname>quadbinset</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3221,13 +3221,13 @@
 			<title>Conversiones de Geometría</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_point_to_cell"><varname>geoToQuadbinCell</varname></link>: Devuelve la celda QUADBIN en la resolución dada que contiene una geometría de punto. La geometría debe ser un <varname>POINT</varname>; las longitudes se interpretan en SRID 4326.</para>
+					<para><link linkend="tquadbin_quadbin_point_to_cell"><varname>geoToQuadbinCell</varname></link>: Devuelve la celda QUADBIN en la resolución dada que contiene una geometría de punto</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_point"><varname>quadbinCellToPoint</varname>, <varname>tquadbinCellToPoint</varname></link>: Devuelve el centroide de una celda como un punto SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el centroide de cada celda de una trayectoria como un <varname>tgeompoint</varname>.</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_point"><varname>quadbinCellToPoint</varname>, <varname>tquadbinCellToPoint</varname></link>: Devuelve el centroide de una celda como un punto SRID 4326</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_boundary"><varname>quadbinCellToBoundary</varname>, <varname>tquadbinCellToBoundary</varname></link>: Devuelve el contorno poligonal cuadrado de una celda como una geometría SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el contorno de cada celda de una trayectoria como un <varname>tgeometry</varname>.</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_boundary"><varname>quadbinCellToBoundary</varname>, <varname>tquadbinCellToBoundary</varname></link>: Devuelve el contorno poligonal cuadrado de una celda como una geometría SRID 4326</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3241,7 +3241,7 @@
 					<para><link linkend="tquadbin_quadbin_cell_to_tile"><varname>quadbinCellToTile</varname></link>: Descompone una celda en su triple de coordenadas de tesela, devuelto como un arreglo de enteros <varname>{x, y, z}</varname>, la inversa de <varname>quadbinTileToCell</varname></para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_quadkey"><varname>quadbinCellToQuadkey</varname>, <varname>tquadbinCellToQuadkey</varname></link>: Emite la cadena quadkey en base 4 de una celda (un dígito por nivel de zoom, primero el más significativo; la celda mundial de resolución 0 se corresponde con la cadena vacía). La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el quadkey de cada celda de una trayectoria como un <varname>ttext</varname>.</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_quadkey"><varname>quadbinCellToQuadkey</varname>, <varname>tquadbinCellToQuadkey</varname></link>: Emite la cadena quadkey en base 4 de una celda (un dígito por nivel de zoom, primero el más significativo; la celda mundial de resolución 0 se corresponde con la cadena vacía)</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3249,7 +3249,7 @@
 			<title>Métricas</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_area"><varname>quadbinCellArea</varname>, <varname>tquadbinCellArea</varname></link>: Devuelve el área de una celda sobre la esfera, en metros cuadrados. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el área de cada celda de una trayectoria como un <varname>tfloat</varname>. El área de la celda se reduce hacia los polos, ya que los cuadrados web-mercator cubren progresivamente menos terreno a latitudes más altas.</para>
+					<para><link linkend="tquadbin_quadbin_cell_area"><varname>quadbinCellArea</varname>, <varname>tquadbinCellArea</varname></link>: Devuelve el área de una celda sobre la esfera, en metros cuadrados</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3268,10 +3268,10 @@
 			<title>Indexación</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_btree_ops"><varname>tquadbin_btree_ops</varname></link>: Clase de operadores de árbol B por defecto para las celdas QUADBIN temporales, ordenando por el valor temporal subyacente.</para>
+					<para><link linkend="tquadbin_btree_ops"><varname>tquadbin_btree_ops</varname></link>: Clase de operadores de árbol B por defecto para las celdas QUADBIN temporales, ordenando por el valor temporal subyacente</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_hash_ops"><varname>tquadbin_hash_ops</varname></link>: Clase de operadores hash por defecto para las celdas QUADBIN temporales, usada por las uniones hash y la agregación hash.</para>
+					<para><link linkend="tquadbin_hash_ops"><varname>tquadbin_hash_ops</varname></link>: Clase de operadores hash por defecto para las celdas QUADBIN temporales, usada por las uniones hash y la agregación hash</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -67,11 +67,12 @@ SELECT ((th3index '831c02fffffffff@2001-01-01')::tbigint)::th3index
 
 			<listitem xml:id="th3_tgeogpoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
-				<para>Convertir una celda H3 temporal en un punto temporal geodésico o planar de los centroides de las celdas. Las dos sobrecargas dan al usuario una elección entre la representación geodésica (<varname>tgeogpoint</varname>) y la planar SRID 4326 (<varname>tgeompoint</varname>).</para>
+				<para>Convertir una celda H3 temporal en un punto temporal geodésico o planar de los centroides de las celdas</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3index::tgeogpoint
 th3index::tgeompoint
 </programlisting>
+				<para>Las dos sobrecargas dan al usuario una elección entre la representación geodésica (<varname>tgeogpoint</varname>) y la planar SRID 4326 (<varname>tgeompoint</varname>).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeogpoint;
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint;
@@ -88,10 +89,11 @@ SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint;
 		<itemizedlist>
 			<listitem xml:id="th3_geoToH3Cell">
 				<indexterm significance="normal"><primary><varname>geoToH3Cell</varname></primary></indexterm>
-				<para>Devuelve la celda H3 que contiene una geometría de punto a la resolución dada. La geometría debe ser un <varname>POINT</varname>.</para>
+				<para>Devuelve la celda H3 que contiene una geometría de punto a la resolución dada</para>
 				<programlisting xml:space="preserve" format="linespecific">
 geoToH3Cell(geometry,integer) → h3index
 </programlisting>
+				<para>La geometría debe ser un <varname>POINT</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3Cell(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- 871fa4418ffffff
@@ -100,10 +102,11 @@ SELECT geoToH3Cell(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 
 			<listitem xml:id="th3_geoToH3IndexSet">
 				<indexterm significance="normal"><primary><varname>geoToH3IndexSet</varname></primary></indexterm>
-				<para>Devuelve el conjunto de celdas H3 que cubren una geometría a la resolución dada. Se admiten todos los tipos de geometría: un <varname>POINT</varname> produce una sola celda, una <varname>LINESTRING</varname> muestrea sus segmentos, un <varname>POLYGON</varname> rellena su interior, y los valores <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> devuelven la unión de sus componentes.</para>
+				<para>Devuelve el conjunto de celdas H3 que cubren una geometría a la resolución dada</para>
 				<programlisting xml:space="preserve" format="linespecific">
 geoToH3IndexSet(geometry,integer) → h3indexset
 </programlisting>
+				<para>Se admiten todos los tipos de geometría: un <varname>POINT</varname> produce una sola celda, una <varname>LINESTRING</varname> muestrea sus segmentos, un <varname>POLYGON</varname> rellena su interior, y los valores <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> devuelven la unión de sus componentes.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- {"871fa4418ffffff"}
@@ -112,11 +115,12 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 
 			<listitem xml:id="th3_ever_eq_set">
 				<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
-				<para>Devuelve si una trayectoria H3 temporal toma alguna vez una de las celdas de un conjunto de celdas. Combinada con <varname>geoToH3IndexSet</varname> responde si un viaje pasa alguna vez por una región, sin materializar la geometría de la trayectoria, el prefiltro robusto y conservador para el predicado exacto <varname>eIntersects(geometry,th3index)</varname>.</para>
+				<para>Devuelve si una trayectoria H3 temporal toma alguna vez una de las celdas de un conjunto de celdas</para>
 				<programlisting xml:space="preserve" format="linespecific">
 eEq(h3indexset,th3index) → boolean
 h3indexset ?= th3index → boolean
 </programlisting>
+				<para>Combinada con <varname>geoToH3IndexSet</varname> responde si un viaje pasa alguna vez por una región, sin materializar la geometría de la trayectoria, el prefiltro robusto y conservador para el predicado exacto <varname>eIntersects(geometry,th3index)</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
   th3index '871fa4418ffffff@2001-01-01';
@@ -147,10 +151,11 @@ SELECT endValue(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-0
 
 			<listitem xml:id="th3_valueN">
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
-				<para>Devolver el <varname>n</varname>-ésimo identificador de celda H3 distinto (indexado desde 1). Devuelve <varname>NULL</varname> si está fuera del rango.</para>
+				<para>Devolver el <varname>n</varname>-ésimo identificador de celda H3 distinto (indexado desde 1)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 valueN(th3index,integer) → h3index
 </programlisting>
+				<para>Devuelve <varname>NULL</varname> si está fuera del rango.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}', 1);
 -- 831c02fffffffff
@@ -227,10 +232,11 @@ SELECT isValidCell(th3index '0@2001-01-01');
 
 			<listitem xml:id="th3_h3_is_res_class_iii">
 				<indexterm significance="normal"><primary><varname>th3IsResClassIii</varname></primary></indexterm>
-				<para>Devolver un booleano temporal que indica si cada celda tiene orientación de Clase III. La Clase III se alterna con la resolución: las resoluciones impares son de clase III, las pares son de clase II.</para>
+				<para>Devolver un booleano temporal que indica si cada celda tiene orientación de Clase III</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3IsResClassIii(th3index) → tbool
 </programlisting>
+				<para>La Clase III se alterna con la resolución: las resoluciones impares son de clase III, las pares son de clase II.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3IsResClassIii(th3index '871fa44a8ffffff@2001-01-01');
 -- t@2001-01-01
@@ -258,11 +264,12 @@ SELECT th3IsPentagon(th3index '831c02fffffffff@2001-01-01');
 		<itemizedlist>
 			<listitem xml:id="th3_h3_cell_to_parent">
 				<indexterm significance="normal"><primary><varname>th3CellToParent</varname></primary></indexterm>
-				<para>Devolver la celda padre temporal en la resolución dada. La forma sin argumento desciende a la siguiente resolución más gruesa.</para>
+				<para>Devolver la celda padre temporal en la resolución dada</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3CellToParent(th3index,integer) → th3index
 th3CellToParent(th3index) → th3index
 </programlisting>
+				<para>La forma sin argumento desciende a la siguiente resolución más gruesa.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(
   th3CellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
@@ -272,11 +279,12 @@ SELECT th3GetResolution(
 
 			<listitem xml:id="th3_h3_cell_to_center_child">
 				<indexterm significance="normal"><primary><varname>th3CellToCenterChild</varname></primary></indexterm>
-				<para>Devolver la celda hijo central temporal en la resolución dada. La forma sin argumento desciende a la siguiente resolución más fina.</para>
+				<para>Devolver la celda hijo central temporal en la resolución dada</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3CellToCenterChild(th3index,integer) → th3index
 th3CellToCenterChild(th3index) → th3index
 </programlisting>
+				<para>La forma sin argumento desciende a la siguiente resolución más fina.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01', 8);
 -- 881fa44a81fffff@2001-01-01
@@ -300,10 +308,11 @@ SELECT th3CellToChildPos(th3index '871fa44a8ffffff@2001-01-01', 6);
 
 			<listitem xml:id="th3_h3_child_pos_to_cell">
 				<indexterm significance="normal"><primary><varname>th3ChildPosToCell</varname></primary></indexterm>
-				<para>Devolver la celda hijo temporal en una posición ordinal dada del padre dado, en la resolución de hijo dada. Los dos operandos temporales se sincronizan sobre su eje de tiempo compartido.</para>
+				<para>Devolver la celda hijo temporal en una posición ordinal dada del padre dado, en la resolución de hijo dada</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3ChildPosToCell(tbigint,th3index,integer) → th3index
 </programlisting>
+				<para>Los dos operandos temporales se sincronizan sobre su eje de tiempo compartido.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3ChildPosToCell(tbigint '0@2001-01-01', th3index '871fa44a8ffffff@2001-01-01',
   8);
@@ -336,11 +345,12 @@ SELECT th3GetResolution(th3index(
 			<listitem xml:id="th3_h3_cell_to_latlng">
 				<indexterm significance="normal"><primary><varname>th3CellToLatlng</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3CellToLatlngTgeompoint</varname></primary></indexterm>
-				<para>Devolver el centroide geodésico temporal de cada celda en una trayectoria. Una sobrecarga planar (SRID 4326) está disponible bajo el nombre <varname>th3CellToLatlngTgeompoint</varname>.</para>
+				<para>Devolver el centroide geodésico temporal de cada celda en una trayectoria</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3CellToLatlng(th3index) → tgeogpoint
 th3CellToLatlngTgeompoint(th3index) → tgeompoint
 </programlisting>
+				<para>Una sobrecarga planar (SRID 4326) está disponible bajo el nombre <varname>th3CellToLatlngTgeompoint</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3CellToLatlng(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
@@ -374,10 +384,11 @@ SELECT ST_NPoints(getValue(th3CellToBoundary(th3index
 		<itemizedlist>
 			<listitem xml:id="th3_h3_are_neighbor_cells">
 				<indexterm significance="normal"><primary><varname>th3AreNeighborCells</varname></primary></indexterm>
-				<para>Devolver un booleano temporal que indica si dos celdas temporales son vecinas en la cuadrícula en cada instante. Los dos operandos se sincronizan.</para>
+				<para>Devolver un booleano temporal que indica si dos celdas temporales son vecinas en la cuadrícula en cada instante</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3AreNeighborCells(th3index,th3index) → tbool
 </programlisting>
+				<para>Los dos operandos se sincronizan.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3AreNeighborCells(
   th3index '880326b885fffff@2001-01-01',
@@ -498,11 +509,12 @@ SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
 			<listitem xml:id="th3_h3_grid_distance">
 				<indexterm significance="normal"><primary><varname>th3GridDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
-				<para>Devolver la distancia temporal de saltos en la cuadrícula (número de pasos de una sola celda) entre dos celdas temporales. De forma equivalente, el operador <varname>&lt;-&gt;</varname> devuelve la misma distancia. Los dos operandos se sincronizan sobre su eje de tiempo compartido.</para>
+				<para>Devolver la distancia temporal de saltos en la cuadrícula (número de pasos de una sola celda) entre dos celdas temporales</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3GridDistance(th3index,th3index) → tbigint
 th3index &lt;-&gt; th3index → tbigint
 </programlisting>
+				<para>De forma equivalente, el operador <varname>&lt;-&gt;</varname> devuelve la misma distancia. Los dos operandos se sincronizan sobre su eje de tiempo compartido.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '880326b885fffff@2001-01-01'
    &lt;-&gt; th3index '880326b88dfffff@2001-01-01';
@@ -513,11 +525,12 @@ SELECT th3index '880326b885fffff@2001-01-01'
 			<listitem xml:id="th3_h3_cell_to_local_ij">
 				<indexterm significance="normal"><primary><varname>th3CellToLocalIj</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3LocalIjToCell</varname></primary></indexterm>
-				<para>Convertir entre una celda temporal y un par de coordenadas locales (I, J) temporales relativas a una celda temporal de origen. La coordenada local se expone como un <varname>tgeompoint</varname> con el eje I en el slot <varname>x</varname> y J en <varname>y</varname>.</para>
+				<para>Convertir entre una celda temporal y un par de coordenadas locales (I, J) temporales relativas a una celda temporal de origen</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3CellToLocalIj(th3index,th3index) → tgeompoint
 th3LocalIjToCell(th3index,tgeompoint) → th3index
 </programlisting>
+				<para>La coordenada local se expone como un <varname>tgeompoint</varname> con el eje I en el slot <varname>x</varname> y J en <varname>y</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3CellToLocalIj(th3index '871fa44a8ffffff@2001-01-01',
   th3index '871fa44aeffffff@2001-01-01'));
@@ -565,10 +578,11 @@ SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01
 
 			<listitem xml:id="th3_h3_great_circle_distance">
 				<indexterm significance="normal"><primary><varname>greatCircleDistance</varname></primary></indexterm>
-				<para>Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas). Los dos operandos se sincronizan.</para>
+				<para>Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat
 </programlisting>
+				<para>Los dos operandos se sincronizan.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
   tgeogpoint 'Point(1 0)@2001-01-01');
@@ -765,7 +779,7 @@ SELECT th3index '871fa44a8ffffff@2001-01-01' #&gt;&gt;
 		<itemizedlist>
 			<listitem xml:id="th3_h3_grid_disk">
 				<indexterm significance="normal"><primary><varname>h3GridDisk</varname></primary></indexterm>
-				<para>Todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (incluyendo el origen cuando k=0).</para>
+				<para>Todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (incluyendo el origen cuando k=0)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3GridDisk(h3index, integer) → h3indexset
 </programlisting>
@@ -778,10 +792,11 @@ SELECT h3GridDisk(h3index '871fa44a8ffffff', 1);
 
 			<listitem xml:id="th3_h3_grid_ring">
 				<indexterm significance="normal"><primary><varname>h3GridRing</varname></primary></indexterm>
-				<para>Las celdas a <emphasis>exactamente</emphasis> <varname>k</varname> pasos de cuadrícula del origen. Falla cerca de pentágonos.</para>
+				<para>Las celdas a <emphasis>exactamente</emphasis> <varname>k</varname> pasos de cuadrícula del origen</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3GridRing(h3index, integer) → h3indexset
 </programlisting>
+				<para>Falla cerca de pentágonos.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
 -- {"871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff", "871fa44acffffff",
@@ -791,7 +806,7 @@ SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
 
 			<listitem xml:id="th3_h3_grid_path_cells">
 				<indexterm significance="normal"><primary><varname>h3GridPathCells</varname></primary></indexterm>
-				<para>El camino inclusivo de celdas entre dos celdas de la misma resolución.</para>
+				<para>El camino inclusivo de celdas entre dos celdas de la misma resolución</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3GridPathCells(h3index, h3index) → h3indexset
 </programlisting>
@@ -804,7 +819,7 @@ SELECT h3GridPathCells(h3index '871fa44a8ffffff', h3index '871fa44b1ffffff');
 
 			<listitem xml:id="th3_h3_cell_to_children">
 				<indexterm significance="normal"><primary><varname>h3CellToChildren</varname></primary></indexterm>
-				<para>Todas las celdas hijas de una celda en la resolución objetivo.</para>
+				<para>Todas las celdas hijas de una celda en la resolución objetivo</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3CellToChildren(h3index, integer) → h3indexset
 </programlisting>
@@ -817,7 +832,7 @@ SELECT h3CellToChildren(h3index '831c02fffffffff', 4);
 
 			<listitem xml:id="th3_h3_compact_cells">
 				<indexterm significance="normal"><primary><varname>h3CompactCells</varname></primary></indexterm>
-				<para>Representación compactada de un conjunto de celdas, las celdas más finas se fusionan en su padre cuando el conjunto hexagonal completo de hermanas está presente.</para>
+				<para>Representación compactada de un conjunto de celdas, las celdas más finas se fusionan en su padre cuando el conjunto hexagonal completo de hermanas está presente</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3CompactCells(h3indexset) → h3indexset
 </programlisting>
@@ -829,7 +844,7 @@ SELECT h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4));
 
 			<listitem xml:id="th3_h3_uncompact_cells">
 				<indexterm significance="normal"><primary><varname>h3UncompactCells</varname></primary></indexterm>
-				<para>Representación descompactada a la resolución dada, la inversa de <varname>h3CompactCells</varname>.</para>
+				<para>Representación descompactada a la resolución dada, la inversa de <varname>h3CompactCells</varname></para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3UncompactCells(h3indexset, integer) → h3indexset
 </programlisting>
@@ -842,7 +857,7 @@ SELECT numValues(h3UncompactCells(
 
 			<listitem xml:id="th3_h3_origin_to_directed_edges">
 				<indexterm significance="normal"><primary><varname>h3OriginToDirectedEdges</varname></primary></indexterm>
-				<para>Todas las aristas dirigidas salientes de una celda (6 para hexágonos, 5 para pentágonos).</para>
+				<para>Todas las aristas dirigidas salientes de una celda (6 para hexágonos, 5 para pentágonos)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3OriginToDirectedEdges(h3index) → h3indexset
 </programlisting>
@@ -855,7 +870,7 @@ SELECT h3OriginToDirectedEdges(h3index '871fa44a8ffffff');
 
 			<listitem xml:id="th3_h3_cell_to_vertexes">
 				<indexterm significance="normal"><primary><varname>h3CellToVertexes</varname></primary></indexterm>
-				<para>Todos los vértices de una celda (6 para hexágonos, 5 para pentágonos).</para>
+				<para>Todos los vértices de una celda (6 para hexágonos, 5 para pentágonos)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3CellToVertexes(h3index) → h3indexset
 </programlisting>
@@ -868,7 +883,7 @@ SELECT h3CellToVertexes(h3index '871fa44a8ffffff');
 
 			<listitem xml:id="th3_h3_get_icosahedron_faces">
 				<indexterm significance="normal"><primary><varname>h3GetIcosahedronFaces</varname></primary></indexterm>
-				<para>Los índices de caras del icosaedro (0..19) intersectadas por una celda.</para>
+				<para>Los índices de caras del icosaedro (0..19) intersectadas por una celda</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3GetIcosahedronFaces(h3index) → intset
 </programlisting>
@@ -1047,7 +1062,8 @@ FROM Temp;
 		<itemizedlist>
 			<listitem xml:id="th3_rtree_ops">
 				<indexterm significance="normal"><primary><varname>th3_rtree_ops</varname></primary></indexterm>
-				<para>Clase de operadores GiST para celdas H3 temporales. Indexa una caja envolvente espaciotemporal <varname>stbox</varname> por fila (la extensión geodésica de los límites de las celdas junto con el período temporal).</para>
+				<para>Clase de operadores GiST para celdas H3 temporales</para>
+				<para>Indexa una caja envolvente espaciotemporal <varname>stbox</varname> por fila (la extensión geodésica de los límites de las celdas junto con el período temporal).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX ON trips USING gist(cells);       -- usa th3_rtree_ops por defecto
 CREATE INDEX ON trips USING gist(cells th3_rtree_ops);
@@ -1057,7 +1073,8 @@ CREATE INDEX ON trips USING gist(cells th3_rtree_ops);
 			<listitem xml:id="th3_quadtree_ops">
 				<indexterm significance="normal"><primary><varname>th3_quadtree_ops</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3_kdtree_ops</varname></primary></indexterm>
-				<para>Clases de operadores SP-GiST para celdas H3 temporales, indexadas por la caja envolvente espaciotemporal <varname>stbox</varname>. <varname>th3_quadtree_ops</varname> es la predeterminada (partición por quadtree); <varname>th3_kdtree_ops</varname> utiliza partición por árbol k-d y debe ser nombrada explícitamente.</para>
+				<para>Clases de operadores SP-GiST para celdas H3 temporales, indexadas por la caja envolvente espaciotemporal <varname>stbox</varname></para>
+<para><varname>th3_quadtree_ops</varname> es la predeterminada (partición por quadtree); <varname>th3_kdtree_ops</varname> utiliza partición por árbol k-d y debe ser nombrada explícitamente.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX ON trips USING spgist(cells);     -- usa th3_quadtree_ops por defecto
 CREATE INDEX ON trips USING spgist(cells th3_kdtree_ops);

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -74,10 +74,11 @@ SELECT ((tquadbin '480fffffffffffff@2001-01-01')::tbigint)::tquadbin
 
 			<listitem xml:id="tquadbin_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
-				<para>Convertir una celda QUADBIN temporal a un punto planar temporal (SRID 4326) de los centroides de las celdas. La conversión delega en <varname>tquadbinCellToPoint</varname>.</para>
+				<para>Convertir una celda QUADBIN temporal a un punto planar temporal (SRID 4326) de los centroides de las celdas</para>
 				<programlisting xml:space="preserve" format="linespecific">
 tquadbin::tgeompoint
 </programlisting>
+				<para>La conversión delega en <varname>tquadbinCellToPoint</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tquadbin '480fffffffffffff@2001-01-01')::tgeompoint;
 </programlisting>
@@ -144,10 +145,11 @@ SELECT endValue(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01
 
 			<listitem xml:id="tquadbin_valueN">
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
-				<para>Devuelve el <varname>n</varname>-ésimo identificador de celda QUADBIN distinto (índice base 1). Devuelve <varname>NULL</varname> si está fuera de rango.</para>
+				<para>Devuelve el <varname>n</varname>-ésimo identificador de celda QUADBIN distinto (índice base 1)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 valueN(tquadbin,integer) → quadbin
 </programlisting>
+				<para>Devuelve <varname>NULL</varname> si está fuera de rango.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}', 1);
 -- 480fffffffffffff
@@ -196,11 +198,12 @@ SELECT valueAtTimestamp(tquadbin
 			<listitem xml:id="tquadbin_quadbin_get_resolution">
 				<indexterm significance="normal"><primary><varname>quadbinGetResolution</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinGetResolution</varname></primary></indexterm>
-				<para>Devuelve el nivel de resolución (zoom) (0–26) de una celda. La forma estática devuelve un <varname>integer</varname>; la forma temporal devuelve la resolución de cada celda de una trayectoria como un <varname>tint</varname>.</para>
+				<para>Devuelve el nivel de resolución (zoom) (0–26) de una celda</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinGetResolution(quadbin) → integer
 tquadbinGetResolution(tquadbin) → tint
 </programlisting>
+				<para>La forma estática devuelve un <varname>integer</varname>; la forma temporal devuelve la resolución de cada celda de una trayectoria como un <varname>tint</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinGetResolution(quadbin '480fffffffffffff');
 -- 0
@@ -229,11 +232,12 @@ SELECT isValidCell(tquadbin '480fffffffffffff@2001-01-01');
 			<listitem xml:id="tquadbin_quadbin_cell_to_parent">
 				<indexterm significance="normal"><primary><varname>quadbinCellToParent</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToParent</varname></primary></indexterm>
-				<para>Devuelve la celda padre en la resolución más gruesa dada. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el padre de cada celda de una trayectoria.</para>
+				<para>Devuelve la celda padre en la resolución más gruesa dada</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToParent(quadbin,integer) → quadbin
 tquadbinCellToParent(tquadbin,integer) → tquadbin
 </programlisting>
+				<para>La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el padre de cada celda de una trayectoria.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToParent(quadbin '48a6227affffffff', 5);
 -- 485623ffffffffff
@@ -245,10 +249,11 @@ SELECT tquadbinGetResolution(
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_children">
 				<indexterm significance="normal"><primary><varname>quadbinCellToChildren</varname></primary></indexterm>
-				<para>Devuelve las cuatro celdas hijas en la resolución más fina solicitada como un <varname>quadbinset</varname>. Es un auxiliar estático que devuelve un conjunto sobre un único <varname>quadbin</varname>; no tiene elevación temporal (los hijos son un conjunto por instante, diferido a la espera de una primitiva <varname>tset&lt;T&gt;</varname>).</para>
+				<para>Devuelve las cuatro celdas hijas en la resolución más fina solicitada como un <varname>quadbinset</varname></para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToChildren(quadbin,integer) → quadbinset
 </programlisting>
+				<para>Es un auxiliar estático que devuelve un conjunto sobre un único <varname>quadbin</varname>; no tiene elevación temporal (los hijos son un conjunto por instante, diferido a la espera de una primitiva <varname>tset&lt;T&gt;</varname>).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToChildren(quadbin '480fffffffffffff', 1);
 -- {4813ffffffffffff, 4817ffffffffffff, 481bffffffffffff, 481fffffffffffff}
@@ -271,10 +276,11 @@ SELECT quadbinCellSibling(
 
 			<listitem xml:id="tquadbin_quadbin_grid_disk">
 				<indexterm significance="normal"><primary><varname>quadbinGridDisk</varname></primary></indexterm>
-				<para>Devuelve todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (inclusive del origen en k=0), como un <varname>quadbinset</varname>. En la cuadrícula cuadrada el disco en el paso <varname>k</varname> es el bloque cuadrado de <varname>(2k+1)</varname>×<varname>(2k+1)</varname> celdas centrado en el origen.</para>
+				<para>Devuelve todas las celdas dentro de <varname>k</varname> pasos de cuadrícula del origen (inclusive del origen en k=0), como un <varname>quadbinset</varname></para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinGridDisk(quadbin,integer) → quadbinset
 </programlisting>
+				<para>En la cuadrícula cuadrada el disco en el paso <varname>k</varname> es el bloque cuadrado de <varname>(2k+1)</varname>×<varname>(2k+1)</varname> celdas centrado en el origen.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 0));  -- 1
 SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 1));  -- 9
@@ -289,10 +295,11 @@ SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 2));  -- 25
 		<itemizedlist>
 			<listitem xml:id="tquadbin_quadbin_point_to_cell">
 				<indexterm significance="normal"><primary><varname>geoToQuadbinCell</varname></primary></indexterm>
-				<para>Devuelve la celda QUADBIN en la resolución dada que contiene una geometría de punto. La geometría debe ser un <varname>POINT</varname>; las longitudes se interpretan en SRID 4326.</para>
+				<para>Devuelve la celda QUADBIN en la resolución dada que contiene una geometría de punto</para>
 				<programlisting xml:space="preserve" format="linespecific">
 geoToQuadbinCell(geometry,integer) → quadbin
 </programlisting>
+				<para>La geometría debe ser un <varname>POINT</varname>; las longitudes se interpretan en SRID 4326.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
   = quadbin '48a6227affffffff';
@@ -303,11 +310,12 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 			<listitem xml:id="tquadbin_quadbin_cell_to_point">
 				<indexterm significance="normal"><primary><varname>quadbinCellToPoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToPoint</varname></primary></indexterm>
-				<para>Devuelve el centroide de una celda como un punto SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el centroide de cada celda de una trayectoria como un <varname>tgeompoint</varname>.</para>
+				<para>Devuelve el centroide de una celda como un punto SRID 4326</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToPoint(quadbin) → geometry
 tquadbinCellToPoint(tquadbin) → tgeompoint
 </programlisting>
+				<para>La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el centroide de cada celda de una trayectoria como un <varname>tgeompoint</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(quadbinCellToPoint(quadbin '48427fffffffffff'));
 -- POINT(-101.25 48.92249926375824)
@@ -321,11 +329,12 @@ SELECT asText(tquadbinCellToPoint(tquadbin
 			<listitem xml:id="tquadbin_quadbin_cell_to_boundary">
 				<indexterm significance="normal"><primary><varname>quadbinCellToBoundary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToBoundary</varname></primary></indexterm>
-				<para>Devuelve el contorno poligonal cuadrado de una celda como una geometría SRID 4326. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el contorno de cada celda de una trayectoria como un <varname>tgeometry</varname>.</para>
+				<para>Devuelve el contorno poligonal cuadrado de una celda como una geometría SRID 4326</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToBoundary(quadbin) → geometry
 tquadbinCellToBoundary(tquadbin) → tgeometry
 </programlisting>
+				<para>La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el contorno de cada celda de una trayectoria como un <varname>tgeometry</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(quadbinCellToBoundary(quadbin '480fffffffffffff'));
 -- POLYGON((-180 -85.0511287798066,180 -85.0511287798066,
@@ -375,11 +384,12 @@ SELECT quadbinCellToTile(quadbin '48a6227affffffff');
 			<listitem xml:id="tquadbin_quadbin_cell_to_quadkey">
 				<indexterm significance="normal"><primary><varname>quadbinCellToQuadkey</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToQuadkey</varname></primary></indexterm>
-				<para>Emite la cadena quadkey en base 4 de una celda (un dígito por nivel de zoom, primero el más significativo; la celda mundial de resolución 0 se corresponde con la cadena vacía). La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el quadkey de cada celda de una trayectoria como un <varname>ttext</varname>.</para>
+				<para>Emite la cadena quadkey en base 4 de una celda (un dígito por nivel de zoom, primero el más significativo; la celda mundial de resolución 0 se corresponde con la cadena vacía)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToQuadkey(quadbin) → text
 tquadbinCellToQuadkey(tquadbin) → ttext
 </programlisting>
+				<para>La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el quadkey de cada celda de una trayectoria como un <varname>ttext</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToQuadkey(quadbin '480fffffffffffff');
 -- (cadena vacía)
@@ -398,11 +408,12 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
 			<listitem xml:id="tquadbin_quadbin_cell_area">
 				<indexterm significance="normal"><primary><varname>quadbinCellArea</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellArea</varname></primary></indexterm>
-				<para>Devuelve el área de una celda sobre la esfera, en metros cuadrados. La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el área de cada celda de una trayectoria como un <varname>tfloat</varname>. El área de la celda se reduce hacia los polos, ya que los cuadrados web-mercator cubren progresivamente menos terreno a latitudes más altas.</para>
+				<para>Devuelve el área de una celda sobre la esfera, en metros cuadrados</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellArea(quadbin) → float8
 tquadbinCellArea(tquadbin) → tfloat
 </programlisting>
+				<para>La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el área de cada celda de una trayectoria como un <varname>tfloat</varname>. El área de la celda se reduce hacia los polos, ya que los cuadrados web-mercator cubren progresivamente menos terreno a latitudes más altas.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(quadbinCellArea(quadbin '480fffffffffffff')::numeric, 0);
 -- 508164135963886
@@ -465,7 +476,7 @@ FROM Temp;
 		<itemizedlist>
 			<listitem xml:id="tquadbin_btree_ops">
 				<indexterm significance="normal"><primary><varname>tquadbin_btree_ops</varname></primary></indexterm>
-				<para>Clase de operadores de árbol B por defecto para las celdas QUADBIN temporales, ordenando por el valor temporal subyacente.</para>
+				<para>Clase de operadores de árbol B por defecto para las celdas QUADBIN temporales, ordenando por el valor temporal subyacente</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX ON trips USING btree(cells);       -- usa tquadbin_btree_ops por defecto
 </programlisting>
@@ -473,7 +484,7 @@ CREATE INDEX ON trips USING btree(cells);       -- usa tquadbin_btree_ops por de
 
 			<listitem xml:id="tquadbin_hash_ops">
 				<indexterm significance="normal"><primary><varname>tquadbin_hash_ops</varname></primary></indexterm>
-				<para>Clase de operadores hash por defecto para las celdas QUADBIN temporales, usada por las uniones hash y la agregación hash.</para>
+				<para>Clase de operadores hash por defecto para las celdas QUADBIN temporales, usada por las uniones hash y la agregación hash</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX ON trips USING hash(cells);        -- usa tquadbin_hash_ops por defecto
 </programlisting>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2891,7 +2891,7 @@
 					<para><link linkend="th3_tbigint"><varname>::</varname></link>: Convert between a <varname>th3index</varname> and a <varname>tbigint</varname> (explicit, zero-cost)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_tgeogpoint"><varname>::</varname></link>: Cast a temporal H3 cell to a temporal geodetic / planar point of cell centroids. The two overloads give the caller a choice between the geodetic (<varname>tgeogpoint</varname>) and SRID-4326 planar (<varname>tgeompoint</varname>) representations.</para>
+					<para><link linkend="th3_tgeogpoint"><varname>::</varname></link>: Cast a temporal H3 cell to a temporal geodetic / planar point of cell centroids</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2899,13 +2899,13 @@
 			<title>Static Geometry Coverage</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_geoToH3Cell"><varname>geoToH3Cell</varname></link>: Return the H3 cell that contains a point geometry at the given resolution. The geometry must be a <varname>POINT</varname>.</para>
+					<para><link linkend="th3_geoToH3Cell"><varname>geoToH3Cell</varname></link>: Return the H3 cell that contains a point geometry at the given resolution</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_geoToH3IndexSet"><varname>geoToH3IndexSet</varname></link>: Return the set of H3 cells covering a geometry at the given resolution. Every geometry type is supported: a <varname>POINT</varname> yields a single cell, a <varname>LINESTRING</varname> samples its segments, a <varname>POLYGON</varname> fills its interior, and <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> values return the union of their components.</para>
+					<para><link linkend="th3_geoToH3IndexSet"><varname>geoToH3IndexSet</varname></link>: Return the set of H3 cells covering a geometry at the given resolution</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_ever_eq_set"><varname>eEq</varname></link>: Return whether a temporal H3 trajectory ever takes one of the cells in a cell set. Combined with <varname>geoToH3IndexSet</varname> it answers whether a trip ever passes through a region, without materialising the trajectory geometry, the sound, conservative prefilter for the exact <varname>eIntersects(geometry,th3index)</varname>.</para>
+					<para><link linkend="th3_ever_eq_set"><varname>eEq</varname></link>: Return whether a temporal H3 trajectory ever takes one of the cells in a cell set</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2916,7 +2916,7 @@
 					<para><link linkend="th3_startValue"><varname>startValue</varname>, <varname>endValue</varname></link>: Return the first or last H3 cell identifier of a temporal value</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_valueN"><varname>valueN</varname></link>: Return the <varname>n</varname>th distinct H3 cell identifier (1-indexed). Returns <varname>NULL</varname> if out of range.</para>
+					<para><link linkend="th3_valueN"><varname>valueN</varname></link>: Return the <varname>n</varname>th distinct H3 cell identifier (1-indexed)</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_getValues"><varname>getValues</varname></link>: Return the set of distinct H3 cell identifiers the trajectory takes</para>
@@ -2939,7 +2939,7 @@
 					<para><link linkend="th3_h3_is_valid_cell"><varname>isValidCell</varname></link>: Return a temporal boolean stating at each instant whether the value is a valid H3 cell</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_is_res_class_iii"><varname>th3IsResClassIii</varname></link>: Return a temporal boolean stating whether each cell has Class-III orientation. Class III alternates with resolution: odd resolutions are class III, even are class II.</para>
+					<para><link linkend="th3_h3_is_res_class_iii"><varname>th3IsResClassIii</varname></link>: Return a temporal boolean stating whether each cell has Class-III orientation</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_is_pentagon"><varname>th3IsPentagon</varname></link>: Return a temporal boolean stating whether each cell is a pentagon (12 cells per resolution are pentagons, the remaining 110 at each base cell descend as hexagons)</para>
@@ -2950,16 +2950,16 @@
 			<title>Hierarchy</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_parent"><varname>th3CellToParent</varname></link>: Return the temporal parent cell at the given resolution. The no-argument form drops to the next-coarser resolution.</para>
+					<para><link linkend="th3_h3_cell_to_parent"><varname>th3CellToParent</varname></link>: Return the temporal parent cell at the given resolution</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_center_child"><varname>th3CellToCenterChild</varname></link>: Return the temporal center-child cell at the given resolution. The no-argument form drops to the next-finer resolution.</para>
+					<para><link linkend="th3_h3_cell_to_center_child"><varname>th3CellToCenterChild</varname></link>: Return the temporal center-child cell at the given resolution</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_cell_to_child_pos"><varname>th3CellToChildPos</varname></link>: Return the ordinal position (0-based) of each cell among the children of its parent at the given resolution</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_child_pos_to_cell"><varname>th3ChildPosToCell</varname></link>: Return the temporal child cell at a given ordinal position of the given parent, at the given child resolution. The two temporal operands are synchronised over their shared time axis.</para>
+					<para><link linkend="th3_h3_child_pos_to_cell"><varname>th3ChildPosToCell</varname></link>: Return the temporal child cell at a given ordinal position of the given parent, at the given child resolution</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -2970,7 +2970,7 @@
 					<para><link linkend="th3_tgeompoint_to_th3"><varname>th3index</varname></link>: Return the temporal H3 cell at the given resolution that contains each point in a temporal geodetic or planar point (SRID must be 4326 for the <varname>tgeompoint</varname> overload)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_latlng"><varname>th3CellToLatlng</varname>, <varname>th3CellToLatlngTgeompoint</varname></link>: Return the temporal geodetic centroid of each cell in a trajectory. A planar (SRID 4326) overload is available under the name <varname>th3CellToLatlngTgeompoint</varname>.</para>
+					<para><link linkend="th3_h3_cell_to_latlng"><varname>th3CellToLatlng</varname>, <varname>th3CellToLatlngTgeompoint</varname></link>: Return the temporal geodetic centroid of each cell in a trajectory</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_cell_to_boundary"><varname>th3CellToBoundary</varname></link>: Return the temporal polygon boundary of each cell in a trajectory, as a temporal geography</para>
@@ -2981,7 +2981,7 @@
 			<title>Directed Edges</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_are_neighbor_cells"><varname>th3AreNeighborCells</varname></link>: Return a temporal boolean stating whether two temporal cells are grid neighbours at each instant. The two operands are synchronised.</para>
+					<para><link linkend="th3_h3_are_neighbor_cells"><varname>th3AreNeighborCells</varname></link>: Return a temporal boolean stating whether two temporal cells are grid neighbours at each instant</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_cells_to_directed_edge"><varname>th3CellsToDirectedEdge</varname></link>: Return a temporal directed-edge identifier from an origin/destination pair of temporal cells</para>
@@ -3015,10 +3015,10 @@
 			<title>Grid Traversal</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_grid_distance"><varname>th3GridDistance</varname>, <varname>&lt;-&gt;</varname></link>: Return the temporal grid-hop distance (number of single-cell steps) between two temporal cells. Equivalently, the <varname>&lt;-&gt;</varname> operator returns the same distance. The two operands are synchronised over their shared time axis.</para>
+					<para><link linkend="th3_h3_grid_distance"><varname>th3GridDistance</varname>, <varname>&lt;-&gt;</varname></link>: Return the temporal grid-hop distance (number of single-cell steps) between two temporal cells</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_local_ij"><varname>th3CellToLocalIj</varname>, <varname>th3LocalIjToCell</varname></link>: Convert between a temporal cell and a temporal local (I, J) coordinate pair relative to an origin temporal cell. The local coordinate is exposed as a <varname>tgeompoint</varname> with the I axis in the <varname>x</varname> slot and J in <varname>y</varname>.</para>
+					<para><link linkend="th3_h3_cell_to_local_ij"><varname>th3CellToLocalIj</varname>, <varname>th3LocalIjToCell</varname></link>: Convert between a temporal cell and a temporal local (I, J) coordinate pair relative to an origin temporal cell</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3032,7 +3032,7 @@
 					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLength</varname></link>: Return the temporal length of each directed edge in a trajectory, in the requested unit</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistance</varname></link>: Return the temporal great-circle distance between two temporal geodetic points (not between cells). The two operands are synchronised.</para>
+					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistance</varname></link>: Return the temporal great-circle distance between two temporal geodetic points (not between cells)</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3082,31 +3082,31 @@
 			<title>Set-Returning Helpers</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_grid_disk"><varname>h3GridDisk</varname></link>: All cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0).</para>
+					<para><link linkend="th3_h3_grid_disk"><varname>h3GridDisk</varname></link>: All cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_grid_ring"><varname>h3GridRing</varname></link>: The cells at <emphasis>exactly</emphasis> <varname>k</varname> grid steps from the origin. Fails near pentagons.</para>
+					<para><link linkend="th3_h3_grid_ring"><varname>h3GridRing</varname></link>: The cells at <emphasis>exactly</emphasis> <varname>k</varname> grid steps from the origin</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_grid_path_cells"><varname>h3GridPathCells</varname></link>: The inclusive path of cells between two cells of the same resolution.</para>
+					<para><link linkend="th3_h3_grid_path_cells"><varname>h3GridPathCells</varname></link>: The inclusive path of cells between two cells of the same resolution</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_children"><varname>h3CellToChildren</varname></link>: All children of a cell at the given target resolution.</para>
+					<para><link linkend="th3_h3_cell_to_children"><varname>h3CellToChildren</varname></link>: All children of a cell at the given target resolution</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_compact_cells"><varname>h3CompactCells</varname></link>: Compacted representation of a cell set, finer cells are merged into their parent whenever a full hexagonal set of siblings is present.</para>
+					<para><link linkend="th3_h3_compact_cells"><varname>h3CompactCells</varname></link>: Compacted representation of a cell set, finer cells are merged into their parent whenever a full hexagonal set of siblings is present</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_uncompact_cells"><varname>h3UncompactCells</varname></link>: Uncompacted representation at the given resolution, the inverse of <varname>h3CompactCells</varname>.</para>
+					<para><link linkend="th3_h3_uncompact_cells"><varname>h3UncompactCells</varname></link>: Uncompacted representation at the given resolution, the inverse of <varname>h3CompactCells</varname></para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_origin_to_directed_edges"><varname>h3OriginToDirectedEdges</varname></link>: All outgoing directed edges of a cell (6 for hexagons, 5 for pentagons).</para>
+					<para><link linkend="th3_h3_origin_to_directed_edges"><varname>h3OriginToDirectedEdges</varname></link>: All outgoing directed edges of a cell (6 for hexagons, 5 for pentagons)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_vertexes"><varname>h3CellToVertexes</varname></link>: All vertexes of a cell (6 for hexagons, 5 for pentagons).</para>
+					<para><link linkend="th3_h3_cell_to_vertexes"><varname>h3CellToVertexes</varname></link>: All vertexes of a cell (6 for hexagons, 5 for pentagons)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_get_icosahedron_faces"><varname>h3GetIcosahedronFaces</varname></link>: The icosahedron face indexes (0..19) intersected by a cell.</para>
+					<para><link linkend="th3_h3_get_icosahedron_faces"><varname>h3GetIcosahedronFaces</varname></link>: The icosahedron face indexes (0..19) intersected by a cell</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3148,10 +3148,10 @@
 			<title>Indexing</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_rtree_ops"><varname>th3_rtree_ops</varname></link>: GiST operator class for temporal H3 cells. Indexes an <varname>stbox</varname> spatiotemporal bounding box per row (the geodetic extent of the cell boundaries together with the time period).</para>
+					<para><link linkend="th3_rtree_ops"><varname>th3_rtree_ops</varname></link>: GiST operator class for temporal H3 cells</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_quadtree_ops"><varname>th3_quadtree_ops</varname>, <varname>th3_kdtree_ops</varname></link>: SP-GiST operator classes for temporal H3 cells, keyed on the <varname>stbox</varname> spatiotemporal bounding box. <varname>th3_quadtree_ops</varname> is the default (quadtree partitioning); <varname>th3_kdtree_ops</varname> uses k-d tree partitioning and must be named explicitly.</para>
+					<para><link linkend="th3_quadtree_ops"><varname>th3_quadtree_ops</varname>, <varname>th3_kdtree_ops</varname></link>: SP-GiST operator classes for temporal H3 cells, keyed on the <varname>stbox</varname> spatiotemporal bounding box</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3166,7 +3166,7 @@
 					<para><link linkend="tquadbin_tbigint"><varname>::</varname></link>: Convert between a <varname>tquadbin</varname> and a <varname>tbigint</varname> (explicit, zero-cost)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_tgeompoint"><varname>::</varname></link>: Cast a temporal QUADBIN cell to a temporal planar (SRID 4326) point of cell centroids. The cast delegates to <varname>tquadbinCellToPoint</varname>.</para>
+					<para><link linkend="tquadbin_tgeompoint"><varname>::</varname></link>: Cast a temporal QUADBIN cell to a temporal planar (SRID 4326) point of cell centroids</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3188,7 +3188,7 @@
 					<para><link linkend="tquadbin_startValue"><varname>startValue</varname>, <varname>endValue</varname></link>: Return the first or last QUADBIN cell identifier of a temporal value</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_valueN"><varname>valueN</varname></link>: Return the <varname>n</varname>th distinct QUADBIN cell identifier (1-indexed). Returns <varname>NULL</varname> if out of range.</para>
+					<para><link linkend="tquadbin_valueN"><varname>valueN</varname></link>: Return the <varname>n</varname>th distinct QUADBIN cell identifier (1-indexed)</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tquadbin_getValues"><varname>getValues</varname></link>: Return the set of distinct QUADBIN cell identifiers the trajectory takes</para>
@@ -3202,7 +3202,7 @@
 			<title>Index Inspection</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_get_resolution"><varname>quadbinGetResolution</varname>, <varname>tquadbinGetResolution</varname></link>: Return the resolution (zoom) level (0–26) of a cell. The static form returns an <varname>integer</varname>; the temporal form returns the resolution of each cell in a trajectory as a <varname>tint</varname>.</para>
+					<para><link linkend="tquadbin_quadbin_get_resolution"><varname>quadbinGetResolution</varname>, <varname>tquadbinGetResolution</varname></link>: Return the resolution (zoom) level (0–26) of a cell</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tquadbin_quadbin_is_valid_cell"><varname>isValidCell</varname></link>: Return a temporal boolean stating at each instant whether the value is a valid QUADBIN cell</para>
@@ -3213,16 +3213,16 @@
 			<title>Hierarchy</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_parent"><varname>quadbinCellToParent</varname>, <varname>tquadbinCellToParent</varname></link>: Return the parent cell at the given coarser resolution. The static form takes a single <varname>quadbin</varname>; the temporal form returns the parent of each cell in a trajectory.</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_parent"><varname>quadbinCellToParent</varname>, <varname>tquadbinCellToParent</varname></link>: Return the parent cell at the given coarser resolution</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_children"><varname>quadbinCellToChildren</varname></link>: Return the four child cells at the requested finer resolution as a <varname>quadbinset</varname>. This is a static set-returning helper on a single <varname>quadbin</varname>; it has no temporal lift (children are a per-instant set, deferred pending a <varname>tset&lt;T&gt;</varname> primitive).</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_children"><varname>quadbinCellToChildren</varname></link>: Return the four child cells at the requested finer resolution as a <varname>quadbinset</varname></para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tquadbin_quadbin_cell_sibling"><varname>quadbinCellSibling</varname></link>: Return the neighbouring cell at the same resolution in the given direction (<varname>up</varname> / <varname>down</varname> / <varname>left</varname> / <varname>right</varname>)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_grid_disk"><varname>quadbinGridDisk</varname></link>: Return all cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0), as a <varname>quadbinset</varname>. On the square grid the disk at step <varname>k</varname> is the <varname>(2k+1)</varname>×<varname>(2k+1)</varname> square block of cells centred on the origin.</para>
+					<para><link linkend="tquadbin_quadbin_grid_disk"><varname>quadbinGridDisk</varname></link>: Return all cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0), as a <varname>quadbinset</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3230,13 +3230,13 @@
 			<title>Geometry Conversions</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_point_to_cell"><varname>geoToQuadbinCell</varname></link>: Return the QUADBIN cell at the given resolution that contains a point geometry. The geometry must be a <varname>POINT</varname>; longitudes are interpreted in SRID 4326.</para>
+					<para><link linkend="tquadbin_quadbin_point_to_cell"><varname>geoToQuadbinCell</varname></link>: Return the QUADBIN cell at the given resolution that contains a point geometry</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_point"><varname>quadbinCellToPoint</varname>, <varname>tquadbinCellToPoint</varname></link>: Return the centroid of a cell as an SRID-4326 point. The static form takes a single <varname>quadbin</varname>; the temporal form returns the centroid of each cell in a trajectory as a <varname>tgeompoint</varname>.</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_point"><varname>quadbinCellToPoint</varname>, <varname>tquadbinCellToPoint</varname></link>: Return the centroid of a cell as an SRID-4326 point</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_boundary"><varname>quadbinCellToBoundary</varname>, <varname>tquadbinCellToBoundary</varname></link>: Return the square polygon boundary of a cell as an SRID-4326 geometry. The static form takes a single <varname>quadbin</varname>; the temporal form returns the boundary of each cell in a trajectory as a <varname>tgeometry</varname>.</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_boundary"><varname>quadbinCellToBoundary</varname>, <varname>tquadbinCellToBoundary</varname></link>: Return the square polygon boundary of a cell as an SRID-4326 geometry</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3250,7 +3250,7 @@
 					<para><link linkend="tquadbin_quadbin_cell_to_tile"><varname>quadbinCellToTile</varname></link>: Decompose a cell back into its tile coordinate triple, returned as an integer array <varname>{x, y, z}</varname>, the inverse of <varname>quadbinTileToCell</varname></para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_to_quadkey"><varname>quadbinCellToQuadkey</varname>, <varname>tquadbinCellToQuadkey</varname></link>: Emit the base-4 slippy-tile quadkey string of a cell (one digit per zoom level, MSB-first; the resolution-0 world cell maps to the empty string). The static form takes a single <varname>quadbin</varname>; the temporal form returns the quadkey of each cell in a trajectory as a <varname>ttext</varname>.</para>
+					<para><link linkend="tquadbin_quadbin_cell_to_quadkey"><varname>quadbinCellToQuadkey</varname>, <varname>tquadbinCellToQuadkey</varname></link>: Emit the base-4 slippy-tile quadkey string of a cell (one digit per zoom level, MSB-first; the resolution-0 world cell maps to the empty string)</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3258,7 +3258,7 @@
 			<title>Metrics</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_quadbin_cell_area"><varname>quadbinCellArea</varname>, <varname>tquadbinCellArea</varname></link>: Return the area of a cell on the sphere, in square metres. The static form takes a single <varname>quadbin</varname>; the temporal form returns the area of each cell in a trajectory as a <varname>tfloat</varname>. Cell area shrinks toward the poles, as web-mercator squares cover progressively less ground at higher latitudes.</para>
+					<para><link linkend="tquadbin_quadbin_cell_area"><varname>quadbinCellArea</varname>, <varname>tquadbinCellArea</varname></link>: Return the area of a cell on the sphere, in square metres</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3285,10 +3285,10 @@
 			<title>Indexing</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tquadbin_btree_ops"><varname>tquadbin_btree_ops</varname></link>: Default B-tree operator class for temporal QUADBIN cells, ordering by the underlying temporal value.</para>
+					<para><link linkend="tquadbin_btree_ops"><varname>tquadbin_btree_ops</varname></link>: Default B-tree operator class for temporal QUADBIN cells, ordering by the underlying temporal value</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tquadbin_hash_ops"><varname>tquadbin_hash_ops</varname></link>: Default hash operator class for temporal QUADBIN cells, used by hash joins and hash aggregation.</para>
+					<para><link linkend="tquadbin_hash_ops"><varname>tquadbin_hash_ops</varname></link>: Default hash operator class for temporal QUADBIN cells, used by hash joins and hash aggregation</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -67,11 +67,12 @@ SELECT ((th3index '831c02fffffffff@2001-01-01')::tbigint)::th3index
 
 			<listitem xml:id="th3_tgeogpoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
-				<para>Cast a temporal H3 cell to a temporal geodetic / planar point of cell centroids. The two overloads give the caller a choice between the geodetic (<varname>tgeogpoint</varname>) and SRID-4326 planar (<varname>tgeompoint</varname>) representations.</para>
+				<para>Cast a temporal H3 cell to a temporal geodetic / planar point of cell centroids</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3index::tgeogpoint
 th3index::tgeompoint
 </programlisting>
+				<para>The two overloads give the caller a choice between the geodetic (<varname>tgeogpoint</varname>) and SRID-4326 planar (<varname>tgeompoint</varname>) representations.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeogpoint;
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint;
@@ -88,10 +89,11 @@ SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint;
 		<itemizedlist>
 			<listitem xml:id="th3_geoToH3Cell">
 				<indexterm significance="normal"><primary><varname>geoToH3Cell</varname></primary></indexterm>
-				<para>Return the H3 cell that contains a point geometry at the given resolution. The geometry must be a <varname>POINT</varname>.</para>
+				<para>Return the H3 cell that contains a point geometry at the given resolution</para>
 				<programlisting xml:space="preserve" format="linespecific">
 geoToH3Cell(geometry,integer) → h3index
 </programlisting>
+				<para>The geometry must be a <varname>POINT</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3Cell(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- 871fa4418ffffff
@@ -100,10 +102,11 @@ SELECT geoToH3Cell(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 
 			<listitem xml:id="th3_geoToH3IndexSet">
 				<indexterm significance="normal"><primary><varname>geoToH3IndexSet</varname></primary></indexterm>
-				<para>Return the set of H3 cells covering a geometry at the given resolution. Every geometry type is supported: a <varname>POINT</varname> yields a single cell, a <varname>LINESTRING</varname> samples its segments, a <varname>POLYGON</varname> fills its interior, and <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> values return the union of their components.</para>
+				<para>Return the set of H3 cells covering a geometry at the given resolution</para>
 				<programlisting xml:space="preserve" format="linespecific">
 geoToH3IndexSet(geometry,integer) → h3indexset
 </programlisting>
+				<para>Every geometry type is supported: a <varname>POINT</varname> yields a single cell, a <varname>LINESTRING</varname> samples its segments, a <varname>POLYGON</varname> fills its interior, and <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> values return the union of their components.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- {"871fa4418ffffff"}
@@ -112,11 +115,12 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 
 			<listitem xml:id="th3_ever_eq_set">
 				<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
-				<para>Return whether a temporal H3 trajectory ever takes one of the cells in a cell set. Combined with <varname>geoToH3IndexSet</varname> it answers whether a trip ever passes through a region, without materialising the trajectory geometry, the sound, conservative prefilter for the exact <varname>eIntersects(geometry,th3index)</varname>.</para>
+				<para>Return whether a temporal H3 trajectory ever takes one of the cells in a cell set</para>
 				<programlisting xml:space="preserve" format="linespecific">
 eEq(h3indexset,th3index) → boolean
 h3indexset ?= th3index → boolean
 </programlisting>
+				<para>Combined with <varname>geoToH3IndexSet</varname> it answers whether a trip ever passes through a region, without materialising the trajectory geometry, the sound, conservative prefilter for the exact <varname>eIntersects(geometry,th3index)</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
   th3index '871fa4418ffffff@2001-01-01';
@@ -147,10 +151,11 @@ SELECT endValue(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-0
 
 			<listitem xml:id="th3_valueN">
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
-				<para>Return the <varname>n</varname>th distinct H3 cell identifier (1-indexed). Returns <varname>NULL</varname> if out of range.</para>
+				<para>Return the <varname>n</varname>th distinct H3 cell identifier (1-indexed)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 valueN(th3index,integer) → h3index
 </programlisting>
+				<para>Returns <varname>NULL</varname> if out of range.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}', 1);
 -- 831c02fffffffff
@@ -237,10 +242,11 @@ SELECT isValidCell(th3index '0@2001-01-01');
 
 			<listitem xml:id="th3_h3_is_res_class_iii">
 				<indexterm significance="normal"><primary><varname>th3IsResClassIii</varname></primary></indexterm>
-				<para>Return a temporal boolean stating whether each cell has Class-III orientation. Class III alternates with resolution: odd resolutions are class III, even are class II.</para>
+				<para>Return a temporal boolean stating whether each cell has Class-III orientation</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3IsResClassIii(th3index) → tbool
 </programlisting>
+				<para>Class III alternates with resolution: odd resolutions are class III, even are class II.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3IsResClassIii(th3index '871fa44a8ffffff@2001-01-01');
 -- t@2001-01-01
@@ -268,11 +274,12 @@ SELECT th3IsPentagon(th3index '831c02fffffffff@2001-01-01');
 		<itemizedlist>
 			<listitem xml:id="th3_h3_cell_to_parent">
 				<indexterm significance="normal"><primary><varname>th3CellToParent</varname></primary></indexterm>
-				<para>Return the temporal parent cell at the given resolution. The no-argument form drops to the next-coarser resolution.</para>
+				<para>Return the temporal parent cell at the given resolution</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3CellToParent(th3index,integer) → th3index
 th3CellToParent(th3index) → th3index
 </programlisting>
+				<para>The no-argument form drops to the next-coarser resolution.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(
   th3CellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
@@ -282,11 +289,12 @@ SELECT th3GetResolution(
 
 			<listitem xml:id="th3_h3_cell_to_center_child">
 				<indexterm significance="normal"><primary><varname>th3CellToCenterChild</varname></primary></indexterm>
-				<para>Return the temporal center-child cell at the given resolution. The no-argument form drops to the next-finer resolution.</para>
+				<para>Return the temporal center-child cell at the given resolution</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3CellToCenterChild(th3index,integer) → th3index
 th3CellToCenterChild(th3index) → th3index
 </programlisting>
+				<para>The no-argument form drops to the next-finer resolution.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3CellToCenterChild(th3index '871fa44a8ffffff@2001-01-01', 8);
 -- 881fa44a81fffff@2001-01-01
@@ -310,10 +318,11 @@ SELECT th3CellToChildPos(th3index '871fa44a8ffffff@2001-01-01', 6);
 
 			<listitem xml:id="th3_h3_child_pos_to_cell">
 				<indexterm significance="normal"><primary><varname>th3ChildPosToCell</varname></primary></indexterm>
-				<para>Return the temporal child cell at a given ordinal position of the given parent, at the given child resolution. The two temporal operands are synchronised over their shared time axis.</para>
+				<para>Return the temporal child cell at a given ordinal position of the given parent, at the given child resolution</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3ChildPosToCell(tbigint,th3index,integer) → th3index
 </programlisting>
+				<para>The two temporal operands are synchronised over their shared time axis.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3ChildPosToCell(tbigint '0@2001-01-01', th3index '871fa44a8ffffff@2001-01-01',
   8);
@@ -346,11 +355,12 @@ SELECT th3GetResolution(th3index(
 			<listitem xml:id="th3_h3_cell_to_latlng">
 				<indexterm significance="normal"><primary><varname>th3CellToLatlng</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3CellToLatlngTgeompoint</varname></primary></indexterm>
-				<para>Return the temporal geodetic centroid of each cell in a trajectory. A planar (SRID 4326) overload is available under the name <varname>th3CellToLatlngTgeompoint</varname>.</para>
+				<para>Return the temporal geodetic centroid of each cell in a trajectory</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3CellToLatlng(th3index) → tgeogpoint
 th3CellToLatlngTgeompoint(th3index) → tgeompoint
 </programlisting>
+				<para>A planar (SRID 4326) overload is available under the name <varname>th3CellToLatlngTgeompoint</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3CellToLatlng(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
@@ -384,10 +394,11 @@ SELECT ST_NPoints(getValue(th3CellToBoundary(th3index
 		<itemizedlist>
 			<listitem xml:id="th3_h3_are_neighbor_cells">
 				<indexterm significance="normal"><primary><varname>th3AreNeighborCells</varname></primary></indexterm>
-				<para>Return a temporal boolean stating whether two temporal cells are grid neighbours at each instant. The two operands are synchronised.</para>
+				<para>Return a temporal boolean stating whether two temporal cells are grid neighbours at each instant</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3AreNeighborCells(th3index,th3index) → tbool
 </programlisting>
+				<para>The two operands are synchronised.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3AreNeighborCells(
   th3index '880326b885fffff@2001-01-01',
@@ -508,11 +519,12 @@ SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
 			<listitem xml:id="th3_h3_grid_distance">
 				<indexterm significance="normal"><primary><varname>th3GridDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
-				<para>Return the temporal grid-hop distance (number of single-cell steps) between two temporal cells. Equivalently, the <varname>&lt;-&gt;</varname> operator returns the same distance. The two operands are synchronised over their shared time axis.</para>
+				<para>Return the temporal grid-hop distance (number of single-cell steps) between two temporal cells</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3GridDistance(th3index,th3index) → tbigint
 th3index &lt;-&gt; th3index → tbigint
 </programlisting>
+				<para>Equivalently, the <varname>&lt;-&gt;</varname> operator returns the same distance. The two operands are synchronised over their shared time axis.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index '880326b885fffff@2001-01-01'
    &lt;-&gt; th3index '880326b88dfffff@2001-01-01';
@@ -523,11 +535,12 @@ SELECT th3index '880326b885fffff@2001-01-01'
 			<listitem xml:id="th3_h3_cell_to_local_ij">
 				<indexterm significance="normal"><primary><varname>th3CellToLocalIj</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3LocalIjToCell</varname></primary></indexterm>
-				<para>Convert between a temporal cell and a temporal local (I, J) coordinate pair relative to an origin temporal cell. The local coordinate is exposed as a <varname>tgeompoint</varname> with the I axis in the <varname>x</varname> slot and J in <varname>y</varname>.</para>
+				<para>Convert between a temporal cell and a temporal local (I, J) coordinate pair relative to an origin temporal cell</para>
 				<programlisting xml:space="preserve" format="linespecific">
 th3CellToLocalIj(th3index,th3index) → tgeompoint
 th3LocalIjToCell(th3index,tgeompoint) → th3index
 </programlisting>
+				<para>The local coordinate is exposed as a <varname>tgeompoint</varname> with the I axis in the <varname>x</varname> slot and J in <varname>y</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(th3CellToLocalIj(th3index '871fa44a8ffffff@2001-01-01',
   th3index '871fa44aeffffff@2001-01-01'));
@@ -575,10 +588,11 @@ SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01
 
 			<listitem xml:id="th3_h3_great_circle_distance">
 				<indexterm significance="normal"><primary><varname>greatCircleDistance</varname></primary></indexterm>
-				<para>Return the temporal great-circle distance between two temporal geodetic points (not between cells). The two operands are synchronised.</para>
+				<para>Return the temporal great-circle distance between two temporal geodetic points (not between cells)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat
 </programlisting>
+				<para>The two operands are synchronised.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
   tgeogpoint 'Point(1 0)@2001-01-01');
@@ -783,7 +797,7 @@ SELECT th3index '871fa44a8ffffff@2001-01-01' #&gt;&gt;
 		<itemizedlist>
 			<listitem xml:id="th3_h3_grid_disk">
 				<indexterm significance="normal"><primary><varname>h3GridDisk</varname></primary></indexterm>
-				<para>All cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0).</para>
+				<para>All cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3GridDisk(h3index, integer) → h3indexset
 </programlisting>
@@ -796,10 +810,11 @@ SELECT h3GridDisk(h3index '871fa44a8ffffff', 1);
 
 			<listitem xml:id="th3_h3_grid_ring">
 				<indexterm significance="normal"><primary><varname>h3GridRing</varname></primary></indexterm>
-				<para>The cells at <emphasis>exactly</emphasis> <varname>k</varname> grid steps from the origin. Fails near pentagons.</para>
+				<para>The cells at <emphasis>exactly</emphasis> <varname>k</varname> grid steps from the origin</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3GridRing(h3index, integer) → h3indexset
 </programlisting>
+				<para>Fails near pentagons.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
 -- {"871fa44a9ffffff", "871fa44aaffffff", "871fa44abffffff", "871fa44acffffff",
@@ -809,7 +824,7 @@ SELECT h3GridRing(h3index '871fa44a8ffffff', 1);
 
 			<listitem xml:id="th3_h3_grid_path_cells">
 				<indexterm significance="normal"><primary><varname>h3GridPathCells</varname></primary></indexterm>
-				<para>The inclusive path of cells between two cells of the same resolution.</para>
+				<para>The inclusive path of cells between two cells of the same resolution</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3GridPathCells(h3index, h3index) → h3indexset
 </programlisting>
@@ -822,7 +837,7 @@ SELECT h3GridPathCells(h3index '871fa44a8ffffff', h3index '871fa44b1ffffff');
 
 			<listitem xml:id="th3_h3_cell_to_children">
 				<indexterm significance="normal"><primary><varname>h3CellToChildren</varname></primary></indexterm>
-				<para>All children of a cell at the given target resolution.</para>
+				<para>All children of a cell at the given target resolution</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3CellToChildren(h3index, integer) → h3indexset
 </programlisting>
@@ -835,7 +850,7 @@ SELECT h3CellToChildren(h3index '831c02fffffffff', 4);
 
 			<listitem xml:id="th3_h3_compact_cells">
 				<indexterm significance="normal"><primary><varname>h3CompactCells</varname></primary></indexterm>
-				<para>Compacted representation of a cell set, finer cells are merged into their parent whenever a full hexagonal set of siblings is present.</para>
+				<para>Compacted representation of a cell set, finer cells are merged into their parent whenever a full hexagonal set of siblings is present</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3CompactCells(h3indexset) → h3indexset
 </programlisting>
@@ -847,7 +862,7 @@ SELECT h3CompactCells(h3CellToChildren(h3index '831c02fffffffff', 4));
 
 			<listitem xml:id="th3_h3_uncompact_cells">
 				<indexterm significance="normal"><primary><varname>h3UncompactCells</varname></primary></indexterm>
-				<para>Uncompacted representation at the given resolution, the inverse of <varname>h3CompactCells</varname>.</para>
+				<para>Uncompacted representation at the given resolution, the inverse of <varname>h3CompactCells</varname></para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3UncompactCells(h3indexset, integer) → h3indexset
 </programlisting>
@@ -860,7 +875,7 @@ SELECT numValues(h3UncompactCells(
 
 			<listitem xml:id="th3_h3_origin_to_directed_edges">
 				<indexterm significance="normal"><primary><varname>h3OriginToDirectedEdges</varname></primary></indexterm>
-				<para>All outgoing directed edges of a cell (6 for hexagons, 5 for pentagons).</para>
+				<para>All outgoing directed edges of a cell (6 for hexagons, 5 for pentagons)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3OriginToDirectedEdges(h3index) → h3indexset
 </programlisting>
@@ -873,7 +888,7 @@ SELECT h3OriginToDirectedEdges(h3index '871fa44a8ffffff');
 
 			<listitem xml:id="th3_h3_cell_to_vertexes">
 				<indexterm significance="normal"><primary><varname>h3CellToVertexes</varname></primary></indexterm>
-				<para>All vertexes of a cell (6 for hexagons, 5 for pentagons).</para>
+				<para>All vertexes of a cell (6 for hexagons, 5 for pentagons)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3CellToVertexes(h3index) → h3indexset
 </programlisting>
@@ -886,7 +901,7 @@ SELECT h3CellToVertexes(h3index '871fa44a8ffffff');
 
 			<listitem xml:id="th3_h3_get_icosahedron_faces">
 				<indexterm significance="normal"><primary><varname>h3GetIcosahedronFaces</varname></primary></indexterm>
-				<para>The icosahedron face indexes (0..19) intersected by a cell.</para>
+				<para>The icosahedron face indexes (0..19) intersected by a cell</para>
 				<programlisting xml:space="preserve" format="linespecific">
 h3GetIcosahedronFaces(h3index) → intset
 </programlisting>
@@ -1065,7 +1080,8 @@ FROM Temp;
 		<itemizedlist>
 			<listitem xml:id="th3_rtree_ops">
 				<indexterm significance="normal"><primary><varname>th3_rtree_ops</varname></primary></indexterm>
-				<para>GiST operator class for temporal H3 cells. Indexes an <varname>stbox</varname> spatiotemporal bounding box per row (the geodetic extent of the cell boundaries together with the time period).</para>
+				<para>GiST operator class for temporal H3 cells</para>
+				<para>Indexes an <varname>stbox</varname> spatiotemporal bounding box per row (the geodetic extent of the cell boundaries together with the time period).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX ON trips USING gist(cells);       -- uses th3_rtree_ops by default
 CREATE INDEX ON trips USING gist(cells th3_rtree_ops);
@@ -1075,7 +1091,8 @@ CREATE INDEX ON trips USING gist(cells th3_rtree_ops);
 			<listitem xml:id="th3_quadtree_ops">
 				<indexterm significance="normal"><primary><varname>th3_quadtree_ops</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>th3_kdtree_ops</varname></primary></indexterm>
-				<para>SP-GiST operator classes for temporal H3 cells, keyed on the <varname>stbox</varname> spatiotemporal bounding box. <varname>th3_quadtree_ops</varname> is the default (quadtree partitioning); <varname>th3_kdtree_ops</varname> uses k-d tree partitioning and must be named explicitly.</para>
+				<para>SP-GiST operator classes for temporal H3 cells, keyed on the <varname>stbox</varname> spatiotemporal bounding box</para>
+				<para><varname>th3_quadtree_ops</varname> is the default (quadtree partitioning); <varname>th3_kdtree_ops</varname> uses k-d tree partitioning and must be named explicitly.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX ON trips USING spgist(cells);     -- uses th3_quadtree_ops by default
 CREATE INDEX ON trips USING spgist(cells th3_kdtree_ops);

--- a/doc/temporal_quadbin_index.xml
+++ b/doc/temporal_quadbin_index.xml
@@ -74,10 +74,11 @@ SELECT ((tquadbin '480fffffffffffff@2001-01-01')::tbigint)::tquadbin
 
 			<listitem xml:id="tquadbin_tgeompoint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
-				<para>Cast a temporal QUADBIN cell to a temporal planar (SRID 4326) point of cell centroids. The cast delegates to <varname>tquadbinCellToPoint</varname>.</para>
+				<para>Cast a temporal QUADBIN cell to a temporal planar (SRID 4326) point of cell centroids</para>
 				<programlisting xml:space="preserve" format="linespecific">
 tquadbin::tgeompoint
 </programlisting>
+				<para>The cast delegates to <varname>tquadbinCellToPoint</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (tquadbin '480fffffffffffff@2001-01-01')::tgeompoint;
 </programlisting>
@@ -144,10 +145,11 @@ SELECT endValue(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01
 
 			<listitem xml:id="tquadbin_valueN">
 				<indexterm significance="normal"><primary><varname>valueN</varname></primary></indexterm>
-				<para>Return the <varname>n</varname>th distinct QUADBIN cell identifier (1-indexed). Returns <varname>NULL</varname> if out of range.</para>
+				<para>Return the <varname>n</varname>th distinct QUADBIN cell identifier (1-indexed)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 valueN(tquadbin,integer) → quadbin
 </programlisting>
+				<para>Returns <varname>NULL</varname> if out of range.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(tquadbin '{480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02}', 1);
 -- 480fffffffffffff
@@ -196,11 +198,12 @@ SELECT valueAtTimestamp(tquadbin
 			<listitem xml:id="tquadbin_quadbin_get_resolution">
 				<indexterm significance="normal"><primary><varname>quadbinGetResolution</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinGetResolution</varname></primary></indexterm>
-				<para>Return the resolution (zoom) level (0–26) of a cell. The static form returns an <varname>integer</varname>; the temporal form returns the resolution of each cell in a trajectory as a <varname>tint</varname>.</para>
+				<para>Return the resolution (zoom) level (0–26) of a cell</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinGetResolution(quadbin) → integer
 tquadbinGetResolution(tquadbin) → tint
 </programlisting>
+				<para>The static form returns an <varname>integer</varname>; the temporal form returns the resolution of each cell in a trajectory as a <varname>tint</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinGetResolution(quadbin '480fffffffffffff');
 -- 0
@@ -229,11 +232,12 @@ SELECT isValidCell(tquadbin '480fffffffffffff@2001-01-01');
 			<listitem xml:id="tquadbin_quadbin_cell_to_parent">
 				<indexterm significance="normal"><primary><varname>quadbinCellToParent</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToParent</varname></primary></indexterm>
-				<para>Return the parent cell at the given coarser resolution. The static form takes a single <varname>quadbin</varname>; the temporal form returns the parent of each cell in a trajectory.</para>
+				<para>Return the parent cell at the given coarser resolution</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToParent(quadbin,integer) → quadbin
 tquadbinCellToParent(tquadbin,integer) → tquadbin
 </programlisting>
+				<para>The static form takes a single <varname>quadbin</varname>; the temporal form returns the parent of each cell in a trajectory.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToParent(quadbin '48a6227affffffff', 5);
 -- 485623ffffffffff
@@ -245,10 +249,11 @@ SELECT tquadbinGetResolution(
 
 			<listitem xml:id="tquadbin_quadbin_cell_to_children">
 				<indexterm significance="normal"><primary><varname>quadbinCellToChildren</varname></primary></indexterm>
-				<para>Return the four child cells at the requested finer resolution as a <varname>quadbinset</varname>. This is a static set-returning helper on a single <varname>quadbin</varname>; it has no temporal lift (children are a per-instant set, deferred pending a <varname>tset&lt;T&gt;</varname> primitive).</para>
+				<para>Return the four child cells at the requested finer resolution as a <varname>quadbinset</varname></para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToChildren(quadbin,integer) → quadbinset
 </programlisting>
+				<para>This is a static set-returning helper on a single <varname>quadbin</varname>; it has no temporal lift (children are a per-instant set, deferred pending a <varname>tset&lt;T&gt;</varname> primitive).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToChildren(quadbin '480fffffffffffff', 1);
 -- {4813ffffffffffff, 4817ffffffffffff, 481bffffffffffff, 481fffffffffffff}
@@ -271,10 +276,11 @@ SELECT quadbinCellSibling(
 
 			<listitem xml:id="tquadbin_quadbin_grid_disk">
 				<indexterm significance="normal"><primary><varname>quadbinGridDisk</varname></primary></indexterm>
-				<para>Return all cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0), as a <varname>quadbinset</varname>. On the square grid the disk at step <varname>k</varname> is the <varname>(2k+1)</varname>×<varname>(2k+1)</varname> square block of cells centred on the origin.</para>
+				<para>Return all cells within <varname>k</varname> grid steps of the origin (inclusive of the origin at k=0), as a <varname>quadbinset</varname></para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinGridDisk(quadbin,integer) → quadbinset
 </programlisting>
+				<para>On the square grid the disk at step <varname>k</varname> is the <varname>(2k+1)</varname>×<varname>(2k+1)</varname> square block of cells centred on the origin.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 0));  -- 1
 SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 1));  -- 9
@@ -289,10 +295,11 @@ SELECT numValues(quadbinGridDisk(quadbin '48a6227affffffff', 2));  -- 25
 		<itemizedlist>
 			<listitem xml:id="tquadbin_quadbin_point_to_cell">
 				<indexterm significance="normal"><primary><varname>geoToQuadbinCell</varname></primary></indexterm>
-				<para>Return the QUADBIN cell at the given resolution that contains a point geometry. The geometry must be a <varname>POINT</varname>; longitudes are interpreted in SRID 4326.</para>
+				<para>Return the QUADBIN cell at the given resolution that contains a point geometry</para>
 				<programlisting xml:space="preserve" format="linespecific">
 geoToQuadbinCell(geometry,integer) → quadbin
 </programlisting>
+				<para>The geometry must be a <varname>POINT</varname>; longitudes are interpreted in SRID 4326.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
   = quadbin '48a6227affffffff';
@@ -303,11 +310,12 @@ SELECT geoToQuadbinCell(geometry 'SRID=4326;POINT(4.35 50.85)', 10)
 			<listitem xml:id="tquadbin_quadbin_cell_to_point">
 				<indexterm significance="normal"><primary><varname>quadbinCellToPoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToPoint</varname></primary></indexterm>
-				<para>Return the centroid of a cell as an SRID-4326 point. The static form takes a single <varname>quadbin</varname>; the temporal form returns the centroid of each cell in a trajectory as a <varname>tgeompoint</varname>.</para>
+				<para>Return the centroid of a cell as an SRID-4326 point</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToPoint(quadbin) → geometry
 tquadbinCellToPoint(tquadbin) → tgeompoint
 </programlisting>
+				<para>The static form takes a single <varname>quadbin</varname>; the temporal form returns the centroid of each cell in a trajectory as a <varname>tgeompoint</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(quadbinCellToPoint(quadbin '48427fffffffffff'));
 -- POINT(-101.25 48.92249926375824)
@@ -321,11 +329,12 @@ SELECT asText(tquadbinCellToPoint(tquadbin
 			<listitem xml:id="tquadbin_quadbin_cell_to_boundary">
 				<indexterm significance="normal"><primary><varname>quadbinCellToBoundary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToBoundary</varname></primary></indexterm>
-				<para>Return the square polygon boundary of a cell as an SRID-4326 geometry. The static form takes a single <varname>quadbin</varname>; the temporal form returns the boundary of each cell in a trajectory as a <varname>tgeometry</varname>.</para>
+				<para>Return the square polygon boundary of a cell as an SRID-4326 geometry</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToBoundary(quadbin) → geometry
 tquadbinCellToBoundary(tquadbin) → tgeometry
 </programlisting>
+				<para>The static form takes a single <varname>quadbin</varname>; the temporal form returns the boundary of each cell in a trajectory as a <varname>tgeometry</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(quadbinCellToBoundary(quadbin '480fffffffffffff'));
 -- POLYGON((-180 -85.0511287798066,180 -85.0511287798066,
@@ -375,11 +384,12 @@ SELECT quadbinCellToTile(quadbin '48a6227affffffff');
 			<listitem xml:id="tquadbin_quadbin_cell_to_quadkey">
 				<indexterm significance="normal"><primary><varname>quadbinCellToQuadkey</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellToQuadkey</varname></primary></indexterm>
-				<para>Emit the base-4 slippy-tile quadkey string of a cell (one digit per zoom level, MSB-first; the resolution-0 world cell maps to the empty string). The static form takes a single <varname>quadbin</varname>; the temporal form returns the quadkey of each cell in a trajectory as a <varname>ttext</varname>.</para>
+				<para>Emit the base-4 slippy-tile quadkey string of a cell (one digit per zoom level, MSB-first; the resolution-0 world cell maps to the empty string)</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellToQuadkey(quadbin) → text
 tquadbinCellToQuadkey(tquadbin) → ttext
 </programlisting>
+				<para>The static form takes a single <varname>quadbin</varname>; the temporal form returns the quadkey of each cell in a trajectory as a <varname>ttext</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToQuadkey(quadbin '480fffffffffffff');
 -- (empty string)
@@ -398,11 +408,12 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
 			<listitem xml:id="tquadbin_quadbin_cell_area">
 				<indexterm significance="normal"><primary><varname>quadbinCellArea</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tquadbinCellArea</varname></primary></indexterm>
-				<para>Return the area of a cell on the sphere, in square metres. The static form takes a single <varname>quadbin</varname>; the temporal form returns the area of each cell in a trajectory as a <varname>tfloat</varname>. Cell area shrinks toward the poles, as web-mercator squares cover progressively less ground at higher latitudes.</para>
+				<para>Return the area of a cell on the sphere, in square metres</para>
 				<programlisting xml:space="preserve" format="linespecific">
 quadbinCellArea(quadbin) → float8
 tquadbinCellArea(tquadbin) → tfloat
 </programlisting>
+				<para>The static form takes a single <varname>quadbin</varname>; the temporal form returns the area of each cell in a trajectory as a <varname>tfloat</varname>. Cell area shrinks toward the poles, as web-mercator squares cover progressively less ground at higher latitudes.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(quadbinCellArea(quadbin '480fffffffffffff')::numeric, 0);
 -- 508164135963886
@@ -465,7 +476,7 @@ FROM Temp;
 		<itemizedlist>
 			<listitem xml:id="tquadbin_btree_ops">
 				<indexterm significance="normal"><primary><varname>tquadbin_btree_ops</varname></primary></indexterm>
-				<para>Default B-tree operator class for temporal QUADBIN cells, ordering by the underlying temporal value.</para>
+				<para>Default B-tree operator class for temporal QUADBIN cells, ordering by the underlying temporal value</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX ON trips USING btree(cells);       -- uses tquadbin_btree_ops by default
 </programlisting>
@@ -473,7 +484,7 @@ CREATE INDEX ON trips USING btree(cells);       -- uses tquadbin_btree_ops by de
 
 			<listitem xml:id="tquadbin_hash_ops">
 				<indexterm significance="normal"><primary><varname>tquadbin_hash_ops</varname></primary></indexterm>
-				<para>Default hash operator class for temporal QUADBIN cells, used by hash joins and hash aggregation.</para>
+				<para>Default hash operator class for temporal QUADBIN cells, used by hash joins and hash aggregation</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX ON trips USING hash(cells);        -- uses tquadbin_hash_ops by default
 </programlisting>


### PR DESCRIPTION
The reference appendix prints an entry's opening paragraph verbatim as its row description, so that paragraph is one sentence and carries no closing period. Seventy-six entries across the two chapters and their Spanish twins open with more than that; each keeps its first sentence above the signature and states the rest in the single explanation paragraph below it, and the two entries carrying no signature state the explanation above their example. The appendix is regenerated from the corrected one-liners.