### PR TITLE
Keep the reference geometry through the generic temporal operations

### DIFF
--- a/meos/include/rgeo/trgeo.h
+++ b/meos/include/rgeo/trgeo.h
@@ -71,6 +71,8 @@ extern TSequence *geo_tposeseq_to_trgeo(const GSERIALIZED *gs,
   const TSequence *seq);
 extern TSequenceSet *geo_tposeseqset_to_trgeo(const GSERIALIZED *gs,
   const TSequenceSet *ss);
+extern Temporal *geo_tpose_to_trgeo(const GSERIALIZED *gs,
+  const Temporal *temp);
 
 /* Conversion functions */
 

--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -486,6 +486,9 @@ extern bool ensure_positive_duration(const Interval *duration);
 /* General functions */
 
 extern void *temporal_bbox_ptr(const Temporal *temp);
+extern Temporal *temporal_strip_geom(const Temporal *temp,
+  const GSERIALIZED **geom);
+extern Temporal *temporal_attach_geom(const GSERIALIZED *geom, Temporal *temp);
 
 extern bool intersection_temporal_temporal(const Temporal *temp1,
 const Temporal *temp2, SyncMode mode, Temporal **inter1, Temporal **inter2);

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -944,7 +944,7 @@ trgeometry_segments(const Temporal *temp, int *count)
  * @param[in] gs Reference geometry
  * @param[in] temp Temporal pose
  */
-static Temporal *
+Temporal *
 geo_tpose_to_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 {
   assert(gs); assert(temp);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -72,6 +72,7 @@
   #include "posechain/posechain.h"
 #endif
 #if RGEO
+  #include <meos_rgeo.h>
   #include "rgeo/trgeo.h"
 #endif
 
@@ -605,6 +606,63 @@ ensure_positive_duration(const Interval *duration)
     "The interval must be positive: %s", str);
   pfree(str);
   return false;
+}
+
+/*****************************************************************************
+ * Reference geometry of the temporal types that carry one
+ *****************************************************************************/
+
+/**
+ * @brief Return the temporal value an operation is to be computed on, and the
+ * reference geometry it carries
+ * @details A temporal rigid geometry is a temporal pose with a reference
+ * geometry appended to it, and an operation that rebuilds a temporal value
+ * from its instants reproduces the poses and not the geometry. Such an
+ * operation therefore computes on the poses this function answers, and gives
+ * the result its geometry back with #temporal_attach_geom.
+ * @param[in] temp Temporal value
+ * @param[out] geom Reference geometry the value carries, NULL where it carries
+ * none
+ * @return The temporal value to compute on, which is the argument itself for
+ * every type that carries no reference geometry
+ * @note The geometry is the argument's own, so it is read while the argument
+ * lives, and #temporal_attach_geom copies it into the result
+ */
+Temporal *
+temporal_strip_geom(const Temporal *temp, const GSERIALIZED **geom)
+{
+  assert(temp); assert(geom);
+  *geom = NULL;
+#if RGEO
+  if (temp->temptype == T_TRGEOMETRY)
+  {
+    *geom = trgeo_geom_p(temp);
+    return trgeometry_to_tpose(temp);
+  }
+#endif /* RGEO */
+  return (Temporal *) temp;
+}
+
+/**
+ * @brief Return the temporal value that carries a reference geometry again
+ * @param[in] geom Reference geometry, NULL where the value carries none
+ * @param[in] temp Temporal value the operation computed
+ * @return The temporal value the caller answers, which is the argument itself
+ * where there is no geometry to give back
+ * @note The argument is freed where a value carrying the geometry replaces it
+ */
+Temporal *
+temporal_attach_geom(const GSERIALIZED *geom, Temporal *temp)
+{
+  if (! geom || ! temp)
+    return temp;
+#if RGEO
+  Temporal *result = geo_tpose_to_trgeo(geom, temp);
+  pfree(temp);
+  return result;
+#else
+  return temp;
+#endif /* RGEO */
 }
 
 /*****************************************************************************
@@ -1351,18 +1409,26 @@ temporal_round(const Temporal *temp, int maxdd)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
 
+  const GSERIALIZED *geom;
+  Temporal *work = temporal_strip_geom(temp, &geom);
+  if (! work)
+    return NULL;
+
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
-  lfinfo.func = (varfunc) round_fn(temptype_basetype(temp->temptype));
+  lfinfo.func = (varfunc) round_fn(temptype_basetype(work->temptype));
   lfinfo.numparam = 1;
   lfinfo.param[0] = Int32GetDatum(maxdd);
-  lfinfo.argtype[0] = temp->temptype;
-  lfinfo.restype = temp->temptype;
+  lfinfo.argtype[0] = work->temptype;
+  lfinfo.restype = work->temptype;
   /* Rounding to a precision finer than the segment's variation is effectively
    * affine; the chord-of-f deviation is bounded by 0.5*10^-maxdd which is below
    * the user-requested precision.  Treat as affine and inherit interpolation. */
