### PR TITLE
Read the edges of a geometry once for a walk that asks about it many times

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -149,6 +149,18 @@ extern bool meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2,
   const char *pattern, bool *result);
 extern bool meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
   bool *result);
+
+/* The edges of one geometry, kept so that several relationships asked about it
+ * read them once. A relationship extracts the edges of both its operands, and
+ * for a multi-surface — whose edges are those of the union of its members —
+ * that is what the call mostly costs. A caller asking about the same geometry
+ * many times, as an all-pairs walk does, holds its context and pays the
+ * extraction once instead of once per pair. NULL where the geometry is one the
+ * engine does not cover, which is what #meos_spatialrel answers false for */
+extern void *relate_ctx_make(const LWGEOM *geom);
+extern void relate_ctx_free(void *ctx);
+extern bool meos_spatialrel_ctx(const void *ctx1, const void *ctx2,
+  spatialRel rel, bool *result);
 extern bool de9im_match(const char matrix[10], const char pattern[10]);
 extern int point_in_polygon(double x, double y, Edge **edges, int nedges);
 extern int point_in_polygon_index(double x, double y, Edge **edges,

--- a/meos/src/geo/geo_cluster.c
+++ b/meos/src/geo/geo_cluster.c
@@ -243,6 +243,16 @@ geo_union_intersecting(LWGEOM **geoms, uint32_t ngeoms, UNIONFIND *uf)
   GBOX *boxes = cluster_boxes(geoms, ngeoms);
   if (! boxes)
     return false;
+
+  /* Each geometry is asked about against many others, and every one of those
+   * questions reads the same edges, so the edges are read once per geometry
+   * and kept. ⛔ They are read where the FIRST question about that geometry is
+   * asked, never up front: the box test below rejects most pairs outright, and
+   * a geometry every one of whose pairs it rejects is never read at all, so a
+   * walk over well-separated geometries reads none of them */
+  void **ctxs = palloc0(sizeof(void *) * ngeoms);
+  bool *ctx_read = palloc0(sizeof(bool) * ngeoms);
+
   bool result = true;
   for (uint32_t p = 0; p < ngeoms && result; p++)
   {
@@ -257,8 +267,19 @@ geo_union_intersecting(LWGEOM **geoms, uint32_t ngeoms, UNIONFIND *uf)
         continue;
       if (! cluster_boxes_within(&boxes[p], &boxes[q], 0.0))
         continue;
+      /* The first question asked about a geometry reads its edges, and every
+       * later one about the same geometry reads them again from here */
+      for (uint32_t k = 0; k < 2; k++)
+      {
+        uint32_t i = k ? q : p;
+        if (! ctx_read[i])
+        {
+          ctxs[i] = relate_ctx_make(geoms[i]);
+          ctx_read[i] = true;
+        }
+      }
       bool meet;
-      if (! meos_spatialrel(geoms[p], geoms[q], INTERSECTS, &meet))
+      if (! meos_spatialrel_ctx(ctxs[p], ctxs[q], INTERSECTS, &meet))
       {
         result = false;
         break;
@@ -267,6 +288,11 @@ geo_union_intersecting(LWGEOM **geoms, uint32_t ngeoms, UNIONFIND *uf)
         UF_union(uf, p, q);
     }
   }
+
+  for (uint32_t i = 0; i < ngeoms; i++)
+    relate_ctx_free(ctxs[i]);
+  pfree(ctx_read);
+  pfree(ctxs);
   pfree(boxes);
   return result;
 }

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -7281,31 +7281,12 @@ meos_covers_possible(const RelateOperands *ops, bool *result)
  * @param[out] result True if the geometries stand in the relationship
  * @return True if the pair is covered
  */
