### PR TITLE
Name the H3 cell areas after the units libh3 publishes

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2890,7 +2890,7 @@
 			<title>Métricas</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_cell_area"><varname>cellArea</varname></link>: Devolver el área temporal de cada celda en una trayectoria, en metros cuadrados o en la unidad solicitada</para>
+					<para><link linkend="th3_h3_cell_area"><varname>cellArea</varname>, <varname>th3CellAreaKm2</varname>, <varname>th3CellAreaRads2</varname></link>: Devolver el área temporal de cada celda en una trayectoria, en metros cuadrados, kilómetros cuadrados o radianes cuadrados</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLength</varname></link>: Devolver la longitud temporal de cada arista dirigida en una trayectoria, en la unidad solicitada</para>

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -557,20 +557,25 @@ SELECT th3LocalIjToCell(th3index '871fa44a8ffffff@2001-01-01',
 
 	<sect1 xml:id="th3_metrics">
 		<title>Métricas</title>
-		<para>Las tres funciones métricas aceptan un argumento opcional de unidad. Para áreas: <varname>m2</varname> (por defecto), <varname>km2</varname>, o <varname>rads2</varname>. Para longitudes: <varname>km</varname> (por defecto), <varname>m</varname>, o <varname>rads</varname>. Pasar una unidad de área a una función de longitud (o viceversa) provoca un error.</para>
+		<para>Un área se devuelve en metros cuadrados mediante <varname>cellArea</varname>, la unidad y el nombre que comparte cada índice de celdas, y en las otras dos unidades que publica libh3 mediante <varname>th3CellAreaKm2</varname> y <varname>th3CellAreaRads2</varname>. Una longitud acepta un argumento de unidad: <varname>km</varname> (por defecto), <varname>m</varname>, o <varname>rads</varname>; pasar una unidad de área a una función de longitud provoca un error.</para>
 		<itemizedlist>
 			<listitem xml:id="th3_h3_cell_area">
 				<indexterm significance="normal"><primary><varname>cellArea</varname></primary></indexterm>
-				<para>Devolver el área temporal de cada celda en una trayectoria, en metros cuadrados o en la unidad solicitada</para>
+				<indexterm significance="normal"><primary><varname>th3CellAreaKm2</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3CellAreaRads2</varname></primary></indexterm>
+				<para>Devolver el área temporal de cada celda en una trayectoria, en metros cuadrados, kilómetros cuadrados o radianes cuadrados</para>
 				<programlisting xml:space="preserve" format="linespecific">
 cellArea(th3index) → tfloat
-cellArea(th3index,text) → tfloat
+th3CellAreaKm2(th3index) → tfloat
+th3CellAreaRads2(th3index) → tfloat
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT cellArea(th3index '871fa44a8ffffff@2001-01-01');
 -- 4441914.270110932@2001-01-01
-SELECT cellArea(th3index '871fa44a8ffffff@2001-01-01', 'km2');
+SELECT th3CellAreaKm2(th3index '871fa44a8ffffff@2001-01-01');
 -- 4.441914270110932@2001-01-01
+SELECT th3CellAreaRads2(th3index '871fa44a8ffffff@2001-01-01');
+-- 0.000000109434431@2001-01-01
 </programlisting>
 			</listitem>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2899,7 +2899,7 @@
 			<title>Metrics</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="th3_h3_cell_area"><varname>cellArea</varname></link>: Return the temporal area of each cell in a trajectory, in square metres or in the requested unit</para>
+					<para><link linkend="th3_h3_cell_area"><varname>cellArea</varname>, <varname>th3CellAreaKm2</varname>, <varname>th3CellAreaRads2</varname></link>: Return the temporal area of each cell in a trajectory, in square metres, square kilometres, or square radians</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLength</varname></link>: Return the temporal length of each directed edge in a trajectory, in the requested unit</para>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -557,20 +557,25 @@ SELECT th3LocalIjToCell(th3index '871fa44a8ffffff@2001-01-01',
 
 	<sect1 xml:id="th3_metrics">
 		<title>Metrics</title>
-		<para>The three metric functions take an optional unit argument. For areas: <varname>m2</varname> (default), <varname>km2</varname>, or <varname>rads2</varname>. For lengths: <varname>km</varname> (default), <varname>m</varname>, or <varname>rads</varname>. Passing an area unit to a length function (or vice-versa) raises an error.</para>
+		<para>An area is answered in square metres by <varname>cellArea</varname>, the unit and the name every cell index shares, and in the two other units libh3 publishes by <varname>th3CellAreaKm2</varname> and <varname>th3CellAreaRads2</varname>. A length takes a unit argument: <varname>km</varname> (default), <varname>m</varname>, or <varname>rads</varname>; passing an area unit to a length function raises an error.</para>
 		<itemizedlist>
 			<listitem xml:id="th3_h3_cell_area">
 				<indexterm significance="normal"><primary><varname>cellArea</varname></primary></indexterm>
-				<para>Return the temporal area of each cell in a trajectory, in square metres or in the requested unit</para>
+				<indexterm significance="normal"><primary><varname>th3CellAreaKm2</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3CellAreaRads2</varname></primary></indexterm>
+				<para>Return the temporal area of each cell in a trajectory, in square metres, square kilometres, or square radians</para>
 				<programlisting xml:space="preserve" format="linespecific">
 cellArea(th3index) → tfloat
-cellArea(th3index,text) → tfloat
+th3CellAreaKm2(th3index) → tfloat
+th3CellAreaRads2(th3index) → tfloat
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT cellArea(th3index '871fa44a8ffffff@2001-01-01');
 -- 4441914.270110932@2001-01-01
-SELECT cellArea(th3index '871fa44a8ffffff@2001-01-01', 'km2');
+SELECT th3CellAreaKm2(th3index '871fa44a8ffffff@2001-01-01');
 -- 4.441914270110932@2001-01-01
+SELECT th3CellAreaRads2(th3index '871fa44a8ffffff@2001-01-01');
+-- 0.000000109434431@2001-01-01
 </programlisting>
 			</listitem>
 

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -271,7 +271,8 @@ extern Temporal *th3index_local_ij_to_cell(const Temporal *origin,
  * Metrics
  *****************************************************************************/
 
-extern Temporal *th3index_cell_area_unit(const Temporal *temp, const char *unit);
+extern Temporal *th3index_cell_area_km2(const Temporal *temp);
+extern Temporal *th3index_cell_area_rads2(const Temporal *temp);
 extern Temporal *th3index_edge_length(const Temporal *temp, const char *unit);
 extern Temporal *tgeogpoint_great_circle_distance(const Temporal *a,
   const Temporal *b, const char *unit);

--- a/meos/src/h3/th3index_metrics.c
+++ b/meos/src/h3/th3index_metrics.c
@@ -166,22 +166,16 @@ h3_gs_great_circle_distance_meos(const GSERIALIZED *a, const GSERIALIZED *b,
 }
 
 /*****************************************************************************
- * cellArea(th3index) and cellArea(th3index, text) — lift_with_const
+ * cellArea(th3index), th3CellAreaKm2 and th3CellAreaRads2 — lift_with_const
  *****************************************************************************/
 
 /**
- * @ingroup meos_h3_metrics
  * @brief Return the per-instant area of a temporal H3 cell in the given
- * unit.
- * @csqlfn #Th3index_cell_area_unit()
+ * H3 unit
  */
-Temporal *
-th3index_cell_area_unit(const Temporal *temp, const char *unit)
+static Temporal *
+th3index_cell_area_in(const Temporal *temp, H3Unit u)
 {
-  /* Ensure the validity of the arguments */
-  VALIDATE_TH3INDEX(temp, NULL); VALIDATE_NOT_NULL(unit, NULL);
-
-  H3Unit u = h3_unit_from_cstring(unit);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_h3_cell_area;
@@ -193,6 +187,34 @@ th3index_cell_area_unit(const Temporal *temp, const char *unit)
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal(temp, &lfinfo);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant area of a temporal H3 cell in square
+ * kilometres, the quantity libh3 answers as cellAreaKm2
+ * @csqlfn #Th3index_cell_area_km2()
+ */
+Temporal *
+th3index_cell_area_km2(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TH3INDEX(temp, NULL);
+  return th3index_cell_area_in(temp, H3_UNIT_KM2);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant area of a temporal H3 cell in square
+ * radians, the quantity libh3 answers as cellAreaRads2
+ * @csqlfn #Th3index_cell_area_rads2()
+ */
+Temporal *
+th3index_cell_area_rads2(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TH3INDEX(temp, NULL);
+  return th3index_cell_area_in(temp, H3_UNIT_RADS2);
 }
 
 /*****************************************************************************

--- a/mobilitydb/sql/h3/286_th3index_metrics.in.sql
+++ b/mobilitydb/sql/h3/286_th3index_metrics.in.sql
@@ -50,9 +50,14 @@ CREATE FUNCTION cellArea(th3index)
   AS 'MODULE_PATHNAME', 'Th3index_cell_area'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION cellArea(th3index, text)
+CREATE FUNCTION th3CellAreaKm2(th3index)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Th3index_cell_area_unit'
+  AS 'MODULE_PATHNAME', 'Th3index_cell_area_km2'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION th3CellAreaRads2(th3index)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Th3index_cell_area_rads2'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************

--- a/mobilitydb/src/h3/th3index_metrics.c
+++ b/mobilitydb/src/h3/th3index_metrics.c
@@ -45,7 +45,7 @@
 #include "pg_temporal/temporal.h"
 
 /*****************************************************************************
- * cellArea(th3index) and cellArea(th3index, text)
+ * cellArea(th3index), th3CellAreaKm2 and th3CellAreaRads2
  *****************************************************************************/
 
 PGDLLEXPORT Datum Th3index_cell_area(PG_FUNCTION_ARGS);
@@ -64,21 +64,35 @@ Th3index_cell_area(PG_FUNCTION_ARGS)
   PG_RETURN_TEMPORAL_P(result);
 }
 
-PGDLLEXPORT Datum Th3index_cell_area_unit(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Th3index_cell_area_unit);
+PGDLLEXPORT Datum Th3index_cell_area_km2(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Th3index_cell_area_km2);
 /**
  * @ingroup mobilitydb_h3_metrics
- * @brief Return the per-instant area of a temporal H3 cell in the given unit
- * @sqlfn cellArea()
+ * @brief Return the per-instant area of a temporal H3 cell in square
+ * kilometres
+ * @sqlfn th3CellAreaKm2()
  */
 Datum
-Th3index_cell_area_unit(PG_FUNCTION_ARGS)
+Th3index_cell_area_km2(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  text *unit_txt = PG_GETARG_TEXT_P(1);
-  char *unit = text_to_cstring(unit_txt);
-  Temporal *result = th3index_cell_area_unit(temp, unit);
-  pfree(unit);
+  Temporal *result = th3index_cell_area_km2(temp);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Th3index_cell_area_rads2(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Th3index_cell_area_rads2);
+/**
+ * @ingroup mobilitydb_h3_metrics
+ * @brief Return the per-instant area of a temporal H3 cell in square radians
+ * @sqlfn th3CellAreaRads2()
+ */
+Datum
+Th3index_cell_area_rads2(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Temporal *result = th3index_cell_area_rads2(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }

--- a/mobilitydb/test/h3/expected/286_th3index_metrics.test.out
+++ b/mobilitydb/test/h3/expected/286_th3index_metrics.test.out
@@ -1,38 +1,37 @@
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01')
-  = cellArea(th3index '831c02fffffffff@2001-01-01', 'm2');
- ?column? 
-----------
- t
-(1 row)
-
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01')
-  = cellArea(th3index '831c02fffffffff@2001-01-01', 'km2');
- ?column? 
-----------
- f
-(1 row)
-
 SELECT round(startValue(cellArea(th3index '831c02fffffffff@2001-01-01'))::numeric, 1);
     round     
 --------------
  7725505767.6
 (1 row)
 
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'km2')
-  IS NOT NULL;
+SELECT round(startValue(th3CellAreaKm2(th3index '831c02fffffffff@2001-01-01'))::numeric, 7);
+    round     
+--------------
+ 7725.5057676
+(1 row)
+
+SELECT round(startValue(th3CellAreaRads2(th3index '831c02fffffffff@2001-01-01'))::numeric, 9);
+    round    
+-------------
+ 0.000190332
+(1 row)
+
+SELECT startValue(cellArea(th3index '831c02fffffffff@2001-01-01'))
+  = startValue(th3CellAreaKm2(th3index '831c02fffffffff@2001-01-01')) * 1e6;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'm2')
-  IS NOT NULL;
+SELECT startValue(th3CellAreaRads2(th3index '831c02fffffffff@2001-01-01'))
+  < startValue(th3CellAreaKm2(th3index '831c02fffffffff@2001-01-01'));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'rads2')
+SELECT th3CellAreaKm2(th3index
+  '[831c02fffffffff@2001-01-01, 8a2a1072b59ffff@2001-01-02]')
   IS NOT NULL;
  ?column? 
 ----------
@@ -40,18 +39,13 @@ SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'rads2')
 (1 row)
 
 SELECT cellArea(th3index
-  '[831c02fffffffff@2001-01-01, 8a2a1072b59ffff@2001-01-02]', 'km2')
+  '[831c02fffffffff@2001-01-01, 8a2a1072b59ffff@2001-01-02]')
   IS NOT NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-/* Errors */
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'km');
-ERROR:  h3_cell_area: expected an area unit (km2, m2, rads2)
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'lightyears');
-ERROR:  invalid h3 unit "lightyears" (expected one of km, m, rads, km2, m2, rads2)
 SELECT th3EdgeLength(th3CellsToDirectedEdge(
     th3index '880326b885fffff@2001-01-01',
     th3index '880326b88dfffff@2001-01-01')) IS NOT NULL;