-  lfinfo.reslinear = MEOS_FLAGS_LINEAR_INTERP(temp->flags);
-  return tfunc_temporal(temp, &lfinfo);
+  lfinfo.reslinear = MEOS_FLAGS_LINEAR_INTERP(work->flags);
+  Temporal *result = tfunc_temporal(work, &lfinfo);
+  if (work != temp)
+    pfree(work);
+  return temporal_attach_geom(geom, result);
 }
 
 /**

--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -1250,19 +1250,30 @@ temporal_tsample(const Temporal *temp, const Interval *duration,
   if (! ensure_positive_duration(duration))
     return NULL;
 
-  assert(temptype_subtype(temp->subtype));
-  switch (temp->subtype)
+  const GSERIALIZED *geom;
+  Temporal *work = temporal_strip_geom(temp, &geom);
+  if (! work)
+    return NULL;
+
+  Temporal *result;
+  assert(temptype_subtype(work->subtype));
+  switch (work->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tinstant_tsample((TInstant *) temp, duration,
+      result = (Temporal *) tinstant_tsample((TInstant *) work, duration,
         torigin);
+      break;
     case TSEQUENCE:
-      return (Temporal *) tsequence_tsample((TSequence *) temp, duration,
+      result = (Temporal *) tsequence_tsample((TSequence *) work, duration,
         torigin, interp);
+      break;
     default: /* TSEQUENCESET */
-      return (Temporal *) tsequenceset_tsample((TSequenceSet *) temp,
+      result = (Temporal *) tsequenceset_tsample((TSequenceSet *) work,
         duration, torigin, interp);
   }
+  if (work != temp)
+    pfree(work);
+  return temporal_attach_geom(geom, result);
 }
 
 /*****************************************************************************

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -1585,21 +1585,32 @@ temporal_delete_timestamptz(const Temporal *temp, TimestampTz t, bool connect)
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
 
-  assert(temptype_subtype(temp->subtype));
-  switch (temp->subtype)
+  const GSERIALIZED *geom;
+  Temporal *work = temporal_strip_geom(temp, &geom);
+  if (! work)
+    return NULL;
+
+  Temporal *result;
+  assert(temptype_subtype(work->subtype));
+  switch (work->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tinstant_restrict_timestamptz((TInstant *) temp, t,
+      result = (Temporal *) tinstant_restrict_timestamptz((TInstant *) work, t,
         REST_MINUS);
+      break;
     case TSEQUENCE:
-      return (Temporal *) tsequence_delete_timestamptz((TSequence *) temp, t,
+      result = (Temporal *) tsequence_delete_timestamptz((TSequence *) work, t,
         connect);
+      break;
     default: /* TSEQUENCESET */
-      return connect ?
-        (Temporal *) tsequenceset_restrict_timestamptz((TSequenceSet *) temp, t,
+      result = connect ?
+        (Temporal *) tsequenceset_restrict_timestamptz((TSequenceSet *) work, t,
           REST_MINUS) :
-        (Temporal *) tsequenceset_delete_timestamptz((TSequenceSet *) temp, t);
+        (Temporal *) tsequenceset_delete_timestamptz((TSequenceSet *) work, t);
   }
+  if (work != temp)
+    pfree(work);
+  return temporal_attach_geom(geom, result);
 }
 
 /**

--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -441,27 +441,38 @@ Temporal *
 temporal_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
 {
   assert(temp);
-  assert(temptype_subtype(temp->subtype));
-  switch (temp->subtype)
+  const GSERIALIZED *geom;
+  Temporal *work = temporal_strip_geom(temp, &geom);
+  if (! work)
+    return NULL;
+
+  Temporal *result;
+  assert(temptype_subtype(work->subtype));
+  switch (work->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tinstant_restrict_timestamptz((TInstant *) temp, t,
+      result = (Temporal *) tinstant_restrict_timestamptz((TInstant *) work, t,
         atfunc);
+      break;
     case TSEQUENCE:
     {
-      if (MEOS_FLAGS_DISCRETE_INTERP(temp->flags))
-        return atfunc ?
-          (Temporal *) tdiscseq_at_timestamptz((TSequence *) temp, t) :
-          (Temporal *) tdiscseq_minus_timestamptz((TSequence *) temp, t);
+      if (MEOS_FLAGS_DISCRETE_INTERP(work->flags))
+        result = atfunc ?
+          (Temporal *) tdiscseq_at_timestamptz((TSequence *) work, t) :
+          (Temporal *) tdiscseq_minus_timestamptz((TSequence *) work, t);
       else
-        return atfunc ?
-          (Temporal *) tcontseq_at_timestamptz((TSequence *) temp, t) :
-          (Temporal *) tcontseq_minus_timestamptz((TSequence *) temp, t);
+        result = atfunc ?
+          (Temporal *) tcontseq_at_timestamptz((TSequence *) work, t) :
+          (Temporal *) tcontseq_minus_timestamptz((TSequence *) work, t);
+      break;
     }
     default: /* TSEQUENCESET */
-      return (Temporal *) tsequenceset_restrict_timestamptz(
-        (TSequenceSet *) temp, t, atfunc);
+      result = (Temporal *) tsequenceset_restrict_timestamptz(
+        (TSequenceSet *) work, t, atfunc);
   }
