### PR TITLE
Restrict to an extremum only where the base type carries an order

### DIFF
--- a/meos/src/temporal/temporal_restrict_meos.c
+++ b/meos/src/temporal/temporal_restrict_meos.c
@@ -331,6 +331,8 @@ temporal_at_min(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
+  if (! ensure_torder_type(temp->temptype))
+    return NULL;
   return temporal_restrict_minmax(temp, GET_MIN, REST_AT);
 }
 
@@ -346,6 +348,8 @@ temporal_minus_min(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
+  if (! ensure_torder_type(temp->temptype))
+    return NULL;
   return temporal_restrict_minmax(temp, GET_MIN, REST_MINUS);
 }
 
@@ -360,6 +364,8 @@ temporal_at_max(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
+  if (! ensure_torder_type(temp->temptype))
+    return NULL;
   return temporal_restrict_minmax(temp, GET_MAX, REST_AT);
 }
 
@@ -375,6 +381,8 @@ temporal_minus_max(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(temp, NULL);
+  if (! ensure_torder_type(temp->temptype))
+    return NULL;
   return temporal_restrict_minmax(temp, GET_MAX, REST_MINUS);
 }
 

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -224,6 +224,46 @@ int main(void)
   printf("tlt_temporal_temporal(tint, tint): answered, errno %d\n",
     meos_errno());
   free(ordered);
+
+  /* Restricting a temporal value to where it takes its minimum or its maximum
+   * reads the same order, so it admits the same types. A geometry and a pose
+   * carry a B-tree order for indexing and no order to take an extremum over,
+   * and the four entries decline them */
+  meos_errno_reset();
+  assert(temporal_at_min(tpt1) == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_TYPE);
+  meos_errno_reset();
+  assert(temporal_at_max(tpt1) == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_TYPE);
+  meos_errno_reset();
+  assert(temporal_minus_min(tpt1) == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_TYPE);
+  meos_errno_reset();
+  assert(temporal_minus_max(tpt1) == NULL);
+  printf("temporal_at_min/at_max/minus_min/minus_max(tgeompoint): declined, "
+    "errno %d\n", meos_errno());
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_TYPE);
+
+  /* A temporal pose declines them for the same reason, and a pose is the value
+   * a temporal rigid geometry carries */
+  meos_errno_reset();
+  Temporal *tps = tpose_in("[Pose(Point(0 0),0)@2000-01-01, "
+    "Pose(Point(2 2),0.5)@2000-01-02]");
+  assert(tps != NULL && meos_errno() == 0);
+  assert(temporal_minus_max(tps) == NULL);
+  printf("temporal_minus_max(tpose): declined, errno %d\n", meos_errno());
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_TYPE);
+  free(tps);
+
+  /* The same restriction over a temporal integer answers, so the declines
+   * above discriminate */
+  meos_errno_reset();
+  Temporal *extremum = temporal_at_max(num);
+  assert(extremum != NULL);
+  assert(meos_errno() == 0);
+  printf("temporal_at_max(tint): answered, errno %d\n", meos_errno());
+  free(extremum);
+
   free(tpt1); free(tpt2);
 
   meos_errno_reset();


### PR DESCRIPTION
Restricting a temporal value to where it takes its minimum or its maximum reads an order over its base values, and the four entries take any temporal type at all. A geometry and a pose carry a B-tree order so that they can be indexed, which is not a meaning to take an extremum over, so the four answer a value for a question the type does not have.

## The catalog already states which types carry one

`torder_type()` holds exactly the temporal integer, big integer, float and text — `T_TRGEOMETRY` and `T_TPOSE` appear 0 times in its body against a `T_TTEXT` control of 1. SQL agrees: `atMin`, `atMax`, `minusMin` and `minusMax` are declared for those same four types and nothing else, 16 `CREATE FUNCTION` lines in `022_temporal.in.sql` against 8202 across `mobilitydb/sql`.

The guard is already written and already used: `ensure_torder_type` (`meos_catalog.c`, declared in `meos_catalog.h`) is called at four sites in `temporal_compops.c` for the ordered comparisons, and at **0** sites in `temporal_restrict_meos.c` (control: 15 `VALIDATE_NOT_NULL` in that file). This change has the four entries read it.

## What moves

The SQL surface never exposes these operations for another type, so no expected output moves.

A MEOS C program and a language binding reach the entries directly, and there a call that answers today declines with `MEOS_ERR_INVALID_ARG_TYPE`. That is the behaviour change this carries, and it is the same reading already applied to `atMin(tjsonb)`: a total order existing in C does not license exposing order-based semantics for a type whose order is an indexing artifact.

## The witness fails without the fix

`meos/test/error_test.c` already holds this reasoning for the ordered *comparison* — `tlt_temporal_temporal` on a temporal geometry point, with the note that a geometry has a B-tree order so that it can be indexed, which is not a meaning to compare over time. The restriction joins it: the four entries over a temporal geometry point, one over a temporal pose — the value a temporal rigid geometry carries — and the temporal integer that still answers, so the declines discriminate.

Compiled against two staged prefixes from the same source, the unpatched one **aborts (134)** at the first new assertion and the patched one exits **0**:

```
temporal_at_min/at_max/minus_min/minus_max(tgeompoint): declined, errno 11
temporal_minus_max(tpose): declined, errno 11
temporal_at_max(tint): answered, errno 0
```