--- a/mobilitydb/test/h3/queries/286_th3index_metrics.test.sql
+++ b/mobilitydb/test/h3/queries/286_th3index_metrics.test.sql
@@ -16,35 +16,28 @@
 -- per-instant adapters being filled in.
 
 -------------------------------------------------------------------------------
--- cellArea(th3index) and cellArea(th3index, text) — lift_with_const
+-- cellArea(th3index), th3CellAreaKm2 and th3CellAreaRads2 — lift_with_const
 -------------------------------------------------------------------------------
 
--- The one-argument form answers square metres, the unit the DggsCellOps
--- cell_area slot declares, so it agrees with 'm2' and differs from 'km2'
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01')
-  = cellArea(th3index '831c02fffffffff@2001-01-01', 'm2');
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01')
-  = cellArea(th3index '831c02fffffffff@2001-01-01', 'km2');
+-- cellArea answers square metres, the unit the DggsCellOps cell_area slot
+-- declares, and the two H3 units are the ones libh3 names
 SELECT round(startValue(cellArea(th3index '831c02fffffffff@2001-01-01'))::numeric, 1);
+SELECT round(startValue(th3CellAreaKm2(th3index '831c02fffffffff@2001-01-01'))::numeric, 7);
+SELECT round(startValue(th3CellAreaRads2(th3index '831c02fffffffff@2001-01-01'))::numeric, 9);
 
