### PR TITLE
Restrict a temporal rigid geometry to the pose it interpolates

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2414,6 +2414,9 @@
 			<title>Restricciones</title>
 			<itemizedlist>
 				<listitem>
+					<para><link linkend="trgeometry_atValue"><varname>atValue</varname>, <varname>minusValue</varname>, <varname>atValues</varname>, <varname>minusValues</varname></link>: Restringe al (complemento de) una pose o un conjunto de poses</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="trgeometry_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restringe una trgeometry a (el complemento de) una geometría</para>
 				</listitem>
 				<listitem>

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -575,6 +575,31 @@ SELECT asText(merge( trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 		<para>Las funciones <varname>atGeometry</varname>, <varname>minusGeometry</varname>, <varname>atStbox</varname> y <varname>minusStbox</varname> restringen una trgeometry a (el complemento de) una geometría o una caja espaciotemporal. La semántica refleja la de <varname>tpose</varname>: una geometría rígida temporal está «en» una región en el instante <varname>t</varname> si y solo si su centroide (antena) en <varname>t</varname> se encuentra en esa región.</para>
 
 		<itemizedlist>
+			<listitem xml:id="trgeometry_atValue">
+				<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
+				<para>Restringe al (complemento de) una pose o un conjunto de poses</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+atValue(trgeometry,pose) &#8594; trgeometry
+minusValue(trgeometry,pose) &#8594; trgeometry
+atValues(trgeometry,poseset) &#8594; trgeometry
+minusValues(trgeometry,poseset) &#8594; trgeometry
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));
+  [Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02,
+  Pose(Point(1 1), 0.5)@2000-01-03]', pose 'Pose(Point(1 1), 0.5)'));
+-- POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.5)@2000-01-03]}
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));
+  {Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02,
+  Pose(Point(1 1), 0.5)@2000-01-03}', pose 'Pose(Point(1 1), 0.5)'));
+-- POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.3)@2000-01-01}
+</programlisting>
+				<para>El valor de restricción es una pose, el valor base que interpola una geometría rígida temporal. La geometría de referencia se conserva sin cambios, de modo que el resultado describe el mismo cuerpo.</para>
+			</listitem>
+
 			<listitem xml:id="trgeometry_atGeometry">
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2423,6 +2423,9 @@
 			<title>Restrictions</title>
 			<itemizedlist>
 				<listitem>
+					<para><link linkend="trgeometry_atValue"><varname>atValue</varname>, <varname>minusValue</varname>, <varname>atValues</varname>, <varname>minusValues</varname></link>: Restrict to (the complement of) a pose or a set of poses</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="trgeometry_atGeometry"><varname>atGeometry</varname>, <varname>minusGeometry</varname></link>: Restrict a trgeometry to (the complement of) a geometry</para>
 				</listitem>
 				<listitem>

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -576,6 +576,31 @@ SELECT asText(merge( trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 		<para>The <varname>atGeometry</varname>, <varname>minusGeometry</varname>, <varname>atStbox</varname>, and <varname>minusStbox</varname> functions restrict a trgeometry to (the complement of) a geometry or a spatiotemporal box. The semantic mirrors <varname>tpose</varname>: a temporal rigid geometry is "in" a region at time <varname>t</varname> iff its centroid (antenna) at <varname>t</varname> lies in that region.</para>
 
 		<itemizedlist>
+			<listitem xml:id="trgeometry_atValue">
+				<indexterm significance="normal"><primary><varname>atValue</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusValue</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>atValues</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>minusValues</varname></primary></indexterm>
+				<para>Restrict to (the complement of) a pose or a set of poses</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+atValue(trgeometry,pose) &#8594; trgeometry
+minusValue(trgeometry,pose) &#8594; trgeometry
+atValues(trgeometry,poseset) &#8594; trgeometry
+minusValues(trgeometry,poseset) &#8594; trgeometry
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));
+  [Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02,
+  Pose(Point(1 1), 0.5)@2000-01-03]', pose 'Pose(Point(1 1), 0.5)'));
+-- POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.5)@2000-01-03]}
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));
+  {Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02,
+  Pose(Point(1 1), 0.5)@2000-01-03}', pose 'Pose(Point(1 1), 0.5)'));
+-- POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.3)@2000-01-01}
+</programlisting>
+				<para>The restricting value is a pose, the base value a temporal rigid geometry interpolates. The reference geometry is carried through unchanged, so the result describes the same body.</para>
+			</listitem>
+
 			<listitem xml:id="trgeometry_atGeometry">
 				<indexterm significance="normal"><primary><varname>atGeometry</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>minusGeometry</varname></primary></indexterm>

