### PR TITLE
Read the times a rotating rigid geometry meets a geometry

### DIFF
--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -333,6 +333,125 @@ segment_overlap_spans(const GSERIALIZED *ref, const Pose *pose1,
  * @brief Test the posed body overlap at a single instant timestamp,
  * appending an instantaneous span to the buffer if it overlaps.
  */
+/**
+ * @brief Turn a rotating segment carries before it is read as one piece
+ * @details A vertex of a rotating body travels an arc, and the swept-edge clip
+ * the translating path solves reads straight travel alone, so a rotating
+ * segment is read in pieces short enough that the overlap holds or fails
+ * throughout each. The same turn bounds the pieces of the traversed area
+ */
+#define TRGEO_OVERLAP_ANGLE_TOL 0.05
+
+/**
+ * @brief Return whether a body placed by the pose at a ratio of a segment
+ * meets a target
+ */
+static bool
+body_meets_at(const GSERIALIZED *ref, const Pose *pose1, const Pose *pose2,
+  double ratio, const GSERIALIZED *target, const STBox *excl)
+{
+  Pose *p = posesegm_interpolate(pose1, pose2, ratio);
+  GSERIALIZED *body = pose_apply_geo(p, ref);
+  bool ov = body_meets_target(body, target, excl);
+  pfree(body); pfree(p);
+  return ov;
+}
+
+/**
+ * @brief Return the ratio at which the overlap of a rotating body with a
+ * target changes between two ratios that answer differently
+ * @details The two ratios answer differently, so a change stands between them
+ * and halving the bracket closes on it. What the halving reads is the overlap
+ * itself, so the ratio it returns is the one the predicate changes at
+ */
+static double
+rotating_change_ratio(const GSERIALIZED *ref, const Pose *pose1,
+  const Pose *pose2, double lo, double hi, bool ov_lo,
+  const GSERIALIZED *target, const STBox *excl)
+{
+  for (int k = 0; k < 40 && hi - lo > MEOS_GEOM_TOLERANCE; k++)
+  {
+    double mid = 0.5 * (lo + hi);
+    if (body_meets_at(ref, pose1, pose2, mid, target, excl) == ov_lo)
+      lo = mid;
+    else
+      hi = mid;
+  }
+  return hi;
+}
+
+/**
+ * @brief Compute the times at which a body meets a target over a segment
+ * along which it also ROTATES
+ * @details The translating path takes its events from a swept-edge clip,
+ * which reads straight travel and has nothing to say about a vertex on an
+ * arc. A rotating segment is read instead in pieces each carrying at most
+ * `TRGEO_OVERLAP_ANGLE_TOL` of turn: the overlap is asked at the ends of every
+ * piece, and where two consecutive readings differ the ratio the answer
+ * changes at is found by halving that piece. The times so found are exact in
+ * the overlap they read and carry the resolution of the halving, where the
+ * translating path solves its events in closed form
+ * @param[in] ref Reference geometry
+ * @param[in] pose1,pose2 Poses at the ends of the segment
+ * @param[in] t1,t2 Times at the ends of the segment
+ * @param[in] target Target geometry
+ * @param[in] excl Box whose upper borders are left out, NULL for none
+ * @param[in,out] spans,nspans,spancap Spans to append to
+ */
+static void
+segment_overlap_spans_rotating(const GSERIALIZED *ref, const Pose *pose1,
+  const Pose *pose2, TimestampTz t1, TimestampTz t2,
+  const GSERIALIZED *target, const STBox *excl, Span **spans, int *nspans,
+  int *spancap)
+{
+  double dtheta = fabs(pose2->data[2] - pose1->data[2]);
+  int npieces = (int) ceil(dtheta / TRGEO_OVERLAP_ANGLE_TOL);
+  if (npieces < 1)
+    npieces = 1;
+
+  bool prev = body_meets_at(ref, pose1, pose2, 0.0, target, excl);
+  double run_start = 0.0;
+  for (int k = 1; k <= npieces; k++)
+  {
+    double f = (double) k / npieces;
+    bool ov = body_meets_at(ref, pose1, pose2, f, target, excl);
+    if (ov == prev)
+      continue;
+    double change = rotating_change_ratio(ref, pose1, pose2,
+      (double) (k - 1) / npieces, f, prev, target, excl);
+    if (ov)
+      run_start = change;
+    else
+    {
+      if (*nspans + 1 > *spancap)
+      {
+        *spancap = (*nspans + 1) * 2 + 8;
+        *spans = repalloc(*spans, (size_t) *spancap * sizeof(Span));
+      }
+      TimestampTz lo = t1 +
+        (TimestampTz) llround(run_start * (double) (t2 - t1));
+      TimestampTz hi = t1 + (TimestampTz) llround(change * (double) (t2 - t1));
+      span_set(TimestampTzGetDatum(lo), TimestampTzGetDatum(hi), true, true,
+        T_TIMESTAMPTZ, T_TSTZSPAN, &(*spans)[*nspans]);
+      (*nspans)++;
+    }
+    prev = ov;
+  }
+  if (prev)
+  {
+    if (*nspans + 1 > *spancap)
+    {
+      *spancap = (*nspans + 1) * 2 + 8;
+      *spans = repalloc(*spans, (size_t) *spancap * sizeof(Span));
+    }
+    TimestampTz lo = t1 + (TimestampTz) llround(run_start * (double) (t2 - t1));
+    span_set(TimestampTzGetDatum(lo), TimestampTzGetDatum(t2), true, true,
+      T_TIMESTAMPTZ, T_TSTZSPAN, &(*spans)[*nspans]);
+    (*nspans)++;
+  }
+  return;
+}
+
 static void
 instant_overlap_span(const GSERIALIZED *ref, const Pose *pose, TimestampTz t,
   const GSERIALIZED *target, const STBox *excl, Span **spans, int *nspans,
@@ -444,17 +563,14 @@ trgeo_overlap_spanset(const Temporal *temp, const GSERIALIZED *gs,
         const TInstant *inst2 = TSEQUENCE_INST_N(seq, i + 1);
         const Pose *pose1 = DatumGetPoseP(tinstant_value_p(inst1));
         const Pose *pose2 = DatumGetPoseP(tinstant_value_p(inst2));
-        /* Pure-translation guard: any rotation is honestly not implemented. */
+        /* A rotating segment carries its vertices along arcs, which the
+         * swept-edge clip of the translating path does not solve, so it is
+         * read in pieces short enough to hold one answer each */
         if (fabs(pose2->data[2] - pose1->data[2]) > MEOS_GEOM_TOLERANCE)
         {
-          pfree(spans);
-          if (temp->subtype == TSEQUENCESET)
-            pfree(seqs);
-          *err = true;
-          meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
-            "Exact spatial restriction of a temporal rigid geometry with a "
-            "rotating segment is not implemented");
-          return NULL;
+          segment_overlap_spans_rotating(ref, pose1, pose2, inst1->t,
+            inst2->t, gs, excl, &spans, &nspans, &spancap);
+          continue;
         }
         if (! segment_overlap_spans(ref, pose1, pose2, inst1->t, inst2->t,
             gs, lwgs, excl, &spans, &nspans, &spancap))

--- a/mobilitydb/test/rgeo/expected/158_trgeo_tile.test.out
+++ b/mobilitydb/test/rgeo/expected/158_trgeo_tile.test.out
@@ -67,3 +67,20 @@ FROM unnest(spaceBoxes(
  -2.828427 | 14.828427 | -2.828427 | 2.828427
 (1 row)
 
+SELECT array_length(spaceBoxes(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  2.0), 1);
+ array_length 
+--------------
+           14
+(1 row)
+
+SELECT round(min(xMin(b))::numeric, 6), round(max(xMax(b))::numeric, 6)
+FROM unnest(spaceBoxes(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  2.0)) b;
+   round   |  round   
+-----------+----------
+ -3.006659 | 3.006659
+(1 row)
+

--- a/mobilitydb/test/rgeo/expected/167_trgeo_restrict_exact.test.out
+++ b/mobilitydb/test/rgeo/expected/167_trgeo_restrict_exact.test.out
@@ -125,18 +125,30 @@ WHERE ST_Intersects(
              0
 (1 row)
 
-SELECT atGeometry(
+SELECT asText(atGeometry(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 1.5)@2001-01-05]',
-  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))');
-ERROR:  Exact spatial restriction of a temporal rigid geometry with a rotating segment is not implemented
-SELECT minusGeometry(
+  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'), 6);
+                                                                          astext                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{[Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST, Pose(POINT(3.997426 0),1.499035)@Thu Jan 04 23:56:17.627962 2001 PST]}
+(1 row)
+
+SELECT asText(minusGeometry(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 1.5)@2001-01-05]',
-  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))');
-ERROR:  Exact spatial restriction of a temporal rigid geometry with a rotating segment is not implemented
-SELECT atStbox(
+  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'), 6);
+                                                                           astext                                                                           
+------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{(Pose(POINT(3.997426 0),1.499035)@Thu Jan 04 23:56:17.627962 2001 PST, Pose(POINT(4 0),1.5)@Fri Jan 05 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(atStbox(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 1.5)@2001-01-05]',
-  stbox 'STBOX X((1, -1), (3, 1))');
-ERROR:  Exact spatial restriction of a temporal rigid geometry with a rotating segment is not implemented
+  stbox 'STBOX X((1, -1), (3, 1))'), 6);
+                                                                          astext                                                                          
+----------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{[Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST, Pose(POINT(3.997426 0),1.499035)@Thu Jan 04 23:56:17.627962 2001 PST]}
+(1 row)
+
 SELECT atGeometry(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 0.0)@2001-01-05]',
   geometry 'Polygon((0 -2,6 -2,6 2,0 2,0 -2),(2 -1,4 -1,4 1,2 1,2 -1))');
@@ -215,5 +227,29 @@ SELECT asText(minusStbox(
                                       astext                                      
 ----------------------------------------------------------------------------------
  POLYGON((0 0,1 0,1 1,0 1,0 0));{Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST}
+(1 row)
+
+SELECT asText(atGeometry(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  geometry 'Polygon((-0.4 2,0.4 2,0.4 2.6,-0.4 2.6,-0.4 2))')) IS NOT NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT atGeometry(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))') IS NULL;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT asText(atGeometry(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 6),1.5707963)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))')) IS NOT NULL;
+ ?column? 
+----------
+ t
 (1 row)
 

