### PR TITLE
Give the JSON path type its length in the catalog

### DIFF
--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -717,7 +717,9 @@ meostype_length(MeosType type)
     return -1;
 #endif
 #if JSON
-  if (type == T_JSONB)
+  /* Both JSON types are varlena: Jsonb carries a varlena header and JsonPath is
+   * `int32 vl_len_; uint32 header; char data[]`. */
+  if (type == T_JSONB || type == T_JSONPATH)
     return -1;
 #endif
 #if NPOINT


### PR DESCRIPTION
meostype_length answers -1 for jsonpath beside jsonb: JsonPath is a varlena, `int32 vl_len_; uint32 header; char data[]`, so its length is the varlena sentinel the other JSON type already returns. The enum declares T_JSONPATH a base type and MEOS_TYPE_NAMES names it, so a caller reaching the catalog for its length receives it rather than the internal-type error the fall-through raises. set_basetype and temporal_basetype continue to exclude the type, which has neither a set type nor a temporal type.