### PR TITLE
Show in the analytics chapter the results the server prints

### DIFF
--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -31,7 +31,7 @@ SELECT asText(minDistSimplify(tgeompoint '[Point(1 1 1)@2001-01-01,
 -- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (5 5 5)@2001-01-05)
 SELECT asText(minDistSimplify(tgeompoint '[Point(1 1 1)@2001-01-01,
   Point(2 2 2)@2001-01-02, Point(3 3 3)@2001-01-04, Point(4 4 4)@2001-01-05)', sqrt(3)));
--- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (4 4 4)@2001-01-05]
+-- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (4 4 4)@2001-01-05)
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minTimeDeltaSimplify(tfloat '[1@2001-01-01, 2@2001-01-02, 3@2001-01-04,
@@ -39,7 +39,7 @@ SELECT minTimeDeltaSimplify(tfloat '[1@2001-01-01, 2@2001-01-02, 3@2001-01-04,
 -- [1@2001-01-01, 3@2001-01-04, 4@2001-01-05]
 SELECT asText(minTimeDeltaSimplify(tgeogpoint '[Point(1 1 1)@2001-01-01,
   Point(2 2 2)@2001-01-02, Point(3 3 3)@2001-01-04, Point(5 5 5)@2001-01-05)', '1 day'));
--- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (5 5 5)@2001-01-05]
+-- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (5 5 5)@2001-01-05)
 </programlisting>
 			</listitem>
 
@@ -59,11 +59,9 @@ douglasPeuckerSimplify({tfloat,tgeompoint},maxdist float,
 SELECT maxDistSimplify(tfloat '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03, 3@2001-01-04,
   1@2001-01-05]', 1, false);
 -- [1@2001-01-01, 1@2001-01-03, 3@2001-01-04, 1@2001-01-05]
--- Synchronous distance by default for temporal points
 SELECT asText(maxDistSimplify(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02,
   Point(3 1)@2001-01-03, Point(3 3)@2001-01-05, Point(5 1)@2001-01-06]', 2));
 -- [POINT(1 1)@2001-01-01, POINT(3 3)@2001-01-05, POINT(5 1)@2001-01-06]
--- Spatial distance
 SELECT asText(maxDistSimplify(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02,
   Point(3 1)@2001-01-03, Point(3 3)@2001-01-05, Point(5 1)@2001-01-06]', 2, false));
 -- [POINT(1 1)@2001-01-01, POINT(5 1)@2001-01-06]
@@ -128,8 +126,7 @@ SELECT asText(tsample(tgeompoint '{[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05
 -- {POINT(1 1)@2001-01-01, POINT(4 4)@2001-01-04, POINT(3 3)@2001-01-07}
 SELECT asText(tsample(tgeompoint '{[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05],
   [Point(1 1)@2001-01-06, Point(5 5)@2001-01-08]}', '3 days', '2001-01-01', 'step'));
-/* Interp=Step;{[POINT(1 1)@2001-01-01, POINT(4 4)@2001-01-04],
-   [POINT(3 3)@2001-01-07]} */
+-- Interp=Step;{[POINT(1 1)@2001-01-01, POINT(4 4)@2001-01-04], [POINT(3 3)@2001-01-07]}
 </programlisting>
 				<para>La <xref linkend="fig_tsample" /> ilustra el muestreo para números flotantes temporales con varias interpolaciones. Como ilustra la figura, la operación de muestreo es más adecuada para valores temporales con interpolación continua.</para>
 				<figure xml:id="fig_tsample" float="start">
@@ -170,8 +167,8 @@ SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-
    POINT(1.5 1.5)@2001-01-08] */
 SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05,
   Point(1 1)@2001-01-09)', '2 days', '2001-01-01'));
-/* [POINT(2 2)@2001-01-01, POINT(4 4)@2001-01-03, POINT(4 4)@2001-01-05,
-   POINT(2 2)@2001-01-07] */
+/* [POINT(2 2)@2001-01-01, POINT(4 4)@2001-01-03, POINT(4 4)@2001-01-05, POINT(2
+   2)@2001-01-07] */
 SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05,
   Point(1 1)@2001-01-09)', '4 days', '2001-01-01'));
 -- [POINT(3 3)@2001-01-01, POINT(3 3)@2001-01-05]
@@ -363,15 +360,15 @@ SELECT splitNSpans(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
 -- {"[2000-01-01, 2000-01-03]","[2000-01-03, 2000-01-05]"}
 SELECT splitNSpans(tgeogpoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02],
   [Point(1 1 1)@2000-01-03, Point(2 2 2)@2000-01-04], [Point(1 1 1)@2000-01-05]}', 2);
--- {"[2000-01-01, 2000-01-04])","[2000-01-05, 2000-01-05])"}
+-- {"[2000-01-01, 2000-01-04]","[2000-01-05, 2000-01-05]"}
 SELECT splitNSpans(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 2@2000-01-04,
   2@2000-01-05}', 6);
-/* {"[2000-01-01, 2000-01-01]","[2000-01-02, 2000-01-02]","[2000-01-03, 2000-01-03]",
-   "[2000-01-04, 2000-01-04]","[2000-01-05, 2000-01-05]"} */
+/* {"[2000-01-01, 2000-01-01]","[2000-01-02, 2000-01-02]","[2000-01-03,
+   2000-01-03]","[2000-01-04, 2000-01-04]","[2000-01-05, 2000-01-05]"} */
 SELECT splitNSpans(ttext '[A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-04,
   A@2000-01-05]', 6);
-/* {"[2000-01-01, 2000-01-02]","[2000-01-02, 2000-01-03]",
-   "[2000-01-03, 2000-01-04]","[2000-01-04, 2000-01-05]"} */
+/* {"[2000-01-01, 2000-01-02]","[2000-01-02, 2000-01-03]","[2000-01-03,
+   2000-01-04]","[2000-01-04, 2000-01-05]"} */
 </programlisting>
 			</listitem>
 
@@ -385,17 +382,17 @@ splitEachNSpans(temp,integer) → tstzspan[]
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNSpans(ttext '{A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-04,
   A@2000-01-05}', 1);
-/* {"[2000-01-01, 2000-01-01]","[2000-01-02, 2000-01-02]","[2000-01-03, 2000-01-03]",
-   "[2000-01-04, 2000-01-04]","[2000-01-05, 2000-01-05]} */
+/* {"[2000-01-01, 2000-01-01]","[2000-01-02, 2000-01-02]","[2000-01-03,
+   2000-01-03]","[2000-01-04, 2000-01-04]","[2000-01-05, 2000-01-05]"} */
 SELECT splitEachNSpans(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 2@2000-01-04,
   1@2000-01-05]', 2);
---  {"[2000-01-01, 2000-01-03]","[2000-01-03, 2000-01-05]"}
+-- {"[2000-01-01, 2000-01-03]","[2000-01-03, 2000-01-05]"}
 SELECT splitEachNSpans(tgeompoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02],
   [Point(1 1 1)@2000-01-03, Point(2 2 2)@2000-01-04], [Point(1 1 1)@2000-01-05]}', 2);
---  {"[2000-01-01, 2000-01-02]","[2000-01-03, 2000-01-04]","[2000-01-05, 2000-01-05]"}
+-- {"[2000-01-01, 2000-01-02]","[2000-01-03, 2000-01-04]","[2000-01-05, 2000-01-05]"}
 SELECT splitEachNSpans(tgeogpoint '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02,
   Point(1 1 1)@2000-01-03, Point(2 2 2)@2000-01-04, Point(1 1 1)@2000-01-05]', 6);
--- {"[2000-01-01, 2000-01-05])"}
+-- {"[2000-01-01, 2000-01-05]"}
 SELECT splitEachNSpans(tgeogpoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02],
   [Point(1 1 1)@2000-01-03, Point(2 2 2)@2000-01-04], [Point(1 1 1)@2000-01-05]}', 6);
 -- {"[2000-01-01, 2000-01-02]","[2000-01-03, 2000-01-04]","[2000-01-05, 2000-01-05]"}
@@ -415,26 +412,22 @@ SELECT splitNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-0
 -- {"TBOXINT XT([1, 5),[2000-01-01, 2000-01-05])"}
 SELECT splitNTboxes(tfloat '{[1@2000-01-01, 2@2000-01-02], [1@2000-01-03, 4@2000-01-04],
   [1@2000-01-05]}', 2);
-/* {"TBOXFLOAT XT([1, 4],[2000-01-01, 2000-01-04])",
-   "TBOXFLOAT XT([1, 1],[2000-01-05, 2000-01-05])"} */
+/* {"TBOXFLOAT XT([1, 4],[2000-01-01, 2000-01-04])","TBOXFLOAT XT([1, 1],[2000-01-05,
+   2000-01-05])"} */
 SELECT splitNTboxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 3);
-/* {"TBOXFLOAT XT([1, 2],[2000-01-01, 2000-01-03])",
-   "TBOXFLOAT XT([1, 4],[2000-01-03, 2000-01-04])",
-   "TBOXFLOAT XT([1, 4],[2000-01-04, 2000-01-05])"} */
+/* {"TBOXFLOAT XT([1, 2],[2000-01-01, 2000-01-03])","TBOXFLOAT XT([1, 4],[2000-01-03,
+   2000-01-04])","TBOXFLOAT XT([1, 4],[2000-01-04, 2000-01-05])"} */
 SELECT splitNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 6);
