### PR TITLE
Keep the reference geometry through the two-operand modifications

### DIFF
--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -489,6 +489,8 @@ extern void *temporal_bbox_ptr(const Temporal *temp);
 extern Temporal *temporal_strip_geom(const Temporal *temp,
   const GSERIALIZED **geom);
 extern Temporal *temporal_attach_geom(const GSERIALIZED *geom, Temporal *temp);
+extern bool temporal_geom_combinable(const GSERIALIZED *geom1,
+  const GSERIALIZED *geom2);
 
 extern bool intersection_temporal_temporal(const Temporal *temp1,
 const Temporal *temp2, SyncMode mode, Temporal **inter1, Temporal **inter2);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -74,6 +74,7 @@
 #if RGEO
   #include <meos_rgeo.h>
   #include "rgeo/trgeo.h"
+  #include "rgeo/trgeo_utils.h"
 #endif
 
 /*****************************************************************************
@@ -641,6 +642,26 @@ temporal_strip_geom(const Temporal *temp, const GSERIALIZED **geom)
   }
 #endif /* RGEO */
   return (Temporal *) temp;
+}
+
+/**
+ * @brief Return whether two temporal values carry a reference geometry that
+ * allows them to be combined into one
+ * @details Two values carrying a reference geometry combine into one only
+ * where the body is the same, since the result carries a single one. A value
+ * carrying none imposes nothing.
+ * @param[in] geom1,geom2 Reference geometries, NULL where a value carries none
+ */
+bool
+temporal_geom_combinable(const GSERIALIZED *geom1, const GSERIALIZED *geom2)
+{
+  if (! geom1 || ! geom2)
+    return true;
+#if RGEO
+  return ensure_same_geom(geom1, geom2);
+#else
+  return true;
+#endif /* RGEO */
 }
 
 /**

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -1528,9 +1528,19 @@ temporal_insert(const Temporal *temp1, const Temporal *temp2, bool connect)
       ! ensure_spatial_validity(temp1, temp2))
     return NULL;
 
+  const GSERIALIZED *geom1, *geom2;
+  Temporal *work1 = temporal_strip_geom(temp1, &geom1);
+  Temporal *work2 = temporal_strip_geom(temp2, &geom2);
+  if (! work1 || ! work2 || ! temporal_geom_combinable(geom1, geom2))
+  {
+    if (work1 != temp1) pfree(work1);
+    if (work2 != temp2) pfree(work2);
+    return NULL;
+  }
+
   /* Convert to the same subtype */
   Temporal *new1, *new2;
-  temporal_convert_same_subtype(temp1, temp2, &new1, &new2);
+  temporal_convert_same_subtype(work1, work2, &new1, &new2);
 
   Temporal *result;
   assert(temptype_subtype(new1->subtype));
@@ -1550,11 +1560,15 @@ temporal_insert(const Temporal *temp1, const Temporal *temp2, bool connect)
         (Temporal *) tsequenceset_insert((TSequenceSet *) new1,
           (TSequenceSet *) new2);
   }
-  if (temp1 != new1)
+  if (work1 != new1)
     pfree(new1);
-  if (temp2 != new2)
+  if (work2 != new2)
     pfree(new2);
-  return result;
+  if (work1 != temp1)
+    pfree(work1);
+  if (work2 != temp2)
+    pfree(work2);
+  return temporal_attach_geom(geom1, result);
 }
 
 /**
@@ -2276,6 +2290,17 @@ temporal_append_tinstant(Temporal *temp, const TInstant *inst,
   /* The test to ensure the increasing timestamps must be done in the
    * subtype function since the inclusive/exclusive bounds must be
    * taken into account for temporal sequences and sequence sets */
+
+#if RGEO
+  /* A temporal rigid geometry carries a reference geometry that a value
+   * rebuilt from instants does not reproduce. It appends as the poses it is
+   * made of and takes its body back afterwards, which the rigid geometry
+   * entry does; unlike the operations that read their argument, this one
+   * consumes it in expandable mode, so the entry owns that contract */
+  if (temp->temptype == T_TRGEOMETRY)
+    return trgeometry_append_tinstant(temp, inst, interp, maxdist, maxt,
+      expand);
+#endif /* RGEO */
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -597,18 +597,29 @@ temporal_restrict_tstzspanset(const Temporal *temp, const SpanSet *ss,
   bool atfunc)
 {
   assert(temp); assert(ss);
-  assert(temptype_subtype(temp->subtype));
-  switch (temp->subtype)
+  const GSERIALIZED *geom;
+  Temporal *work = temporal_strip_geom(temp, &geom);
+  if (! work)
+    return NULL;
+
+  Temporal *result;
+  assert(temptype_subtype(work->subtype));
+  switch (work->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tinstant_restrict_tstzspanset(
-        (TInstant *) temp, ss, atfunc);
+      result = (Temporal *) tinstant_restrict_tstzspanset(
+        (TInstant *) work, ss, atfunc);
+      break;
     case TSEQUENCE:
-      return tsequence_restrict_tstzspanset((TSequence *) temp, ss, atfunc);
+      result = tsequence_restrict_tstzspanset((TSequence *) work, ss, atfunc);
+      break;
     default: /* TSEQUENCESET */
-      return (Temporal *) tsequenceset_restrict_tstzspanset(
-        (TSequenceSet *) temp, ss, atfunc);
+      result = (Temporal *) tsequenceset_restrict_tstzspanset(
+        (TSequenceSet *) work, ss, atfunc);
   }
+  if (work != temp)
+    pfree(work);
+  return temporal_attach_geom(geom, result);
 }
 
 /*****************************************************************************/