--- a/mobilitydb/test/rgeo/queries/158_trgeo_tile.test.sql
+++ b/mobilitydb/test/rgeo/queries/158_trgeo_tile.test.sql
@@ -39,3 +39,18 @@ FROM unnest(spaceBoxes(
   2.0)) b;
 
 -------------------------------------------------------------------------------
+-- The tiles read the region the body reaches, which a body that TURNS reaches
+-- by turning. The rod below spans 6 units and turns a quarter circle, so it
+-- covers a disk of radius 3.007 about its centre whether or not it travels.
+-------------------------------------------------------------------------------
+
+SELECT array_length(spaceBoxes(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  2.0), 1);
+
+SELECT round(min(xMin(b))::numeric, 6), round(max(xMax(b))::numeric, 6)
+FROM unnest(spaceBoxes(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  2.0)) b;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/queries/167_trgeo_restrict_exact.test.sql
+++ b/mobilitydb/test/rgeo/queries/167_trgeo_restrict_exact.test.sql
@@ -174,17 +174,17 @@ WHERE ST_Intersects(
 -- exactly, so it raises an error instead of silently reducing to the centre.
 -------------------------------------------------------------------------------
 
-SELECT atGeometry(
+SELECT asText(atGeometry(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 1.5)@2001-01-05]',
-  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))');
+  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'), 6);
 
