### PR TITLE
Show the same examples in the Spanish manual as in the English one

### DIFF
--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -25,12 +25,14 @@
 		</para>
 
 		<para>Un <varname>tbox</varname> se compone de dimensiónes de valor numérico y/o de tiempo. Para cada dimensión, se proporciona un rango, es decir, ya sea un <varname>intspan</varname> o un <varname>floatspan</varname> para la dimensión de valor y un <varname>tstzspan</varname> para la dimensión de tiempo. Ejemplos de entrada de valores <varname>tbox</varname> son los siguientes:
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Dimensiones de valor y tiempo
 SELECT tbox 'TBOXINT XT([1,3),[2001-01-01,2001-01-02])';
+SELECT tbox 'TBOXBIGINT XT([1,3),[2001-01-01,2001-01-02])';
 SELECT tbox 'TBOXFLOAT XT([1.5,2.5],[2001-01-01,2001-01-02])';
 -- Sólo dimensión de valor
 SELECT tbox 'TBOXINT X([1,3))';
+SELECT tbox 'TBOXBIGINT X([1,3))';
 SELECT tbox 'TBOXFLOAT X((1.5,2.5))';
 -- Sólo dimensión de tiempo
 SELECT tbox 'TBOX T((2001-01-01,2001-01-02))';
@@ -38,7 +40,7 @@ SELECT tbox 'TBOX T((2001-01-01,2001-01-02))';
 		</para>
 
 		<para>Un <varname>stbox</varname> se compone de dimensiónes espacial y/o temporal, donde las coordenadas de la dimensión espacial pueden ser 2D o 3D. Para la dimensión de tiempo se da un <varname>tstzspan</varname>, y para la dimensión espacial se dan los valores mínimos y máximos de las coordenadas, donde estas últimas pueden ser cartesianas (planas) o geodésicas (esféricas). Se puede especificar el SRID de las coordenadas; si no es el caso, se asume un valor de 0 (desconocido) y 4326 (correspondiente a WGS84), respectivamente, para coordenadas planas y geodésicas. Los cuadros geodésicos siempre tienen una dimensión Z para tener en cuenta la curvatura de la esfera o esferoide subyacente. Ejemplos de entrada de valores <varname>stbox</varname> son los siguientes:
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sólo dimensión de valor con coordenadas X e Y
 SELECT stbox 'STBOX X((1.0,2.0),(1.0,2.0))';
 -- Sólo dimensión de valor con coordenadas X, Y y Z
@@ -73,7 +75,7 @@ SELECT stbox 'SRID=4326;GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
 asText(box,maxdecimaldigits integer=15) → text
 </programlisting>
 					<para>El argumento <varname>maxdecimaldigits</varname> se puede utilizar para definir el número máximo de decimales para la salida de los valores de coma flotante (por defecto 15).</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tbox 'TBOXFLOAT XT([1.123456789,2.123456789),[2001-01-01,2001-01-02))', 3);
 -- TBOXFLOAT XT([1.123, 2.123),[2001-01-01, 2001-01-02))
 SELECT asText(stbox 'STBOX Z((1.55,1.55,1.55),(2.55,2.55,2.55))', 0);
@@ -90,7 +92,7 @@ asBinary(box,endian text='') → bytea
 asHexWKB(box,endian text='') → text
 </programlisting>
 					<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tbox 'TBOXFLOAT XT([1,2),[2001-01-01,2001-01-02))');
 -- \x0103270001009c57d3c11c000000fc2ef1d51c00000d0001000000000000f03f0000000000000040
 SELECT asBinary(tbox 'TBOXFLOAT XT([1,2),[2001-01-01,2001-01-02))', 'XDR');
@@ -115,7 +117,7 @@ boxFromBinary(bytea) → box
 boxFromHexWKB(text) → box
 </programlisting>
 					<para>En las funciones anteriores, <varname>box</varname> reemplaza cualquier tipo de cuadro delimitador, a saber, <varname>tbox</varname> o <varname>stbox</varname>.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboxFromBinary(
   '\x0103270001009c57d3c11c000000fc2ef1d51c00000d0001000000000000f03f0000000000000040');
 -- TBOXFLOAT XT([1,2),[2001-01-01,2001-01-02))
@@ -150,10 +152,10 @@ tbox({number,numspan}) → tbox
 tbox({timestamptz,tstzspan}) → tbox
 tbox({number,numspan},{timestamptz,tstzspan}) → tbox
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Dimensiones de valores y de tiempo
 SELECT tbox(1.0, timestamptz '2001-01-01');
-SELECT tbox(floatspan '[1.0,2.0)', tstzspan '[2001-01-01,2001-01-02)');
+SELECT tbox(floatspan '[1.0, 2.0)', tstzspan '[2001-01-01,2001-01-02)');
 -- Sólo dimensión de valores
 SELECT tbox(floatspan '[1.0,2.0)');
 -- Sólo dimensión de tiempo
@@ -192,7 +194,7 @@ geodstboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},
 stbox(geo) → stbox
 stbox(geo,{timestamptz,tstzspan}) → stbox
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sólo dimensión de valores con coordenadas X e Y
 SELECT stboxX(1.0,2.0,1.0,2.0);
 -- Sólo dimensión de valores con coordenadas X, Y y Z
@@ -212,9 +214,9 @@ SELECT geodstboxT(tstzspan '[2001-01-03,2001-01-03]');
 -- Dimensiones de valor (con coordenadas geodéticas X, Y y Z) y de tiempo
 SELECT geodstboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-04]');
 -- Geometry and time dimensión
-SELECT stbox(geometry 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03, 2001-01-05]');
+SELECT stbox(geometry 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03,2001-01-05]');
 -- Geography and time dimensión
-SELECT stbox(geography 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03, 2001-01-05]');
+SELECT stbox(geography 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03,2001-01-05]');
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -236,7 +238,7 @@ intspan(tbox) → tbox
 floatspan(tbox) → tbox
 tstzspan(tbox) → tbox
 </programlisting>
-          <programlisting language="sql" xml:space="preserve">
+          <programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,4),[2001-01-01,2001-01-02))'::intspan;
 -- [1,4)
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02))'::floatspan;
@@ -254,7 +256,7 @@ SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02))'::tstzspan;
 {numbers,times,tnumber}::tbox
 tbox({numbers,times,tnumber}) → tbox
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intset '{1,2}'::tbox;
 -- TBOXINT X([1, 3))
 SELECT intspan '[1,3)'::tbox;
@@ -282,7 +284,7 @@ geometry(stbox) &#8594; geometry
 geography(stbox) &#8594; geography
 tstzspan(stbox) &#8594; tstzspan
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-03])'::box2d;
 -- BOX(1 2,3 4)
 SELECT ST_AsEWKT(stbox 'SRID=4326;
@@ -310,7 +312,7 @@ SELECT stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-03])'::tstzspan
 {box2d,box3d,geo,time,tgeo}::stbox
 stbox({box2d,box3d,geo,time,tgeo}) → stbox
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geometry 'Linestring(1 1 1,2 2 2)'::box3d::stbox;
 -- STBOX Z((1,1,1),(2,2,2))
 SELECT geography 'Linestring(1 1,2 2)'::stbox;
@@ -336,7 +338,7 @@ hasX(box) → boolean
 hasZ(stbox) → boolean
 hasT(box) → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT hasX(tbox 'TBOX T([2001-01-01,2001-01-03))');
 -- false
 SELECT hasX(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
@@ -356,7 +358,7 @@ SELECT hasT(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 isGeodetic(stbox) → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isGeodetic(stbox 'GEODSTBOX Z((1.0,1.0,0.0),(3.0,3.0,1.0))');
 -- true
 SELECT isGeodetic(stbox 'STBOX XT(((1.0,2.0),(3.0,4.0)),[2001-01-01,2001-01-02])');
@@ -376,7 +378,7 @@ yMin(stbox) → float
 zMin(stbox) → float
 tMin(box) → timestamptz
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT xMin(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- 1
 SELECT yMin(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
@@ -400,8 +402,8 @@ yMax(stbox) → float
 zMax(stbox) → float
 tMax(box) → timestamptz
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
-SELECT xMax(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT xMax(tbox 'TBOXINT X([1,4))');
 -- 3
 SELECT yMax(stbox 'STBOX X((1.0,2.0),(3.0,4.0))');
 -- 4
@@ -420,7 +422,7 @@ SELECT tMax(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 xMinInc(tbox) → boolean
 tMinInc(box) → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT xMinInc(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- false
 SELECT tMinInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
@@ -436,7 +438,7 @@ SELECT tMinInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 xMaxInc(tbox) → boolean
 tMaxInc(box) → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT xMaxInc(tbox 'TBOXFLOAT XT((1.0,3.0),[2001-01-01,2001-01-03))');
 -- false
 SELECT tMaxInc(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
@@ -455,7 +457,7 @@ volume(stbox) → float
 perimeter(stbox,spheroid boolean=true) → float
 </programlisting>
 				<para>Para cuadros geodésicos, el cálculo se realiza en el esferoide WGS 84 por defecto. Si el último argumento es falso, se utiliza un cálculo esférico más rápido. La función <varname>volume</varname> no acepta cuadros geodésicos.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT area(stbox 'STBOX XT(((1,1),(3,3)),[2001-01-01,2001-01-03))');
 -- 4
 SELECT volume(stbox 'STBOX ZT(((1,1,1),(3,3,3)),[2001-01-01,2001-01-03))');
@@ -485,7 +487,7 @@ shiftValue(tbox,{integer,float}) &#8594; tbox
 scaleValue(tbox,{integer,float}) &#8594; tbox
 shiftScaleValue(tbox,{integer,float},{integer,float}) &#8594; tbox
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 1.0);
 -- TBOXFLOAT XT([2.5, 3.5],[2001-01-01, 2001-01-02])
 SELECT scaleValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 2.0);
@@ -494,7 +496,10 @@ SELECT shiftScaleValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 
 -- TBOXFLOAT XT([3.5, 6.5],[2001-01-01, 2001-01-02])
 </programlisting>
 
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+shiftTime(box,interval) → box
+scaleTime(box,interval) → box
+shiftScaleTime(box,interval,interval) → box
 </programlisting>
 			</listitem>
 
@@ -503,13 +508,7 @@ SELECT shiftScaleValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 
 				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Desplaza y/o escalar el período de un cuadro delimitador con uno o dos intervalos</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-shiftTime(box,interval) → box
-scaleTime(box,interval) → box
-shiftScaleTime(box,interval,interval) → box
-</programlisting>
-				<para>Si el ancho o el lapso de tiempo del valor de tiempo es cero (es decir, los límites inferior y superior son iguales), el resultado es el cuadro delimitador. El valor o intervalo dado debe ser estrictamente mayor que cero.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftTime(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])',
   interval '1 day');
 -- TBOXFLOAT XT([1.5, 2.5],[2001-01-02, 2001-01-03])
@@ -534,17 +533,23 @@ SELECT shiftScaleTime(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-02])
   interval '1 hour', interval '3 hours');
 -- STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01 01:00:00, 2001-01-01 04:00:00])
 </programlisting>
+				<para>Si el ancho o el lapso de tiempo del valor de tiempo es cero (es decir, los límites inferior y superior son iguales), el resultado es el cuadro delimitador. El valor o intervalo dado debe ser estrictamente mayor que cero.</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+getSpace(stbox) → stbox
+</programlisting>
 			</listitem>
 
 			<listitem xml:id="box_getSpace">
 				<indexterm significance="normal"><primary><varname>getSpace</varname></primary></indexterm>
 				<para>Devuelve la dimensión espacial del cuadro delimitador, eliminando la dimensión temporal, si existe</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-getSpace(stbox) → stbox
-</programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getSpace(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])');
 -- STBOX Z((1,1,1),(2,2,2))
+</programlisting>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+expandValue(tbox,{integer,float}) → tbox
+expandSpace(stbox,float) → stbox
+expandTime(box,interval) → box
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -558,13 +563,7 @@ SELECT getSpace(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])');
 					<indexterm significance="normal"><primary><varname>expandSpace</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>expandTime</varname></primary></indexterm>
 					<para>Extiende la dimensión numérica, espacial o temporal del cuadro delimitador con un valor o un intervalo</para>
-					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-expandValue(tbox,{integer,float}) → tbox
-expandSpace(stbox,float) → stbox
-expandTime(box,interval) → box
-</programlisting>
-					<para>La función devuelve NULL si el valor o intervalo dado como segundo argumento es negativo y el rango resultante de desplazar los límites con el argumento está vacío.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expandValue(tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-03])', 1.0);
 -- TBOXFLOAT XT((0,3),[2001-01-01,2001-01-03])
 SELECT expandValue(tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-03])', -1.0);
@@ -572,13 +571,14 @@ SELECT expandValue(tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-03])', -1.0);
 SELECT expandValue(tbox 'TBOX T([2001-01-01,2001-01-03))', 1);
 -- The box must have value dimension
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<para>La función devuelve NULL si el valor o intervalo dado como segundo argumento es negativo y el rango resultante de desplazar los límites con el argumento está vacío.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expandSpace(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])', 1);
--- STBOX ZT(((0,0,0),(3,3,3)),[2001-01-01, 2001-01-03])
+-- STBOX ZT(((0,0,0),(3,3,3)),[2001-01-01,2001-01-03])
 SELECT expandSpace(stbox 'STBOX T([2001-01-01,2001-01-03))', 1);
 -- The box must have space dimension
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expandTime(tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-03])', interval '1 day');
 -- TBOXFLOAT XT((1,2),[2000-12-31,2001-01-04])
 SELECT expandTime(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])',
@@ -587,22 +587,26 @@ SELECT expandTime(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])',
 SELECT expandTime(tbox 'TBOX XT((1,2),[2001-01-01,2001-01-03])', interval '-2 days');
 -- NULL
 </programlisting>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+round(box,integer=0) → box
+</programlisting>
 				</listitem>
 
 				<listitem xml:id="box_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Redondea el valor o las coordenadas del cuadro delimitador a un número de decimales</para>
-					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-round(box,integer=0) → box
-</programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tbox 'TBOXFLOAT XT((1.12345,2.12345),[2001-01-01,2001-01-02])', 2);
--- TBOXFLOAT XT((1.12, 2.12),[2001-01-01,2001-01-02])
-SELECT round(stbox 'STBOX XT(((1.12345,1.12345),(2.12345,2.12345)),
+-- TBOXFLOAT XT((1.12,2.12),[2001-01-01, 2001-01-02])
+SELECT round(stbox 'STBOX XT(((1.12345, 1.12345),(2.12345, 2.12345)),
   [2001-01-01,2001-01-02])', 2);
--- STBOX XT(((1.12,1.12),(2.12,2.12)),[2001-01-01,2001-01-02])
+-- STBOX XT(((1.12,1.12),(2.12,2.12)),[2001-01-01, 2001-01-02])
 SELECT round(tstzspan '[2000-01-01, 2001-01-02]'::tbox);
 -- The tbox must have X dimension
+</programlisting>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+SRID(stbox) → integer
+setSRID(stbox) → stbox
 </programlisting>
 				</listitem>
 
@@ -617,17 +621,15 @@ SELECT round(tstzspan '[2000-01-01, 2001-01-02]'::tbox);
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Devuelve o especifica el identificador de referencia espacial</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-SRID(stbox) → integer
-setSRID(stbox) → stbox
-</programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2001-01-01,2001-01-02])');
 -- 0
 SELECT SRID(stbox 'SRID=5676;STBOX XT(((1.0,2.0),(4.0,5.0)),[2001-01-01,2001-01-02])');
 -- 5676
 SELECT SRID(stbox 'GEODSTBOX T([2001-01-01,2001-01-02))');
 -- ERROR:  The box must have space dimension
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT setSRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)), [2001-01-01,2001-01-02])',
   5676);
 -- SRID=5676;STBOX ZT(((1,2,3),(4,5,6)),[2001-01-01,2001-01-02])
@@ -646,7 +648,7 @@ transformPipeline(stbox,pipeline text,srid integer,is_forward boolean=true) → 
 				<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
 				<para>El SRID del cuadro de entrada se ignora y el SRID del cuadro de salida se establecerá en cero a menos que se proporcione un valor a través del parámetro opcional <varname>srid</varname>. Como se indica en el último parámetro, la canalización se ejecuta de forma predeterminada en dirección hacia adelante; al establecer el parámetro en falso, la canalización se ejecuta en la dirección inversa.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(transform(stbox 'SRID=4326;STBOX XT(((2.340088, 49.400250),
   (6.575317, 51.553167)),[2001-01-01,2001-01-02])', 3812), 6);
 /* SRID=3812;STBOX XT(((502773.429981,511805.120402),(803028.908265,751590.742629)),
@@ -673,7 +675,7 @@ SELECT asEWKT(transformPipeline(transformPipeline(box, pipeline, 4326), pipeline
 quadSplit(stbox) → {stbox}
 </programlisting>
 				<para>Como lo indica el símbolo &SRF;, esta función es una <emphasis>función de retorno de conjuntos</emphasis> (también conocida como <emphasis>función de tabla</emphasis>) ya que normalmente devuelve más de un valor.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadSplit(stbox 'STBOX XT(((0,0),(4,4)),[2001-01-01,2001-01-05])');
 /* {"STBOX XT(((0,0),(2,2)),[2001-01-01, 2001-01-05])",
    "STBOX XT(((2,0),(4,2)),[2001-01-01, 2001-01-05])",
@@ -711,18 +713,18 @@ SELECT quadSplit(stbox 'STBOX Z((0,0,0),(4,4,4))');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 box {+, *} box → box
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,3),[2001-01-01,2001-01-03])' + tbox 'TBOXINT XT([2,4),
   [2001-01-02,2001-01-04])';
--- TBOXINT XT([1,4),[2001-01-01, 2001-01-04])
+-- TBOXINT XT([1,4),[2001-01-01,2001-01-04])
 SELECT stbox 'STBOX ZT(((1,1,1),(2,2,2)),
-  [2001-01-01,2001-01-02])' + stbox 'STBOX XT(((2,2),(3,3)),[2001-01-01,2001-01-03])';
+  [2001-01-01,2001-01-02])' + stbox 'STBOX XT(((2,2),(3,3))),[2001-01-01,2001-01-03]';
 -- ERROR:  The arguments must be of the same dimensionality
 SELECT tbox 'TBOXFLOAT XT((1,3),[2001-01-01,2001-01-02])' + tbox 'TBOXFLOAT XT((3,4),
   [2001-01-03,2001-01-04])';
 -- ERROR:  Result of box union would not be contiguous
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,3),
   [2001-01-01,2001-01-03])' * tbox 'TBOX T([2001-01-02,2001-01-04))';
 -- TBOX T([2001-01-02,2001-01-03))
@@ -748,12 +750,12 @@ SELECT stbox 'STBOX ZT(((1,1,1),(3,3,3)),
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 box &amp;&amp; box → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,3),[2001-01-01,2001-01-03])' &amp;&amp;
   tbox 'TBOXFLOAT XT((2,4),[2001-01-02,2001-01-04])';
 -- true
 SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' &amp;&amp;
-  stbox 'STBOX XT([2001-01-02,2001-01-02])';
+  stbox 'STBOX T([2001-01-02,2001-01-02])';
 -- true
 </programlisting>
 				</listitem>
@@ -764,7 +766,7 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' &amp;&amp;
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 box @&gt; box → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])' @&gt;
   tbox 'TBOXFLOAT XT((2,3),[2001-01-01,2001-01-02])';
 -- true
@@ -780,11 +782,11 @@ SELECT stbox 'STBOX Z((1,1,1),(3,3,3))' @&gt;
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 box &lt;@ box → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;@ tbox 'TBOXFLOAT XT((1,2),
   [2001-01-01,2001-01-02])';
 -- true
-SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02)' &lt;@
+SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])' &lt;@
   stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-02])';
 -- true
 </programlisting>
@@ -796,9 +798,9 @@ SELECT stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02)' &lt;@
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 box ~= box → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,2),
-  [2001-01-01,2001-01-02])' ~= tbox 'TBOXFLOAT XT([2001-01-01,2001-01-02])';
+  [2001-01-01,2001-01-02])' ~= tbox 'TBOXFLOAT T([2001-01-01,2001-01-02])';
 -- true
 SELECT stbox 'STBOX XT(((1,1),(3,3)),
   [2001-01-01,2001-01-03])' ~= stbox 'STBOX Z((1,1,1),(3,3,3))';
@@ -813,12 +815,12 @@ SELECT stbox 'STBOX XT(((1,1),(3,3)),
 box -|- box → boolean
 </programlisting>
 					<para>Dos cuadros delimitadores son adyacentes si sus extensiones se encuentran en todas las dimensiones que los cuadros comparten y se tocan en un solo valor en al menos una de ellas. Una dimensión en la que los cuadros están separados los separa sea cual sea el comportamiento de las demás dimensiones.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,2),[2001-01-01,2001-01-02])' -|- tbox 'TBOXINT XT([2,3),
   [2001-01-02,2001-01-03])';
 -- true
-SELECT tbox 'TBOXFLOAT XT((1,2)[2001-01-01,2001-01-02])' -|- tbox 'TBOX T([2001-01-02,
-  2001-01-03])';
+SELECT tbox 'TBOXFLOAT XT((1,2),
+  [2001-01-01,2001-01-02])' -|- tbox 'TBOX T([2001-01-02,2001-01-03])';
 -- true
 SELECT stbox 'STBOX XT(((1,1),(3,3)),
   [2001-01-01,2001-01-03])' -|- stbox 'STBOX XT(((2,2),(4,4)),[2001-01-03,2001-01-04])';
@@ -845,15 +847,13 @@ SELECT stbox 'STBOX XT(((1,1),(3,3)),
 tbox {&lt;&lt;, &lt;&lt;#} tbox → boolean
 stbox {&lt;&lt;, &lt;&lt;|, &lt;&lt;/, &lt;&lt;#} stbox → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;&lt;
   tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])';
 -- true
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &lt;&lt;
-  tbox 'TBOXFLOAT XT([2001-01-03,2001-01-04])';
+  tbox 'TBOXFLOAT T([2001-01-03,2001-01-04])';
 -- ERROR:  The box must have value dimension
-SELECT stbox 'STBOX Z((1,1,1),(2,2,2))' &lt;&lt; stbox 'STBOX Z((3,3,3),(4,4,4))';
--- true
 SELECT stbox 'STBOX Z((1,1,1),(2,2,2))' &lt;&lt;| stbox 'STBOX Z((3,3,3),(4,4,4))';
 -- true
 SELECT stbox 'STBOX Z((1,1,1),(2,2,2))' &lt;&lt;/ stbox 'STBOX Z((3,3,3),(4,4,4))';
@@ -874,17 +874,15 @@ SELECT tbox 'TBOXFLOAT XT((1,2),
 tbox {&gt;&gt;, #&gt;&gt;} tbox → boolean
 stbox {&gt;&gt;, |&gt;&gt;, /&gt;&gt;, #&gt;&gt;} stbox → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])' &gt;&gt;
   tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])';
--- true
-SELECT stbox 'STBOX Z((3,3,3),(4,4,4))' &gt;&gt; stbox 'STBOX Z((1,1,1),(2,2,2))';
 -- true
 SELECT stbox 'STBOX Z((3,3,3),(4,4,4))' |&gt;&gt; stbox 'STBOX Z((1,1,1),(2,2,2))';
 -- true
 SELECT stbox 'STBOX Z((3,3,3),(4,4,4))' /&gt;&gt; stbox 'STBOX Z((1,1,1),(2,2,2))';
 -- true
-SELECT stbox 'STBOX XT((4,4),[2001-01-03,2001-01-04],((3,3)))' #&gt;&gt;
+SELECT stbox 'STBOX XT(((3,3),(4,4)),[2001-01-03,2001-01-04])' #&gt;&gt;
   stbox 'STBOX XT(((1,1),(2,2)),[2001-01-01,2001-01-02])';
 -- true
 </programlisting>
@@ -900,11 +898,9 @@ SELECT stbox 'STBOX XT((4,4),[2001-01-03,2001-01-04],((3,3)))' #&gt;&gt;
 tbox {&amp;&lt;, &amp;&lt;#} box → boolean
 stbox {&amp;&lt;, &amp;&lt;|, &amp;&lt;/, &amp;&lt;#} stbox → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])' &amp;&lt;
   tbox 'TBOXFLOAT XT((3,4),[2001-01-03,2001-01-04])';
--- true
-SELECT stbox 'STBOX Z((1,1,1),(4,4,4))' &amp;&lt; stbox 'STBOX Z((3,3,3),(4,4,4))';
 -- true
 SELECT stbox 'STBOX Z((1,1,1),(4,4,4))' &amp;&lt;| stbox 'STBOX Z((3,3,3),(4,4,4))';
 -- true
@@ -926,11 +922,9 @@ SELECT tbox 'TBOXFLOAT XT((1,4),
 tbox {&amp;&gt;, #&amp;&gt;} tbox → boolean
 stbox {&amp;&gt;, |&amp;&gt;, /&amp;&gt;, #&amp;&gt;} stbox} → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-02])' &amp;&gt;
   tbox 'TBOXFLOAT XT((1,4),[2001-01-01,2001-01-04])';
--- true
-SELECT stbox 'STBOX Z((3,3,3),(4,4,4))' &amp;&gt; stbox 'STBOX Z((1,1,1),(2,2,2))';
 -- true
 SELECT stbox 'STBOX Z((3,3,3),(4,4,4))' |&amp;&gt; stbox 'STBOX Z((1,1,1),(2,2,2))';
 -- false
@@ -965,7 +959,7 @@ box {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} box → boolean
 cmp(box,box) → int
 </programlisting>
 				<para>La función <varname>cmp</varname> devuelve -1, 0 o 1 según que el primer argumento sea, respectivamente, menor que, igual a o mayor que el segundo.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbox 'TBOXINT XT([1,1],[2001-01-01,2001-01-04])' = tbox 'TBOXINT XT([2,2],
   [2001-01-03,2001-01-05])';
 -- false
@@ -984,6 +978,9 @@ SELECT tbox 'TBOXINT XT([1,1],[2001-01-01,2001-01-04])' &lt;= tbox 'TBOXINT XT([
 SELECT tbox 'TBOXFLOAT XT([1,1],[2001-01-01,2001-01-04])' &gt;= tbox 'TBOXFLOAT XT([2,2],
   [2001-01-03,2001-01-05])';
 -- false
+SELECT cmp(tbox 'TBOXFLOAT XT([1,1],[2001-01-01,2001-01-04])',
+  tbox 'TBOXFLOAT XT([2,2],[2001-01-03,2001-01-05])');
+-- -1
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -999,7 +996,7 @@ SELECT tbox 'TBOXFLOAT XT([1,1],[2001-01-01,2001-01-04])' &gt;= tbox 'TBOXFLOAT 
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 extent(box) → box
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH boxes(b) AS (
   SELECT tbox 'TBOXFLOAT XT((1,3),[2001-01-01,2001-01-03])' UNION
   SELECT tbox 'TBOXFLOAT XT((5,7),[2001-01-05,2001-01-07])' UNION
@@ -1020,9 +1017,9 @@ SELECT extent(b) FROM boxes;
 	<sect1 xml:id="box_indexing">
 		<title>Indexación</title>
 		<para>Se pueden crear índices GiST y SP-GiST para columnas de tablas de los tipos <varname>tbox</varname> y <varname>stbox</varname>. El índice GiST implementa un árbol R, mientras que el índice SP-GiST implementa un árbol cuádruple n-dimensiónal. Un ejemplo de creación de un índice GiST en una columna <varname>Box</varname> de tipo <varname>stbox</varname> en una tabla <varname>Trips</varname> es el siguiente:
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE Trips(TripID integer PRIMARY KEY, Trip tgeompoint, Box stbox);
-CREATE INDEX Trips_Box_Idx ON Trips USING GIST(Box);
+CREATE INDEX Trips_Box_Idx ON Trips USING GIST(bbox);
 </programlisting>
 		</para>
 		<para>Un índice GiST o SP-GiST puede acelerar las consultas que involucran a los siguientes operadores: <varname>&amp;&amp;</varname>, <varname>&lt;@</varname>, <varname>@&gt;</varname>, <varname>~=</varname>, <varname>-|-</varname>, <varname>&lt;&lt;</varname>, <varname>&gt;&gt;</varname>, <varname>&amp;&lt;</varname>, <varname>&amp;&gt;</varname>, <varname>&lt;&lt;|</varname>, <varname>|&gt;&gt;</varname>, <varname>&amp;&lt;|</varname>, <varname>|&amp;&gt;</varname>, <varname>&lt;&lt;/</varname>, <varname>/&gt;&gt;</varname>, <varname>&amp;&lt;/</varname>, <varname>/&amp;&gt;</varname>, <varname>&lt;&lt;#</varname>, <varname>#&gt;&gt;</varname>, <varname>&amp;&lt;#</varname> y <varname>#&amp;&gt;</varname>.</para>

--- a/doc/es/data_generator.xml
+++ b/doc/es/data_generator.xml
@@ -301,7 +301,7 @@
 			Los archivos <varname>create_test_tables_temporal.sql</varname> y <varname>create_test_tables_tpoint.sql</varname> dan ejemplos de utilización de las funciones que generan valores aleatorios listadas arriba. Por ejemplo, el primer archivo define la función siguiente.
 		</para>
 
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE OR REPLACE FUNCTION create_test_tables_temporal(size integer DEFAULT 100)
 RETURNS text AS $$ DECLARE perc integer;
 BEGIN perc := size * 0.01;
@@ -318,9 +318,9 @@ $$ LANGUAGE 'plpgsql';
 		<para>
 			La creación de una tabla <varname>tbl_float</varname> que contiene valores aleatorios <varname>float</varname> en el rango [0,100] con 1% de valores nulos se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_float AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS f FROM generate_series(1, perc) AS k UNION
 SELECT k, random_float(0, 100) FROM generate_series(perc+1, size) AS k;
 </programlisting>
@@ -328,9 +328,9 @@ SELECT k, random_float(0, 100) FROM generate_series(perc+1, size) AS k;
 		<para>
 			La creación de una tabla <varname>tbl_tbox</varname> que contiene valores aleatorios <varname>tbox</varname> donde los límites de los valores están en el rango [0,100] y los límites de las marcas de tiempo están en el rango [2001-01-01, 2001-12-31] se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_tbox AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS b FROM generate_series(1, perc) AS k UNION
 SELECT k, random_tbox(0, 100, '2001-01-01', '2001-12-31', 10, 10)
 FROM generate_series(perc+1, size) AS k;
@@ -339,9 +339,9 @@ FROM generate_series(perc+1, size) AS k;
 		<para>
 			La creación de una tabla <varname>tbl_floatspan</varname> que contiene valores aleatorios <varname>floatspan</varname> donde los límites de los valores están en el rango [0,100] y la máxima diferencia entre los límites inferiores y superiores es 10 se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_floatspan AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS f FROM generate_series(1, perc) AS k UNION
 SELECT k, random_floatspan(0, 100, 10) FROM generate_series(perc+1, size) AS k;
 </programlisting>
@@ -349,9 +349,9 @@ SELECT k, random_floatspan(0, 100, 10) FROM generate_series(perc+1, size) AS k;
 		<para>
 			La creación de una tabla <varname>tbl_tstzset</varname> que contiene valores aleatorios <varname>tstzset</varname> que tienen entre 5 y 10 marcas de tiempo donde las marcas de tiempo están en el rango [2001-01-01, 2001-12-31] y el máximo intervalo entre marcas de tiempo consecutivas es 10 minutos se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_tstzset AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS ts FROM generate_series(1, perc) AS k UNION
 SELECT k, random_tstzset('2001-01-01', '2001-12-31', 10, 5, 10)
 FROM generate_series(perc+1, size) AS k;
@@ -360,9 +360,9 @@ FROM generate_series(perc+1, size) AS k;
 		<para>
 			La creación de una tabla <varname>tbl_tstzspan</varname> que contiene valores aleatorios <varname>tstzspan</varname> donde las marcas de tiempo están en el rango [2001-01-01, 2001-12-31] y la máxima diferencia entre los límites inferiores y superiores es 10 minutos se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_tstzspan AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS p FROM generate_series(1, perc) AS k UNION
 SELECT k,
   random_tstzspan('2001-01-01', '2001-12-31', 10) FROM generate_series(perc+1, size) AS k;
@@ -371,7 +371,7 @@ SELECT k,
 		<para>
 			La creación de una tabla <varname>tbl_geom_point</varname> que contiene valores aleatorios <varname>geometry</varname> 2D point valores, donde las coordenadas x e y están en el rango [0, 100] y en SRID 3812 se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_geom_point AS
 SELECT 1 AS k, geometry 'SRID=3812;point empty' AS g UNION
 SELECT k, random_geom_point(0, 100, 0, 100, 3812) FROM generate_series(2, size) k;
@@ -383,7 +383,7 @@ SELECT k, random_geom_point(0, 100, 0, 100, 3812) FROM generate_series(2, size) 
 		<para>
 			La creación de una tabla <varname>tbl_geog_point3D</varname> que contiene valores aleatorios <varname>geography</varname> 3D point valores, donde las coordenadas x, y, y z están, respectivament, en los rangos [-10, 32], [35, 72] y [0, 1000] y en SRID 7844 se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_geog_point3D AS
 SELECT 1 AS k, geography 'SRID=7844;pointZ empty' AS g UNION
 SELECT k,
@@ -396,7 +396,7 @@ SELECT k,
 		<para>
 			La creación de una tabla <varname>tbl_geom_linestring</varname> que contiene valores aleatorios <varname>geometry</varname> 2D linestring valores que tienen entre 5 y 10 vértices, donde las coordenadas x e y están en el rango [0, 100] y en SRID 3812 y la máxima diferencia entre valores de coordenadas consecutivos es 10 unidades en el SRID subyacente se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_geom_linestring AS
 SELECT 1 AS k, geometry 'linestring empty' AS g UNION
 SELECT k,
@@ -406,7 +406,7 @@ SELECT k,
 		<para>
 			La creación de una tabla <varname>tbl_geom_linestring</varname> que contiene valores aleatorios <varname>geometry</varname> 2D linestring valores que tienen entre 5 y 10 vértices, donde las coordenadas x e y están en el rango [0, 100] y la máxima diferencia entre valores de coordenadas consecutivos es 10 unidades en el SRID subyacente se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_geom_linestring AS
 SELECT 1 AS k, geometry 'linestring empty' AS g UNION
 SELECT k,
@@ -416,7 +416,7 @@ SELECT k,
 		<para>
 			La creación de una tabla <varname>tbl_geom_polygon3D</varname> que contiene valores aleatorios <varname>geometry</varname> 3D polygon valores sin agujeros, que tienen entre 5 y 10 vértices, donde las coordenadas x, y, y z están en el rango [0, 100] y la máxima diferencia entre valores de coordenadas consecutivos es 10 unidades en el SRID subyacente se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_geom_polygon3D AS
 SELECT 1 AS k, geometry 'polygon Z empty' AS g UNION
 SELECT k, random_geom_polygon3D(0, 100, 0, 100, 0, 100, 10, 5, 10)
@@ -426,9 +426,9 @@ FROM generate_series(2, size) k;
 		<para>
 			La creación de una tabla <varname>tbl_geom_multipoint</varname> que contiene valores aleatorios <varname>geometry</varname> 2D multipunto valores que tienen entre 5 y 10 points, donde las coordenadas x e y están en el rango [0, 100] y la máxima diferencia entre valores de coordenadas consecutivos es 10 unidades en el SRID subyacente se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_geom_multipoint AS
-SELECT 1 AS k, geometry 'multipunto empty' AS g UNION
+SELECT 1 AS k, geometry 'multipoint empty' AS g UNION
 SELECT k,
   random_geom_multipoint(0, 100, 0, 100, 10, 5, 10) FROM generate_series(2, size) k;
 </programlisting>
@@ -436,7 +436,7 @@ SELECT k,
 		<para>
 			La creación de una tabla <varname>tbl_geog_multilinestring</varname> que contiene valores aleatorios <varname>geography</varname> 2D multilinestring valores que tienen entre 5 y 10 linestrings, cada una teniendo entre 5 y 10 vértices, donde las coordenadas x e y estan, respectivamente, en el rangos [-10, 32] y [35, 72] y la máxima diferencia entre valores de coordenadas consecutivos es 10 se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_geog_multilinestring AS
 SELECT 1 AS k, geography 'multilinestring empty' AS g UNION
 SELECT k, random_geog_multilinestring(-10, 32, 35, 72, 10, 5, 10, 5, 10)
@@ -446,7 +446,7 @@ FROM generate_series(2, size) k;
 		<para>
 			La creación de una tabla <varname>tbl_geometry3D</varname> que contiene valores aleatorios <varname>geometry</varname> 3D de varios tipos se da a continuación. Esta función requiere que las tablas para los diversos tipos de geometría se hayan creado previamente.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_geometry3D (k serial PRIMARY KEY, g geometry);
 INSERT INTO tbl_geometry3D(g)
 (SELECT g FROM tbl_geom_point3D ORDER BY k LIMIT (size * 0.1)) UNION ALL
@@ -461,9 +461,9 @@ INSERT INTO tbl_geometry3D(g)
 		<para>
 			La creación de una tabla <varname>tbl_tbool_inst</varname> que contiene valores aleatorios <varname>tbool</varname> valores de subtipo instante donde las marcas de tiempo están en el rango [2001-01-01, 2001-12-31] se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_tbool_inst AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS inst FROM generate_series(1, perc) AS k UNION
 SELECT k,
   random_tbool_inst('2001-01-01', '2001-12-31') FROM generate_series(perc+1, size) k;
@@ -471,7 +471,7 @@ SELECT k,
 UPDATE tbl_tbool_inst t1
 SET inst = (SELECT inst FROM tbl_tbool_inst t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);
-/* Add perc rows con the same timestamp */
+/* Add perc rows with the same timestamp */
 UPDATE tbl_tbool_inst t1
 SET inst = (SELECT tboolInst(random_bool(), getTimestamp(inst))
   FROM tbl_tbool_inst t2 WHERE t2.k = t1.k+perc)
