### PR TITLE
Reject a geometry string the readers cannot parse

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -3649,13 +3649,28 @@ geom_in(const char *str, int32 typmod)
   {
     size_t hexsize = strlen(str1);
     unsigned char *wkb = bytes_from_hexbytes(str1, hexsize);
-    /* TODO: 20101206: No parser checks! This is inline with current 1.5 behavior, but needs discussion */
+    /* A string of an odd length, or one carrying a character that is not a
+     * hexadecimal digit, encodes nothing */
+    if (! wkb)
+    {
+      meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+        "Could not parse geometry value: %s", str);
+      return NULL;
+    }
     lwgeom = lwgeom_from_wkb(wkb, hexsize/2, LW_PARSER_CHECK_NONE);
+    lwfree(wkb);
+    /* The reader is asked for no parser checks, so it answers NULL for bytes
+     * that do not spell a geometry */
+    if (! lwgeom)
+    {
+      meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+        "Could not parse geometry value: %s", str);
+      return NULL;
+    }
     /* If we picked up an SRID at the head of the WKB set it manually */
     if ( srid ) lwgeom_set_srid(lwgeom, srid);
     /* Add a bbox if necessary */
     if ( lwgeom_needs_bbox(lwgeom) ) lwgeom_add_bbox(lwgeom);
-    lwfree(wkb);
     result = geo_serialize(lwgeom);
     lwgeom_free(lwgeom);
   }
@@ -3663,6 +3678,14 @@ geom_in(const char *str, int32 typmod)
   {
     char *srs = NULL;
     lwgeom = lwgeom_from_geojson(str1, &srs);
+    if (! lwgeom)
+    {
+      if (srs)
+        lwfree(srs);
+      meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+        "Could not parse geometry value: %s", str);
+      return NULL;
+    }
     if (srs)
     {
       srid = SRID_DEFAULT; // TODO

--- a/meos/test/parse_test.c
+++ b/meos/test/parse_test.c
@@ -158,6 +158,12 @@ static const char *invalid_geoms[] = {
   "NOTAGEOMETRY(1 2)",                            /* unknown keyword       */
   "POINT(1)",                                     /* too few coordinates   */
   "",                                             /* empty string          */
+  /* A leading zero selects the hexadecimal reader and a leading brace the
+   * GeoJSON one, so these reach neither the keyword nor the paren check */
+  "0",                                            /* hexadecimal, too short */
+  "010",                                          /* hexadecimal, odd length */
+  "0101",                                         /* hexadecimal, truncated */
+  "{",                                            /* GeoJSON, unterminated */
 };
 
 int


### PR DESCRIPTION
A leading zero sends a geometry string to the hexadecimal reader and a leading brace to the GeoJSON one. Neither answer is tested before it is used, so four shapes of input fault instead of being rejected:

```
geom_in on malformed input:
  a valid polygon (control)              answers, errno 0
  a lone brace                           CRASHED (signal 11)
  hex-looking, truncated                 CRASHED (signal 11)
  hex-looking, odd length                CRASHED (signal 11)
  a zero                                 CRASHED (signal 11)
  garbage words                          NULL, errno 2
  empty string                           NULL, errno 22
```

The fault is `geo_serialize` reading a null geometry. `bytes_from_hexbytes` answers NULL for a string of an odd length or one carrying a character that is not a hexadecimal digit; `lwgeom_from_wkb` is asked for no parser checks and answers NULL for bytes that do not spell a geometry; `lwgeom_from_geojson` answers NULL for a document it cannot read.

## What the fix is

Both readers are asked for their answer before it is read, and report the string they could not parse.

This is the shape the third branch of the same function already has — the Well-Known Text branch tests `LW_FAILURE` and returns — and the shape `geo_from_ewkb` and `geo_from_geojson` carry for these same two readers, a few hundred lines down the same file. The line the change replaces says so itself: *"TODO: 20101206: No parser checks!"*.

## Who reaches it

Every type whose input carries a geometry reaches this entry. Among them is the reference geometry of a temporal rigid geometry, whose parser takes the text up to its first semicolon and hands it here — so `trgeometry '0;…'` reaches the hexadecimal branch with one character.

## The witness fails without the fix

`meos/test/parse_test.c` already carries an `invalid_geoms[]` array and the checker for it; it gains the four shapes. Compiled against two staged prefixes from the same source, the unpatched one exits **139** (segmentation fault) and the patched one exits **0** with `parse_test: all parses validated`.

Every input that is answered or rejected today keeps its answer and its errno — the valid polygon still answers, and the two strings the readers already rejected still report the same codes.
