### PR TITLE
Answer a JSONB comparison with its three-way result

### DIFF
--- a/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
+++ b/mobilitydb/test/json/expected/450_jsonbset_tbl.test.out
@@ -54,19 +54,19 @@ SELECT MAX(memSize(set(jb))) FROM tbl_jsonb;
 SELECT COUNT(*) FROM tbl_jsonbset WHERE s @> startValue(s);
  count 
 -------
-     0
+    99
 (1 row)
 
 SELECT COUNT(*) FROM tbl_jsonbset WHERE startValue(s) <@ s;
  count 
 -------
-     0
+    99
 (1 row)
 
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s && t2.s;
  count 
 -------
-  5614
+    99
 (1 row)
 
 SELECT MAX(memSize(s || jb)) FROM tbl_jsonbset, tbl_jsonb;
@@ -108,7 +108,7 @@ SELECT MAX(memSize(t1.s - t2.s)) FROM tbl_jsonbset t1, tbl_jsonbset t2;
 SELECT MAX(memSize(t1.s * t2.s)) FROM tbl_jsonbset t1, tbl_jsonbset t2;
  max  
 ------
- 1464
+ 1624
 (1 row)
 
 SELECT MAX(memSize(s)) FROM tbl_jsonbset;
@@ -160,13 +160,13 @@ test2 (k, s) AS (
 SELECT COUNT(*) FROM test2 t1, tbl_jsonbset t2 WHERE t1.k = t2.k AND t1.s <> t2.s;
  count 
 -------
-    35
+     0
 (1 row)
 
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE cmp(t1.s, t2.s) = -1;
  count 
 -------
-   557
+  1136
 (1 row)
 
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s = t2.s;
@@ -184,37 +184,37 @@ SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s <> t2.s;
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s < t2.s;
  count 
 -------
-   557
+  4851
 (1 row)
 
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s <= t2.s;
  count 
 -------
-   718
+  4950
 (1 row)
 
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s > t2.s;
  count 
 -------
-  9083
+  4851
 (1 row)
 
 SELECT COUNT(*) FROM tbl_jsonbset t1, tbl_jsonbset t2 WHERE t1.s >= t2.s;
  count 
 -------
-  9244
+  4950
 (1 row)
 
 SELECT MAX(hash(s)) FROM tbl_jsonbset;
     max     
 ------------
- 2107504745
+ 2129107175
 (1 row)
 
 SELECT MAX(hashExtended(s, 1)) FROM tbl_jsonbset;
          max         
 ---------------------
- 9209195217540800445
+ 9160053331433996777
 (1 row)
 
 SELECT numValues(setUnion(jb)) FROM tbl_jsonb;
@@ -232,12 +232,12 @@ SELECT setMinus(jsonb '{"a": 1}', jsonbset '{"{\"b\": 2}"}');
 SELECT setIntersection(jsonb '{"a": 1}', jsonbset '{"{\"a\": 1}", "{\"b\": 2}"}');
  setintersection 
 -----------------
- 
+ {"{\"a\": 1}"}
 (1 row)
 
 SELECT setIntersection(jsonbset '{"{\"a\": 1}", "{\"b\": 2}"}', jsonb '{"a": 1}');
  setintersection 
 -----------------
- 
+ {"{\"a\": 1}"}
 (1 row)
 

--- a/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
+++ b/mobilitydb/test/json/expected/451_jsonbset_jsonfuncs.test.out
@@ -19,7 +19,7 @@ SELECT jsonbset '{"{\"geom\": \"Point(1 1)\"}"}' - text 'xxx';
 SELECT jsonbset '{"{\"geom\": \"Point(1 1)\"}", "{\"geom\": \"Point(2 2)\"}", "{\"geom\": \"Point(3 3)\"}"}' - text 'xxx';
                                           ?column?                                          
 --------------------------------------------------------------------------------------------
- {"{\"geom\": \"Point(3 3)\"}", "{\"geom\": \"Point(2 2)\"}", "{\"geom\": \"Point(1 1)\"}"}
+ {"{\"geom\": \"Point(1 1)\"}", "{\"geom\": \"Point(2 2)\"}", "{\"geom\": \"Point(3 3)\"}"}
 (1 row)
 
 SELECT jsonbset '{"{\"geom\": \"Point(1 1)\"}"}' - ARRAY[text 'geom'];
@@ -43,7 +43,7 @@ SELECT jsonbset '{"[\"Point(1 1)\", \"Point(2 2)\"]"}' - 0;
 SELECT jsonbset '{"[\"Point(1 1)\", \"Point(2 2)\"]", "[\"Point(2 2)\", \"Point(3 3)\"]", "[\"Point(1 1)\", \"Point(2 2)\"]"}' - 0;
                  ?column?                 
 ------------------------------------------
- {"[\"Point(3 3)\"]", "[\"Point(2 2)\"]"}
+ {"[\"Point(2 2)\"]", "[\"Point(3 3)\"]"}
 (1 row)
 
 /* Errors */
@@ -72,7 +72,7 @@ SELECT jsonbsetSet(jsonbset '{"{\"speed\": 10}"}', ARRAY['units'], '"km/h"'::jso
 SELECT jsonbsetSet(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20}", "{\"speed\": 30}"}', ARRAY['units'], '"km/h"'::jsonb);
                                                        jsonbsetset                                                        
 --------------------------------------------------------------------------------------------------------------------------
- {"{\"speed\": 30, \"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10, \"units\": \"km/h\"}"}
+ {"{\"speed\": 10, \"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 30, \"units\": \"km/h\"}"}
 (1 row)
 
 SELECT jsonbsetInsert(jsonbset '{"{\"speed\": 10}"}', ARRAY['units'], '"km/h"'::jsonb);
@@ -84,7 +84,7 @@ SELECT jsonbsetInsert(jsonbset '{"{\"speed\": 10}"}', ARRAY['units'], '"km/h"'::
 SELECT jsonbsetInsert(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20}", "{\"speed\": 30}"}', ARRAY['units'], '"km/h"'::jsonb);
                       jsonbsetinsert                       
 -----------------------------------------------------------
- {"{\"speed\": 30}", "{\"speed\": 20}", "{\"speed\": 10}"}
+ {"{\"speed\": 10}", "{\"speed\": 20}", "{\"speed\": 30}"}
 (1 row)
 
 SELECT jsonbsetExtractPath(jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}"}', ARRAY[text 'speed']);
@@ -96,7 +96,7 @@ SELECT jsonbsetExtractPath(jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}"}', 
 SELECT jsonbsetExtractPath(jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10, \"units\": \"km/h\"}"}', ARRAY[text 'speed']);
  jsonbsetextractpath 
 ---------------------
- {20, 10}
+ {10, 20}
 (1 row)
 
 /* Null handling */
@@ -105,13 +105,13 @@ ERROR:  The lifted operation returned NULL
 SELECT jsonbsetExtractPath(jsonbset '{"{\"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10, \"units\": \"km/h\"}"}', ARRAY['speed'],'use_json_null');
  jsonbsetextractpath 
 ---------------------
- {20, 10, "null"}
+ {"null", 10, 20}
 (1 row)
 
 SELECT jsonbsetExtractPath(jsonbset '{"{\"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10, \"units\": \"km/h\"}"}', ARRAY['speed'],'delete_key');
  jsonbsetextractpath 
 ---------------------
- {20, 10}
+ {10, 20}
 (1 row)
 
 SELECT jsonbsetExtractPath(jsonbset '{"{\"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10, \"units\": \"km/h\"}"}', ARRAY['speed'],'return_null');
@@ -129,14 +129,14 @@ SELECT jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}"}' #> ARRAY['speed'];
 SELECT jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10, \"units\": \"km/h\"}"}' #> ARRAY['speed'];
  ?column? 
 ----------
- {20, 10}
+ {10, 20}
 (1 row)
 
 /* Null handling */
 SELECT jsonbset '{"{\"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10, \"units\": \"km/h\"}"}' #> ARRAY['speed'];
      ?column?     
 ------------------
- {20, 10, "null"}
+ {"null", 10, 20}
 (1 row)
 
 SELECT jsonbsetExtractPathText(jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}"}', ARRAY['speed']);
@@ -224,7 +224,7 @@ SELECT jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}"}' -> 'speed';
 SELECT jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}", "{\"speed\": 20, \"units\": \"km/h\"}", "{\"speed\": 10, \"units\": \"km/h\"}"}' -> 'speed';
  ?column? 
 ----------