-bool
-meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
-  bool *result)
+static bool
+relate_spatialrel_ops(const RelateOperands *opsp, spatialRel rel, bool *result)
 {
-  assert(g1); assert(g2); assert(result);
-
-  /* Every native implementation reads the same predicate: the engine answers
-   * a geometry the edge decomposition reaches, and nothing else */
-  if (! geom_meos_supported(g1) || ! geom_meos_supported(g2))
-    return false;
-
-  /* An empty geometry holds no point to share with another, and none of the
-   * four patterns admits an empty operand */
-  if (lwgeom_is_empty(g1) || lwgeom_is_empty(g2))
-  {
-    *result = false;
-    return true;
-  }
-
-  /* Each step below reads the edges of the same two geometries, so both are
-   * extracted ONCE here and every step borrows the answer. Reading the edges
-   * of a multi-surface as those of the union of its members is what a call on
-   * such a geometry mostly costs, and it was paid once per step */
-  RelateOperands ops;
-  relate_operands_init(&ops, g1, g2);
+  const RelateOperands ops = *opsp;
+  const LWGEOM *g1 = ops.op[0].geom;
+  const LWGEOM *g2 = ops.op[1].geom;
 
   bool covered = true;
 
@@ -7358,6 +7339,127 @@ meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
     }
   }
 
+  return covered;
+}
+
+/**
+ * @brief The edges of one geometry, kept for every relationship asked about it
+ */
+struct RelateCtx
+{
+  RelateOperand op;  /**< The geometry and the edges it draws */
+};
+
+/**
+ * @brief Read the edges of a geometry once, for a caller that asks about it
+ * more than once
+ * @param[in] geom Geometry
+ * @return The context, or NULL where the geometry is one the engine does not
+ * cover, which #meos_spatialrel_ctx then answers as uncovered
+ * @note Building the context is what a relationship does at its own entry, so
+ * a caller holding one pays the extraction once instead of once per pair
+ */
+void *
+relate_ctx_make(const LWGEOM *geom)
+{
+  assert(geom);
+  /* The same predicate a relationship reads at its entry. Answering NULL here
+   * rather than extracting keeps an uncovered geometry on the path it already
+   * takes: a relationship over it reports itself uncovered and raises nothing */
+  if (! geom_meos_supported(geom))
+    return NULL;
+  struct RelateCtx *ctx = palloc(sizeof(struct RelateCtx));
+  ctx->op.geom = geom;
+  ctx->op.arr = relate_extract_edges(geom);
+  return ctx;
+}
+
+/**
+ * @brief Release a context #relate_ctx_make answered
+ */
+void
+relate_ctx_free(void *ctxv)
+{
+  struct RelateCtx *ctx = (struct RelateCtx *) ctxv;
+  if (! ctx)
+    return;
+  meos_array_destroy(ctx->op.arr);
+  pfree(ctx);
+  return;
+}
+
+/**
+ * @brief Return whether two geometries stand in a spatial relationship,
+ * reading edges each context has already extracted
+ * @param[in] ctx1,ctx2 Contexts of the two geometries, in the order asked
+ * about
+ * @param[in] rel Relationship asked for
+ * @param[out] result True if the geometries stand in the relationship
+ * @return True if the pair is covered
+ * @note The contexts keep owning their edges: this borrows them for the call
+ * and releases nothing, so one context serves as many relationships as the
+ * caller asks
+ */
+bool
+meos_spatialrel_ctx(const void *ctx1, const void *ctx2, spatialRel rel,
+  bool *result)
+{
+  assert(result);
+  const struct RelateCtx *c1 = (const struct RelateCtx *) ctx1;
+  const struct RelateCtx *c2 = (const struct RelateCtx *) ctx2;
+
+  /* A geometry the engine does not cover carries no context, and the pair is
+   * uncovered exactly as #meos_spatialrel reports it */
+  if (! c1 || ! c2)
+    return false;
+
+  /* An empty geometry holds no point to share with another, and none of the
+   * four patterns admits an empty operand */
+  if (lwgeom_is_empty(c1->op.geom) || lwgeom_is_empty(c2->op.geom))
+  {
+    *result = false;
+    return true;
+  }
+
+  RelateOperands ops;
+  ops.op[0] = c1->op;
+  ops.op[1] = c2->op;
+  return relate_spatialrel_ops(&ops, rel, result);
+}
+
+/**
+ * @brief Return whether two geometries stand in a spatial relationship
+ * @param[in] g1,g2 Geometries
+ * @param[in] rel Relationship asked for
+ * @param[out] result True if the geometries stand in the relationship
+ * @return True if the pair is covered
+ */
+bool
+meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
+  bool *result)
+{
+  assert(g1); assert(g2); assert(result);
+
+  /* Every native implementation reads the same predicate: the engine answers
+   * a geometry the edge decomposition reaches, and nothing else */
+  if (! geom_meos_supported(g1) || ! geom_meos_supported(g2))
+    return false;
+
+  /* An empty geometry holds no point to share with another, and none of the
+   * four patterns admits an empty operand */
+  if (lwgeom_is_empty(g1) || lwgeom_is_empty(g2))
+  {
+    *result = false;
+    return true;
+  }
+
+  /* Each step below reads the edges of the same two geometries, so both are
+   * extracted ONCE here and every step borrows the answer. Reading the edges
+   * of a multi-surface as those of the union of its members is what a call on
+   * such a geometry mostly costs, and it was paid once per step */
+  RelateOperands ops;
+  relate_operands_init(&ops, g1, g2);
+  bool covered = relate_spatialrel_ops(&ops, rel, result);
   relate_operands_free(&ops);
   return covered;
 }