-/* {"TBOXINT XT([1, 2),[2000-01-01, 2000-01-01])",
-   "TBOXINT XT([2, 3),[2000-01-02, 2000-01-02])",
-   "TBOXINT XT([1, 2),[2000-01-03, 2000-01-03])",
-   "TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])",
-   "TBOXINT XT([1, 2),[2000-01-05, 2000-01-05])"} */
+/* {"TBOXINT XT([1, 2),[2000-01-01, 2000-01-01])","TBOXINT XT([2, 3),[2000-01-02,
+   2000-01-02])","TBOXINT XT([1, 2),[2000-01-03, 2000-01-03])","TBOXINT XT([4,
+   5),[2000-01-04, 2000-01-04])","TBOXINT XT([1, 2),[2000-01-05, 2000-01-05])"} */
 SELECT splitNTboxes(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 6);
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])",
-   "TBOXINT XT([1, 3),[2000-01-02, 2000-01-03])",
-   "TBOXINT XT([1, 5),[2000-01-03, 2000-01-04])",
-   "TBOXINT XT([1, 5),[2000-01-04, 2000-01-05])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])","TBOXINT XT([1, 3),[2000-01-02,
+   2000-01-03])","TBOXINT XT([1, 5),[2000-01-03, 2000-01-04])","TBOXINT XT([1,
+   5),[2000-01-04, 2000-01-05])"} */
 </programlisting>
 			</listitem>
 
@@ -448,25 +441,22 @@ splitEachNTboxes(tnumber,integer) → tbox[]
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 1);
-/* {"TBOXINT XT([1, 2),[2000-01-01, 2000-01-01])",
-   "TBOXINT XT([2, 3),[2000-01-02, 2000-01-02])",
-   "TBOXINT XT([1, 2),[2000-01-03, 2000-01-03])",
-   "TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])"} */
+/* {"TBOXINT XT([1, 2),[2000-01-01, 2000-01-01])","TBOXINT XT([2, 3),[2000-01-02,
+   2000-01-02])","TBOXINT XT([1, 2),[2000-01-03, 2000-01-03])","TBOXINT XT([4,
+   5),[2000-01-04, 2000-01-04])","TBOXINT XT([1, 2),[2000-01-05, 2000-01-05])"} */
 SELECT splitEachNTboxes(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 1);
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])",
-   "TBOXINT XT([1, 3),[2000-01-02, 2000-01-03])",
-   "TBOXINT XT([1, 5),[2000-01-03, 2000-01-04])",
-   "TBOXINT XT([1, 5),[2000-01-04, 2000-01-05])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])","TBOXINT XT([1, 3),[2000-01-02,
+   2000-01-03])","TBOXINT XT([1, 5),[2000-01-03, 2000-01-04])","TBOXINT XT([1,
+   5),[2000-01-04, 2000-01-05])"} */
 SELECT splitEachNTboxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 3);
-/* {"TBOXFLOAT XT([1, 4],[2000-01-01, 2000-01-04])",
-   "TBOXFLOAT XT([1, 4],[2000-01-04, 2000-01-05])"} */
+/* {"TBOXFLOAT XT([1, 4],[2000-01-01, 2000-01-04])","TBOXFLOAT XT([1, 4],[2000-01-04,
+   2000-01-05])"} */
 SELECT splitEachNTboxes(tfloat '{[1@2000-01-01, 2@2000-01-02],
   [1@2000-01-03, 4@2000-01-04], [1@2000-01-05]}', 6);
-/* {"TBOXFLOAT XT([1, 2],[2000-01-01, 2000-01-02])",
-   "TBOXFLOAT XT([1, 4],[2000-01-03, 2000-01-04])",
-   "TBOXFLOAT XT([1, 1],[2000-01-05, 2000-01-05])"} */
+/* {"TBOXFLOAT XT([1, 2],[2000-01-01, 2000-01-02])","TBOXFLOAT XT([1, 4],[2000-01-03,
+   2000-01-04])","TBOXFLOAT XT([1, 1],[2000-01-05, 2000-01-05])"} */
 </programlisting>
 			</listitem>
 
@@ -483,8 +473,9 @@ SELECT splitNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 1);
 SELECT splitNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 2);
 -- {"STBOX X((1,1),(3,2))","STBOX X((3,1),(5,2))"}
 SELECT splitNStboxes(geography 'Linestring(1 1 1,2 2 1,3 1 1,4 2 1,5 1 1)', 6);
-/* {"SRID=4326;GEODSTBOX Z((1,1,1),(2,2,1))", "SRID=4326;GEODSTBOX Z((2,1,1),(3,2,1))",
-   "SRID=4326;GEODSTBOX Z((3,1,1),(4,2,1))", "SRID=4326;GEODSTBOX Z((4,1,1),(5,2,1))"} */
+/* {"SRID=4326;GEODSTBOX Z((1,1,1),(2,2,1))","SRID=4326;GEODSTBOX
+   Z((2,1,1),(3,2,1))","SRID=4326;GEODSTBOX Z((3,1,1),(4,2,1))","SRID=4326;GEODSTBOX
+   Z((4,1,1),(5,2,1))"} */
 SELECT splitNStboxes(geometry 'MultiLinestring((1 1,2 2),(3 1,4 2),(5 1,6 2))', 2);
 -- {"STBOX X((1,1),(4,2))","STBOX X((5,1),(6,2))"}
 </programlisting>
