### PR TITLE
Name the H3 edge lengths after the units libh3 publishes

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2893,7 +2893,7 @@
 					<para><link linkend="th3_h3_cell_area"><varname>cellArea</varname>, <varname>th3CellAreaKm2</varname>, <varname>th3CellAreaRads2</varname></link>: Devolver el área temporal de cada celda en una trayectoria, en metros cuadrados, kilómetros cuadrados o radianes cuadrados</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLength</varname></link>: Devolver la longitud temporal de cada arista dirigida en una trayectoria, en la unidad solicitada</para>
+					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLengthKm</varname>, <varname>th3EdgeLengthM</varname>, <varname>th3EdgeLengthRads</varname></link>: Devolver la longitud temporal de cada arista dirigida en una trayectoria, en kilómetros, metros o radianes</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistance</varname></link>: Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas)</para>

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -580,15 +580,25 @@ SELECT th3CellAreaRads2(th3index '871fa44a8ffffff@2001-01-01');
 			</listitem>
 
 			<listitem xml:id="th3_h3_edge_length">
-				<indexterm significance="normal"><primary><varname>th3EdgeLength</varname></primary></indexterm>
-				<para>Devolver la longitud temporal de cada arista dirigida en una trayectoria, en la unidad solicitada</para>
+				<indexterm significance="normal"><primary><varname>th3EdgeLengthKm</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3EdgeLengthM</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3EdgeLengthRads</varname></primary></indexterm>
+				<para>Devolver la longitud temporal de cada arista dirigida en una trayectoria, en kilómetros, metros o radianes</para>
 				<programlisting xml:space="preserve" format="linespecific">
-th3EdgeLength(th3index,text='km') → tfloat
+th3EdgeLengthKm(th3index) → tfloat
+th3EdgeLengthM(th3index) → tfloat
+th3EdgeLengthRads(th3index) → tfloat
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+SELECT th3EdgeLengthKm(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
     th3index '871fa44aeffffff@2001-01-01'));
 -- 1.272084901305088@2001-01-01
