### PR TITLE
Keep the body of a rigid geometry through a merge

### DIFF
--- a/meos/include/rgeo/trgeo.h
+++ b/meos/include/rgeo/trgeo.h
@@ -80,6 +80,12 @@ extern TSequenceSet *geo_tposeseqset_to_trgeo(const GSERIALIZED *gs,
 extern bool trgeo_value_at_timestamptz(const Temporal *temp, TimestampTz t,
   bool strict, Datum *result);
 
+/* Modification functions */
+
+extern Temporal *trgeometry_merge(const Temporal *temp1,
+  const Temporal *temp2);
+extern Temporal *trgeometry_merge_array(Temporal **temparr, int count);
+
 /* Restriction functions */
 
 extern Temporal *trgeometry_restrict_value(const Temporal *temp, Datum value,

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -935,6 +935,124 @@ trgeometry_segments(const Temporal *temp, int *count)
 }
 
 /*****************************************************************************
+ * Modification functions
+ *****************************************************************************/
+
+/**
+ * @brief Return the temporal rigid geometry a reference geometry and a
+ * temporal pose make, whatever subtype the pose has
+ * @param[in] gs Reference geometry
+ * @param[in] temp Temporal pose
+ */
+static Temporal *
+geo_tpose_to_trgeo(const GSERIALIZED *gs, const Temporal *temp)
+{
+  assert(gs); assert(temp);
+  assert(temptype_subtype(temp->subtype));
+  switch (temp->subtype)
+  {
+    case TINSTANT:
+      return (Temporal *) geo_tposeinst_to_trgeo(gs, (const TInstant *) temp);
+    case TSEQUENCE:
+      return (Temporal *) geo_tposeseq_to_trgeo(gs, (const TSequence *) temp);
+    default: /* TSEQUENCESET */
+      return (Temporal *) geo_tposeseqset_to_trgeo(gs,
+        (const TSequenceSet *) temp);
+  }
+}
+
+/**
+ * @brief Return two temporal rigid geometries merged into one
+ * @param[in] temp1,temp2 Temporal rigid geometries
+ * @details A temporal rigid geometry is a temporal pose carrying a reference
+ * geometry, and a merge rebuilds the temporal value from the poses of both.
+ * The rebuilt value carries no reference geometry of its own, so the body the
+ * operands share is attached to it: the merge of two rigid geometries is a
+ * rigid geometry, and reading its body is what a caller does next.
+ * @csqlfn #Temporal_merge()
+ */
+Temporal *
+trgeometry_merge(const Temporal *temp1, const Temporal *temp2)
+{
+  /* Where one argument is null the answer is a copy of the other */
+  if (! temp1 && ! temp2)
+    return NULL;
+  if (! temp1)
+    return temporal_copy(temp2);
+  if (! temp2)
+    return temporal_copy(temp1);
+
+  /* Ensure the validity of the arguments */
+  VALIDATE_TRGEOMETRY(temp1, NULL);
+  VALIDATE_TRGEOMETRY(temp2, NULL);
+  const GSERIALIZED *geo = trgeo_geom_p(temp1);
+  /* Two rigid geometries merge into one only where they are the same body */
+  if (! ensure_same_geom(geo, trgeo_geom_p(temp2)))
+    return NULL;
+
+  Temporal *tpose1 = trgeometry_to_tpose(temp1);
+  Temporal *tpose2 = trgeometry_to_tpose(temp2);
+  if (! tpose1 || ! tpose2)
+  {
+    if (tpose1) pfree(tpose1);
+    if (tpose2) pfree(tpose2);
+    return NULL;
+  }
+  Temporal *merged = temporal_merge(tpose1, tpose2);
+  pfree(tpose1); pfree(tpose2);
+  if (! merged)
+    return NULL;
+  Temporal *result = geo_tpose_to_trgeo(geo, merged);
+  pfree(merged);
+  return result;
+}
+
+/**
+ * @brief Return the temporal rigid geometries of an array merged into one
+ * @param[in] temparr Array of temporal rigid geometries
+ * @param[in] count Number of elements in the array
+ * @csqlfn #Temporal_merge_array()
+ */
+Temporal *
+trgeometry_merge_array(Temporal **temparr, int count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(temparr, NULL);
+  if (! ensure_positive(count))
+    return NULL;
+  for (int i = 0; i < count; i++)
+    VALIDATE_TRGEOMETRY(temparr[i], NULL);
+
+  const GSERIALIZED *geo = trgeo_geom_p(temparr[0]);
+  /* Every body merged into one is the same body */
+  for (int i = 1; i < count; i++)
+    if (! ensure_same_geom(geo, trgeo_geom_p(temparr[i])))
+      return NULL;
+
+  Temporal **poses = palloc(sizeof(Temporal *) * count);
+  for (int i = 0; i < count; i++)
+  {
+    poses[i] = trgeometry_to_tpose(temparr[i]);
+    if (! poses[i])
+    {
+      for (int j = 0; j < i; j++)
+        pfree(poses[j]);
+      pfree(poses);
+      return NULL;
+    }
+  }
+  Temporal *merged = temporal_merge_array(poses, count);
+  for (int i = 0; i < count; i++)
+    pfree(poses[i]);
+  pfree(poses);
+  if (! merged)
+    return NULL;
+  Temporal *result = geo_tpose_to_trgeo(geo, merged);
+  pfree(merged);
+  return result;
+}
+
+/*****************************************************************************
  * Transformation functions
  *****************************************************************************/
 

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -58,6 +58,9 @@
   #include "npoint/tnpoint_distance.h"
   #include "npoint/tnpoint_spatialfuncs.h"
 #endif
+#if RGEO
+  #include "rgeo/trgeo_all.h"
+#endif
 
 #include <utils/jsonb.h>
 #include <utils/numeric.h>
@@ -556,6 +559,14 @@ temporal_merge(const Temporal *temp1, const Temporal *temp2)
       ! ensure_spatial_validity(temp1, temp2))
     return NULL;
 