@@ -493,28 +484,27 @@ SELECT splitNStboxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05}', 1);
 -- {"STBOX XT(((1,1),(5,2)),[2000-01-01, 2000-01-05])"}
 SELECT splitNStboxes(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
-  Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05]');
+  Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05]', 4);
 /* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
    "STBOX XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])",
    "STBOX XT(((3,1),(4,2)),[2000-01-03, 2000-01-04])",
    "STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
 SELECT splitNStboxes(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02],
   [Point(3 1)@2000-01-03, Point(4 2)@2000-01-04], [Point(5 1)@2000-01-05]}', 2);
-/* {"STBOX XT(((1,1),(4,2)),[2000-01-01, 2000-01-04])",
-   "STBOX XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
+/* {"STBOX XT(((1,1),(4,2)),[2000-01-01, 2000-01-04])","STBOX
+   XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
 SELECT splitNStboxes(tgeogpoint '{Point(1 1 1)@2000-01-01, Point(2 2 1)@2000-01-02,
   Point(3 1 1)@2000-01-03, Point(4 2 1)@2000-01-04, Point(5 1 1)@2000-01-05}', 6);
-/* {"SRID=4326;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01, 2000-01-01])",
-   "SRID=4326;GEODSTBOX ZT(((2,2,1),(2,2,1)),[2000-01-02, 2000-01-02])",
-   "SRID=4326;GEODSTBOX ZT(((3,1,1),(3,1,1)),[2000-01-03, 2000-01-03])",
-   "SRID=4326;GEODSTBOX ZT(((4,2,1),(4,2,1)),[2000-01-04, 2000-01-04])",
-   "SRID=4326;GEODSTBOX ZT(((5,1,1),(5,1,1)),[2000-01-05, 2000-01-05])"} */
+/* {"SRID=4326;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01,
+   2000-01-01])","SRID=4326;GEODSTBOX ZT(((2,2,1),(2,2,1)),[2000-01-02,
+   2000-01-02])","SRID=4326;GEODSTBOX ZT(((3,1,1),(3,1,1)),[2000-01-03,
+   2000-01-03])","SRID=4326;GEODSTBOX ZT(((4,2,1),(4,2,1)),[2000-01-04,
+   2000-01-04])","SRID=4326;GEODSTBOX ZT(((5,1,1),(5,1,1)),[2000-01-05, 2000-01-05])"} */
 SELECT splitNStboxes(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05]', 6);
-/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
-   "STBOX XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])",
-   "STBOX XT(((3,1),(4,2)),[2000-01-03, 2000-01-04])",
-   "STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])","STBOX
+   XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])","STBOX XT(((3,1),(4,2)),[2000-01-03,
+   2000-01-04])","STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
 </programlisting>
 			</listitem>
 
@@ -527,34 +517,32 @@ splitEachNStboxes({lines,tpoint},integer) → stbox[]
 				<para>Para puntos temporales, la elección entre instantes o segmentos depende de si la interpolación es discreta or continua. El último argumento especifica el número de instantes o segmentos de entrada que se fusionan para producir un cuadro de salida. Si el número de instantes o segmentos es menor que el número dado, la matriz resultante tendrá un único cuadro por secuencia. En caso contrario, el número especificado de instantes o segmentos consecutivos será fusionado en cada cuadro de salida. Observe que, a diferencia de la función <link linkend="ttype_splitNStboxes"><varname>splitNStboxes</varname></link>, el número de cuadros en el resultado depende del número de instantes o de segmentos de entrada.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 1);
--- {"STBOX X((1,1),(5,2))"}
+/* {"STBOX X((1,1),(2,2))","STBOX X((2,1),(3,2))","STBOX X((3,1),(4,2))","STBOX
+   X((4,1),(5,2))"} */
 SELECT splitEachNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 2);
 -- {"STBOX X((1,1),(3,2))","STBOX X((3,1),(5,2))"}
 SELECT splitEachNStboxes(geography 'Linestring(1 1 1,2 2 1,3 1 1,4 2 1,5 1 1)', 6);
-/* {"SRID=4326;GEODSTBOX Z((1,1,1),(2,2,1))", "SRID=4326;GEODSTBOX Z((2,1,1),(3,2,1))",
-   "SRID=4326;GEODSTBOX Z((3,1,1),(4,2,1))", "SRID=4326;GEODSTBOX Z((4,1,1),(5,2,1))"} */
+-- {"SRID=4326;GEODSTBOX Z((1,1,1),(5,2,1))"}
 SELECT splitEachNStboxes(geometry 'MultiLinestring((1 1,2 2),(3 1,4 2),(5 1,6 2))', 2);
--- {"STBOX X((1,1),(4,2))","STBOX X((5,1),(6,2))"}
+-- {"STBOX X((1,1),(2,2))","STBOX X((3,1),(4,2))","STBOX X((5,1),(6,2))"}
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNStboxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05}', 1);
-/* {"STBOX XT(((1,1),(1,1)),[2000-01-01, 2000-01-01])",
-   "STBOX XT(((2,2),(2,2)),[2000-01-02, 2000-01-02])",
-   "STBOX XT(((3,1),(3,1)),[2000-01-03, 2000-01-03])",
-   "STBOX XT(((4,2),(4,2)),[2000-01-04, 2000-01-04])",
-   "STBOX XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
+/* {"STBOX XT(((1,1),(1,1)),[2000-01-01, 2000-01-01])","STBOX
+   XT(((2,2),(2,2)),[2000-01-02, 2000-01-02])","STBOX XT(((3,1),(3,1)),[2000-01-03,
+   2000-01-03])","STBOX XT(((4,2),(4,2)),[2000-01-04, 2000-01-04])","STBOX
+   XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
 SELECT splitEachNStboxes(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05]', 1);
-/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
-   "STBOX XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])",
-   "STBOX XT(((3,1),(4,2)),[2000-01-03, 2000-01-04])",
-   "STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])","STBOX
+   XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])","STBOX XT(((3,1),(4,2)),[2000-01-03,
+   2000-01-04])","STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
 SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02],
   [Point(3 1)@2000-01-03, Point(4 2)@2000-01-04], [Point(5 1)@2000-01-05]}', 2);
-/* {"SRID=4326;GEODSTBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
-   "SRID=4326;GEODSTBOX XT(((3,1),(4,2)),[2000-01-03, 2000-01-04])",
-   "SRID=4326;GEODSTBOX XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
+/* {"SRID=4326;GEODSTBOX XT(((1,1),(2,2)),[2000-01-01,
+   2000-01-02])","SRID=4326;GEODSTBOX XT(((3,1),(4,2)),[2000-01-03,
+   2000-01-04])","SRID=4326;GEODSTBOX XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -633,7 +621,7 @@ SELECT getBin(2, 2);
 SELECT getBin(2, 2.5, 1.5);
 -- [1.5, 4)
 SELECT getBin('2001-01-04', interval '1 week');
--- [2001-01-01, 2001-01-08)
+-- [2001-01-01 08:00:00, 2001-01-08 08:00:00)
 SELECT getBin('2001-01-04', interval '1 week', '2001-01-07');
 -- [2000-12-31, 2001-01-07)
 </programlisting>
@@ -754,13 +742,13 @@ getValueTimeTile(v float,t timestamptz,vsize float,duration interval,
 					<para>Si el origen de las dimensiones de valores y/o de tiempo no se especifica, su valor se establece por defecto en 0 y en el lunes 3 de enero de 2000, respectivamente.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValueTile(15, 2);
--- TBOX ([14,16))
+-- TBOXFLOAT X([14, 16))
 SELECT getTboxTimeTile('2001-01-15', interval '2 days');
--- TBOX ([2001-01-15,2001-01-17))
+-- TBOX T([2001-01-13 08:00:00, 2001-01-15 08:00:00))
 SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days');
--- TBOX XT([14,16),[2001-01-15,2001-01-17))
+-- TBOXFLOAT XT([14, 16),[2001-01-13 08:00:00, 2001-01-15 08:00:00))
 SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days', 1, '2001-01-02');
--- TBOX XT([15,17),[2001-01-14,2001-01-16))
+-- TBOXFLOAT XT([15, 17),[2001-01-14, 2001-01-16))
 </programlisting>
 				</listitem>
 
@@ -783,9 +771,9 @@ getSpaceTimeTile(point geometry,time timestamptz,xsize float,
 SELECT getSpaceTile(geometry 'Point(1 1 1)', 2.0);
 -- STBOX Z((0,0,0),(2,2,2))
 SELECT getStboxTimeTile(timestamptz '2001-01-01', interval '2 days');
--- STBOX T([2001-01-01,2001-01-03))
+-- STBOX T([2000-12-30 08:00:00, 2001-01-01 08:00:00))
 SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 days');
--- STBOX XT(((0,0),(2,2)),[2001-01-01, 2001-01-03))
+-- STBOX XT(((0,0),(2,2)),[2000-12-30 08:00:00, 2001-01-01 08:00:00))
 SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 days',
   'Point(1 1)', '2001-01-02');
 -- STBOX XT(((1,1),(3,3)),[2000-12-31, 2001-01-02))
@@ -810,18 +798,19 @@ timeBins(temp,duration interval,torigin timestamptz='2000-01-03') → tstzspan[]
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueBins(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 3);
--- {"[1, 3)","[4, 5)"}
+-- {"[0, 3)","[3, 6)"}
 SELECT valueBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 3, 1);
--- {"[1, 4)","[4, 4]"}
+-- {"[1, 4)","[4, 7)"}
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeBins(ttext '{AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03, CCC@2000-01-04,
   AAA@2000-01-05}', '3 days');
--- {"[2000-01-01, 2000-01-02]","[2000-01-03, 2000-01-05]"}
+/* {"[1999-12-31 08:00:00, 2000-01-03 08:00:00)","[2000-01-03 08:00:00, 2000-01-06
+   08:00:00)"} */
 SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', '3 days', '2000-01-01');
