### PR TITLE
Answer a geography where the engine works on the spheroid

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -400,6 +400,7 @@ extern GSERIALIZED *geo_geo_n(const GSERIALIZED *geom, int n);
 extern GSERIALIZED **geo_pointarr(const GSERIALIZED *gs, int *count);
 extern GSERIALIZED *geo_points(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_array_union(GSERIALIZED **gsarr, int count);
+extern GSERIALIZED *geog_array_union(GSERIALIZED **gsarr, int count);
 extern GSERIALIZED *geom_boundary(const GSERIALIZED *gs);
 extern GSERIALIZED *geom_buffer(const GSERIALIZED *gs, double size, const char *params);
 extern GSERIALIZED *geom_centroid(const GSERIALIZED *gs);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2119,7 +2119,7 @@ GSERIALIZED *
 geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_geo_geo(gs1, gs2))
+  if (! ensure_valid_geo_geo(gs1, gs2) || ! ensure_not_geodetic_geo(gs1))
     return NULL;
 
   /* Clipper2 fast-path for 2D polygonal inputs */
@@ -2272,13 +2272,20 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   VALIDATE_NOT_NULL(gsarr, NULL);
   if (! ensure_positive(count))
     return NULL;
+  /* This entry answers on the plane; #geog_array_union() answers a geodetic
+   * array. The flag is read from one member, so the array is turned away
+   * before the SRID test walks all of them */
+  if (! ensure_not_geodetic_geo(gsarr[0]))
+    return NULL;
   /* The members of the array carry one SRID */
   if (! ensure_same_srid_geoarr((const GSERIALIZED **) gsarr, count))
     return NULL;
 
-  /* One geom geom? Return it */
+  /* A single member is its own union, returned as a value of its own: the
+   * array belongs to the caller, and a result aliasing a member of it is
+   * released when the caller releases the array */
   if (count == 1)
-    return gsarr[0];
+    return geo_copy(gsarr[0]);
 
   /* An array holding nothing but empties has an empty union, which is read
    * from the array alone. It is answered here so that a build carrying no
@@ -2454,6 +2461,48 @@ geom_array_union(GSERIALIZED **gsarr, int count)
     "configure with -DGEOS=ON");
   return NULL;
 #endif /* GEOS */
+}
+
+/**
+ * @ingroup meos_geo_base_transf
+ * @brief Return the union of an array of geographies
+ * @param[in] gsarr Array of geographies
+ * @param[in] count Number of elements in the array
+ * @return On error return @p NULL
+ * @details The union of a set of positions is the set with its duplicates
+ * removed, and two positions are the same when their coordinates are, so the
+ * answer is read without measuring anything and holds on the spheroid as it
+ * does on the plane. A geodetic array carrying anything else is a different
+ * question: a geodesic is not the segment joining two positions in degree
+ * space, and two geodesics meet where those segments need not, so the answer
+ * awaits an overlay that works on the spheroid.
+ * @csqlfn #Geo_union()
+ */
+GSERIALIZED *
+geog_array_union(GSERIALIZED **gsarr, int count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(gsarr, NULL);
+  if (! ensure_positive(count))
+    return NULL;
+  if (! ensure_geodetic_geo(gsarr[0]))
+    return NULL;
+  /* The members of the array carry one SRID */
+  if (! ensure_same_srid_geoarr((const GSERIALIZED **) gsarr, count))
+    return NULL;
+
+  /* A single member is its own union, returned as a value of its own, as on
+   * the planar side */
+  if (count == 1)
+    return geo_copy(gsarr[0]);
+
+  if (! geom_array_point_only(gsarr, count))
+  {
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "The union of a geodetic array is answered for positions only");
+    return NULL;
+  }
+  return geom_array_linear_union(gsarr, count, true);
 }
 
 /**

--- a/meos/src/temporal/temporal_modif.c
+++ b/meos/src/temporal/temporal_modif.c
@@ -140,7 +140,12 @@ GSERIALIZED *
 geoarr_merge(GSERIALIZED **gsarr, int count)
 {
   assert(gsarr); assert(count > 0);
-  GSERIALIZED *result = geom_array_union(gsarr, count);
+  /* The union of the values is read on the plane or on the spheroid according
+   * to what they are, and each entry answers only for its own */
+  GSERIALIZED *result = FLAGS_GET_GEODETIC(gsarr[0]->gflags) ?
+    geog_array_union(gsarr, count) : geom_array_union(gsarr, count);
+  if (! result)
+    return NULL;
   /*
    * ST_Union creates MultiLineString and does not sew LineStrings into a
    * single LineString. Use ST_LineMerge to sew LineStrings.

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -672,25 +672,42 @@ int main(void)
   free(phsurf); free(mp); free(uu2);
   meos_errno_reset();
 
-  /* The union of a GEODETIC array is serialized twice: GEOS answers a planar
-   * value, and the geodetic flag cannot be set on it because the planar
-   * bounding box already written occupies a different number of floats. The
-   * deserialization that carries the value across reads its coordinates OUT OF
-   * the planar buffer, so releasing that buffer before the geodetic value is
-   * built leaves the second serialization walking freed memory -- it answered
-   * a MULTIPOINT of denormal coordinates, and valgrind reported the read in
-   * ll2cart under lwgeom_calculate_gbox_geodetic */
+  /* A geography is answered on the spheroid, so it is #geog_array_union() that
+   * takes it and #geom_array_union() that turns it away. The union of a set of
+   * positions is the set with its duplicates removed, and two positions are
+   * the same when their coordinates are, so the answer is read without
+   * measuring anything and is the same on the spheroid as on the plane */
   GSERIALIZED *gg1 = geog_in("POINT(1 1)", -1);
   GSERIALIZED *gg2 = geog_in("POINT(2 2)", -1);
   assert(gg1 != NULL); assert(gg2 != NULL);
   GSERIALIZED *ggarr[2] = {gg1, gg2};
   meos_errno_reset();