@@ -484,9 +484,9 @@ WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
 		<para>
 			La creación de una tabla <varname>tbl_tint_discseq</varname> que contiene valores aleatorios <varname>tint</varname> valores de subtipo secuencia con interpolación discreta que tienen entre 5 y 10 marcas de tiempo donde the integer valores están en el rango [0, 100], las marcas de tiempo están en el rango [2001-01-01, 2001-12-31], la máxima diferencia entre dos valores consecutivos es 10 y el máximo intervalo entre dos instantes consecutivos es 10 minutos se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_tint_discseq AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS ti FROM generate_series(1, perc) AS k UNION
 SELECT k, random_tint_discseq(0, 100, '2001-01-01', '2001-12-31', 10, 10, 5, 10) AS ti
 FROM generate_series(perc+1, size) k;
@@ -494,7 +494,7 @@ FROM generate_series(perc+1, size) k;
 UPDATE tbl_tint_discseq t1
 SET ti = (SELECT ti FROM tbl_tint_discseq t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);
-/* Add perc rows con the same timestamp */
+/* Add perc rows with the same timestamp */
 UPDATE tbl_tint_discseq t1
 SET ti = (SELECT ti + random_int(1, 2) FROM tbl_tint_discseq t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
@@ -516,11 +516,11 @@ WHERE t1.k in (SELECT i FROM generate_series(1 + 8*perc, 9*perc) i);
 		<para>
 			La creación de una tabla <varname>tbl_tfloat_seq</varname> que contiene valores aleatorios <varname>tfloat</varname> valores de subtipo secuencia que tienen entre 5 y 10 marcas de tiempo donde los valores <varname>float</varname> están en el rango [0, 100], las marcas de tiempo están en el rango [2001-01-01, 2001-12-31], la máxima diferencia entre dos valores consecutivos es 10 y el máximo intervalo entre dos instantes consecutivos es 10 minutos se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_tfloat_seq AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS seq FROM generate_series(1, perc) AS k UNION
-SELECT k, random_tfloat_contseq(0, 100, '2001-01-01', '2001-12-31', 10, 10, 5, 10) AS seq
+SELECT k, random_tfloat_seq(0, 100, '2001-01-01', '2001-12-31', 10, 10, 5, 10) AS seq
 FROM generate_series(perc+1, size) k;
 /* Add perc duplicates */
 UPDATE tbl_tfloat_seq t1
@@ -544,9 +544,9 @@ WHERE t1.k in (SELECT i FROM generate_series(1 + 8*perc, 9*perc) i);
 		<para>
 			La creación de una tabla <varname>tbl_ttext_seqset</varname> que contiene valores aleatorios <varname>ttext</varname> de subtipo conjunto de secuencias que tienen entre 5 y 10 sequences, cada una teniendo entre 5 y 10 marcas de tiempo, donde los valores de texto tienen máximo 10 caracteres, las marcas de tiempo están en el rango [2001-01-01, 2001-12-31] y el máximo intervalo entre dos instantes consecutivos es 10 minutos se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_ttext_seqset AS
-/* Add perc NULL valores */
+/* Add perc NULL values */
 SELECT k, NULL AS ts FROM generate_series(1, perc) AS k UNION
 SELECT k, random_ttext_seqset('2001-01-01', '2001-12-31', 10, 10, 5, 10, 5, 10) AS ts
 FROM generate_series(perc+1, size) AS k;
@@ -554,7 +554,7 @@ FROM generate_series(perc+1, size) AS k;
 UPDATE tbl_ttext_seqset t1
 SET ts = (SELECT ts FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);
-/* Add perc tuples con the same timestamp */
+/* Add perc tuples with the same timestamp */
 UPDATE tbl_ttext_seqset t1
 SET ts = (SELECT ts || text 'A' FROM tbl_ttext_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE k in (SELECT i FROM generate_series(1 + 4*perc, 5*perc) i);
@@ -572,7 +572,7 @@ WHERE t1.k in (SELECT i FROM generate_series(1 + 8*perc, 9*perc) i);
 		<para>
 			La creación de una tabla <varname>tbl_tgeompoint_discseq</varname> que contiene valores aleatorios <varname>tgeompoint</varname> 2D valores de subtipo secuencia con interpolación discreta que tienen entre 5 y 10 instantes, donde the x e y coordenadas están en el rango [0, 100] y en SRID 3812, las marcas de tiempo están en el rango [2001-01-01, 2001-12-31], la máxima diferencia entre coordenadas successivas máximo 10 unidades en el SRID subyacente y el máximo intervalo entre dos instantes consecutivos es 10 minutos se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE tbl_tgeompoint_discseq AS
 SELECT k, random_tgeompoint_discseq(0, 100, 0, 100, '2001-01-01', '2001-12-31',
   10, 10, 5, 10, 3812) AS ti FROM generate_series(1, size) k;
@@ -580,7 +580,7 @@ SELECT k, random_tgeompoint_discseq(0, 100, 0, 100, '2001-01-01', '2001-12-31',
 UPDATE tbl_tgeompoint_discseq t1
 SET ti = (SELECT ti FROM tbl_tgeompoint_discseq t2 WHERE t2.k = t1.k+perc)
 WHERE k IN (SELECT i FROM generate_series(1, perc) i);
-/* Add perc tuples con the same timestamp */
+/* Add perc tuples with the same timestamp */
 UPDATE tbl_tgeompoint_discseq t1
 SET ti = (SELECT round(ti,6) FROM tbl_tgeompoint_discseq t2 WHERE t2.k = t1.k+perc)
 WHERE k IN (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);
@@ -599,7 +599,7 @@ WHERE t1.k IN (SELECT i FROM generate_series(1 + 6*perc, 7*perc) i);
 		<para>
 			Finalmente, la creación de una tabla <varname>tbl_tgeompoint3D_seqset</varname> que contiene valores aleatorios <varname>tgeompoint</varname> 3D valores de subtipo conjunto de secuencias que tienen entre 5 y 10 sequences, cada una teniendo entre 5 y 10 marcas de tiempo, donde las coordenadas x, y, y z están en el rango [0, 100] y en SRID 3812, las marcas de tiempo están en el rango [2001-01-01, 2001-12-31], la máxima diferencia entre coordenadas successivas máximo 10 unidades en el SRID subyacente y el máximo intervalo entre dos instantes consecutivos es 10 minutos se da a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 DROP TABLE IF EXISTS tbl_tgeompoint3D_seqset;
 CREATE TABLE tbl_tgeompoint3D_seqset AS
 SELECT k, random_tgeompoint3D_seqset(0, 100, 0, 100, 0, 100, '2001-01-01', '2001-12-31',
@@ -608,7 +608,7 @@ SELECT k, random_tgeompoint3D_seqset(0, 100, 0, 100, 0, 100, '2001-01-01', '2001
 UPDATE tbl_tgeompoint3D_seqset t1
 SET ts = (SELECT ts FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE k IN (SELECT i FROM generate_series(1, perc) i);
-/* Add perc tuples con the same timestamp */
+/* Add perc tuples with the same timestamp */
 UPDATE tbl_tgeompoint3D_seqset t1
 SET ts = (SELECT round(ts,3) FROM tbl_tgeompoint3D_seqset t2 WHERE t2.k = t1.k+perc)
 WHERE k IN (SELECT i FROM generate_series(1 + 2*perc, 3*perc) i);

--- a/doc/es/introduction.xml
+++ b/doc/es/introduction.xml
@@ -97,7 +97,7 @@
 			<para>
 				Para compilar asumiendo que tiene todas las dependencias en su ruta de búsqueda
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 git clone https://github.com/MobilityDB/MobilityDB
 mkdir MobilityDB/build
 cd MobilityDB/build
@@ -108,14 +108,14 @@ sudo make install
 			<para>
 				Los comandos anteriores instalan la rama <varname>master</varname>. Si desea instalar otra rama, por ejemplo, <varname>develop</varname>, puede reemplazar el primer comando anterior de la siguiente manera:
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 git clone --branch develop https://github.com/MobilityDB/MobilityDB
 </programlisting>
 
 			<para>
 				También debe configurar lo siguiente en el archivo <varname>postgresql.conf</varname> según la versión de PostGIS que haya instalado (a continuación usamos PostGIS 3):
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 shared_preload_libraries = 'postgis-3'
 max_locks_per_transaction = 128
 </programlisting>
@@ -123,7 +123,7 @@ max_locks_per_transaction = 128
 			<para>
 				Si no carga previamente la biblioteca PostGIS con la configuración anterior, no podrá cargar la biblioteca MobilityDB y obtendrá un mensaje de error como el siguiente:
 			</para>
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 ERROR:  could not load library "/usr/local/pgsql/lib/libMobilityDB-1.1.so":
   undefined symbol: ST_Distance
 </programlisting>
@@ -131,7 +131,7 @@ ERROR:  could not load library "/usr/local/pgsql/lib/libMobilityDB-1.1.so":
 			<para>
 				Puede encontrar la ubicación del archivo <varname>postgresql.conf</varname> de la manera siguiente.
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 $ which postgres
 /usr/local/pgsql/bin/postgres
 $ ls /usr/local/pgsql/data/postgresql.conf
@@ -144,7 +144,7 @@ $ ls /usr/local/pgsql/data/postgresql.conf
 			<para>
 				Una vez que MobilityDB está instalado, debe habilitarse en cada base de datos en la que desee usarlo. En el siguiente ejemplo, usamos una base de datos llamada <varname>mobility</varname>.
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 createdb mobility
 psql mobility -c "CREATE EXTENSION PostGIS"
 psql mobility -c "CREATE EXTENSION MobilityDB"
@@ -153,7 +153,7 @@ psql mobility -c "CREATE EXTENSION MobilityDB"
 			<para>
 				Las dos extensiones PostGIS y MobilityDB también se pueden crear en un solo comando.
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 psql mobility -c "CREATE EXTENSION MobilityDB cascade"
 </programlisting>
 		</sect2>
@@ -171,7 +171,7 @@ psql mobility -c "CREATE EXTENSION MobilityDB cascade"
 			<para>
 				Para descargar esta versión:
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 wget -O mobilitydb-1.3.tar.gz https://github.com/MobilityDB/MobilityDB/archive/v1.3.tar.gz
 </programlisting>
 			<para>
@@ -185,7 +185,7 @@ wget -O mobilitydb-1.3.tar.gz https://github.com/MobilityDB/MobilityDB/archive/v
 			<para>
 				Para descargar el repositorio
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 git clone https://github.com/MobilityDB/MobilityDB.git
 cd MobilityDB
 git checkout v1.3
@@ -199,14 +199,14 @@ git checkout v1.3
 			<para>
 				MobilityDB es una extensión que depende de PostGIS. Habilitar PostGIS antes de habilitar MobilityDB en la base de datos se puede hacer de la siguiente manera
 			</para>
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE EXTENSION postgis;
 CREATE EXTENSION mobilitydb;
 </programlisting>
 			<para>
 				Alternativamente, esto se puede hacer con un solo comando usando <varname>CASCADE</varname>, que instala la extensión PostGIS requerida antes de instalar la extensión MobilityDB
 			</para>
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE EXTENSION mobilitydb CASCADE;
 </programlisting>
 		</sect2>
@@ -254,11 +254,11 @@ CREATE EXTENSION mobilitydb CASCADE;
 			</para>
 
 			<para>Dependencias de base de datos</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 sudo apt-get install postgresql-16 postgresql-server-dev-16 postgresql-16-postgis
 </programlisting>
 			<para>Dependencias de construcción</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 sudo apt-get install cmake gcc
 </programlisting>
 
@@ -269,7 +269,7 @@ sudo apt-get install cmake gcc
 			<para>
 				En Fedora, Red Hat Enterprise Linux y sus derivados, los paquetes de la distribución incluyen una versión compatible de PostgreSQL y de PostGIS, por lo que un solo comando cubre tanto las dependencias de base de datos como las de construcción.
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 sudo dnf install gcc gcc-c++ cmake make postgresql-server-devel postgis \
   geos-devel proj-devel json-c-devel
 </programlisting>
@@ -284,11 +284,11 @@ sudo dnf install gcc gcc-c++ cmake make postgresql-server-devel postgis \
 				MobilityDB usa el sistema <varname>cmake</varname> para realizar la configuración. El directorio de compilación deber ser diferente del directorio de origen.
 			</para>
 			<para>Para crear el directorio de compilación</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 mkdir build
 </programlisting>
 			<para>Para ver las variables que se pueden configurar</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 cd build
 cmake -L ..
 </programlisting>
@@ -302,7 +302,7 @@ cmake -L ..
 			<para>
 				Las siguientes instrucciones comienzan desde <varname>path/to/MobilityDB</varname> en un sistema Linux
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 mkdir build
 cd build
 cmake ..
@@ -312,7 +312,7 @@ sudo make install
 			<para>
 				Cuando cambia la configuración
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 rm -rf build
 </programlisting>
 			<para>
@@ -328,19 +328,19 @@ rm -rf build
 			<para>
 				Para ejecutar todas las pruebas
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 ctest
 </programlisting>
 			<para>
 				Para ejecutar un archivo de prueba dado
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 ctest -R '021_tbox'
 </programlisting>
 			<para>
 				Para ejecutar un conjunto de archivos de prueba determinados se pueden utilizar comodines
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 ctest -R '022_*'
 </programlisting>
 		</sect2>
@@ -406,7 +406,7 @@ ctest -R '022_*'
 			<para>
 				Generar la documentación del usuario y del desarrollador en todos los formatos y en todos los idiomas.
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 cmake -D DOC_ALL=ON -D LANG_ALL=ON -D DOC_DEV=ON ..
 make doc
 make doc_dev
@@ -414,21 +414,21 @@ make doc_dev
 			<para>
 				Generar la documentación del usuario en formato HTML y en todos los idiomas.
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 cmake -D DOC_HTML=ON -D LANG_ALL=ON ..
 make doc
 </programlisting>
 			<para>
 				Generar la documentación del usuario en inglés en todos los formatos.
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 cmake -D DOC_ALL=ON ..
 make doc
 </programlisting>
 			<para>
 				Generar la documentación del usuario en formato PDF en inglés y en español.
 			</para>
-			<programlisting language="bash" xml:space="preserve">
+			<programlisting language="bash" xml:space="preserve" format="linespecific">
 cmake -D DOC_PDF=ON -D ES=ON ..
 make doc
 </programlisting>
@@ -466,7 +466,7 @@ make doc
 				<listitem><para>Si su problema no se ha informado, cree un <ulink url="https://github.com/MobilityDB/MobilityDB/issues/new">nuevo asunto</ulink> para ello.</para></listitem>
 				<listitem><para>En su informe, incluya instrucciones explícitas para replicar su problema. Las mejores etradas incluyen consultas SQL exactas que se necesitan para reproducir un problema. Reporte también el sistema operativo y las versiones de MobilityDB, PostGIS y PostgreSQL.</para></listitem>
 				<listitem><para>Se recomienda utilizar el siguiente envoltorio en su problema para determinar el paso que está causando el problema.
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SET client_min_messages TO debug;
 &lt;your code&gt;
 SET client_min_messages TO notice;

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -91,14 +91,14 @@
 		Como ejemplo, la firma del operador contiene (<varname>@&gt;</varname>) es como sigue:
 	</para>
 	<programlisting role="syntax" xml:space="preserve" format="linespecific">
-{set,spans} @&gt; {base,set,spans} → boolean
+{set,spans} @&gt; {set,spans,base} → boolean
 </programlisting>
 	<para>
 		Nótese que la firma anterior es una versión abreviada de la firma más precisa a continuación
 	</para>
 	<programlisting role="syntax" xml:space="preserve" format="linespecific">
-set @&gt; {base,set} → boolean
-spans @&gt; {base,spans} → boolean
+set @&gt; {set,base} → boolean
+spans @&gt; {spans,base} → boolean
 </programlisting>
 	<para>
 			ya que los conjuntos y los rangos no se pueden mezclar en las operaciones y, por lo tanto, por ejemplo, no se puede preguntar si un rango contiene un conjunto. A continuación, por concisión, utilizamos el estilo abreviado de las firmas anteriores. Además, la parte de tiempo de las marcas de tiempo se omite en la mayoría de los ejemplos. Recuerde que en ese caso PostgreSQL asume el tiempo <varname>00:00:00</varname>.
@@ -117,7 +117,7 @@ spans @&gt; {base,spans} → boolean
 		<para>
 			Los tipos de conjunto representan un conjunto <emphasis>ordenado</emphasis> de valores <emphasis>diferentes</emphasis>. Un conjunto debe contener al menos un elemento. Ejemplos de valores de tipos de conjunto son como sigue:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tstzset '{2001-01-01 08:00:00, 2001-01-03 09:30:00}';
 -- Conjunto unitario
 SELECT textset '{"highway"}';
@@ -135,7 +135,7 @@ SELECT cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),1.0)"}';
 		<para>
 			Un valor de un tipo de rango unitario tiene dos límites, el <emphasis>límite inferior</emphasis> y el <emphasis>límite superior</emphasis>, que son valores del <emphasis>tipo de base</emphasis> subyacente. Por ejemplo, un valor del tipo <varname>tstzspan</varname> tiene dos límites, que son valores de <varname>timestamptz</varname>. Los límites pueden ser inclusivos o exclusivos. Un límite inclusivo significa que el instante límite está incluido en el rango, mientras que un límite exclusivo significa que el instante límite no está incluido en el rango. En el formato textual de un valor de un rango, los límites inferiores inclusivos y exclusivos están representados, respectivamente, por “<varname>[</varname>” y “<varname>(</varname>”. Asimismo, los límites superiores inclusivos y exclusivos se representan, respectivamente, por “<varname>]</varname>” y “<varname>)</varname>”. En un valor de un rango, el límite inferior debe ser menor o igual que el límite superior. Un valor de rango con límites iguales e inclusivos se llama <emphasis>rango instantáneo</emphasis> y corresponde a un valor del tipo de base. Ejemplos de valores de rango son como sigue:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[1, 3)';
 SELECT floatspan '[1.5, 3.5]';
 SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-03 09:30:00)';
@@ -151,7 +151,7 @@ SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-01 08:00:00)';
 		<para>
 			Los valores de <varname>intspan</varname>, <varname>bigintspan</varname> y <varname>datespan</varname> son convertidos en <emphasis>forma normal</emphasis> para que los valores equivalentes tengan representaciones idénticas. En la representación canónica de estos tipos, el límite inferior es inclusivo y el límite superior es exclusivo, como se muestra en los siguientes ejemplos:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[1, 1]';
 -- [1, 2)
 SELECT bigintspan '(1, 3]';
@@ -163,7 +163,7 @@ SELECT datespan '[2001-01-01, 2001-01-03]';
 		<para>
 			Un valor de un tipo de conjunto de rangos representa un conjunto <emphasis>ordenado</emphasis> de valores de rango <emphasis>disjuntos</emphasis>. Un valor de conjunto de rangos debe contener al menos un elemento, en cuyo caso corresponde a un único valor de rango. Ejemplos de valores conjunto de rangos son los siguientes:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floatspanset '{[8.1, 8.5],[9.2, 9.4]}';
 -- Singleton spanset
 SELECT tstzspanset '{[2001-01-01 08:00:00, 2001-01-01 08:10:00]}';
@@ -177,7 +177,7 @@ SELECT tstzspanset '{[2001-01-01 08:00:00, 2001-01-01 08:10:00],
 		<para>
 			Los valores de los tipos conjunto de rangos son convertidos en <emphasis>forma normal</emphasis> de modo que los valores equivalentes tengan representaciones idénticas. Para ello, los valores de rango consecutivos que son adyacentes se fusionan cuando es posible. Ejemplos de transformación a forma normal son los siguientes:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspanset '{[1,2],[3,4]}';
 -- {[1, 5)}
 SELECT floatspanset '{[1.5,2.5],(2.5,4.5]}';
@@ -200,7 +200,7 @@ SELECT tstzspanset '{[2001-01-01 08:00:00, 2001-01-01 08:10:00),
 asText({floatset,floatspans},maxdecimaldigits integer=15) → text
 </programlisting>
 					<para>El argumento <varname>maxdecimaldigits</varname> se puede utilizar para definir el número máximo de decimales para la salida de los valores de coma flotante (por defecto 15).</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(floatset '{1.123456789,2.123456789}', 3);
 -- {1.123, 2.123}
 SELECT asText(floatspanset '{[1.55,2.55],[4,5]}',0);
@@ -217,7 +217,7 @@ asBinary({set,spans},endian text='') → bytea
 asHexWKB({set,spans},endian text='') → text
 </programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(dateset '{2001-01-01, 2001-01-03}');
 -- \x01050001020000006e01000070010000
 SELECT asBinary(intspan '[1, 3)');
@@ -244,7 +244,7 @@ asHexEWKB({geomset,geogset,cbufferset,npointset,poseset,posechainset,pcpointset,
   pcpatchset},endian text='') → text
 </programlisting>
 				<para>Para <varname>geomset</varname>, <varname>geogset</varname>, <varname>cbufferset</varname>, <varname>npointset</varname>, <varname>poseset</varname> y <varname>posechainset</varname> el SRID (cuando se conoce) se incluye una única vez en la cabecera del conjunto: <varname>asEWKB</varname> y <varname>asHexEWKB</varname> lo incluyen, mientras que <varname>asBinary</varname> y <varname>asHexWKB</varname> devuelven la representación binaria conocida (WKB) sin él, siguiendo la convención OGC y el <varname>asBinary</varname>/<varname>asHexWKB</varname> de los tipos base <varname>cbuffer</varname>, <varname>npoint</varname> y <varname>pose</varname>. Para <varname>pcpointset</varname> y <varname>pcpatchset</varname> el esquema, y su SRID, se resuelve fuera de banda a partir del catálogo <varname>pointcloud_formats</varname> en lugar de incluirse en el valor, por lo que las cuatro funciones siempre devuelven los mismos bytes para estos dos tipos.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(geomset 'SRID=4326;{Point(1 1)}');
 -- \x012b0001010000000101000000000000000000f03f000000000000f03f
 SELECT asHexWKB(geomset 'SRID=4326;{Point(1 1)}');
@@ -271,7 +271,7 @@ spantypeFromBinary(bytea) → span
 spansettypeFromBinary(bytea) → spanset
 </programlisting>
 				<para>Hay una función por tipo de conjunto o de rango, el nombre de la función tiene como prefijo el nombre del tipo.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT datesetFromBinary('\x01050001020000006e01000070010000');
 -- {2001-01-01, 2001-01-03}
 SELECT intspanFromBinary('\x011300010100000003000000');
@@ -293,7 +293,7 @@ spantypeFromHexWKB(text) → span
 spansettypeFromHexWKB(text) → spanset
 </programlisting>
 				<para>Hay una función por tipo de conjunto o de rango, el nombre de la función tiene como prefijo el nombre del tipo.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT datesetFromHexWKB('01050001020000006E01000070010000');
 -- {2001-01-01, 2001-01-03}
 SELECT intspanFromHexWKB('011300010100000003000000');
@@ -321,7 +321,7 @@ SELECT floatspansetFromHexWKB(
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 set(base[]) → set
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT set(ARRAY['highway', 'primary', 'secondary']);
 -- {"highway", "primary", "secondary"}
 SELECT set(ARRAY[timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00']);
@@ -339,7 +339,7 @@ SELECT set(ARRAY[timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00']);
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 span(lower base,upper base,lower_inc boolean=true,upper_inc boolean=false) → span
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT span(20.5, 25);
 -- [20.5, 25)
 SELECT span(20, 25, false, true);
@@ -359,7 +359,7 @@ SELECT span(timestamptz '2001-01-01 08:00:00', '2001-01-03 09:30:00', false, tru
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 spanset(span[]) → spanset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spanset(ARRAY[intspan '[10,12]', '[13,15]']);
 -- {[10, 16)}
 SELECT spanset(ARRAY[floatspan '[10.5,12.5]', '[13.5,15.5]']);
@@ -390,7 +390,7 @@ set(base) → set
 span(base) → span
 spanset(base) → spanset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT CAST(timestamptz '2001-01-01 08:00:00' AS tstzset);
 -- {2001-01-01 08:00:00}
 SELECT timestamptz '2001-01-01 08:00:00'::tstzspan;
@@ -408,7 +408,7 @@ SELECT spanset(timestamptz '2001-01-01 08:00:00');
 set::spanset
 spanset(set) → spanset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spanset(tstzset '{2001-01-01 08:00:00, 2001-01-01 08:15:00, 2001-01-01 08:25:00}');
 /* {[2001-01-01 08:00:00, 2001-01-01 08:00:00], [2001-01-01 08:15:00,
    2001-01-01 08:15:00],
@@ -424,7 +424,7 @@ SELECT spanset(tstzset '{2001-01-01 08:00:00, 2001-01-01 08:15:00, 2001-01-01 08
 span::spanset
 spanset(span) → spanset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floatspan '[1.5,2.5]'::floatspanset;
 -- {[1.5, 2.5]}
 SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-01 08:30:00)'::tstzspanset;
@@ -439,7 +439,7 @@ SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-01 08:30:00)'::tstzspanset;
 {set,spanset}::span
 span({set,spanset}) → span
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT span(dateset '{2001-01-01, 2001-01-03, 2001-01-05}');
 -- [2001-01-01, 2001-01-06)
 SELECT span(tstzspanset '{[2001-01-01, 2001-01-02), [2001-01-03, 2001-01-04)}');
@@ -458,7 +458,7 @@ range(span) → range
 span(range) → span
 </programlisting>
 				<para>Nótese que los valores de rango en PostgreSQL aceptan rangos vacíos y rangos con límites infinitos, que no están permitidos como valores de rango en MobilityDB</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[10, 20)'::int4range;
 -- [10,20)
 SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-01 08:30:00)'::tstzrange;
@@ -484,7 +484,7 @@ SELECT tstzrange '[2001-01-01 08:00:00, 2001-01-01 08:30:00)'::tstzspan;
 multirange(spanset) → multirange
 spanset(multirange) → spanset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspanset '{[1,2],[4,5]}'::int4multirange;
 -- {[1,3),[4,6)}
 SELECT tstzspanset '{[2001-01-01,2001-01-02],[2001-01-04,2001-01-05]}'::tstzmultirange;
@@ -508,7 +508,7 @@ SELECT tstzmultirange '{[2001-01-01,2001-01-02],[2001-01-04,2001-01-05]}'::tstzs
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 memSize({set,spanset}) → integer
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT memSize(tstzset '{2001-01-01, 2001-01-02, 2001-01-03}');
 -- 48
 SELECT memSize(tstzspanset '{[2001-01-01, 2001-01-02], [2001-01-03, 2001-01-04],
@@ -525,13 +525,13 @@ SELECT memSize(tstzspanset '{[2001-01-01, 2001-01-02], [2001-01-03, 2001-01-04],
 lower(spans) → base
 upper(spans) → base
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lower(tstzspan '[2001-01-01, 2001-01-05)');
 -- 2001-01-01
 SELECT lower(intspanset '{[1,2],[4,5]}');
 --  1
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lower(tstzspan '[2001-01-01, 2001-01-05)');
 -- 2001-01-01
 SELECT upper(intspanset '{[1,2],[4,5]}');
@@ -541,7 +541,7 @@ SELECT lower(tstzspan '[2001-01-01, 2001-01-05)');
 SELECT lower(intspanset '{[1,2],[4,5]}');
 --  1
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT upper(floatspan '[20.5, 25.3)');
 -- 25.3
 SELECT upper(tstzspan '[2001-01-01, 2001-01-05)');
@@ -557,17 +557,13 @@ SELECT upper(tstzspan '[2001-01-01, 2001-01-05)');
 lowerInc(spans) → boolean
 upperInc(spans) → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lowerInc(datespan '[2001-01-01, 2001-01-05)');
 -- true
 SELECT lowerInc(intspanset '{[1,2],[4,5]}');
 -- true
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
-SELECT lowerInc(tstzspan '[2001-01-01, 2001-01-05)');
--- true
-SELECT upperInc(intspanset '{[1,2],[4,5]}');
--- false
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT upper(floatspan '[20.5, 25.3]');
 -- true
 SELECT upperInc(tstzspan '[2001-01-01, 2001-01-05)');
@@ -583,7 +579,7 @@ width(numspan) → float
 width(numspanset,boundspan boolean=false) → float
 </programlisting>
 				<para>Se puede establecer a verdadero un parámetro adicional para calcular el ancho del rango delimitador, ignorando así las posibles brechas de valors</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT width(floatspan '[1, 3)');
 -- 2
 SELECT width(intspanset '{[1,3),[5,7)}');
@@ -601,7 +597,7 @@ duration({datespan,tstzspan}) → interval
 duration({datespanset,tstzspanset},boundspan boolean=false) → interval
 </programlisting>
 				<para>Se puede establecer a verdadero un parámetro adicional para calcular la duración en el rango delimitador, ignorando así las posibles brechas de tiempo</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT duration(datespan '[2001-01-01, 2001-01-03)');
 -- 2 days
 SELECT duration(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-05)}');
@@ -619,11 +615,11 @@ SELECT duration(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-05)
 numValues(set) → integer
 getValues(set) → base[]
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numValues(intset '{1,3,5,7}');
 -- 4
 SELECT getValues(tstzset '{2001-01-01, 2001-01-03, 2001-01-05, 2001-01-07}');
--- {"2001-01-01", "2001-01-03", "2001-01-05", "2001-01-07"}
+-- {"2001-01-01","2001-01-03","2001-01-05","2001-01-07"}
 </programlisting>
 			</listitem>
 
@@ -637,7 +633,7 @@ startValue(set) → base
 endValue(set) → base
 valueN(set,integer) → base
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(intset '{1,3,5,7}');
 -- 1
 SELECT endValue(dateset '{2001-01-01, 2001-01-03, 2001-01-05, 2001-01-07}');
@@ -655,12 +651,14 @@ SELECT valueN(floatset '{1,3,5,7}',2);
 numSpans(spanset) → integer
 spans(spanset) → span[]
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSpans(intspanset '{[1,3),[4,5),[6,7)}');
 -- 3
 SELECT numSpans(datespanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-05),
   [2001-01-06, 2001-01-07)}');
 -- 3
+</programlisting>
+<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spans(floatspanset '{[1,3),[4,4],[6,7)}');
 -- {"[1,3)","[4,4]","[6,7)"}
 SELECT spans(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-04],
@@ -679,21 +677,21 @@ startSpan(spanset) → span
 endSpan(spanset) → span
 spanN(spanset,integer) → span
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startSpan(intspanset '{[1,3),[4,5),[6,7)}');
 -- [1,3)
 SELECT startSpan(datespanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-05),
   [2001-01-06, 2001-01-07)}');
 -- [2001-01-01,2001-01-03)
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT endSpan(floatspanset '{[1,3),[4,4],[6,7)}');
 -- [6,7)
 SELECT endSpan(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-04],
   [2001-01-05, 2001-01-06)}');
 -- [2001-01-05,2001-01-06)
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spanN(floatspanset '{[1,3),[4,4],[6,7)}',2);
 -- [4,4]
 SELECT spanN(tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-04],
@@ -813,7 +811,7 @@ shift(numbers,base) → numbers
 shift(dates,integer) → dates
 shift(times,interval) → times
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shift(dateset '{2001-01-01, 2001-01-03, 2001-01-05}', 1);
 -- {2001-01-02, 2001-01-04, 2001-01-06}
 SELECT shift(intspan '[1, 4)', -1);
@@ -837,8 +835,8 @@ scale(dates,integer) → dates
 scale(times,interval) → times
 </programlisting>
 				<para>Si el ancho o el lapso de tiempo del valor de entrada es cero (por ejemplo, para un conjunto de marcas de tiempo único), el resultado es el valor de entrada. El valor o rango de tiempo dado debe ser estrictamente mayor que cero.</para>
-				<programlisting language="sql" xml:space="preserve">
-SELECT scale(tstzset '{2001-01-01}', interval '1 day');
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT scale(tstzset '{2001-01-01}', '1 day');
 -- {2001-01-01}
 SELECT scale(tstzset '{2001-01-01, 2001-01-03, 2001-01-05}', '2 days');
 -- {2001-01-01, 2001-01-02, 2001-01-03}
@@ -851,8 +849,8 @@ SELECT scale(tstzspan '[2001-01-01, 2001-01-03]', '1 day');
 SELECT scale(floatspanset '{[1, 2], [3, 4]}', 6);
 -- {[1, 3], [5, 7]}
 SELECT scale(tstzspanset '{[2001-01-01, 2001-01-03], [2001-01-04, 2001-01-05]}', '1 day');
--- {[2001-01-01 00:00:00, 2001-01-01 12:00:00],
-  [2001-01-01 18:00:00, 2001-01-02 00:00:00]}
+/* {[2001-01-01 00:00:00, 2001-01-01 12:00:00],
+   [2001-01-01 18:00:00, 2001-01-02 00:00:00]} */
 SELECT scale(tstzset '{2001-01-01}', '-1 day');
 -- ERROR:  The duration must be a positive interval: -1 days
 </programlisting>
@@ -867,7 +865,7 @@ shiftScale(dates,integer,integer) → dates
 shiftScale(times,interval,interval) → times
 </programlisting>
 				<para>Estas funciones combinan las funciones <link linkend="setspan_shift"><varname>shift</varname></link> y <link linkend="setspan_scale"><varname>scale</varname></link>.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftScale(tstzset '{2001-01-01}', '1 day', '1 day');
 -- {2001-01-02}
 SELECT shiftScale(tstzset '{2001-01-01, 2001-01-03, 2001-01-05}', '1 day','2 days');
@@ -895,7 +893,7 @@ SELECT shiftScale(tstzspanset '{[2001-01-01, 2001-01-03], [2001-01-04, 2001-01-0
 floor({floatset,floatspans}) → {floatset,floatspans}
 ceil({floatset,floatspans}) → {floatset,floatspans}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floor(floatset '{1.5,2.5}');
 -- {1, 2}
 SELECT ceil(floatspan '[1.5,2.5)');
@@ -913,7 +911,7 @@ SELECT ceil(floatspanset '{[1.5, 2.5],[3.5,4.5]}');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 round({floatset,floatspans},integer=0) → {floatset,floatspans}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(floatset '{1.123456789,2.123456789}', 3);
 -- {1.123, 2.123}
 SELECT round(floatspan '[1.123456789,2.123456789)', 3);
@@ -934,7 +932,7 @@ degrees({floatset,floatspans},normalize boolean=false) → {floatset,floatspans}
 radians({floatset,floatspans}) → {floatset,floatspans}
 </programlisting>
 				<para>El parámetro adicional en la función <varname>degrees</varname> puede ser utilizado para normalizar los valores entre 0 y 360 grados.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(degrees(floatset '{0, 0.5, 0.7, 1.0}', true), 3);
 -- {0, 28.648, 40.107, 57.296}
 SELECT round(radians(floatspanset '{[0, 45], [90, 135]}'), 3);
@@ -952,7 +950,7 @@ lower(textset) → textset
 upper(textset) → textset
 initcap(textset) → textset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lower(textset '{"AAA", "BBB", "CCC"}');
 -- {"aaa", "bbb", "ccc"}
 SELECT upper(textset '{"aaa", "bbb", "ccc"}');
@@ -968,7 +966,7 @@ SELECT initcap(textset '{"aaa", "bbb", "ccc"}');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {text,textset} || {text,textset} → textset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT textset '{aaa, bbb}' || text 'XX';
 -- {"aaaXX", "bbbXX"}
 SELECT text 'XX' || textset '{aaa, bbb}';
@@ -983,7 +981,7 @@ SELECT text 'XX' || textset '{aaa, bbb}';
 tprecision(times,duration interval,origin timestamptz='2000-01-03') → times
 </programlisting>
 				<para>Si el origen no se especifica, su valor se establece por defecto en lunes 3 de enero de 2000.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tprecision(timestamptz '2001-12-03', '30 days');
 -- 2001-11-23
 SELECT tprecision(timestamptz '2001-12-03', '30 days', '2001-12-01');
@@ -1018,7 +1016,7 @@ SELECT tprecision(tstzspanset '{[2001-12-01 08:00, 2001-12-01 09:00],
 SRID(spatialset) → integer
 setSRID(spatialset) → spatialset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(geomset '{"Point(1 1)", "Point(2 2)"}');
 -- 0
 SELECT SRID(geogset '{"Linestring(1 1,2 2)","Polygon((1 1,1 2,2 2,2 1,1 1))"}');
@@ -1050,7 +1048,7 @@ transformPipeline(spatialset,pipeline text,srid integer,
 				<para>La función <varname>transform</varname> especifica la transformación con un SRID de destino. Se genera un error cuando el conjunto tiene un SRID desconocido (representado por 0). La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas en el siguiente formato:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
 				<para>El SRID del conjunto de entrada se ignora y el SRID de la conjunto de salida se establecerá en cero a menos que se proporcione un valor a través del parámetro opcional <varname>srid</varname>. Como se indica en el último parámetro, la canalización se ejecuta de forma predeterminada en dirección hacia adelante; al establecer el parámetro en falso, la canalización se ejecuta en la dirección inversa.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(geomset 'SRID=4326;
   {Point(2.340088 49.400250), Point(6.575317 51.553167)}', 3812), 6);
 -- SRID=3812;{"POINT(502773.429981 511805.120402)", "POINT(803028.908265 751590.742629)"}
@@ -1081,7 +1079,7 @@ SELECT asEWKT(transformPipeline(transformPipeline(geoset, pipeline, 4326), pipel
 set {+, -, *} set → set
 spans {+, -, *} spans → spans
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT dateset '{2001-01-01, 2001-01-03, 2001-01-05}' + dateset '{2001-01-03,
   2001-01-06}';
 -- {2001-01-01, 2001-01-03, 2001-01-05, 2001-01-06}
@@ -1094,7 +1092,7 @@ SELECT tstzspanset '{[2001-01-01, 2001-01-03),
 -- {[2001-01-01, 2001-01-05)}
 </programlisting>
 
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intset '{1, 3, 5}' - intset '{3, 6}';
 -- {1, 5}
 SELECT datespan '[2001-01-01, 2001-01-05)' - datespan '[2001-01-03, 2001-01-07)';
@@ -1108,13 +1106,13 @@ SELECT tstzspanset '{[2001-01-01, 2001-01-06],
    [2001-01-07,2001-01-08), (2001-01-09,2001-01-10]} */
 </programlisting>
 
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tstzset '{2001-01-01, 2001-01-03}' * tstzset '{2001-01-03, 2001-01-05}';
 -- {2001-01-03}
 SELECT intspan '[1, 5)' * intspan '[3, 6)';
 -- [3, 5)
 SELECT floatspanset '{[1, 5),[6, 8)}' * floatspan '[1, 6)';
--- {[3, 5)}
+-- {[1, 5)}
 SELECT tstzspan '[2001-01-01, 2001-01-05)' * tstzspan '[2001-01-03, 2001-01-07)';
 -- [2001-01-03, 2001-01-05)
 </programlisting>
@@ -1138,14 +1136,14 @@ SELECT tstzspan '[2001-01-01, 2001-01-05)' * tstzspan '[2001-01-03, 2001-01-07)'
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {set,spans} &amp;&amp; {set,spans} → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intset '{1, 3}' &amp;&amp; intset '{2, 3, 4}';
 -- true
 SELECT floatspan '[1, 3)' &amp;&amp; floatspan '[3, 4)';
 -- false
-SELECT floatspanset '{[1, 5),[6, 8)}' &amp;&amp; floatspan '[1, 6)';
--- true
 SELECT tstzspan '[2001-01-01, 2001-01-05)' &amp;&amp; tstzspan '[2001-01-02, 2001-01-07)';
+-- true
+SELECT floatspanset '{[1, 5),[6, 8)}' &amp;&amp; floatspan '[1, 6)';
 -- true
 </programlisting>
 				</listitem>
@@ -1156,7 +1154,7 @@ SELECT tstzspan '[2001-01-01, 2001-01-05)' &amp;&amp; tstzspan '[2001-01-02, 200
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {set,spans} @&gt; {base,set,spans} → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floatset '{1.5, 2.5}' @&gt; 2.5;
 -- true
 SELECT tstzspan '[2001-01-01, 2001-05-01)' @&gt; timestamptz '2001-02-01';
@@ -1172,14 +1170,14 @@ SELECT floatspanset '{[1, 2),(2, 3)}' @&gt; 2.0;
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {base,set,spans} &lt;@ {set,spans} → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timestamptz '2001-01-10' &lt;@ tstzspan '[2001-01-01, 2001-05-01)';
 -- true
 SELECT floatspan '[2, 5]' &lt;@ floatspan '[1, 5)';
 -- false
-SELECT floatspanset '{[1,2],[3,4]}' &lt;@ floatspan '[1, 6]';
--- true
 SELECT tstzspan '[2001-02-01, 2001-03-01)' &lt;@ tstzspan '[2001-01-01, 2001-05-01)';
+-- true
+SELECT floatspanset '{[1,2],[3,4]}' &lt;@ floatspan '[1, 6]';
 -- true
 </programlisting>
 				</listitem>
@@ -1191,7 +1189,7 @@ SELECT tstzspan '[2001-02-01, 2001-03-01)' &lt;@ tstzspan '[2001-01-01, 2001-05-
 spans -|- spans → boolean
 </programlisting>
 					<para>Dos valores son adyacentes cuando se tocan sin solaparse, es decir, cuando comparten una frontera y no tienen ningún valor en común en ella. Para los tipos base continuos <varname>float</varname> y <varname>timestamptz</varname>, un límite compartido es ese contacto. Para los tipos base discretos <varname>int</varname>, <varname>bigint</varname> y <varname>date</varname>, cuyos rangos se almacenan en forma normal, significa valores consecutivos.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[2, 6)' -|- intspan '[6, 7)';
 -- true
 SELECT intspan '[1, 5]' -|- intspan '[6, 10]';
@@ -1208,7 +1206,7 @@ SELECT tstzspanset '{[2001-01-01, 2001-01-02]}' -|- tstzspan '[2001-01-02, 2001-
 -- true
 </programlisting>
 					<para>Un conjunto de rangos responde como su caja delimitadora, y las tres escrituras de un valor coinciden:</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 3;
 -- false
 SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- intspan '[3,3]';
@@ -1235,7 +1233,7 @@ SELECT intspanset '{[1,3), [5,8), [10,12)}' -|- 12;
 numbers &lt;&lt; numbers → boolean
 times &lt;&lt;# times → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[15, 20)' &lt;&lt; 20;
 -- true
 SELECT intspanset '{[15, 17],[18, 20)}' &lt;&lt; 20;
@@ -1255,7 +1253,7 @@ SELECT dateset '{2001-01-01, 2001-01-02}' &lt;&lt;# dateset '{2001-01-03, 2001-0
 numbers &gt;&gt; numbers → boolean
 times #&gt;&gt; times → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[15, 20)' &gt;&gt; 10;
 -- true
 SELECT floatspan '[15, 20)' &gt;&gt; floatspan '[5, 10]';
@@ -1276,7 +1274,7 @@ SELECT tstzspan '[2001-01-04, 2001-01-05)' #&gt;&gt;
 numbers &amp;&lt; numbers → boolean
 times &amp;&lt;# times → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[15, 20)' &amp;&lt; 18;
 -- false
 SELECT intspanset '{[15, 16],[17, 18)}' &amp;&lt; 18;
@@ -1296,7 +1294,7 @@ SELECT dateset '{2001-01-02, 2001-01-05}' &amp;&lt;# dateset '{2001-01-01, 2001-
 numbers &amp;&gt; numbers → boolean
 times #&amp;&gt; times → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[15, 20)' &amp;&gt; 30;
 -- true
 SELECT floatspan '[1, 6]' &amp;&gt; floatspan '(1, 3)';
@@ -1325,7 +1323,7 @@ SELECT timestamp '2001-01-01' #&amp;&gt; tstzspan '[2001-01-01, 2001-01-05)';
 splitNSpans({set,spanset},integer) → span[]
 </programlisting>
 					<para>El último argumento especifica el número de rangos de salida. Si el número de elementos o rangos de entrada es menor que el número especificado, la matriz resultante tendrá un rango por elemento o rango de entrada. De lo contrario, el número especificado de rangos de salida se obtendrá fusionando elementos o rangos de entrada consecutivos.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
 -- {"[1, 11)"}
 SELECT splitNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 3);
@@ -1336,7 +1334,7 @@ SELECT splitNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 12);
 /* {"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)",
    "[9, 10)","[10, 11)"} */
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitNSpans(intspanset '{[1, 2), [3, 4), [5, 6), [7, 8), [9, 10)}');
 -- {"[1, 2)","[3, 4)","[5, 6)","[7, 8)","[9, 10)"}
 SELECT splitNSpans(floatspanset '{[1, 2), [3, 4), [5, 6), [7, 8), [9, 10)}', 3);
@@ -1353,7 +1351,7 @@ SELECT splitNSpans(datespanset '{[2000-01-01, 2000-01-04), [2000-01-05, 2000-01-
 splitEachNSpans({set,spanset},integer) → span[]
 </programlisting>
 					<para>El último argumento especifica el número de elementos de entrada que se fusionan para producir un rango de salida. Si la cantidad de elementos de entrada es menor que el número especificado, la matriz resultante tendrá un rango de salida por elemento. De lo contrario, la cantidad especificada de elementos de entrada consecutivos se fusionará en un único rango de salida en la respuesta. Observe que, a diferencia de la función <link linkend="setspan_splitNSpans"><varname>splitNSpans</varname></link>, el número de rangos en el resultado depende del número de elementos o de rangos de entrada.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNSpans(intset '{1, 2, 3, 4, 5, 6, 7, 8, 9, 10}', 1);
 /* {"[1, 2)","[2, 3)","[3, 4)","[4, 5)","[5, 6)","[6, 7)","[7, 8)","[8, 9)",
    "[9, 10)","[10, 11)"} */
@@ -1383,7 +1381,7 @@ numbers &lt;-&gt; numbers → base
 dates &lt;-&gt; dates → integer
 times &lt;-&gt; times → float
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT 3 &lt;-&gt; intspan '[6, 8)';
 -- 3
 SELECT floatspan '[1, 3]' &lt;-&gt; floatspan '(5.5, 7]';
@@ -1422,7 +1420,7 @@ set {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} set → boolean
 spans {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} spans → boolean
 cmp({set,span,spanset},{set,span,spanset}) → int
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT intspan '[1,3]' = intspan '[1,4)';
 -- true
 SELECT floatspanset '{[1, 2),[2,3)}' = floatspanset '{[1,3)}';
@@ -1448,6 +1446,8 @@ SELECT tstzspan '[2001-01-03, 2001-01-05)' &gt;= tstzspan '[2001-01-03, 2001-01-
 -- true
 SELECT intspanset '{[1, 4)}' &gt;= intspanset '{[1, 5), [6, 7)}';
 -- false
+SELECT cmp(intspanset '{[1, 4)}', intspanset '{[1, 5), [6, 7)}');
+-- -1
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -1471,7 +1471,7 @@ SELECT intspanset '{[1, 4)}' &gt;= intspanset '{[1, 5), [6, 7)}';
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 extent({set,spans}) → span
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH spans(r) AS (
   SELECT floatspan '[1, 4)' UNION SELECT floatspan '(5, 8)' UNION
   SELECT floatspan '(7, 9)' )
@@ -1502,7 +1502,7 @@ setUnion({value,set}) → set
 spanUnion(spans) → spanset
 spansetUnion(spansets) → spanset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH times(ts) AS (
   SELECT tstzset '{2001-01-01, 2001-01-03, 2001-01-05}' UNION
   SELECT tstzset '{2001-01-02, 2001-01-04, 2001-01-06}' UNION
@@ -1513,7 +1513,7 @@ WITH periods(ps) AS (
   SELECT tstzspanset '{[2001-01-01, 2001-01-02], [2001-01-03, 2001-01-04]}' UNION
   SELECT tstzspanset '{[2001-01-02, 2001-01-03], [2001-01-05, 2001-01-06]}' UNION
   SELECT tstzspanset '{[2001-01-07, 2001-01-08]}' )
-SELECT spanUnion(ps) FROM periods;
+SELECT spansetUnion(ps) FROM periods;
 -- {[2001-01-01, 2001-01-04], [2001-01-05, 2001-01-06], [2001-01-07, 2001-01-08]}
 </programlisting>
 			</listitem>
@@ -1524,7 +1524,7 @@ SELECT spanUnion(ps) FROM periods;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tCount(times) → {tintSeq,tintSeqSet}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH times(ts) AS (
   SELECT tstzset '{2001-01-01, 2001-01-03, 2001-01-05}' UNION
   SELECT tstzset '{2001-01-02, 2001-01-04, 2001-01-06}' UNION
@@ -1546,7 +1546,7 @@ SELECT tCount(ps) FROM periods;
 		<title>Indexación</title>
 
 		<para>Se pueden crear índices GiST y SP-GiST en columnas de tablas de los tipos de conjunto y de rango. El índice GiST implementa un árbol R, mientras que el índice SP-GiST implementa un árbol cuádruple. Un ejemplo de creación de un índice GiST en una columna <varname>During</varname> de tipo <varname>tstzspan</varname> en una tabla <varname>Reservation</varname> es como sigue:
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE Reservation (ReservationID integer PRIMARY KEY, RoomID integer,
   During tstzspan);
 CREATE INDEX Reservation_During_Idx ON Reservation USING GIST(During);

--- a/doc/es/temporal_alpha.xml
+++ b/doc/es/temporal_alpha.xml
@@ -81,12 +81,13 @@ SELECT tfloat '(1@2001-01-01, 3@2001-01-03, 2@2001-01-05]'::tbox;
 				<indexterm significance="normal"><primary><varname>tint</varname></primary></indexterm>
 				<para>Convierte entre un booleano temporal y un entero temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tbool::tint
-tint(tbool) → tint
+valueSpan(tnumber) → numspan
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
--- [1@2001-01-01, 0@2001-01-03]
+SELECT valueSpan(tint '{1@2001-01-01, 5@2001-01-02, 3@2001-01-03}');
+-- [1, 6)
+SELECT valueSpan(tfloat '[1.5@2001-01-01, 4.5@2001-01-03]');
+-- [1.5, 4.5]
 </programlisting>
 			</listitem>
 
@@ -95,6 +96,24 @@ SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>tnumber(tnumber)</varname></primary></indexterm>
 				<para>Convierte entre enteros temporales, enteros grandes temporales y flotantes temporales</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+tbool::tint
+tint(tbool) → tint
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
+-- [1@2001-01-01, 0@2001-01-03]
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="talpha_accessors">
+		<title>Accessores</title>
+		<itemizedlist>
+			<listitem xml:id="talpha_valueSpan">
+				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
+				<para>Devuelve el intervalo de valores ignorando las brechas potenciales</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tnumber::tnumber
 tnumber(tnumber) → tnumber
@@ -108,25 +127,6 @@ SELECT tfloat 'Interp=Step;[1.5@2001-01-01, 2.5@2001-01-03]'::tint;
 -- [1@2001-01-01, 2@2001-01-03]
 SELECT tint(tfloat '[1.5@2001-01-01, 2.5@2001-01-03]');
 -- ERROR:  Cannot cast temporal float with linear interpolation to temporal integer
-</programlisting>
-			</listitem>
-		</itemizedlist>
-	</sect1>
-
-	<sect1 xml:id="talpha_accessors">
-		<title>Accessores</title>
-		<itemizedlist>
-			<listitem xml:id="talpha_valueSpan">
-				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
-				<para>Devuelve el intervalo de valores ignorando las brechas potenciales</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-valueSpan(tnumber) → numspan
-</programlisting>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT valueSpan(tint '{[1@2001-01-01, 1@2001-01-03), [4@2001-01-03, 6@2001-01-05]}');
--- [1,7)
-SELECT valueSpan(tfloat '{1@2001-01-01, 2@2001-01-03, 3@2001-01-05}');
--- [1,3])
 </programlisting>
 			</listitem>
 
@@ -256,7 +256,7 @@ minusMin(torder) → torder
 minusMax(torder) → torder
 </programlisting>
 				<para>La función devuelve un valor nulo si el valor mínimo o máximo sólo ocurre en límites exclusivos.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atMin(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}');
 -- {1@2001-01-01, 1@2001-01-05}
 SELECT atMin(tint '(1@2001-01-01, 3@2001-01-03]');
@@ -274,7 +274,7 @@ SELECT atMax(tfloat '{(2@2001-01-01, 1@2001-01-03), [2@2001-01-03, 2@2001-01-05)
 SELECT atMax(ttext '{(AA@2001-01-01, AA@2001-01-03), (BB@2001-01-03, AA@2001-01-05]}');
 -- {("BB"@2001-01-03, "BB"@2001-01-05)}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minusMin(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}');
 -- {2@2001-01-03}
 SELECT minusMin(tfloat '[1@2001-01-01, 3@2001-01-03]');
@@ -305,12 +305,12 @@ atTbox(tnumber,tbox) → tnumber
 minusTbox(tnumber,tbox) → tnumber
 </programlisting>
 				<para>When the bounding box has both value and time dimensions, the functions restrict the temporal number with respect to the value <emphasis>and</emphasis> the time extents of the box.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atTbox(tfloat '[0@2001-01-01, 3@2001-01-04)',
   tbox 'TBOXFLOAT XT((0,2),[2001-01-02, 2001-01-04])');
 -- {[1@2001-01-02, 2@2001-01-03]}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minusTbox(tfloat '[1@2001-01-01, 4@2001-01-04)',
   'TBOXFLOAT XT((1,4),[2001-01-03, 2001-01-04])');
 -- {[1@2001-01-01, 3@2001-01-03)}
@@ -334,16 +334,13 @@ SELECT minusSpan(minusTime(temp, box::tstzspan), box::floatspan) FROM temp;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {boolean,tbool} {&amp;, |} {boolean,tbool} → tbool
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool '[true@2001-01-03, true@2001-01-05)' &amp;
   tbool '[false@2001-01-03, false@2001-01-05)';
 -- [f@2001-01-03, f@2001-01-05)
 SELECT tbool '[true@2001-01-03, true@2001-01-05)' &amp;
   tbool '{[false@2001-01-03, false@2001-01-04), [true@2001-01-04, true@2001-01-05)}';
 -- {[f@2001-01-03, t@2001-01-04, t@2001-01-05)}
-</programlisting>
-
-				<programlisting language="sql" xml:space="preserve">
 SELECT tbool '[true@2001-01-03, true@2001-01-05)' | tbool '[false@2001-01-03,
   false@2001-01-05)';
 -- [t@2001-01-03, t@2001-01-05)
@@ -356,7 +353,7 @@ SELECT tbool '[true@2001-01-03, true@2001-01-05)' | tbool '[false@2001-01-03,
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 ~tbool → tbool
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ~tbool '[true@2001-01-03, true@2001-01-05)';
 -- [f@2001-01-03, f@2001-01-05)
 </programlisting>
@@ -368,8 +365,8 @@ SELECT ~tbool '[true@2001-01-03, true@2001-01-05)';
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 whenTrue(tbool) → tstzspanset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
-SELECT whenTrue(tfloat '[1@2001-01-01, 4@2001-01-04, 1@2001-01-07]' #> 2);
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT whenTrue(tfloat '[1@2001-01-01, 4@2001-01-04, 1@2001-01-07]' #&gt; 2);
 -- {(2001-01-02, 2001-01-06)}
 SELECT whenTrue(tdwithin(tgeompoint '[Point(1 1)@2001-01-01, Point(4 4)@2001-01-04,
   Point(1 1)@2001-01-07]', geometry 'Point(1 1)', sqrt(2)));
@@ -393,7 +390,7 @@ SELECT whenTrue(tdwithin(tgeompoint '[Point(1 1)@2001-01-01, Point(4 4)@2001-01-
 {number,tnumber} {+, -, *, /} {number,tnumber} → tnumber
 </programlisting>
 				<para>La división temporal genera un error si el denominador es alguna vez igual a cero durante el intervalo de tiempo común de los argumentos.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[2@2001-01-01, 2@2001-01-04)' + 1;
 -- [3@2001-01-01, 3@2001-01-04)
 SELECT tfloat '[2@2001-01-01, 2@2001-01-04)' + tfloat '[1@2001-01-01, 4@2001-01-04)';
@@ -403,14 +400,14 @@ SELECT tfloat '[1@2001-01-01, 4@2001-01-04)' + tfloat '{[1@2001-01-01, 2@2001-01
 -- {[2@2001-01-01, 4@2001-01-04), [3@2001-01-02, 6@2001-01-04)}
 </programlisting>
 
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 1@2001-01-04)' - tint '[2@2001-01-03, 2@2001-01-05)';
 -- [-1@2001-01-03, -1@2001-01-04)
 SELECT tfloat '[3@2001-01-01, 6@2001-01-04)' - tfloat '[2@2001-01-01, 2@2001-01-04)';
 -- [1@2001-01-01, 4@2001-01-04)
 </programlisting>
 
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 4@2001-01-04]' * 2;
 -- [2@2001-01-01, 8@2001-01-04]
 SELECT tfloat '[1@2001-01-01, 4@2001-01-04)' * tfloat '[2@2001-01-01, 2@2001-01-04)';
@@ -419,7 +416,7 @@ SELECT tfloat '[1@2001-01-01, 3@2001-01-03)' * '[3@2001-01-01, 1@2001-01-03)';
 -- {[3@2001-01-01, 4@2001-01-02, 3@2001-01-03)}
 </programlisting>
 
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT 2 / tfloat '[1@2001-01-01, 3@2001-01-04)';
 -- [2@2001-01-01, 0.666666666666667@2001-01-04)
 SELECT tfloat '[1@2001-01-01, 5@2001-01-05)' / tfloat '[5@2001-01-01, 1@2001-01-05)';
@@ -437,9 +434,9 @@ SELECT tfloat '[-1@2001-01-04, 1@2001-01-05]' / tfloat '[-1@2001-01-01, 1@2001-0
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 abs(tnumber) → tnumber
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT abs(tfloat '[1@2001-01-01, -1@2001-01-03, 1@2001-01-05]');
--- [1@2001-01-01, 0@2001-01-02, 1@2001-01-03, 0@2001-01-04, 1@2001-01-05],
+-- [1@2001-01-01, 0@2001-01-02, 1@2001-01-03, 0@2001-01-04, 1@2001-01-05]
 SELECT abs(tint '[1@2001-01-01, -1@2001-01-03, 1@2001-01-05]');
 -- [1@2001-01-01, 1@2001-01-05]
 </programlisting>
@@ -453,7 +450,7 @@ SELECT abs(tint '[1@2001-01-01, -1@2001-01-03, 1@2001-01-05]');
 floor(tfloat) → tfloat
 ceil(tfloat) → tfloat
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT floor(tfloat '[0.5@2001-01-01, 1.5@2001-01-02]');
 -- [0@2001-01-01, 1@2001-01-02]
 SELECT ceil(tfloat '[0.5@2001-01-01, 0.6@2001-01-02, 0.7@2001-01-03]');
@@ -467,7 +464,7 @@ SELECT ceil(tfloat '[0.5@2001-01-01, 0.6@2001-01-02, 0.7@2001-01-03]');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 round(tfloat,integer=0) → tfloat
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tfloat '[0.785398163397448@2001-01-01, 2.356194490192345@2001-01-02]', 2);
 -- [0.79@2001-01-01, 2.36@2001-01-02]
 </programlisting>
@@ -482,12 +479,13 @@ degrees({float,tfloat},normalize boolean=false) → tfloat
 radians(tfloat) → tfloat
 </programlisting>
 				<para>El parámetro adicional en la función <varname>degrees</varname> puede ser utilizado para normalizar los valores entre 0 y 360 grados.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT degrees(pi() * 5);
 -- 900
 SELECT degrees(pi() * 5, true);
 -- 180
-SELECT round(degrees(tfloat '[0.7853981633974@2001-01-01, 2.3561944901923@2001-01-02]'));
+SELECT round(degrees(tfloat '[0.785398163397448@2001-01-01,
+  2.356194490192345@2001-01-02]'));
 -- [45@2001-01-01, 135@2001-01-02]
 SELECT radians(tfloat '[45@2001-01-01, 135@2001-01-02]');
 -- [0.785398163397448@2001-01-01, 2.356194490192345@2001-01-02]
@@ -500,7 +498,7 @@ SELECT radians(tfloat '[45@2001-01-01, 135@2001-01-02]');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 deltaValue(tnumber) → tnumber
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT deltaValue(tint '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03]');
 -- [1@2001-01-01, -1@2001-01-02, -1@2001-01-03)
 SELECT deltaValue(tfloat '{[1.5@2001-01-01, 2@2001-01-02, 1@2001-01-03],
@@ -533,7 +531,7 @@ SELECT trend(tfloat '[1@2001-01-01]');
 derivative(tfloat) → tfloat
 </programlisting>
 				<para>El número flotante temporal debe tener interpolación linear. Nótese que esta función corresponde a la función <link linkend="tgeo_speed"><varname>speed</varname></link> para los puntos temporales.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT derivative(tfloat '{[0@2001-01-01, 10@2001-01-02, 5@2001-01-03],
   [1@2001-01-04, 0@2001-01-05]}') * 3600 * 24;
 /* Interp=Step;{[-10@2001-01-01, 5@2001-01-02, 5@2001-01-03],
@@ -549,7 +547,7 @@ SELECT derivative(tfloat 'Interp=Step;[0@2001-01-01, 10@2001-01-02, 5@2001-01-03
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 integral(tnumber) → float
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT integral(tint '[1@2001-01-01,2@2001-01-02]') / (24 * 3600 * 1e6);
 -- 1
 SELECT integral(tfloat '[1@2001-01-01,2@2001-01-02]') / (24 * 3600 * 1e6);
@@ -563,7 +561,7 @@ SELECT integral(tfloat '[1@2001-01-01,2@2001-01-02]') / (24 * 3600 * 1e6);
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 twAvg(tnumber) → float
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT twAvg(tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-04, 2@2001-01-06)}');
 -- 1.75
 </programlisting>
@@ -578,7 +576,7 @@ ln(tfloat) → tfloat
 log10(tfloat) → tfloat
 </programlisting>
 				<para>El número flotante temporal no puede ser cero o negativo</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ln(tfloat '{[1@2001-01-01, 10@2001-01-02, 5@2001-01-03],
   [1@2001-01-04, 1@2001-01-05]}');
 /* {[0@2001-01-01, 2.302585092994046@2001-01-02, 1.6094379124341@2001-01-03], 
@@ -594,7 +592,7 @@ SELECT log10(tfloat 'Interp=Step;[-10@2001-01-01, 10@2001-01-02]');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 exp(tfloat) → tfloat
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT exp(tfloat '{[1@2001-01-01, 10@2001-01-02], [1@2001-01-04, 1@2001-01-05]}');
 /* {[2.718281828459045@2001-01-01, 22026.465794806718@2001-01-02],
    [2.718281828459045@2001-01-04, 2.718281828459045@2001-01-05]} */
@@ -613,7 +611,7 @@ sin(tfloat) → tfloat
 cos(tfloat) → tfloat
 tan(tfloat) → tfloat
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(sin(tfloat '[0@2001-01-01, 6.283185307@2001-01-02]'), 6);
 -- [0@2001-01-01, -0.000000@2001-01-02]
 SELECT round(cos(tfloat '[0@2001-01-01, 3.141592654@2001-01-02]'), 6);
@@ -635,7 +633,7 @@ SELECT round(tan(tfloat '{0@2001-01-01, 0.785398163@2001-01-02}'), 6);
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {text,ttext} || {text,ttext} → ttext
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '[AA@2001-01-01, AA@2001-01-04)' || text 'B';
 -- ["AAB"@2001-01-01, "AAB"@2001-01-04)
 SELECT ttext '[AA@2001-01-01, AA@2001-01-04)' || ttext '[BB@2001-01-02, BB@2001-01-05)';
@@ -656,13 +654,13 @@ upper(ttext) → ttext
 lower(ttext) → ttext
 initcap(ttext) → ttext
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
-SELECT upper(ttext '[AA@2001-01-01, bb@2001-01-02]');
--- ["AA"@2001-01-01, "BB"@2001-01-02]
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lower(ttext '[AA@2001-01-01, bb@2001-01-02]');
 -- ["aa"@2001-01-01, "bb"@2001-01-02]
+SELECT upper(ttext '[AA@2001-01-01, bb@2001-01-02]');
+-- ["AA"@2001-01-01, "BB"@2001-01-02]
 SELECT initcap(ttext '[AA@2001-01-01, bb@2001-01-02]');
--- ["aa"@2001-01-01, "bb"@2001-01-02]
+-- ["Aa"@2001-01-01, "Bb"@2001-01-02]
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -355,8 +355,8 @@ SELECT asText(tcbuffer '[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 SELECT asText(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2001-01-01,
   Cbuffer(Point(2 2), 0.3)@2001-01-02, Cbuffer(Point(2 2), 0.5)@2001-01-03),
   [Cbuffer(Point(2 2), 0.5)@2001-01-03, Cbuffer(Point(2 2), 0.7)@2001-01-04)}');
-/* {[Cbuffer(Point(1 1),0.2)@2001-01-01, Cbuffer(Point(2 2),0.3)@2001-01-02,
-   Cbuffer(Point(2 2),0.7)@2001-01-04)} */
+/* {[Cbuffer(POINT(1 1),0.2)@2001-01-01, Cbuffer(POINT(2 2),0.3)@2001-01-02, 
+   Cbuffer(POINT(2 2),0.7)@2001-01-04)} */
 </programlisting>
 	</sect1>
 
@@ -528,8 +528,8 @@ SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.5)', timestamptz '2001-01-01'));
 -- Cbuffer(POINT(1 1),0.5)@2001-01-01
 SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.3)',
   tstzset '{2001-01-01, 2001-01-03, 2001-01-05}'));
-/* {Cbuffer(Point(1 1),0.3)@2001-01-01, Cbuffer(Point(1 1),0.3)@2001-01-03,
-   Cbuffer(Point(1 1),0.3)@2001-01-05} */
+/* {Cbuffer(POINT(1 1),0.3)@2001-01-01, Cbuffer(POINT(1 1),0.3)@2001-01-03, 
+   Cbuffer(POINT(1 1),0.3)@2001-01-05} */
 SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.5)', tstzspan '[2001-01-01, 2001-01-02]'));
 -- [Cbuffer(POINT(1 1),0.5)@2001-01-01, Cbuffer(POINT(1 1),0.5)@2001-01-02]
 SELECT asText(tcbuffer('Cbuffer(Point(1 1), 0.2)',
@@ -548,8 +548,8 @@ tcbufferSeq(tcbufferInst[],interp text='linear',lower_inc boolean=true,
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.3)@2001-01-01',
   'Cbuffer(Point(2 2), 0.5)@2001-01-02', 'Cbuffer(Point(1 1), 0.5)@2001-01-03']));
-/* [Cbuffer(Point(1 1),0.3)@2001-01-01, Cbuffer(Point(2 2),0.5)@2001-01-02,
-   Cbuffer(Point(1 1),0.5)@2001-01-03] */
+/* [Cbuffer(POINT(1 1),0.3)@2001-01-01, Cbuffer(POINT(2 2),0.5)@2001-01-02, 
+   Cbuffer(POINT(1 1),0.5)@2001-01-03] */
 SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.3)@2001-01-01',
   'Cbuffer(Point(2 2), 0.5)@2001-01-02', 'Cbuffer(Point(1 1), 0.5)@2001-01-03'],
   'discrete'));
@@ -557,8 +557,8 @@ SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.3)@2001-01-01',
    Cbuffer(POINT(1 1),0.5)@2001-01-03} */
 SELECT asText(tcbufferSeq(ARRAY[tcbuffer 'Cbuffer(Point(1 1), 0.2)@2001-01-01',
   'Cbuffer(Point(1 1), 0.4)@2001-01-02', 'Cbuffer(Point(1 1), 0.5)@2001-01-03'], 'step'));
-/* Interp=Step;[Cbuffer(Point(1 1),0.2)@2001-01-01, Cbuffer(Point(1 1),0.4)@2001-01-02,
-   Cbuffer(Point(1 1),0.5)@2001-01-03] */
+/* Interp=Step;[Cbuffer(POINT(1 1),0.2)@2001-01-01, Cbuffer(POINT(1 1),0.4)@2001-01-02, 
+   Cbuffer(POINT(1 1),0.5)@2001-01-03] */
 </programlisting>
 			</listitem>
 
@@ -579,8 +579,8 @@ SELECT asText(tcbufferSeqSet(ARRAY[tcbuffer '[Cbuffer(Point(1 1),0.2)@2001-01-01
    [Cbuffer(Point(2 2),0.6)@2001-01-03, Cbuffer(Point(2 2),0.6)@2001-01-04]} */
 SELECT asText(tcbufferSeqSetGaps(ARRAY[tcbuffer 'Cbuffer(Point(1 1),0.1)@2001-01-01',
   'Cbuffer(Point(1 1),0.3)@2001-01-03', 'Cbuffer(Point(1 1),0.5)@2001-01-05'], '1 day'));
-/* {[Cbuffer(Point(1 1),0.1)@2001-01-01], [Cbuffer(Point(1 1),0.3)@2001-01-03],
-   [Cbuffer(Point(1 1),0.5)@2001-01-05]} */
+/* {[Cbuffer(POINT(1 1),0.1)@2001-01-01], [Cbuffer(POINT(1 1),0.3)@2001-01-03], 
+   [Cbuffer(POINT(1 1),0.5)@2001-01-05]} */
 </programlisting>
 			</listitem>
 
@@ -826,8 +826,8 @@ SELECT asText(atValue(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 -- {[Cbuffer(POINT(2 2),0.5)@2001-01-02]}
 SELECT asText(minusValue(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
   Cbuffer(Point(2 2), 0.7)@2001-01-03]', cbuffer 'Cbuffer(Point(2 2), 0.5)'));
-/* {[Cbuffer(Point(2 2),0.3)@2001-01-01, Cbuffer(Point(2 2),0.5)@2001-01-02),
-   (Cbuffer(Point(2 2),0.5)@2001-01-02, Cbuffer(Point(2 2),0.7)@2001-01-03]} */
+/* {[Cbuffer(POINT(2 2),0.3)@2001-01-01, Cbuffer(POINT(2 2),0.5)@2001-01-02),
+   (Cbuffer(POINT(2 2),0.5)@2001-01-02, Cbuffer(POINT(2 2),0.7)@2001-01-03]} */
 </programlisting>
 			</listitem>
 
@@ -909,7 +909,7 @@ WITH test(tcbuffer, pipeline) AS (
     text 'urn:ogc:def:coordinateOperation:EPSG::16031' )
 SELECT asEWKT(transformPipeline(transformPipeline(tcbuffer, pipeline, 4326), pipeline,
   4326, false), 6) FROM test;
-/* SRID=4326;{Cbuffer(POINT(4.3525 50.846667),1)@2001-01-01,
+/* SRID=4326;{Cbuffer(POINT(4.3525 50.846667),1)@2001-01-01, 
    Cbuffer(POINT(-0.1275 51.507222),2)@2001-01-02} */
 </programlisting>
 			</listitem>
@@ -998,16 +998,16 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 {tstzspan,stbox,tcbuffer} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tcbuffer} → boolean
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt; cbuffer 'Cbuffer(Point(1 1), 0.2)';
 -- false
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt;| stbox(cbuffer 'Cbuffer(Point(1 1), 0.5)');
 -- false
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &amp;&gt; cbuffer 'Cbuffer(Point(1 1), 0.3)'::geometry;
 -- true
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &gt;&gt;#
   tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-03, Cbuffer(Point(1 1), 0.5)@2001-01-05]';
 -- true
@@ -1105,9 +1105,7 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
 				<para>Devuelve la distancia espacial mínima, ignorando el tiempo</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-minDistance({geometry,cbuffer},tcbuffer) → float
-minDistance(tcbuffer,{geometry,cbuffer}) → float
-minDistance(tcbuffer,tcbuffer) → float
+minDistance({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → float
 </programlisting>
 				<para>El resultado es la distancia espacial entre las áreas barridas por los dos argumentos durante toda su vida útil, igual a <varname>ST_Distance</varname> del <varname>traversedArea</varname> de cada uno. La forma de dos argumentos de búfer circular temporal es un agregado, de modo que una combinación cruzada agrupada por una clave produce el mínimo sobre cada par del grupo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1197,8 +1195,8 @@ tTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → tbool
 SELECT tDisjoint(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
   tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.3)@2001-01-03)');
 -- {[t@2001-01-01, t@2001-01-03)}
-SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
-  Cbuffer(Point(1 1), 0.5)@2001-01-03)', tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01,
+SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
+  Cbuffer(Point(1 1), 0.5)@2001-01-03)', tcbuffer '[Cbuffer(Point(1 1), 0.5)@2001-01-01, 
   Cbuffer(Point(1 1), 0.3)@2001-01-03)', 1);
 /* {[t@2001-01-01, t@2001-01-01 22:35:55.379053],
    (f@2001-01-01 22:35:55.379053, t@2001-01-02 01:24:04.620946, t@2001-01-03)} */
@@ -1222,7 +1220,7 @@ SELECT tDwithin(tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 tcbuffer {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tcbuffer → boolean
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.1)@2001-01-01,
+SELECT tcbuffer '{[Cbuffer(Point(1 1), 0.1)@2001-01-01, 
   Cbuffer(Point(1 1), 0.3)@2001-01-02),
   [Cbuffer(Point(1 1), 0.3)@2001-01-02, Cbuffer(Point(1 1), 0.5)@2001-01-03]}' =
   tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.5)@2001-01-03]';

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -32,7 +32,7 @@ SELECT th3index '{[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02],
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3index(Instant) '831c02fffffffff@2001-01-01';
 SELECT th3index(SequenceSet) '{[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02]}';
--- ERROR: el tipo temporal (Instant) no coincide con el tipo de columna (Sequence)
+-- ERROR: temporal type (Instant) does not match column type (Sequence)
 SELECT th3index(Sequence) '831c02fffffffff@2001-01-01';
 </programlisting>
 		<para>Las funciones <varname>asText</varname>, <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>th3index</varname>, y <varname>th3indexFromBinary</varname> y <varname>th3indexFromHexWKB</varname> lo reconstruyen. La forma hexadecimal WKB permite que una columna de índice H3 temporal se transfiera de ida y vuelta mediante un <varname>COPY</varname> basado en texto.</para>
@@ -159,6 +159,8 @@ valueN(th3index,integer) → h3index
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueN(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}', 1);
 -- 831c02fffffffff
+SELECT valueN(th3index '{831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02}', 2);
+-- 831c00fffffffff
 SELECT valueN(th3index '831c02fffffffff@2001-01-01', 99);
 -- NULL
 </programlisting>
@@ -173,6 +175,10 @@ getValues(th3index) → h3indexset
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(th3index '831c02fffffffff@2001-01-01');
 -- {831c02fffffffff}
+SELECT getValues(th3index
+  '[831c02fffffffff@2001-01-01, 831c00fffffffff@2001-01-02,
+    880326b885fffff@2001-01-03]');
+-- {831c00fffffffff, 831c02fffffffff, 880326b885fffff}
 </programlisting>
 			</listitem>
 
@@ -204,6 +210,8 @@ th3GetResolution(th3index) → tint
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT th3GetResolution(th3index '831c02fffffffff@2001-01-01');
 -- 3@2001-01-01
+SELECT th3GetResolution(th3index '880326b885fffff@2001-01-01');
+-- 8@2001-01-01
 </programlisting>
 			</listitem>
 
@@ -225,6 +233,8 @@ SELECT th3GetBaseCellNumber(th3index '831c02fffffffff@2001-01-01');
 isValidCell(th3index) → tbool
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidCell(th3index '831c02fffffffff@2001-01-01');
+-- t@2001-01-01
 SELECT isValidCell(th3index '0@2001-01-01');
 -- f@2001-01-01
 </programlisting>
@@ -641,6 +651,8 @@ SELECT aEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
 					<programlisting xml:space="preserve" format="linespecific">
 eNe({h3index,th3index},th3index) → boolean
 eNe(th3index,h3index) → boolean
+{h3index,th3index} ?&lt;&gt; th3index
+th3index ?&lt;&gt; h3index
 </programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
@@ -655,6 +667,8 @@ SELECT eNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
 					<programlisting xml:space="preserve" format="linespecific">
 aNe({h3index,th3index},th3index) → boolean
 aNe(th3index,h3index) → boolean
+{h3index,th3index} %&lt;&gt; th3index
+th3index %&lt;&gt; h3index
 </programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT aNe(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44aeffffff');
@@ -678,6 +692,10 @@ tEq({h3index,th3index},th3index) → tbool
 tEq(th3index,h3index) → tbool
 tNe({h3index,th3index},th3index) → tbool
 tNe(th3index,h3index) → tbool
+{h3index,th3index} #= th3index
+th3index #= h3index
+{h3index,th3index} #&lt;&gt; th3index
+th3index #&lt;&gt; h3index
 </programlisting>
 									<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tEq(th3index '871fa44a8ffffff@2001-01-01', h3index '871fa44a8ffffff');
@@ -1065,7 +1083,7 @@ FROM Temp;
 				<para>Clase de operadores GiST para celdas H3 temporales</para>
 				<para>Indexa una caja envolvente espaciotemporal <varname>stbox</varname> por fila (la extensión geodésica de los límites de las celdas junto con el período temporal).</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-CREATE INDEX ON trips USING gist(cells);       -- usa th3_rtree_ops por defecto
+CREATE INDEX ON trips USING gist(cells);       -- uses th3_rtree_ops by default
 CREATE INDEX ON trips USING gist(cells th3_rtree_ops);
 </programlisting>
 			</listitem>
@@ -1076,7 +1094,7 @@ CREATE INDEX ON trips USING gist(cells th3_rtree_ops);
 				<para>Clases de operadores SP-GiST para celdas H3 temporales, indexadas por la caja envolvente espaciotemporal <varname>stbox</varname></para>
 <para><varname>th3_quadtree_ops</varname> es la predeterminada (partición por quadtree); <varname>th3_kdtree_ops</varname> utiliza partición por árbol k-d y debe ser nombrada explícitamente.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-CREATE INDEX ON trips USING spgist(cells);     -- usa th3_quadtree_ops por defecto
+CREATE INDEX ON trips USING spgist(cells);     -- uses th3_quadtree_ops by default
 CREATE INDEX ON trips USING spgist(cells th3_kdtree_ops);
 </programlisting>
 			</listitem>

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -37,32 +37,32 @@
 		<title>Tipos de red estáticos</title>
 
 		<para>Un valor <varname>npoint</varname> es un par de la forma <varname>(rid, position)</varname> donde <varname>rid</varname> es un valor <varname>bigint</varname> que representa un identificador de ruta y <varname>position</varname> es un valor <varname>float</varname> en el rango [0,1] que indica su posición relativa. Los valores 0 y 1 de <varname>position</varname> denotan, respectivamente, la posición inicial y final de la ruta. La distancia de la ruta entre un valor de <varname>npoint</varname> y la posición inicial de la ruta con el identificador <varname>rid</varname> se calcula multiplicando <varname>position</varname> por <varname>length</varname>, donde este último es la longitud de la ruta. Ejemplos de entrada de valores de puntos de red son los siguientes:</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT npoint 'Npoint(76, 0.3)';
 SELECT npoint 'Npoint(64, 1.0)';
 </programlisting>
 
 		<para>La función de constructor para puntos de red tiene un argumento para el identificador de ruta y un argumento para la posición relativa. Un ejemplo de un valor de punto de red definido con la función constructora es el siguiente:</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT npoint(76, 0.3);
 </programlisting>
 
 		<para>Un valor <varname>nsegment</varname> es un triple de la forma <varname>(rid, startPosition, endPosition)</varname> donde <varname>rid</varname> es un valor <varname>bigint</varname> que representa un identificador de ruta y <varname>startPosition</varname> y <varname>endPosition</varname> son valores de <varname>float</varname> en el rango [0,1] tal que <varname>startPosition ≤ endPosition</varname>. Semánticamente, un segmento de red representa un conjunto de puntos de red <varname>(rid, position)</varname> con <varname>startPosition ≤ position ≤ endPosition</varname>. Si <varname>startPosition = 0</varname> y <varname>endPosition = 1</varname>, el segmento de red es equivalente a la ruta completa. Si <varname>startPosition = endPosition</varname>, el segmento de red representa un único punto de red. Ejemplos de entrada de valores de puntos de red son los siguientes:</para>
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nsegment 'Nsegment(76, 0.3, 0.5)';
 SELECT nsegment 'Nsegment(64, 0.5, 0.5)';
 SELECT nsegment 'Nsegment(64, 0.0, 1.0)';
 SELECT nsegment 'Nsegment(64, 1.0, 0.0)';
--- convertido a nsegment 'Nsegment(64, 0.0, 1.0)';
+-- converted to nsegment 'Nsegment(64, 0.0, 1.0)';
 </programlisting>
 		<para>Como se puede ver en el último ejemplo, los valores <varname>startPosition</varname> y <varname>endPosition</varname> se invertirán para asegurar que la condición <varname>startPosition ≤ endPosition</varname> siempre se satisface. La función de constructor para segmentos de red tiene un argumento para el identificador de ruta y dos argumentos opcionales para las posiciones inicial y final. Los ejemplos de valores de segmento de red definidos con la función constructora son los siguientes:</para>
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nsegment(76, 0.3, 0.3);
-SELECT nsegment(76); -- se asume que las posiciones inicial y final son 0 y 1
-SELECT nsegment(76, 0.5); -- se asume que la posición final es 1
+SELECT nsegment(76); -- start and end position assumed to be 0 and 1 respectively
+SELECT nsegment(76, 0.5); -- end position assumed to be 1
 </programlisting>
 		<para>Los valores del tipo <varname>npoint</varname> se pueden convertir al tipo <varname>nsegment</varname> usando un <varname>CAST</varname> explícito o usando la notación <varname>::</varname> como se muestra a continuación.</para>
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT npoint(76, 0.33)::nsegment;
 </programlisting>
 
@@ -76,7 +76,7 @@ SELECT npoint(76, 0.33)::nsegment;
 			</listitem>
 		</itemizedlist>
 		<para>Ejemplos de valores de tipo de red estática incorrectos son los siguientes.</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Valor rid incorrecto
 SELECT npoint 'Npoint(87.5, 1.0)';
 -- Valor de posición incorrecto
@@ -183,7 +183,7 @@ SELECT asEWKT(npointFromHexEWKB('01412C1600000100000000000000000000000000E03F'))
 npoint(bigint,float) → npoint
 nsegment(bigint,float,float) → nsegment
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT npoint(76, 0.3);
 SELECT nsegment(76, 0.3, 0.5);
 </programlisting>
@@ -202,7 +202,7 @@ SELECT nsegment(76, 0.3, 0.5);
 {npoint,nsegment}::geometry
 geometry::{npoint,nsegment}
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(npoint(76, 0.33)::geometry);
 -- POINT(21.6338731332283 50.0545869554067)
 SELECT ST_AsText(nsegment(76, 0.33, 0.66)::geometry);
@@ -210,7 +210,7 @@ SELECT ST_AsText(nsegment(76, 0.33, 0.66)::geometry);
 SELECT ST_AsText(nsegment(76, 0.33, 0.33)::geometry);
 -- POINT(21.6338731332283 50.0545869554067)
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geometry 'SRID=5676;Point(279.269156511873 811.497076880187)'::npoint;
 -- NPoint(3,0.781413)
 SELECT geometry 'SRID=5676;LINESTRING(406.729536784738 702.58583437902,
@@ -254,7 +254,7 @@ SELECT stbox(npoint 'NPoint(1,0.3)', tstzspan '[2001-01-01,2001-01-02]');
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 route({npoint,nsegment}) → bigint
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT route(npoint 'Npoint(63, 0.3)');
 -- 63
 SELECT route(nsegment 'Nsegment(76, 0.3, 0.3)');
@@ -268,7 +268,7 @@ SELECT route(nsegment 'Nsegment(76, 0.3, 0.3)');
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 getPosition(npoint) → float
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getPosition(npoint 'Npoint(63, 0.3)');
 -- 0.3
 </programlisting>
@@ -282,7 +282,7 @@ SELECT getPosition(npoint 'Npoint(63, 0.3)');
 startPosition(nsegment) → float
 endPosition(nsegment) → float
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startPosition(nsegment 'Nsegment(76, 0.3, 0.5)');
 -- 0.3
 SELECT endPosition(nsegment 'Nsegment(76, 0.3, 0.5)');
@@ -301,7 +301,7 @@ SELECT endPosition(nsegment 'Nsegment(76, 0.3, 0.5)');
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 round({npoint,nsegment},integer=0) → {npoint,nsegment}
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(npoint(76, 0.123456789), 6);
 --  NPoint(76,0.123457)
 SELECT round(nsegment(76, 0.123456789, 0.223456789), 6);
@@ -321,7 +321,7 @@ SELECT round(nsegment(76, 0.123456789, 0.223456789), 6);
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID({npoint,nsegment}) → integer
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(npoint 'Npoint(76, 0.3)');
 -- 5676
 SELECT SRID(nsegment 'Nsegment(76, 0.3, 0.5)');
@@ -339,7 +339,7 @@ SELECT SRID(nsegment 'Nsegment(76, 0.3, 0.5)');
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 equals(npoint,npoint)::Boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH inter(geom) AS (
   SELECT st_intersection(t1.the_geom, t2.the_geom)
   FROM ways t1, ways t2 WHERE t1.gid = 1 AND t2.gid = 2), fractions(f1, f2) AS (
@@ -369,11 +369,11 @@ SELECT equals(npoint(1, f1), npoint(2, f2)) FROM fractions;
 npoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} npoint
 nsegment {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} nsegment
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT npoint 'Npoint(3, 0.5)' = npoint 'Npoint(3, 0.5)';
 -- true
-SELECT npoint 'Npoint(3, 0.5)' &lt;&gt; npoint 'Npoint(3, 0.6)';
--- true
+SELECT nsegment 'Nsegment(3, 0.5, 0.5)' &lt;&gt; nsegment 'Nsegment(3, 0.5, 0.5)';
+-- false
 SELECT nsegment 'Nsegment(3, 0.5, 0.5)' &lt; nsegment 'Nsegment(3, 0.5, 0.6)';
 -- true
 SELECT nsegment 'Nsegment(3, 0.5, 0.5)' &gt; nsegment 'Nsegment(2, 0.5, 0.5)';
@@ -391,7 +391,7 @@ SELECT npoint 'Npoint(1, 0.6)' &gt;= npoint 'Npoint(1, 0.5)';
 	<sect1 xml:id="temp_network_points">
 		<title>Puntos de red temporales</title>
 		<para>El tipo de punto de red temporal <varname>tnpoint</varname> permite representar el movimiento de objetos en una red. Corresponde al tipo de punto temporal <varname>tgeompoint</varname> restringido a coordenadas bidimensionales. Como todos los demás tipos temporales, se presenta en tres subtipos, a saber, instante, secuencia y conjunto de secuencias. A continuación se dan ejemplos de valores de <varname>tnpoint</varname> en estos subtipos.</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint 'Npoint(1, 0.5)@2001-01-01';
 SELECT tnpoint '{Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-02,
   Npoint(1, 0.5)@2001-01-03}';
@@ -401,7 +401,7 @@ SELECT tnpoint '{[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.4)@2001-01-02,
   Npoint(1, 0.5)@2001-01-03], [Npoint(2, 0.6)@2001-01-04, Npoint(2, 0.6)@2001-01-05]}';
 </programlisting>
 		<para>El tipo de punto de red temporal acepta modificadores de tipo (o <varname>typmod</varname> en la terminología de PostgreSQL). Los valores posibles para el modificador de tipo son <varname>Instant</varname>, <varname>Sequence</varname> y <varname>SequenceSet</varname>. Si no se especifica ningún modificador de tipo para una columna, se permiten valores de cualquier subtipo.</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint(Sequence) '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.4)@2001-01-02,
   Npoint(1, 0.5)@2001-01-03]';
 SELECT tnpoint(Sequence) 'Npoint(1, 0.2)@2001-01-01';
