### PR TITLE
Break the distance of a rigid geometry where it reaches a geometry

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -1610,6 +1610,62 @@ compute_dist_tpoly_poly(cfp_elem *cfp, tdist_array *tda)
 }
 
 /**
+ * @brief Append the time at which a moving polygon first reaches, or first
+ * leaves, a polygon it touches
+ * @details The v-clip oracle answers zero for every pose at which the two
+ * overlap, so the distance of a fixed feature pair is its separation while
+ * they stand apart and a floor of zero once they meet. The join between the
+ * two is a kink, and a kink that carries no point of its own is a straight
+ * line drawn across it: the distance then leaves zero early or reaches it
+ * late, by as much as the gap to the next closest-feature time.
+ *
+ * The separation falls to zero exactly once between a pose that stands apart
+ * and a pose that overlaps, so the time it does is bracketed by the two and
+ * found by halving the bracket. The oracle decides each probe, which keeps
+ * the answer the one v-clip gives rather than a model of it.
+ * @param[in] cfp_s Closest-feature pair opening the interval
+ * @param[in] pose_s,pose_e Poses at the ends of the temporal segment
+ * @param[in] t_lo,t_hi Ends of the temporal segment
+ * @param[in] ta,tb Ends of the bracket, within `[t_lo,t_hi]`
+ * @param[in,out] tda Distance points to append to
+ */
+static void
+compute_contact_tpoly_poly(const cfp_elem *cfp_s, const Pose *pose_s,
+  const Pose *pose_e, TimestampTz t_lo, TimestampTz t_hi, TimestampTz ta,
+  TimestampTz tb, tdist_array *tda)
+{
+  if (t_hi == t_lo || tb <= ta)
+    return;
+  double lo = (double) (ta - t_lo) / (double) (t_hi - t_lo);
+  double hi = (double) (tb - t_lo) / (double) (t_hi - t_lo);
+  /* Halving to the resolution of the timestamp the answer carries: a
+   * microsecond over the segment, and never more than the iterations that
+   * reach it */
+  for (int k = 0; k < 60 && (hi - lo) * (double) (t_hi - t_lo) > 1.0; k++)
+  {
+    double mid = 0.5 * (lo + hi);
+    Pose *pm = posesegm_interpolate(pose_s, pose_e, mid);
+    uint32_t cf_1 = 0, cf_2 = 0;
+    double d;
+    v_clip_tpoly_tpoly((LWPOLY *) cfp_s->geom_1, (LWPOLY *) cfp_s->geom_2,
+      pm, NULL, &cf_1, &cf_2, &d);
+    pfree(pm);
+    if (d > 0.0)
+      lo = mid;
+    else
+      hi = mid;
+  }
+  /* The kink stands where the separation reaches zero, so it carries zero */
+  TimestampTz tc = t_lo + (TimestampTz) llround(hi * (double) (t_hi - t_lo));
+  if (tc > t_lo && tc < t_hi)
+  {
+    tdist_elem td = tdist_make(0.0, tc);
+    append_tdist_elem(tda, td);
+  }
+  return;
+}
+
+/**
  * @brief Append the interior turning points (local extrema) of the distance
  * realized by the fixed closest-feature pair of @p cfp_s while the rigid
  * geometry moves over the temporal segment @p [t_lo,t_hi]
@@ -1840,6 +1896,33 @@ dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs,
 
   /* Order the distance points by time before building the result */
   tdist_array_sort(&tda);
+
+  /* The distance of a fixed feature pair is a separation while the polygons
+   * stand apart and a floor of zero once they meet, so where two neighbouring
+   * points stand on either side of that floor the join between them is a
+   * kink. A kink carrying no point of its own is drawn as a straight line
+   * across, which reaches zero late on the way in and leaves it early on the
+   * way out; the time the separation actually reaches zero is a point of the
+   * answer */
+  uint32_t ncontact = tda.count;
+  for (uint32_t i = 0; i + 1 < ncontact; ++i)
+  {
+    if ((tda.arr[i].dist > 0.0) == (tda.arr[i + 1].dist > 0.0))
+      continue;
+    TimestampTz ta = tda.arr[i].t, tb = tda.arr[i + 1].t;
+    int sgi = trgeoseq_segment_index(seq, ta + (tb - ta) / 2);
+    const TInstant *ssi = TSEQUENCE_INST_N(seq, sgi);
+    const TInstant *sei = TSEQUENCE_INST_N(seq, sgi + 1);
+    cfp_elem probe = cfp_make_zero((LWGEOM *) poly1, (LWGEOM *) poly2,
+      NULL, NULL, ta, MEOS_CFP_STORE_NO);
+    compute_contact_tpoly_poly(&probe,
+      DatumGetPoseP(tinstant_value_p(ssi)),
+      DatumGetPoseP(tinstant_value_p(sei)), ssi->t, sei->t,
+      (tda.arr[i].dist > 0.0) ? ta : tb,
+      (tda.arr[i].dist > 0.0) ? tb : ta, &tda);
+  }
+  if (tda.count != ncontact)
+    tdist_array_sort(&tda);
 
   /* Create the result tfloat */
   TInstant **instants = palloc(sizeof(TInstant *) * tda.count);

