### PR TITLE
Ask the circular buffer position operators for the operands they take

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -998,18 +998,19 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 {tstzspan,stbox,tcbuffer} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tcbuffer} → boolean
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt; cbuffer 'Cbuffer(Point(1 1), 0.2)';
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
+  Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt;
+  stbox(cbuffer 'Cbuffer(Point(1 1), 0.2)');
 -- false
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt;| stbox(cbuffer 'Cbuffer(Point(1 1), 0.5)');
 -- false
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.5)@2001-01-02]' &amp;&gt; cbuffer 'Cbuffer(Point(1 1), 0.3)'::geometry;
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-03,
+  Cbuffer(Point(1 1), 0.5)@2001-01-05]' #&amp;&gt; tstzspan '[2001-01-01,2001-01-03]';
 -- true
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.5)@2001-01-02]' &gt;&gt;#
-  tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-03, Cbuffer(Point(1 1), 0.5)@2001-01-05]';
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-03,
+  Cbuffer(Point(1 1), 0.5)@2001-01-05]' #&gt;&gt;
+  tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, Cbuffer(Point(1 1), 0.5)@2001-01-02]';
 -- true
 </programlisting>
 			</listitem>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -1000,18 +1000,19 @@ SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
 {tstzspan,stbox,tcbuffer} {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} {tstzspan,stbox,tcbuffer} → boolean
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt; cbuffer 'Cbuffer(Point(1 1), 0.2)';
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
+  Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt;
+  stbox(cbuffer 'Cbuffer(Point(1 1), 0.2)');
 -- false
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-02]' &lt;&lt;| stbox(cbuffer 'Cbuffer(Point(1 1), 0.5)');
 -- false
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.5)@2001-01-02]' &amp;&gt; cbuffer 'Cbuffer(Point(1 1), 0.3)'::geometry;
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-03,
+  Cbuffer(Point(1 1), 0.5)@2001-01-05]' #&amp;&gt; tstzspan '[2001-01-01,2001-01-03]';
 -- true
-SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, 
-  Cbuffer(Point(1 1), 0.5)@2001-01-02]' &gt;&gt;#
-  tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-03, Cbuffer(Point(1 1), 0.5)@2001-01-05]';
+SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-03,
+  Cbuffer(Point(1 1), 0.5)@2001-01-05]' #&gt;&gt;
+  tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01, Cbuffer(Point(1 1), 0.5)@2001-01-02]';
 -- true
 </programlisting>
 			</listitem>


### PR DESCRIPTION
The position operator entry states that the operands are an stbox or a tcbuffer for the four spatial pairs, and a tstzspan, an stbox or a tcbuffer for the four temporal ones. Its examples ask for those operands and name the operator the family declares, so each of the four runs and states what the server answers, following the network point entry that documents the same operators.