@@ -409,14 +409,14 @@ SELECT tnpoint(Sequence) 'Npoint(1, 0.2)@2001-01-01';
 </programlisting>
 
 		<para>Los valores de puntos de red temporales del subtipo de secuencia et interpolación linear o escalonada deben definirse en una única ruta. Por lo tanto, se necesita un valor de subtipo de conjunto de secuencias para representar el movimiento de un objeto que atraviesa varias rutas, incluso si no hay un espacio temporal. Por ejemplo, en el siguiente valor</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '{[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.5)@2001-01-03),
   [NPoint(2, 0.4)@2001-01-03, NPoint(2, 0.6)@2001-01-04)}';
 </programlisting>
 		<para>el punto de red cambia su ruta en 2001-01-03. </para>
 
 		<para>Los valores de puntos de red temporal del subtipo de secuencia o conjunto de secuencias se convierten en una forma normal para que los valores equivalentes tengan representaciones idénticas. Para ello, los valores instantáneos consecutivos se fusionan cuando es posible. Tres valores instantáneos consecutivos se pueden fusionar en dos si las funciones lineales que definen la evolución de los valores son las mismas. Los ejemplos de transformación a una forma normal son los siguientes.</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.4)@2001-01-02,
   NPoint(1, 0.6)@2001-01-03)';
 -- [NPoint(1,0.2)@2001-01-01, NPoint(1,0.6)@2001-01-03)