-SELECT minusGeometry(
+SELECT asText(minusGeometry(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 1.5)@2001-01-05]',
-  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))');
+  geometry 'Polygon((1 -1,3 -1,3 1,1 1,1 -1))'), 6);
 
-SELECT atStbox(
+SELECT asText(atStbox(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(4 0), 1.5)@2001-01-05]',
-  stbox 'STBOX X((1, -1), (3, 1))');
+  stbox 'STBOX X((1, -1), (3, 1))'), 6);
 
 -------------------------------------------------------------------------------
 -- Honest NOT_IMPLEMENTED: the M1 clip ignores polygon holes, so a target
@@ -252,5 +252,25 @@ SELECT asText(atStbox(
 SELECT asText(minusStbox(
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{Pose(Point(0 0), 0.0)@2001-01-01}',
   stbox 'STBOX X((-2, 0), (0, 2))', false));
+
+-------------------------------------------------------------------------------
+-- A body that turns carries its vertices along arcs, which the swept-edge
+-- clip of a translating segment does not solve, so a rotating segment is read
+-- in pieces short enough to hold one answer each. The rod below reaches
+-- x in [-3.007, 3.007] as it turns, so it meets a target within that reach
+-- and never meets one outside it.
+-------------------------------------------------------------------------------
+
+SELECT asText(atGeometry(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  geometry 'Polygon((-0.4 2,0.4 2,0.4 2.6,-0.4 2.6,-0.4 2))')) IS NOT NULL;
+
+SELECT atGeometry(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 0),1.5707963)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))') IS NULL;
+
+SELECT asText(atGeometry(
+  trgeometry 'Polygon((-3 -0.2,3 -0.2,3 0.2,-3 0.2,-3 -0.2));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(0 6),1.5707963)@2001-01-02]',
+  geometry 'Polygon((-0.5 4,0.5 4,0.5 5,-0.5 5,-0.5 4))')) IS NOT NULL;
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The times a rigid geometry meets a geometry are computed one inter-instant segment at a time, and a segment along which the body only translates is answered exactly: the times an edge of the body touches the boundary of the target are the endpoints of the intervals a swept-edge clip returns, the overlap holds or fails throughout each interval those events delimit, and one reading at the middle of each classifies it.