- {20, 10}
+ {10, 20}
 (1 row)
 
 SELECT jsonbset '{"{\"speed\": 10, \"units\": \"km/h\"}"}' ->> 'speed';
@@ -289,7 +289,7 @@ ERROR:  Invalid numeric string for key "a": xxx
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'units';
  ?column? 
 ----------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ? text 'speed';
@@ -313,13 +313,13 @@ SELECT jsonbsetExists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": 
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ?| ARRAY[text 'units', text 'lights'];
  ?column? 
 ----------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' ?& ARRAY[text 'speed', text 'units'];
  ?column? 
 ----------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbsetExistsAny(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', ARRAY[text 'speed']);
@@ -344,13 +344,13 @@ SELECT jsonbset '{"{\"speed\": 10}"}' ?| ARRAY[]::text[];
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.units';
  ?column? 
 ----------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.speed ? (@ > 15)';
  ?column? 
 ----------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @? '$.xxx';
@@ -362,19 +362,19 @@ SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @?
 SELECT jsonbsetPathExists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.units');
  jsonbsetpathexists 
 --------------------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbsetPathExists(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed ? (@ > $min)', '{"min": 15}');
  jsonbsetpathexists 
 --------------------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbsetPathExistsTz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.units');
  jsonbsetpathexiststz 
 ----------------------
- {t,f}
+ {f,t}
 (1 row)
 
 /* .datetime() casts a JSON string to a date/time value for comparison */
@@ -387,45 +387,45 @@ SELECT jsonbsetPathExistsTz(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"199
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed > 15';
  ?column? 
 ----------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}' @@ '$.speed == 10';
  ?column? 
 ----------
- {f,t}
+ {t,f}
 (1 row)
 
 SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > 15');
  jsonbsetpathmatch 
 -------------------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > $min', '{"min": 15}');
  jsonbsetpathmatch 
 -------------------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbsetPathMatchTz(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.speed > 15');
  jsonbsetpathmatchtz 
 ---------------------
- {t,f}
+ {f,t}
 (1 row)
 
 /* .datetime() casts a JSON string to a date/time value for comparison */
 SELECT jsonbsetPathMatch(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
  jsonbsetpathmatch 
 -------------------
- {t,f}
+ {f,t}
 (1 row)
 
 /* Every datetime comparison in a session parses its format afresh */
 SELECT jsonbsetPathMatchTz(jsonbset '{"{\"d\": \"2001-01-01\"}", "{\"d\": \"1999-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
  jsonbsetpathmatchtz 
 ---------------------
- {t,f}
+ {f,t}
 (1 row)
 
 SELECT jsonbsetPathExists(jsonbset '{"{\"d\": \"2001-01-01\"}"}', '$.d.datetime() > "2000-06-01".datetime()');
@@ -457,5 +457,70 @@ SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\
  jsonbsetpathmatch 
 -------------------
  {f,f}
+(1 row)
+
+/* The comparison of two JSONB values is a three-way answer, so a set of them
+ * sorts ascending as every other set type does, and each of the assertions
+ * below holds whatever the values are */
+SELECT set(ARRAY[jsonb '1', '2', '3']);
+    set    
+-----------
+ {1, 2, 3}
+(1 row)
+
+SELECT startValue(set(ARRAY[jsonb '1', '2', '3'])) <= endValue(set(ARRAY[jsonb '1', '2', '3']));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT jsonb '{"a": 1}' <= jsonb '{"a": 1}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT jsonb '{"a": 1}' < jsonb '{"b": 2}' AND jsonb '{"b": 2}' < jsonb '{"c": 3}';
+ ?column? 
+----------
+ t
+(1 row)
+
+/* A set contains its own start value and its own end value */
+SELECT set(ARRAY[jsonb '1', '2', '3']) @> startValue(set(ARRAY[jsonb '1', '2', '3']));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT set(ARRAY[jsonb '1', '2', '3']) @> endValue(set(ARRAY[jsonb '1', '2', '3']));
+ ?column? 
+----------
+ t
+(1 row)
+
+/* A set minus itself is empty, and a set intersected with itself is itself */
+SELECT setMinus(set(ARRAY[jsonb '1', '2']), set(ARRAY[jsonb '1', '2']));
+ setminus 
+----------
+ 
+(1 row)
+
+SELECT setIntersection(set(ARRAY[jsonb '1', '2']), set(ARRAY[jsonb '1', '2']));
+ setintersection 
+-----------------
+ {1, 2}
+(1 row)
+
+SELECT setMinus(set(ARRAY[jsonb '1', '2']), set(ARRAY[jsonb '1']));
+ setminus 
+----------
+ {2}
+(1 row)
+
+SELECT setIntersection(set(ARRAY[jsonb '1', '2']), set(ARRAY[jsonb '2']));
+ setintersection 
+-----------------
+ {2}
 (1 row)
 

--- a/mobilitydb/test/json/expected/452_tjsonb.test.out
+++ b/mobilitydb/test/json/expected/452_tjsonb.test.out
@@ -505,7 +505,7 @@ SELECT getValues(tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1
 SELECT getValues(tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}');
                           getvalues                           
 --------------------------------------------------------------
- {"{\"geom\": \"Point(2 2)\"}", "{\"geom\": \"Point(1 1)\"}"}
+ {"{\"geom\": \"Point(1 1)\"}", "{\"geom\": \"Point(2 2)\"}"}
 (1 row)
 
 SELECT getTime(tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01');
@@ -1807,7 +1807,7 @@ SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-0
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' < tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' < tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}';
@@ -1867,7 +1867,7 @@ SELECT tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01' <= tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01' <= tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}';
@@ -1897,13 +1897,13 @@ SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-0
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' <= tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' <= tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' <= tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}';
@@ -1927,7 +1927,7 @@ SELECT tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-0
 SELECT tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]' <= tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]' <= tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}';
@@ -1957,13 +1957,13 @@ SELECT tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-
 SELECT tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}' <= tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}';
  ?column? 
 ----------
- f
+ t
 (1 row)
 
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01' > tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01' > tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}';
@@ -1993,13 +1993,13 @@ SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-0
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' > tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' > tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' > tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}';
@@ -2023,7 +2023,7 @@ SELECT tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-0
 SELECT tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]' > tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]' > tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}';