--- a/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
+++ b/mobilitydb/test/rgeo/expected/168_trgeo_distance.test.out
@@ -412,3 +412,39 @@ SELECT round(abs(valueAtTimestamp(tDistance(
  0.000000000
 (1 row)
 
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 6),0)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))'),
+  '2001-01-01 15:11:00')::numeric, 6);
+  round   
+----------
+ 0.004167
+(1 row)
+
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 6),0)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))'),
+  '2001-01-01 15:30:00')::numeric, 6);
+  round   
+----------
+ 0.000000
+(1 row)
+
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 6),0)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))'),
+  '2001-01-01 21:00:00')::numeric, 6);
+  round   
+----------
+ 0.050000
+(1 row)
+
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  geometry 'Polygon((-0.4 2,0.4 2,0.4 2.6,-0.4 2.6,-0.4 2))'),
+  '2001-01-01 12:00:00')::numeric, 6);
+  round   
+----------
+ 0.691363
+(1 row)
+

--- a/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
+++ b/mobilitydb/test/rgeo/queries/168_trgeo_distance.test.sql
@@ -267,3 +267,34 @@ SELECT round(abs(valueAtTimestamp(tDistance(
   '2001-01-01 12:00'), geometry 'MultiLinestring((0 5,0 6),(11 5,11 6))'))::numeric, 9);
 
 -------------------------------------------------------------------------------
+-- The distance of a rigid geometry to a static geometry stands at its
+-- separation while the two are apart and at zero once they meet, so the join
+-- between the two is a kink and the moment of contact is a point of the
+-- answer. The rod below covers y in [c-0.2, c+0.2] at centre height c and is
+-- carried from c = 0 to c = 6, so it meets the band y in [4,5] exactly while
+-- c lies in [3.8, 5.2], that is from 15:12 to 20:48 of the first day.
+-------------------------------------------------------------------------------
+
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 6),0)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))'),
+  '2001-01-01 15:11:00')::numeric, 6);
+
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 6),0)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))'),
+  '2001-01-01 15:30:00')::numeric, 6);
+
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 6),0)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))'),
+  '2001-01-01 21:00:00')::numeric, 6);
+
+-- A body that turns rather than travels reaches the same floor, and leaves it.
+
+SELECT round(valueAtTimestamp(tDistance(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  geometry 'Polygon((-0.4 2,0.4 2,0.4 2.6,-0.4 2.6,-0.4 2))'),
+  '2001-01-01 12:00:00')::numeric, 6);
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
The v-clip oracle answers the separation of two polygons while they stand apart and zero for every pose at which they overlap, so the distance realised by a fixed closest-feature pair falls to a floor and stays there. The points of the temporal distance are the closest-feature times and the interior extrema of each pair, and the moment the separation reaches that floor is neither of those: a body travelling into a geometry passes no feature transition as it arrives, and the arrival is not an extremum of a distance that is falling through it.

A kink carrying no point of its own is drawn as the straight line between the points either side, so the distance leaves zero early on the way in and reaches it late on the way out. A rod covering `y` in `[c-0.2, c+0.2]` carried from `c = 0` to `c = 6` meets the band `y` in `[4,5]` exactly while `c` lies in `[3.8, 5.2]`, that is over the fraction `[0.633333, 0.866667]` of its segment. The distance reports that arrival at `0.65625`, a fortieth of the segment late, while it reports the departure exactly.

The separation falls to zero exactly once between a point that stands apart and a point that overlaps, so the time it does is bracketed by the two and found by halving that bracket down to the microsecond a timestamp carries. The oracle decides each probe, so the contact time is the one v-clip gives rather than a model of it, and the point it adds carries zero.

Over the rod above the arrival reads `0.633333` against a true `0.633333`. Against a placement oracle that samples a segment 2001 times and asks GEOS of each posed body, the times the distance calls zero and the times the body genuinely overlaps agree exactly: 467 of 2001 samples for that rod, 377 for a rod that turns into reach rather than travelling, 947 for one that turns while it travels, and none at all for a rod whose reach falls short. Each of those four disagrees beforehand, by 33 to 46 samples.

Four readings join `168_trgeo_distance`, each of a value the geometry fixes rather than a number the engine happens to print: the gap `0.004167` one minute before contact, zero within it, the gap `0.050000` after it, and the distance of a rod that turns. The other three distance suites read exactly as they read before, which is why the readings are added: a suite that stays green over a change of this kind is uncovered rather than confirmed.
