### PR TITLE
Dispatch the segment operations on the base type

### DIFF
--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -154,7 +154,7 @@ datum_collinear(Datum value1, Datum value2, Datum value3, MeosType basetype,
     return npoint_collinear(DatumGetNpointP(value1), DatumGetNpointP(value2),
       DatumGetNpointP(value3), ratio);
 #endif
-#if POSE || RGEO
+#if POSE
   if (basetype == T_POSE)
     return pose_collinear(DatumGetPoseP(value1), DatumGetPoseP(value2),
       DatumGetPoseP(value3), ratio);
@@ -231,7 +231,7 @@ datumsegm_locate(Datum value1, Datum value2, Datum value, MeosType basetype)
     return npointsegm_locate(DatumGetNpointP(value1), DatumGetNpointP(value2),
       DatumGetNpointP(value));
 #endif
-#if POSE || RGEO
+#if POSE
   if (basetype == T_POSE)
     return posesegm_locate(DatumGetPoseP(value1), DatumGetPoseP(value2),
       DatumGetPoseP(value));
@@ -311,8 +311,10 @@ datumsegm_interpolate(Datum start, Datum end, MeosType temptype,
     return PointerGetDatum(posechainsegm_interpolate(
       DatumGetPoseChainP(start), DatumGetPoseChainP(end), ratio));
 #endif
-#if POSE || RGEO
-  else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
+#if POSE
+  /* Interpolating a segment is an operation of the base type, so every
+   * temporal type over the pose reaches it, the rigid geometry among them */
+  else if (temptype_basetype(temptype) == T_POSE)
     return PointerGetDatum(posesegm_interpolate(DatumGetPoseP(start),
       DatumGetPoseP(end), (double) ratio));
 #endif
@@ -2742,8 +2744,10 @@ tsegment_intersection(Datum start1, Datum end1, Datum start2, Datum end2,
     result = tnpointsegm_intersection(start1, end1, start2, end2, lower,
       upper, t1, t2);
 #endif
-#if POSE || RGEO
-  else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
+#if POSE
+  /* Intersecting two segments is an operation of the base type, so every
+   * temporal type over the pose reaches it, the rigid geometry among them */
+  else if (temptype_basetype(temptype) == T_POSE)
     result = tposesegm_intersection(start1, end1, start2, end2, lower,
       upper, t1, t2);
 #endif


### PR DESCRIPTION
Interpolating a segment and intersecting two of them are operations of the **base type**, and two chains in `tsequence.c` select them by temporal type instead. Each temporal type over one base value therefore has to be named again:

```c
#if POSE || RGEO
  else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
    return PointerGetDatum(posesegm_interpolate(DatumGetPoseP(start), …));
#endif
```

The catalog already records that both are the same base value — `meos_catalog.c` gives `T_TPOSE` and `T_TRGEOMETRY` alike `.temptype_basetype = T_POSE` — and the call itself says so, reaching `posesegm_interpolate` through `DatumGetPoseP`.

## The file already does this, twenty lines above

`pose_collinear` and `posesegm_locate`, in the same file, dispatch on `basetype == T_POSE`. The two chains are the outliers, not the new shape, and this change has them read the base type as their neighbours do.

A temporal type added over the pose reaches both without either chain being touched.

## The guard follows

`RGEO` is `CMAKE_DEPENDENT_OPTION(RGEO … ON "POSE" OFF)`, so rigid geometries are configured only where poses are and `#if POSE` alone selects the block. All four `#if POSE || RGEO` in the file narrow, and `T_TRGEOMETRY` goes from 1 occurrence to **0**.

## What moves

Nothing. `temptype_basetype(T_TRGEOMETRY)` and `temptype_basetype(T_TPOSE)` are both `T_POSE`, so each chain selects the same arm for the same input, and the narrowed guard admits the same set of builds. No expected output moves.