--- a/meos/test/trgeo_test.c
+++ b/meos/test/trgeo_test.c
@@ -426,6 +426,71 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* Inserting one temporal rigid geometry into another, and updating one with
+   * another, answer a rigid geometry carrying the body the two share. Two
+   * values carrying DIFFERENT bodies combine into nothing, since the result
+   * carries a single one */
+  {
+    const char *body = "POLYGON((0 0,1 0,1 1,0 1,0 0))";
+    Temporal *i1 = trgeometry_in("Polygon((0 0,1 0,1 1,0 1,0 0));"
+      "[Pose(Point(0 0), 0.0)@2001-01-01, Pose(Point(5 0), 0.0)@2001-01-02]");
+    Temporal *i2 = trgeometry_in("Polygon((0 0,1 0,1 1,0 1,0 0));"
+      "[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]");
+    Temporal *i3 = trgeometry_in("Polygon((0 0,2 0,2 2,0 2,0 0));"
+      "[Pose(Point(0 0), 0.0)@2001-01-04, Pose(Point(5 0), 0.0)@2001-01-05]");
+    if (! i1 || ! i2 || ! i3)
+    {
+      printf("FAILED: the rigid geometries to insert did not parse\n");
+      result = 1;
+    }
+    else
+    {
+      meos_errno_reset();
+      Temporal *ins = temporal_insert(i1, i2, true);
+      GSERIALIZED *igeo = ins ? trgeometry_geom(ins) : NULL;
+      char *iwkt = igeo ? geo_as_text(igeo, 6) : NULL;
+      if (! iwkt || strcmp(iwkt, body) != 0)
+      {
+        printf("FAILED: inserting a rigid geometry answers body %s, wanted "
+          "%s\n", iwkt ? iwkt : "none", body);
+        result = 1;
+      }
+      else
+        printf("OK: inserting a rigid geometry keeps the body\n");
+      free(iwkt); free(igeo); free(ins);
+
+      meos_errno_reset();
+      Temporal *upd = temporal_update(i1, i2, true);
+      GSERIALIZED *ugeo = upd ? trgeometry_geom(upd) : NULL;
+      char *uwkt = ugeo ? geo_as_text(ugeo, 6) : NULL;
+      if (! uwkt || strcmp(uwkt, body) != 0)
+      {
+        printf("FAILED: updating a rigid geometry answers body %s, wanted "
+          "%s\n", uwkt ? uwkt : "none", body);
+        result = 1;
+      }
+      else
+        printf("OK: updating a rigid geometry keeps the body\n");
+      free(uwkt); free(ugeo); free(upd);
+
+      /* Two different bodies do not combine, and say so rather than answering
+       * a value that carries neither */
+      meos_errno_reset();
+      Temporal *bad = temporal_insert(i1, i3, true);
+      if (bad)
+      {
+        printf("FAILED: inserting a rigid geometry of another body answered "
+          "a value\n");
+        result = 1;
+        free(bad);
+      }
+      else
+        printf("OK: two rigid geometries of different bodies do not insert\n");
+    }
+    free(i1); free(i2); free(i3);
+    meos_errno_reset();
+  }
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
Inserting one temporal value into another, updating one with another and appending an instant to one all rebuild the value from its instants, so a temporal rigid geometry loses the reference geometry appended to it:

```
CONTROL   insert, disjoint, same body    answers, BODY LOST
          insert, disjoint, other body   answers, BODY LOST
          update, disjoint, same body    answers, BODY LOST
FIXED     insert, disjoint, same body    answers, body KEPT
          insert, disjoint, other body   NULL, errno 12
          update, disjoint, same body    answers, body KEPT
```

The middle row is a second defect the first one hides: two values carrying **different** bodies combine into a value carrying neither, rather than reporting that they do not combine.

## What the fix is

The insert and the restriction to a period set read their argument through `temporal_strip_geom` / `temporal_attach_geom`, so neither names a type. Two operands carrying a body combine only where the body is the same, which `temporal_geom_combinable` answers beside them; a value carrying none imposes nothing. Updating is the restriction plus the insert, so it inherits from the two.

Appending takes the entry the rigid geometry family owns. Unlike the operations that read their argument, appending **consumes** it in expandable mode, and `trgeometry_append_tinstant` already holds that contract: it appends the poses, takes the body back, and frees both stripped values where the append reports nothing. Re-deriving those semantics in a generic wrapper would be the riskier half of this change for no gain.

## The witness fails without the fix

`meos/test/trgeo_test.c` covers the three operations, the body two operands share, and the two bodies that do not combine. Compiled against two staged prefixes from the same source, the unpatched one exits **1** with three failures and the patched one exits **0**:

```
FAILED: inserting a rigid geometry answers body none, wanted POLYGON((0 0,1 0,1 1,0 1,0 0))
FAILED: updating a rigid geometry answers body none, wanted POLYGON((0 0,1 0,1 1,0 1,0 0))
FAILED: inserting a rigid geometry of another body answered a value
```

## Scope

This completes the class the audit of the generic entries opened: every generic `temporal_*` that rebuilds a value from its instants keeps the reference geometry, or reports why it cannot.