@@ -429,7 +429,7 @@ SELECT tnpoint '{[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.3)@2001-01-02,
 	<sect1 xml:id="tnpoint_validity">
 		<title>Validez de los puntos de red temporal</title>
 		<para>Los valores de los puntos de red temporal deben satisfacer las restricciones especificadas en la <xref linkend="ttype_validity" /> para que estén bien definidos. Se genera un error cuando no se cumple una de estas restricciones. Ejemplos de valores incorrectos son los siguientes.</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- No se permiten valores nulos
 SELECT tnpoint 'NULL@2001-01-01 08:05:00';
 SELECT tnpoint 'Point(0 0)@NULL';
@@ -455,14 +455,14 @@ tnpoint(npoint,tstzset) → tnpointDiscSeq
 tnpoint(npoint,tstzspan,interp text='linear') → tnpointContSeq
 tnpoint(npoint,tstzspanset,interp text='linear') → tnpointSeqSet
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint('Npoint(1, 0.5)', timestamptz '2001-01-01');
 -- NPoint(1,0.5)@2001-01-01
-SELECT tnpoint('Npoint(1, 0.3)', tstzset '{2001-01-01, 2001-01-03, 2001-01-05}');
+SELECT tnpointSeq('Npoint(1, 0.3)', tstzset '{2001-01-01, 2001-01-03, 2001-01-05}');
 -- {NPoint(1,0.3)@2001-01-01, NPoint(1,0.3)@2001-01-03, NPoint(1,0.3)@2001-01-05}
-SELECT tnpoint('Npoint(1, 0.5)', tstzspan '[2001-01-01, 2001-01-02]');
+SELECT tnpointSeq('Npoint(1, 0.5)', tstzspan '[2001-01-01, 2001-01-02]');
 -- [NPoint(1,0.5)@2001-01-01, NPoint(1,0.5)@2001-01-02]
-SELECT tnpoint('Npoint(1, 0.2)', tstzspanset '{[2001-01-01, 2001-01-03]}', 'step');
+SELECT tnpointSeqSet('Npoint(1, 0.2)', tstzspanset '{[2001-01-01, 2001-01-03]}', 'step');
 -- Interp=Step;{[NPoint(1,0.2)@2001-01-01, NPoint(1,0.2)@2001-01-03]}
 </programlisting>
 				</listitem>
@@ -474,7 +474,7 @@ SELECT tnpoint('Npoint(1, 0.2)', tstzspanset '{[2001-01-01, 2001-01-03]}', 'step
 tnpointSeq(tnpointInst[],interp text={'step','linear'},lower_inc boolean=true,
   upper_inc boolean=true) &#8594; tnpointSeq
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointSeq(ARRAY[tnpoint 'Npoint(1, 0.3)@2001-01-01', 'Npoint(1, 0.5)@2001-01-02',
   'Npoint(1, 0.5)@2001-01-03']);
 -- {NPoint(1,0.3)@2001-01-01, NPoint(1,0.5)@2001-01-02, NPoint(1,0.5)@2001-01-03}
@@ -493,7 +493,7 @@ tnpointSeqSet(tnpoint[]) → tnpointSeqSet
 tnpointSeqSetGaps(tnpointInst[],maxt interval=NULL,maxdist float=NULL,
   interp text='linear') → tnpointSeqSet
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointSeqSet(ARRAY[tnpoint '[Npoint(1,0.2)@2001-01-01, Npoint(1,0.4)@2001-01-02,
   Npoint(1,0.5)@2001-01-03]', '[Npoint(2,0.6)@2001-01-04, Npoint(2,0.6)@2001-01-05]']);
 /* {[NPoint(1,0.2)@2001-01-01, NPoint(1,0.4)@2001-01-02, NPoint(1,0.5)@2001-01-03],
@@ -516,8 +516,8 @@ SELECT tnpointSeqSetGaps(ARRAY[tnpoint 'NPoint(1,0.1)@2001-01-01',
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {tnpoint,tgeompoint}::{tgeompoint,tnpoint}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
-SELECT astext((tnpoint '[NPoint(1, 0.2)@2001-01-01,
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText((tnpoint '[NPoint(1, 0.2)@2001-01-01,
   NPoint(1, 0.3)@2001-01-02)')::tgeompoint);
 /* [POINT(23.057077727326 28.7666335767956)@2001-01-01,
    POINT(48.7117553116406 20.9256801894708)@2001-01-02) */
@@ -565,7 +565,7 @@ SELECT tnpointFromMFJSON(asMFJSON(tnpoint 'NPoint(1, 0.5)@2001-01-01'))
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 getValues(tnpoint) → npointset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02)}');
 -- {"NPoint(1,0.3)","NPoint(1,0.5)"}
 SELECT getValues(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.3)@2001-01-02)}');
@@ -579,7 +579,7 @@ SELECT getValues(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.3)@2001-01-02
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 routes(tnpoint) → bigintset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT routes(tnpoint '{NPoint(3, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02}');
 -- {1, 3}
 </programlisting>
@@ -591,7 +591,7 @@ SELECT routes(tnpoint '{NPoint(3, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02}');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 valueAtTimestamp(tnpoint,timestamptz) → npoint
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03)',
   '2001-01-02');
 -- NPoint(1,0.4)
@@ -604,7 +604,7 @@ SELECT valueAtTimestamp(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 length(tnpoint) → float
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]');
 -- 54.3757408468784
 </programlisting>
@@ -616,7 +616,7 @@ SELECT length(tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 cumulativeLength(tnpoint) → tfloat
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT cumulativeLength(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02,
   NPoint(1, 0.5)@2001-01-03], [NPoint(1, 0.6)@2001-01-04, NPoint(1, 0.7)@2001-01-05]}');
 /* {[0@2001-01-01, 54.3757408468784@2001-01-02, 54.3757408468784@2001-01-03],
@@ -630,7 +630,7 @@ SELECT cumulativeLength(tnpoint '{[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@200
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 speed({tnpointSeq,tnpointSeqSet}) → tfloatSeqSet
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT speed(tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.4)@2001-01-02,
   NPoint(1, 0.6)@2001-01-03]') * 3600 * 24;
 /* Interp=Step;[21.4016800272077@2001-01-01, 14.2677866848051@2001-01-02,
@@ -653,7 +653,7 @@ tnpointInst(tnpoint) → tnpointInst
 tnpointSeq(tnpoint) → tnpointSeq
 tnpointSeqSet(tnpoint) → tnpointSeqSet
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpointSeq(tnpoint 'NPoint(1, 0.5)@2001-01-01', 'discrete');
 -- {NPoint(1,0.5)@2001-01-01}
 SELECT tnpointSeq(tnpoint 'NPoint(1, 0.5)@2001-01-01');
@@ -669,7 +669,7 @@ SELECT tnpointSeqSet(tnpoint 'NPoint(1, 0.5)@2001-01-01');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 setInterp(tnpoint,interp) → tnpoint
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT setInterp(tnpoint 'NPoint(1,0.2)@2001-01-01','linear');
 -- [NPoint(1,0.2)@2001-01-01]
 SELECT setInterp(tnpoint '{[NPoint(1,0.1)@2001-01-01], [NPoint(1,0.2)@2001-01-02]}',
@@ -684,7 +684,7 @@ SELECT setInterp(tnpoint '{[NPoint(1,0.1)@2001-01-01], [NPoint(1,0.2)@2001-01-02
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 round(tnpoint,integer=0) &#8594; tnpoint
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tnpoint '{[NPoint(1,0.123456789)@2001-01-01, NPoint(1,0.5)@2001-01-02)}', 6);
 -- {[NPoint(1,0.123457)@2001-01-01, NPoint(1,0.5)@2001-01-02)}
 </programlisting>
@@ -756,7 +756,7 @@ minusValue(tnpoint,value) → tnpoint
 atValues(tnpoint,valueset) → tnpoint
 minusValues(tnpoint,valueset) → tnpoint
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atValue(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03]',
   'NPoint(2, 0.5)');
 -- {[NPoint(2,0.5)@2001-01-02]}
@@ -775,7 +775,7 @@ SELECT minusValue(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03
 atGeometry(tnpoint,geometry) → tnpoint
 minusGeometry(tnpoint,geometry) → tnpoint
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03]',
   'Polygon((40 40,40 50,50 50,50 40,40 40))');
 SELECT minusGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-03]',
@@ -795,7 +795,7 @@ SELECT minusGeometry(tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 twCentroid(tnpoint) → geometry(Point)
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(twCentroid(tnpoint '{[NPoint(1, 0.3)@2001-01-01,
   NPoint(1, 0.5)@2001-01-02, NPoint(1, 0.5)@2001-01-03, NPoint(1, 0.7)@2001-01-04)}'));
 -- POINT(79.9787466444847 46.2385558051041)
@@ -844,7 +844,7 @@ SELECT tnpoint '{NPoint(1, 0.3)@2001-01-01,
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {tstzspan,stbox,tnpoint} {&amp;&amp;, &lt;@, @&gt;, ~=, -|-} {tstzspan,stbox,tnpoint} → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]' &amp;&amp;
   tstzspan '[2001-01-02,2001-01-03]';
 -- true
@@ -866,7 +866,7 @@ SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01,
 {stbox,tnpoint} {&lt;&lt;|, &amp;&lt;|, |&gt;&gt;, |&amp;&gt;} {stbox,tnpoint} → boolean
 {tstzspan,stbox,tnpoint} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tnpoint} → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-02]' &lt;&lt;
   stbox(npoint 'NPoint(1, 0.2)');
 -- true
@@ -913,7 +913,7 @@ SELECT tnpoint '[NPoint(2, 0.3)@2001-01-01, NPoint(2, 0.7)@2001-01-02]' |=|
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 nearestApproachInstant({geo,npoint,tnpoint},{geo,npoint,tnpoint}) → tnpoint
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT nearestApproachInstant(tnpoint '[NPoint(2, 0.3)@2001-01-01,
   NPoint(2, 0.7)@2001-01-02]', geometry 'Linestring(50 50,55 55)');
 -- NPoint(2,0.349928)@2001-01-01 02:59:44.402905
@@ -930,7 +930,7 @@ SELECT nearestApproachInstant(tnpoint '[NPoint(2, 0.3)@2001-01-01,
 shortestLine({geo,npoint,tpoint},{geo,npoint,tpoint}) → geometry
 </programlisting>
 				<para>La función devuelve la primera línea que encuentre si hay más de una.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(tnpoint '[NPoint(2, 0.3)@2001-01-01,
   NPoint(2, 0.7)@2001-01-02]', geometry 'Linestring(50 50,55 55)'));
 -- LINESTRING(50.7960725266492 48.8266286733015,50 50)
@@ -946,7 +946,7 @@ SELECT ST_AsText(shortestLine(tnpoint '[NPoint(2, 0.3)@2001-01-01,
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tnpoint &lt;-&gt; tnpoint → tfloat
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;-&gt;
   npoint 'NPoint(1, 0.2)';
 -- [2.34988300875063@2001-01-02, 2.34988300875063@2001-01-03]
@@ -995,7 +995,7 @@ aTouches(geometry,tnpoint) &#8594; boolean
 aTouches(tnpoint,geometry) &#8594; boolean
 </programlisting>
 				<para>Las relaciones <emphasis>alguna vez</emphasis> y <emphasis>siempre</emphasis> determinan si la relación topológica o de distancia se satisface alguna vez o siempre y dan como resultado un <varname>boolean</varname>. Un punto de red temporal las responde en la posición a la que se resuelven su ruta y su fracción, de modo que una secuencia con interpolación lineal se responde a lo largo de su ruta y no solo en sus instantes. El punto de red temporal declara las relaciones que responde un punto en movimiento: <varname>eContains</varname>, <varname>aContains</varname>, <varname>eCovers</varname> y <varname>aCovers</varname> toman la geometría en primer lugar únicamente, y <varname>eTouches</varname> y <varname>aTouches</varname> no tienen dirección entre dos puntos de red temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
   tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
 -- false
@@ -1040,7 +1040,7 @@ tTouches(geometry,tnpoint) &#8594; tbool
 tTouches(tnpoint,geometry) &#8594; tbool
 </programlisting>
 				<para>Las relaciones <emphasis>temporales</emphasis> calculan la relación topológica o de distancia en cada instante y dan como resultado un <varname>tbool</varname>. Un punto de red temporal las responde en la posición a la que se resuelven su ruta y su fracción. El punto de red temporal declara las relaciones que responde un punto en movimiento: <varname>tContains</varname> y <varname>tCovers</varname> toman la geometría en primer lugar únicamente, y <varname>tTouches</varname> no tiene dirección entre dos puntos de red temporales, ya que un punto en movimiento no contiene ni cubre una geometría y dos puntos en movimiento no se tocan.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tContains(geometry 'SRID=5676;Polygon((0 0,0 50,50 50,50 0,0 0))',
   tnpoint '[Npoint(1, 0.1)@2001-01-01, Npoint(1, 0.3)@2001-01-03]');
 -- {[f@2001-01-01, f@2001-01-03]}
@@ -1074,7 +1074,7 @@ SELECT tDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]'
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tnpoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tnpoint → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '{[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-02),
   [NPoint(1, 0.3)@2001-01-02, NPoint(1, 0.5)@2001-01-03]}' =
   tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.5)@2001-01-03]';
@@ -1097,7 +1097,7 @@ SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.5)@2001-01-03]' &lt;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {npoint,tnpoint} {?=, ?&lt;&gt;, %=, %&lt;&gt;} {npoint,tnpoint} → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.4)@2001-01-04)' ?= Npoint(1, 0.3);
 -- true
 SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.2)@2001-01-04)' &amp;= Npoint(1, 0.2);
@@ -1112,7 +1112,7 @@ SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.2)@2001-01-04)' &amp;= N
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {npoint,tnpoint} {#=, #&lt;&gt;} {npoint,tnpoint} → tbool
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tnpoint '[NPoint(1, 0.2)@2001-01-01,
   NPoint(1, 0.4)@2001-01-03)' #= npoint 'NPoint(1, 0.3)';
 -- {[f@2001-01-01, t@2001-01-02], (f@2001-01-02, f@2001-01-03)}
@@ -1136,11 +1136,11 @@ SELECT tnpoint '[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.8)@2001-01-03)' #&lt;&gt
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tCount(tnpoint) → {tintSeq,tintSeqSet}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
-SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
-SELECT tnpoint '[NPoint(1, 0.2)@2001-01-02, NPoint(1, 0.4)@2001-01-04)' UNION
-SELECT tnpoint '[NPoint(1, 0.3)@2001-01-03, NPoint(1, 0.5)@2001-01-05)' )
+  SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
+  SELECT tnpoint '[NPoint(1, 0.2)@2001-01-02, NPoint(1, 0.4)@2001-01-04)' UNION
+  SELECT tnpoint '[NPoint(1, 0.3)@2001-01-03, NPoint(1, 0.5)@2001-01-05)' )
 SELECT tCount(Temp) FROM Temp;
 -- {[1@2001-01-01, 2@2001-01-02, 1@2001-01-04, 1@2001-01-05)}
 </programlisting>
@@ -1152,11 +1152,11 @@ SELECT tCount(Temp) FROM Temp;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 wCount(tnpoint) → {tintSeq,tintSeqSet}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
-SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
-SELECT tnpoint '[NPoint(1, 0.2)@2001-01-02, NPoint(1, 0.4)@2001-01-04)' UNION
-SELECT tnpoint '[NPoint(1, 0.3)@2001-01-03, NPoint(1, 0.5)@2001-01-05)' )
+  SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
+  SELECT tnpoint '[NPoint(1, 0.2)@2001-01-02, NPoint(1, 0.4)@2001-01-04)' UNION
+  SELECT tnpoint '[NPoint(1, 0.3)@2001-01-03, NPoint(1, 0.5)@2001-01-05)' )
 SELECT wCount(Temp, '1 day') FROM Temp;
 /* {[1@2001-01-01, 2@2001-01-02, 3@2001-01-03, 2@2001-01-04, 1@2001-01-05,
    1@2001-01-06)} */
