### PR TITLE
Name the H3 planar point cast after the type it casts to

### DIFF
--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2840,7 +2840,7 @@
 					<para><link linkend="th3_tgeompoint_to_th3"><varname>th3index</varname></link>: Return the temporal H3 cell at the given resolution that contains each point in a temporal geodetic or planar point (SRID must be 4326 for the <varname>tgeompoint</varname> overload)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_cell_to_latlng"><varname>cellToPoint</varname>, <varname>th3CellToLatlngTgeompoint</varname></link>: Return the temporal geodetic centroid of each cell in a trajectory</para>
+					<para><link linkend="th3_h3_cell_to_latlng"><varname>cellToPoint</varname>, <varname>tgeompoint</varname></link>: Return the temporal geodetic centroid of each cell in a trajectory</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_cell_to_boundary"><varname>cellToBoundary</varname></link>: Return the temporal polygon boundary of each cell in a trajectory, as a temporal geography</para>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -354,17 +354,17 @@ SELECT getResolution(th3index(
 
 			<listitem xml:id="th3_h3_cell_to_latlng">
 				<indexterm significance="normal"><primary><varname>cellToPoint</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>th3CellToLatlngTgeompoint</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tgeompoint</varname></primary></indexterm>
 				<para>Return the temporal geodetic centroid of each cell in a trajectory</para>
 				<programlisting xml:space="preserve" format="linespecific">
 cellToPoint(th3index) → tgeogpoint
-th3CellToLatlngTgeompoint(th3index) → tgeompoint
+tgeompoint(th3index) → tgeompoint
 </programlisting>
-				<para>A planar (SRID 4326) overload is available under the name <varname>th3CellToLatlngTgeompoint</varname>.</para>
+				<para>A planar (SRID 4326) overload is available under the name <varname>tgeompoint</varname>.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asText(cellToPoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
-SELECT asText(th3CellToLatlngTgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
+SELECT asText(tgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
 </programlisting>
 			</listitem>

--- a/mobilitydb/sql/h3/255_th3index_spatialfuncs.in.sql
+++ b/mobilitydb/sql/h3/255_th3index_spatialfuncs.in.sql
@@ -75,7 +75,7 @@ CREATE FUNCTION cellToPoint(th3index)
   AS 'MODULE_PATHNAME', 'Th3index_cell_to_tgeogpoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION th3CellToLatlngTgeompoint(th3index)
+CREATE FUNCTION tgeompoint(th3index)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Th3index_cell_to_tgeompoint'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -103,7 +103,7 @@ CREATE FUNCTION cellToBoundary(th3index)
 
 CREATE CAST (th3index AS tgeogpoint) WITH FUNCTION cellToPoint(th3index);
 CREATE CAST (th3index AS tgeompoint)
-  WITH FUNCTION th3CellToLatlngTgeompoint(th3index);
+  WITH FUNCTION tgeompoint(th3index);
 
 /******************************************************************************
  * h3indexset × th3index — ever-equal (sound cell-set prefilter)

--- a/mobilitydb/src/h3/th3index_latlng.c
+++ b/mobilitydb/src/h3/th3index_latlng.c
@@ -108,7 +108,7 @@ PG_FUNCTION_INFO_V1(Th3index_cell_to_tgeompoint);
  * @ingroup mobilitydb_h3_latlng
  * @brief Return the planar centroid trajectory (SRID 4326) of a temporal
  * H3 cell
- * @sqlfn th3CellToLatlngTgeompoint()
+ * @sqlfn tgeompoint()
  */
 Datum
 Th3index_cell_to_tgeompoint(PG_FUNCTION_ARGS)

--- a/mobilitydb/test/h3/expected/282_th3index_latlng.test.out
+++ b/mobilitydb/test/h3/expected/282_th3index_latlng.test.out
@@ -32,7 +32,7 @@ SELECT th3index(
  t
 (1 row)
 
-SELECT th3CellToLatlngTgeompoint(th3index
+SELECT tgeompoint(th3index
   '831c02fffffffff@2001-01-01') IS NOT NULL;
  ?column? 
 ----------
@@ -142,7 +142,7 @@ SELECT (th3index
 (1 row)
 
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint
-  ~= th3CellToLatlngTgeompoint(th3index '831c02fffffffff@2001-01-01');
+  ~= tgeompoint(th3index '831c02fffffffff@2001-01-01');
  ?column? 
 ----------
  t

--- a/mobilitydb/test/h3/queries/282_th3index_latlng.test.sql
+++ b/mobilitydb/test/h3/queries/282_th3index_latlng.test.sql
@@ -38,10 +38,10 @@ SELECT th3index(
   = th3index '8a2a1072b59ffff@2001-01-01';
 
 -------------------------------------------------------------------------------
--- th3CellToLatlngTgeompoint — planar (SRID 4326) overload
+-- tgeompoint — planar (SRID 4326) overload
 -------------------------------------------------------------------------------
 
-SELECT th3CellToLatlngTgeompoint(th3index
+SELECT tgeompoint(th3index
   '831c02fffffffff@2001-01-01') IS NOT NULL;
 
 -------------------------------------------------------------------------------
@@ -127,6 +127,6 @@ SELECT (th3index
   '[831c02fffffffff@2001-01-01, 8a2a1072b59ffff@2001-01-02]')::tgeompoint
   IS NOT NULL;
 SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint
-  ~= th3CellToLatlngTgeompoint(th3index '831c02fffffffff@2001-01-01');
+  ~= tgeompoint(th3index '831c02fffffffff@2001-01-01');
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
A cast surfaces in SQL as the constructor of its target type, so the cast from th3index to tgeompoint is spelled tgeompoint(th3index), the spelling tnpoint, tcbuffer and trgeometry each give their own cast to that type. The MEOS export backing it already reads th3index_to_tgeompoint, so the function name, the :: cast and the MEOS symbol are three faces of one function and a generator deriving any one of them from another resolves it. The geodetic cast keeps the semantic accessor cellToPoint as its backing function, the form timeSpan(tint) takes for the cast to tstzspan.