--- {"[2000-01-01, 2000-01-04)","[2000-01-04, 2000-01-05)"}
+-- {"[2000-01-01, 2000-01-04)","[2000-01-04, 2000-01-07)"}
 </programlisting>
 				</listitem>
 
@@ -840,22 +829,20 @@ valueTimeBoxes(tnumber,vsize number,tsize interval,vorigin number=0,
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueBoxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 3);
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-05])",
-   "TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-05])","TBOXINT XT([4, 5),[2000-01-04,
+   2000-01-04])"} */
 SELECT timeBoxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', '3 days');
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])",
-   "TBOXINT XT([1, 5),[2000-01-03, 2000-01-05])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-03])","TBOXINT XT([1, 5),[2000-01-04,
+   2000-01-05])"} */
 SELECT valueTimeBoxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 3, '3 days');
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])",
-   "TBOXINT XT([1, 2),[2000-01-03, 2000-01-05])",
-   "TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-03])","TBOXINT XT([1, 2),[2000-01-05,
+   2000-01-05])","TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])"} */
 SELECT valueTimeBoxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 3, '3 days', 1, '2000-01-01');
-/* {"TBOXFLOAT XT([1, 4),[2000-01-01, 2000-01-04))",
-   "TBOXFLOAT XT([1, 4),(2000-01-04, 2000-01-05])",
-   "TBOXFLOAT XT([4, 4],[2000-01-04, 2000-01-04])"} */
+/* {"TBOXFLOAT XT([1, 4),[2000-01-01, 2000-01-04))","TBOXFLOAT XT([1, 4),(2000-01-04,
+   2000-01-05])","TBOXFLOAT XT([4, 4],[2000-01-04, 2000-01-04])"} */
 </programlisting>
 				</listitem>
 
@@ -880,29 +867,29 @@ spaceTimeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spaceBoxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(1 1)@2000-01-03, Point(4 4)@2000-01-04, Point(1 1)@2000-01-05}', 3);
-/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-05])",
-   "STBOX XT(((4,4),(4,4)),[2000-01-04, 2000-01-04])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-05])","STBOX
+   XT(((4,4),(4,4)),[2000-01-04, 2000-01-04])"} */
 SELECT timeBoxes(tgeompoint '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02,
   Point(1 1 1)@2000-01-03, Point(4 4 4)@2000-01-04, Point(1 1 1)@2000-01-05}',
   interval '2 days', '2000-01-01');
-/* {"STBOX ZT(((1,1,1),(2,2,2)),[2000-01-01, 2000-01-02])",
-   "STBOX ZT(((1,1,1),(4,4,4)),[2000-01-03, 2000-01-04])",
-   "STBOX ZT(((1,1,1),(1,1,1)),[2000-01-05, 2000-01-05])"} */
+/* {"STBOX ZT(((1,1,1),(2,2,2)),[2000-01-01, 2000-01-02])","STBOX
+   ZT(((1,1,1),(4,4,4)),[2000-01-03, 2000-01-04])","STBOX
+   ZT(((1,1,1),(1,1,1)),[2000-01-05, 2000-01-05])"} */
 SELECT spaceTimeBoxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(1 1)@2000-01-03, Point(4 4)@2000-01-04, Point(1 1)@2000-01-05}', 3, '3 days');
-/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
-   "STBOX XT(((1,1),(1,1)),[2000-01-03, 2000-01-05])",
-   "STBOX XT(((4,4),(4,4)),[2000-01-04, 2000-01-04])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-03])","STBOX
+   XT(((1,1),(1,1)),[2000-01-05, 2000-01-05])","STBOX XT(((4,4),(4,4)),[2000-01-04,
+   2000-01-04])"} */
 SELECT spaceTimeBoxes(tgeompoint '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02,
   Point(1 1 1)@2000-01-03, Point(4 4 4)@2000-01-04, Point(1 1 1)@2000-01-05]', 3,
   interval '3 days', 'Point(1 1 1)', '2000-01-01');
-/* {"STBOX ZT(((1,1,1),(4,4,4)),[2000-01-01, 2000-01-04))",
-   "STBOX ZT(((1,1,1),(4,4,4)),(2000-01-04, 2000-01-05])",
-   "STBOX ZT(((4,4,4),(4,4,4)),[2000-01-04, 2000-01-04])"} */
+/* {"STBOX ZT(((1,1,1),(4,4,4)),[2000-01-01, 2000-01-04))","STBOX
+   ZT(((1,1,1),(4,4,4)),(2000-01-04, 2000-01-05])","STBOX
+   ZT(((4,4,4),(4,4,4)),[2000-01-04, 2000-01-04])"} */
 SELECT spaceBoxes(tpose '[Pose(Point(1 1),0.1)@2001-01-01,
   Pose(Point(3 3),0.1)@2001-01-03]', 2.0);
