### PR TITLE
State the distances the circular buffer entry measures

### DIFF
--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -1092,14 +1092,14 @@ SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt; cbuffer 'Cbuffer(Point(1 1), 0.2)';
--- [2.34988300875063@2001-01-02, 2.34988300875063@2001-01-03]
+-- [0@2001-01-01, 0@2001-01-03]
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt; geometry 'Point(50 50)';
--- [25.0496666945044@2001-01-01, 26.4085688426232@2001-01-03]
+-- [68.99646455628167@2001-01-01, 68.79646455628166@2001-01-03]
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt;
   tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-02, Cbuffer(Point(1 1), 0.5)@2001-01-04]';
--- [2.34988300875063@2001-01-02, 2.34988300875063@2001-01-03]
+-- [0@2001-01-02, 0@2001-01-03]
 </programlisting>
 			</listitem>
 			<listitem xml:id="tcbuffer_minDistance">

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -1094,14 +1094,14 @@ SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt; cbuffer 'Cbuffer(Point(1 1), 0.2)';
--- [2.34988300875063@2001-01-02, 2.34988300875063@2001-01-03]
+-- [0@2001-01-01, 0@2001-01-03]
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt; geometry 'Point(50 50)';
--- [25.0496666945044@2001-01-01, 26.4085688426232@2001-01-03]
+-- [68.99646455628167@2001-01-01, 68.79646455628166@2001-01-03]
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,
   Cbuffer(Point(1 1), 0.5)@2001-01-03]' &lt;-&gt;
   tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-02, Cbuffer(Point(1 1), 0.5)@2001-01-04]';
--- [2.34988300875063@2001-01-02, 2.34988300875063@2001-01-03]
+-- [0@2001-01-02, 0@2001-01-03]
 </programlisting>
 			</listitem>
 


### PR DESCRIPTION
The three distance examples state what the server answers for a circular buffer, in both manuals. Two buffers about the same centre overlap, so their distance is zero, and a buffer about (1 1) reaches Point(50 50) at 68.996464 and 68.796464, the distance between the centres less the radius the buffer carries at each end.