+SELECT th3EdgeLengthM(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 1272.0849013050881@2001-01-01
+SELECT th3EdgeLengthRads(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 0.000199667786455@2001-01-01
 </programlisting>
 			</listitem>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2902,7 +2902,7 @@
 					<para><link linkend="th3_h3_cell_area"><varname>cellArea</varname>, <varname>th3CellAreaKm2</varname>, <varname>th3CellAreaRads2</varname></link>: Return the temporal area of each cell in a trajectory, in square metres, square kilometres, or square radians</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLength</varname></link>: Return the temporal length of each directed edge in a trajectory, in the requested unit</para>
+					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLengthKm</varname>, <varname>th3EdgeLengthM</varname>, <varname>th3EdgeLengthRads</varname></link>: Return the temporal length of each directed edge in a trajectory, in kilometres, metres, or radians</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistance</varname></link>: Return the temporal great-circle distance between two temporal geodetic points (not between cells)</para>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -580,15 +580,25 @@ SELECT th3CellAreaRads2(th3index '871fa44a8ffffff@2001-01-01');
 			</listitem>
 
 			<listitem xml:id="th3_h3_edge_length">
-				<indexterm significance="normal"><primary><varname>th3EdgeLength</varname></primary></indexterm>
-				<para>Return the temporal length of each directed edge in a trajectory, in the requested unit</para>
+				<indexterm significance="normal"><primary><varname>th3EdgeLengthKm</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3EdgeLengthM</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>th3EdgeLengthRads</varname></primary></indexterm>
+				<para>Return the temporal length of each directed edge in a trajectory, in kilometres, metres, or radians</para>
 				<programlisting xml:space="preserve" format="linespecific">
-th3EdgeLength(th3index,text='km') → tfloat
+th3EdgeLengthKm(th3index) → tfloat
+th3EdgeLengthM(th3index) → tfloat
+th3EdgeLengthRads(th3index) → tfloat
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT th3EdgeLength(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+SELECT th3EdgeLengthKm(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
     th3index '871fa44aeffffff@2001-01-01'));
 -- 1.272084901305088@2001-01-01
+SELECT th3EdgeLengthM(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 1272.0849013050881@2001-01-01
+SELECT th3EdgeLengthRads(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-01-01',
+    th3index '871fa44aeffffff@2001-01-01'));
+-- 0.000199667786455@2001-01-01
 </programlisting>
 			</listitem>
 

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -273,7 +273,9 @@ extern Temporal *th3index_local_ij_to_cell(const Temporal *origin,
 
 extern Temporal *th3index_cell_area_km2(const Temporal *temp);
 extern Temporal *th3index_cell_area_rads2(const Temporal *temp);
-extern Temporal *th3index_edge_length(const Temporal *temp, const char *unit);
+extern Temporal *th3index_edge_length_km(const Temporal *temp);
+extern Temporal *th3index_edge_length_m(const Temporal *temp);
+extern Temporal *th3index_edge_length_rads(const Temporal *temp);
 extern Temporal *tgeogpoint_great_circle_distance(const Temporal *a,
   const Temporal *b, const char *unit);
 

--- a/meos/src/h3/th3index_metrics.c
+++ b/meos/src/h3/th3index_metrics.c
@@ -218,22 +218,16 @@ th3index_cell_area_rads2(const Temporal *temp)
 }
 
 /*****************************************************************************
- * th3EdgeLength(th3index, text) — lift_with_const
+ * th3EdgeLengthKm, th3EdgeLengthM and th3EdgeLengthRads — lift_with_const
  *****************************************************************************/
 
 /**
- * @ingroup meos_h3_metrics
  * @brief Return the per-instant length of a temporal H3 directed edge in
- * the given unit.
- * @csqlfn #Th3index_edge_length()
+ * the given H3 unit
  */
-Temporal *
-th3index_edge_length(const Temporal *temp, const char *unit)
+static Temporal *
+th3index_edge_length_in(const Temporal *temp, H3Unit u)
 {
-  /* Ensure the validity of the arguments */
-  VALIDATE_TH3INDEX(temp, NULL); VALIDATE_NOT_NULL(unit, NULL);
-
-  H3Unit u = h3_unit_from_cstring(unit);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_h3_edge_length;
@@ -245,6 +239,48 @@ th3index_edge_length(const Temporal *temp, const char *unit)
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal(temp, &lfinfo);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant length of a temporal H3 directed edge in
+ * kilometres, the quantity libh3 answers as edgeLengthKm
+ * @csqlfn #Th3index_edge_length_km()
+ */
+Temporal *
+th3index_edge_length_km(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TH3INDEX(temp, NULL);
+  return th3index_edge_length_in(temp, H3_UNIT_KM);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant length of a temporal H3 directed edge in
+ * metres, the quantity libh3 answers as edgeLengthM
+ * @csqlfn #Th3index_edge_length_m()
+ */
+Temporal *
+th3index_edge_length_m(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TH3INDEX(temp, NULL);
+  return th3index_edge_length_in(temp, H3_UNIT_M);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant length of a temporal H3 directed edge in
+ * radians, the quantity libh3 answers as edgeLengthRads
+ * @csqlfn #Th3index_edge_length_rads()
+ */
+Temporal *
+th3index_edge_length_rads(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TH3INDEX(temp, NULL);
+  return th3index_edge_length_in(temp, H3_UNIT_RADS);
 }
 
 /*****************************************************************************

--- a/mobilitydb/sql/h3/286_th3index_metrics.in.sql
+++ b/mobilitydb/sql/h3/286_th3index_metrics.in.sql
@@ -61,12 +61,22 @@ CREATE FUNCTION th3CellAreaRads2(th3index)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
- * th3EdgeLength
+ * th3EdgeLengthKm, th3EdgeLengthM and th3EdgeLengthRads
  ******************************************************************************/
 
-CREATE FUNCTION th3EdgeLength(th3index, text DEFAULT 'km')
+CREATE FUNCTION th3EdgeLengthKm(th3index)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Th3index_edge_length'
+  AS 'MODULE_PATHNAME', 'Th3index_edge_length_km'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION th3EdgeLengthM(th3index)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Th3index_edge_length_m'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION th3EdgeLengthRads(th3index)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Th3index_edge_length_rads'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************

--- a/mobilitydb/src/h3/th3index_metrics.c
+++ b/mobilitydb/src/h3/th3index_metrics.c
@@ -98,25 +98,56 @@ Th3index_cell_area_rads2(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
- * th3EdgeLength(th3index, text)
+ * th3EdgeLengthKm, th3EdgeLengthM and th3EdgeLengthRads
  *****************************************************************************/
 
-PGDLLEXPORT Datum Th3index_edge_length(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Th3index_edge_length);
+PGDLLEXPORT Datum Th3index_edge_length_km(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Th3index_edge_length_km);
 /**
  * @ingroup mobilitydb_h3_metrics
  * @brief Return the per-instant length of a temporal H3 directed edge in
- * the given unit
- * @sqlfn th3EdgeLength()
+ * kilometres
+ * @sqlfn th3EdgeLengthKm()
  */
 Datum
-Th3index_edge_length(PG_FUNCTION_ARGS)
+Th3index_edge_length_km(PG_FUNCTION_ARGS)
 {
   Temporal *temp = PG_GETARG_TEMPORAL_P(0);
-  text *unit_txt = PG_GETARG_TEXT_P(1);
-  char *unit = text_to_cstring(unit_txt);
-  Temporal *result = th3index_edge_length(temp, unit);
-  pfree(unit);
+  Temporal *result = th3index_edge_length_km(temp);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Th3index_edge_length_m(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Th3index_edge_length_m);
+/**
+ * @ingroup mobilitydb_h3_metrics
+ * @brief Return the per-instant length of a temporal H3 directed edge in
+ * metres
+ * @sqlfn th3EdgeLengthM()
+ */
+Datum
+Th3index_edge_length_m(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Temporal *result = th3index_edge_length_m(temp);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Th3index_edge_length_rads(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Th3index_edge_length_rads);
+/**
+ * @ingroup mobilitydb_h3_metrics
+ * @brief Return the per-instant length of a temporal H3 directed edge in
+ * radians
+ * @sqlfn th3EdgeLengthRads()
+ */
+Datum
+Th3index_edge_length_rads(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Temporal *result = th3index_edge_length_rads(temp);
   PG_FREE_IF_COPY(temp, 0);
   PG_RETURN_TEMPORAL_P(result);
 }

--- a/mobilitydb/test/h3/expected/286_th3index_metrics.test.out
+++ b/mobilitydb/test/h3/expected/286_th3index_metrics.test.out
@@ -46,47 +46,52 @@ SELECT cellArea(th3index
  t
 (1 row)
 
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
+SELECT round(startValue(th3EdgeLengthKm(th3CellsToDirectedEdge(
     th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01')) IS NOT NULL;
+    th3index '880326b88dfffff@2001-01-01')))::numeric, 7);
+   round   
+-----------
+ 0.5459490
+(1 row)
+
+SELECT round(startValue(th3EdgeLengthM(th3CellsToDirectedEdge(
+    th3index '880326b885fffff@2001-01-01',
+    th3index '880326b88dfffff@2001-01-01')))::numeric, 4);
+  round   
+----------
+ 545.9490
+(1 row)
+
+SELECT round(startValue(th3EdgeLengthRads(th3CellsToDirectedEdge(
+    th3index '880326b885fffff@2001-01-01',
+    th3index '880326b88dfffff@2001-01-01')))::numeric, 9);
+    round    
+-------------
+ 0.000085693
+(1 row)
+
+SELECT startValue(th3EdgeLengthM(th3CellsToDirectedEdge(
+    th3index '880326b885fffff@2001-01-01',
+    th3index '880326b88dfffff@2001-01-01')))
+  = startValue(th3EdgeLengthKm(th3CellsToDirectedEdge(
+    th3index '880326b885fffff@2001-01-01',
+    th3index '880326b88dfffff@2001-01-01'))) * 1000;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
+SELECT startValue(th3EdgeLengthRads(th3CellsToDirectedEdge(
     th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'km') IS NOT NULL;
+    th3index '880326b88dfffff@2001-01-01')))
+  < startValue(th3EdgeLengthKm(th3CellsToDirectedEdge(
+    th3index '880326b885fffff@2001-01-01',
+    th3index '880326b88dfffff@2001-01-01')));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
-    th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'm') IS NOT NULL;
- ?column? 
-----------
- t
-(1 row)
-
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
-    th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'rads') IS NOT NULL;
- ?column? 
-----------
- t
-(1 row)
-
-/* Errors */
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
-    th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'km2');
-ERROR:  h3_edge_length: expected a length unit (km, m, rads)
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
-    th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'parsec');
-ERROR:  invalid h3 unit "parsec" (expected one of km, m, rads, km2, m2, rads2)
 SELECT greatCircleDistance(
   tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
   tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',

--- a/mobilitydb/test/h3/queries/286_th3index_metrics.test.sql
+++ b/mobilitydb/test/h3/queries/286_th3index_metrics.test.sql
@@ -40,34 +40,33 @@ SELECT cellArea(th3index
   IS NOT NULL;
 
 -------------------------------------------------------------------------------
--- th3EdgeLength(th3index, text) — lift_with_const
+-- th3EdgeLengthKm, th3EdgeLengthM and th3EdgeLengthRads — lift_with_const
 -------------------------------------------------------------------------------
 
--- Default unit ('km')
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
+-- The three name the units libh3 names
+SELECT round(startValue(th3EdgeLengthKm(th3CellsToDirectedEdge(
     th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01')) IS NOT NULL;
+    th3index '880326b88dfffff@2001-01-01')))::numeric, 7);
+SELECT round(startValue(th3EdgeLengthM(th3CellsToDirectedEdge(
+    th3index '880326b885fffff@2001-01-01',
+    th3index '880326b88dfffff@2001-01-01')))::numeric, 4);
+SELECT round(startValue(th3EdgeLengthRads(th3CellsToDirectedEdge(
+    th3index '880326b885fffff@2001-01-01',
+    th3index '880326b88dfffff@2001-01-01')))::numeric, 9);
 
--- All three valid length units
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
+-- The three answer one quantity in three units
+SELECT startValue(th3EdgeLengthM(th3CellsToDirectedEdge(
     th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'km') IS NOT NULL;
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
+    th3index '880326b88dfffff@2001-01-01')))
+  = startValue(th3EdgeLengthKm(th3CellsToDirectedEdge(
     th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'm') IS NOT NULL;
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
+    th3index '880326b88dfffff@2001-01-01'))) * 1000;
+SELECT startValue(th3EdgeLengthRads(th3CellsToDirectedEdge(
     th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'rads') IS NOT NULL;
-
--- Area unit on a length function — must error.
-/* Errors */
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
+    th3index '880326b88dfffff@2001-01-01')))
+  < startValue(th3EdgeLengthKm(th3CellsToDirectedEdge(
     th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'km2');
--- Invalid unit string
-SELECT th3EdgeLength(th3CellsToDirectedEdge(
-    th3index '880326b885fffff@2001-01-01',
-    th3index '880326b88dfffff@2001-01-01'), 'parsec');
+    th3index '880326b88dfffff@2001-01-01')));
 
 -------------------------------------------------------------------------------
 -- greatCircleDistance(tgeogpoint, tgeogpoint, text) — binary_synced


### PR DESCRIPTION
libh3 answers the length of a directed edge through edgeLengthKm, edgeLengthM and edgeLengthRads, three functions each naming its unit, so the lifted surface carries the same three answers under the same words: th3EdgeLengthKm, th3EdgeLengthM and th3EdgeLengthRads. A unit argument names no libh3 function, so it is gone. The three keep the family stem because an edge length fills no DggsCellOps slot and no sibling cell index answers one.