### PR TITLE
Name the text-returning JSON field operator in its tag

### DIFF
--- a/mobilitydb/src/json/jsonbset_jsonfuncs.c
+++ b/mobilitydb/src/json/jsonbset_jsonfuncs.c
@@ -83,7 +83,7 @@ Jsonbset_array_length(PG_FUNCTION_ARGS)
 /**
  * @brief Extract a field from a JSONB set value
  * @sqlfn jsonbsetObjectField(), jsonbsetObjectFieldText()
- * @sqlop @p ->, @p ->
+ * @sqlop @p ->, @p ->>
  */
 Datum
 Jsonbset_object_field_common(FunctionCallInfo fcinfo, bool astext)

--- a/mobilitydb/src/json/tjsonb_jsonfuncs.c
+++ b/mobilitydb/src/json/tjsonb_jsonfuncs.c
@@ -244,7 +244,7 @@ Tjson_object_field_opr(PG_FUNCTION_ARGS)
 /**
  * @brief Extract a field from a temporal JSONB value
  * @sqlfn tjsonbObjectField(), tjsonbObjectFieldText()
- * @sqlop @p ->, @p ->
+ * @sqlop @p ->, @p ->>
  */
 Datum
 Tjsonb_object_field_common(FunctionCallInfo fcinfo, bool astext)


### PR DESCRIPTION
Each block lists one operator per SQL function it names, and the second function of these two is the text-returning form, which SQL declares under `->>`: `CREATE OPERATOR ->> (PROCEDURE = tjsonbObjectFieldTextOpr, ...)` in 454_tjsonb_jsonfuncs.in.sql and the jsonbset counterpart in 451_jsonbset_jsonfuncs.in.sql. The tags name that operator. Comments only: the operators themselves are declared in the SQL files and are unaffected, so this changes what a catalog derived from the tags carries.