-/* {"STBOX XT(((1,1),(2,2)),[2001-01-01, 2001-01-02))",
-   "STBOX XT(((2,2),(3,3)),[2001-01-02, 2001-01-03])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2001-01-01, 2001-01-02))","STBOX
+   XT(((2,2),(3,3)),[2001-01-02, 2001-01-03])"} */
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -31,7 +31,7 @@ SELECT asText(minDistSimplify(tgeompoint '[Point(1 1 1)@2001-01-01,
 -- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (5 5 5)@2001-01-05)
 SELECT asText(minDistSimplify(tgeompoint '[Point(1 1 1)@2001-01-01,
   Point(2 2 2)@2001-01-02, Point(3 3 3)@2001-01-04, Point(4 4 4)@2001-01-05)', sqrt(3)));
--- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (4 4 4)@2001-01-05]
+-- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (4 4 4)@2001-01-05)
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minTimeDeltaSimplify(tfloat '[1@2001-01-01, 2@2001-01-02, 3@2001-01-04,
@@ -39,7 +39,7 @@ SELECT minTimeDeltaSimplify(tfloat '[1@2001-01-01, 2@2001-01-02, 3@2001-01-04,
 -- [1@2001-01-01, 3@2001-01-04, 4@2001-01-05]
 SELECT asText(minTimeDeltaSimplify(tgeogpoint '[Point(1 1 1)@2001-01-01,
   Point(2 2 2)@2001-01-02, Point(3 3 3)@2001-01-04, Point(5 5 5)@2001-01-05)', '1 day'));
--- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (5 5 5)@2001-01-05]
+-- [POINT Z (1 1 1)@2001-01-01, POINT Z (3 3 3)@2001-01-04, POINT Z (5 5 5)@2001-01-05)
 </programlisting>
 			</listitem>
 
@@ -59,11 +59,9 @@ douglasPeuckerSimplify({tfloat,tgeompoint},maxdist float,
 SELECT maxDistSimplify(tfloat '[1@2001-01-01, 2@2001-01-02, 1@2001-01-03, 3@2001-01-04,
   1@2001-01-05]', 1, false);
 -- [1@2001-01-01, 1@2001-01-03, 3@2001-01-04, 1@2001-01-05]
--- Synchronous distance by default for temporal points
 SELECT asText(maxDistSimplify(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02,
   Point(3 1)@2001-01-03, Point(3 3)@2001-01-05, Point(5 1)@2001-01-06]', 2));
 -- [POINT(1 1)@2001-01-01, POINT(3 3)@2001-01-05, POINT(5 1)@2001-01-06]
--- Spatial distance
 SELECT asText(maxDistSimplify(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02,
   Point(3 1)@2001-01-03, Point(3 3)@2001-01-05, Point(5 1)@2001-01-06]', 2, false));
 -- [POINT(1 1)@2001-01-01, POINT(5 1)@2001-01-06]
@@ -128,8 +126,7 @@ SELECT asText(tsample(tgeompoint '{[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05
 -- {POINT(1 1)@2001-01-01, POINT(4 4)@2001-01-04, POINT(3 3)@2001-01-07}
 SELECT asText(tsample(tgeompoint '{[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05],
   [Point(1 1)@2001-01-06, Point(5 5)@2001-01-08]}', '3 days', '2001-01-01', 'step'));
-/* Interp=Step;{[POINT(1 1)@2001-01-01, POINT(4 4)@2001-01-04],
-   [POINT(3 3)@2001-01-07]} */
+-- Interp=Step;{[POINT(1 1)@2001-01-01, POINT(4 4)@2001-01-04], [POINT(3 3)@2001-01-07]}
 </programlisting>
 				<para><xref linkend="fig_tsample" /> illustrates the sampling of temporal floats with various interpolations. As shown in the figure, the sampling operation is best suited for temporal values with continuous interpolation.</para>
 				<figure xml:id="fig_tsample" float="start">
@@ -170,8 +167,8 @@ SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-
    POINT(1.5 1.5)@2001-01-08] */
 SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05,
   Point(1 1)@2001-01-09)', '2 days', '2001-01-01'));
-/* [POINT(2 2)@2001-01-01, POINT(4 4)@2001-01-03, POINT(4 4)@2001-01-05,
-   POINT(2 2)@2001-01-07] */
+/* [POINT(2 2)@2001-01-01, POINT(4 4)@2001-01-03, POINT(4 4)@2001-01-05, POINT(2
+   2)@2001-01-07] */
 SELECT asText(tprecision(tgeompoint '[Point(1 1)@2001-01-01, Point(5 5)@2001-01-05,
   Point(1 1)@2001-01-09)', '4 days', '2001-01-01'));
 -- [POINT(3 3)@2001-01-01, POINT(3 3)@2001-01-05]
@@ -370,15 +367,15 @@ SELECT splitNSpans(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
 -- {"[2000-01-01, 2000-01-03]","[2000-01-03, 2000-01-05]"}
 SELECT splitNSpans(tgeogpoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02],
   [Point(1 1 1)@2000-01-03, Point(2 2 2)@2000-01-04], [Point(1 1 1)@2000-01-05]}', 2);
--- {"[2000-01-01, 2000-01-04])","[2000-01-05, 2000-01-05])"}
+-- {"[2000-01-01, 2000-01-04]","[2000-01-05, 2000-01-05]"}
 SELECT splitNSpans(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 2@2000-01-04,
   2@2000-01-05}', 6);
-/* {"[2000-01-01, 2000-01-01]","[2000-01-02, 2000-01-02]","[2000-01-03, 2000-01-03]",
-   "[2000-01-04, 2000-01-04]","[2000-01-05, 2000-01-05]"} */
+/* {"[2000-01-01, 2000-01-01]","[2000-01-02, 2000-01-02]","[2000-01-03,
+   2000-01-03]","[2000-01-04, 2000-01-04]","[2000-01-05, 2000-01-05]"} */
 SELECT splitNSpans(ttext '[A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-04,
   A@2000-01-05]', 6);
-/* {"[2000-01-01, 2000-01-02]","[2000-01-02, 2000-01-03]",
-   "[2000-01-03, 2000-01-04]","[2000-01-04, 2000-01-05]"} */
+/* {"[2000-01-01, 2000-01-02]","[2000-01-02, 2000-01-03]","[2000-01-03,
+   2000-01-04]","[2000-01-04, 2000-01-05]"} */
 </programlisting>
 			</listitem>
 
@@ -394,17 +391,17 @@ splitEachNSpans(temp,integer) → tstzspan[]
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNSpans(ttext '{A@2000-01-01, B@2000-01-02, A@2000-01-03, B@2000-01-04,
   A@2000-01-05}', 1);
-/* {"[2000-01-01, 2000-01-01]","[2000-01-02, 2000-01-02]","[2000-01-03, 2000-01-03]",
-   "[2000-01-04, 2000-01-04]","[2000-01-05, 2000-01-05]} */
+/* {"[2000-01-01, 2000-01-01]","[2000-01-02, 2000-01-02]","[2000-01-03,
+   2000-01-03]","[2000-01-04, 2000-01-04]","[2000-01-05, 2000-01-05]"} */
 SELECT splitEachNSpans(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 2@2000-01-04,
   1@2000-01-05]', 2);
---  {"[2000-01-01, 2000-01-03]","[2000-01-03, 2000-01-05]"}
+-- {"[2000-01-01, 2000-01-03]","[2000-01-03, 2000-01-05]"}
 SELECT splitEachNSpans(tgeompoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02],
   [Point(1 1 1)@2000-01-03, Point(2 2 2)@2000-01-04], [Point(1 1 1)@2000-01-05]}', 2);
---  {"[2000-01-01, 2000-01-02]","[2000-01-03, 2000-01-04]","[2000-01-05, 2000-01-05]"}
+-- {"[2000-01-01, 2000-01-02]","[2000-01-03, 2000-01-04]","[2000-01-05, 2000-01-05]"}
 SELECT splitEachNSpans(tgeogpoint '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02,
   Point(1 1 1)@2000-01-03, Point(2 2 2)@2000-01-04, Point(1 1 1)@2000-01-05]', 6);
--- {"[2000-01-01, 2000-01-05])"}
+-- {"[2000-01-01, 2000-01-05]"}
 SELECT splitEachNSpans(tgeogpoint '{[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02],
   [Point(1 1 1)@2000-01-03, Point(2 2 2)@2000-01-04], [Point(1 1 1)@2000-01-05]}', 6);
 -- {"[2000-01-01, 2000-01-02]","[2000-01-03, 2000-01-04]","[2000-01-05, 2000-01-05]"}
@@ -424,26 +421,22 @@ SELECT splitNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-0
 -- {"TBOXINT XT([1, 5),[2000-01-01, 2000-01-05])"}
 SELECT splitNTboxes(tfloat '{[1@2000-01-01, 2@2000-01-02], [1@2000-01-03, 4@2000-01-04],
   [1@2000-01-05]}', 2);
-/* {"TBOXFLOAT XT([1, 4],[2000-01-01, 2000-01-04])",
-   "TBOXFLOAT XT([1, 1],[2000-01-05, 2000-01-05])"} */
+/* {"TBOXFLOAT XT([1, 4],[2000-01-01, 2000-01-04])","TBOXFLOAT XT([1, 1],[2000-01-05,
+   2000-01-05])"} */
 SELECT splitNTboxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 3);
-/* {"TBOXFLOAT XT([1, 2],[2000-01-01, 2000-01-03])",
-   "TBOXFLOAT XT([1, 4],[2000-01-03, 2000-01-04])",
-   "TBOXFLOAT XT([1, 4],[2000-01-04, 2000-01-05])"} */
+/* {"TBOXFLOAT XT([1, 2],[2000-01-01, 2000-01-03])","TBOXFLOAT XT([1, 4],[2000-01-03,
+   2000-01-04])","TBOXFLOAT XT([1, 4],[2000-01-04, 2000-01-05])"} */
 SELECT splitNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 6);
-/* {"TBOXINT XT([1, 2),[2000-01-01, 2000-01-01])",
-   "TBOXINT XT([2, 3),[2000-01-02, 2000-01-02])",
-   "TBOXINT XT([1, 2),[2000-01-03, 2000-01-03])",
-   "TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])",
-   "TBOXINT XT([1, 2),[2000-01-05, 2000-01-05])"} */
+/* {"TBOXINT XT([1, 2),[2000-01-01, 2000-01-01])","TBOXINT XT([2, 3),[2000-01-02,
+   2000-01-02])","TBOXINT XT([1, 2),[2000-01-03, 2000-01-03])","TBOXINT XT([4,
+   5),[2000-01-04, 2000-01-04])","TBOXINT XT([1, 2),[2000-01-05, 2000-01-05])"} */
 SELECT splitNTboxes(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 6);
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])",
-   "TBOXINT XT([1, 3),[2000-01-02, 2000-01-03])",
-   "TBOXINT XT([1, 5),[2000-01-03, 2000-01-04])",
-   "TBOXINT XT([1, 5),[2000-01-04, 2000-01-05])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])","TBOXINT XT([1, 3),[2000-01-02,
+   2000-01-03])","TBOXINT XT([1, 5),[2000-01-03, 2000-01-04])","TBOXINT XT([1,
+   5),[2000-01-04, 2000-01-05])"} */
 </programlisting>
 			</listitem>
 