@@ -2053,7 +2053,7 @@ SELECT tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-
 SELECT tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}' > tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01' >= tjsonb '"{\"geom\": \"Point(1 1)\"}"@2000-01-01';
@@ -2095,7 +2095,7 @@ SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-0
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' >= tjsonb '[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03]';
  ?column? 
 ----------
- t
+ f
 (1 row)
 
 SELECT tjsonb '{{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03}' >= tjsonb '{[{"geom": "Point(1 1)"}@2000-01-01, {"geom": "Point(1 1)"}@2000-01-02, {"geom": "Point(1 1)"}@2000-01-03], [{"geom": "Point(2 2)"}@2000-01-04, {"geom": "Point(2 2)"}@2000-01-05]}';

--- a/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
+++ b/mobilitydb/test/json/queries/451_jsonbset_jsonfuncs.test.sql
@@ -176,3 +176,25 @@ SELECT jsonbsetPathQueryFirst(jsonbset '{"{\"d\": \"2001-01-01\"}"}', '$.d.datet
 SELECT jsonbsetPathMatch(jsonbset '{"{\"speed\": 10}", "{\"speed\": 20, \"units\": \"km/h\"}"}', '$.xxx > 15', '{}', false);
 
 -------------------------------------------------------------------------------
+-- Ordering
+-------------------------------------------------------------------------------
+
+/* The comparison of two JSONB values is a three-way answer, so a set of them
+ * sorts ascending as every other set type does, and each of the assertions
+ * below holds whatever the values are */
+SELECT set(ARRAY[jsonb '1', '2', '3']);
+SELECT startValue(set(ARRAY[jsonb '1', '2', '3'])) <= endValue(set(ARRAY[jsonb '1', '2', '3']));
+SELECT jsonb '{"a": 1}' <= jsonb '{"a": 1}';
+SELECT jsonb '{"a": 1}' < jsonb '{"b": 2}' AND jsonb '{"b": 2}' < jsonb '{"c": 3}';
+
+/* A set contains its own start value and its own end value */
+SELECT set(ARRAY[jsonb '1', '2', '3']) @> startValue(set(ARRAY[jsonb '1', '2', '3']));
+SELECT set(ARRAY[jsonb '1', '2', '3']) @> endValue(set(ARRAY[jsonb '1', '2', '3']));
+
+/* A set minus itself is empty, and a set intersected with itself is itself */
+SELECT setMinus(set(ARRAY[jsonb '1', '2']), set(ARRAY[jsonb '1', '2']));
+SELECT setIntersection(set(ARRAY[jsonb '1', '2']), set(ARRAY[jsonb '1', '2']));
+SELECT setMinus(set(ARRAY[jsonb '1', '2']), set(ARRAY[jsonb '1']));
+SELECT setIntersection(set(ARRAY[jsonb '1', '2']), set(ARRAY[jsonb '2']));
+
+-------------------------------------------------------------------------------

--- a/pgtypes/utils/jsonb_op.c
+++ b/pgtypes/utils/jsonb_op.c
@@ -361,8 +361,11 @@ pg_jsonb_cmp(const Jsonb *jb1, const Jsonb *jb2)
       "jsonb comparison: NULL argument");
     return 0;
   }