@@ -1169,12 +1169,12 @@ SELECT wCount(Temp, '1 day') FROM Temp;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tCentroid(tnpoint) → tgeompoint
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(temp) AS (
 SELECT tnpoint '[NPoint(1, 0.1)@2001-01-01, NPoint(1, 0.3)@2001-01-03)' UNION
 SELECT tnpoint '[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.4)@2001-01-03)' UNION
-SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01, NPoint(1, 0.5)@2001-01-03)' )
-SELECT astext(tCentroid(Temp)) FROM Temp;
+SELECT tnpoint '[NPoint(1, 0.3)@2001-01-01,
+  NPoint(1, 0.5)@2001-01-03)' ) SELECT astext(tCentroid(Temp)) FROM Temp;
 /* {[POINT(72.451531682218 76.5231414472853)@2001-01-01,
    POINT(55.7001249027598 72.9552602410653)@2001-01-03)} */
 </programlisting>
@@ -1186,7 +1186,7 @@ SELECT astext(tCentroid(Temp)) FROM Temp;
 		<title>Indexación</title>
 
 		<para>Se pueden crear índices GiST y SP-GiST para columnas de tabla de puntos de redes temporales. A continuación, se muestra un ejemplo de creación de índice:</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 </programlisting>
 		<para>Los índices GiST y SP-GiST almacenan el cuadro delimitador para los puntos de la red temporal, que es un <varname>stbox</varname> y, por lo tanto, almacena las coordenadas absolutas del espacio subyacente.</para>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -30,12 +30,12 @@ CREATE EXTENSION mobilitydb CASCADE;
 		<para>Cada valor <varname>pcpoint</varname> y <varname>pcpatch</varname> lleva un <varname>pcid</varname> que se resuelve en un <emphasis>esquema</emphasis>, que declara las dimensiones que contiene el valor (X, Y, Z, …), el tipo numérico con el que se almacena cada una, y su escala y desplazamiento. El esquema se declara en SQL, en dos tablas: <varname>pointcloud_schemas</varname> contiene lo que declara un esquema en conjunto, y <varname>pointcloud_dimensions</varname> una fila por dimensión. Un esquema 3D mínimo, con cada dimensión almacenada como <varname>int32_t</varname> con escala unitaria:</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 INSERT INTO pointcloud_schemas (pcid, srid, compression, description)
-VALUES (1, 4326, 'none', 'Esquema 3D mínimo');
+VALUES (1, 4326, 'none', 'Minimal 3D schema');
 INSERT INTO pointcloud_dimensions (pcid, dim_no, dim_name, interpretation, dim_scale,
   dim_offset, active, description)
-VALUES (1, 1, 'X', 'int32_t', 1, 0, true, 'Este'),
-  (1, 2, 'Y', 'int32_t', 1, 0, true, 'Norte'),
-  (1, 3, 'Z', 'int32_t', 1, 0, true, 'Elevación');
+VALUES (1, 1, 'X', 'int32_t', 1, 0, true, 'Easting'),
+  (1, 2, 'Y', 'int32_t', 1, 0, true, 'Northing'),
+  (1, 3, 'Z', 'int32_t', 1, 0, true, 'Elevation');
 </programlisting>
 		<para>El tamaño de cada dimensión y su desplazamiento dentro de un punto no aparecen porque se derivan de la interpretación, y las dimensiones X, Y, Z y M tampoco porque se resuelven a partir de los nombres. La columna <varname>dim_no</varname> declara el orden en el que se almacenan las dimensiones, de modo que no depende del orden en el que se insertan las filas, y <varname>dim_name</varname> es el nombre por el que se resuelven. Ningún nombre de columna necesita comillas en ninguno de los hosts en los que se materializan estas tablas. Un esquema es global a la base de datos y suele registrarse una sola vez, al cargar los datos; el SRID es por esquema y lo heredan todos los valores que llevan ese <varname>pcid</varname>.</para>
 		<para>Una base de datos cuyos esquemas ya están registrados en el catálogo <varname>pointcloud_formats</varname> de pgPointCloud, como documento XML, sigue funcionando: ese catálogo se lee para un <varname>pcid</varname> que las dos tablas anteriores no declaren.</para>
@@ -1055,7 +1055,7 @@ SELECT round(nearestApproachDistance( tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz),
   tpcpoint(pcpoint(1, 10, 10, 10), '2001-01-01'::timestamptz))::numeric, 4);
 -- 15.5885
--- Un tpcbox sin extensión temporal mide únicamente el acercamiento espacial.
+-- A tpcbox without a time span measures the spatial approach only.
 SELECT round(nearestApproachDistance(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz), tpcpoint(pcpoint(1, 2, 2, 2), '2001-01-02'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]),