### PR DESCRIPTION
A spatial relationship extracts the edges of both its operands where the call begins, and for a multi-surface — whose edges are those of the union of its members — that extraction is what the call mostly costs. Instrumenting the engine over the corpora puts a number on it: edge extraction is **99.3%** of an `INTERSECTS` call over the 1444 areal pairs and **95.1%** over ten mid-size protected-area pairs.

A walk that asks about the same geometry many times therefore pays that extraction once per pair rather than once per geometry, and the corpora say how often the same geometry comes back: the 1444 areal pairs draw on **38** distinct geometries and the 670 box-overlapping protected-area pairs on **255**, so the same edges are read again 98.7% and 81.0% of the time.

The edges of one geometry become a context the caller holds. `relate_ctx_make` reads them, `meos_spatialrel_ctx` answers a relationship from two such contexts without extracting, and `relate_ctx_free` releases them; the contexts keep owning their edges, so one serves as many relationships as the caller asks. This is the shape the clip engine and the circular-buffer engine already take — `geo_edge_ctx_make` at `tpoint_geom_clip.c:907`, `tcbuffer_geo_ctx_make` — down to the opaque pointer their callers hold. Nothing here reaches a public header: `geo/geo_funcs.h` carries no install rule, so the surface is unchanged.

`meos_spatialrel` keeps its signature and its behaviour. It builds the two contexts, answers from them and releases them, so a single call costs what it did, and a geometry the engine does not cover carries no context and reports the pair uncovered rather than raising where it did not.

Clustering geometries that share a point is the walk this is for: it asks about every pair, so a geometry is extracted as many times as it has neighbours.

## The contexts are read on first use, and that is the whole design

A geometry's edges are read where the first pair that survives its bounding-box test asks about it, never up front. The box test rejects most pairs of a well-separated set outright, so a geometry every one of whose pairs it rejects is never read at all — exactly as it is not read today.

Reading eagerly instead charges such a walk an extraction per geometry that it otherwise never performs, and on real data that is not a rounding error:

| 14 real protected-area polygons, none meeting another | per run |
|---|---|
| master | 5.107 s |
| contexts read eagerly | **90.646 s** |
| contexts read on first use | 5.301 s |

## Measured

Both arms built from their own build directory, answers compared before clocks.

| corpus | master | this branch |
|---|---|---|
| 38 areal geometries, every pair related | 0.0450 s | **0.0098 s** |
| 14 real protected-area polygons, no pair meeting | 5.107 s | 5.301 s |
| 24 mixed points, lines and polygons | 10 µs | 11 µs |

## Answer-preserving

- The four relationships over **14 580 pairs** — 1444 areal, 54 adversarial, 202 real-trip, 12 880 fixture — are identical between the two arms, with 4254 pairs carrying a true and none unreadable.
- The clustering partition is identical on every corpus. The 24 mixed geometries answer **15 clusters** — a nine-member one, a two-member one and singletons — so the signature can distinguish a wrong merge from a right one; the 38 areal geometries fall in a single cluster and cannot.
- No expected output moves anywhere in the suite, and the ctest set is 323/323.