@@ -457,25 +450,22 @@ splitEachNTboxes(tnumber,integer) → tbox[]
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNTboxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 1);
-/* {"TBOXINT XT([1, 2),[2000-01-01, 2000-01-01])",
-   "TBOXINT XT([2, 3),[2000-01-02, 2000-01-02])",
-   "TBOXINT XT([1, 2),[2000-01-03, 2000-01-03])",
-   "TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])"} */
+/* {"TBOXINT XT([1, 2),[2000-01-01, 2000-01-01])","TBOXINT XT([2, 3),[2000-01-02,
+   2000-01-02])","TBOXINT XT([1, 2),[2000-01-03, 2000-01-03])","TBOXINT XT([4,
+   5),[2000-01-04, 2000-01-04])","TBOXINT XT([1, 2),[2000-01-05, 2000-01-05])"} */
 SELECT splitEachNTboxes(tint '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 1);
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])",
-   "TBOXINT XT([1, 3),[2000-01-02, 2000-01-03])",
-   "TBOXINT XT([1, 5),[2000-01-03, 2000-01-04])",
-   "TBOXINT XT([1, 5),[2000-01-04, 2000-01-05])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])","TBOXINT XT([1, 3),[2000-01-02,
+   2000-01-03])","TBOXINT XT([1, 5),[2000-01-03, 2000-01-04])","TBOXINT XT([1,
+   5),[2000-01-04, 2000-01-05])"} */
 SELECT splitEachNTboxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 3);
-/* {"TBOXFLOAT XT([1, 4],[2000-01-01, 2000-01-04])",
-   "TBOXFLOAT XT([1, 4],[2000-01-04, 2000-01-05])"} */
+/* {"TBOXFLOAT XT([1, 4],[2000-01-01, 2000-01-04])","TBOXFLOAT XT([1, 4],[2000-01-04,
+   2000-01-05])"} */
 SELECT splitEachNTboxes(tfloat '{[1@2000-01-01, 2@2000-01-02],
   [1@2000-01-03, 4@2000-01-04], [1@2000-01-05]}', 6);
-/* {"TBOXFLOAT XT([1, 2],[2000-01-01, 2000-01-02])",
-   "TBOXFLOAT XT([1, 4],[2000-01-03, 2000-01-04])",
-   "TBOXFLOAT XT([1, 1],[2000-01-05, 2000-01-05])"} */
+/* {"TBOXFLOAT XT([1, 2],[2000-01-01, 2000-01-02])","TBOXFLOAT XT([1, 4],[2000-01-03,
+   2000-01-04])","TBOXFLOAT XT([1, 1],[2000-01-05, 2000-01-05])"} */
 </programlisting>
 			</listitem>
 
@@ -493,8 +483,9 @@ SELECT splitNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 1);
 SELECT splitNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 2);
 -- {"STBOX X((1,1),(3,2))","STBOX X((3,1),(5,2))"}
 SELECT splitNStboxes(geography 'Linestring(1 1 1,2 2 1,3 1 1,4 2 1,5 1 1)', 6);
-/* {"SRID=4326;GEODSTBOX Z((1,1,1),(2,2,1))", "SRID=4326;GEODSTBOX Z((2,1,1),(3,2,1))",
-   "SRID=4326;GEODSTBOX Z((3,1,1),(4,2,1))", "SRID=4326;GEODSTBOX Z((4,1,1),(5,2,1))"} */
+/* {"SRID=4326;GEODSTBOX Z((1,1,1),(2,2,1))","SRID=4326;GEODSTBOX
+   Z((2,1,1),(3,2,1))","SRID=4326;GEODSTBOX Z((3,1,1),(4,2,1))","SRID=4326;GEODSTBOX
+   Z((4,1,1),(5,2,1))"} */
 SELECT splitNStboxes(geometry 'MultiLinestring((1 1,2 2),(3 1,4 2),(5 1,6 2))', 2);
 -- {"STBOX X((1,1),(4,2))","STBOX X((5,1),(6,2))"}
 </programlisting>
