### PR TITLE
Reach the shared cell index operations through the descriptor entry

### DIFF
--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -202,9 +202,7 @@ extern Temporal *tne_th3index_th3index(const Temporal *temp1,
  * Inspection
  *****************************************************************************/
 
-extern Temporal *th3index_get_resolution(const Temporal *temp);
 extern Temporal *th3index_get_base_cell_number(const Temporal *temp);
-extern Temporal *th3index_is_valid_cell(const Temporal *temp);
 extern Temporal *th3index_is_res_class_iii(const Temporal *temp);
 extern Temporal *th3index_is_pentagon(const Temporal *temp);
 
@@ -212,7 +210,6 @@ extern Temporal *th3index_is_pentagon(const Temporal *temp);
  * Hierarchy
  *****************************************************************************/
 
-extern Temporal *th3index_cell_to_parent(const Temporal *temp, int32 resolution);
 extern Temporal *th3index_cell_to_parent_next(const Temporal *temp);
 extern Temporal *th3index_cell_to_center_child(const Temporal *temp, int32 resolution);
 extern Temporal *th3index_cell_to_center_child_next(const Temporal *temp);
@@ -228,7 +225,6 @@ extern Temporal *tgeogpoint_to_th3index(const Temporal *temp, int32 resolution);
 extern Temporal *tgeompoint_to_th3index(const Temporal *temp, int32 resolution);
 extern Temporal *th3index_to_tgeogpoint(const Temporal *temp);
 extern Temporal *th3index_to_tgeompoint(const Temporal *temp);
-extern Temporal *th3index_cell_to_boundary(const Temporal *temp);
 
 /* Static geometry → H3 cell / cell set.  See meos/src/h3/h3_geo.c. */
 extern H3Index geo_to_h3index_cell(const GSERIALIZED *point, int32 resolution);
@@ -275,7 +271,6 @@ extern Temporal *th3index_local_ij_to_cell(const Temporal *origin,
  * Metrics
  *****************************************************************************/
 
-extern Temporal *th3index_cell_area(const Temporal *temp);
 extern Temporal *th3index_cell_area_unit(const Temporal *temp, const char *unit);
 extern Temporal *th3index_edge_length(const Temporal *temp, const char *unit);
 extern Temporal *tgeogpoint_great_circle_distance(const Temporal *a,

--- a/meos/src/h3/th3index_hierarchy.c
+++ b/meos/src/h3/th3index_hierarchy.c
@@ -94,19 +94,6 @@ h3_cell_to_center_child_next_meos(H3Index cell)
  * cellToParent(th3index, integer)
  *****************************************************************************/
 
-/**
- * @ingroup meos_h3_hierarchy
- * @brief Return the temporal parent cell at the given resolution.
- * @csqlfn #Th3index_cell_to_parent()
- */
-Temporal *
-th3index_cell_to_parent(const Temporal *temp, int32 resolution)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_TH3INDEX(temp, NULL);
-  return tcellindex_cell_to_parent(temp, resolution);
-}
-
 /*****************************************************************************
  * cellToParent(th3index)
  *****************************************************************************/

--- a/meos/src/h3/th3index_inspection.c
+++ b/meos/src/h3/th3index_inspection.c
@@ -52,19 +52,6 @@
  * getResolution
  *****************************************************************************/
 
-/**
- * @ingroup meos_h3_inspection
- * @brief Return the temporal resolution (int32) of a temporal H3 cell.
- * @csqlfn #Th3index_get_resolution()
- */
-Temporal *
-th3index_get_resolution(const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_TH3INDEX(temp, NULL);
-  return tcellindex_get_resolution(temp);
-}
-
 /*****************************************************************************
  * th3GetBaseCellNumber
  *****************************************************************************/
@@ -95,20 +82,6 @@ th3index_get_base_cell_number(const Temporal *temp)
 /*****************************************************************************
  * isValidCell
  *****************************************************************************/
-
-/**
- * @ingroup meos_h3_inspection
- * @brief Return a temporal boolean stating at each instant whether the
- * value is a valid H3 cell.
- * @csqlfn #Th3index_is_valid_cell()
- */
-Temporal *
-th3index_is_valid_cell(const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_TH3INDEX(temp, NULL);
-  return tcellindex_is_valid_cell(temp);
-}
 
 /*****************************************************************************
  * th3IsResClassIii

--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -455,18 +455,4 @@ th3index_to_tgeompoint(const Temporal *temp)
  * cellToBoundary — polygon per instant, emitted as tgeography
  *****************************************************************************/
 
-/**
- * @ingroup meos_h3_latlng
- * @brief Return the per-instant polygon boundary of a temporal H3 cell as
- * a temporal geography.
- * @csqlfn #Th3index_cell_to_boundary()
- */
-Temporal *
-th3index_cell_to_boundary(const Temporal *temp)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_TH3INDEX(temp, NULL);
-  return tcellindex_cell_to_boundary(temp);
-}
-
 /*****************************************************************************/

--- a/meos/src/h3/th3index_metrics.c
+++ b/meos/src/h3/th3index_metrics.c
@@ -195,17 +195,6 @@ th3index_cell_area_unit(const Temporal *temp, const char *unit)
   return tfunc_temporal(temp, &lfinfo);
 }
 