+  if (work != temp)
+    pfree(work);
+  return temporal_attach_geom(geom, result);
 }
 
 /*****************************************************************************/
@@ -547,18 +558,29 @@ Temporal *
 temporal_restrict_tstzspan(const Temporal *temp, const Span *s, bool atfunc)
 {
   assert(temp); assert(s);
-  assert(temptype_subtype(temp->subtype));
-  switch (temp->subtype)
+  const GSERIALIZED *geom;
+  Temporal *work = temporal_strip_geom(temp, &geom);
+  if (! work)
+    return NULL;
+
+  Temporal *result;
+  assert(temptype_subtype(work->subtype));
+  switch (work->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tinstant_restrict_tstzspan(
-        (TInstant *) temp, s, atfunc);
+      result = (Temporal *) tinstant_restrict_tstzspan(
+        (TInstant *) work, s, atfunc);
+      break;
     case TSEQUENCE:
-      return tsequence_restrict_tstzspan((TSequence *) temp, s, atfunc);
+      result = tsequence_restrict_tstzspan((TSequence *) work, s, atfunc);
+      break;
     default: /* TSEQUENCESET */
-      return (Temporal *) tsequenceset_restrict_tstzspan(
-        (TSequenceSet *) temp, s, atfunc);
+      result = (Temporal *) tsequenceset_restrict_tstzspan(
+        (TSequenceSet *) work, s, atfunc);
   }
+  if (work != temp)
+    pfree(work);
+  return temporal_attach_geom(geom, result);
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
A temporal rigid geometry is a temporal pose with a reference geometry appended to it, and an operation that rebuilds a temporal value from its instants reproduces the poses and not the geometry. Seven generic entries answer a value carrying the rigid geometry type with its geometry flag clear:

```
generic temporal_* entries on a trgeometry:
  temporal_round                     ⛔ CLAIMS trgeometry, NO BODY
  temporal_at_tstzspan               ⛔ CLAIMS trgeometry, NO BODY
  temporal_minus_tstzspan            ⛔ CLAIMS trgeometry, NO BODY
  temporal_at_timestamptz            ⛔ CLAIMS trgeometry, NO BODY
  temporal_minus_timestamptz         ⛔ CLAIMS trgeometry, NO BODY
  temporal_delete_timestamptz        ⛔ CLAIMS trgeometry, NO BODY
  temporal_tsample                   ⛔ CLAIMS trgeometry, NO BODY
```

Each reports no error, so nothing fails until a reader asks for the body — which is what a caller does next, and which aborts under a build carrying the assertion and runs off the end of the value where it does not.

## What the fix is

Two functions state the operation once. `temporal_strip_geom` answers the temporal value to compute on and the geometry it carries; `temporal_attach_geom` gives the geometry back to the result. A type carrying no reference geometry passes through both untouched, so an entry reads:

```c
const GSERIALIZED *geom;
Temporal *work = temporal_strip_geom(temp, &geom);
...  the existing algorithm, on work  ...
if (work != temp) pfree(work);
return temporal_attach_geom(geom, result);
```

**No entry names a type.** The one place that does is `temporal_strip_geom`, which is the shape `pcschema_header_to_wkb_size` already has in `type_out.c` — one function holding the test that its call sites would otherwise repeat — carrying the strip-operate-re-attach idiom the rigid geometry family already uses for its own merge.

Wrapping a shared dispatcher pays several entries at once: `temporal_restrict_tstzspan` and `temporal_restrict_timestamptz` carry four of the seven between them.

The geometry reaches the pair through `geo_tpose_to_trgeo`, which the rigid geometry family already uses for its own merge and which its internal header declares. `meos/include/rgeo/trgeo.h` and `meos/include/temporal/temporal.h` are both internal headers with no install rule, so the public surface is unchanged.

## Why the core rather than the wrapper

`mobilitydb/src/temporal/temporal.c` repairs this for SQL one function at a time — 25 of its 91 wrappers carry a hand-written `(temp->temptype == T_TRGEOMETRY) ? trgeometry_X(…) : temporal_X(…)`. So `round(trgeometry)` in SQL is right today while MEOS C `temporal_round` is wrong, and every generated binding and every C caller reads the broken one. Fixing at the core serves all of them, and the SQL answers do not move.

⭐ It also writes less: 7 of the 10 entries in the audit have a `trgeometry_*` twin and three do not, so the per-operation route would add three more functions where this adds none.

## Not in this change

`minusMax`, `update` and `append_tinstant` carry the same defect and are left alone here. `minusMax` needs the order question rather than the body one; `append_tinstant` consumes its argument in expandable mode and wants its own reading.

## Measurement

`~/probes/trgeo_body_audit.c` calls each generic entry on a rigid geometry, each in its own child, reading the geometry flag before the body. The seven rows above move to `keeps its body`; the input itself is asserted as a positive control, and a result of another temporal type is reported apart from a bodyless one, since `temporal_derivative` answers a `tfloat` and that is correct.

No expected output moves: the SQL surface reaches these operations through the wrappers that already repair the type.