@@ -1594,7 +1594,7 @@ SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[ tpcpatch(pcpatch(pcpoint(1, 1, 1,
   tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
 -- El parche descartado sigue presente en el intervalo abierto anterior a su instante,
--- por lo que el complemento conserva dos instantes.
+-- so the complement keeps two instants.
 SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[ tpcpatch(pcpatch(pcpoint(1, 1, 1, 1),
   pcpoint(1, 2, 2, 2)), '2001-01-01'::timestamptz),
   tpcpatch(pcpatch(pcpoint(1, 3, 3, 3), pcpoint(1, 4, 4, 4)),

--- a/doc/es/temporal_pose_types.xml
+++ b/doc/es/temporal_pose_types.xml
@@ -104,6 +104,11 @@ SELECT pose 'Pose(Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)';
 SELECT pose 'SRID=3812;Pose(Point(1 1), 0.5)';
 SELECT pose 'Pose(SRID=5676;Point Z(1 1 1), 0.5, 0.5, 0.5, 0.5)';
 </programlisting>
+		<para>Al igual que para otros tipos espaciales, un <varname>pose</varname> puede ser planar (geométrico) o geodésico (geográfico). Un pose geodésico se denota con la palabra clave <varname>GeodPose</varname>, de la misma manera que un <varname>stbox</varname> geodésico se denota con <varname>GEODSTBOX</varname>.</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pose 'GeodPose(Point(1 1), 0.5)';
+SELECT pose 'SRID=4326;GeodPose(Point Z(1 1 1), 1, 0, 0, 0)';
+</programlisting>
 
 		<para>Los valores del tipo pose deben satisfacer varias restricciones para que estén bien definidos. Ejemplos de valores incorrectos del tipo pose son los siguientes.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -631,9 +636,6 @@ SELECT asEWKT(tposechain(Sequence,5676) 'SRID=5676;
   PoseChain(Pose(Point(1 1), 0.5))@2001-01-03]');
 /* SRID=5676;[PoseChain(Pose(POINT(1 1),0.2))@2001-01-01,
    PoseChain(Pose(POINT(1 1),0.5))@2001-01-03] */
-SELECT tposechain(Sequence) 'PoseChain(Pose(Point(1 1), 0.2))@2001-01-01';
-/* ERROR:  Temporal subtype of the tposechain value (Instant) does not match
-   column subtype (Sequence) */
 </programlisting>
 
 		<para>Los valores de pose temporal del subtipo de secuencia o conjunto de secuencias se convierten en una forma normal para que los valores equivalentes tengan representaciones idénticas. Para ello, los valores instantáneos consecutivos se fusionan cuando es posible. Tres valores instantáneos consecutivos se pueden fusionar en dos si las funciones lineales que definen la evolución de los valores son las mismas. Los ejemplos de transformación a una forma normal son los siguientes.</para>
@@ -644,8 +646,8 @@ SELECT asText(tpose '[Pose(Point(1 1), 0.2)@2001-01-01, Pose(Point(2 2), 0.4)@20
 SELECT asText(tpose '{[Pose(Point(1 1), 0.2)@2001-01-01, Pose(Point(2 2), 0.3)@2001-01-02,
   Pose(Point(2 2), 0.5)@2001-01-03),
   [Pose(Point(2 2), 0.5)@2001-01-03, Pose(Point(2 2), 0.7)@2001-01-04)}');
-/* {[Pose(Point(1 1),0.2)@2001-01-01, Pose(Point(2 2),0.3)@2001-01-02, 
-   Pose(Point(2 2),0.7)@2001-01-04)} */
+/* {[Pose(POINT(1 1),0.2)@2001-01-01, Pose(POINT(2 2),0.3)@2001-01-02, 
+   Pose(POINT(2 2),0.7)@2001-01-04)} */
 </programlisting>
 	</sect1>
 
@@ -860,8 +862,8 @@ SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.3)@2001-01-01',
    Pose(Point(1 1),0.5)@2001-01-03} */
 SELECT asText(tposeSeq(ARRAY[tpose 'Pose(Point(1 1), 0.2)@2001-01-01',
   'Pose(Point(1 1), 0.4)@2001-01-02', 'Pose(Point(1 1), 0.5)@2001-01-03']));
-/* [Pose(Point(1 1),0.2)@2001-01-01, Pose(Point(1 1),0.4)@2001-01-02, 
-   Pose(Point(1 1),0.5)@2001-01-03] */
+/* [Pose(POINT(1 1),0.2)@2001-01-01, Pose(POINT(1 1),0.4)@2001-01-02, 
+   Pose(POINT(1 1),0.5)@2001-01-03] */
 </programlisting>
 			</listitem>
 
@@ -1015,10 +1017,9 @@ speed(tpose) → tfloat
 </programlisting>
 				<para>La orientación no es considerada; para la velocidad angular véase <varname>angularSpeed</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01,
-  Pose(Point(1 1), 0.5)@2000-01-02]'));
--- Interp=Step;[1.6368e-5@2000-01-01, 1.6368e-5@2000-01-02]
--- (sqrt(2) units / 86400 seconds, units depend on the SRID's CRS)
+SELECT asText(speed(tpose '[Pose(Point(0 0), 0)@2000-01-01 08:00,
+  Pose(Point(1 1), 0.5)@2000-01-02 08:00]') * 3600);
+-- Interp=Step;[1.414213562373095@2000-01-01, 1.414213562373095@2000-01-02]
 </programlisting>
 			</listitem>
 
@@ -1166,7 +1167,7 @@ WITH temp(inst) AS (
   SELECT tpose 'Pose(Point(1 1),0.1)@2001-01-01' UNION
   SELECT tpose 'Pose(Point(2 2),0.2)@2001-01-02' UNION
   SELECT tpose 'Pose(Point(3 3),0.3)@2001-01-03' )
-SELECT asText(mergeAgg(inst)) FROM temp;
+SELECT asText(merge(inst)) FROM temp;
 /* {Pose(POINT(1 1),0.1)@2001-01-01, Pose(POINT(2 2),0.2)@2001-01-02, 
    Pose(POINT(3 3),0.3)@2001-01-03} */
 SELECT asText(mergeAgg(temp)) FROM (VALUES
@@ -1870,8 +1871,7 @@ yaw({pose,tpose}) → {float,tfloat}
 pitch({pose,tpose}) → {float,tfloat}
 roll({pose,tpose}) → {float,tfloat}
 </programlisting>
-					<para>Para una pose 2D, <varname>yaw</varname> devuelve la rotación almacenada <varname>theta</varname>,por convención, el yaw del marco del cuerpo— y <varname>pitch</varname> y <varname>roll</varname> devuelven <varname>0</varname>. Para una pose 3D, los tres valores provienen de la descomposición Tait-Bryan intrínseca ZYX del cuaternión de orientación. El término de pitch <varname>asin</varname> se acota a <varname>[-1, 1]</varname> para absorber la pequeña deriva numérica que pueden introducir las composiciones largas de cuaterniones. Sobre una pose temporal, la interpolación del resultado sigue a la dimensión. Una pose 2D interpola linealmente su ángulo almacenado y ese ángulo es su yaw, de modo que un <varname>tpose</varname> 2D lineal se proyecta en un <varname>tfloat</varname> lineal. Una pose 3D interpola mediante SLERP, cuya descomposición Tait-Bryan no es lineal en el tiempo, de modo que un <varname>tpose</varname> 3D se proyecta en un <varname>tfloat</varname> escalonado: leerlo entre dos instantes devuelve el ángulo del instante de la izquierda en lugar de un ángulo que ninguna pose contiene.</para>
-					<programlisting language="sql" xml:space="preserve" format="linespecific">
+<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT yaw(pose 'Pose(Point(1 1), 0.5)');
 -- 0.5
 SELECT pitch(pose 'Pose(Point(1 1), 0.5)');
@@ -1880,6 +1880,11 @@ SELECT roll(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.707106781186547
 -- 0
 SELECT yaw(pose 'Pose(Point(0 0 0), 0.7071067811865476, 0, 0, 0.7071067811865475)');
 -- 1.5707963267948966
+</programlisting>
+<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
+  Pose(Point(1 1), 0.5)@2000-01-02]'));
+-- [0@2000-01-01, 0.5@2000-01-02]
 </programlisting>
 				</listitem>
 
@@ -1911,9 +1916,11 @@ pitch(tpose) → tfloat
 roll(tpose) → tfloat
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT asText(yaw(tpose '[Pose(Point(0 0), 0.0)@2000-01-01,
-  Pose(Point(1 1), 0.5)@2000-01-02]'));
--- [0@2000-01-01, 0.5@2000-01-02]
+SELECT round(yaw(tpose '[Pose(Point(0 0),0.5)@2001-01-01,
+  Pose(Point(1 1),1.5)@2001-01-02]'), 6);
+-- Interp=Step;[0.5@2001-01-01, 1.5@2001-01-02]
+SELECT round(pitch(tpose 'Pose(Point(0 0 0),1,0,0,0)@2001-01-01'), 6);
+-- 0@2001-01-01
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -2064,9 +2071,58 @@ SELECT asEWKT(round(applyPose(pose 'Pose(Point(1 0 0), 1, 0, 0, 0)',
 asGeoPose(tpose,conformance integer=0,maxdecimaldigits integer=-1) → text
 tposeFromGeoPose(text) → tpose
 </programlisting>
-					<para>Cada carga útil por instante es un documento GeoPose de clase Basic estrictamente válido según OGC más un miembro <varname>validTime</varname>; la envoltura registra la clase de conformidad, la interpolación y (para secuencias y conjuntos de secuencias) la inclusión de los límites del período. Un consumidor GeoPose ajeno a MEOS puede iterar sobre <varname>instants[]</varname> (o cada <varname>sequences[].instants[]</varname>) y consumir cada elemento como un documento GeoPose estático.</para>
-					<para>La forma de la envoltura es</para>
-					<programlisting xml:space="preserve" format="linespecific">
+<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asGeoPose(tpose '[Pose(Point(0 0 0), 0.5, 0.5, 0.5, 0.5)@2026-01-01,
+  Pose(Point(0 0 100), 0.5, 0.5, 0.5, 0.5)@2026-01-02,
+  Pose(Point(0 0 300), 0.5, 0.5, 0.5, 0.5)@2026-01-05]', 0, 6);
+-- {
+--  "header": {
+--   "poseCount": 3,
+--   "startInstant": 1767254400000,
+--   "stopInstant": 1767600000000,
+--   "transitionModel": {
+--    "authority": "/geopose/1.0",
+--    "id": "interpolate",
+--    "parameters": "interpolation=Linear"
+--   }
+--  },
+--  "outerFrame": {
+--   "authority": "/geopose/1.0",
+--   "id": "LTP-ENU",
+--   "parameters": "longitude=0&amp;latitude=0&amp;height=0&amp;crs=EPSG:4979"
+--  },
+--  "innerFrameAndTimeSeries": [
+--   {
+--    "frame": {
+--     "authority": "/geopose/1.0",
+--     "id": "RotateTranslate",
+--     "parameters": "translation=[0, 0, 0]&amp;rotation=[0.5, 0.5, 0.5, 0.5]"
+--    },
+--    "validTime": 1767254400000
+--   },
+--   {
+--    "frame": {
+--     "authority": "/geopose/1.0",
+--     "id": "RotateTranslate",
+--     "parameters": "translation=[0, 0, 100]&amp;rotation=[0.5, 0.5, 0.5, 0.5]"
+--    },
+--    "validTime": 1767340800000
+--   },
+--   {
+--    "frame": {
+--     "authority": "/geopose/1.0",
+--     "id": "RotateTranslate",
+--     "parameters": "translation=[0, 0, 300]&amp;rotation=[0.5, 0.5, 0.5, 0.5]"
+--    },
+--    "validTime": 1767600000000
+--   }
+--  ],
+--  "trailer": {
+--   "poseCount": 3
+--  }
+-- }
+</programlisting>
+<programlisting xml:space="preserve" format="linespecific">
 {
   "type":          "TemporalGeoPose",
   "version":       "1.0",
@@ -2078,7 +2134,7 @@ tposeFromGeoPose(text) → tpose
   "sequences":     [{...}, ...]           // for TSequenceSet only
 }
 </programlisting>
-					<programlisting language="sql" xml:space="preserve" format="linespecific">
+<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asGeoPose(tpose '[Pose(Point(8 47), 0)@2026-01-01,
   Pose(Point(9 48), 0.5)@2026-01-02]', 1, 4);
 /* {"type":"TemporalGeoPose","version":"1.0","conformance":"Basic-YPR",

--- a/doc/es/temporal_quadbin_index.xml
+++ b/doc/es/temporal_quadbin_index.xml
@@ -33,7 +33,7 @@ SELECT tquadbin '{[480fffffffffffff@2001-01-01, 48427fffffffffff@2001-01-02],
 SELECT tquadbin(Instant) '480fffffffffffff@2001-01-01';
 SELECT tquadbin(SequenceSet) '{[480fffffffffffff@2001-01-01,
   48427fffffffffff@2001-01-02]}';
--- ERROR: el tipo temporal (Instant) no coincide con el tipo de columna (Sequence)
+-- ERROR: temporal type (Instant) does not match column type (Sequence)
 SELECT tquadbin(Sequence) '480fffffffffffff@2001-01-01';
 </programlisting>
 		<para>Las funciones <varname>asText</varname>, <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>tquadbin</varname>, y <varname>tquadbinFromBinary</varname> y <varname>tquadbinFromHexWKB</varname> lo reconstruyen. La forma hexadecimal WKB permite que una columna de índice QUADBIN temporal se transfiera de ida y vuelta mediante un <varname>COPY</varname> basado en texto.</para>
@@ -392,7 +392,7 @@ tquadbinCellToQuadkey(tquadbin) → ttext
 				<para>La forma estática toma un único <varname>quadbin</varname>; la forma temporal devuelve el quadkey de cada celda de una trayectoria como un <varname>ttext</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT quadbinCellToQuadkey(quadbin '480fffffffffffff');
--- (cadena vacía)
+-- (empty string)
 SELECT quadbinCellToQuadkey(quadbin '48427fffffffffff');
 -- 0213
 SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
@@ -478,7 +478,7 @@ FROM Temp;
 				<indexterm significance="normal"><primary><varname>tquadbin_btree_ops</varname></primary></indexterm>
 				<para>Clase de operadores de árbol B por defecto para las celdas QUADBIN temporales, ordenando por el valor temporal subyacente</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-CREATE INDEX ON trips USING btree(cells);       -- usa tquadbin_btree_ops por defecto
+CREATE INDEX ON trips USING btree(cells);       -- uses tquadbin_btree_ops by default
 </programlisting>
 			</listitem>
 
@@ -486,7 +486,7 @@ CREATE INDEX ON trips USING btree(cells);       -- usa tquadbin_btree_ops por de
 				<indexterm significance="normal"><primary><varname>tquadbin_hash_ops</varname></primary></indexterm>
 				<para>Clase de operadores hash por defecto para las celdas QUADBIN temporales, usada por las uniones hash y la agregación hash</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-CREATE INDEX ON trips USING hash(cells);        -- usa tquadbin_hash_ops por defecto
+CREATE INDEX ON trips USING hash(cells);        -- uses tquadbin_hash_ops by default
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -45,6 +45,7 @@ WITH rast AS (
     [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
 SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2000-01-01,
   POINT(2.5 2.5)@2000-01-02, POINT(0.5 0.5)@2000-01-03]', r)::text FROM rast;
+-- {10@2000-01-01, 30@2000-01-02, 70@2000-01-03}
 </programlisting>
 				<para>Aplicado a un conjunto de datos de trayectorias con un ráster de elevación del terreno:</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -95,7 +96,7 @@ SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
 -- Step 1: identify which tiles the trajectory overlaps
 SELECT DISTINCT q FROM unnest(quadbins(traj, 8)) AS q;
 -- Step 2: sample each matching tile
-SELECT rasterTileValueQuadbin(traj, band_data, width, height, quadbin, 'float32', nodata,
+SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'float32', nodata,
   true) FROM elevation_raquet WHERE quadbin = ANY(quadbins(traj, 8));
 </programlisting>
 
@@ -128,8 +129,8 @@ rasterTileValueQuadbin(tgeompoint,pixels bytea,width integer,height integer,
 				<para>Evalúa un arreglo de píxeles de banda única en orden de fila mayor en cada instante de <varname>traj</varname> (SRID 4326). La georreferenciación de la tesela (rectángulo delimitador, mapeo de píxel a coordenadas) se deriva únicamente de <varname>quadbin</varname> mediante la transformada de tesela deslizante Web-Mercator. El argumento <varname>pixtype</varname> debe ser uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Cuando <varname>has_nodata</varname> es verdadero, los instantes cuyo píxel equivale a <varname>nodata</varname> se descartan silenciosamente. Devuelve <varname>NULL</varname> cuando ningún instante sobrevive.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Sample elevation tiles from a Raquet Parquet table for all ship trajectories
-SELECT t.tripid, rasterTileValueQuadbin(t.trip
-  r.band_data, r.width, r.height, r.quadbin, 'float32', r.nodata, true) FROM trips t
+SELECT t.tripid, rasterTileValueQuadbin(t.trip, r.band_data, r.width, r.height,
+  r.quadbin, 'float32', r.nodata, true) FROM trips t
 JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
 -- Average sea-surface temperature per trajectory
 SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
@@ -179,8 +180,8 @@ rasterTileValue(tgeompoint,rast raquet) → tfloat
 				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Muestrear teselas raquet preempaquetadas a lo largo de trayectorias de barcos
-SELECT t.tripid, rasterTileValue(t.trip, r.tile) FROM trips t
-JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
+SELECT t.tripid, rasterTileValue(t.trip, r.tile)
+FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
 </programlisting>
 			</listitem>
 
@@ -234,12 +235,13 @@ SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'u
 				<indexterm significance="normal"><primary><varname>pixels</varname></primary></indexterm>
 				<para>Devuelve los bytes de píxeles de un mosaico Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-pixels(raquet) → bytea
+raquetFromBinary(bytea) → raquet
 </programlisting>
 				<para>Los bytes están en orden de fila mayor y empaquetados, <varname>width</varname> × <varname>height</varname> píxeles del tamaño de <varname>pixtype</varname> cada uno, en little-endian cuando un píxel ocupa más de un byte, que es la disposición que aceptan los constructores. Por lo tanto, un mosaico se reconstruye a través de sus propios accesores.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
--- \x01020304
+SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
+  'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
+-- true
 </programlisting>
 			</listitem>
 
@@ -247,10 +249,10 @@ SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
 				<para>Devuelve una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetFromBinary(bytea) → raquet
+raquetFromHexWKB(text) → raquet
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 -- true
 </programlisting>
@@ -260,12 +262,11 @@ SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265
 				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
 				<para>Devuelve una tesela Raquet a partir de su representación hexadecimal binaria conocida (HexWKB)</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetFromHexWKB(text) → raquet
+quadbin(raquet) → bigint
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
-  'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
--- true
+SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
+-- 5193776270265024512
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -283,18 +284,6 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Devuelve la celda QUADBIN de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-quadbin(raquet) → bigint
-</programlisting>
-							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
--- 5193776270265024512
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raquet_width">
-				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
-				<para>Devuelve el ancho en píxeles de una tesela Raquet</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 width(raquet) → integer
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -303,9 +292,9 @@ SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="raquet_height">
-				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
-				<para>Devuelve el alto en píxeles de una tesela Raquet</para>
+			<listitem xml:id="raquet_width">
+				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
+				<para>Devuelve el ancho en píxeles de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 height(raquet) → integer
 </programlisting>
@@ -315,9 +304,9 @@ SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="raquet_nodata">
-				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
-				<para>Devuelve el valor centinela nodata de una tesela Raquet</para>
+			<listitem xml:id="raquet_height">
+				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
+				<para>Devuelve el alto en píxeles de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 nodata(raquet) → float8
 </programlisting>
@@ -330,18 +319,30 @@ SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="raquet_pixtype">
-				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
-				<para>Devuelve el nombre del tipo de dato de píxel de una tesela Raquet</para>
+			<listitem xml:id="raquet_nodata">
+				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
+				<para>Devuelve el valor centinela nodata de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 pixtype(raquet) → text
 </programlisting>
-				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que el nombre que el ráster de PostGIS da a un tipo de píxel pasa a ellos tal cual; el nombre devuelto aquí es la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela, por lo que se compara igual a ese campo tal cual.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Leer la disposición de una tesela empaquetada
 SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
 FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS tile) t;
 -- 5193776270265024512 | 2 | 2 | uint8 | 0
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raquet_pixtype">
+				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
+				<para>Devuelve el nombre del tipo de dato de píxel de una tesela Raquet</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+pixels(raquet) → bytea
+</programlisting>
+				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que el nombre que el ráster de PostGIS da a un tipo de píxel pasa a ellos tal cual; el nombre devuelto aquí es la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela, por lo que se compara igual a ese campo tal cual.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
+-- \x01020304
 </programlisting>
 			</listitem>
 
@@ -421,6 +422,7 @@ WITH rast AS (
 SELECT asText(atRasterValue(tgeompoint 'SRID=4326;
   [POINT(0.5 2.5)@2000-01-01, POINT(1.5 1.5)@2000-01-02, POINT(0.5 0.5)@2000-01-03]', r,
   floatspan '[40, 90]')) FROM rast;
+-- {[POINT(1.5 1.5)@2000-01-02], [POINT(0.5 0.5)@2000-01-03]}
 </programlisting>
 			</listitem>
 
@@ -462,7 +464,7 @@ aRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that stayed entirely below 100 m elevation
 SELECT tripid FROM trips,
-  elevation_raster WHERE aRasterValue(elev_raster, trip, floatspan '[0, 100]');
+  elevation_raster WHERE aRasterValue(trip, elev_raster, floatspan '[0, 100]');
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -920,14 +920,14 @@ trgeometry {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} trgeometry → boolean
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
-  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),
-  0.0)@2001-01-02]' = trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
-  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]' = 
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
 -- t
 SELECT trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
-  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),
-  0.0)@2001-01-02]' &lt;&gt; trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
-  [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0),0.0)@2001-01-02]' &lt;&gt; 
+  trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
+    [Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(10 0), 0.0)@2001-01-02]';
 -- f
 </programlisting>
 			</listitem>

--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -240,7 +240,7 @@ SELECT symDifference(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 asText({tspatial,tspatial[],spatial[]}) → {text,text[]}
 asEWKT({tspatial,tspatial[],spatial[]}) → {text,text[]}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tgeompoint 'SRID=4326;[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02)');
 -- [POINT Z (0 0 0)@2001-01-01, POINT Z (1 1 1)@2001-01-02)
 SELECT asText(ARRAY[tgeometry 'SRID=4326;[Point(0 0)@2001-01-01, 
@@ -282,7 +282,7 @@ asMFJSON(tspatial,options integer=0,flags integer=0,maxdecimaldigits integer=15)
 					<listitem><para>2: JSON_C_TO_STRING_PRETTY</para></listitem>
 				</itemizedlist>
 				<para>El argumento <varname>maxdecimaldigits</varname> puede usarse para establecer el número máximo de decimales en la salida de los valores en punto flotante (por defecto 15).</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tgeompoint 'Point(1 2)@2019-01-01 18:00:00.15+02');
 /* {"type":"MovingPoint","coordinates":[[1,2]],"datetimes":["2019-01-01T17:00:00.15"],
    "interpolation":"None"} */
@@ -311,7 +311,7 @@ asEWKB(tspatial,endian text='') → bytea
 asHexEWKB(tspatial,endian text='') → text
 </programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tgeompoint 'Point(1 2 3)@2001-01-01');
 -- \x012e001101e9030000000000000000f03f00000000000000400000000000000840009c57d3c11c0000
 SELECT asEWKB(tgeogpoint 'SRID=7844;Point(1 2 3)@2001-01-01');
@@ -330,7 +330,7 @@ tspatialFromText(text) → tspatial
 tspatialFromEWKT(text) → tspatial
 </programlisting>
 				<para>En las funciones anteriores, <varname>tspatial</varname> reemplaza cualquier tipo espacial, como <varname>tgeompoint</varname>, <varname>tgeometry</varname> o <varname>tpose</varname></para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tgeompointFromText(text '[POINT(1 2)@2001-01-01, POINT(3 4)@2001-01-02]'));
 -- [POINT(1 2)@2001-01-01, POINT(3 4)@2001-01-02]
 SELECT asEWKT(tgeographyFromText(text '[Point(1 2)@2001-01-01,
@@ -354,7 +354,7 @@ SELECT asEWKT(tgeographyFromEWKT(text 'SRID=7844;
 tspatialFromMFJSON(text) → tspatial
 </programlisting>
 				<para>En la funcion anterior, <varname>tspatial</varname> reemplaza cualquier tipo espacial, como <varname>tgeompoint</varname>, <varname>tgeometry</varname> o <varname>tpose</varname></para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tgeompointFromMFJSON(text '{"type":"MovingPoint",
   "crs":{"type":"name", "properties":{"name":"EPSG:4326"}},"coordinates":[[50.81,4.38]],
   "datetimes":["2019-01-01T17:00:00.15+01"],"interpolation":"None"}'));
@@ -382,7 +382,7 @@ tspatialFromEWKB(bytea) → tspatial
 tspatialFromHexEWKB(text) → tspatial
 </programlisting>
 				<para>En las funciones anteriores, <varname>tspatial</varname> reemplaza cualquier tipo espacial, como <varname>tgeompoint</varname>, <varname>tgeometry</varname> o <varname>tpose</varname></para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tgeompointFromBinary(
   '\x012e0011000000000000f03f00000000000000400000000000000840009c57d3c11c0000'));
 -- POINT Z (1 2 3)@2001-01-01
@@ -410,8 +410,6 @@ tspatial::stbox
 stbox(tspatial)
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]'::tstzspan;
--- [2001-01-01, 2001-01-03]
 SELECT tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]'::stbox;
 -- STBOX XT(((1,1),(3,3)),[2001-01-01, 2001-01-03])
 SELECT tgeography '[Point(1 1 1)@2001-01-01, Point(3 3 3)@2001-01-03]'::stbox;
@@ -426,7 +424,7 @@ SELECT tgeography '[Point(1 1 1)@2001-01-01, Point(3 3 3)@2001-01-03]'::stbox;
 {tgeometry,tgeography}::{tgeography,tgeometry}
 {tgeompoint,tgeogpoint}::{tgeogpoint,tgeompoint}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText((tgeompoint '[Point(0 0)@2001-01-01, Point(0 1)@2001-01-02)')::tgeogpoint);
 -- [POINT(0 0)@2001-01-01, POINT(0 1)@2001-01-02)
 SELECT asText((tgeography 'Linestring(0 0,1 1)@2001-01-01')::tgeometry);
@@ -446,12 +444,12 @@ SELECT asText((tgeography 'Linestring(0 0,1 1)@2001-01-01')::tgeometry);
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {tpoint,geo}::{geo,tpoint}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText((tgeompoint 'Point(0 0)@2001-01-01')::geometry);
 -- POINT M (0 0 978307200)
 SELECT ST_AsText((tgeompoint '{Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(1 1)@2001-01-03}')::geometry);
--- MULTIPOINT M (0 0 978307200,1 1 978393600,1 1 978480000)
+-- MULTIPOINT M (0 0 978307200,1 1 978393600,1 1 978480000)"
 SELECT ST_AsText((tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02)')::geometry);
 -- LINESTRING M (0 0 978307200,1 1 978393600)
 SELECT ST_AsText((tgeompoint '{[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02),
@@ -464,10 +462,10 @@ SELECT ST_AsText((tgeompoint '{[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02),
 /* GEOMETRYCOLLECTION M (LINESTRING M (0 0 978307200,1 1 978393600),
    POINT M (1 1 978480000),LINESTRING M (1 1 978652800,0 0 978739200)) */
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(geometry 'LINESTRING M (0 0 978307200,0 1 978393600,
   1 1 978480000)'::tgeompoint);
--- [POINT(0 0)@2001-01-01, POINT(0 1)@2001-01-02, POINT(1 1)@2001-01-03]
+-- [POINT(0 0)@2001-01-01, POINT(0 1)@2001-01-02, POINT(1 1)@2001-01-03];
 SELECT asText(geometry 'GEOMETRYCOLLECTION M (LINESTRING M (0 0 978307200,1 1 978393600),
   POINT M (1 1 978480000),LINESTRING M (1 1 978652800,0 0 978739200))'::tgeompoint);
 /* {[POINT(0 0)@2001-01-01, POINT(1 1)@2001-01-02], [POINT(1 1)@2001-01-03],
@@ -501,7 +499,7 @@ SELECT ST_AsText(trajectory(tgeompoint '{[Point(0 0)@2001-01-01, Point(0 1)@2001
 -- LINESTRING(0 0,0 1)
 SELECT ST_AsText(trajectory(tgeompoint 'Interp=Step;{[Point(0 0)@2001-01-01,
   Point(0 1)@2001-01-02], [Point(0 1)@2001-01-03, Point(1 1)@2001-01-04]}'));
--- MULTIPOINT((0 0),(0 1),(1 1))
+-- MULTIPOINT((0 0),(1 1),(0 1))
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(traversedArea(tgeometry '[Point(1 1)@2001-01-01,
@@ -539,7 +537,7 @@ getX(tpoint) → tfloat
 getY(tpoint) → tfloat
 getZ(tpoint) → tfloat
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getX(tgeompoint '{Point(1 2)@2001-01-01, Point(3 4)@2001-01-02,
   Point(5 6)@2001-01-03}');
 -- {1@2001-01-01, 3@2001-01-02, 5@2001-01-03}
@@ -568,7 +566,7 @@ SELECT getZ(tgeogpoint 'Interp=Step;
 isSimple(tpoint) → boolean
 </programlisting>
 				<para>Nótese que un punto temporal de conjunto de secuencias es simple si cada una de las secuencias que lo componen es simple.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT isSimple(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(0 0)@2001-01-03]');
 -- false
@@ -587,7 +585,7 @@ SELECT isSimple(tgeompoint '{[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02],
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 length(tpoint) → float
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02]');
 -- 1.73205080756888
 SELECT length(tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-02,
@@ -605,7 +603,7 @@ SELECT length(tgeompoint 'Interp=Step;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 cumulativeLength(tpoint) → tfloatSeq
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(cumulativeLength(tgeompoint '{[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(1 0)@2001-01-03], [Point(1 0)@2001-01-04, Point(0 0)@2001-01-05]}'), 6);
 -- {[0@2001-01-01, 1.414214@2001-01-02, 2.414214@2001-01-03],
@@ -623,7 +621,7 @@ SELECT cumulativeLength(tgeompoint 'Interp=Step;
 speed(tpoint) → tfloatSeqSet
 </programlisting>
 				<para>El punto temporal debe tener interpolación linear</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT speed(tgeompoint '{[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(1 0)@2001-01-03], [Point(1 0)@2001-01-04, Point(0 0)@2001-01-05]}') * 3600 * 24;
 /* Interp=Step;{[1.4142135623731@2001-01-01, 1@2001-01-02, 1@2001-01-03],
@@ -653,7 +651,7 @@ SELECT ST_AsText(twCentroid(tgeompoint '{[Point(0 0 0)@2001-01-01,
 direction(tpoint) → float
 </programlisting>
 				<para>El resultado se expresa en radianes. Es NULL si solo hay una ubicación o si las ubicaciones inicial y final son iguales.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(degrees(direction(tgeompoint '[Point(0 0)@2001-01-01,
   Point(-1 -1)@2001-01-02, Point(1 1)@2001-01-03]'))::numeric, 6);
 -- 45.000000
@@ -670,7 +668,7 @@ SELECT direction(tgeompoint '{[Point(0 0 0)@2001-01-01, Point(0 1 1)@2001-01-02,
 azimuth(tpoint) → tfloat
 </programlisting>
 				<para>El resultado se expresa en radianes. El azimut es indefinido cuando dos localizaciones sucesivas son iguales y en este caso se añade una brecha de tempo.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(degrees(azimuth(tgeompoint '[Point(0 0 0)@2001-01-01,
   Point(1 1 1)@2001-01-02, Point(1 1 1)@2001-01-03, Point(0 0 0)@2001-01-04)')));
 -- Interp=Step;{[45@2001-01-01, 45@2001-01-02], [225@2001-01-03, 225@2001-01-04)}
@@ -684,7 +682,7 @@ SELECT round(degrees(azimuth(tgeompoint '[Point(0 0 0)@2001-01-01,
 angularDifference(tpoint) → tfloat
 </programlisting>
 				<para>El resultado se expresa en grados.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(angularDifference(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02,
   Point(1 1)@2001-01-03]'), 3);
 -- {0@2001-01-01, 180@2001-01-02, 0@2001-01-03}
@@ -701,7 +699,7 @@ SELECT round(degrees(angularDifference(tgeompoint '{[Point(1 1)@2001-01-01,
 bearing({tpoint,point},{tpoint,point}) → tfloat
 </programlisting>
 				<para>Nótese que esta función no acepta dos puntos geográficos temporales.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT degrees(bearing(tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]',
   geometry 'Point(2 2)'));
 -- [45@2001-01-01, 0@2001-01-02, 225@2001-01-03]
@@ -725,7 +723,7 @@ SELECT round(degrees(bearing(tgeompoint '[Point(2 1)@2001-01-01, Point(0 1)@2001
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 round(tspatial,integer=0) → tspatial
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(round(tgeompoint '{Point(1.12345 1.12345 1.12345)@2001-01-01,
   Point(2 2 2)@2001-01-02, Point(1.12345 1.12345 1.12345)@2001-01-03}', 2));
 /* {POINT Z (1.12 1.12 1.12)@2001-01-01, POINT Z (2 2 2)@2001-01-02,
@@ -742,7 +740,7 @@ SELECT asText(round(tgeography 'Linestring(1.12345 1.12345,2.12345 2.12345)@2001
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 makeSimple(tpoint) → tgeompoint[]
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(makeSimple(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02,
   Point(0 0)@2001-01-03]'));
 /* {"[POINT(0 0)@2001-01-01, POINT(1 1)@2001-01-02)",
@@ -769,7 +767,7 @@ SELECT asText(makeSimple(tgeompoint '{[Point(0 0 0)@2001-01-01, Point(1 1 1)@200
 geoMeasure(tpoint,tfloat,segmentize boolean=false) → geo
 </programlisting>
 				<para>El último argumento <varname>segmentize</varname> establece si el valor resultado ya sea es un <varname>Linestring M</varname> o un <varname>MultiLinestring M</varname> donde cada componente es un segmento de dos puntos.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(geoMeasure(tgeompoint '{Point(1 1 1)@2001-01-01,
   Point(2 2 2)@2001-01-02}', '{5@2001-01-01, 5@2001-01-02}'));
 -- MULTIPOINT ZM (1 1 1 5,2 2 2 5)
@@ -782,7 +780,7 @@ SELECT ST_AsText(geoMeasure(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-
 -- MULTILINESTRING M ((1 1 5,2 2 5),(2 2 7,1 1 7))
 </programlisting>
 				<para>Una visualización típica de los datos de movilidad es mostrar en un mapa la trayectoria del objeto móvil utilizando diferentes colores según la velocidad. La <xref linkend="figspeed" /> muestra el resultado de la consulta a continuación usando una rampa de color en QGIS.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH Temp(t) AS (
   SELECT tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-05, Point(2 0)@2001-01-08,
     Point(3 1)@2001-01-10, Point(4 0)@2001-01-11]' )
@@ -791,7 +789,7 @@ SELECT ST_AsText(geoMeasure(t, round(speed(t) * 3600 * 24, 2), true)) FROM Temp;
    (3 1 1.41,4 0 1.41)) */
 </programlisting>
 				<para>La siguiente expresión se usa en QGIS para lograr esto. La función <varname>scale_linear</varname> transforma el valor M de cada segmento componente al rango [0, 1]. Este valor luego se pasa a la función <varname>ramp_color</varname>.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 ramp_color('RdYlBu', scale_linear(
     m(start_point(geometry_n($geometry,@geometry_part_num))), 0, 2, 0, 1) )
 </programlisting>
@@ -811,7 +809,7 @@ affine(tgeo,a float,b float,c float,d float,e float,f float,g float,
   h float,i float,xoff float,yoff float,zoff float) → tgeo
 affine(tgeo,a float,b float,d float,e float,xoff float,yoff float) → tgeo
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Rotate a 3D temporal point 180 degrees about the z axis
 SELECT asEWKT(affine(temp, cos(pi()), -sin(pi()), 0, sin(pi()), cos(pi()), 0, 0, 0, 1,
   0, 0, 0))
@@ -836,7 +834,7 @@ rotate(tgeo,radians float) → tgeo
 rotate(tgeo,radians float,x0 float,y0 float) → tgeo
 rotate(tgeo,radians float,origin geometry) → tgeo
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Rotate a temporal point 180 degrees
 SELECT asEWKT(rotate(tgeompoint '[Point(5 10)@2001-01-01, Point(5 5)@2001-01-02,
   Point(10 5)@2001-01-03]', pi()), 6);
@@ -863,7 +861,7 @@ scale(tgeo,Xfactor float,Yfactor float) → tgeo
 scale(tgeo,factor geometry) → tgeo
 scale(tgeo,factor geometry,origin geometry) → tgeo
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(scale(tgeompoint '[Point(1 2 3)@2001-01-01, Point(1 1 1)@2001-01-02]', 0.5,
   0.75, 0.8));
 --  [POINT Z (0.5 1.5 2.4)@2001-01-01, POINT Z (0.5 0.75 0.8)@2001-01-02]
@@ -894,7 +892,7 @@ asMVTGeom(tpoint,bounds,extent integer=4096,buffer integer=256,
 					<listitem><para><varname>buffer</varname> es la distancia del búfer en el espacio de coordenadas de mosaico</para></listitem>
 					<listitem><para><varname>clip</varname> es un booleano que determina si las geometrías resultantes y las marcas de tiempo deben recortarse o no</para></listitem>
 				</itemizedlist>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText((mvt).geom),
   (mvt).times FROM (SELECT asMVTGeom(tgeompoint '[Point(0 0)@2001-01-01,
   Point(100 100)@2001-01-02]', stbox 'STBOX X((40,40),(60,60))') AS mvt ) AS t;

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -126,7 +126,7 @@ SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
 SRID(tspatial) → integer
 setSRID(tspatial) → tspatial
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tgeompoint 'Point(0 0)@2001-01-01');
 -- 0
 SELECT asEWKT(setSRID(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-02)', 4326));
@@ -147,11 +147,11 @@ transformPipeline(tspatial,pipeline text,srid integer,
 				<para>La función <varname>transformPipeline</varname> especifica la transformación con una canalización de transformación de coordenadas definida representada con el siguiente formato:</para>
 				<para><varname>urn:ogc:def:coordinateOperation:AUTHORITY::CODE</varname></para>
 				<para>El SRID del punto temporal de entrada se ignora y el SRID del punto temporal de salida se establecerá en cero a menos que se proporcione un valor a través del parámetro opcional <varname>srid</varname>. Como se indica en el último parámetro, la canalización se ejecuta de forma predeterminada en dirección hacia adelante; al establecer el parámetro en falso, la canalización se ejecuta en la dirección inversa.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(transform(tgeompoint 'SRID=4326;Point(4.35 50.85)@2001-01-01', 3812));
 -- SRID=3812;POINT(648679.018035303 671067.055638114)@2001-01-01
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH test(tgeo, pipeline) AS (
   SELECT tgeogpoint 'SRID=4326;{Point(4.3525 50.846667 100.0)@2001-01-01,
     Point(-0.1275 51.507222 100.0)@2001-01-02}',
@@ -175,7 +175,7 @@ SELECT asEWKT(transformPipeline(transformPipeline(tgeo, pipeline, 4326), pipelin
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 expandSpace({spatial,tspatial},float) → stbox
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expandSpace(geography 'Linestring(0 0,1 1)', 2);
 -- SRID=4326;GEODSTBOX X((-2,-2),(3,3))
 SELECT expandSpace(tgeompoint 'Point(0 0)@2001-01-01', 2);
@@ -195,7 +195,7 @@ SELECT expandSpace(tgeompoint 'Point(0 0)@2001-01-01', 2);
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {geo,tgeo,stbox} |=| {geo,tgeo,stbox} → float
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[Point(0 0)@2001-01-02, Point(1 1)@2001-01-04,
   Point(0 0)@2001-01-06)' |=| geometry 'Linestring(2 2,2 1,3 1)';
 -- 1
@@ -212,7 +212,7 @@ SELECT tgeometry '(Point(1 1)@2001-01-01,
 </programlisting>
 				<para>El operador <varname>|=|</varname> se puede utilizar para realizar una búsqueda de vecino más cercano utilizando un índice GiST o SP-GIST (ver la <xref linkend="ttype_indexing" />). Esta función corresponde a la función <varname>ST_DistanceCPA</varname> proporcionada por PostGIS, aunque este última requiere que ambos argumentos sean una trayectoria.</para>
 				<para>Cuando un argumento es una caja espaciotemporal que lleva un período, la distancia se mide desde la parte del valor temporal que está dentro de ese período, y el resultado es <varname>NULL</varname> cuando ninguna parte de él lo está. Una caja que no lleva período mide el valor temporal entero.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_DistanceCPA(tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-03,
   Point(0 0 0)@2001-01-05)'::geometry,
   tgeompoint '[Point(2 0 0)@2001-01-02, Point(1 1 1)@2001-01-04,
@@ -228,7 +228,7 @@ SELECT ST_DistanceCPA(tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01
 nearestApproachInstant({geo,tgeo},{geo,tgeo}) → tgeo
 </programlisting>
 				<para>La función sólo devuelve el primer instante que encuentre si hay más de uno. El instante resultante puede tener un límite exclusivo.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(nearestApproachInstant(tgeompoint '(Point(1 1)@2001-01-01,
   Point(3 1)@2001-01-03]', geometry 'Linestring(1 3,2 2,3 3)'));
 -- POINT(2 1)@2001-01-02
@@ -244,7 +244,7 @@ SELECT asText(nearestApproachInstant(tgeometry
 -- LINESTRING Z (0 0 0,1 1 1)@2001-01-02
 </programlisting>
 				<para>La función <varname>nearestApproachInstant</varname> generaliza the la función PostGIS <varname>ST_ClosestPointOfApproach</varname>. Primero, la última función requiere que ambos argumentos sean trayectorias. Segundo, la función <varname>nearestApproachInstant</varname> devuelve tanto el punto como la marca de tiempo del punto de aproximación más cercano, mientras que la función PostGIS sólo proporciona la marca de tiempo como se muestra a continuación.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT to_timestamp(ST_ClosestPointOfApproach( tgeompoint '[Point(0 0 0)@2001-01-01,
   Point(1 1 1)@2001-01-03, Point(0 0 0)@2001-01-05)'::geometry,
   tgeompoint '[Point(2 0 0)@2001-01-02, Point(1 1 1)@2001-01-04,
@@ -262,7 +262,7 @@ minDistance(tgeo[],tgeo[]) → float
 minDistance(tgeo,tgeo) → float
 </programlisting>
 				<para>La forma escalar devuelve la distancia mínima alcanzada entre los dos argumentos sobre la intersección de sus extensiones temporales, equivalente al valor mínimo de la distancia temporal <varname>&lt;-&gt;</varname>. La forma de arreglo generaliza esto a dos conjuntos de geometrías temporales y devuelve el mínimo sobre todos los pares. La forma de agregado, utilizada con <varname>GROUP BY</varname>, devuelve la distancia mínima alcanzada sobre todos los pares agregados en el grupo.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minDistance(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)',
   geometry 'Point(0 1)');
 -- 0.707106781186548
@@ -314,7 +314,7 @@ SELECT i, j FROM eDwithinPairs(
 SELECT i, j, periods FROM tDwithinPairs(
   ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(0 10)@2001-01-02]'],
   ARRAY[tgeompoint '[Point(1 0)@2001-01-01, Point(1 10)@2001-01-02]'], 2.0);
--- un par, con el período durante el cual está dentro de la distancia
+-- one pair, with the period during which it is within the distance
 SELECT i, j FROM aDisjointPairs(
   ARRAY[tgeompoint '[Point(0 0)@2001-01-01, Point(0 10)@2001-01-02]'],
   ARRAY[tgeompoint '[Point(5 0)@2001-01-01, Point(5 10)@2001-01-02]']);
@@ -329,7 +329,7 @@ SELECT i, j FROM aDisjointPairs(
 shortestLine({geo,tgeo},{geo,tgeo}) → geo
 </programlisting>
 				<para>La función sólo devolverá la primera línea que encuentre si hay más de una.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_AsText(shortestLine(tgeompoint '(Point(1 1)@2001-01-01, Point(3 1)@2001-01-03]',
   geometry 'Linestring(1 3,2 2,3 3)'));
 -- LINESTRING(2 1,2 2)
@@ -342,7 +342,7 @@ SELECT ST_AsText(shortestLine(tgeometry
 -- LINESTRING Z (0 0 0,2 0 0)
 </programlisting>
 				<para>La función <varname>shortestLine</varname> se puede utilizar para obtener el resultado proporcionado por la función PostGIS <varname>ST_CPAWithin</varname> cuando ambos argumentos son trayectorias como se muestra a continuación.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ST_Length(shortestLine( tgeompoint '[Point(0 0 0)@2001-01-01,
   Point(1 1 1)@2001-01-03, Point(0 0 0)@2001-01-05)',
   tgeompoint '[Point(2 0 0)@2001-01-02, Point(1 1 1)@2001-01-04,
@@ -368,7 +368,7 @@ SELECT ST_CPAWithin(tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 1)@2001-01-0
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {geo,tgeo} &lt;-&gt; {geo,tgeo} → tfloat
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)' &lt;-&gt;
   geometry 'Point(0 1)';
 -- [1@2001-01-01, 0.707106781186548@2001-01-02, 1@2001-01-03)
@@ -398,7 +398,7 @@ eContains({geometry,tgeom},{geometry,tgeom}) → boolean
 aContains({geometry,tgeom},{geometry,tgeom}) → boolean
 </programlisting>
 					<para>Esta función devuelve verdadero si el punto temporal está alguna vez en el interior de la geometría. Recuerde que una geometría no contiene cosas en su borde y, por lo tanto, los polígonos y las líneas no contienen líneas y puntos que se encuentran en su borde. Consulte la documentación de la función <ulink url="https://postgis.net/docs/ST_Contains.html">ST_Contains</ulink> en PostGIS.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Linestring(1 1,3 3)',
   tgeompoint '[Point(4 2)@2001-01-01, Point(2 4)@2001-01-02]');
 -- false
@@ -445,7 +445,7 @@ SELECT eCovers(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 eDisjoint({geo,tgeo},{geo,tgeo}) → boolean
 aDisjoint({geo,tgeo},{geo,tgeo}) → boolean
 </programlisting>
-						<programlisting language="sql" xml:space="preserve">
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eDisjoint(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)');
 -- false
@@ -462,7 +462,7 @@ SELECT eDisjoint(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 eDwithin({geo,tgeo},{geo,tgeo},float) → boolean
 aDwithin({geometry,tgeom},{geometry,tgeom},float) → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eDwithin(geometry 'Point(1 1 1)',
   tgeompoint '[Point(0 0 0)@2001-01-01, Point(1 1 0)@2001-01-02]', 1);
 -- true
@@ -479,7 +479,7 @@ SELECT eDwithin(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 eIntersects({geo,tgeo},{geo,tgeo}) → boolean
 aIntersects({geometry,tgeom},{geometry,tgeom}) → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eIntersects(geometry 'Polygon((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0))',
   tgeompoint '[Point(0 0 1)@2001-01-01, Point(1 1 1)@2001-01-03)');
 -- false
@@ -496,7 +496,7 @@ SELECT eIntersects(geometry 'Polygon((0 0 0,0 1 1,1 1 1,1 0 0,0 0 0))',
 eTouches({geometry,tgeom},{geometry,tgeom}) → boolean
 aTouches({geometry,tgeom},{geometry,tgeom}) → boolean
 </programlisting>
-						<programlisting language="sql" xml:space="preserve">
+						<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eTouches(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(0 1)@2001-01-03)');
 -- true
@@ -514,7 +514,7 @@ SELECT eTouches(geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))',
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tContains(geometry,tgeom) → tbool
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tContains(geometry 'Linestring(1 1,3 3)',
   tgeompoint '[Point(4 2)@2001-01-01, Point(2 4)@2001-01-02]');
 -- {[f@2001-01-01, f@2001-01-02]}
@@ -536,7 +536,7 @@ SELECT tContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))',
 tDisjoint({geo,tgeo},{geo,tgeo}) → tbool
 </programlisting>
 					<para>La función solo admite 3D o geografías para dos puntos temporales</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tDisjoint(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)');
 -- {[t@2001-01-01, f@2001-01-02, f@2001-01-03], (t@2001-01-03, t@2001-01-04]}
@@ -551,7 +551,7 @@ SELECT tDisjoint(tgeompoint '[Point(0 3)@2001-01-01, Point(3 0)@2001-01-05)',
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tDwithin({geo,tgeo},{geo,tgeo},float) → tbool
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tDwithin(geometry 'Point(1 1)',
   tgeompoint '[Point(0 0)@2001-01-01, Point(2 2)@2001-01-03)', sqrt(2));
 --  {[t@2001-01-01, t@2001-01-03)}
@@ -567,7 +567,7 @@ SELECT tDwithin(tgeompoint '[Point(1 0)@2001-01-01, Point(1 4)@2001-01-05]',
 tIntersects({geo,tgeo},{geo,tgeo}) → tbool
 </programlisting>
 					<para>La función solo admite 3D o geografías para dos puntos temporales</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(geometry 'MultiPoint(1 1,2 2)',
   tgeompoint '[Point(0 0)@2001-01-01, Point(3 3)@2001-01-04)');
 /* {[f@2001-01-01, t@2001-01-02], (f@2001-01-02, t@2001-01-03],
@@ -583,7 +583,7 @@ SELECT tIntersects(tgeompoint '[Point(0 3)@2001-01-01, Point(3 0)@2001-01-05)',
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tTouches({geometry,tgeom},{geometry,tgeom}) → tbool
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tTouches(geometry 'Polygon((1 0,1 2,2 2,2 0,1 0))',
   tgeompoint '[Point(0 0)@2001-01-01, Point(3 0)@2001-01-04)');
 -- {[f@2001-01-01, t@2001-01-02, t@2001-01-03], (f@2001-01-03, f@2001-01-04]}

--- a/doc/es/temporal_types_aggregation.xml
+++ b/doc/es/temporal_types_aggregation.xml
@@ -38,7 +38,7 @@
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tCount(ttype) → {tintSeq,tintSeqSet}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tCount(NoEmps) FROM Department;
 -- {[1@2001-01-01, 2@2001-02-01, 1@2001-08-01, 1@2001-10-01)}
 </programlisting>
@@ -50,11 +50,11 @@ SELECT tCount(NoEmps) FROM Department;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 extent(temp) → {tstzspan,tbox,stbox}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT extent(noEmps) FROM Department;
 -- TBOX XT((4,12),[2001-01-01,2001-10-01])
 SELECT extent(Trip) FROM Trips;
--- STBOX XT(((0,0),(3,3),[2001-01-01 08:00:00, 2001-01-01 08:20:00)))
+-- STBOX XT(((0,0),(3,3)),[2001-01-01 08:00:00, 2001-01-01 08:20:00))
 </programlisting>
 			</listitem>
 
@@ -66,7 +66,7 @@ SELECT extent(Trip) FROM Trips;
 tOr(tbool) → tbool
 tAnd(tbool) → tbool
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tAnd(NoEmps #&gt; 6) FROM Department;
 -- {[t@2001-01-01, f@2001-04-01, f@2001-10-01)}
 SELECT tOr(NoEmps #&gt; 6) FROM Department;
@@ -87,7 +87,7 @@ tSum(tnumber) → {tnumberSeq,tnumberSeqSet}
 tAvg(tnumber) → {tfloatSeq,tfloatSeqSet}
 </programlisting>
 				<para>Los nombres <varname>tMin</varname> y <varname>tMax</varname> designan las mismas funciones de agregación y se mantienen por compatibilidad con versiones anteriores.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tMinAgg(NoEmps) FROM Department;
 -- {[10@2001-01-01, 4@2001-02-01, 6@2001-06-01, 6@2001-10-01)}
 SELECT tMaxAgg(NoEmps) FROM Department;
@@ -108,7 +108,7 @@ SELECT tAvg(NoEmps) FROM Department;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 wCount(tnumber,interval) → {tintSeq,tintSeqSet}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT wCount(NoEmps, interval '2 days') FROM Department;
 /* {[1@2001-01-01, 2@2001-02-01, 3@2001-04-01, 2@2001-04-03, 3@2001-06-01, 2@2001-06-03,
    1@2001-08-03, 1@2001-10-03)} */
@@ -127,7 +127,7 @@ wMax(tnumber,interval) → {tnumberDiscSeq,tnumberSeqSet}
 wSum(tint,interval) → {tintSeq,tintSeqSet}
 wAvg(tint,interval) → {tfloatSeq,tfloatSeqSet}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT wMin(NoEmps, interval '2 days') FROM Department;
 -- {[10@2001-01-01, 4@2001-04-01, 6@2001-06-03, 6@2001-10-03)}
 SELECT wMax(NoEmps, interval '2 days') FROM Department;
@@ -147,7 +147,7 @@ SELECT round(wAvg(NoEmps, interval '2 days'), 3) FROM Department;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tCentroid(tgeompoint) → tgeompoint
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tCentroid(Trip) FROM Trips;
 /* {[POINT(0 0)@2001-01-01 08:00:00, POINT(1 0)@2001-01-01 08:05:00),
    [POINT(0.5 0)@2001-01-01 08:05:00, POINT(1.5 0.5)@2001-01-01 08:10:00,
@@ -162,7 +162,7 @@ SELECT tCentroid(Trip) FROM Trips;
 	<sect1 xml:id="ttype_indexing">
 		<title>Indexación</title>
 		<para>Se pueden crear índices GiST y SP-GiST para columnas de tabla de tipos temporales. El índice GiST implementa un árbol R, mientras que el índice SP-GiST implementa un árbol cuádruple n-dimensional. Ejemplos de creación de índices son los siguientes:
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE INDEX Department_NoEmps_Gist_Idx ON Department USING Gist(NoEmps);
 CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 </programlisting>
@@ -205,7 +205,7 @@ CREATE INDEX Trips_Trip_SPGist_Idx ON Trips USING SPGist(Trip);
 		</para>
 
 		<para>Por ejemplo, dado el índice definido anteriormente en la tabla <varname>Department</varname> y una consulta que implica una condición con el operador <varname>&amp;&amp;</varname> (superposición), si el argumento derecho es un flotante temporal, entonces se consideran tanto el valor como las dimensiones de tiempo para filtrar las tuplas de la relación, mientras que si el argumento derecho es un valor flotante, un rango flotante o un tipo de tiempo, entonces el valor o la dimensión de tiempo se utilizará para filtrar las tuplas de la relación. Además, se puede construir un cuadro delimitador a partir de un valor/rango y/o una marca de tiempo/período, que se puede usar para filtrar las tuplas de la relación. Ejemplos de consultas que utilizan el índice en la tabla <varname>Department</varname> definida anteriormente se dan a continuación.
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT * FROM Department WHERE NoEmps &amp;&amp; intspan '[1, 5)';
 SELECT * FROM Department WHERE NoEmps &amp;&amp; tstzspan '[2001-04-01, 2001-05-01)';
 SELECT * FROM Department WHERE NoEmps &amp;&amp;
@@ -216,7 +216,7 @@ SELECT * FROM Department WHERE NoEmps &amp;&amp;
 		</para>
 
 		<para>Del mismo modo, los ejemplos de consultas que utilizan el índice en la tabla <varname>Trips</varname> definida anteriormente se dan a continuación.
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT * FROM Trips WHERE Trip &amp;&amp; geometry 'Polygon((0 0,0 1,1 1,1 0,0 0))';
 SELECT * FROM Trips WHERE Trip &amp;&amp; timestamptz '2001-01-01';
 SELECT * FROM Trips WHERE Trip &amp;&amp; tstzspan '[2001-01-01, 2001-01-05)';
@@ -230,7 +230,7 @@ SELECT * FROM Trips WHERE Trip &amp;&amp;
 		<para>Finalmente, se pueden crear índices de árbol B para columnas de tabla de todos los tipos temporales. Para este tipo de índice, la única operación útil es la igualdad. Hay un orden de clasificación de árbol B definido para valores de tipos temporales, con los correspondientes operadores <varname>&lt;</varname>, <varname>&lt;=</varname>, <varname>&gt;</varname> y <varname>&gt;=</varname>, pero el orden es bastante arbitrario y no suele ser útil en el mundo real. El soporte de árbol B para tipos temporales está destinado principalmente a permitir la clasificación interna en las consultas, en lugar de la creación de índices reales.</para>
 
 		<para>Para acelerar algunas de las funciones de los tipos temporales, se puede agregar en la cláusula <varname>WHERE</varname> de las consultas una comparación de cuadro delimitador que hace uso de los índices disponibles. Por ejemplo, este sería típicamente el caso de las funciones que proyectan los tipos temporales a las dimensiones de valor/espacio y/o tiempo. Esto filtrará las tuplas con un índice como se muestra en la siguiente consulta.
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atTime(T.Trip, tstzspan '[2001-01-01, 2001-01-02)') FROM Trips T
 -- Filtro de índice con cuadro delimitador
 WHERE T.Trip &amp;&amp; tstzspan '[2001-01-01, 2001-01-02)';
@@ -238,7 +238,7 @@ WHERE T.Trip &amp;&amp; tstzspan '[2001-01-01, 2001-01-02)';
 		</para>
 
 		<para>En el caso de los geometrías temporales, todas las relaciones espaciales con la semántica alguna vez o siempre (ver la <xref linkend="tgeo_spatiotemp_rel" />) incluyen automáticamente una comparación de cuadro delimitador que hará uso de cualquier índice que esté disponible en los puntos temporales. Por esta razón, la primera versión de las relaciones se usa típicamente para filtrar las tuplas con la ayuda de un índice al calcular las relaciones temporales como se muestra en la siguiente consulta.
-			<programlisting language="sql" xml:space="preserve">
+			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(T.Trip, R.Geom) FROM Trips T, Regions R
 -- Filtro de índice con cuadro delimitador
 WHERE eIntersects(T.Trip, R.Geom);

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -674,9 +674,9 @@ SELECT (gr).index,
   2.0, '2 days') AS gr) t;
 -- 1 | TBOX XT([14,16),[2001-01-15,2001-01-17))
 -- 2 | TBOX XT([16,18),[2001-01-15,2001-01-17))
--- 3 | TBOX XT([18,20),[2001-01-15,2001-01-17),)
+-- 3 | TBOX XT([18,20),[2001-01-15,2001-01-17))
 -- ...
-SELECT valueTimeTiles(tfloat '[15@2001-01-15, 25@2001-01-25]'::tbox, 2.0, '2 days', 11.5);
+SELECT valueTimeTiles(tfloat '[15@2001-01-15,25@2001-01-25]'::tbox, 2.0, '2 days', 11.5);
 -- (1,"TBOX XT([13.5,15.5),[2001-01-15,2001-01-17))")
 -- (2,"TBOX XT([15.5,17.5),[2001-01-15,2001-01-17))")
 -- (3,"TBOX XT([17.5,19.5),[2001-01-15,2001-01-17))")
@@ -700,14 +700,12 @@ spaceTimeTiles({stbox,tgeompoint},xsize float,[ysize float,zsize float,]duration
 </programlisting>
 					<para>Si el origen de las dimensiones espacial y/o de tiempo no se especifican, su valor se establece por defecto en <varname>'Point (0 0 0)'</varname> y en el lunes 3 de enero de 2000, respectivamente. El argumento opcional <varname>borderInc</varname> indica si se incluye el borde superior de la extensión y, por lo tanto, se generan mosaicos adicionales que contienen el borde. En el caso de una malla espacio-temporal, <varname>ysize</varname> y <varname>zsize</varname> son opcionales, se supone que el tamaño de las dimensiones faltantes es igual a <varname>xsize</varname>. El SRID de las coordenadas de los mosaicos está determinado por el del cuadro de entrada y el tamaño se da en las unidades del SRID. Si se especifica el origen de las coordenadas espaciales, que debe ser un punto, su dimensionalidad y SRID deben ser iguales al del cuadro delimitador, de lo contrario se genera un error.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT spaceTiles(tgeompoint '[Point(3 3)@2001-01-15, Point(15 15)@2001-01-25]'::stbox,
-  2.0);
+SELECT spaceTiles(tgeompoint '[Point(3 3)@2001-01-15, Point(15 15)@2001-01-25]', 2.0);
 -- (1,"STBOX X((2,2),(4,4))")
 -- (2,"STBOX X((4,2),(6,4))")
 -- (3,"STBOX X((6,2),(8,4))")
 -- ...
-SELECT timeTiles(tgeompoint '[Point(3 3)@2001-01-15, Point(15 15)@2001-01-25]'::stbox,
-  '2 days');
+SELECT timeTiles(tgeompoint '[Point(3 3)@2001-01-15, Point(15 15)@2001-01-25]', '2 days');
 -- (1,"STBOX T([2001-01-15, 2001-01-17))")
 -- (2,"STBOX T([2001-01-17, 2001-01-19))")
 -- (3,"STBOX T([2001-01-19, 2001-01-21))")
@@ -724,8 +722,8 @@ SELECT spaceTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
 -- (2,"STBOX Z((5,3,3),(7,5,5))")
 -- (3,"STBOX Z((7,3,3),(9,5,5))")
 -- ...
-SELECT spaceTimeTiles(tgeompoint '[Point(3 3)@2001-01-15,
-  Point(15 15)@2001-01-25]'::stbox, 2.0, interval '2 days');
+SELECT spaceTimeTiles(tgeompoint '[Point(3 3)@2001-01-15, Point(15 15)@2001-01-25]', 2.0,
+  interval '2 days');
 -- (1,"STBOX XT(((2,2),(4,4)),[2001-01-15,2001-01-17))")
 -- (2,"STBOX XT(((4,2),(6,4)),[2001-01-15,2001-01-17))")
 -- (3,"STBOX XT(((6,2),(8,4)),[2001-01-15,2001-01-17))")
@@ -734,8 +732,8 @@ SELECT spaceTimeTiles(tgeompoint '[Point(3 3 3)@2001-01-15,
   Point(15 15 15)@2001-01-25]'::stbox, 2.0, interval '2 days', 'Point(3 3 3)',
   '2001-01-15');
 -- (1,"STBOX ZT(((3,3,3),(5,5,5)),[2001-01-15,2001-01-17))")
--- (2,"STBOX ZT(((5,3,3),(7,5,5)),[2001-01-15,2001-01-17))")
--- (3,"STBOX ZT(((7,3,3),(9,5,5)),[2001-01-15,2001-01-17))")
+-- (2,"STBOX ZT(((5,3,3),(7,5,5))),[2001-01-15,2001-01-17)")
+-- (3,"STBOX ZT(((7,3,3),(9,5,5))),[2001-01-15,2001-01-17)")
 -- ...
 </programlisting>
 				</listitem>
@@ -759,7 +757,7 @@ SELECT getValueTile(15, 2);
 SELECT getTboxTimeTile('2001-01-15', interval '2 days');
 -- TBOX ([2001-01-15,2001-01-17))
 SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days');
--- TBOX ([14,16),[2001-01-15,2001-01-17))
+-- TBOX XT([14,16),[2001-01-15,2001-01-17))
 SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days', 1, '2001-01-02');
 -- TBOX XT([15,17),[2001-01-14,2001-01-16))
 </programlisting>
@@ -786,10 +784,10 @@ SELECT getSpaceTile(geometry 'Point(1 1 1)', 2.0);
 SELECT getStboxTimeTile(timestamptz '2001-01-01', interval '2 days');
 -- STBOX T([2001-01-01,2001-01-03))
 SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 days');
--- STBOX XT((0,0),(2,2),[2001-01-01,2001-01-03))
-SELECT getSspaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 days',
+-- STBOX XT(((0,0),(2,2)),[2001-01-01, 2001-01-03))
+SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 days',
   'Point(1 1)', '2001-01-02');
--- STBOX XT(((1,1),(3,3)),[2000-12-31,2001-01-02))
+-- STBOX XT(((1,1),(3,3)),[2000-12-31, 2001-01-02))
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -949,7 +947,7 @@ FROM (SELECT timeSplit(tfloat '[1@2001-02-01, 10@2001-02-10)', '2 days') AS ts) 
 -- 2001-02-04 | [4@2001-02-04, 6@2001-02-06)
 -- ...
 SELECT (ts).time,
-  asText((ts).temp) AS temp FROM (SELECT timeSplit(tgeompoint '[Point(1 1)@2001-02-01,
+  astext((ts).temp) AS temp FROM (SELECT timeSplit(tgeompoint '[Point(1 1)@2001-02-01,
   Point(10 10)@2001-02-10]', '2 days', '2001-02-01') AS ts) AS t;
 -- 2001-02-01 | [POINT(1 1)@2001-02-01, POINT(3 3)@2001-02-03)
 -- 2001-02-03 | [POINT(3 3)@2001-02-03, POINT(5 5)@2001-02-05)
@@ -1019,14 +1017,14 @@ spaceTimeSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
 </programlisting>
 					<para>Una pose temporal y un punto de nube de puntos temporal responden a estas funciones en el punto geométrico temporal al que se resuelve su posición, de modo que un valor con interpolación lineal se divide en mosaicos a lo largo de su trayectoria y no solo en sus instantes. La segunda columna de una división lleva el tipo del primer argumento, de modo que dividir una pose temporal devuelve poses temporales. El resultado es un conjunto de pares o un conjunto de triples. Si el origen de la dimensión espacial y/o el tiempo no se especifica, su valor se establece por defecto en <varname>'Point(0 0 0)'</varname> y en el lunes 3 de enero de 2000, respectivamente. Los argumentos <varname>ysize</varname> y <varname>zsize</varname> son opcionales, se supone que el tamaño de las dimensiones faltantes es igual a <varname>xsize</varname>. Si no se especifica el argumento <varname>bitmatrix</varname>, el cálculo utilizará una matriz de bits para acelerar el proceso. El argumento opcional <varname>borderInc</varname> indica si se incluye el borde superior de la extensión espacial y, por lo tanto, se generan mosaicos adicionales que contienen el borde.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText((sp).point) AS point, asText((sp).tpoint) AS tpoint
+SELECT ST_AsText((sp).point) AS point, astext((sp).tpoint) AS tpoint
 FROM (SELECT spaceSplit(tgeompoint '[Point(1 1)@2001-03-01, Point(10 10)@2001-03-10]',
   2.0) AS sp) t;
 -- POINT(0 0) | {[POINT(1 1)@2001-03-01, POINT(2 2)@2001-03-02)}
 -- POINT(2 2) | {[POINT(2 2)@2001-03-02, POINT(4 4)@2001-03-04)}
 -- POINT(4 4) | {[POINT(4 4)@2001-03-04, POINT(6 6)@2001-03-06)}
 -- ...
-SELECT ST_AsText((sp).point) AS point, asText((sp).tpoint) AS tpoint
+SELECT ST_AsText((sp).point) AS point, astext((sp).tpoint) AS tpoint
 FROM (SELECT spaceSplit(tgeompoint '[Point(1 1 1)@2001-03-01,
   Point(10 10 10)@2001-03-10]', 2.0, geometry 'Point(1 1 1)') AS sp) t;
 -- POINT Z(1 1 1) | {[POINT Z (1 1 1)@2001-03-01, POINT Z (3 3 3)@2001-03-03)}
@@ -1051,14 +1049,14 @@ SELECT (sp).time,
 </programlisting>
 
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT ST_AsText((sp).point) AS point, (sp).time, asText((sp).tpoint) AS tpoint
+SELECT ST_AsText((sp).point) AS point, (sp).time, astext((sp).tpoint) AS tpoint
 FROM (SELECT spaceTimeSplit(tgeompoint '[Point(1 1)@2001-02-01, Point(10 10)@2001-02-10]',
   2.0, interval '2 days') AS sp) t;
 -- POINT(0 0) | 2001-01-31 | {[POINT(1 1)@2001-02-01, POINT(2 2)@2001-02-02)}
 -- POINT(2 2) | 2001-01-31 | {[POINT(2 2)@2001-02-02]}
 -- POINT(2 2) | 2001-02-02 | {[POINT(2 2)@2001-02-02, POINT(4 4)@2001-02-04)}
 -- ...
-SELECT ST_AsText((sp).point) AS point, (sp).time, asText((sp).tpoint) AS tpoint
+SELECT ST_AsText((sp).point) AS point, (sp).time, astext((sp).tpoint) AS tpoint
 FROM (SELECT spaceTimeSplit(tgeompoint '[Point(1 1 1)@2001-02-01,
   Point(10 10 10)@2001-02-10]', 2.0, interval '2 days', 'Point(1 1 1)',
   '2001-03-01') AS sp) t;

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -29,14 +29,14 @@
 		<para>
 			Un valor temporal de subtipo <emphasis>instante</emphasis> (brevemente, un <emphasis>valor de instante</emphasis>) representa el valor en un instante de tiempo, por ejemplo
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat '17@2018-01-01 08:00:00';
 </programlisting>
 
 		<para>
 		Un valor temporal de subtipo <emphasis>secuencia</emphasis> (brevemente, un <emphasis>valor de secuencia</emphasis>) representa la evolución del valor durante una secuencia de instantes de tiempo, donde los valores entre estos instantes se interpolan usando una función discreta, escalonada, o lineal (ver arriba). Un ejemplo es el siguiente:
 	</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Interpolación discreta
 SELECT tfloat '{17@2018-01-01 08:00:00, 17.5@2018-01-01 08:05:00,
   18@2018-01-01 08:10:00}';
@@ -50,7 +50,7 @@ SELECT tfloat '(10@2018-01-01 08:00:00, 20@2018-01-01 08:05:00, 15@2018-01-01 08
 		<para>
 		Como puede verse, un valor de secuencia tiene un límite superior e inferior que pueden ser inclusivos (representados por ‘<varname>[</varname>’ y ‘<varname>]</varname>’) o exclusivos (representados por ‘<varname>(</varname>' y ‘<varname>)</varname>'). Por definición, ambos límites deben ser inclusivos cuando la interpolación es discreta o cuando la secuencia tiene un solo instante (que se llama <emphasis>secuencia instantánea</emphasis>), como el ejemplo suiguiente.
 	</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[10@2018-01-01 08:00:00]';
 </programlisting>
 		<para>
@@ -59,7 +59,7 @@ SELECT tint '[10@2018-01-01 08:00:00]';
 
 		<para>
 			El valor de una secuencia temporal se interpreta asumiendo que el período de tiempo definido por cada par de valores consecutivos <varname>v1@t1</varname> y <varname>v2@t2</varname> es inferior inclusivo y superior exclusivo, a menos que sean el primer o el último instantes de la secuencia y, en ese caso, se aplican los límites de toda la secuencia. Además, el valor que toma la secuencia temporal entre dos instantes consecutivos depende de si la interpolación es escalonada o lineal. Por ejemplo, la secuencia temporal anterior representa que el valor es <varname>10</varname> durante<varname>(2018-01-01 08:00:00, 2018-01-01 08:05:00)</varname>, <varname>20</varname> durante <varname>[2018-01-01 08:05:00, 2018-01-01 08:10:00)</varname> y <varname>15</varname> en el instante final <varname>2018-01-01 08:10:00</varname>. Por otro lado, la siguiente secuencia temporal
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat '(10@2018-01-01 08:00:00, 20@2018-01-01 08:05:00, 15@2018-01-01 08:10:00]';
 </programlisting>
 			representa que el valor evoluciona linealmente de <varname>10</varname> a <varname>20</varname> durante <varname>(2018-01-01 08:00:00, 2018-01-01 08:05:00)</varname> y evoluciona de <varname>20</varname> a <varname>15</varname> durante <varname>[2018-01-01 08:05:00, 2018-01-01 08:10:00]</varname>.
@@ -68,7 +68,7 @@ SELECT tfloat '(10@2018-01-01 08:00:00, 20@2018-01-01 08:05:00, 15@2018-01-01 08
 		<para>
 			Finalmente, un valor temporal de subtipo <emphasis>conjunto de secuencias</emphasis> (brevemente, un <emphasis>valor de conjunto de secuencias</emphasis>) representa la evolución del valor en un conjunto de secuencias, donde se desconocen los valores entre estas secuencias. Un ejemplo es el siguiente:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat '{[17@2018-01-01 08:00:00, 17.5@2018-01-01 08:05:00],
   [18@2018-01-01 08:10:00, 18@2018-01-01 08:15:00]}';
 </programlisting>
@@ -79,7 +79,7 @@ SELECT tfloat '{[17@2018-01-01 08:00:00, 17.5@2018-01-01 08:05:00],
 		<para>
 			Los valores de secuencia continuos se convierten en <emphasis>forma normal</emphasis> de modo que los valores equivalentes tengan representaciones idénticas. Para ello, los valores de instante consecutivos se fusionan cuando es posible. Para la interpolación escalonada, tres valores instantáneos consecutivos se pueden fusionar en dos si tienen el mismo valor. Para la interpolación lineal, tres valores instantáneos consecutivos se pueden fusionar en dos si las funciones lineales que definen la evolución de los valores son las mismas. Ejemplos de transformación en forma normal son los siguientes.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 2@2001-01-03, 2@2001-01-04, 2@2001-01-05)';
 -- [1@2001-01-01, 2@2001-01-03, 2@2001-01-05)
 SELECT asText(tgeompoint '[Point(1 1)@2001-01-01 08:00:00, Point(1 1)@2001-01-01 08:05:00,
@@ -95,7 +95,7 @@ SELECT asText(tgeompoint '[Point(1 1)@2001-01-01 08:00:00, Point(2 2)@2001-01-01
 		<para>
 			De manera similar, los valores del conjunto de secuencias temporales se convierten en forma normal. Para ello, los valores de secuencia consecutivos se fusionan cuando es posible. Ejemplos de transformación en forma normal son los siguientes.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '{[1@2001-01-01, 1@2001-01-03), [2@2001-01-03, 2@2001-01-05)}';
 -- '{[1@2001-01-01, 2@2001-01-03, 2@2001-01-05)}'
 SELECT tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-03, 3@2001-01-05]}';
@@ -119,7 +119,7 @@ SELECT asText(tgeompoint '{[Point(1 1)@2001-01-01 08:00:00,
 		<para>
 		Los tipos temporales soportan <emphasis>modificadores de typo</emphasis> (o <varname>typmod</varname> en terminología de PostgreSQL), que especifican información adicional para la definición de una columna. Por ejemplo, en la siguiente definición de tabla:
 	</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE Department(DeptNo integer, DeptName varchar(25), NoEmps tint(Sequence));
 </programlisting>
 		<para>
@@ -129,8 +129,9 @@ CREATE TABLE Department(DeptNo integer, DeptName varchar(25), NoEmps tint(Sequen
 		<para>
 			Por otro lado, en el caso de tipos de puntos temporales (es decir, <varname>tgeompoint</varname> o <varname>tgeogpoint</varname>) el modificador de tipo se puede utilizar para especificar el subtipo, la dimensionalidad y/o el identificador de referencia espacial (SRID). Por ejemplo, en la siguiente definición de tabla:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE Flight(FlightNo integer, Route tgeogpoint(Sequence, PointZ, 4326));
+CREATE TABLE Storm(StormId integer, Route tgeography(Sequence, Linestring, 4326));
 </programlisting>
 		<para>
 			el modificador de typo para el tipo <varname>tgeogpoint</varname> se compone de tres valores, el primero indica el subtipo como arriba, el segundo el tipo espacial de las geografías que componen el punto temporal y el último el SRID de las geografías que componen. Para los puntos temporales, los valores posibles para el primer argumento del modificador de tipo son los anteriores, los del segundo argumento son <varname>Point</varname> o <varname>PointZ</varname> y los del tercer argumento son SRID válidos. Los tres argumentos son opcionales y si alguno de ellos no se especifica para una columna, se permiten valores de cualquier subtipo, dimensionalidad y/o SRID.
@@ -161,7 +162,7 @@ CREATE TABLE Flight(FlightNo integer, Route tgeogpoint(Sequence, PointZ, 4326));
 	<sect1 xml:id="ttype_examples">
 		<title>Ejemplos de tipos temporales</title>
 		<para>A continuación se dan ejemplos de uso de tipos alfanuméricos temporales.</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE Department(DeptNo integer, DeptName varchar(25), NoEmps tint);
 INSERT INTO Department VALUES
   (10, 'Research', tint '[10@2001-01-01, 12@2001-04-01, 12@2001-08-01)'),
@@ -177,7 +178,7 @@ SELECT RoomNo, valueAtTimestamp(Temp, '2001-01-01 08:10:00') FROM temperature;
 -- Restricción a un valor
 SELECT DeptNo, atValue(NoEmps, 10) FROM Department;
 -- 10 | [10@2001-01-01, 10@2001-04-01)
--- 20 | 
+-- 20 |
 -- Restricción a un período
 SELECT DeptNo, atTime(NoEmps, tstzspan '[2001-01-01, 2001-04-01]') FROM Department;
 -- 10 | [10@2001-01-01, 12@2001-04-01]
@@ -192,7 +193,7 @@ SELECT tsum(NoEmps) FROM Department;
    18@2001-06-01, 6@2001-08-01, 6@2001-10-01)} */
 </programlisting>
 		<para>A continuación se dan ejemplos de uso de tipos de puntos temporales.</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 CREATE TABLE Trips(CarId integer, TripId integer, Trip tgeompoint);
 INSERT INTO Trips VALUES
   (10, 1, tgeompoint '{[Point(0 0)@2001-01-01 08:00:00, Point(2 0)@2001-01-01 08:10:00,
@@ -207,7 +208,7 @@ SELECT CarId,
 -- Restricción a un valor
 SELECT CarId, asText(atValue(Trip, geometry 'Point(2 0)')) FROM Trips;
 -- 10 | {"[POINT(2 0)@2001-01-01 08:10:00]"}
--- 20 |
+-- 20 | 
 -- Restricción a un período
 SELECT CarId,
   asText(atTime(Trip, tstzspan '[2001-01-01 08:05:00,2001-01-01 08:10:00]')) FROM Trips;
@@ -259,7 +260,7 @@ SELECT T1.CarId, T2.CarId, T1.Trip &lt;-&gt; T2.Trip FROM Trips T1,
 		<para>
 			Se genera un error cuando no se satisface una de estas restricciones. Ejemplos de valores temporales incorrectos son los siguientes.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Valor del tipo de base incorrecto
 SELECT tbool '1.5@2001-01-01 08:00:00';
 -- Valor del tipo base no es un punto
@@ -292,7 +293,7 @@ SELECT tint '{[1@2001-01-01 08:00:00, 1@2001-01-01 10:00:00),
 		<para>
 			Una forma común de generalizar las operaciones tradicionales a los tipos temporales es aplicar la operación en <emphasis>cada instante</emphasis>, lo que da un valor temporal como resultado. En ese caso, la operación sólo se define en la intersección de las extensiones temporales de los operandos; si las extensiones temporales son disjuntas, el resultado es nulo. Por ejemplo, los operadores de comparación temporal, como <varname>#&lt;</varname>, determinan si los valores tomados por sus operandos en cada instante satisfacen la condición y devuelven un booleano temporal. A continuación se dan ejemplos de las diversas generalizaciones de los operadores.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Comparación temporal
 SELECT tfloat '[2@2001-01-01, 2@2001-01-03)' #&lt; tfloat '[1@2001-01-01, 3@2001-01-03)';
 -- {[f@2001-01-01, f@2001-01-02], (t@2001-01-02, t@2001-01-03)}
@@ -302,19 +303,19 @@ SELECT tfloat '[1@2001-01-01, 3@2001-01-03)' #&lt; tfloat '[3@2001-01-03, 1@2001
 SELECT tint '[1@2001-01-01, 1@2001-01-03)' + tint '[2@2001-01-02, 2@2001-01-05)';
 -- [3@2001-01-02, 3@2001-01-03)
 -- Intersección temporal
-SELECT tintersects(tgeompoint '[Point(0 1)@2001-01-01, Point(3 1)@2001-01-04)',
+SELECT tIntersects(tgeompoint '[Point(0 1)@2001-01-01, Point(3 1)@2001-01-04)',
   geometry 'Polygon((1 0,1 2,2 2,2 0,1 0))');
 -- {[f@2001-01-01, t@2001-01-02, t@2001-01-03], (f@2001-01-03, f@2001-01-04]}
 -- Distancia temporal
 SELECT tgeompoint '[Point(0 0)@2001-01-01 08:00:00, Point(0 1)@2001-01-03 08:10:00)' &lt;-&gt;
-tgeompoint '[Point(0 0)@2001-01-02 08:05:00, Point(1 1)@2001-01-05 08:15:00)';
+  tgeompoint '[Point(0 0)@2001-01-02 08:05:00, Point(1 1)@2001-01-05 08:15:00)';
 -- [0.5@2001-01-02 08:05:00, 0.745184033794557@2001-01-03 08:10:00)
 </programlisting>
 
 		<para>
 			Otro requisito común es determinar si los operandos satisfacen <emphasis>alguna vez</emphasis> o <emphasis>siempre</emphasis> una condición con respecto a una operación. Estos se pueden obtener aplicando los operadores de comparación alguna vez o siempre. Estos operadores se indican anteponiendo los operadores de comparación tradicionales con, respectivamente, <varname>?</varname> (alguna vez) y <varname>%</varname> (siempre). A continuación se dan ejemplos de operadores de comparación alguna vez y siempre.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- ¿Se cruzan los operandos alguna vez?
 SELECT eIntersects(tgeompoint '[Point(0 1)@2001-01-01, Point(3 1)@2001-01-04)',
   geometry 'Polygon((1 0,1 2,2 2,2 0,1 0))') ?= true;
@@ -324,11 +325,11 @@ SELECT aIntersects(tgeompoint '[Point(0 1)@2001-01-01, Point(3 1)@2001-01-04)',
   geometry 'Polygon((0 0,0 2,4 2,4 0,0 0))') %= true;
 -- true
 -- ¿Es el operando izquierdo alguna vez menor que el derecho?
-SELECT (tfloat '[1@2001-01-01, 3@2001-01-03)' ?&lt;
+SELECT (tfloat '[1@2001-01-01, 3@2001-01-03)' #&lt;
   tfloat '[3@2001-01-01, 1@2001-01-03)') ?= true;
 -- true
 -- ¿Es el operando izquierdo siempre menor que el derecho?
-SELECT (tfloat '[1@2001-01-01, 3@2001-01-03)' %&lt;
+SELECT (tfloat '[1@2001-01-01, 3@2001-01-03)' #&lt;
   tfloat '[2@2001-01-01, 4@2001-01-03)') %= true;
 -- true
 </programlisting>
@@ -397,9 +398,10 @@ SELECT (tfloat '[1@2001-01-01, 3@2001-01-03)' %&lt;
 		<para>
 			Un valor de instante es un par de la forma <varname>v@t</varname>, donde <varname>v</varname> es un valor del tipo de base y <varname>t</varname> es un valor de <varname>timestamptz</varname>. Ejemplos de entrada de valores de instante son los siguientes:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool 'true@2001-01-01 08:00:00';
 SELECT tint '1@2001-01-01 08:00:00';
+SELECT tbigint '5@2001-01-01 08:00:00';
 SELECT tfloat '1.5@2001-01-01 08:00:00';
 SELECT ttext 'AAA@2001-01-01 08:00:00';
 SELECT tgeompoint 'Point(0 0)@2017-01-01 08:00:05';
@@ -411,10 +413,10 @@ SELECT tgeography 'Polygon((0 0,1 1,2 0,0 0))@2017-01-01 08:00:05';
 		<para>
 			Un valor de secuencia es un conjunto de valores <varname>v1@t1,...,vn@tn</varname> delimitado por límites superior e inferior, que pueden ser inclusivo (representados por ‘<varname>[</varname>’ y ‘<varname>]</varname>’) o exclusivos (representados por ‘<varname>(</varname>’ y ‘<varname>)</varname>’). Un valor de secuencia compuesto por una sola pareja <varname>v@t</varname> se denomina <emphasis>secuencia instantánea</emphasis>. Los valores de secuencia tienen una <emphasis>función de interpolación</emphasis> asociada que puede ser discreta, lineal o escalonada. Por definición, los límites inferior y superior de una secuencia instantánea o de un valor de secuencia con interpolación discreta son inclusivos. La extensión temporal de un valor de secuencia con interpolación discreta es un conjunto de marcas de tiempo. Ejemplos de valores de secuencia con interpolación discreta son los siguientes.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool '{true@2001-01-01 08:00:00, false@2001-01-03 08:00:00}';
 SELECT tint '{1@2001-01-01 08:00:00, 2@2001-01-03 08:00:00}';
-SELECT tint '{1@2001-01-01 08:00:00}'; -- Instantaneous sequence
+SELECT tbigint '{1@2001-01-01 08:00:00}'; -- Instantaneous sequence
 SELECT tfloat '{1.0@2001-01-01 08:00:00, 2.0@2001-01-03 08:00:00}';
 SELECT ttext '{AAA@2001-01-01 08:00:00, BBB@2001-01-03 08:00:00}';
 SELECT tgeompoint '{Point(0 0)@2017-01-01 08:00:00, Point(0 1)@2017-01-02 08:05:00}';
@@ -427,7 +429,7 @@ SELECT tgeography '{Point(0 0)@2017-01-01 08:00:00,
 		<para>
 			La extensión temporal de un valor de secuencia con interpolación lineal o escalonada es un período definido por el primer y el últimpo instante, así como por los límites inferior y superior. Ejemplos de valores de secuencia con interpolación lineal son los siguientes:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool '[true@2001-01-01 08:00:00, true@2001-01-03 08:00:00]';
 SELECT tint '[1@2001-01-01 08:00:00, 1@2001-01-03 08:00:00]';
 SELECT tfloat '[2.5@2001-01-01 08:00:00, 3@2001-01-03 08:00:00, 1@2001-01-04 08:00:00]';
@@ -444,7 +446,7 @@ SELECT tgeography '[Point(0 0)@2017-01-01 08:00:00,
 		<para>
 			Los valores de secuencia cuyo tipo base es continuo pueden especificar que la interpolación es escalonada con el prefijo <varname>Interp=Step</varname>. Si no se especifica, se supone que la interpolación es lineal por defecto. A continuación se dan ejemplos de valores de secuencia con interpolación escalonada:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat 'Interp=Step;[2.5@2001-01-01 08:00:00, 3@2001-01-01 08:10:00]';
 SELECT tgeompoint 'Interp=Step;[Point(0 0)@2017-01-01 08:00:00,
   Point(1 1)@2017-01-01 08:05:00, Point(1 1)@2017-01-01 08:10:00)';
@@ -460,7 +462,7 @@ SELECT tgeogpoint 'Interp=Step;
 		<para>
 			Un <emphasis>valor de conjunto de secuencias</emphasis> es un conjunto <varname>{v1,...,vn}</varname> donde cada <varname>vi</varname> es un valor de secuencia. La interpolación de los valores conjunto de secuencias solo puede ser lineal o escalonada, no discreta. Todas las secuencias que componen un valor de conjunto de secuencias deben tener la misma interpolación. La extensión temporal de un valor de conjunto de secuencias es un conjunto de períodos. Ejemplos de valores de conjunto de secuencias con interpolación lineal son los siguientes:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool '{[false@2001-01-01 08:00:00, false@2001-01-03 08:00:00),
   [true@2001-01-03 08:00:00], (false@2001-01-04 08:00:00, false@2001-01-06 08:00:00]}';
 SELECT tint '{[1@2001-01-01 08:00:00, 1@2001-01-03 08:00:00),
@@ -483,7 +485,7 @@ SELECT tgeography '{[Point(0 0)@2017-01-01 08:00:00,
 		<para>
 			Los valores de conjunto de secuencias cuyo tipo base es continuo pueden especificar que la interpolación es escalonada con el prefijo <varname>Interp=Step</varname>. Si no se especifica, se supone que la interpolación es lineal por defecto. A continuación se dan ejemplos de valores de conjunto de secuencias con interpolación escalonada:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat 'Interp=Step;{[1@2001-01-01 08:00:00, 2@2001-01-03 08:00:00,
   2@2001-01-04 08:00:00, 3@2001-01-06 08:00:00]}';
 SELECT tgeompoint 'Interp=Step;
@@ -497,20 +499,20 @@ SELECT tgeogpoint 'Interp=Step;
 		<para>
 			Para geometrías temporales, es posible especificar el identificador de referencia espacial (SRID) utilizando la representación extendida de texto conocido (EWKT) de la siguiente manera:
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint 'SRID=5435;[Point(0 0)@2001-01-01,Point(0 1)@2001-01-02]'
 SELECT tgeography 'SRID=7844;[Point(0 0)@2001-01-01,Linestring(1 0,0 1)@2001-01-02]';
 </programlisting>
 		<para>
 			Todas las geometrías componentes serán entonces del SRID dado. Además, cada geometría componente puede especificar su SRID con el formato EWKT como en el siguiente ejemplo
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[SRID=5435;Point(0 0)@2001-01-01,SRID=5435;Point(0 1)@2001-01-02]';
 </programlisting>
 		<para>
 			Se genera un error si las geometrías componentes no están todas en el mismo SRID o si el SRID de una geometría componente es diferente al del punto temporal.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint '[SRID=5435;Point(0 0)@2001-01-01,SRID=4326;Point(0 1)@2001-01-02]';
 -- ERROR: Geometry SRID (4326) does not match temporal type SRID (5435)
 SELECT tgeography 'SRID=7844;
@@ -520,7 +522,7 @@ SELECT tgeography 'SRID=7844;
 		<para>
 			Si no se especifica, el SRID predeterminado para los geometrías temporales es 0 (desconocido) y para los geografías temporales es 4326 (WGS 84). Los puntos temporales con interpolación escalonada también pueden especificar el SRID, como se muestra a continuación.
 		</para>
-		<programlisting language="sql" xml:space="preserve">
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tgeompoint 'SRID=5435,Interp=Step;[Point(0 0)@2001-01-01, Point(0 1)@2001-01-02]';
 SELECT tgeogpoint 'Interp=Step;
   [SRID=4326;Point(0 0)@2001-01-01, SRID=4326;Point(0 1)@2001-01-02]';
@@ -538,7 +540,7 @@ SELECT tgeogpoint 'Interp=Step;
 asText(ttype,maxdecimaldigits integer=15) → text
 </programlisting>
 				<para>El argumento <varname>maxdecimaldigits</varname> puede usarse para establecer el número máximo de decimales en la salida de los valores en punto flotante (por defecto 15).</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(tfloat '[10.55@2001-01-01, 25.55@2001-01-02]', 0);
 -- [11@2001-01-01, 26@2001-01-02]
 SELECT asText(tgeometry '[Point(1.55 1.55)@2001-01-01,
@@ -565,7 +567,7 @@ asMFJSON(ttype,options integer=0,flags integer=0,maxdecimaldigits integer=15) �
 					<listitem><para>2: JSON_C_TO_STRING_PRETTY</para></listitem>
 				</itemizedlist>
 				<para>El argumento <varname>maxdecimaldigits</varname> puede usarse para establecer el número máximo de decimales en la salida de los valores en punto flotante (por defecto 15).</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asMFJSON(tbool 't@2001-01-01 18:00:00', 1);
 /* {"type":"MovingBoolean","period":{"begin":"2001-01-01T18:00:00",
    "end":"2001-01-01T18:00:00","lowerInc":true,"upperInc":true},
@@ -600,7 +602,7 @@ asBinary(ttype,endian text='') → bytea
 asHexWKB(ttype,endian text='') → text
 </programlisting>
 				<para>El resultado se codifica utilizando la codificación little-endian (NDR) o big-endian (XDR). Si no se especifica ninguna codificación, se utiliza la codificación de la máquina.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asBinary(tbool 'true@2001-01-01');
 -- \x011a000101009c57d3c11c0000
 SELECT asBinary(tfloat '1.5@2001-01-01');
@@ -619,7 +621,7 @@ SELECT asHexWKB(ttext 'AAA@2001-01-01');
 ttypeFromMFJSON(bytea) → ttype
 </programlisting>
 				<para>Hay una función por tipo temporal, el nombre de esta función tiene como prefijo el nombre del tipo, que son <varname>tbool</varname> o <varname>tint</varname> en los ejemplos a continuación</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolFromMFJSON(text '{"type":"MovingBoolean",
   "period":{"begin":"2001-01-01T18:00:00+01", "end":"2001-01-01T18:00:00+01",
   "lowerInc":true,"upperInc":true}, "values":[true],
@@ -657,7 +659,7 @@ ttypeFromBinary(bytea) → ttype
 ttypeFromHexWKB(text) → ttype
 </programlisting>
 				<para>Hay una función por tipo temporal, el nombre de la función tiene como prefijo el nombre del tipo, que son <varname>tbool</varname> o <varname>tint</varname> en los ejemplos a continuación.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolFromBinary('\x011a000101009c57d3c11c0000');
 -- t@2001-01-01
 SELECT tintFromBinary('\x000023010000000100001cc1d3579c00');
@@ -698,7 +700,7 @@ ttype(base,tstzspan,interp text='linear') → ttypeContSeq
 ttype(base,tstzspanset,interp text='linear') → ttypeSeqSet
 </programlisting>
 				<para>Estos constructores tienen dos argumentos, un tipo base y un tipo de tiempo, donde el último es un valor de <varname>timestamptz</varname>, <varname>tstzset</varname>, <varname>tstzspan</varname> o <varname>tstzspanset</varname> para construir, respectivamente, un valor de subtipo instante, una secuencia con interpolación discreta, una secuencia con interpolación linear o escalonada o un conjunto de secuencias. Las funciones para valores de secuencia o de conjunto de secuencias con tipo de base continuo tienen además un tercer argumento opcional que indica si el valor temporal resultante tiene interpolación lineal o escalonada. Se asume por defecto una interpolación lineal si el argumento no se especifica.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tbool(true, timestamptz '2001-01-01');
 SELECT tint(1, timestamptz '2001-01-01');
 SELECT tfloat(1.5, tstzset '{2001-01-01, 2001-01-02}');
@@ -719,7 +721,7 @@ ttypeSeq(ttypeInst[],interp text={'step','linear'},lowerInc boolean=true,
   upperInc boolean=true) → ttypeSeq
 </programlisting>
 				<para>Estos constructores tienen un primer argumento obligatorio, que es una matriz de valores de los valores instantáneos correspondientes y argumentos opcionales adicionales. El segundo argumento establece la interpolación. Si no se proporciona el argumento, es por defecto escalonada para los tipos de base base discretos como los enteros y es lineal para tipos de base continuous como los flotantes. Se genera un error cuando se establece la interpolación lineal para valores temporales con tipos de base discretos. Para secuencias continuas, el tercero y el cuarto argumentos son valores booleanos que indican, respectivamente, si los límites izquierdo y derecho son inclusivos o exclusivos. Se supone que estos argumentos son verdaderos de forma predeterminada si no se especifican.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolSeq(ARRAY[tbool 'true@2001-01-01 08:00:00','false@2001-01-01 08:05:00'],
   'discrete');
 SELECT tintSeq(ARRAY[tint '1@2001-01-01 08:00:00', '2@2001-01-01 08:05:00']);
@@ -745,7 +747,7 @@ ttypeSeqSetGaps(ttypeInst[],maxt interval=NULL,maxdist float=NULL,
   interp text='linear') → ttypeSeqSet
 </programlisting>
 				<para>Un primer conjunto de constructores tiene un solo argumento, que es una matriz de valores de los valores de <emphasis>secuencia</emphasis> correspondientes. La interpolación del valor temporal resultante depende de la interpolación de las secuencias que lo componen. Se genera un error si las secuencias que componen la matriz tienen una interpolación diferente.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolSeqSet(ARRAY[tbool '[false@2001-01-01 08:00:00, false@2001-01-01 08:05:00)',
   '[true@2001-01-01 08:05:00]','(false@2001-01-01 08:05:00, false@2001-01-01 08:10:00)']);
 SELECT tintSeqSet(ARRAY[tint '[1@2001-01-01 08:00:00, 2@2001-01-01 08:05:00,
@@ -770,12 +772,12 @@ SELECT tfloatSeqSet(ARRAY[tfloat 'Interp=Step;
 </programlisting>
 				<para>Otro conjunto de constructores para valores de conjunto de secuencias tiene como primer argumento una matriz de valores de <emphasis>instante</emphasis> correspondientes, y dos argumentos que establecen un intervalo de tiempo máximo y una distancia máxima tal que se introduce un espacio entre secuencias del resultado siempre que dos instantes de entrada consecutivos tengan un intervalo de tiempo o una distancia mayor que estos valores. Para puntos temporales, la distancia se especifica en unidades del sistema de coordenadas. Estos dos argumentos de brechas son opcionales, pero al menos uno de ellos debe especificarse. Además, cuando el tipo base es continuo, un último argumento adicional establece si la interpolación es escalonada o lineal. Si no se especifica este argumento, se asume que es lineal por defecto.</para>
 				<para>Los parámetros de la función dependen del tipo temporal. Por ejemplo, el parámetro de interpolación no está permitido para tipos temporales con subtipos discretos como <varname>tint</varname>. De manera similar, el parámetro <varname>maxdist</varname> no está permitido para tipos escalares como <varname>ttext</varname> que no tienen una función de distancia estándar.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tintSeqSetGaps(ARRAY[tint '1@2001-01-01', '3@2001-01-02', '4@2001-01-03',
   '5@2001-01-05']);
 -- {[1@2001-01-01, 3@2001-01-02, 4@2001-01-03, 5@2001-01-05]}
-SELECT tintSeqSetGaps(ARRAY[tint '1@2001-01-01', '3@2001-01-02', '4@2001-01-03',
-  '5@2001-01-05'], '1 day', 1);
+  SELECT tbigintSeqSetGaps(ARRAY[tbigint '1@2001-01-01', '3@2001-01-02', '4@2001-01-03',
+    '5@2001-01-05'], '1 day', 1);
 -- {[1@2001-01-01], [3@2001-01-02, 4@2001-01-03], [5@2001-01-05]}
 SELECT ttextSeqSetGaps(ARRAY[ttext 'AA@2001-01-01', 'BB@2001-01-02', 'AA@2001-01-03',
   'CC@2001-01-05'], '1 day');
@@ -808,7 +810,7 @@ SELECT asText(tgeompointSeqSetGaps(ARRAY[tgeompoint 'Point(1 1)@2001-01-01',
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 ttype::tstzspan
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 2@2001-01-03]'::tstzspan;
 -- [2001-01-01, 2001-01-03]
 SELECT ttext '(A@2001-01-01, B@2001-01-03, C@2001-01-05]'::tstzspan;
@@ -829,7 +831,7 @@ SELECT tgeompoint '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03]'::tstzspan;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 memSize(ttype) → integer
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT memSize(tint '{1@2001-01-01, 2@2001-01-02, 3@2001-01-03}');
 -- 176
 </programlisting>
@@ -841,7 +843,7 @@ SELECT memSize(tint '{1@2001-01-01, 2@2001-01-02, 3@2001-01-03}');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tempSubtype(ttype) → {'Instant','Sequence','SequenceSet'}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tempSubtype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 -- Sequence
 </programlisting>
@@ -853,7 +855,7 @@ SELECT tempSubtype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tempBasetype(ttype) → text
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tempBasetype(tint '[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]');
 -- integer
 SELECT tempBasetype(tgeompoint 'Point(1 1)@2001-01-01');
@@ -867,7 +869,7 @@ SELECT tempBasetype(tgeompoint 'Point(1 1)@2001-01-01');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 interp(ttype) → {'None','Discrete','Step','Linear'}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT interp(tbool 'true@2001-01-01');
 -- None
 SELECT interp(tfloat '{1@2001-01-01, 2@2001-01-02, 3@2001-01-03}');
@@ -895,7 +897,7 @@ SELECT interp(tgeometry '[Point(1 1)@2001-01-01, Linestring(1 1,2 2)@2001-01-02,
 getValue(ttypeInst) → base
 getTimestamp(ttypeInst) → timestamptz
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValue(tint '1@2001-01-01');
 -- 1
 SELECT getTimestamp(tfloat '1@2001-01-01');
@@ -911,7 +913,7 @@ SELECT getTimestamp(tfloat '1@2001-01-01');
 getValues(ttype) → baseset
 getTime(ttype) → tstzspanset
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValues(tbool '[false@2001-01-01, true@2001-01-02, false@2001-01-03]');
 -- {f,t}
 SELECT getValues(tint '[1@2001-01-01, 3@2001-01-02, 1@2001-01-03]');
@@ -930,7 +932,7 @@ SELECT getValues(tfloat '{[1@2001-01-01, 2@2001-01-02, 1@2001-01-03],
   [3@2001-01-04, 3@2001-01-05]}');
 -- {[1, 2], [3, 3]}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getTime(ttext 'walking@2001-01-01');
 -- {[2001-01-01, 2001-01-01]}
 SELECT getTime(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}');
@@ -948,7 +950,7 @@ SELECT getTime(tfloat '{[1@2001-01-01, 1@2001-01-10), [12@2001-01-12, 12@2001-01
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 timeSpan(ttype) → tstzspan
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeSpan(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}');
 -- [2001-01-01, 2001-01-03]
 SELECT timeSpan(tint '[1@2001-01-01, 1@2001-01-15)');
@@ -967,7 +969,7 @@ endValue(ttype) → base
 valueN(ttype,int) → base
 </programlisting>
 				<para>La función no tiene en cuenta si los límites son inclusivos o no.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startValue(tfloat '(1@2001-01-01, 2@2001-01-03)');
 -- 1
 SELECT endValue(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01-05)}');
@@ -983,7 +985,7 @@ SELECT valueN(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01-05
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 valueAtTimestamp(ttype,timestamptz) → base
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueAtTimestamp(tfloat '[1@2001-01-01, 4@2001-01-04)', '2001-01-02');
 -- 2
 </programlisting>
@@ -996,7 +998,7 @@ SELECT valueAtTimestamp(tfloat '[1@2001-01-01, 4@2001-01-04)', '2001-01-02');
 duration(ttype,boundspan boolean=false) → interval
 </programlisting>
 				<para>Se puede poner en verdadero un parámetro adicional para calcular la duración del período limitador, ignorando así los posibles intervalos de tiempo</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT duration(tfloat '{1@2001-01-01, 2@2001-01-03, 2@2001-01-05}');
 -- 00:00:00
 SELECT duration(tfloat '{1@2001-01-01, 2@2001-01-03, 2@2001-01-05}', true);
@@ -1019,7 +1021,7 @@ SELECT duration(tfloat '{[1@2001-01-01, 2@2001-01-03), [2@2001-01-04, 2@2001-01-
 lowerInc(ttype) → boolean
 upperInc(ttype) → boolean
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT lowerInc(tint '[1@2001-01-01, 2@2001-01-02)');
 -- true
 SELECT upperInc(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-03)}');
@@ -1035,7 +1037,7 @@ SELECT upperInc(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 numInstants(ttype) → integer
 instants(ttype) → ttypeInst[]
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numInstants(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-03)}');
 -- 3
 SELECT instants(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-03)}');
@@ -1054,7 +1056,7 @@ endInstant(ttype) → ttypeInst
 instantN(ttype,integer) → ttypeInst
 </programlisting>
 				<para>Las funciones no tienen en cuenta si los límites son inclusivos o no.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startInstant(tfloat '{[1@2001-01-01, 2@2001-01-02),
   (2@2001-01-02, 3@2001-01-03)}');
 -- 1@2001-01-01
@@ -1073,7 +1075,7 @@ SELECT instantN(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 numTimestamps(ttype) → integer
 timestamps(ttype) → timestamptz[]
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numTimestamps(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
 -- 3
@@ -1093,7 +1095,7 @@ endTimestamp(ttype) → timestamptz
 timestampN(ttype,integer) → timestamptz
 </programlisting>
 				<para>Las funciones no tienen en cuenta si los límites son inclusivos o no.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startTimestamp(tfloat '[1@2001-01-01, 2@2001-01-03)');
 -- 2001-01-01
 SELECT endTimestamp(tfloat '{[1@2001-01-01, 2@2001-01-03),
@@ -1113,7 +1115,7 @@ SELECT timestampN(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-0
 numSequences({ttypeContSeq,ttypeSeqSet}) → integer
 sequences({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT numSequences(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
 -- 2
@@ -1132,7 +1134,7 @@ startSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq
 endSequence({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq
 sequenceN({ttypeContSeq,ttypeSeqSet},integer) → ttypeContSeq
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT startSequence(tfloat '{[1@2001-01-01, 2@2001-01-03),
   [3@2001-01-03, 5@2001-01-05)}');
 -- [1@2001-01-01, 2@2001-01-03)
@@ -1150,7 +1152,7 @@ SELECT sequenceN(tfloat '{[1@2001-01-01, 2@2001-01-03), [3@2001-01-03, 5@2001-01
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 segments({ttypeContSeq,ttypeSeqSet}) → ttypeContSeq[]
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT segments(tint '{[1@2001-01-01, 3@2001-01-02, 2@2001-01-03],
   (3@2001-01-03, 5@2001-01-05]}');
 /* {"[1@2001-01-01, 1@2001-01-02)","[3@2001-01-02, 3@2001-01-03)","[2@2001-01-03]",
@@ -1178,7 +1180,7 @@ ttypeInst(ttype) → ttypeInst
 ttypeSeq(ttype) → ttypeSeq
 ttypeSeqSet(ttype) → ttypeSeqSet
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tboolInst(tbool '{[true@2001-01-01]}');
 -- t@2001-01-01
 SELECT tboolInst(tbool '{[true@2001-01-01, true@2001-01-02]}');
@@ -1198,7 +1200,7 @@ SELECT tfloatSeqSet(tfloat '{2.5@2001-01-01, 1.5@2001-01-02, 3.5@2001-01-03}');
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 setInterp(ttype,interp) → ttype
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT setInterp(tbool 'true@2001-01-01','discrete');
 -- {t@2001-01-01}
 SELECT setInterp(tfloat '{[1@2001-01-01], [2@2001-01-02], [1@2001-01-03]}', 'discrete');
@@ -1223,12 +1225,37 @@ SELECT setInterp(tgeometry '[Point(1 1)@2001-01-01, Linestring(1 1,2 2)@2001-01-
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Desplaza y/o escalear el intervalo de tiempo de un valor temporal a uno o dos intervalos</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+segmentMinDuration(temp,interval,strict boolean=true) → tbool
+segmentMaxDuration(temp,interval,strict boolean=true) → tbool
+</programlisting>
+				<para>Cuando se escalea, si el rango de valores o el intervalo de tiempo del valor temporal es cero (por ejemplo, para un instante temporal), el resultado es el valor temporal. Igualmente, el ancho o intervalo dado debe ser estrictamente mayor que cero.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT segmentMinDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
+  -1@2001-01-06]', '1 day');
+-- {[t@2001-01-01, f@2001-01-03, t@2001-01-04, t@2001-01-06)}
+SELECT segmentMinDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
+  -1@2001-01-06]', '1 day', false);
+-- {[t@2001-01-01, t@2001-01-06)}
+SELECT segmentMaxDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
+  -1@2001-01-06]', '1 day');
+-- {[f@2001-01-01, f@2001-01-06)}
+SELECT segmentMaxDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
+  -1@2001-01-06]', '1 day', false);
+-- {[f@2001-01-01, t@2001-01-03, f@2001-01-04, f@2001-01-06)}
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="ttype_segmentMinDuration">
+				<indexterm significance="normal"><primary><varname>segmentMinDuration</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>segmentMaxDuration</varname></primary></indexterm>
+				<para>Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 shiftTime(ttype,interval) → ttype
 scaleTime(ttype,interval) → ttype
 shiftScaleTime(ttype,interval,interval) → ttype
 </programlisting>
-				<para>Cuando se escalea, si el rango de valores o el intervalo de tiempo del valor temporal es cero (por ejemplo, para un instante temporal), el resultado es el valor temporal. Igualmente, el ancho o intervalo dado debe ser estrictamente mayor que cero.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<para>Si el argumento <varname>strict</varname> no se especifica, se asume el valor <varname>true</varname> por defecto y, por lo tanto, la función verifica si la duración del segmento es estrictamente menor o mayor que el intervalo. Si el argumento es <varname>false</varname>, la función verifica si la duración del segmento es menor/mayor o <emphasis>igual</emphasis> que el intervalo.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftTime(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}', '1 day');
 -- {1@2001-01-02, 2@2001-01-04, 1@2001-01-06}
 SELECT shiftTime(tfloat '[1@2001-01-01, 2@2001-01-03]', '1 day');
@@ -1265,38 +1292,13 @@ SELECT asText(shiftScaleTime(tgeometry '{[Point(1 1)@2001-01-01,
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="ttype_segmentMinDuration">
-				<indexterm significance="normal"><primary><varname>segmentMinDuration</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>segmentMaxDuration</varname></primary></indexterm>
-				<para>Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-segmentMinDuration(temp,interval,strict boolean=true) → tbool
-segmentMaxDuration(temp,interval,strict boolean=true) → tbool
-</programlisting>
-				<para>Si el argumento <varname>strict</varname> no se especifica, se asume el valor <varname>true</varname> por defecto y, por lo tanto, la función verifica si la duración del segmento es estrictamente menor o mayor que el intervalo. Si el argumento es <varname>false</varname>, la función verifica si la duración del segmento es menor/mayor o <emphasis>igual</emphasis> que el intervalo.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT segmentMinDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
-  -1@2001-01-06]', '1 day');
--- {[t@2001-01-01, f@2001-01-03, t@2001-01-04, t@2001-01-06)}
-SELECT segmentMinDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
-  -1@2001-01-06]', '1 day', false);
--- {[t@2001-01-01, t@2001-01-06)}
-SELECT segmentMaxDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
-  -1@2001-01-06]', '1 day');
--- {[f@2001-01-01, f@2001-01-06)}
-SELECT segmentMaxDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
-  -1@2001-01-06]', '1 day', false);
--- {[f@2001-01-01, t@2001-01-03, f@2001-01-04, f@2001-01-06)}
-</programlisting>
-			</listitem>
-
 			<listitem xml:id="ttype_unnest">
 				<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
 				<para>Transforma un valor temporal no lineal en un conjunto de filas, cada una es una pareja compuesta de un valor de base y un conjunto de períodos durante el cual el valor temporal tiene el valor de base &SRF;</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 unnest(ttype) → {(value,time)}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT (un).value, (un).time
 FROM (SELECT unnest(tfloat '{1@2001-01-01, 2@2001-01-02, 1@2001-01-03}') AS un) t;
 -- 1 | {[2001-01-01, 2001-01-01], [2001-01-03, 2001-01-03]}

--- a/doc/es/temporal_types_p2.xml
+++ b/doc/es/temporal_types_p2.xml
@@ -85,12 +85,12 @@
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 insert(ttype,ttype,connect boolean=true) → ttype
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT insert(tint '{1@2001-01-01, 3@2001-01-03, 5@2001-01-05}',
   tint '{3@2001-01-03, 7@2001-01-07}');
 -- {1@2001-01-01, 3@2001-01-03, 5@2001-01-05, 7@2001-01-07}
-SELECT insert(tint '{1@2001-01-01, 3@2001-01-03, 5@2001-01-05}',
-  tint '{5@2001-01-03, 7@2001-01-07}');
+SELECT insert(tbigint '{1@2001-01-01, 3@2001-01-03, 5@2001-01-05}',
+  tbigint '{5@2001-01-03, 7@2001-01-07}');
 -- ERROR: The temporal values have different value at their overlapping instant 2001-01-03
 SELECT insert(tfloat '[1@2001-01-01, 2@2001-01-02]',
   tfloat '[1@2001-01-03, 1@2001-01-05]');
@@ -112,7 +112,7 @@ SELECT asText(insert(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 update(ttype,ttype,connect boolean=true) → ttype
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT update(tint '{1@2001-01-01, 3@2001-01-03, 5@2001-01-05}',
   tint '{5@2001-01-03, 7@2001-01-07}');
 -- {1@2001-01-01, 5@2001-01-03, 5@2001-01-05, 7@2001-01-07}
@@ -122,7 +122,7 @@ SELECT update(tfloat '[1@2001-01-01, 1@2001-01-05]',
 SELECT asText(update(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(3 3 3)@2001-01-03,
   Point(1 1 1)@2001-01-05], [Point(1 1 1)@2001-01-07]}',
   tgeompoint '[Point(2 2 2)@2001-01-02, Point(2 2 2)@2001-01-04]'));
-/*  {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 2 2)@2001-01-02, POINT Z (2 2 2)@2001-01-04,
+/* {[POINT Z (1 1 1)@2001-01-01, POINT Z (2 2 2)@2001-01-02, POINT Z (2 2 2)@2001-01-04,
    POINT Z (1 1 1)@2001-01-05], [POINT Z (1 1 1)@2001-01-07]} */
 SELECT asText(update( tgeometry '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03,
   Point(1 1)@2001-01-05]',
@@ -138,10 +138,10 @@ SELECT asText(update( tgeometry '[Point(1 1)@2001-01-01, Point(3 3)@2001-01-03,
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 deleteTime(ttype,time,connect boolean=true) → ttype
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT deleteTime(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-02', false);
 -- {[1@2001-01-01, 1@2001-01-02), (1@2001-01-02, 1@2001-01-03]}
-SELECT deleteTime(tint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-02');
+SELECT deleteTime(tbigint '[1@2001-01-01, 1@2001-01-03]', timestamptz '2001-01-04');
 -- [1@2001-01-01, 1@2001-01-03]
 SELECT deleteTime(tfloat '[1@2001-01-01, 4@2001-01-02, 2@2001-01-04, 5@2001-01-05]',
   tstzspan '[2001-01-02, 2001-01-04]');
@@ -164,10 +164,10 @@ appendInstantAgg(ttypeInst,interp text=NULL,maxdist float=NULL,
   maxt interval=NULL) → ttypeSeq
 </programlisting>
 				<para>La primera versión de la función devuelve el resultado de agregar el segundo argumento al primero. Si cualquiera de las entradas es NULL, se devuelve NULL. La función <varname>appendInstantAgg</varname> es una función de <emphasis>agregación</emphasis> que devuelve el resultado de agregar sucesivamente un conjunto de filas de valores temporales. Esto significa que funciona de la misma manera que las funciones <varname>SUM()</varname> y <varname>AVG()</varname> y, como la mayoría de los agregados, también ignora los valores NULL. Dos argumentos opcionales establecen una distancia máxima y un intervalo de tiempo máximo de modo que se introduce una brecha de tiempo cada vez que dos instantes consecutivos tienen una distancia o un intervalo de tiempo mayor que estos valores. Para puntos temporales, la distancia se especifica en unidades del sistema de coordenadas. Si uno de estos argumentos no se dan, no se tiene en cuenta para determinar las brechas. El nombre <varname>appendInstant</varname> designa la misma función de agregación y se mantiene por compatibilidad con versiones anteriores.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT appendInstant(tint '1@2001-01-01', tint '1@2001-01-02');
 -- [1@2001-01-01, 1@2001-01-02]
-SELECT appendInstant(tint '1@2001-01-01', tint '1@2001-01-02', 'discrete');
+SELECT appendInstant(tbigint '1@2001-01-01', tbigint '1@2001-01-02', 'discrete');
 -- {1@2001-01-01, 1@2001-01-02}
 SELECT appendInstant(tint '[1@2001-01-01]', tint '1@2001-01-02');
 -- [1@2001-01-01, 1@2001-01-02]
@@ -183,7 +183,7 @@ SELECT asText(appendInstant(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-
 /* {[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02], [LINESTRING(2 2,3 3)@2001-01-04, 
    POINT(3 3)@2001-01-05, LINESTRING(1 1,2 2)@2001-01-06]} */
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH temp(inst) AS (
   SELECT tfloat '1@2001-01-01' UNION SELECT tfloat '2@2001-01-02' UNION
   SELECT tfloat '3@2001-01-03' UNION SELECT tfloat '4@2001-01-04' UNION
@@ -207,7 +207,7 @@ SELECT asText(appendInstantAgg(inst ORDER BY inst)) FROM temp;
    POINT(4 4)@2001-01-04, POINT(5 5)@2001-01-05] */
 </programlisting>
 				<para>Observe que en la primera consulta con <varname>tfloat</varname>, las observaciones intermedias fueron eliminadas por el proceso de normalización ya que eran redundantes debido a la interpolación lineal. Este no es el caso de la segunda consulta con interpolación discreta o la tercera consulta con <varname>tgeogpoint</varname>, donde se utilizan coordenadas geodésicas.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH temp(inst) AS (
   SELECT tfloat '1@2001-01-01' UNION SELECT tfloat '2@2001-01-02' UNION
   SELECT tfloat '4@2001-01-04' UNION SELECT tfloat '5@2001-01-05' UNION
@@ -235,11 +235,11 @@ appendSequence(ttype,ttypeSeq) → {ttypeSeq,ttypeSeqSet}
 appendSequenceAgg(ttypeSeq) → {ttypeSeq,ttypeSeqSet}
 </programlisting>
 				<para>La primera versión de la función devuelve el resultado de agregar el segundo argumento al primero. Si cualquiera de las entradas es NULL, se devuelve NULL. La función <varname>appendSequenceAgg</varname> es una función de <emphasis>agregación</emphasis> que devuelve el resultado de agregar sucesivamente un conjunto de filas de valores temporales. Esto significa que funciona de la misma manera que las funciones <varname>SUM()</varname> y <varname>AVG()</varname> y, como la mayoría de los agregados, también ignora los valores NULL. El nombre <varname>appendSequence</varname> designa la misma función de agregación y se mantiene por compatibilidad con versiones anteriores.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT appendSequence(tint '1@2001-01-01', tint '{2@2001-01-02, 3@2001-01-03}');
 -- {1@2001-01-01, 2@2001-01-02, 3@2001-01-03}
-SELECT appendSequence(tint '[1@2001-01-01, 2@2001-01-02]',
-  tint '[2@2001-01-02, 3@2001-01-03]');
+SELECT appendSequence(tbigint '[1@2001-01-01, 2@2001-01-02]',
+  tbigint '[2@2001-01-02, 3@2001-01-03]');
 -- [1@2001-01-01, 2@2001-01-02, 3@2001-01-03]
 SELECT asText(appendSequence(tgeompoint '{[Point(1 1 1)@2001-01-01,
   Point(2 2 2)@2001-01-02], [Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}',
@@ -265,10 +265,11 @@ merge(ttype[]) → ttype
 mergeAgg(ttype) → ttype
 </programlisting>
 				<para>Los valores temporales solo pueden intersectar en su límite. En ese caso, para todos los tipos temporales excepto <varname>tgeometry</varname> y <varname>tgeography</varname>, sus valores de base en las marcas de tiempo comunes deben ser los mismos, de lo contrario se genera un error. Para los tipos <varname>tgeometry</varname> y <varname>tgeography</varname>, si el valor en sus marcas de tiempo comunes es diferente, el valor resultante después de la <varname>merge</varname> será la unión espacial de los valores. La razón de un comportamiento diferente para estos tipos es que son los únicos tipos temporales que no son tipos <emphasis>escalares</emphasis>, es decir, su valor en una marca de tiempo dada no es un único elemento del dominio del tipo base, sino más bien un subconjunto de su dominio. La función <varname>mergeAgg</varname> es una función de <emphasis>agregación</emphasis> que devuelve el resultado de agregar sucesivamente un conjunto de filas de valores temporales. Esto significa que funciona de la misma manera que las funciones <varname>SUM()</varname> y <varname>AVG()</varname> y, como la mayoría de los agregados, también ignora los valores NULL. El nombre <varname>merge</varname> designa la misma función de agregación y se mantiene por compatibilidad con versiones anteriores.</para>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT merge(tint '1@2001-01-01', tint '1@2001-01-02');
 -- {1@2001-01-01, 1@2001-01-02}
-SELECT merge(tint '[1@2001-01-01, 2@2001-01-02]', tint '[2@2001-01-02, 1@2001-01-03]');
+SELECT merge(tbigint '[1@2001-01-01, 2@2001-01-02]',
+  tbigint '[2@2001-01-02, 1@2001-01-03]');
 -- [1@2001-01-01, 2@2001-01-02, 1@2001-01-03]
 SELECT merge(tint '[1@2001-01-01, 2@2001-01-02]', tint '[3@2001-01-03, 1@2001-01-04]');
 -- {[1@2001-01-01, 2@2001-01-02], [3@2001-01-03, 1@2001-01-04]}
@@ -284,23 +285,25 @@ SELECT asText(merge(tgeometry 'Linestring(1 1,5 1)@2001-01-01',
   tgeometry '{Linestring(5 1,10 1)@2001-01-01, Point(3 3)@2001-01-02}'));
 -- {LINESTRING(1 1,5 1,10 1)@2001-01-01, POINT(3 3)@2001-01-02}  
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT merge(ARRAY[tint '1@2001-01-01', '1@2001-01-02']);
 -- {1@2001-01-01, 1@2001-01-02}
 SELECT merge(ARRAY[tint '{1@2001-01-01, 2@2001-01-02}', '{2@2001-01-02, 3@2001-01-03}']);
 -- {1@2001-01-01, 2@2001-01-02, 3@2001-01-03}
 SELECT merge(ARRAY[tint '{1@2001-01-01, 2@2001-01-02}', '{3@2001-01-03, 4@2001-01-04}']);
 -- {1@2001-01-01, 2@2001-01-02, 3@2001-01-03, 4@2001-01-04}
-SELECT merge(ARRAY[tint '[1@2001-01-01, 2@2001-01-02]', '[2@2001-01-02, 1@2001-01-03]']);
+SELECT merge(ARRAY[tbigint '[1@2001-01-01, 2@2001-01-02]',
+  '[2@2001-01-02, 1@2001-01-03]']);
 -- [1@2001-01-01, 2@2001-01-02, 1@2001-01-03]
-SELECT merge(ARRAY[tint '[1@2001-01-01, 2@2001-01-02]', '[3@2001-01-03, 4@2001-01-04]']);
+SELECT merge(ARRAY[tbigint '[1@2001-01-01, 2@2001-01-02]',
+  '[3@2001-01-03, 4@2001-01-04]']);
 -- {[1@2001-01-01, 2@2001-01-02], [3@2001-01-03, 4@2001-01-04]}
 SELECT asText(merge(ARRAY[tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02],
   [Point(3 3)@2001-01-03, Point(4 4)@2001-01-04]}', '{[Point(4 4)@2001-01-04,
   Point(3 3)@2001-01-05], [Point(6 6)@2001-01-06, Point(7 7)@2001-01-07]}']));
-/* {[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02], [Point(3 3)@2001-01-03,
-   Point(4 4)@2001-01-04, Point(3 3)@2001-01-05],
-   [Point(6 6)@2001-01-06, Point(7 7)@2001-01-07]} */
+/* {[POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02], [POINT(3 3)@2001-01-03,
+   POINT(4 4)@2001-01-04, POINT(3 3)@2001-01-05],
+   [POINT(6 6)@2001-01-06, POINT(7 7)@2001-01-07]} */
 SELECT asText(merge(ARRAY[tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02]}',
   '{[Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]}']));
 -- [POINT(1 1)@2001-01-01, POINT(2 2)@2001-01-02, POINT(1 1)@2001-01-03]
@@ -308,7 +311,7 @@ SELECT asText(merge(ARRAY[tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01
   '{[Linestring(2 2,1 1)@2001-01-02, Point(1 1)@2001-01-03]}']));
 -- {[POINT(1 1)@2001-01-01, LINESTRING(2 2,1 1)@2001-01-02, POINT(1 1)@2001-01-03]}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH temp(inst) AS (
 SELECT tfloat '1@2001-01-01' UNION SELECT tfloat '2@2001-01-02' UNION
 SELECT tfloat '3@2001-01-03' UNION SELECT tfloat '4@2001-01-04' UNION
@@ -344,7 +347,7 @@ minusSpan(tnumber,span) → tnumber
 atSpanset(tnumber,spanset) → tnumber
 minusSpanset(tnumber,spanset) → tnumber
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atValue(tint '[1@2001-01-01, 1@2001-01-15)', 1);
 -- [1@2001-01-01, 1@2001-01-15)
 SELECT atValues(tfloat '[1@2001-01-01, 4@2001-01-4)', floatset '{1, 3, 5}');
@@ -363,7 +366,7 @@ SELECT asText(atValue(tgeometry '[Point(0 0)@2001-01-01, Linestring(0 0,2 2)@200
   Linestring(0 0,2 2)@2001-01-03]', geometry 'Linestring(0 0,2 2)'));
 -- {[LINESTRING(0 0,2 2)@2001-01-02, LINESTRING(0 0,2 2)@2001-01-03]}
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minusValue(tint '[1@2001-01-01, 2@2001-01-02, 2@2001-01-03)', 1);
 -- {[2@2001-01-02, 2@2001-01-03)}
 SELECT minusValues(tfloat '[1@2001-01-01, 4@2001-01-4)', floatset '{2, 3}');
@@ -397,10 +400,10 @@ SELECT asText(minusValue(tgeometry '[Point(0 0)@2001-01-01,
 atTime(ttype,times) → ttype
 minusTime(ttype,times) → ttype
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atTime(tfloat '[1@2001-01-01, 5@2001-01-05)', timestamptz '2001-01-02');
 -- 2@2001-01-02
-SELECT atTime(tint '[1@2001-01-01, 1@2001-01-15)', tstzset '{2001-01-01, 2001-01-03}');
+SELECT atTime(tbigint '[1@2001-01-01, 1@2001-01-15)', tstzset '{2001-01-01, 2001-01-03}');
 -- {1@2001-01-01, 1@2001-01-03}
 SELECT atTime(tfloat '{[1@2001-01-01, 3@2001-01-03), [3@2001-01-04, 1@2001-01-06)}',
   tstzspan '[2001-01-02,2001-01-05)');
@@ -409,7 +412,7 @@ SELECT atTime(tint '[1@2001-01-01, 1@2001-01-15)',
   tstzspanset '{[2001-01-01, 2001-01-03), [2001-01-04, 2001-01-05)}');
 -- {[1@2001-01-01, 1@2001-01-03),[1@2001-01-04, 1@2001-01-05)}
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minusTime(tfloat '[1@2001-01-01, 5@2001-01-05)', timestamptz '2001-01-02');
 -- {[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 5@2001-01-05)}
 SELECT minusTime(tint '[1@2001-01-01, 1@2001-01-15)', tstzset '{2001-01-02, 2001-01-03}');
@@ -476,7 +479,7 @@ SELECT asText(afterTimestamp(tgeompoint '{[Point(1 1 1)@2001-01-01,
 			<para>Los operadores de comparación tradicionales (<varname>=</varname>, <varname>&lt;</varname>, etc.) requieren que los operandos izquierdo y derecho sean del mismo tipo base. Excepto la igualdad y la no igualdad, los otros operadores de comparación no son útiles en el mundo real pero permiten que los índices de árbol B se construyan sobre tipos temporales. Estos operadores comparan los períodos delimitadores (ver la <xref linkend="setspan_comparisons" />), después los cuadros delimitadores (ver la <xref linkend="box_comparisons" />) y si son iguales, entonces la comparación depende del subtipo. Para los valores de instante, primero comparan las marcas de tiempo y, si son iguales, comparan los valores. Para los valores de secuencia, comparan los primeros N instantes, donde N es el mínimo del número de instantes que componen ambos valores. Finalmente, para los valores de conjuntos de secuencias, comparan los primeros N valores de secuencia, donde N es el mínimo del número de secuencias que componen ambos valores.</para>
 
 			<para>Los operadores de igualdad y no igualdad consideran la representación equivalente para diferentes subtipos como se muestra a continuación.
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '1@2001-01-01' = tint '{1@2001-01-01}';
 -- true
 SELECT tfloat '1.5@2001-01-01' = tfloat '[1.5@2001-01-01]';
@@ -486,8 +489,8 @@ SELECT ttext 'AAA@2001-01-01' = ttext '{[AAA@2001-01-01]}';
 SELECT tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02}' =
   tgeompoint '{[Point(1 1)@2001-01-01], [Point(2 2)@2001-01-02]}';
 -- true
-SELECT tgeogpoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02]' =
-  tgeogpoint '{[Point(1 1 1)@2001-01-01], [Point(2 2 2)@2001-01-02]}';
+SELECT tgeography '[Point(1 1)@2001-01-01, Linestring(1 1,2 2)@2001-01-02]' =
+  tgeography '{[Point(1 1)@2001-01-01, Linestring(1 1,2 2)@2001-01-02]}';
 -- true
 </programlisting>
 			</para>
@@ -506,19 +509,21 @@ SELECT tgeogpoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02]' =
 ttype {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} ttype → boolean
 cmp(ttype,ttype) → int
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 1@2001-01-04)' = tint '[2@2001-01-03, 2@2001-01-05)';
 -- false
 SELECT tint '[1@2001-01-01, 1@2001-01-04)' &lt;&gt; tint '[2@2001-01-03, 2@2001-01-05)';
 -- true
 SELECT tint '[1@2001-01-01, 1@2001-01-04)' &lt; tint '[2@2001-01-03, 2@2001-01-05)';
 -- true
-SELECT tint '[1@2001-01-01, 1@2001-01-04)' &gt; tint '[2@2001-01-03, 2@2001-01-05)';
+SELECT ttfloat '[1@2001-01-01, 1@2001-01-04)' &gt; ttfloat '[2@2001-01-03, 2@2001-01-05)';
 -- false
-SELECT tint '[1@2001-01-01, 1@2001-01-04)' &lt;= tint '[2@2001-01-03, 2@2001-01-05)';
+SELECT tbigint '[1@2001-01-01, 1@2001-01-04)' &lt;= tbigint '[2@2001-01-03, 2@2001-01-05)';
 -- true
-SELECT tint '[1@2001-01-01, 1@2001-01-04)' &gt;= tint '[2@2001-01-03, 2@2001-01-05)';
+SELECT tbigint '[1@2001-01-01, 1@2001-01-04)' &gt;= tbigint '[2@2001-01-03, 2@2001-01-05)';
 -- false
+SELECT cmp(tfloat '[1@2001-01-01, 1@2001-01-04)', '[2@2001-01-03, 2@2001-01-05)');
+-- -1
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -548,7 +553,7 @@ SELECT tint '[1@2001-01-01, 1@2001-01-04)' &gt;= tint '[2@2001-01-03, 2@2001-01-
 {base,ttype} {%=, %&lt;&gt;, %&lt;, %&gt;, %&lt;=, %&gt;=} {base,ttype} → boolean
 </programlisting>
 					<para>Los operadores no tienen en cuenta si los límites son inclusivos o no.</para>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 3@2001-01-04]' ?= 2;
 -- false
 SELECT tgeometry '[Point(0 0)@2001-01-01,
@@ -560,7 +565,7 @@ SELECT tgeometry '[Linestring(0 0,1 1)@2001-01-01,
   Linestring(1 1,0 0)@2001-01-04)' %= geometry 'Linestring(0 0,1 1)';
 -- true
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat '[1@2001-01-01, 3@2001-01-04)' ?&lt;&gt; 2;
 -- true
 SELECT tgeompoint '[Point(1 1)@2001-01-01, Point(1 1)@2001-01-04)' ?&lt;&gt;
@@ -572,25 +577,25 @@ SELECT tgeogpoint '[Point(1 1)@2001-01-01, Point(1 1)@2001-01-04)' %&lt;&gt;
   geography 'Point(2 2)';
 -- true
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 4@2001-01-04]' ?&lt; 2;
 -- true
 SELECT tfloat '[1@2001-01-01, 4@2001-01-04)' %&lt; 2;
 -- false
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-03, 1@2001-01-05]' ?&gt; 0;
 -- true
 SELECT tfloat '[1@2001-01-03, 1@2001-01-05)' %&gt; 1;
 -- false
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tint '[1@2001-01-01, 1@2001-01-05]' ?&lt;= 2;
 -- true
 SELECT tfloat '[1@2001-01-01, 1@2001-01-05)' %&lt;= 4;
 -- true
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT ttext '{[AAA@2001-01-01, AAA@2001-01-03),
   [BBB@2001-01-04, BBB@2001-01-05)}' ?&gt; 'AAA'::text;
 -- true
@@ -618,7 +623,7 @@ SELECT ttext '{[AAA@2001-01-01, AAA@2001-01-03),
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {base,ttype} {#=, #&lt;&gt;, #&lt;, #&gt;, #&lt;=, #&gt;=} {base,ttype} → boolean
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat '[1@2001-01-01, 2@2001-01-04)' #= 3;
 -- {[f@2001-01-01, f@2001-01-04)}
 SELECT tfloat '[1@2001-01-01, 4@2001-01-04)' #= tfloat '[4@2001-01-02, 1@2001-01-05)';
@@ -630,7 +635,7 @@ SELECT tgeometry '[Point(0 0)@2001-01-01,
   Linestring(1 1,2 2)@2001-01-03]' #= geometry 'Linestring(2 2,1 1)';
 -- {[f@2001-01-01, t@2001-01-03]}
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat '[1@2001-01-01, 4@2001-01-04)' #&lt;&gt; 2;
 -- {[t@2001-01-01, f@2001-01-02], (t@2001-01-02, 2001-01-04)}
 SELECT tfloat '[1@2001-01-01, 4@2001-01-04)' #&lt;&gt; tfloat '[2@2001-01-02, 2@2001-01-05)';
@@ -639,7 +644,7 @@ SELECT tgeometry '[Point(0 0)@2001-01-01, Linestring(1 1,2 2)@2001-01-03]' #&lt;
   geometry 'Linestring(2 2,1 1)';
 -- {[t@2001-01-01, f@2001-01-03]}
 </programlisting>
-					<programlisting language="sql" xml:space="preserve">
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tfloat '[1@2001-01-01, 4@2001-01-04)' #&lt; 2;
 -- {[t@2001-01-01, f@2001-01-02, f@2001-01-04)}
 SELECT 1 #&gt; tint '[1@2001-01-03, 1@2001-01-05)';
@@ -664,7 +669,7 @@ SELECT 'AAA'::text #&gt; ttext '{[AAA@2001-01-01, AAA@2001-01-03),
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 mobilitydbVersion() → text
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT mobilitydbVersion();
 -- MobilityDB 1.3.0
 </programlisting>
@@ -676,7 +681,8 @@ SELECT mobilitydbVersion();
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 mobilitydbFullVersion() → text
 </programlisting>
-				<programlisting language="sql" xml:space="preserve">
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT mobilitydbFullVersion();
 /* MobilityDB 1.3.0, PostgreSQL 17.2, PostGIS 3.5.2, GEOS 3.12.0-CAPI-1.18.0, PROJ 9.2.0,
    JSON-C 0.13.1 */
 </programlisting>


### PR DESCRIPTION
Every example of the Spanish manual states the statements and the results of its English twin verbatim, so a reader of either manual runs the same query and reads the same answer. The annotations a listing carries stay in Spanish, since they are the translator's prose rather than something the server prints. The Spanish pose chapter states that a pose is planar or geodetic and shows the GeodPose examples, which only the English chapter carried.