-/**
- * @ingroup meos_h3_metrics
- * @brief Return the per-instant area of a temporal H3 cell in square metres
- * @csqlfn #Th3index_cell_area()
- */
-Temporal *
-th3index_cell_area(const Temporal *temp)
-{
-  return th3index_cell_area_unit(temp, "m2");
-}
-
 /*****************************************************************************
  * th3EdgeLength(th3index, text) — lift_with_const
  *****************************************************************************/

--- a/mobilitydb/src/h3/th3index_hierarchy.c
+++ b/mobilitydb/src/h3/th3index_hierarchy.c
@@ -39,6 +39,7 @@
 #include <meos.h>
 #include <meos_h3.h>
 #include "temporal/temporal.h"
+#include "temporal/tcellindex.h"
 /* MobilityDB */
 #include "pg_temporal/temporal.h"
 
@@ -58,7 +59,7 @@ Th3index_cell_to_parent(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   int32 resolution = PG_GETARG_INT32(1);
-  Temporal *result = th3index_cell_to_parent(temp, resolution);
+  Temporal *result = tcellindex_cell_to_parent(temp, resolution);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }

--- a/mobilitydb/src/h3/th3index_inspection.c
+++ b/mobilitydb/src/h3/th3index_inspection.c
@@ -39,6 +39,7 @@
 #include <meos.h>
 #include <meos_h3.h>
 #include "temporal/temporal.h"
+#include "temporal/tcellindex.h"
 /* MobilityDB */
 #include "pg_temporal/temporal.h"
 
@@ -57,7 +58,7 @@ Datum
 Th3index_get_resolution(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = th3index_get_resolution(temp);
+  Temporal *result = tcellindex_get_resolution(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }
@@ -99,7 +100,7 @@ Datum
 Th3index_is_valid_cell(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = th3index_is_valid_cell(temp);
+  Temporal *result = tcellindex_is_valid_cell(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }

--- a/mobilitydb/src/h3/th3index_latlng.c
+++ b/mobilitydb/src/h3/th3index_latlng.c
@@ -39,6 +39,7 @@
 #include <meos.h>
 #include <meos_h3.h>
 #include "temporal/temporal.h"
+#include "temporal/tcellindex.h"
 /* MobilityDB */
 #include "pg_temporal/temporal.h"
 
@@ -135,7 +136,7 @@ Datum
 Th3index_cell_to_boundary(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = th3index_cell_to_boundary(temp);
+  Temporal *result = tcellindex_cell_to_boundary(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }

--- a/mobilitydb/src/h3/th3index_metrics.c
+++ b/mobilitydb/src/h3/th3index_metrics.c
@@ -40,6 +40,7 @@
 #include <meos.h>
 #include <meos_h3.h>
 #include "temporal/temporal.h"
+#include "temporal/tcellindex.h"
 /* MobilityDB */
 #include "pg_temporal/temporal.h"
 
@@ -58,7 +59,7 @@ Datum
 Th3index_cell_area(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  Temporal *result = th3index_cell_area(temp);
+  Temporal *result = tcellindex_cell_area(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }


### PR DESCRIPTION
The six operations the DggsCellOps descriptor declares are answered by the generic tcellindex_ entries, which validate the value is a cell index and dispatch on its own type, so a family adds nothing by publishing a typed entry that forwards to one. H3's five such entries are removed and the PostgreSQL wrappers call the generic entry, the form the QUADBIN wrappers already take. What H3 keeps is what carries content of its own: th3index_cell_area_unit takes a unit the descriptor slot does not, th3index_cell_to_parent_next has no generic twin, and th3index_to_tgeogpoint and th3index_to_tgeompoint name the casts, which a generator derives from the source and target types.