### PR TITLE
Name the set operation in the JSONB set entries of both manuals

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2543,19 +2543,19 @@
 					<para><link linkend="jsonbset_alphanumset"><varname>intset</varname>, <varname>floatset</varname>, <varname>textset</varname></link>: Extrae un valor alfanumérico de un conjunto JSONB dado por una clave</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="jsonbset_concat"><varname>||</varname></link>: Concatenación JSONB temporal</para>
+					<para><link linkend="jsonbset_concat"><varname>||</varname></link>: Concatenación de un conjunto JSONB</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="jsonbset_delete"><varname>-</varname></link>: Eliminación JSONB temporal</para>
+					<para><link linkend="jsonbset_delete"><varname>-</varname></link>: Eliminación en un conjunto JSONB</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="jsonbset_exists"><varname>?</varname></link>: Existencia en un conjunto JSONB</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="jsonbset_set"><varname>jsonbsetSet</varname>, <varname>jsonbsetSetLax</varname></link>: Asignación JSONB temporal</para>
+					<para><link linkend="jsonbset_set"><varname>jsonbsetSet</varname>, <varname>jsonbsetSetLax</varname></link>: Asignación en un conjunto JSONB</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="jsonbset_insert"><varname>jsonbsetInsert</varname></link>: Inserción JSONB temporal</para>
+					<para><link linkend="jsonbset_insert"><varname>jsonbsetInsert</varname></link>: Devuelve el valor <varname>jsonbset</varname> con <varname>jsonb</varname> insertado</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="jsonbset_strip_nulls"><varname>jsonbsetStripNulls</varname></link>: Devuelve un conjunto JSONB sin nulos</para>

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -146,10 +146,11 @@ SELECT textset(jsonbset '{"{\"road\": \"Bvd Gén. Jacques\", \"category\": \"pri
 
 			<listitem xml:id="jsonbset_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
-				<para>Concatenación JSONB temporal</para>
+				<para>Concatenación de un conjunto JSONB</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {jsonb,jsonbset} || {jsonbset,jsonb} → jsonbset
 </programlisting>
+				<para>El valor se concatena con cada elemento del conjunto, y el orden de los operandos es libre.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT set(ARRAY[jsonb '{"speed":10}', '{"speed":20}']) || '{"unit":"km"}'::jsonb;
 -- {"{\"unit\": \"km\", \"speed\": 10}", "{\"unit\": \"km\", \"speed\": 20}"}
@@ -160,7 +161,7 @@ SELECT jsonb '{"unit":"km"}' || set(ARRAY[jsonb '{"speed":10}', '{"speed":20}'])
 
 			<listitem xml:id="jsonbset_delete">
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
-				<para>Eliminación JSONB temporal</para>
+				<para>Eliminación en un conjunto JSONB</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 jsonbset - {int,text,text[]} → jsonbset
 jsonbset #- text[] → jsonbset
@@ -178,7 +179,7 @@ SELECT set(ARRAY[jsonb '{"location":"Point(1 1)", "PoIs": ["Grand Place", "La Bo
 /* {"{\"PoIs\": [\"Grand Place\"], \"location\": \"Point(1 1)\"}", "{\"PoIs\":
    [\"Palais Royal\"], \"location\": \"Point(2 2)\"}"} */
 </programlisting>
-				<para>Como se muestra a continuación, el resultado de una operación de eliminación puede ser un registro vacío o un arreglo vacío. Para eliminar estos valores, puede utilizarse la función <varname>minusValue</varname>.</para>
+				<para>Como se muestra a continuación, el resultado de una operación de eliminación puede ser un registro vacío o un arreglo vacío. Para eliminar estos valores, puede utilizarse la función <varname>setMinus</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT set(ARRAY[jsonb '{"unit": "km", "speed": 10, "light": true}',
   '{"unit": "km", "speed": 20}']) - ARRAY[text 'unit', 'speed'];
@@ -224,7 +225,7 @@ SELECT jsonbset '{"{\"speed\": 10}",
 			<listitem xml:id="jsonbset_set">
 				<indexterm significance="normal"><primary><varname>jsonbsetSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetSetLax</varname></primary></indexterm>
-				<para>Asignación JSONB temporal</para>
+				<para>Asignación en un conjunto JSONB</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 jsonbsetSet(jsonbset,path text[],val jsonb,create boolean=true) → jsonbset
 jsonbsetSetLax(jsonbset,path text[],val jsonb,create boolean=true,
@@ -249,11 +250,11 @@ SELECT jsonbsetSetLax(set(ARRAY[jsonb '{"speed": 10, "units": "km/h"}', '{"speed
 
 			<listitem xml:id="jsonbset_insert">
 				<indexterm significance="normal"><primary><varname>jsonbsetInsert</varname></primary></indexterm>
-				<para>Inserción JSONB temporal</para>
+				<para>Devuelve el valor <varname>jsonbset</varname> con <varname>jsonb</varname> insertado</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 jsonbsetInsert(jsonbset,path text[],val jsonb,after boolean=false) → jsonbset
 </programlisting>
-				<para>Devuelve el valor <varname>jsonbset</varname> con <varname>jsonb</varname> insertado. Si el elemento especificado por la ruta es un elemento de arreglo, el nuevo valor se insertará antes de ese elemento si <varname>after</varname> es falso, o después en caso contrario. Si el elemento especificado por la ruta es un campo de objeto, el nuevo valor se insertará solo si el objeto no contiene ya esa clave. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo.</para>
+				<para>Si el elemento especificado por la ruta es un elemento de arreglo, el nuevo valor se insertará antes de ese elemento si <varname>after</varname> es falso, o después en caso contrario. Si el elemento especificado por la ruta es un campo de objeto, el nuevo valor se insertará solo si el objeto no contiene ya esa clave. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetInsert(set(ARRAY[jsonb '{"speed":10}', '{"speed":20}']), ARRAY['units'],
   '"km/h"'::jsonb);
@@ -289,7 +290,7 @@ SELECT jsonbsetStripNulls(set(ARRAY[jsonb
 /* {"{\"road\": \"rue de l'Abbaye\"}", "{\"road\": \"Bvd Gén. Jacques\", \"category\":
    \"primary\"}", "{\"road\": \"Bvd de la Cambre\", \"category\": \"primary\"}"} */
 </programlisting>
-				<para>Como se muestra a continuación, la función no elimina los valores nulos simples. Para este propósito puede utilizarse la función <varname>minusValue</varname>.</para>
+				<para>Como se muestra a continuación, la función no elimina los valores nulos simples. Para este propósito puede utilizarse la función <varname>setMinus</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetStripNulls(set(ARRAY[jsonb '{"speed": 10}', 'null',
   '{"speed": 20, "PoIs": ["Grand Place", "La Bourse"]}']));
@@ -961,7 +962,7 @@ SELECT tjsonb
 /* {["{\"PoIs\": [\"Grand Place\"], \"location\": \"Point(1 1)\"}"@2001-01-01,
    "{\"PoIs\": [\"Palais Royal\"], \"location\": \"Point(2 2)\"}"@2001-01-02]} */
 </programlisting>
-				<para>Como se muestra a continuación, el resultado de una operación de eliminación puede ser un registro vacío o un arreglo vacío. Para eliminar estos valores, puede utilizarse la función <varname>minusValue</varname>.</para>
+				<para>Como se muestra a continuación, el resultado de una operación de eliminación puede ser un registro vacío o un arreglo vacío. Para eliminar estos valores, puede utilizarse la función <varname>minusValues</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '{[{"unit": "km", "speed": 10, "light": true}@2001-01-01,
   {"unit": "km", "speed": 20}@2001-01-02]}' - ARRAY[text 'unit', 'speed'];
@@ -1095,7 +1096,7 @@ SELECT tjsonbStripNulls(tjsonb '{{"road": "Bvd Gén. Jacques",
    "{\"road\": \"Bvd de la Cambre\", \"category\": \"primary\"}"@2001-01-02,
    "{\"road\": \"rue de l'Abbaye\"}"@2001-01-03} */
 </programlisting>
-				<para>Como se muestra a continuación, la función no elimina los valores nulos simples. Para este propósito puede utilizarse la función <varname>minusValue</varname>.</para>
+				<para>Como se muestra a continuación, la función no elimina los valores nulos simples. Para este propósito puede utilizarse la función <varname>minusValues</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonStripNulls(ttext '[{"speed": 10}@2001-01-01, null@2001-01-02,
   {"speed": 20, "PoIs": ["Grand Place", "La Bourse"]}@2001-01-03]');

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2552,16 +2552,16 @@
 					<para><link linkend="jsonbset_alphanumset"><varname>intset</varname>, <varname>floatset</varname>, <varname>textset</varname></link>: Extract a alphanumeric value from a JSONB set given by a key</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="jsonbset_concat"><varname>||</varname></link>: Temporal JSONB concatenation</para>
+					<para><link linkend="jsonbset_concat"><varname>||</varname></link>: JSONB set concatenation</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="jsonbset_delete"><varname>-</varname></link>: Temporal JSONB deletion</para>
+					<para><link linkend="jsonbset_delete"><varname>-</varname></link>: JSONB set deletion</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="jsonbset_exists"><varname>?</varname></link>: JSONB set exists</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="jsonbset_set"><varname>jsonbsetSet</varname>, <varname>jsonbsetSetLax</varname></link>: Temporal JSONB set</para>
+					<para><link linkend="jsonbset_set"><varname>jsonbsetSet</varname>, <varname>jsonbsetSetLax</varname></link>: JSONB set assignment</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="jsonbset_insert"><varname>jsonbsetInsert</varname></link>: Return the <varname>jsonbset</varname> value with <varname>jsonb</varname> inserted</para>

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -146,10 +146,11 @@ SELECT textset(jsonbset '{"{\"road\": \"Bvd Gén. Jacques\", \"category\": \"pri
 
 			<listitem xml:id="jsonbset_concat">
 				<indexterm significance="normal"><primary><varname>||</varname></primary></indexterm>
-				<para>Temporal JSONB concatenation</para>
+				<para>JSONB set concatenation</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {jsonb,jsonbset} || {jsonbset,jsonb} → jsonbset
 </programlisting>
+				<para>The value is concatenated with every element of the set, and the operand order is free.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT set(ARRAY[jsonb '{"speed":10}', '{"speed":20}']) || '{"unit":"km"}'::jsonb;
 -- {"{\"unit\": \"km\", \"speed\": 10}", "{\"unit\": \"km\", \"speed\": 20}"}
@@ -160,7 +161,7 @@ SELECT jsonb '{"unit":"km"}' || set(ARRAY[jsonb '{"speed":10}', '{"speed":20}'])
 
 			<listitem xml:id="jsonbset_delete">
 				<indexterm significance="normal"><primary><varname>-</varname></primary></indexterm>
-				<para>Temporal JSONB deletion</para>
+				<para>JSONB set deletion</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 jsonbset - {int,text,text[]} → jsonbset
 jsonbset #- text[] → jsonbset
@@ -178,7 +179,7 @@ SELECT set(ARRAY[jsonb '{"location":"Point(1 1)", "PoIs": ["Grand Place", "La Bo
 /* {"{\"PoIs\": [\"Grand Place\"], \"location\": \"Point(1 1)\"}", "{\"PoIs\":
    [\"Palais Royal\"], \"location\": \"Point(2 2)\"}"} */
 </programlisting>
-				<para>As shown below, the result of a delete operation may be an empty record or an empty array. To remove these values, the function <varname>minusValue</varname> can used.</para>
+				<para>As shown below, the result of a delete operation may be an empty record or an empty array. To remove these values, the function <varname>setMinus</varname> can be used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT set(ARRAY[jsonb '{"unit": "km", "speed": 10, "light": true}',
   '{"unit": "km", "speed": 20}']) - ARRAY[text 'unit', 'speed'];
@@ -224,7 +225,7 @@ SELECT jsonbset '{"{\"speed\": 10}",
 			<listitem xml:id="jsonbset_set">
 				<indexterm significance="normal"><primary><varname>jsonbsetSet</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>jsonbsetSetLax</varname></primary></indexterm>
-				<para>Temporal JSONB set</para>
+				<para>JSONB set assignment</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 jsonbsetSet(jsonbset,path text[],val jsonb,create boolean=true) → jsonbset
 jsonbsetSetLax(jsonbset,path text[],val jsonb,create boolean=true,
@@ -289,7 +290,7 @@ SELECT jsonbsetStripNulls(set(ARRAY[jsonb
 /* {"{\"road\": \"rue de l'Abbaye\"}", "{\"road\": \"Bvd Gén. Jacques\", \"category\":
    \"primary\"}", "{\"road\": \"Bvd de la Cambre\", \"category\": \"primary\"}"} */
 </programlisting>
-				<para>As shown below, the function does not strip bare null values. Function <varname>minusValue</varname> can be used for this purpose.</para>
+				<para>As shown below, the function does not strip a bare null value. The function <varname>setMinus</varname> can be used for this purpose.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT jsonbsetStripNulls(set(ARRAY[jsonb '{"speed": 10}', 'null',
   '{"speed": 20, "PoIs": ["Grand Place", "La Bourse"]}']));
@@ -961,7 +962,7 @@ SELECT tjsonb
 /* {["{\"PoIs\": [\"Grand Place\"], \"location\": \"Point(1 1)\"}"@2001-01-01,
    "{\"PoIs\": [\"Palais Royal\"], \"location\": \"Point(2 2)\"}"@2001-01-02]} */
 </programlisting>
-				<para>As shown below, the result of a delete operation may be an empty record or an empty array. To remove these values, the function <varname>minusValue</varname> can used.</para>
+				<para>As shown below, the result of a delete operation may be an empty record or an empty array. To remove these values, the function <varname>minusValues</varname> can be used.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonb '{[{"unit": "km", "speed": 10, "light": true}@2001-01-01,
   {"unit": "km", "speed": 20}@2001-01-02]}' - ARRAY[text 'unit', 'speed'];
@@ -1095,7 +1096,7 @@ SELECT tjsonbStripNulls(tjsonb '{{"road": "Bvd Gén. Jacques",
    "{\"road\": \"Bvd de la Cambre\", \"category\": \"primary\"}"@2001-01-02,
    "{\"road\": \"rue de l'Abbaye\"}"@2001-01-03} */
 </programlisting>
-				<para>As shown below, the function does not strip bare null values. Function <varname>minusValue</varname> can be used for this purpose.</para>
+				<para>As shown below, the function does not strip bare null values. The function <varname>minusValues</varname> can be used for this purpose.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tjsonStripNulls(ttext '[{"speed": 10}@2001-01-01, null@2001-01-02,
   {"speed": 20, "PoIs": ["Grand Place", "La Bourse"]}@2001-01-03]');


### PR DESCRIPTION
The concatenation, deletion, assignment and insertion entries of the JSONB set each state the operation they perform on a set, so the reference appendix lists them as set operations rather than temporal ones. The paragraphs beside the examples name the function the example below them calls: setMinus for a set and minusValues for a temporal value. The Spanish insertion entry keeps its one-liner apart from its explanation, as the English one does.