### PR TITLE
Report a merge conflict between sequences instead of faulting

### DIFF
--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -344,6 +344,9 @@ static TSequence **
 tcontseq_merge_array_iter(TSequence **sequences, int count, int *totalcount)
 {
   assert(sequences); assert(totalcount);
+  /* The count is set before any rejection below, so a caller reading it after
+   * a failure finds zero rather than whatever its variable held */
+  *totalcount = 0;
   if (count > 1)
     tseqarr_sort((TSequence **) sequences, count);
 
@@ -398,6 +401,11 @@ tsequence_merge_array(TSequence **sequences, int count)
   /* Continuous sequences */
   int totalcount;
   TSequence **newseqs = tcontseq_merge_array_iter(sequences, count, &totalcount);
+  /* The iterator has already ensured the validity of the sequences; it returns
+   * NULL when they cannot be merged */
+  if (newseqs == NULL)
+    return NULL;
+
   Temporal *result;
   if (totalcount == 1)
   {
@@ -454,6 +462,11 @@ tsequenceset_merge_array(TSequenceSet **seqsets, int count)
   TSequence **newseqs = tcontseq_merge_array_iter(sequences, totalcount,
     &newcount);
   pfree(sequences);
+  /* The iterator has already ensured the validity of the sequences; it returns
+   * NULL when they cannot be merged */
+  if (newseqs == NULL)
+    return NULL;
+
   return tsequenceset_make_free(newseqs, newcount, NORMALIZE);
 }
 

--- a/meos/test/merge_test.c
+++ b/meos/test/merge_test.c
@@ -97,6 +97,47 @@ int main(void)
   assert(merged == NULL);
   assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
 
+  /* Two CONTINUOUS sequences meeting at a shared instant with different
+   * values. This reaches a different merge path from the instant sets above:
+   * the sequences are merged as an array and assembled into a sequence set */
+  Temporal *seq1 = tfloat_in("[77@2000-01-01, 88@2000-01-03]");
+  Temporal *seq2 = tfloat_in("[99@2000-01-03, 44@2000-01-05]");
+  assert(seq1); assert(seq2);
+  meos_errno_reset();
+  merged = temporal_merge(seq1, seq2);
+  printf("temporal_merge(%s, %s): NULL, errno %d\n",
+    "[77@2000-01-01, 88@2000-01-03]", "[99@2000-01-03, 44@2000-01-05]",
+    meos_errno());
+  assert(merged == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+
+  /* The same conflict between two sequence SETS */
+  Temporal *ss1 = tfloat_in("{[77@2000-01-01, 88@2000-01-03]}");
+  Temporal *ss2 = tfloat_in("{[99@2000-01-03, 44@2000-01-05]}");
+  assert(ss1); assert(ss2);
+  meos_errno_reset();
+  merged = temporal_merge(ss1, ss2);
+  printf("temporal_merge({[77@…, 88@…]}, {[99@…, 44@…]}): NULL, errno %d\n",
+    meos_errno());
+  assert(merged == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+
+  /* Two continuous sequences meeting at a shared instant that carries the
+   * SAME value merge into one sequence */
+  Temporal *join1 = tfloat_in("[77@2000-01-01, 88@2000-01-03]");
+  Temporal *join2 = tfloat_in("[88@2000-01-03, 44@2000-01-05]");
+  assert(join1); assert(join2);
+  meos_errno_reset();
+  Temporal *joined = temporal_merge(join1, join2);
+  assert(joined);
+  char *joined_out = tfloat_out(joined, 6);
+  printf("temporal_merge(%s, %s): %s\n", "[77@2000-01-01, 88@2000-01-03]",
+    "[88@2000-01-03, 44@2000-01-05]", joined_out);
+  assert(joined_out[0] == '[');
+
+  free(seq1); free(seq2); free(ss1); free(ss2);
+  free(join1); free(join2); free(joined); free(joined_out);
+
   /* Merging compatible values still succeeds after the reported conflicts */
   Temporal *ok1 = tfloat_in("{77@2000-01-01}");
   Temporal *ok2 = tfloat_in("{88@2000-01-02}");


### PR DESCRIPTION
Merging two temporal sequences that meet at a shared instant carrying different values is an error, and reporting it walks a null array:

```
tint        CRASHED (signal 11)
tfloat      CRASHED (signal 11)
tgeompoint  CRASHED (signal 11)
tpose       CRASHED (signal 11)
trgeometry  CRASHED (signal 11)
```

Read at the fault, with `rdi = 0x0`:

```
#0 pfree_array   #1 tsequenceset_make_free   #2 tcontseq_merge_array_iter
#3 tsequence_merge   #4 temporal_merge
```

`tcontseq_merge_array_iter` rejects the sequences and answers NULL without writing the count beside it, so `tsequence_merge_array` reads an uninitialised length and a null array, and `tsequenceset_merge_array` does the same one level up.

## What the fix is

The count is written before any rejection, so a caller finds zero rather than whatever its variable held, and the two callers that read the array without testing it answer NULL — which is what the third caller of the same iterator, in the same file, already does.

This is the sibling of the defect PR #1549 closes for `tinstant_merge_array_iter`. That path carries its check today; the continuous-sequence path beside it carries none.

## Who reaches it

PostgreSQL raises through `ereport`, which does not return, so the code after the rejection is unreachable there. It is reached by a MEOS C program and by every language binding, each of which installs `meos_initialize_noexit_error_handler` — a binding must raise an exception to its host rather than terminate it.

⚠️ The crash is deterministic at `-O1` and absent at `-O0`, so a debug build hides it.

## The witness fails without the fix

`meos/test/merge_test.c` covers only the discrete path today. It gains the continuous cases: two sequences and two sequence sets that conflict, and — as the control that the fix does not simply refuse everything — two sequences meeting at a shared instant carrying the same value, which still merge into one sequence.

Compiled against two staged prefixes from the same source, the unpatched one exits **139** (segmentation fault) and the patched one exits **0**:

```
temporal_merge([77@2000-01-01, 88@2000-01-03], [99@2000-01-03, 44@2000-01-05]): NULL, errno 12
temporal_merge({[77@…, 88@…]}, {[99@…, 44@…]}): NULL, errno 12
temporal_merge([77@2000-01-01, 88@2000-01-03], [88@2000-01-03, 44@2000-01-05]): [77@2000-01-01 00:00:00+00, 88@2000-01-03 00:00:00+00, 44@2000-01-05 00:00:00+00]
```

The test is already wired into `.github/workflows/meos.yml`, so it runs in CI as it stands.
