### PR TITLE
Compare an SRID a component wrote instead of overwriting it

### DIFF
--- a/meos/src/geo/tspatial_parser.c
+++ b/meos/src/geo/tspatial_parser.c
@@ -298,6 +298,10 @@ geo_parse(const char **str, MeosType basetype, char delim, int *srid,
   GSERIALIZED **result)
 {
   p_whitespace(str);
+  /* A geography that writes no SRID is parsed as SRID_DEFAULT, so afterwards
+   * the value cannot say whether 4326 was asserted or merely defaulted. The
+   * text still can, and it is in hand only here */
+  bool srid_written = (pg_strncasecmp(*str, "SRID=", 5) == 0);
   /* The next instruction will throw an exception if it fails */
   Datum geo;
   if (! basetype_parse(str, basetype, delim, &geo))
@@ -313,8 +317,8 @@ geo_parse(const char **str, MeosType basetype, char delim, int *srid,
   int gs_srid = gserialized_get_srid(gs);
   if (*srid == SRID_UNKNOWN && gs_srid != SRID_UNKNOWN)
     *srid = gs_srid;
-  else if (*srid != SRID_UNKNOWN &&
-    ( gs_srid == SRID_UNKNOWN || gs_srid == SRID_DEFAULT ))
+  else if (*srid != SRID_UNKNOWN && (gs_srid == SRID_UNKNOWN ||
+    (basetype == T_GEOGRAPHY && ! srid_written && gs_srid == SRID_DEFAULT)))
     gserialized_set_srid(gs, *srid);
   /* If the SRID of the temporal point and of the geometry do not match */
   else if (*srid != SRID_UNKNOWN && gs_srid != SRID_UNKNOWN &&
@@ -350,6 +354,9 @@ spatial_parse_elem(const char **str, MeosType temptype, char delim,
   int *temp_srid, Datum *result)
 {
   p_whitespace(str);
+  /* See #geo_parse: only the text distinguishes a geography that asserted
+   * 4326 from one that said nothing and was defaulted to it */
+  bool srid_written = (pg_strncasecmp(*str, "SRID=", 5) == 0);
   /* The next instruction will throw an exception if it fails */
   Datum d;
   MeosType basetype = temptype_basetype(temptype);
@@ -361,8 +368,8 @@ spatial_parse_elem(const char **str, MeosType temptype, char delim,
   int base_srid = spatial_srid(d, basetype);
   if (*temp_srid == SRID_UNKNOWN && base_srid != SRID_UNKNOWN)
     *temp_srid = base_srid;
-  else if (*temp_srid != SRID_UNKNOWN &&
-    ( base_srid == SRID_UNKNOWN || base_srid == SRID_DEFAULT ))
+  else if (*temp_srid != SRID_UNKNOWN && (base_srid == SRID_UNKNOWN ||
+    (basetype == T_GEOGRAPHY && ! srid_written && base_srid == SRID_DEFAULT)))
       spatial_set_srid(d, basetype, *temp_srid);
   /* If the SRID of the spatiotemporal value and of the spatial value
    * do not match */


### PR DESCRIPTION
A spatiotemporal literal names an SRID once, and each component may name one of
its own. The parser inherits the outer SRID into a component that names none,
which is right, but it also inherited it into a component that named 4326,
because the test asked whether the parsed SRID equalled `SRID_DEFAULT` and read
that as meaning "absent". The second component's coordinates were then
relabelled with the first one's frame, and the literal answered a value nobody
wrote:

```
tgeometry 'SRID=3857;[SRID=4326;Point(1 1)@2000-01-01]'   -- accepted, SRID=3857
```

The same literal with the two codes the other way round already errors, as does
every other pair of differing codes. Only 4326 was silently absorbed.

For a geometry the two cases are plainly distinct: a component that writes
nothing parses as `SRID_UNKNOWN`, so 4326 can only have been written. For a
geography they are genuinely indistinguishable after parsing, since a geography
that writes no SRID is given `SRID_DEFAULT`, which is 4326 -- that is what the
test was for, and removing it outright makes every ordinary `tgeography`
literal fail.

The distinction is not lost, though, only absent from the parsed value: the
input text says whether an SRID was written, and both sites still hold that
text when they decide. Each now reads it once, before parsing consumes it, and
treats 4326 as absent only where a geography could have been given it by
default and did not write it.

| literal | before | after |
| --- | --- | --- |
| geometry, outer 3857, component writes 4326 | accepted, SRID=3857 | error |
| geometry, outer 3857, component writes 3857 | accepted | accepted |
| geometry, outer 3857, component writes nothing | inherits 3857 | inherits 3857 |
| geography, outer 7844, component writes nothing | inherits 7844 | inherits 7844 |
| geography, outer 7844, component writes 4326 | accepted, SRID=7844 | error |
| geography, outer 4326, component writes nothing | accepted | accepted |

The fifth row is the case the old test could not reach at all: a geography that
explicitly wrote a conflicting 4326 was absorbed just as silently, and reading
the text closes that too.

Full pg_regress passes with no expected output changed. The suite carries 41
lines writing two SRIDs one of which is 4326, across 15 files, and none of them
moves -- every one either matches the outer SRID or belongs to a geography that
wrote nothing. The h3 and quadbin suites are unaffected.