+#if RGEO
+  /* A temporal rigid geometry carries a reference geometry that a value
+   * rebuilt from instants does not reproduce, so it merges as the poses it is
+   * made of and takes its body back afterwards */
+  if (temp1->temptype == T_TRGEOMETRY)
+    return trgeometry_merge(temp1, temp2);
+#endif /* RGEO */
+
   /* Convert to the same subtype */
   Temporal *new1, *new2;
   temporal_convert_same_subtype(temp1, temp2, &new1, &new2);
@@ -634,6 +645,13 @@ temporal_merge_array(Temporal **temparr, int count)
 
   if (count == 1)
     return temporal_copy(temparr[0]);
+
+#if RGEO
+  /* A temporal rigid geometry carries a reference geometry that a value
+   * rebuilt from instants does not reproduce */
+  if (temparr[0]->temptype == T_TRGEOMETRY)
+    return trgeometry_merge_array(temparr, count);
+#endif /* RGEO */
 
   /* Ensure all values have the same interpolation and, if they are spatial,
    * have the same SRID and dimensionality, and determine subtype of the

--- a/meos/test/trgeo_test.c
+++ b/meos/test/trgeo_test.c
@@ -360,6 +360,72 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* Merging two temporal rigid geometries answers a rigid geometry, and the
+   * body it answers is the body they share. A value rebuilt from instants
+   * carries no reference geometry of its own, so a merge that does not attach
+   * one answers a value that claims to be a rigid geometry while holding no
+   * body: reading it aborts on the assertion where the build carries one, and
+   * runs off the end of the value where it does not. Temporally DISJOINT
+   * operands are what reaches the sequence-set path. */
+  {
+    const char *body = "POLYGON((0 0,1 0,1 1,0 1,0 0))";
+    Temporal *m1 = trgeometry_in("Polygon((0 0,1 0,1 1,0 1,0 0));"
+      "[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]");
+    Temporal *m2 = trgeometry_in("Polygon((0 0,1 0,1 1,0 1,0 0));"
+      "[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]");
+    if (! m1 || ! m2)
+    {
+      printf("FAILED: the two rigid geometries to merge did not parse\n");
+      result = 1;
+    }
+    else
+    {
+      meos_errno_reset();
+      Temporal *merged = temporal_merge(m1, m2);
+      if (! merged)
+      {
+        printf("FAILED: merging two rigid geometries answered NULL, errno "
+          "%d\n", meos_errno());
+        result = 1;
+      }
+      else
+      {
+        /* Reading the body is what a caller does next, and it is what a
+         * bodiless answer cannot serve */
+        GSERIALIZED *geo = trgeometry_geom(merged);
+        char *wkt = geo ? geo_as_text(geo, 6) : NULL;
+        if (! wkt || strcmp(wkt, body) != 0)
+        {
+          printf("FAILED: the merged rigid geometry answers body %s, wanted "
+            "%s\n", wkt ? wkt : "none", body);
+          result = 1;
+        }
+        else
+          printf("OK: merging two rigid geometries keeps the body %s\n", wkt);
+        free(wkt); free(geo);
+
+        /* The array form takes the same path one call along */
+        Temporal *arr[2] = {m1, m2};
+        meos_errno_reset();
+        Temporal *marr = temporal_merge_array(arr, 2);
+        GSERIALIZED *ageo = marr ? trgeometry_geom(marr) : NULL;
+        char *awkt = ageo ? geo_as_text(ageo, 6) : NULL;
+        if (! awkt || strcmp(awkt, body) != 0)
+        {
+          printf("FAILED: merging an array of rigid geometries answers body "
+            "%s, wanted %s\n", awkt ? awkt : "none", body);
+          result = 1;
+        }
+        else
+          printf("OK: merging an array of rigid geometries keeps the body\n");
+        free(awkt); free(ageo); free(marr);
+        free(merged);
+      }
+    }
+    free(m1); free(m2);
+    meos_errno_reset();
+  }
+
   /* Finalize MEOS */
   meos_finalize();
 