--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -83,20 +83,9 @@ temporal_bbox_restrict_value(const Temporal *temp, Datum value)
   }
   if (tspatial_type(temp->temptype))
   {
-#if RGEO
-    /* Temporal rigid geometries have poses as base values but are restricted
-     * to geometries */
-    MeosType basetype = (temp->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
-      temptype_basetype(temp->temptype);
-#else
     MeosType basetype = temptype_basetype(temp->temptype);
-#endif /* RGEO */
     assert(tspatial_srid(temp) == spatial_srid(value, basetype));
-    if (tgeo_type_all(temp->temptype)
-#if RGEO
-      || temp->temptype == T_TRGEOMETRY
-#endif /* RGEO */
-    )
+    if (tgeo_type_all(temp->temptype))
     {
       /* Test that the geometry is not empty */
       GSERIALIZED *gs = DatumGetGserializedP(value);
@@ -153,14 +142,7 @@ temporal_restrict_value(const Temporal *temp, Datum value, bool atfunc)
   VALIDATE_NOT_NULL(temp, NULL); 
   if (tspatial_type(temp->temptype))
   {
-#if RGEO
-    /* Temporal rigid geometries have poses as base values but are restricted
-     * to geometries */
-    MeosType basetype = (temp->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
-      temptype_basetype(temp->temptype);
-#else
     MeosType basetype = temptype_basetype(temp->temptype);
-#endif /* RGEO */
     if (! ensure_same_srid(tspatial_srid(temp),
             spatial_srid(value, basetype)) ||
         ! ensure_same_spatial_dimensionality(temp->flags,
@@ -168,18 +150,22 @@ temporal_restrict_value(const Temporal *temp, Datum value, bool atfunc)
       return NULL;
   }
 
+  /* A value carrying a reference geometry is restricted on the base values it
+   * interpolates, and the geometry rides through the operation unchanged */
+  const GSERIALIZED *geom;
+  Temporal *work = temporal_strip_geom(temp, &geom);
+  if (! work)
+    return NULL;
+
+  Temporal *result;
   /* Bounding box test */
-  interpType interp = MEOS_FLAGS_GET_INTERP(temp->flags);
-  if (! temporal_bbox_restrict_value(temp, value))
-  {
-    if (atfunc)
-      return NULL;
-    else
-      return (temp->subtype != TSEQUENCE ||
-          MEOS_FLAGS_DISCRETE_INTERP(temp->flags)) ?
-        temporal_copy(temp) :
-        (Temporal *) tsequence_as_tsequenceset((TSequence *) temp);
-  }
+  interpType interp = MEOS_FLAGS_GET_INTERP(work->flags);
+  if (! temporal_bbox_restrict_value(work, value))
+    result = atfunc ? NULL :
+      ((work->subtype != TSEQUENCE ||
+          MEOS_FLAGS_DISCRETE_INTERP(work->flags)) ?
+        temporal_copy(work) :
+        (Temporal *) tsequence_as_tsequenceset((TSequence *) work));
 
   /* For the minus of a spatial type, the direct per-segment restriction splits
    * every segment and normalises the pieces back with a per-merge collinearity
@@ -187,34 +173,46 @@ temporal_restrict_value(const Temporal *temp, Datum value, bool atfunc)
    * of the at-restriction instead: the at-restriction finds the same crossings
    * but builds a small result, and the time-based minus rebuilds the kept
    * intervals without the value-driven re-split and normalisation. */
-  if (! atfunc && tspatial_type(temp->temptype))
+  else if (! atfunc && tspatial_type(work->temptype))
   {
-    Temporal *at = temporal_restrict_value(temp, value, REST_AT);
+    Temporal *at = temporal_restrict_value(work, value, REST_AT);
     if (at == NULL)
-      return (temp->subtype != TSEQUENCE ||
-          MEOS_FLAGS_DISCRETE_INTERP(temp->flags)) ?
-        temporal_copy(temp) :
-        (Temporal *) tsequence_as_tsequenceset((TSequence *) temp);
-    SpanSet *ss = temporal_time(at);
-    Temporal *result = temporal_restrict_tstzspanset(temp, ss, REST_MINUS);
-    pfree(at); pfree(ss);
-    return result;
+      result = (work->subtype != TSEQUENCE ||
+          MEOS_FLAGS_DISCRETE_INTERP(work->flags)) ?
+        temporal_copy(work) :
+        (Temporal *) tsequence_as_tsequenceset((TSequence *) work);
+    else
+    {
+      SpanSet *ss = temporal_time(at);
+      result = temporal_restrict_tstzspanset(work, ss, REST_MINUS);
+      pfree(at); pfree(ss);
+    }
   }
 
-  assert(temptype_subtype(temp->subtype));
-  switch (temp->subtype)
+  else
   {
-    case TINSTANT:
-      return (Temporal *) tinstant_restrict_value((TInstant *) temp, value,
-        atfunc);
-    case TSEQUENCE:
-      return (interp == DISCRETE) ?
-        (Temporal *) tdiscseq_restrict_value((TSequence *) temp, value, atfunc) :
-        (Temporal *) tcontseq_restrict_value((TSequence *) temp, value, atfunc);
-    default: /* TSEQUENCESET */
-      return (Temporal *) tsequenceset_restrict_value((TSequenceSet *) temp,
-        value, atfunc);
+    assert(temptype_subtype(work->subtype));
+    switch (work->subtype)
+    {
+      case TINSTANT:
+        result = (Temporal *) tinstant_restrict_value((TInstant *) work, value,
+          atfunc);
+        break;
+      case TSEQUENCE:
+        result = (interp == DISCRETE) ?
+          (Temporal *) tdiscseq_restrict_value((TSequence *) work, value,
+            atfunc) :
+          (Temporal *) tcontseq_restrict_value((TSequence *) work, value,
+            atfunc);
+        break;
+      default: /* TSEQUENCESET */
+        result = (Temporal *) tsequenceset_restrict_value((TSequenceSet *) work,
+          value, atfunc);
+    }
   }
+  if (work != temp)
+    pfree(work);
+  return temporal_attach_geom(geom, result);
 }
 
 /*****************************************************************************/
@@ -274,31 +272,42 @@ temporal_restrict_values(const Temporal *temp, const Set *s, bool atfunc)
   if (s->count == 1)
     return temporal_restrict_value(temp, SET_VAL_N(s, 0), atfunc);
 
-  /* Bounding box test */
-  interpType interp = MEOS_FLAGS_GET_INTERP(temp->flags);
-  if (! temporal_bbox_restrict_set(temp, s))
-  {
-    if (atfunc)
-      return NULL;
-    else
-      return (temp->subtype != TSEQUENCE) ? temporal_copy(temp) :
-        (Temporal *) tsequence_as_tsequenceset((TSequence *) temp);
-  }
+  /* A value carrying a reference geometry is restricted on the base values it
+   * interpolates, and the geometry rides through the operation unchanged */
+  const GSERIALIZED *geom;
+  Temporal *work = temporal_strip_geom(temp, &geom);
+  if (! work)
+    return NULL;
 
-  assert(temptype_subtype(temp->subtype));
-  switch (temp->subtype)
+  Temporal *result;
+  /* Bounding box test */
+  interpType interp = MEOS_FLAGS_GET_INTERP(work->flags);
+  if (! temporal_bbox_restrict_set(work, s))
+    result = atfunc ? NULL :
+      ((work->subtype != TSEQUENCE) ? temporal_copy(work) :
+        (Temporal *) tsequence_as_tsequenceset((TSequence *) work));
+  else
+  {
+  assert(temptype_subtype(work->subtype));
+  switch (work->subtype)
   {
     case TINSTANT:
-      return (Temporal *) tinstant_restrict_values((TInstant *) temp, s,
+      result = (Temporal *) tinstant_restrict_values((TInstant *) work, s,
         atfunc);
+      break;
     case TSEQUENCE:
-      return (interp == DISCRETE) ?
-        (Temporal *) tdiscseq_restrict_values((TSequence *) temp, s, atfunc) :
-        (Temporal *) tcontseq_restrict_values((TSequence *) temp, s, atfunc);
+      result = (interp == DISCRETE) ?
+        (Temporal *) tdiscseq_restrict_values((TSequence *) work, s, atfunc) :
+        (Temporal *) tcontseq_restrict_values((TSequence *) work, s, atfunc);
+      break;
     default: /* TSEQUENCESET */
-      return (Temporal *) tsequenceset_restrict_values((TSequenceSet *) temp,
+      result = (Temporal *) tsequenceset_restrict_values((TSequenceSet *) work,
         s, atfunc);
   }
+  }
+  if (work != temp)
+    pfree(work);
+  return temporal_attach_geom(geom, result);
 }
 
 /*****************************************************************************/
@@ -735,14 +744,7 @@ tinstant_restrict_value(const TInstant *inst, Datum value, bool atfunc)
 bool
 tinstant_restrict_values_test(const TInstant *inst, const Set *s, bool atfunc)
 {
-#if RGEO
-  /* Temporal rigid geometries have poses as base values but are restricted
-   * to geometries */
-  MeosType basetype = (inst->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
-    temptype_basetype(inst->temptype);
-#else
-    MeosType basetype = temptype_basetype(inst->temptype);
-#endif /* RGEO */
+  MeosType basetype = temptype_basetype(inst->temptype);
   for (int i = 0; i < s->count; i++)
   {
     if (datum_eq(tinstant_value_p(inst), SET_VAL_N(s, i), basetype))
@@ -962,14 +964,7 @@ TSequence *
 tdiscseq_restrict_value(const TSequence *seq, Datum value, bool atfunc)
 {
   assert(seq); assert(MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE);
-#if RGEO
-  /* Temporal rigid geometries have poses as base values but are restricted
-   * to geometries */
-  MeosType basetype = (seq->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
-    temptype_basetype(seq->temptype);
-#else
-    MeosType basetype = temptype_basetype(seq->temptype);
-#endif /* RGEO */
+  MeosType basetype = temptype_basetype(seq->temptype);
 
   /* Instantaneous sequence */
   if (seq->count == 1)
@@ -1057,10 +1052,6 @@ tsegment_restrict_value(const TInstant *inst1, const TInstant *inst2,
   Datum start = tinstant_value_p(inst1);
   Datum end = tinstant_value_p(inst2);
   MeosType basetype = temptype_basetype(inst1->temptype);
-  // /* Temporal rigid geometries have poses as base values but are restricted
-   // * to geometries */
-  // MeosType basetype1 = (inst1->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
-    // basetype;
   TInstant *instants[2];
   /* Is the segment constant? */
   bool isconst = datum_eq(start, end, basetype);

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -504,25 +504,25 @@ CREATE FUNCTION tprecision(trgeometry, duration interval,
  * Restriction Functions
  *****************************************************************************/
 
--- CREATE FUNCTION atValues(trgeometry, geometry)
-  -- RETURNS trgeometry
-  -- AS 'MODULE_PATHNAME', 'Temporal_at_value'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atValue(trgeometry, pose)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Temporal_at_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION minusValues(trgeometry, geometry)
-  -- RETURNS trgeometry
-  -- AS 'MODULE_PATHNAME', 'Temporal_minus_value'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusValue(trgeometry, pose)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Temporal_minus_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION atValues(trgeometry, geomset)
-  -- RETURNS trgeometry
-  -- AS 'MODULE_PATHNAME', 'Temporal_at_values'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atValues(trgeometry, poseset)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Temporal_at_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
--- CREATE FUNCTION minusValues(trgeometry, geomset)
-  -- RETURNS trgeometry
-  -- AS 'MODULE_PATHNAME', 'Temporal_minus_values'
-  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusValues(trgeometry, poseset)
+  RETURNS trgeometry
+  AS 'MODULE_PATHNAME', 'Temporal_minus_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION atTime(trgeometry, timestamptz)
   RETURNS trgeometry

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -2096,13 +2096,7 @@ Temporal_restrict_value(FunctionCallInfo fcinfo, bool atfunc)
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   Datum value = PG_GETARG_ANYDATUM(1);
   MeosType basetype = oid_meostype(get_fn_expr_argtype(fcinfo->flinfo, 1));
-#if RGEO
-  Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeometry_restrict_value(temp, value, atfunc) :
-    temporal_restrict_value(temp, value, atfunc);
-#else
   Temporal *result = temporal_restrict_value(temp, value, atfunc);
-#endif /* RGEO */
   PG_FREE_IF_COPY(temp, 0);
   DATUM_FREE_IF_COPY(value, basetype, 1);
   if (! result)
@@ -2147,13 +2141,7 @@ Temporal_restrict_values(FunctionCallInfo fcinfo, bool atfunc)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
   Set *s = PG_GETARG_SET_P(1);
-#if RGEO
-  Temporal *result = (temp->temptype == T_TRGEOMETRY) ?
-    trgeometry_restrict_values(temp, s, atfunc) :
-    temporal_restrict_values(temp, s, atfunc);
-#else
   Temporal *result = temporal_restrict_values(temp, s, atfunc);
-#endif /* RGEO */
   PG_FREE_IF_COPY(temp, 0);
   PG_FREE_IF_COPY(s, 1);
   if (! result)

--- a/mobilitydb/test/rgeo/expected/150_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/150_trgeo.test.out
@@ -1543,6 +1543,102 @@ SELECT timestamps(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)
  {"Sat Jan 01 00:00:00 2000 PST","Sun Jan 02 00:00:00 2000 PST","Mon Jan 03 00:00:00 2000 PST","Tue Jan 04 00:00:00 2000 PST","Wed Jan 05 00:00:00 2000 PST"}
 (1 row)
 
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', pose 'Pose(Point(1 1), 0.5)'));
+                                    astext                                    
+------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', pose 'Pose(Point(1 1), 0.5)'));
+                                                              astext                                                               
+-----------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.5)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', pose 'Pose(Point(1 1), 0.5)'));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', pose 'Pose(Point(1 1), 0.5)'));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', pose 'Pose(Point(1 1), 0.5)'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', pose 'Pose(Point(1 1), 0.5)'));
+                                     astext                                     
+--------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', pose 'Pose(Point(1 1), 0.5)'));
+                                                                                         astext                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST)}
+(1 row)
+
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', pose 'Pose(Point(1 1), 0.5)'));
+                                                                                                                                             astext                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST), [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', poseset '{"Pose(Point(1 1), 0.5)"}'));
+                                    astext                                    
+------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));Pose(POINT(1 1),0.5)@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', poseset '{"Pose(Point(1 1), 0.5)"}'));
+                                                              astext                                                               
+-----------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.5)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', poseset '{"Pose(Point(1 1), 0.5)"}'));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', poseset '{"Pose(Point(1 1), 0.5)"}'));
+                                      astext                                      
+----------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', poseset '{"Pose(Point(1 1), 0.5)"}'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', poseset '{"Pose(Point(1 1), 0.5)"}'));
+                                     astext                                     
+--------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{Pose(POINT(1 1),0.3)@Sat Jan 01 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', poseset '{"Pose(Point(1 1), 0.5)"}'));
+                                                                                         astext                                                                                         
+----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST)}
+(1 row)
+
+SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', poseset '{"Pose(Point(1 1), 0.5)"}'));
+                                                                                                                                             astext                                                                                                                                             
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ POLYGON((1 1,2 2,3 1,1 1));{[Pose(POINT(1 1),0.2)@Sat Jan 01 00:00:00 2000 PST, Pose(POINT(1 1),0.4)@Sun Jan 02 00:00:00 2000 PST, Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST), [Pose(POINT(2 2),0.6)@Tue Jan 04 00:00:00 2000 PST, Pose(POINT(2 2),0.6)@Wed Jan 05 00:00:00 2000 PST]}
+(1 row)
+
 SELECT asText(atTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
                                     astext                                    
 ------------------------------------------------------------------------------

--- a/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/150_trgeo.test.sql
@@ -407,25 +407,25 @@ SELECT timestamps(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)
 -- Restriction Functions
 -------------------------------------------------------------------------------
 
--- SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', geometry 'Polygon((1 1,2 2,3 1,1 1))'));
--- SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', geometry 'Polygon((1 1,2 2,3 1,1 1))'));
--- SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', geometry 'Polygon((1 1,2 2,3 1,1 1))'));
--- SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', geometry 'Polygon((1 1,2 2,3 1,1 1))'));
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', pose 'Pose(Point(1 1), 0.5)'));
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', pose 'Pose(Point(1 1), 0.5)'));
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', pose 'Pose(Point(1 1), 0.5)'));
+SELECT asText(atValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', pose 'Pose(Point(1 1), 0.5)'));
 
--- SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', geometry 'Polygon((1 1,2 2,3 1,1 1))'));
--- SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', geometry 'Polygon((1 1,2 2,3 1,1 1))'));
--- SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', geometry 'Polygon((1 1,2 2,3 1,1 1))'));
--- SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', geometry 'Polygon((1 1,2 2,3 1,1 1))'));
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', pose 'Pose(Point(1 1), 0.5)'));
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', pose 'Pose(Point(1 1), 0.5)'));
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', pose 'Pose(Point(1 1), 0.5)'));
+SELECT asText(minusValue(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', pose 'Pose(Point(1 1), 0.5)'));
 
--- SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', geomset '{"Polygon((1 1,2 2,3 1,1 1))"}'));
--- SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', geomset '{"Polygon((1 1,2 2,3 1,1 1))"}'));
--- SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', geomset '{"Polygon((1 1,2 2,3 1,1 1))"}'));
--- SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', geomset '{"Polygon((1 1,2 2,3 1,1 1))"}'));
+SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', poseset '{"Pose(Point(1 1), 0.5)"}'));
+SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', poseset '{"Pose(Point(1 1), 0.5)"}'));
+SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', poseset '{"Pose(Point(1 1), 0.5)"}'));
+SELECT asText(atValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', poseset '{"Pose(Point(1 1), 0.5)"}'));
 
--- SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', geomset '{"Polygon((1 1,2 2,3 1,1 1))"}'));
--- SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', geomset '{"Polygon((1 1,2 2,3 1,1 1))"}'));
--- SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', geomset '{"Polygon((1 1,2 2,3 1,1 1))"}'));
--- SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', geomset '{"Polygon((1 1,2 2,3 1,1 1))"}'));
+SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', poseset '{"Pose(Point(1 1), 0.5)"}'));
+SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', poseset '{"Pose(Point(1 1), 0.5)"}'));
+SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03]', poseset '{"Pose(Point(1 1), 0.5)"}'));
+SELECT asText(minusValues(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{[Pose(Point(1 1), 0.2)@2000-01-01, Pose(Point(1 1), 0.4)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03], [Pose(Point(2 2), 0.6)@2000-01-04, Pose(Point(2 2), 0.6)@2000-01-05]}', poseset '{"Pose(Point(1 1), 0.5)"}'));
 
 SELECT asText(atTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 1), 0.5)@2000-01-01', timestamptz '2000-01-01'));
 SELECT asText(atTime(trgeometry 'Polygon((1 1,2 2,3 1,1 1));{Pose(Point(1 1), 0.3)@2000-01-01, Pose(Point(1 1), 0.5)@2000-01-02, Pose(Point(1 1), 0.5)@2000-01-03}', timestamptz '2000-01-01'));

--- a/tools/codegen/inherited/manifest.d/restriction_families.yaml
+++ b/tools/codegen/inherited/manifest.d/restriction_families.yaml
@@ -572,7 +572,19 @@ restriction_families:
   begin: "\n * Restriction Functions\n"
   end: "\n * Unnest Function\n"
   blocks:
-  - lit: "/*****************************************************************************\n * Restriction Functions\n *****************************************************************************/\n\n-- CREATE FUNCTION atValues(trgeometry, geometry)\n  -- RETURNS trgeometry\n  -- AS 'MODULE_PATHNAME', 'Temporal_at_value'\n  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- CREATE FUNCTION minusValues(trgeometry, geometry)\n  -- RETURNS trgeometry\n  -- AS 'MODULE_PATHNAME', 'Temporal_minus_value'\n  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- CREATE FUNCTION atValues(trgeometry, geomset)\n  -- RETURNS trgeometry\n  -- AS 'MODULE_PATHNAME', 'Temporal_at_values'\n  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n-- CREATE FUNCTION minusValues(trgeometry, geomset)\n  -- RETURNS trgeometry\n  -- AS 'MODULE_PATHNAME', 'Temporal_minus_values'\n  -- LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n"
+  - lit: "/*****************************************************************************\n * Restriction Functions\n *****************************************************************************/\n\n"
+  - fns:
+    - {sig: "atValue(trgeometry, pose)", ret: trgeometry, sym: Temporal_at_value}
+  - lit: "\n"
+  - fns:
+    - {sig: "minusValue(trgeometry, pose)", ret: trgeometry, sym: Temporal_minus_value}
+  - lit: "\n"
+  - fns:
+    - {sig: "atValues(trgeometry, poseset)", ret: trgeometry, sym: Temporal_at_values}
+  - lit: "\n"
+  - fns:
+    - {sig: "minusValues(trgeometry, poseset)", ret: trgeometry, sym: Temporal_minus_values}
+  - lit: "\n"
   - fns:
     - {sig: "atTime(trgeometry, timestamptz)", ret: trgeometry, sym: Temporal_at_timestamptz}
   - lit: "\n"


### PR DESCRIPTION
A temporal rigid geometry is a temporal pose carrying a reference geometry, so
the base value it interpolates is a pose, and that is what a value restriction
compares against. Four sites in `temporal_restrict.c` said otherwise:

```c
/* Temporal rigid geometries have poses as base values but are restricted
 * to geometries */
MeosType basetype = (temp->temptype == T_TRGEOMETRY) ? T_GEOMETRY :
  temptype_basetype(temp->temptype);
```

with a fifth sitting commented out beside them.

The comment does not describe the family it names. `trgeometry_at_value`
declares a `Pose *` parameter, `trgeometry_restrict_values` validates a
`poseset`, and both family entries strip to the temporal pose before doing
anything -- so on the family's own path the substitution is never reached. What
it does reach is the generic entry, where reading a pose as a geometry compares
an SRID that is not there and answers an error on ordinary input.

### What the generic entries now do

They strip the reference geometry, restrict the temporal pose, and give the
geometry back, which is the idiom `temporal_restrict_timestamptz` and its
neighbours in the same file already use. Measured against the built library,
with the input as the positive control:

| | before | after |
| --- | --- | --- |
| control: the input carries a body | `geomflag=1` | `geomflag=1` |
| `trgeometry_at_value(trgeo, POSE)` (family) | `geomflag=1` | `geomflag=1` |
| `temporal_restrict_value(trgeo, POSE)` at | error | `geomflag=1` |
| `temporal_restrict_value(trgeo, POSE)` minus | error | `geomflag=1` |
| `temporal_restrict_values(trgeo, POSESET)` | error | `geomflag=1` |
| `temporal_restrict_value(trgeo, GEOMETRY)` | mixed-SRID error | declines, errno 12 |

A caller reaching `temporal_restrict_value` directly -- every binding, and every
program written against MEOS -- now gets an answer that still carries its body,
where before it got one that had lost it. SQL was already protected by a
hand-written dispatch in the PostgreSQL wrapper; with the core answering for the
type that dispatch is redundant, so it goes, and the two layers take one path.

### The SQL surface

`atValue`/`minusValue` over a `pose` and `atValues`/`minusValues` over a
`poseset`, which is what every other family declares -- `102_tpose.in.sql` and
`205_tcbuffer_spatialfuncs.in.sql` spell the same four. The four declarations
that stood commented out asked for a `geometry` and gave a plural name to a
singular value.

That block of `150_trgeo.in.sql` is generated, so the declarations are added in
`restriction_families.yaml` where they are decided; the emitted file is the
generator's output, byte-for-byte. `generate.py --validate` passes and `--gaps`
reads `restriction_families 19/19, missing: -`.

### Tests and documentation

16 cases over the four subtypes, with the expected output harvested from a real
run rather than written by hand. The oracle is `tpose`: the answer is the
reference geometry followed by the byte-identical pose part that `tpose` gives
for the same restriction, e.g. both read
`{[Pose(POINT(1 1),0.5)@Mon Jan 03 00:00:00 2000 PST]}` for the linear `atValue`.
The `.out` diff is purely additive -- no existing expected output moves.

The manual gains the entry in both languages and the reference appendix is
regenerated; `gen_reference.py --audit` reads 761 chapter entries and 763
appendix rows for EN and ES alike.