@@ -503,28 +494,27 @@ SELECT splitNStboxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05}', 1);
 -- {"STBOX XT(((1,1),(5,2)),[2000-01-01, 2000-01-05])"}
 SELECT splitNStboxes(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
-  Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05]');
+  Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05]', 4);
 /* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
    "STBOX XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])",
    "STBOX XT(((3,1),(4,2)),[2000-01-03, 2000-01-04])",
    "STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
 SELECT splitNStboxes(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02],
   [Point(3 1)@2000-01-03, Point(4 2)@2000-01-04], [Point(5 1)@2000-01-05]}', 2);
-/* {"STBOX XT(((1,1),(4,2)),[2000-01-01, 2000-01-04])",
-   "STBOX XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
+/* {"STBOX XT(((1,1),(4,2)),[2000-01-01, 2000-01-04])","STBOX
+   XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
 SELECT splitNStboxes(tgeogpoint '{Point(1 1 1)@2000-01-01, Point(2 2 1)@2000-01-02,
   Point(3 1 1)@2000-01-03, Point(4 2 1)@2000-01-04, Point(5 1 1)@2000-01-05}', 6);
-/* {"SRID=4326;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01, 2000-01-01])",
-   "SRID=4326;GEODSTBOX ZT(((2,2,1),(2,2,1)),[2000-01-02, 2000-01-02])",
-   "SRID=4326;GEODSTBOX ZT(((3,1,1),(3,1,1)),[2000-01-03, 2000-01-03])",
-   "SRID=4326;GEODSTBOX ZT(((4,2,1),(4,2,1)),[2000-01-04, 2000-01-04])",
-   "SRID=4326;GEODSTBOX ZT(((5,1,1),(5,1,1)),[2000-01-05, 2000-01-05])"} */
+/* {"SRID=4326;GEODSTBOX ZT(((1,1,1),(1,1,1)),[2000-01-01,
+   2000-01-01])","SRID=4326;GEODSTBOX ZT(((2,2,1),(2,2,1)),[2000-01-02,
+   2000-01-02])","SRID=4326;GEODSTBOX ZT(((3,1,1),(3,1,1)),[2000-01-03,
+   2000-01-03])","SRID=4326;GEODSTBOX ZT(((4,2,1),(4,2,1)),[2000-01-04,
+   2000-01-04])","SRID=4326;GEODSTBOX ZT(((5,1,1),(5,1,1)),[2000-01-05, 2000-01-05])"} */
 SELECT splitNStboxes(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05]', 6);
-/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
-   "STBOX XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])",
-   "STBOX XT(((3,1),(4,2)),[2000-01-03, 2000-01-04])",
-   "STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])","STBOX
+   XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])","STBOX XT(((3,1),(4,2)),[2000-01-03,
+   2000-01-04])","STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
 </programlisting>
 			</listitem>
 
@@ -538,34 +528,32 @@ splitEachNStboxes({lines,tpoint},integer) → stbox[]
 				<para>For temporal points, the choice between instants or segments depends on whether the interpolation is discrete or continuous. The last argument specifies the number of input instants or segments that are merged to produce an output box. If the number of instants or segments is less than or equal to the given number, the resulting array will have a single box per sequence. Otherwise, the specified number of consecutive instants or segments will be merged into each output box. Notice that, contrary to the <link linkend="ttype_splitNStboxes"><varname>splitNStboxes</varname></link> function, the number of boxes in the result depends on the number of input instants or segments.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 1);
--- {"STBOX X((1,1),(5,2))"}
+/* {"STBOX X((1,1),(2,2))","STBOX X((2,1),(3,2))","STBOX X((3,1),(4,2))","STBOX
+   X((4,1),(5,2))"} */
 SELECT splitEachNStboxes(geometry 'Linestring(1 1,2 2,3 1,4 2,5 1)', 2);
 -- {"STBOX X((1,1),(3,2))","STBOX X((3,1),(5,2))"}
 SELECT splitEachNStboxes(geography 'Linestring(1 1 1,2 2 1,3 1 1,4 2 1,5 1 1)', 6);
-/* {"SRID=4326;GEODSTBOX Z((1,1,1),(2,2,1))", "SRID=4326;GEODSTBOX Z((2,1,1),(3,2,1))",
-   "SRID=4326;GEODSTBOX Z((3,1,1),(4,2,1))", "SRID=4326;GEODSTBOX Z((4,1,1),(5,2,1))"} */
+-- {"SRID=4326;GEODSTBOX Z((1,1,1),(5,2,1))"}
 SELECT splitEachNStboxes(geometry 'MultiLinestring((1 1,2 2),(3 1,4 2),(5 1,6 2))', 2);
--- {"STBOX X((1,1),(4,2))","STBOX X((5,1),(6,2))"}
+-- {"STBOX X((1,1),(2,2))","STBOX X((3,1),(4,2))","STBOX X((5,1),(6,2))"}
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT splitEachNStboxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05}', 1);
-/* {"STBOX XT(((1,1),(1,1)),[2000-01-01, 2000-01-01])",
-   "STBOX XT(((2,2),(2,2)),[2000-01-02, 2000-01-02])",
-   "STBOX XT(((3,1),(3,1)),[2000-01-03, 2000-01-03])",
-   "STBOX XT(((4,2),(4,2)),[2000-01-04, 2000-01-04])",
-   "STBOX XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
+/* {"STBOX XT(((1,1),(1,1)),[2000-01-01, 2000-01-01])","STBOX
+   XT(((2,2),(2,2)),[2000-01-02, 2000-01-02])","STBOX XT(((3,1),(3,1)),[2000-01-03,
+   2000-01-03])","STBOX XT(((4,2),(4,2)),[2000-01-04, 2000-01-04])","STBOX
+   XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
 SELECT splitEachNStboxes(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(3 1)@2000-01-03, Point(4 2)@2000-01-04, Point(5 1)@2000-01-05]', 1);
-/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
-   "STBOX XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])",
-   "STBOX XT(((3,1),(4,2)),[2000-01-03, 2000-01-04])",
-   "STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])","STBOX
+   XT(((2,1),(3,2)),[2000-01-02, 2000-01-03])","STBOX XT(((3,1),(4,2)),[2000-01-03,
+   2000-01-04])","STBOX XT(((4,1),(5,2)),[2000-01-04, 2000-01-05])"} */
 SELECT splitEachNStboxes(tgeogpoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02],
   [Point(3 1)@2000-01-03, Point(4 2)@2000-01-04], [Point(5 1)@2000-01-05]}', 2);
-/* {"SRID=4326;GEODSTBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
-   "SRID=4326;GEODSTBOX XT(((3,1),(4,2)),[2000-01-03, 2000-01-04])",
-   "SRID=4326;GEODSTBOX XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
+/* {"SRID=4326;GEODSTBOX XT(((1,1),(2,2)),[2000-01-01,
+   2000-01-02])","SRID=4326;GEODSTBOX XT(((3,1),(4,2)),[2000-01-03,
+   2000-01-04])","SRID=4326;GEODSTBOX XT(((5,1),(5,1)),[2000-01-05, 2000-01-05])"} */
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -647,7 +635,7 @@ SELECT getBin(2, 2);
 SELECT getBin(2, 2.5, 1.5);
 -- [1.5, 4)
 SELECT getBin('2001-01-04', interval '1 week');
--- [2001-01-01, 2001-01-08)
+-- [2001-01-01 08:00:00, 2001-01-08 08:00:00)
 SELECT getBin('2001-01-04', interval '1 week', '2001-01-07');
 -- [2000-12-31, 2001-01-07)
 </programlisting>
@@ -771,13 +759,13 @@ getValueTimeTile(v float,t timestamptz,vsize float,duration interval,
 					<para>If the origin of the value and/or time dimension is not specified, it is set by default to 0 and to Monday, January 3, 2000, respectively.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getValueTile(15, 2);
--- TBOX ([14,16))
+-- TBOXFLOAT X([14, 16))
 SELECT getTboxTimeTile('2001-01-15', interval '2 days');
--- TBOX ([2001-01-15,2001-01-17))
+-- TBOX T([2001-01-13 08:00:00, 2001-01-15 08:00:00))
 SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days');
--- TBOX XT([14,16),[2001-01-15,2001-01-17))
+-- TBOXFLOAT XT([14, 16),[2001-01-13 08:00:00, 2001-01-15 08:00:00))
 SELECT getValueTimeTile(15, '2001-01-15', 2, interval '2 days', 1, '2001-01-02');
--- TBOX XT([15,17),[2001-01-14,2001-01-16))
+-- TBOXFLOAT XT([15, 17),[2001-01-14, 2001-01-16))
 </programlisting>
 				</listitem>
 
@@ -801,9 +789,9 @@ getSpaceTimeTile(point geometry,time timestamptz,xsize float,
 SELECT getSpaceTile(geometry 'Point(1 1 1)', 2.0);
 -- STBOX Z((0,0,0),(2,2,2))
 SELECT getStboxTimeTile(timestamptz '2001-01-01', interval '2 days');
--- STBOX T([2001-01-01,2001-01-03))
+-- STBOX T([2000-12-30 08:00:00, 2001-01-01 08:00:00))
 SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 days');
--- STBOX XT(((0,0),(2,2)),[2001-01-01, 2001-01-03))
+-- STBOX XT(((0,0),(2,2)),[2000-12-30 08:00:00, 2001-01-01 08:00:00))
 SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 days',
   'Point(1 1)', '2001-01-02');
 -- STBOX XT(((1,1),(3,3)),[2000-12-31, 2001-01-02))
@@ -828,18 +816,19 @@ timeBins(temp,duration interval,torigin timestamptz='2000-01-03') → tstzspan[]
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueBins(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 3);
--- {"[1, 3)","[4, 5)"}
+-- {"[0, 3)","[3, 6)"}
 SELECT valueBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 3, 1);