A vertex of a rotating body travels an arc rather than a segment, so that clip has nothing to say about it, and a segment carrying any rotation answers `MEOS_ERR_FEATURE_NOT_SUPPORTED`. A rigid body that turns is the ordinary case rather than an exotic one, and the refusal reaches everything built on the restriction: `atGeometry`, `minusGeometry`, `atStbox` and `minusStbox` all decline such a value, and the spatial tiles of a rotating rigid geometry answer no box at all.

A rotating segment is read instead in pieces, each carrying at most the turn by which the traversed area bounds its own pieces. The overlap is asked at the ends of every piece, and where two consecutive readings differ, the ratio at which the answer changes is found by halving that piece. What the halving reads is the overlap itself, so the ratio it returns is the one at which the predicate changes, carried to the resolution of the halving rather than solved in closed form as the translating path solves its events.

Against a placement oracle that samples a segment 2001 times, places the body at each sample and asks GEOS of it, the times the restriction answers and the times the body overlaps agree to the sample: 377 of 2001 for a rod that turns into reach, 947 for one that turns while it travels, and none for a rod whose reach falls short, where each of those answers nothing at all beforehand. The translating readings stand where they are: a square carried through a band answers 1333 of 2001 either way, and a square stopping short answers none.

The tiles follow the restriction, so they follow too. A rod turning in place answers 14 boxes reaching `x` in `[-3.006659, 3.006659]`, which is the circumradius `sqrt(3^2 + 0.2^2)` its turn sweeps and the extent the bounding box of the value carries; one turning while travelling answers 22; a rod that only translates answers the same 16 as ever.

Three readings join `167_trgeo_restrict_exact` and two join `158_trgeo_tile`. Three cases already standing in `167` record the refusal itself, and each now records the answer: the value they hold overlaps its target over 1999 of 2001 samples, which is what the restriction answers for it.
