### PR TITLE
Answer a cell area in square metres

### DIFF
--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2896,7 +2896,7 @@
 			<title>Metrics</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_cell_area"><varname>cellArea</varname></link>: Return the temporal area of each cell in a trajectory, in the requested unit</para>
+					<para><link linkend="th3_h3_cell_area"><varname>cellArea</varname></link>: Return the temporal area of each cell in a trajectory, in square metres or in the requested unit</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLength</varname></link>: Return the temporal length of each directed edge in a trajectory, in the requested unit</para>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -557,19 +557,20 @@ SELECT th3LocalIjToCell(th3index '871fa44a8ffffff@2001-01-01',
 
 	<sect1 xml:id="th3_metrics">
 		<title>Metrics</title>
-		<para>The three metric functions take an optional unit argument. For areas: <varname>km2</varname> (default), <varname>m2</varname>, or <varname>rads2</varname>. For lengths: <varname>km</varname> (default), <varname>m</varname>, or <varname>rads</varname>. Passing an area unit to a length function (or vice-versa) raises an error.</para>
+		<para>The three metric functions take an optional unit argument. For areas: <varname>m2</varname> (default), <varname>km2</varname>, or <varname>rads2</varname>. For lengths: <varname>km</varname> (default), <varname>m</varname>, or <varname>rads</varname>. Passing an area unit to a length function (or vice-versa) raises an error.</para>
 		<itemizedlist>
 			<listitem xml:id="th3_h3_cell_area">
 				<indexterm significance="normal"><primary><varname>cellArea</varname></primary></indexterm>
-				<para>Return the temporal area of each cell in a trajectory, in the requested unit</para>
+				<para>Return the temporal area of each cell in a trajectory, in square metres or in the requested unit</para>
 				<programlisting xml:space="preserve" format="linespecific">
-cellArea(th3index,text='km2') → tfloat
+cellArea(th3index) → tfloat
+cellArea(th3index,text) → tfloat
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT cellArea(th3index '871fa44a8ffffff@2001-01-01');
--- 4.441914270110932@2001-01-01
-SELECT cellArea(th3index '871fa44a8ffffff@2001-01-01', 'm2');
 -- 4441914.270110932@2001-01-01
+SELECT cellArea(th3index '871fa44a8ffffff@2001-01-01', 'km2');
+-- 4.441914270110932@2001-01-01
 </programlisting>
 			</listitem>
 

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -275,7 +275,8 @@ extern Temporal *th3index_local_ij_to_cell(const Temporal *origin,
  * Metrics
  *****************************************************************************/
 
-extern Temporal *th3index_cell_area(const Temporal *temp, const char *unit);
+extern Temporal *th3index_cell_area(const Temporal *temp);
+extern Temporal *th3index_cell_area_unit(const Temporal *temp, const char *unit);
 extern Temporal *th3index_edge_length(const Temporal *temp, const char *unit);
 extern Temporal *tgeogpoint_great_circle_distance(const Temporal *a,
   const Temporal *b, const char *unit);

--- a/meos/src/h3/th3index_metrics.c
+++ b/meos/src/h3/th3index_metrics.c
@@ -166,17 +166,17 @@ h3_gs_great_circle_distance_meos(const GSERIALIZED *a, const GSERIALIZED *b,
 }
 
 /*****************************************************************************
- * cellArea(th3index, text) — lift_with_const (unit as H3Unit enum)
+ * cellArea(th3index) and cellArea(th3index, text) — lift_with_const
  *****************************************************************************/
 
 /**
  * @ingroup meos_h3_metrics
  * @brief Return the per-instant area of a temporal H3 cell in the given
  * unit.
- * @csqlfn #Th3index_cell_area()
+ * @csqlfn #Th3index_cell_area_unit()
  */
 Temporal *
-th3index_cell_area(const Temporal *temp, const char *unit)
+th3index_cell_area_unit(const Temporal *temp, const char *unit)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TH3INDEX(temp, NULL); VALIDATE_NOT_NULL(unit, NULL);
@@ -193,6 +193,17 @@ th3index_cell_area(const Temporal *temp, const char *unit)
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal(temp, &lfinfo);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant area of a temporal H3 cell in square metres
+ * @csqlfn #Th3index_cell_area()
+ */
+Temporal *
+th3index_cell_area(const Temporal *temp)
+{
+  return th3index_cell_area_unit(temp, "m2");
 }
 
 /*****************************************************************************

--- a/mobilitydb/sql/h3/286_th3index_metrics.in.sql
+++ b/mobilitydb/sql/h3/286_th3index_metrics.in.sql
@@ -45,9 +45,14 @@
  * cellArea
  ******************************************************************************/
 
-CREATE FUNCTION cellArea(th3index, text DEFAULT 'km2')
+CREATE FUNCTION cellArea(th3index)
   RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Th3index_cell_area'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cellArea(th3index, text)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Th3index_cell_area_unit'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************

--- a/mobilitydb/src/h3/th3index_metrics.c
+++ b/mobilitydb/src/h3/th3index_metrics.c
@@ -44,23 +44,39 @@
 #include "pg_temporal/temporal.h"
 
 /*****************************************************************************
- * cellArea(th3index, text)
+ * cellArea(th3index) and cellArea(th3index, text)
  *****************************************************************************/
 
 PGDLLEXPORT Datum Th3index_cell_area(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Th3index_cell_area);
 /**
  * @ingroup mobilitydb_h3_metrics
- * @brief Return the per-instant area of a temporal H3 cell in the given unit
+ * @brief Return the per-instant area of a temporal H3 cell in square metres
  * @sqlfn cellArea()
  */
 Datum
 Th3index_cell_area(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Temporal *result = th3index_cell_area(temp);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Th3index_cell_area_unit(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Th3index_cell_area_unit);
+/**
+ * @ingroup mobilitydb_h3_metrics
+ * @brief Return the per-instant area of a temporal H3 cell in the given unit
+ * @sqlfn cellArea()
+ */
+Datum
+Th3index_cell_area_unit(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   text *unit_txt = PG_GETARG_TEXT_P(1);
   char *unit = text_to_cstring(unit_txt);
-  Temporal *result = th3index_cell_area(temp, unit);
+  Temporal *result = th3index_cell_area_unit(temp, unit);
   pfree(unit);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);

--- a/mobilitydb/test/h3/expected/286_th3index_metrics.test.out
+++ b/mobilitydb/test/h3/expected/286_th3index_metrics.test.out
@@ -1,7 +1,21 @@
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01') IS NOT NULL;
+SELECT cellArea(th3index '831c02fffffffff@2001-01-01')
+  = cellArea(th3index '831c02fffffffff@2001-01-01', 'm2');
  ?column? 
 ----------
  t
+(1 row)
+
+SELECT cellArea(th3index '831c02fffffffff@2001-01-01')
+  = cellArea(th3index '831c02fffffffff@2001-01-01', 'km2');
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT round(startValue(cellArea(th3index '831c02fffffffff@2001-01-01'))::numeric, 1);
+    round     
+--------------
+ 7725505767.6
 (1 row)
 
 SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'km2')

--- a/mobilitydb/test/h3/queries/286_th3index_metrics.test.sql
+++ b/mobilitydb/test/h3/queries/286_th3index_metrics.test.sql
@@ -16,11 +16,16 @@
 -- per-instant adapters being filled in.
 
 -------------------------------------------------------------------------------
--- cellArea(th3index, text) — lift_with_const
+-- cellArea(th3index) and cellArea(th3index, text) — lift_with_const
 -------------------------------------------------------------------------------
 
--- Default unit ('km2')
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01') IS NOT NULL;
+-- The one-argument form answers square metres, the unit the DggsCellOps
+-- cell_area slot declares, so it agrees with 'm2' and differs from 'km2'
+SELECT cellArea(th3index '831c02fffffffff@2001-01-01')
+  = cellArea(th3index '831c02fffffffff@2001-01-01', 'm2');
+SELECT cellArea(th3index '831c02fffffffff@2001-01-01')
+  = cellArea(th3index '831c02fffffffff@2001-01-01', 'km2');
+SELECT round(startValue(cellArea(th3index '831c02fffffffff@2001-01-01'))::numeric, 1);
 
 -- All three valid area units
 SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'km2')


### PR DESCRIPTION
The cell_area slot of the DggsCellOps descriptor declares one argument and a result in square metres, so cellArea answers square metres for an H3 cell as it already does for a QUADBIN one, and the same query reads the same quantity whichever grid holds the cell. H3 additionally accepts a unit, so cellArea(th3index, text) answers square kilometres or radians squared; the argument carries no default, which is what keeps the one-argument call unambiguous. MEOS publishes the two forms as th3index_cell_area and th3index_cell_area_unit, the split its own datum_h3_cell_area_m2 wrapper already states. The test asserts the one-argument form against both units, so it answers t for square metres and f for square kilometres.