--- All three valid area units
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'km2')
-  IS NOT NULL;
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'm2')
-  IS NOT NULL;
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'rads2')
-  IS NOT NULL;
+-- The three answer one quantity in three units
+SELECT startValue(cellArea(th3index '831c02fffffffff@2001-01-01'))
+  = startValue(th3CellAreaKm2(th3index '831c02fffffffff@2001-01-01')) * 1e6;
+SELECT startValue(th3CellAreaRads2(th3index '831c02fffffffff@2001-01-01'))
+  < startValue(th3CellAreaKm2(th3index '831c02fffffffff@2001-01-01'));
 
 -- Sequence form
-SELECT cellArea(th3index
-  '[831c02fffffffff@2001-01-01, 8a2a1072b59ffff@2001-01-02]', 'km2')
+SELECT th3CellAreaKm2(th3index
+  '[831c02fffffffff@2001-01-01, 8a2a1072b59ffff@2001-01-02]')
   IS NOT NULL;
-
--- Length unit on an area function — h3-pg behaviour: error.
-/* Errors */
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'km');
--- Invalid unit string
-SELECT cellArea(th3index '831c02fffffffff@2001-01-01', 'lightyears');
+SELECT cellArea(th3index
+  '[831c02fffffffff@2001-01-01, 8a2a1072b59ffff@2001-01-02]')
+  IS NOT NULL;
 
 -------------------------------------------------------------------------------
 -- th3EdgeLength(th3index, text) — lift_with_const


### PR DESCRIPTION
libh3 answers a cell area through cellAreaM2, cellAreaKm2 and cellAreaRads2, three functions each naming its unit, so the lifted surface carries the same three answers under the same words: cellArea is the square metre the DggsCellOps cell_area slot declares and every cell index shares, and th3CellAreaKm2 and th3CellAreaRads2 are the two units only H3 publishes. A unit argument names no libh3 function, so it is gone, and the square metre is answered once.