### PR TITLE
Name an argument in a signature as its SQL declaration names it

### DIFF
--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -980,7 +980,7 @@ SELECT text 'XX' || textset '{aaa, bbb}';
 				<indexterm significance="normal"><primary><varname>tprecision</varname></primary></indexterm>
 				<para>Establece la precisión temporal del valor de tiempo al rango con respecto al origen</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tprecision(times,interval,origin timestamptz='2000-01-03') → times
+tprecision(times,duration interval,origin timestamptz='2000-01-03') → times
 </programlisting>
 				<para>Si el origen no se especifica, su valor se establece por defecto en lunes 3 de enero de 2000.</para>
 				<programlisting language="sql" xml:space="preserve">

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -88,8 +88,8 @@ SELECT jsonbsetObjectField(textset '{[{"unit": "km", "speed": 10}, {"unit": "km"
 				<para>Extrae un campo de objeto JSON especificado por una ruta</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {textset,jsonbset} #> text[] → {textset,jsonbset}
-jsonbsetExtractPath(jsonbset,text[],null_handle text='use_json_null') → jsonbset
-jsonbsetExtractPathText(jsonbset,text[],null_handle text='use_json_null') → textset
+jsonbsetExtractPath(jsonbset,path text[],null_handle text='use_json_null') → jsonbset
+jsonbsetExtractPathText(jsonbset,path text[],null_handle text='use_json_null') → textset
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT textset '[{"speed": {"unit": "km", "value": 10}},
@@ -223,8 +223,8 @@ SELECT jsonbset '{"{\"speed\": 10}",
 				<indexterm significance="normal"><primary><varname>jsonbsetSetLax</varname></primary></indexterm>
 				<para>Asignación JSONB temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-jsonbsetSet(jsonbset,path text[],jsonb,create boolean=true) → jsonbset
-jsonbsetSetLax(jsonbset,path text[],jsonb,create boolean=true,
+jsonbsetSet(jsonbset,path text[],val jsonb,create boolean=true) → jsonbset
+jsonbsetSetLax(jsonbset,path text[],val jsonb,create boolean=true,
   handle_null text) → jsonbset
 </programlisting>
 				<para>Devuelve el valor <varname>jsonbset</varname> con el elemento especificado por la ruta reemplazado por <varname>jsonb</varname>, o añadido si <varname>create</varname> es verdadero y el elemento no existe. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, y create_if_missing es verdadero, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo. La función <varname>jsonbsetSetLax</varname> se comporta de forma idéntica a <varname>jsonbsetSet</varname> si el valor dado no es NULL; de lo contrario, se comporta según el valor de <varname>handle_null</varname>, que debe ser uno de <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname> o <varname>'return_source'</varname>. Como se indicó anteriormente, mantuvimos el comportamiento de PostgreSQL para esta función habilitando el valor <varname>'return_source'</varname>, mientras que para todas las demás operaciones de <emphasis>consulta</emphasis>, este valor se ha reemplazado por <varname>'return_null'</varname>.</para>
@@ -248,7 +248,7 @@ SELECT jsonbsetSetLax(jsonbset '[{"speed": 10, "units": "km/h"}, {"speed": 20}]'
 				<indexterm significance="normal"><primary><varname>jsonbsetInsert</varname></primary></indexterm>
 				<para>Inserción JSONB temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-jsonbsetInsert(jsonbset,path text[],jsonb,after boolean=false) → jsonbset
+jsonbsetInsert(jsonbset,path text[],val jsonb,after boolean=false) → jsonbset
 </programlisting>
 				<para>Devuelve el valor <varname>jsonbset</varname> con <varname>jsonb</varname> insertado. Si el elemento especificado por la ruta es un elemento de arreglo, el nuevo valor se insertará antes de ese elemento si <varname>after</varname> es falso, o después en caso contrario. Si el elemento especificado por la ruta es un campo de objeto, el nuevo valor se insertará solo si el objeto no contiene ya esa clave. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -840,9 +840,9 @@ SELECT tjsonObjectField(ttext '{[{"unit": "km", "speed": 10}@2001-01-01,
 				<para>Extrae un campo de objeto JSON temporal especificado por una ruta</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {ttext,tjsonb} #> text[] → {ttext,tjsonb}
-tjsonExtractPath(ttext,text[],null_handle text='use_json_null') → ttext
-tjsonbExtractPath(tjsonb,text[],null_handle text='use_json_null') → tjsonb
-tjsonbExtractPathText(tjsonb,text[],null_handle text='use_json_null') → ttext
+tjsonExtractPath(ttext,path text[],null_handle text='use_json_null') → ttext
+tjsonbExtractPath(tjsonb,path text[],null_handle text='use_json_null') → tjsonb
+tjsonbExtractPathText(tjsonb,path text[],null_handle text='use_json_null') → ttext
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '[{"speed": {"unit": "km", "value": 10}}@2001-01-01,
@@ -1007,8 +1007,8 @@ SELECT jsonb '{"geom": "Point(1 1)"}' &lt;@ tjsonb '{[{"geom": "Point(1 1)"}@200
 				<indexterm significance="normal"><primary><varname>tjsonbSetLax</varname></primary></indexterm>
 				<para>Asignación JSONB temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tjsonbSet(tjsonb,path text[],jsonb,create boolean=true) → tjsonb
-tjsonbSetLax(tjsonb,path text[],jsonb,create boolean=true,handle_null text) → tjsonb
+tjsonbSet(tjsonb,path text[],val jsonb,create boolean=true) → tjsonb
+tjsonbSetLax(tjsonb,path text[],val jsonb,create boolean=true,handle_null text) → tjsonb
 </programlisting>
 				<para>Devuelve el valor <varname>tjsonb</varname> con el elemento especificado por la ruta reemplazado por <varname>jsonb</varname>, o añadido si <varname>create</varname> es verdadero y el elemento no existe. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, y create_if_missing es verdadero, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo. La función <varname>tjsonbSetLax</varname> se comporta de forma idéntica a <varname>tjsonbSet</varname> si el valor dado no es NULL; de lo contrario, se comporta según el valor de <varname>handle_null</varname>, que debe ser uno de <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname> o <varname>'return_source'</varname>. Como se indicó anteriormente, mantuvimos el comportamiento de PostgreSQL para esta función habilitando el valor <varname>'return_source'</varname>, mientras que para todas las demás operaciones de <emphasis>consulta</emphasis>, este valor se ha reemplazado por <varname>'return_null'</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1031,7 +1031,7 @@ SELECT tjsonbSetLax(tjsonb '[{"speed": 10, "units": "km/h"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tjsonbInsert</varname></primary></indexterm>
 				<para>Inserción JSONB temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tjsonbInsert(tjsonb,path text[],jsonb,after boolean=false) → tjsonb
+tjsonbInsert(tjsonb,path text[],val jsonb,after boolean=false) → tjsonb
 </programlisting>
 				<para>Devuelve el valor <varname>tjsonb</varname> con <varname>jsonb</varname> insertado. Si el elemento especificado por la ruta es un elemento de arreglo, el nuevo valor se insertará antes de ese elemento si <varname>after</varname> es falso, o después en caso contrario. Si el elemento especificado por la ruta es un campo de objeto, el nuevo valor se insertará solo si el objeto no contiene ya esa clave. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -542,7 +542,7 @@ SELECT tgeompoint '[POINT(23.057077727326 28.7666335767956)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tnpointFromMFJSON</varname></primary></indexterm>
 				<para>Genera un punto de red temporal como MF-JSON y lo lee de vuelta; el ciclo de ida y vuelta es sin pérdida</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asMFJSON(tnpoint,integer,integer,integer) → text
+asMFJSON(tnpoint,options integer,flags integer,maxdecimaldigits integer) → text
 tnpointFromMFJSON(text) → tnpoint
 </programlisting>
 				<para>La salida toma los argumentos de opciones, banderas y dígitos decimales compartidos con los demás tipos temporales.</para>

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -32,7 +32,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
 				<para>Muestrea una banda de ráster en cada instante de una trayectoria</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterValue(tgeompoint,raster,band integer=1) → tfloat
+rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
 </programlisting>
 				<para>Evalúa el píxel de la <varname>band</varname> en cada instante de <varname>traj</varname> usando muestreo bilineal-vecino más próximo (<varname>ST_Value</varname> con <varname>resample=false</varname>). Devuelve un <varname>tfloat</varname> de conjunto de instantes cuyos valores se redondean a cuatro decimales. Devuelve <varname>NULL</varname> cuando ningún instante se interseca con el ráster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -104,7 +104,7 @@ SELECT rasterTileValueQuadbin(traj, band_data, width, height, quadbin, 'float32'
 				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
 				<para>Devuelve las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-quadbins(tgeompoint,integer) → bigint[]
+quadbins(tgeompoint,zoom integer) → bigint[]
 </programlisting>
 				<para>Devuelve el conjunto de celdas QUADBIN únicas (deduplicadas) cuyas envolventes de tesela Web-Mercator contienen al menos un instante de <varname>traj</varname>. El resultado es adecuado como clave de unión en la cláusula WHERE contra una tabla Raquet. El parámetro <varname>zoom</varname> debe estar en [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -122,8 +122,8 @@ SELECT array_length(quadbins(trip, 8),
 				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
 				<para>Muestrea un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,
-  boolean) → tfloat
+rasterTileValueQuadbin(tgeompoint,pixels bytea,width integer,height integer,
+  quadbin bigint,pixtype text,nodata float8,has_nodata boolean) → tfloat
 </programlisting>
 				<para>Evalúa un arreglo de píxeles de banda única en orden de fila mayor en cada instante de <varname>traj</varname> (SRID 4326). La georreferenciación de la tesela (rectángulo delimitador, mapeo de píxel a coordenadas) se deriva únicamente de <varname>quadbin</varname> mediante la transformada de tesela deslizante Web-Mercator. El argumento <varname>pixtype</varname> debe ser uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Cuando <varname>has_nodata</varname> es verdadero, los instantes cuyo píxel equivale a <varname>nodata</varname> se descartan silenciosamente. Devuelve <varname>NULL</varname> cuando ningún instante sobrevive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -142,7 +142,8 @@ JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construye una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquet(bytea,integer,integer,bigint,text,float8) → raquet
+raquet(bytea,width integer,height integer,quadbin bigint,pixtype text,
+  nodata float8) → raquet
 </programlisting>
 				<para>Empaqueta un arreglo de píxeles <varname>pixels</varname> de banda única en orden de fila mayor de <varname>width</varname> × <varname>height</varname> píxeles de tipo <varname>pixtype</varname> (uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>), georreferenciado por la celda <varname>quadbin</varname>, en un único valor <varname>raquet</varname> autodescriptivo. El argumento <varname>nodata</varname> es opcional; cuando se omite (<varname>NULL</varname>) la tesela no lleva valor centinela de nodata. Se genera un error cuando el arreglo <varname>pixels</varname> es menor que <varname>width</varname> × <varname>height</varname> × el tamaño del píxel. Los píxeles de más de un byte son little-endian, que es el orden de bytes que les da la especificación RaQuet sea cual sea el orden de bytes del servidor, de modo que una tesela conserva sus valores cuando se lee en otra máquina. Un <varname>raquet</varname> es un valor de longitud variable, libre de GDAL, con una representación portátil en texto Hex-WKB y binaria, distinto de y coexistente con el tipo <varname>raster</varname> de PostGIS usado por <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -158,7 +159,7 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 				<indexterm significance="normal"><primary><varname>raquetRead</varname></primary></indexterm>
 				<para>Decodifica un archivo ráster en memoria en una tesela ráster Raquet mediante GDAL</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetRead(bytea,bigint) → raquet
+raquetRead(bytea,quadbin bigint) → raquet
 </programlisting>
 				<para>Lee los bytes de <varname>rasterfile</varname>, un ráster en cualquier formato compatible con GDAL (GeoTIFF, PNG, …), a través del sistema de archivos virtual <varname>/vsimem/</varname> de GDAL, y empaqueta su primera banda, en orden de fila mayor, en un único valor <varname>raquet</varname> autodescriptivo georreferenciado por la celda <varname>quadbin</varname>. El tipo de datos de la banda debe ser uno de <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname> o <varname>Float64</varname>; el valor de nodata de la banda, cuando está definido, se traslada a la tesela. Como el archivo se suministra como bytes, no se requiere acceso a archivos del lado del servidor. GDAL realiza la decodificación, por lo que el controlador de formato del ráster debe estar permitido por la configuración <varname>postgis.gdal_enabled_drivers</varname> de PostGIS (que deshabilita todos los controladores de forma predeterminada); habilítelo con, por ejemplo, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. Esta es la contraparte de ingesta del constructor <link linkend="raquet"><varname>raquet</varname></link>, que construye una tesela a partir de bytes de píxeles ya decodificados. Cuando se omite <varname>quadbin</varname> o es <varname>NULL</varname>, el identificador de la tesela se deriva de la georreferenciación del ráster: el ráster debe llevar una referencia espacial <varname>EPSG:3857</varname> (Web-Mercator) y una geotransformación alineada con los ejes que describa una única tesela QUADBIN. Un ráster sin referencia espacial, uno que no esté en <varname>EPSG:3857</varname>, o una geotransformación rotada o no alineada con la cuadrícula de teselas provoca un error en lugar de ser forzado.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -173,7 +174,7 @@ SELECT raquetRead(file_bytes) AS tile FROM elevation_files;
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValue(tgeompoint,raquet) → tfloat
+rasterTileValue(tgeompoint,rast raquet) → tfloat
 </programlisting>
 				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -187,7 +188,7 @@ JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrea un arreglo de teselas ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValue(tgeompoint,raquet[]) → tfloat
+rasterTileValue(tgeompoint,rast raquet[]) → tfloat
 </programlisting>
 				<para>Evalúa cada tesela de <varname>rast</varname> en cada instante de <varname>traj</varname> (SRID 4326) y devuelve los valores de píxel muestreados como un único <varname>tfloat</varname>. Una trayectoria que sale de una tesela queda cubierta por varias, y cada una aporta los instantes que caen dentro de ella. Las teselas de un mismo nivel de zoom particionan el plano, de modo que aportan instantes disjuntos. Las teselas de niveles de zoom distintos se solapan, y cuando dos de ellas muestrean el mismo instante se conserva el valor de la tesela de mayor zoom, que es la que tiene la resolución más fina. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de una tesela o sobrevive al filtrado de nodata.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -407,7 +408,7 @@ SELECT DISTINCT tile FROM elevation_tiles;
 				<indexterm significance="normal"><primary><varname>atRasterValue</varname></primary></indexterm>
 				<para>Devuelve los instantes de una trayectoria donde el valor ráster muestreado cae dentro de un rango de flotante</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-atRasterValue(tgeompoint,raster,floatspan,band integer=1) → tgeompoint
+atRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → tgeompoint
 </programlisting>
 				<para>Evalúa <varname>rasterValue</varname> en cada instante de <varname>traj</varname> y devuelve la sub-trayectoria restringida a los tiempos en que el valor del píxel está dentro de <varname>vspan</varname>. Devuelve <varname>NULL</varname> cuando ningún instante satisface la condición.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -427,7 +428,7 @@ SELECT asText(atRasterValue(tgeompoint 'SRID=4326;
 				<indexterm significance="normal"><primary><varname>minusRasterValue</varname></primary></indexterm>
 				<para>Devuelve los instantes de una trayectoria donde el valor ráster muestreado cae fuera de un rango de flotante</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-minusRasterValue(tgeompoint,raster,floatspan,band integer=1) → tgeompoint
+minusRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → tgeompoint
 </programlisting>
 				<para>El complemento de <varname>atRasterValue</varname>: devuelve la sub-trayectoria restringida a los tiempos en que el valor del píxel está fuera de <varname>vspan</varname>. Devuelve <varname>NULL</varname> cuando todos los instantes satisfacen la condición.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -441,7 +442,7 @@ SELECT asText(minusRasterValue(traj, elev_raster, floatspan '[40, 9999]')) FROM 
 				<indexterm significance="normal"><primary><varname>eRasterValue</varname></primary></indexterm>
 				<para>Devuelve verdadero si la trayectoria alguna vez muestrea un valor de píxel ráster dentro de un rango de flotante</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-eRasterValue(tgeompoint,raster,floatspan,band integer=1) → boolean
+eRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
 </programlisting>
 				<para>Devuelve <varname>true</varname> cuando al menos un instante dentro de la extensión de <varname>traj</varname> muestrea un valor de píxel dentro de <varname>vspan</varname>, <varname>false</varname> en caso contrario. Devuelve <varname>NULL</varname> únicamente cuando la entrada es <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -455,7 +456,7 @@ SELECT tripid FROM trips,
 				<indexterm significance="normal"><primary><varname>aRasterValue</varname></primary></indexterm>
 				<para>Devuelve verdadero si cada instante de la trayectoria dentro de la extensión del ráster muestrea un valor de píxel dentro de un rango de flotante</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-aRasterValue(tgeompoint,raster,floatspan,band integer=1) → boolean
+aRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
 </programlisting>
 				<para>Devuelve <varname>true</varname> cuando cada instante dentro de la extensión de <varname>traj</varname> muestrea un valor de píxel dentro de <varname>vspan</varname>, <varname>false</varname> cuando al menos uno no lo hace. Devuelve <varname>NULL</varname> únicamente cuando la entrada es <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -971,7 +971,7 @@ SELECT text 'XX' || textset '{aaa, bbb}';
 				<indexterm significance="normal"><primary><varname>tprecision</varname></primary></indexterm>
 				<para>Set the temporal precision of the time value to the interval with respect to the origin</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tprecision(times,interval,origin timestamptz='2000-01-03') → times
+tprecision(times,duration interval,origin timestamptz='2000-01-03') → times
 </programlisting>
 				<para>If the origin is not specified, it is set by default to Monday, January 3, 2000</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -88,8 +88,8 @@ SELECT jsonbsetObjectField(textset '{[{"unit": "km", "speed": 10}, {"unit": "km"
 				<para>Extract a JSON object field specified by a path</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {textset,jsonbset} #> text[] → {textset,jsonbset}
-jsonbsetExtractPath(jsonbset,text[],null_handle text='use_json_null') → jsonbset
-jsonbsetExtractPathText(jsonbset,text[],null_handle text='use_json_null') → textset
+jsonbsetExtractPath(jsonbset,path text[],null_handle text='use_json_null') → jsonbset
+jsonbsetExtractPathText(jsonbset,path text[],null_handle text='use_json_null') → textset
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT textset '[{"speed": {"unit": "km", "value": 10}},
@@ -223,8 +223,8 @@ SELECT jsonbset '{"{\"speed\": 10}",
 				<indexterm significance="normal"><primary><varname>jsonbsetSetLax</varname></primary></indexterm>
 				<para>Temporal JSONB set</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-jsonbsetSet(jsonbset,path text[],jsonb,create boolean=true) → jsonbset
-jsonbsetSetLax(jsonbset,path text[],jsonb,create boolean=true,
+jsonbsetSet(jsonbset,path text[],val jsonb,create boolean=true) → jsonbset
+jsonbsetSetLax(jsonbset,path text[],val jsonb,create boolean=true,
   handle_null text) → jsonbset
 </programlisting>
 				<para>Return the <varname>jsonbset</varname> value with the item specified by path replaced by <varname>jsonb</varname>, or added if <varname>create</varname> is true and the item does not exist. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, and create_if_missing is true, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive. Function <varname>jsonbsetSetLax</varname> behaves identically to <varname>jsonbsetSet</varname> if the given value is not NULL, Otherwise, it behaves according to the value of <varname>handle_null</varname>, which must be one of <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname>, or <varname>'return_source'</varname>. As stated above, we kept PostgreSQL behavior for this function enabling the value <varname>'return_source'</varname> whereas for all other <emphasis>query</emphasis> operations, this value has been replaced with <varname>'return_null'</varname>.</para>
@@ -248,7 +248,7 @@ SELECT jsonbsetSetLax(jsonbset '[{"speed": 10, "units": "km/h"}, {"speed": 20}]'
 				<indexterm significance="normal"><primary><varname>jsonbsetInsert</varname></primary></indexterm>
 				<para>Return the <varname>jsonbset</varname> value with <varname>jsonb</varname> inserted</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-jsonbsetInsert(jsonbset,path text[],jsonb,after boolean=false) → jsonbset
+jsonbsetInsert(jsonbset,path text[],val jsonb,after boolean=false) → jsonbset
 </programlisting>
 				<para>If the item specified by the path is an array element, the new value will be inserted before that item if <varname>after</varname> is false, or after it otherwise. If the item specified by the path is an object field, the new value will be inserted only if the object does not already contain that key. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -840,9 +840,9 @@ SELECT tjsonObjectField(ttext '{[{"unit": "km", "speed": 10}@2001-01-01,
 				<para>Extract a temporal JSON object field specified by a path</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {ttext,tjsonb} #> text[] → {ttext,tjsonb}
-tjsonExtractPath(ttext,text[],null_handle text='use_json_null') → ttext
-tjsonbExtractPath(tjsonb,text[],null_handle text='use_json_null') → tjsonb
-tjsonbExtractPathText(tjsonb,text[],null_handle text='use_json_null') → ttext
+tjsonExtractPath(ttext,path text[],null_handle text='use_json_null') → ttext
+tjsonbExtractPath(tjsonb,path text[],null_handle text='use_json_null') → tjsonb
+tjsonbExtractPathText(tjsonb,path text[],null_handle text='use_json_null') → ttext
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '[{"speed": {"unit": "km", "value": 10}}@2001-01-01,
@@ -1007,8 +1007,8 @@ SELECT jsonb '{"geom": "Point(1 1)"}' &lt;@ tjsonb '{[{"geom": "Point(1 1)"}@200
 				<indexterm significance="normal"><primary><varname>tjsonbSetLax</varname></primary></indexterm>
 				<para>Temporal JSONB set</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tjsonbSet(tjsonb,path text[],jsonb,create boolean=true) → tjsonb
-tjsonbSetLax(tjsonb,path text[],jsonb,create boolean=true,handle_null text) → tjsonb
+tjsonbSet(tjsonb,path text[],val jsonb,create boolean=true) → tjsonb
+tjsonbSetLax(tjsonb,path text[],val jsonb,create boolean=true,handle_null text) → tjsonb
 </programlisting>
 				<para>Return the <varname>tjsonb</varname> value with the item specified by path replaced by <varname>jsonb</varname>, or added if <varname>create</varname> is true and the item does not exist. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, and create_if_missing is true, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive. Function <varname>tjsonbSetLax</varname> behaves identically to <varname>tjsonbSet</varname> if the given value is not NULL, Otherwise, it behaves according to the value of <varname>handle_null</varname>, which must be one of <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname>, or <varname>'return_source'</varname>. As stated above, we kept PostgreSQL behavior for this function enabling the value <varname>'return_source'</varname> whereas for all other <emphasis>query</emphasis> operations, this value has been replaced with <varname>'return_null'</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1031,7 +1031,7 @@ SELECT tjsonbSetLax(tjsonb '[{"speed": 10, "units": "km/h"}@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tjsonbInsert</varname></primary></indexterm>
 				<para>Temporal JSONB insert</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tjsonbInsert(tjsonb,path text[],jsonb,after boolean=false) → tjsonb
+tjsonbInsert(tjsonb,path text[],val jsonb,after boolean=false) → tjsonb
 </programlisting>
 				<para>Return the <varname>tjsonb</varname> value with <varname>jsonb</varname> inserted. If the item specified by the path is an array element, the new value will be inserted before that item if <varname>after</varname> is false, or after it otherwise. If the item specified by the path is an object field, the new value will be inserted only if the object does not already contain that key. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -543,7 +543,7 @@ SELECT tgeompoint '[POINT(23.057077727326 28.7666335767956)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>tnpointFromMFJSON</varname></primary></indexterm>
 				<para>Output a temporal network point as MF-JSON and read it back; the round trip is lossless</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asMFJSON(tnpoint,integer,integer,integer) → text
+asMFJSON(tnpoint,options integer,flags integer,maxdecimaldigits integer) → text
 tnpointFromMFJSON(text) → tnpoint
 </programlisting>
 				<para>The output takes the options, flags, and decimal-digits arguments shared with the other temporal types.</para>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -32,7 +32,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
 				<para>Sample a raster band at each instant of a trajectory</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterValue(tgeompoint,raster,band integer=1) → tfloat
+rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
 </programlisting>
 				<para>Evaluates pixel <varname>band</varname> at every instant of <varname>traj</varname> using bilinear-nearest sampling (<varname>ST_Value</varname> with <varname>resample=false</varname>). Returns an instant-set <varname>tfloat</varname> whose values are rounded to four decimal places. Returns <varname>NULL</varname> when no instant intersects the raster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -105,7 +105,7 @@ SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'float32
 				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
 				<para>Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-quadbins(tgeompoint,integer) → bigint[]
+quadbins(tgeompoint,zoom integer) → bigint[]
 </programlisting>
 				<para>Returns the set of unique QUADBIN cells (deduplicated) whose Web-Mercator tile envelopes contain at least one instant of <varname>traj</varname>. The result is suitable as a WHERE-clause join key against a Raquet table. <varname>zoom</varname> must be in [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -123,8 +123,8 @@ SELECT array_length(quadbins(trip, 8),
 				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
 				<para>Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValueQuadbin(tgeompoint,bytea,integer,integer,bigint,text,float8,
-  boolean) → tfloat
+rasterTileValueQuadbin(tgeompoint,pixels bytea,width integer,height integer,
+  quadbin bigint,pixtype text,nodata float8,has_nodata boolean) → tfloat
 </programlisting>
 				<para>Evaluates a row-major single-band pixel array at each instant of <varname>traj</varname> (SRID 4326). The tile georeferencing (bounding box, pixel-to-coordinate mapping) is derived from <varname>quadbin</varname> alone via the Web-Mercator slippy-tile transform. The <varname>pixtype</varname> argument must be one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. When <varname>has_nodata</varname> is true, instants whose pixel equals <varname>nodata</varname> are silently dropped. Returns <varname>NULL</varname> when no instant survives.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -143,7 +143,8 @@ JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquet(bytea,integer,integer,bigint,text,float8) → raquet
+raquet(bytea,width integer,height integer,quadbin bigint,pixtype text,
+  nodata float8) → raquet
 </programlisting>
 				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. Pixels of more than one byte are little-endian, which is the byte order the RaQuet specification gives them whatever the byte order of the server, so that a tile keeps its values when it is read on another machine. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -159,7 +160,7 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 				<indexterm significance="normal"><primary><varname>raquetRead</varname></primary></indexterm>
 				<para>Decode an in-memory raster file into a Raquet raster tile via GDAL</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetRead(bytea,bigint) → raquet
+raquetRead(bytea,quadbin bigint) → raquet
 </programlisting>
 				<para>Reads the bytes of <varname>rasterfile</varname>, a raster in any format GDAL supports (GeoTIFF, PNG, …), through GDAL's <varname>/vsimem/</varname> virtual filesystem, and packs its first band, row-major, into a single self-describing <varname>raquet</varname> value georeferenced by the <varname>quadbin</varname> cell. The band data type must be one of <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname>, or <varname>Float64</varname>; the band nodata value, when set, is carried into the tile. Because the file is supplied as bytes, no server-side file access is required. GDAL performs the decode, so the raster's format driver must be permitted by PostGIS's <varname>postgis.gdal_enabled_drivers</varname> setting (which disables all drivers by default); enable it with, for example, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. This is the ingest counterpart of the <link linkend="raquet"><varname>raquet</varname></link> constructor, which builds a tile from already-decoded pixel bytes. When <varname>quadbin</varname> is omitted or <varname>NULL</varname>, the tile identifier is derived from the raster's georeferencing: the raster must carry an <varname>EPSG:3857</varname> (Web-Mercator) spatial reference and an axis-aligned geotransform describing a single QUADBIN tile. A raster with no spatial reference, one that is not in <varname>EPSG:3857</varname>, or a geotransform that is rotated or not aligned to the tile grid raises an error rather than being coerced.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -174,7 +175,7 @@ SELECT raquetRead(file_bytes) AS tile FROM elevation_files;
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValue(tgeompoint,raquet) → tfloat
+rasterTileValue(tgeompoint,rast raquet) → tfloat
 </programlisting>
 				<para>Evaluates the tile at each instant of <varname>traj</varname> (SRID 4326), returning the sampled pixel values as a <varname>tfloat</varname>. This is the typed equivalent of <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: the dimensions, QUADBIN cell, pixel type and nodata handling are taken from the <varname>raquet</varname> value instead of from separate arguments. Returns <varname>NULL</varname> when no instant falls inside the tile or survives nodata filtering.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -188,7 +189,7 @@ FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample an array of <varname>raquet</varname> raster tiles along a trajectory</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValue(tgeompoint,raquet[]) → tfloat
+rasterTileValue(tgeompoint,rast raquet[]) → tfloat
 </programlisting>
 				<para>Evaluates every tile of <varname>rast</varname> at each instant of <varname>traj</varname> (SRID 4326) and returns the sampled pixel values as a single <varname>tfloat</varname>. A trajectory that leaves one tile is covered by several of them, each contributing the instants that fall inside it. Tiles of one zoom level partition the plane, so they contribute disjoint instants. Tiles of different zoom levels overlap, and where two of them sample the same instant the value of the tile of higher zoom is kept, that being the one carrying the finer resolution. Returns <varname>NULL</varname> when no instant falls inside a tile or survives nodata filtering.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -408,7 +409,7 @@ SELECT DISTINCT tile FROM elevation_tiles;
 				<indexterm significance="normal"><primary><varname>atRasterValue</varname></primary></indexterm>
 				<para>Return the instants of a trajectory where the sampled raster value falls inside a float range</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-atRasterValue(tgeompoint,raster,floatspan,band integer=1) → tgeompoint
+atRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → tgeompoint
 </programlisting>
 				<para>Evaluates <varname>rasterValue</varname> at every instant of <varname>traj</varname> and returns the sub-trajectory restricted to the times when the pixel value lies within <varname>vspan</varname>. Returns <varname>NULL</varname> when no instant satisfies the condition.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -429,7 +430,7 @@ SELECT asText(atRasterValue(tgeompoint 'SRID=4326;
 				<indexterm significance="normal"><primary><varname>minusRasterValue</varname></primary></indexterm>
 				<para>Return the instants of a trajectory where the sampled raster value falls outside a float range</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-minusRasterValue(tgeompoint,raster,floatspan,band integer=1) → tgeompoint
+minusRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → tgeompoint
 </programlisting>
 				<para>The complement of <varname>atRasterValue</varname>: returns the sub-trajectory restricted to the times when the pixel value lies outside <varname>vspan</varname>. Returns <varname>NULL</varname> when every instant satisfies the condition.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -443,7 +444,7 @@ SELECT asText(minusRasterValue(traj, elev_raster, floatspan '[40, 9999]')) FROM 
 				<indexterm significance="normal"><primary><varname>eRasterValue</varname></primary></indexterm>
 				<para>Return true if the trajectory ever samples a raster pixel value inside a float range</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-eRasterValue(tgeompoint,raster,floatspan,band integer=1) → boolean
+eRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
 </programlisting>
 				<para>Returns <varname>true</varname> when at least one in-extent instant of <varname>traj</varname> samples a pixel value within <varname>vspan</varname>, <varname>false</varname> otherwise. Returns <varname>NULL</varname> only when the input is <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -457,7 +458,7 @@ SELECT tripid FROM trips,
 				<indexterm significance="normal"><primary><varname>aRasterValue</varname></primary></indexterm>
 				<para>Return true if every in-raster-extent instant of the trajectory samples a pixel value inside a float range</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-aRasterValue(tgeompoint,raster,floatspan,band integer=1) → boolean
+aRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
 </programlisting>
 				<para>Returns <varname>true</varname> when every in-extent instant of <varname>traj</varname> samples a pixel value within <varname>vspan</varname>, <varname>false</varname> when at least one does not. Returns <varname>NULL</varname> only when the input is <varname>NULL</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">


### PR DESCRIPTION
Every argument after the first that the `CREATE FUNCTION` behind an entry declares under a name carries that name in the syntax block, so a reader writing a named-argument call from the manual reaches the function. The raster entries take `rast`, `vspan`, `pixels`, `width`, `height`, `quadbin`, `pixtype`, `nodata`, `has_nodata` and `zoom`; the JSON entries take `path` and `val`; `asMFJSON` takes `options`, `flags` and `maxdecimaldigits`; `tprecision` takes `duration`. The leading operand stays a bare type, as the manual states it everywhere. Both manuals build at 354 and 356 pages with no wrapped line, the two languages carry the same syntax block for every entry, and the reference appendix regenerates unchanged.