-  GSERIALIZED *ggu = geom_array_union(ggarr, 2);
+  GSERIALIZED *ggu = geog_array_union(ggarr, 2);
   assert(ggu != NULL);
   char *ggwkt = geo_as_ewkt(ggu, 6);
   printf("the union of two geography points: %s\n", ggwkt);
   assert(strcmp(ggwkt, "SRID=4326;MULTIPOINT(1 1,2 2)") == 0);
-  free(gg1); free(gg2); free(ggu); free(ggwkt);
+  free(ggu); free(ggwkt);
+  meos_errno_reset();
+
+  /* The planar entry turns a geography away rather than reading its degrees as
+   * cartesian coordinates */
+  GSERIALIZED *ggrefused = geom_array_union(ggarr, 2);
+  assert(ggrefused == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+  printf("the planar union refuses a geography\n");
+  meos_errno_reset();
+
+  /* And the geodetic entry answers no more than the spheroid answers: an array
+   * carrying anything but positions awaits an overlay that works there */
+  GSERIALIZED *ggp1 = geog_in("POLYGON((0 0,0 1,1 1,1 0,0 0))", -1);
+  GSERIALIZED *ggp2 = geog_in("POLYGON((2 2,2 3,3 3,3 2,2 2))", -1);
+  GSERIALIZED *ggparr[2] = {ggp1, ggp2};
+  meos_errno_reset();
+  assert(geog_array_union(ggparr, 2) == NULL);
+  assert(meos_errno() == MEOS_ERR_FEATURE_NOT_SUPPORTED);
+  printf("the geodetic union answers positions and declines the rest\n");
+  free(gg1); free(gg2); free(ggp1); free(ggp2);
   meos_errno_reset();
 
   /* Finalize MEOS */


### PR DESCRIPTION
GEOS states its own model plainly, in its FAQ:

> GEOS assumes that geometries are defined in a Cartesian, planar,
> 2-dimensional space. Thus it cannot be used to compute accurate metrics,
> predicates or constructions on the geodetic ellipsoid which is usually used
> to model the surface of the Earth.

PostGIS draws the same line between its two types -- geometry "is based on a
plane, the shortest path between two points on the plane is a straight line",
geography "is based on a spherical model, the shortest path between two points
on the sphere is a great circle arc" -- which is why a geography carries fewer
functions rather than GEOS-backed ones.

Two entries hand a geography to GEOS anyway, and it answers, because degrees
are numbers like any other. The answer is wrong where the sphere and the plane
disagree, and they disagree most at the antimeridian: two boxes spanning
179 to 180 and -180 to -179 share the meridian at 180 and are one region on
the sphere, and the union of them as geographies reports a MULTIPOLYGON of two
parts -- one connected region reported as two.

### The rule the file already follows

`geom_` answers on the plane, `geog_` answers on the spheroid. Of the six
entries that reach GEOS, four already refuse a geography through
`ensure_not_geodetic_geo` -- `geom_centroid`, `geom_intersection2d`,
`geom_is_simple`, `geom_unary_union` -- and `geog_area`, `geog_length`,
`geog_distance`, `geog_centroid` answer one. `geom_difference2d` sits thirty
lines from the first of them and does not.

So the two stragglers refuse as well, through the same guard, and the union of
a geography moves to the twin the family was missing:

| entry | a geography |
| --- | --- |
| `geom_array_union`, `geom_difference2d` | refused, as by the four siblings |
| `geog_array_union` (new) | answered where the spheroid answers |

The twin answers what the spheroid answers and no more. The union of a set of
positions is the set with its duplicates removed, and two positions are the
same when their coordinates are, so that answer is read without measuring
anything and holds on the spheroid as it does on the plane. A geodetic array
carrying anything else says so rather than guessing: a geodesic is not the
segment joining two positions in degree space, and two geodesics meet where
those segments need not.

Reading the flag is one test on one member, so both entries make it before the
SRID test walks the array.

### Two defects the change uncovers

`geoarr_merge` collects the values of a temporal merge and unions them, and it
called the planar entry whatever it held. It now reads the flag and calls the
entry that answers for what it has, which is what keeps
`merge(tgeography, tgeography)` answering.

Both entries returned the caller's own pointer for a single-element array. The
array belongs to the caller, so a result aliasing a member of it is released
when the caller releases the array -- and `geoarr_merge` releases the result it
decides to re-merge, which was the caller's geometry. Both now answer a value
of their own.

### Checking

`meos/test/geo_test.c` carries the contract in both directions: the geodetic
union of two positions answers `SRID=4326;MULTIPOINT(1 1,2 2)`, the planar
entry refuses a geography, and the geodetic entry declines an array of
polygons. pg_regress passes with no expected output changed.