--- a/mobilitydb/test/rgeo/expected/150_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/150_trgeo.test.out
@@ -2550,3 +2550,31 @@ SELECT asText(tprecision(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{[Pose(Point
  POLYGON((0 0,1 0,1 1,0 1,0 0));{[Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST, Pose(POINT(4 0),0)@Mon Jan 01 00:00:04 2001 PST, Pose(POINT(0 0),0)@Mon Jan 01 00:00:06 2001 PST, Pose(POINT(2 0),0)@Mon Jan 01 00:00:08 2001 PST]}
 (1 row)
 
+SELECT asText(merge(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]'));
+                                                                                                                 astext                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{[Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST, Pose(POINT(5 0),0)@Tue Jan 02 00:00:00 2001 PST], [Pose(POINT(0 0),0)@Thu Jan 04 00:00:00 2001 PST, Pose(POINT(5 0),0)@Fri Jan 05 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(merge(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-03]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(5 0), 0.0)@2001-01-03, Pose(Point(9 0), 0.0)@2001-01-05]'));
+                                                                                       astext                                                                                       
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));[Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST, Pose(POINT(5 0),0)@Wed Jan 03 00:00:00 2001 PST, Pose(POINT(9 0),0)@Fri Jan 05 00:00:00 2001 PST]
+(1 row)
+
+SELECT asText(merge(ARRAY[
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]']));
+                                                                                                                 astext                                                                                                                  
+-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((0 0,1 0,1 1,0 1,0 0));{[Pose(POINT(0 0),0)@Mon Jan 01 00:00:00 2001 PST, Pose(POINT(5 0),0)@Tue Jan 02 00:00:00 2001 PST], [Pose(POINT(0 0),0)@Thu Jan 04 00:00:00 2001 PST, Pose(POINT(5 0),0)@Fri Jan 05 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asText(merge(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]'));
+ERROR:  Operation on different reference geometries

--- a/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
@@ -661,3 +661,22 @@ SELECT numSequences(trgeometrySeqSetGaps(ARRAY[
 
 -- tprecision (extended-shape seqset)
 SELECT asText(tprecision(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));{[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-01 00:00:04],[Pose(Point(0 0),0)@2001-01-01 00:00:06, Pose(Point(2 0),0)@2001-01-01 00:00:08]}', interval '2 secs'));
+
+-------------------------------------------------------------------------------
+-- merge: the answer of merging rigid geometries is a rigid geometry, so it
+-- carries the body its operands share
+-------------------------------------------------------------------------------
+
+SELECT asText(merge(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]'));
+SELECT asText(merge(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-03]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(5 0), 0.0)@2001-01-03, Pose(Point(9 0), 0.0)@2001-01-05]'));
+SELECT asText(merge(ARRAY[
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]']));
+-- two bodies that differ do not merge into one
+SELECT asText(merge(
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]',
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]'));


### PR DESCRIPTION
A temporal rigid geometry is a temporal pose carrying a reference geometry appended to its value, and a merge rebuilds the temporal value from the poses of its operands. The rebuilt value carries no reference geometry, so the merge of two rigid geometries answers a value that claims to be a rigid geometry while holding no body:

```
operand temptype=62 geom=1
merged   temptype=62 geom=0
trgeo_seqset.c:65: trgeoseqset_geom_p: Assertion `ensure_has_geom(ss->flags)' failed.
```

The merge itself reports success — a value returned, `errno 0` — so nothing fails until a reader asks for the body, which is what a caller does next. Under a build carrying the assertion the read aborts; where the assertion compiles out it runs off the end of the value. From SQL that is a backend crash, reachable from `asText(merge(trgeometry, trgeometry))` on two values that are temporally disjoint, which is the shape that reaches the sequence-set reader.

## What the answer is

A rigid geometry merges as the poses it is made of and takes its body back. `trgeometry_merge` and `trgeometry_merge_array` strip the reference geometry, merge the poses and attach the body to the result; `temporal_merge` and `temporal_merge_array` route a `T_TRGEOMETRY` operand to them.

The routing sits in the core rather than in the PostgreSQL wrapper, and that placement is the difference between fixing SQL and fixing every caller: a MEOS C program calling `temporal_merge` reaches the same generic entry, as does every generated binding. The core already reads this type where the appended body matters — six of its files name `T_TRGEOMETRY`, among them the input and output paths — so this follows the shape already there.

Two bodies that differ do not merge into one, and say so:

```
ERROR:  Operation on different reference geometries
```

Nothing valid is refused: each operand answers on its own, and a merge of operands sharing a body answers a rigid geometry.

## Surface

`meos/include/rgeo/trgeo.h` carries the two declarations and has no install rule, so the public surface is unchanged. Whether the type's own merge belongs on the public surface beside `trgeometry_segments` is a separate question this does not decide.

## The witness fails without the fix

`meos/test/trgeo_test.c` reads the body of a merged value and of a merged array. Compiled against two staged arms from the same source, the arm carrying the fix exits 0 and the arm without it exits 1:

```
FAILED: merging an array of rigid geometries answers body none, wanted POLYGON((0 0,1 0,1 1,0 1,0 0))
```

## Coverage

`150_trgeo` gains four cases: two disjoint operands, two that overlap in time, the array form, and two bodies that differ. The diff against the committed expected output is purely additive — 28 lines added, none removed — so no existing answer moves. The ctest set is 323/323.
