### PR TITLE
Name every signature parameter as its own SQL declaration does

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -642,8 +642,8 @@ SELECT setSRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)), [2001-01-01,2001-0
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transform to a spatial reference identifier</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-transform(stbox,to_srid integer) → stbox
-transformPipeline(stbox,pipeline text,to_srid integer,is_forward boolean=true) → stbox
+transform(stbox,srid integer) → stbox
+transformPipeline(stbox,pipeline text,srid integer,is_forward boolean=true) → stbox
 </programlisting>
 				<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input box has an unknown SRID (represented by 0). The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -639,8 +639,8 @@ SELECT setSRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)), [2001-01-01,2001-0
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transforma a una referencia espacial diferente</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-transform(stbox,to_srid integer) → stbox
-transformPipeline(stbox,pipeline text,to_srid integer,is_forward boolean=true) → stbox
+transform(stbox,srid integer) → stbox
+transformPipeline(stbox,pipeline text,srid integer,is_forward boolean=true) → stbox
 </programlisting>
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el cuadro de entrada tiene un SRID desconocido (representado por 0).</para>
 				<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato:</para>

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -337,7 +337,7 @@ SELECT set(ARRAY[timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00']);
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<para>Constructor para tipos de rango</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-span(lower base,upper base,leftInc boolean=true,rightInc boolean=false) → span
+span(lower base,upper base,lower_inc boolean=true,upper_inc boolean=false) → span
 </programlisting>
 				<programlisting language="sql" xml:space="preserve">
 SELECT span(20.5, 25);
@@ -980,7 +980,7 @@ SELECT text 'XX' || textset '{aaa, bbb}';
 				<indexterm significance="normal"><primary><varname>tprecision</varname></primary></indexterm>
 				<para>Establece la precisión temporal del valor de tiempo al rango con respecto al origen</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tprecision(times,interval,origin timestamptz=’2000-01-03’) → times
+tprecision(times,interval,origin timestamptz='2000-01-03') → times
 </programlisting>
 				<para>Si el origen no se especifica, su valor se establece por defecto en lunes 3 de enero de 2000.</para>
 				<programlisting language="sql" xml:space="preserve">
@@ -1043,8 +1043,8 @@ SELECT asEWKT(setSRID(cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transforma a una referencia espacial diferente</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-transform(spatialset,to_srid integer) → spatialset
-transformPipeline(spatialset,pipeline text,to_srid integer,
+transform(spatialset,srid integer) → spatialset
+transformPipeline(spatialset,pipeline text,srid integer,
   is_forward boolean=true) → spatialset
 </programlisting>
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el conjunto tiene un SRID desconocido (representado por 0). La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas en el siguiente formato:</para>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -265,7 +265,7 @@ SELECT asEWKT(setSRID(cbuffer 'Cbuffer(Point(0 0),1)', 4326));
 					<para>Transforma a una referencia espacial diferente</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 transform(cbuffer,integer) → cbuffer
-transformPipeline(cbuffer,pipeline text,to_srid integer,
+transformPipeline(cbuffer,pipeline text,srid integer,
   is_forward boolean=true) → cbuffer
 </programlisting>
 					<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el búfer circular de entrada tiene un SRID desconocido (representado por 0).</para>
@@ -542,8 +542,8 @@ SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.2)',
 				<indexterm significance="normal"><primary><varname>tcbufferSeq</varname></primary></indexterm>
 				<para>Constructor para búferes circulares temporales de subtipo secuencia</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tcbufferSeq(tcbufferInst[],interp text='linear',leftInc boolean=true,
-  rightInc boolean=true) → tcbufferSeq
+tcbufferSeq(tcbufferInst[],interp text='linear',lower_inc boolean=true,
+  upper_inc boolean=true) → tcbufferSeq
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.3)@2001-01-01',
@@ -893,7 +893,7 @@ SELECT asEWKT(setSRID(tcbuffer '[Cbuffer(Point(0 0),1)@2001-01-01,
 				<para>Transforma a una referencia espacial diferente</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 transform(tcbuffer,integer) → tcbuffer
-transformPipeline(tcbuffer,pipeline text,to_srid integer,
+transformPipeline(tcbuffer,pipeline text,srid integer,
   is_forward boolean=true) → tcbuffer
 </programlisting>
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el búfer circular temporal de entrada tiene un SRID desconocido (representado por 0). La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato de cadena: <varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname>. El SRID del búfer circular temporal de entrada se ignora y el SRID del búfer circular temporal de salida se establecerá en cero a menos que se proporcione un valor a través del parámetro opcional <varname>to_srid</varname>. Como se indica en el último parámetro, la canalización se ejecuta de forma predeterminada en dirección hacia adelante; al establecer el parámetro en falso, la canalización se ejecuta en la dirección inversa.</para>

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -592,7 +592,7 @@ SELECT tjsonb('{"vehicleId": 1, "location": "Point(1 1)"}',
 				<indexterm significance="normal"><primary><varname>tjsonbSeq</varname></primary></indexterm>
 				<para>Constructor de valores JSONB temporales del subtipo secuencia</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tjsonbSeq(tjsonbInst[]},leftInc boolean=true,rightInc boolean=true) →tjsonbSeq
+tjsonbSeq(tjsonbInst[],lowerInc boolean=true,upperInc boolean=true) → tjsonbSeq
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeq(ARRAY[tjsonb '"{\"vehicleId\": 1,

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -471,8 +471,8 @@ SELECT tnpoint('Npoint(1, 0.2)', tstzspanset '{[2001-01-01, 2001-01-03]}', 'step
 					<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 					<para>Constructor para puntos de red temporal de subtipo secuencia</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tnpointSeq(tnpointInst[],interp text={'step','linear'},leftInc boolean=true,
-  rightInc boolean=true) &#8594; tnpointSeq
+tnpointSeq(tnpointInst[],interp text={'step','linear'},lower_inc boolean=true,
+  upper_inc boolean=true) &#8594; tnpointSeq
 </programlisting>
 					<programlisting language="sql" xml:space="preserve">
 SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.3)@2001-01-01', 'Npoint(1, 0.5)@2001-01-02',

--- a/doc/es/temporal_pose_types.xml
+++ b/doc/es/temporal_pose_types.xml
@@ -850,8 +850,8 @@ SELECT asEWKT(tposechain(posechain 'PoseChain(Pose(Point(1 1), 0.5))',
 				<indexterm significance="normal"><primary><varname>tposeSeq</varname></primary></indexterm>
 				<para>Constructor para poses temporales de subtipo secuencia</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tposeSeq(tposeInst[],interp text={'step','linear'},leftInc boolean=true,
-  rightInc boolean=true) → tposeSeq
+tposeSeq(tposeInst[],interp text={'step','linear'},lower_inc boolean=true,
+  upper_inc boolean=true) → tposeSeq
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.3)@2001-01-01',

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -140,7 +140,7 @@ SELECT asEWKT(setSRID(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02)
 				<para>Transforma a una referencia espacial diferente &Z_support; &geography_support;</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 transform(tspatial,integer) → tspatial
-transformPipeline(tspatial,pipeline text,to_srid integer,
+transformPipeline(tspatial,pipeline text,srid integer,
   is_forward boolean=true) → tspatial
 </programlisting>
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el punto temporal tiene un SRID desconocido (representado por 0).</para>

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -591,9 +591,9 @@ SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01
 					<indexterm significance="normal"><primary><varname>bins</varname></primary></indexterm>
 					<para>Devuelve una matriz de intervalos que cubre el rango de valores o de tiempo con intervalos de la misma amplitud o duración</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-bins(numspans,size number,origin number=0) → span[]
-bins(datespans,duration interval,origin date='2000-01-03') → span[]
-bins(tstzspans,duration interval,origin timestamptz='2000-01-03') → span[]
+bins(numspans,vsize number,vorigin number=0) → span[]
+bins(datespans,tsize interval,torigin date='2000-01-03') → span[]
+bins(tstzspans,tsize interval,torigin timestamptz='2000-01-03') → span[]
 </programlisting>
 					<para>Si el origen no se especifica, su valor se establece por defecto en 0 para rangos de valores y en lunes 3 de enero de 2000 para rangos de tiempo.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -650,9 +650,9 @@ SELECT getBin('2001-01-04', interval '1 week', '2001-01-07');
 					<indexterm significance="normal"><primary><varname>valueTimeTiles</varname></primary></indexterm>
 					<para>Devuelve el conjunto de mosaicos que cubre un cuadro delimitador temporal con mosaicos del mismo tamaño y/o duración &SRF;</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-valueTiles(tbox,vsize float,vorigin float=0) → {(index,tile)}
+valueTiles(tbox,vsize float,vorigin float=0.0) → {(index,tile)}
 timeTiles(tbox,duration interval,torigin timestamptz='2000-01-03') → {(index,tile)}
-valueTimeTiles(tbox,vsize float,duration interval,vorigin float=0,
+valueTimeTiles(tbox,vsize float,duration interval,vorigin float=0.0,
   torigin timestamptz='2000-01-03') → {(index,tile)}
 </programlisting>
 					<para>Si el origen de la dimensión de valores y/o de tiempo no se especifica, su valor se establece por defecto en 0 y en el lunes 3 de enero de 2000, respectivamente.</para>
@@ -746,10 +746,10 @@ SELECT spaceTimeTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 					<indexterm significance="normal"><primary><varname>getValueTimeTile</varname></primary></indexterm>
 					<para>Devuelve el mosaico temporal que cubre un valor y/o una marca de tiempo</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-getValueTile(value float,vsize float,vorigin float=0.0) &#8594; tbox
+getValueTile(v float,vsize float,vorigin float=0.0) &#8594; tbox
 getTboxTimeTile(time timestamptz,duration interval,
   torigin timestamptz='2000-01-03') &#8594; tbox
-getValueTimeTile(value float,time timestamptz,size float,duration interval,
+getValueTimeTile(v float,t timestamptz,vsize float,duration interval,
   vorigin float=0.0,torigin timestamptz='2000-01-03') &#8594; tbox
 </programlisting>
 					<para>Si el origen de las dimensiones de valores y/o de tiempo no se especifica, su valor se establece por defecto en 0 y en el lunes 3 de enero de 2000, respectivamente.</para>
@@ -834,7 +834,7 @@ SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 valueBoxes(tnumber,size number,vorigin number=0) → tbox[]
 timeBoxes(tnumber,duration interval,torigin timestamptz='2000-01-03') → tbox[]
-valueTimeBoxes(tnumber,size number,duration interval,vorigin number=0,
+valueTimeBoxes(tnumber,vsize number,tsize interval,vorigin number=0,
   torigin timestamptz='2000-01-03') → tbox[]
 </programlisting>
 					<para>La elección entre instantes o segmentos depende de si la interpolación es discreta o continua. Si el origen de la dimensión de valores y/o de tiempo no se especifica, se establece por defecto en 0 y en el lunes 3 de enero de 2000, respectivamente.</para>

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -715,8 +715,8 @@ SELECT tgeography('SRID=7844;Point(0 0)',
 				<indexterm significance="normal"><primary><varname>ttypeSeq</varname></primary></indexterm>
 				<para>Constructores para tipos temporales de subtipo secuencia</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-ttypeSeq(ttypeInst[],interp text={'step','linear'},leftInc boolean=true,
-  rightInc boolean=true) → ttypeSeq
+ttypeSeq(ttypeInst[],interp text={'step','linear'},lowerInc boolean=true,
+  upperInc boolean=true) → ttypeSeq
 </programlisting>
 				<para>Estos constructores tienen un primer argumento obligatorio, que es una matriz de valores de los valores instantáneos correspondientes y argumentos opcionales adicionales. El segundo argumento establece la interpolación. Si no se proporciona el argumento, es por defecto escalonada para los tipos de base base discretos como los enteros y es lineal para tipos de base continuous como los flotantes. Se genera un error cuando se establece la interpolación lineal para valores temporales con tipos de base discretos. Para secuencias continuas, el tercero y el cuarto argumentos son valores booleanos que indican, respectivamente, si los límites izquierdo y derecho son inclusivos o exclusivos. Se supone que estos argumentos son verdaderos de forma predeterminada si no se especifican.</para>
 				<programlisting language="sql" xml:space="preserve">

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -329,7 +329,7 @@ SELECT set(ARRAY[timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00']);
 				<indexterm significance="normal"><primary><varname>span</varname></primary></indexterm>
 				<para>Constructor for span types</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-span(lower base,upper base,leftInc boolean=true,rightInc boolean=false) → span
+span(lower base,upper base,lower_inc boolean=true,upper_inc boolean=false) → span
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT span(20.5, 25);
@@ -971,7 +971,7 @@ SELECT text 'XX' || textset '{aaa, bbb}';
 				<indexterm significance="normal"><primary><varname>tprecision</varname></primary></indexterm>
 				<para>Set the temporal precision of the time value to the interval with respect to the origin</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tprecision(times,interval,origin timestamptz=’2000-01-03’) → times
+tprecision(times,interval,origin timestamptz='2000-01-03') → times
 </programlisting>
 				<para>If the origin is not specified, it is set by default to Monday, January 3, 2000</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1034,8 +1034,8 @@ SELECT asEWKT(setSRID(cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2
 				<indexterm significance="normal"><primary><varname>transformPipeline</varname></primary></indexterm>
 				<para>Transform to a spatial reference identifier</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-transform(spatialset,to_srid integer) → spatialset
-transformPipeline(spatialset,pipeline text,to_srid integer,
+transform(spatialset,srid integer) → spatialset
+transformPipeline(spatialset,pipeline text,srid integer,
   is_forward boolean=true) → spatialset
 </programlisting>
 				<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input set has an unknown SRID (represented by 0). The <varname>transformPipeline</varname> function specifies the transformation with a coordinate transformation pipeline in the following format:</para>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -265,7 +265,7 @@ SELECT asEWKT(setSRID(cbuffer 'Cbuffer(Point(0 0),1)', 4326));
 					<para>Transform to a spatial reference identifier</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 transform(cbuffer,integer) → cbuffer
-transformPipeline(cbuffer,pipeline text,to_srid integer,
+transformPipeline(cbuffer,pipeline text,srid integer,
   is_forward boolean=true) → cbuffer
 </programlisting>
 					<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input circular buffer has an unknown SRID (represented by 0).</para>
@@ -542,8 +542,8 @@ SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.2)',
 				<indexterm significance="normal"><primary><varname>tcbufferSeq</varname></primary></indexterm>
 				<para>Constructor for temporal circular buffers of sequence subtype</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tcbufferSeq(tcbufferInst[],interp text='linear',leftInc boolean=true,
-  rightInc boolean=true) → tcbufferSeq
+tcbufferSeq(tcbufferInst[],interp text='linear',lower_inc boolean=true,
+  upper_inc boolean=true) → tcbufferSeq
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.3)@2001-01-01',
@@ -894,7 +894,7 @@ SELECT asEWKT(setSRID(tcbuffer '[Cbuffer(Point(0 0),1)@2001-01-01,
 				<para>Transform to a spatial reference identifier</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 transform(tcbuffer,integer) → tcbuffer
-transformPipeline(tcbuffer,pipeline text,to_srid integer,
+transformPipeline(tcbuffer,pipeline text,srid integer,
   is_forward boolean=true) → tcbuffer
 </programlisting>
 				<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input temporal circular buffer has an unknown SRID (represented by 0). The <varname>transformPipeline</varname> function specifies the transformation with a defined coordinate transformation pipeline represented with the following string format: <varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname>. The SRID of the input temporal circular buffer is ignored, and the SRID of the output temporal circular buffer will be set to zero unless a value is provided via the optional <varname>to_srid</varname> parameter. As stated by the last parameter, the pipeline is executed by default in a forward direction; by setting the parameter to false, the pipeline is executed in the inverse direction.</para>

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -592,7 +592,7 @@ SELECT tjsonb('{"vehicleId": 1, "location": "Point(1 1)"}',
 				<indexterm significance="normal"><primary><varname>tjsonbSeq</varname></primary></indexterm>
 				<para>Constructor for temporal JSONB values of sequence subtype</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tjsonbSeq(tjsonbInst[]},leftInc boolean=true,rightInc boolean=true) →tjsonbSeq
+tjsonbSeq(tjsonbInst[],lowerInc boolean=true,upperInc boolean=true) → tjsonbSeq
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonbSeq(ARRAY[tjsonb '"{\"vehicleId\": 1,

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -471,8 +471,8 @@ SELECT tnpointSeqSet('Npoint(1, 0.2)', tstzspanset '{[2001-01-01, 2001-01-03]}',
 					<indexterm significance="normal"><primary><varname>tnpointSeq</varname></primary></indexterm>
 					<para>Constructor for temporal network points of sequence subtype</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tnpointSeq(tnpointInst[],interp text={'step','linear'},leftInc boolean=true,
-  rightInc boolean=true) &#8594; tnpointSeq
+tnpointSeq(tnpointInst[],interp text={'step','linear'},lower_inc boolean=true,
+  upper_inc boolean=true) &#8594; tnpointSeq
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.3)@2001-01-01', 'Npoint(1, 0.5)@2001-01-02',

--- a/doc/temporal_pose_types.xml
+++ b/doc/temporal_pose_types.xml
@@ -859,8 +859,8 @@ SELECT asEWKT(tposechain(posechain 'PoseChain(Pose(Point(1 1), 0.5))',
 				<indexterm significance="normal"><primary><varname>tposeSeq</varname></primary></indexterm>
 				<para>Constructor for temporal poses of sequence subtype</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tposeSeq(tposeInst[],interp text={'step','linear'},leftInc boolean=true,
-  rightInc boolean=true) → tposeSeq
+tposeSeq(tposeInst[],interp text={'step','linear'},lower_inc boolean=true,
+  upper_inc boolean=true) → tposeSeq
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.3)@2001-01-01',

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -139,7 +139,7 @@ SELECT asEWKT(setSRID(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02)
 				<para>Transform to a spatial reference identifier &Z_support; &geography_support;</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 transform(tspatial,integer) → tspatial
-transformPipeline(tspatial,pipeline text,to_srid integer,
+transformPipeline(tspatial,pipeline text,srid integer,
   is_forward boolean=true) → tspatial
 </programlisting>
 				<para>The <varname>transform</varname> function specifies the transformation with a target SRID. An error is raised when the input temporal point has an unknown SRID (represented by 0).</para>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -605,9 +605,9 @@ SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01
 					<para>Return an array of bins that cover a value or time span with bins of the same size or duration
 </para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-bins(numspans,size number,origin number=0) → span[]
-bins(datespans,duration interval,origin date='2000-01-03') → span[]
-bins(tstzspans,duration interval,origin timestamptz='2000-01-03') → span[]
+bins(numspans,vsize number,vorigin number=0) → span[]
+bins(datespans,tsize interval,torigin date='2000-01-03') → span[]
+bins(tstzspans,tsize interval,torigin timestamptz='2000-01-03') → span[]
 </programlisting>
 					<para>If the origin is not specified, it is set by default to 0 for value spans and Monday, January 3, 2000 for time spans.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -665,9 +665,9 @@ SELECT getBin('2001-01-04', interval '1 week', '2001-01-07');
 					<para>Return the set of tiles that covers a temporal box with tiles of the same size and/or duration &SRF;
 </para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-valueTiles(tbox,vsize float,vorigin float=0) → {(index,tile)}
+valueTiles(tbox,vsize float,vorigin float=0.0) → {(index,tile)}
 timeTiles(tbox,duration interval,torigin timestamptz='2000-01-03') → {(index,tile)}
-valueTimeTiles(tbox,vsize float,duration interval,vorigin float=0,
+valueTimeTiles(tbox,vsize float,duration interval,vorigin float=0.0,
   torigin timestamptz='2000-01-03') → {(index,tile)}
 </programlisting>
 					<para>The result is a set of pairs <varname>(index,tile)</varname>. If the origin of the value and/or time dimension is not specified, it is set by default to 0 and to Monday, January 3, 2000, respectively.</para>
@@ -762,10 +762,10 @@ SELECT spaceTimeTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 					<para>Return the temporal tile that covers a value and/or a timestamp &Z_support;
 </para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-getValueTile(value float,vsize float,vorigin float=0.0) &#8594; tbox
+getValueTile(v float,vsize float,vorigin float=0.0) &#8594; tbox
 getTboxTimeTile(time timestamptz,duration interval,
   torigin timestamptz='2000-01-03') &#8594; tbox
-getValueTimeTile(value float,time timestamptz,size float,duration interval,
+getValueTimeTile(v float,t timestamptz,vsize float,duration interval,
   vorigin float=0.0,torigin timestamptz='2000-01-03') &#8594; tbox
 </programlisting>
 					<para>If the origin of the value and/or time dimension is not specified, it is set by default to 0 and to Monday, January 3, 2000, respectively.</para>
@@ -851,7 +851,7 @@ SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 valueBoxes(tnumber,size number,vorigin number=0) → tbox[]
 timeBoxes(tnumber,duration interval,torigin timestamptz='2000-01-03') → tbox[]
-valueTimeBoxes(tnumber,size number,duration interval,vorigin number=0,
+valueTimeBoxes(tnumber,vsize number,tsize interval,vorigin number=0,
   torigin timestamptz='2000-01-03') → tbox[]
 </programlisting>
 					<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. If the origin of value and/or time dimension is not specified, it is set by default to 0 and to Monday, January 3, 2000, respectively.</para>

--- a/doc/temporal_types_p1.xml
+++ b/doc/temporal_types_p1.xml
@@ -705,8 +705,8 @@ SELECT tgeography('SRID=7844;Point(0 0)',
 				<indexterm significance="normal"><primary><varname>ttypeSeq</varname></primary></indexterm>
 				<para>Constructors for temporal types of sequence subtype</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-ttypeSeq(ttypeInst[],interp text={'step','linear'},leftInc boolean=true,
-  rightInc boolean=true) → ttypeSeq
+ttypeSeq(ttypeInst[],interp text={'step','linear'},lowerInc boolean=true,
+  upperInc boolean=true) → ttypeSeq
 </programlisting>
 				<para>These contructors have a first mandatory argument, which is an array of values of the corresponding instant values and additional optional arguments. The second argument states the interpolation. If the argument is not given, it is by default step for discrete base types such as integer, and linear for continuous base types such as float. An error is raised when linear interpolation is stated for temporal values with discrete base types. For continuous sequences, the third and fourth arguments are Boolean values stating, respectively, whether the left and right bounds are inclusive or exclusive. These arguments are assumed to be true by default if they are not specified.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">


### PR DESCRIPTION
The syntax block of a manual entry states the parameter name and the default value the `CREATE FUNCTION` behind it declares, so a named-argument call written from the manual reaches the function. `transformPipeline` and `transform` take `srid`; the sequence constructors of the spatial families take `lower_inc` and `upper_inc` while the generic, JSON and cell-index ones take `lowerInc` and `upperInc`; `bins`, `valueTimeBoxes`, `getValueTile` and `getValueTimeTile` take the value and time names `vsize`, `vorigin`, `tsize` and `torigin`. The float origins state their `0.0` default, and `tprecision` states its origin between straight quotes a reader can type. Both manuals build at 354 and 356 pages with no wrapped line, and the reference appendix regenerates unchanged.