--- {"[1, 4)","[4, 4]"}
+-- {"[1, 4)","[4, 7)"}
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT timeBins(ttext '{AAA@2000-01-01, BBB@2000-01-02, AAA@2000-01-03, CCC@2000-01-04,
   AAA@2000-01-05}', '3 days');
--- {"[2000-01-01, 2000-01-02]","[2000-01-03, 2000-01-05]"}
+/* {"[1999-12-31 08:00:00, 2000-01-03 08:00:00)","[2000-01-03 08:00:00, 2000-01-06
+   08:00:00)"} */
 SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', '3 days', '2000-01-01');
--- {"[2000-01-01, 2000-01-04)","[2000-01-04, 2000-01-05)"}
+-- {"[2000-01-01, 2000-01-04)","[2000-01-04, 2000-01-07)"}
 </programlisting>
 				</listitem>
 
@@ -858,22 +847,20 @@ valueTimeBoxes(tnumber,vsize number,tsize interval,vorigin number=0,
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT valueBoxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 3);
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-05])",
-   "TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-05])","TBOXINT XT([4, 5),[2000-01-04,
+   2000-01-04])"} */
 SELECT timeBoxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', '3 days');
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])",
-   "TBOXINT XT([1, 5),[2000-01-03, 2000-01-05])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-03])","TBOXINT XT([1, 5),[2000-01-04,
+   2000-01-05])"} */
 SELECT valueTimeBoxes(tint '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05}', 3, '3 days');
-/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-02])",
-   "TBOXINT XT([1, 2),[2000-01-03, 2000-01-05])",
-   "TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])"} */
+/* {"TBOXINT XT([1, 3),[2000-01-01, 2000-01-03])","TBOXINT XT([1, 2),[2000-01-05,
+   2000-01-05])","TBOXINT XT([4, 5),[2000-01-04, 2000-01-04])"} */
 SELECT valueTimeBoxes(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
   1@2000-01-05]', 3, '3 days', 1, '2000-01-01');
-/* {"TBOXFLOAT XT([1, 4),[2000-01-01, 2000-01-04))",
-   "TBOXFLOAT XT([1, 4),(2000-01-04, 2000-01-05])",
-   "TBOXFLOAT XT([4, 4],[2000-01-04, 2000-01-04])"} */
+/* {"TBOXFLOAT XT([1, 4),[2000-01-01, 2000-01-04))","TBOXFLOAT XT([1, 4),(2000-01-04,
+   2000-01-05])","TBOXFLOAT XT([4, 4],[2000-01-04, 2000-01-04])"} */
 </programlisting>
 				</listitem>
 
@@ -899,29 +886,29 @@ spaceTimeBoxes({tgeompoint,tgeometry,tpose,tpcpoint,trgeometry},xsize float,
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT spaceBoxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(1 1)@2000-01-03, Point(4 4)@2000-01-04, Point(1 1)@2000-01-05}', 3);
-/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-05])",
-   "STBOX XT(((4,4),(4,4)),[2000-01-04, 2000-01-04])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-05])","STBOX
+   XT(((4,4),(4,4)),[2000-01-04, 2000-01-04])"} */
 SELECT timeBoxes(tgeompoint '{Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02,
   Point(1 1 1)@2000-01-03, Point(4 4 4)@2000-01-04, Point(1 1 1)@2000-01-05}',
   interval '2 days', '2000-01-01');
-/* {"STBOX ZT(((1,1,1),(2,2,2)),[2000-01-01, 2000-01-02])",
-   "STBOX ZT(((1,1,1),(4,4,4)),[2000-01-03, 2000-01-04])",
-   "STBOX ZT(((1,1,1),(1,1,1)),[2000-01-05, 2000-01-05])"} */
+/* {"STBOX ZT(((1,1,1),(2,2,2)),[2000-01-01, 2000-01-02])","STBOX
+   ZT(((1,1,1),(4,4,4)),[2000-01-03, 2000-01-04])","STBOX
+   ZT(((1,1,1),(1,1,1)),[2000-01-05, 2000-01-05])"} */
 SELECT spaceTimeBoxes(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02,
   Point(1 1)@2000-01-03, Point(4 4)@2000-01-04, Point(1 1)@2000-01-05}', 3, '3 days');
-/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-02])",
-   "STBOX XT(((1,1),(1,1)),[2000-01-03, 2000-01-05])",
-   "STBOX XT(((4,4),(4,4)),[2000-01-04, 2000-01-04])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2000-01-01, 2000-01-03])","STBOX
+   XT(((1,1),(1,1)),[2000-01-05, 2000-01-05])","STBOX XT(((4,4),(4,4)),[2000-01-04,
+   2000-01-04])"} */
 SELECT spaceTimeBoxes(tgeompoint '[Point(1 1 1)@2000-01-01, Point(2 2 2)@2000-01-02,
   Point(1 1 1)@2000-01-03, Point(4 4 4)@2000-01-04, Point(1 1 1)@2000-01-05]', 3,
   interval '3 days', 'Point(1 1 1)', '2000-01-01');
-/* {"STBOX ZT(((1,1,1),(4,4,4)),[2000-01-01, 2000-01-04))",
-   "STBOX ZT(((1,1,1),(4,4,4)),(2000-01-04, 2000-01-05])",
-   "STBOX ZT(((4,4,4),(4,4,4)),[2000-01-04, 2000-01-04])"} */
+/* {"STBOX ZT(((1,1,1),(4,4,4)),[2000-01-01, 2000-01-04))","STBOX
+   ZT(((1,1,1),(4,4,4)),(2000-01-04, 2000-01-05])","STBOX
+   ZT(((4,4,4),(4,4,4)),[2000-01-04, 2000-01-04])"} */
 SELECT spaceBoxes(tpose '[Pose(Point(1 1),0.1)@2001-01-01,
   Pose(Point(3 3),0.1)@2001-01-03]', 2.0);
-/* {"STBOX XT(((1,1),(2,2)),[2001-01-01, 2001-01-02))",
-   "STBOX XT(((2,2),(3,3)),[2001-01-02, 2001-01-03])"} */
+/* {"STBOX XT(((1,1),(2,2)),[2001-01-01, 2001-01-02))","STBOX
+   XT(((2,2),(3,3)),[2001-01-02, 2001-01-03])"} */
 </programlisting>
 				</listitem>
 			</itemizedlist>


### PR DESCRIPTION
Every example of the chapter that answers a single value states the value that comes back, in both manuals. A query returning a row per bin, tile or split keeps the one representative row the chapter shows, since a listing states the shape of an answer rather than reproducing it. The example of splitNStboxes over a temporal point passes the number of boxes it asks for, which is what its stated result holds.