### PR TITLE
State the 3D icon where the SQL declares a third dimension

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1267,7 +1267,7 @@
 						<para><link linkend="tnumber_valueSplit"><varname>valueSplit</varname>, <varname>timeSplit</varname>, <varname>valueTimeSplit</varname></link>: Fragmenta un número temporal con respecto a intervalos de valores y/o de tiempo &SRF;</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tspatial_spaceSplit"><varname>spaceSplit</varname>, <varname>spaceTimeSplit</varname>, <varname>timeSplit</varname></link>: Fragmenta un punto temporal con respecto a una malla espacial o espacio-temporal &SRF;</para>
+						<para><link linkend="tspatial_spaceSplit"><varname>spaceSplit</varname>, <varname>spaceTimeSplit</varname>, <varname>timeSplit</varname></link>: Fragmenta un punto temporal con respecto a una malla espacial o espacio-temporal &Z_support; &SRF;</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -1003,7 +1003,8 @@ SELECT (sp).number, (sp).time,
 					<indexterm significance="normal"><primary><varname>spaceSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>spaceTimeSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
-					<para>Fragmenta un punto temporal con respecto a una malla espacial o espacio-temporal &SRF;</para>
+					<para>Fragmenta un punto temporal con respecto a una malla espacial o espacio-temporal &Z_support;
+ &SRF;</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 spaceSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
   [ysize float,zsize float,]

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1239,7 +1239,7 @@
 						<para><link linkend="stbox_spaceTimeTiles"><varname>spaceTiles</varname>, <varname>timeTiles</varname>, <varname>spaceTimeTiles</varname></link>: Return the set of tiles that covers a spatiotemporal box with tiles of the same size and/or duration &Z_support; &SRF;</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tbox_getValueTimeTile"><varname>getValueTile</varname>, <varname>getTboxTimeTile</varname>, <varname>getValueTimeTile</varname></link>: Return the temporal tile that covers a value and/or a timestamp &Z_support;</para>
+						<para><link linkend="tbox_getValueTimeTile"><varname>getValueTile</varname>, <varname>getTboxTimeTile</varname>, <varname>getValueTimeTile</varname></link>: Return the temporal tile that covers a value and/or a timestamp</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="stbox_getSpaceTimeTile"><varname>getSpaceTile</varname>, <varname>getStboxTimeTile</varname>, <varname>getSpaceTimeTile</varname></link>: Return the spatiotemporal tile that covers a point and/or a timestamp &Z_support;</para>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -759,8 +759,7 @@ SELECT spaceTimeTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 					<indexterm significance="normal"><primary><varname>getValueTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getTboxTimeTile</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>getValueTimeTile</varname></primary></indexterm>
-					<para>Return the temporal tile that covers a value and/or a timestamp &Z_support;
-</para>
+					<para>Return the temporal tile that covers a value and/or a timestamp</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 getValueTile(v float,vsize float,vorigin float=0.0) &#8594; tbox
 getTboxTimeTile(time timestamptz,duration interval,


### PR DESCRIPTION
The one-liner of an entry carries the 3D icon when a function it states accepts a z dimension. `spaceSplit` declares a `zsize` overload for tgeompoint, tgeometry and tpose, so both manuals mark it; `getValueTile`, `getTBoxTimeTile` and `getValueTimeTile` take floats and timestamps alone, so neither does. Both manuals build at 354 and 356 pages with no wrapped line, and the reference appendix carries the same icons as the chapters.