+  /* The three-way result is the answer, where the sibling predicates above
+   * reduce it to a boolean. A caller ordering values reads the sign, and a
+   * caller matching them reads the zero */
   return compareJsonbContainers((JsonbContainer *) &jb1->root,
-    (JsonbContainer *) &jb2->root) <= 0;
+    (JsonbContainer *) &jb2->root);
 }
 
 /**


### PR DESCRIPTION
`pg_jsonb_cmp` states -1, 0 or 1 depending on whether the first value is less than, equal to or greater than the second, which is what every caller ordering or matching JSONB values reads. The sibling predicates beside it reduce the same container comparison to a boolean, and this entry returns the comparison itself.

A set of JSONB values therefore sorts ascending as every other set type does, so `startValue` answers the smallest element and `endValue` the largest, a strict self-join over the 99 distinct values of `tbl_jsonbset` counts the 4851 pairs a total order has, a value is less than or equal to itself, a set contains its own start and its own end value, and `setMinus` and `setIntersection` find the elements two sets share.

Three expected outputs move — `450_jsonbset_tbl`, `451_jsonbset_jsonfuncs` and `452_tjsonb`, 104 lines — and the nine other JSON suites are unchanged. Each moved line is a set printed in ascending order, or one of the counts above. `451_jsonbset_jsonfuncs` carries the assertions as a witness: a set sorts ascending, holds its own endpoints, is empty when taken from itself, and is itself when intersected with itself.
