### PR TITLE
Name the great circle distances after the units libh3 publishes

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2896,7 +2896,7 @@
 					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLengthKm</varname>, <varname>th3EdgeLengthM</varname>, <varname>th3EdgeLengthRads</varname></link>: Devolver la longitud temporal de cada arista dirigida en una trayectoria, en kilómetros, metros o radianes</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistance</varname></link>: Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas)</para>
+					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistanceKm</varname>, <varname>greatCircleDistanceM</varname>, <varname>greatCircleDistanceRads</varname></link>: Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas), en kilómetros, metros o radianes</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_h3_index.xml
+++ b/doc/es/temporal_h3_index.xml
@@ -603,16 +603,26 @@ SELECT th3EdgeLengthRads(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-0
 			</listitem>
 
 			<listitem xml:id="th3_h3_great_circle_distance">
-				<indexterm significance="normal"><primary><varname>greatCircleDistance</varname></primary></indexterm>
-				<para>Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas)</para>
+				<indexterm significance="normal"><primary><varname>greatCircleDistanceKm</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>greatCircleDistanceM</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>greatCircleDistanceRads</varname></primary></indexterm>
+				<para>Devolver la distancia temporal del gran círculo entre dos puntos geodésicos temporales (no entre celdas), en kilómetros, metros o radianes</para>
 				<programlisting xml:space="preserve" format="linespecific">
-greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat
+greatCircleDistanceKm(tgeogpoint,tgeogpoint) → tfloat
+greatCircleDistanceM(tgeogpoint,tgeogpoint) → tfloat
+greatCircleDistanceRads(tgeogpoint,tgeogpoint) → tfloat
 </programlisting>
 				<para>Los dos operandos se sincronizan.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
+SELECT greatCircleDistanceKm(tgeogpoint 'Point(0 0)@2001-01-01',
   tgeogpoint 'Point(1 0)@2001-01-01');
 -- 111.19505197522943@2001-01-01
+SELECT greatCircleDistanceM(tgeogpoint 'Point(0 0)@2001-01-01',
+  tgeogpoint 'Point(1 0)@2001-01-01');
+-- 111195.05197522943@2001-01-01
+SELECT greatCircleDistanceRads(tgeogpoint 'Point(0 0)@2001-01-01',
+  tgeogpoint 'Point(1 0)@2001-01-01');
+-- 0.017453292519943@2001-01-01
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2905,7 +2905,7 @@
 					<para><link linkend="th3_h3_edge_length"><varname>th3EdgeLengthKm</varname>, <varname>th3EdgeLengthM</varname>, <varname>th3EdgeLengthRads</varname></link>: Return the temporal length of each directed edge in a trajectory, in kilometres, metres, or radians</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistance</varname></link>: Return the temporal great-circle distance between two temporal geodetic points (not between cells)</para>
+					<para><link linkend="th3_h3_great_circle_distance"><varname>greatCircleDistanceKm</varname>, <varname>greatCircleDistanceM</varname>, <varname>greatCircleDistanceRads</varname></link>: Return the temporal great-circle distance between two temporal geodetic points (not between cells), in kilometres, metres, or radians</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_h3_index.xml
+++ b/doc/temporal_h3_index.xml
@@ -603,16 +603,26 @@ SELECT th3EdgeLengthRads(th3CellsToDirectedEdge(th3index '871fa44a8ffffff@2001-0
 			</listitem>
 
 			<listitem xml:id="th3_h3_great_circle_distance">
-				<indexterm significance="normal"><primary><varname>greatCircleDistance</varname></primary></indexterm>
-				<para>Return the temporal great-circle distance between two temporal geodetic points (not between cells)</para>
+				<indexterm significance="normal"><primary><varname>greatCircleDistanceKm</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>greatCircleDistanceM</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>greatCircleDistanceRads</varname></primary></indexterm>
+				<para>Return the temporal great-circle distance between two temporal geodetic points (not between cells), in kilometres, metres, or radians</para>
 				<programlisting xml:space="preserve" format="linespecific">
-greatCircleDistance(tgeogpoint,tgeogpoint,text='km') → tfloat
+greatCircleDistanceKm(tgeogpoint,tgeogpoint) → tfloat
+greatCircleDistanceM(tgeogpoint,tgeogpoint) → tfloat
+greatCircleDistanceRads(tgeogpoint,tgeogpoint) → tfloat
 </programlisting>
 				<para>The two operands are synchronised.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT greatCircleDistance(tgeogpoint 'Point(0 0)@2001-01-01',
+SELECT greatCircleDistanceKm(tgeogpoint 'Point(0 0)@2001-01-01',
   tgeogpoint 'Point(1 0)@2001-01-01');
 -- 111.19505197522943@2001-01-01
+SELECT greatCircleDistanceM(tgeogpoint 'Point(0 0)@2001-01-01',
+  tgeogpoint 'Point(1 0)@2001-01-01');
+-- 111195.05197522943@2001-01-01
+SELECT greatCircleDistanceRads(tgeogpoint 'Point(0 0)@2001-01-01',
+  tgeogpoint 'Point(1 0)@2001-01-01');
+-- 0.017453292519943@2001-01-01
 </programlisting>
 			</listitem>
 		</itemizedlist>

--- a/meos/include/h3/th3index_internal.h
+++ b/meos/include/h3/th3index_internal.h
@@ -118,7 +118,6 @@ extern H3Index h3_local_ij_to_cell_meos(H3Index origin,
   const GSERIALIZED *coord);
 
 /* Metrics — bodies in th3index_metrics.c. */
-extern H3Unit h3_unit_from_cstring(const char *unit);
 extern double h3_cell_area_meos(H3Index cell, H3Unit unit);
 extern double h3_edge_length_meos(H3Index edge, H3Unit unit);
 extern double h3_gs_great_circle_distance_meos(const GSERIALIZED *a,

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -276,7 +276,11 @@ extern Temporal *th3index_cell_area_rads2(const Temporal *temp);
 extern Temporal *th3index_edge_length_km(const Temporal *temp);
 extern Temporal *th3index_edge_length_m(const Temporal *temp);
 extern Temporal *th3index_edge_length_rads(const Temporal *temp);
-extern Temporal *tgeogpoint_great_circle_distance(const Temporal *a,
-  const Temporal *b, const char *unit);
+extern Temporal *tgeogpoint_great_circle_distance_km(const Temporal *a,
+  const Temporal *b);
+extern Temporal *tgeogpoint_great_circle_distance_m(const Temporal *a,
+  const Temporal *b);
+extern Temporal *tgeogpoint_great_circle_distance_rads(const Temporal *a,
+  const Temporal *b);
 
 #endif /* __MEOS_H3_H__ */

--- a/meos/src/h3/th3index_metrics.c
+++ b/meos/src/h3/th3index_metrics.c
@@ -58,30 +58,6 @@
  * Unit-string dispatcher (h3-pg: miscellaneous.c)
  *****************************************************************************/
 
-/**
- * @brief 
- */
-H3Unit
-h3_unit_from_cstring(const char *unit)
-{
-  if (unit == NULL)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "unit must not be null");
-    return H3_UNIT_KM;  /* unreachable */
-  }
-  if (strcasecmp(unit, "km") == 0)    return H3_UNIT_KM;
-  if (strcasecmp(unit, "m") == 0)     return H3_UNIT_M;
-  if (strcasecmp(unit, "rads") == 0)  return H3_UNIT_RADS;
-  if (strcasecmp(unit, "km2") == 0)   return H3_UNIT_KM2;
-  if (strcasecmp(unit, "m2") == 0)    return H3_UNIT_M2;
-  if (strcasecmp(unit, "rads2") == 0) return H3_UNIT_RADS2;
-  meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-    "invalid h3 unit \"%s\" (expected one of km, m, rads, km2, m2, rads2)",
-    unit);
-  return H3_UNIT_KM;  /* unreachable */
-}
-
 /*****************************************************************************
  * Static adapters — libh3 metric dispatch by unit
  *****************************************************************************/
@@ -284,7 +260,8 @@ th3index_edge_length_rads(const Temporal *temp)
 }
 
 /*****************************************************************************
- * greatCircleDistance(tgeogpoint, tgeogpoint, text) — binary_synced
+ * greatCircleDistanceKm, greatCircleDistanceM and greatCircleDistanceRads —
+ * binary_synced
  *
  * Two temporal geodetic points are synchronised over their shared
  * time axis; the unit is constant across instants and is threaded
@@ -294,20 +271,13 @@ th3index_edge_length_rads(const Temporal *temp)
  *****************************************************************************/
 
 /**
- * @ingroup meos_h3_metrics
  * @brief Return the per-instant great-circle distance between two temporal
- * geodetic points in the given unit.
- * @csqlfn #Tgeogpoint_great_circle_distance()
+ * geodetic points in the given H3 unit
  */
-Temporal *
-tgeogpoint_great_circle_distance(const Temporal *a, const Temporal *b,
-  const char *unit)
+static Temporal *
+tgeogpoint_great_circle_distance_in(const Temporal *a, const Temporal *b,
+  H3Unit u)
 {
-  /* Ensure the validity of the arguments */
-  VALIDATE_TGEOGPOINT(a, NULL); VALIDATE_TGEOGPOINT(b, NULL);
-  VALIDATE_NOT_NULL(unit, NULL);
-
-  H3Unit u = h3_unit_from_cstring(unit);
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) &datum_h3_great_circle_distance;
@@ -320,6 +290,51 @@ tgeogpoint_great_circle_distance(const Temporal *a, const Temporal *b,
   lfinfo.invert = INVERT_NO;
   lfinfo.discont = CONTINUOUS;
   return tfunc_temporal_temporal(a, b, &lfinfo);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant great-circle distance between two temporal
+ * geodetic points in kilometres, the quantity libh3 answers as
+ * greatCircleDistanceKm
+ * @csqlfn #Tgeogpoint_great_circle_distance_km()
+ */
+Temporal *
+tgeogpoint_great_circle_distance_km(const Temporal *a, const Temporal *b)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TGEOGPOINT(a, NULL); VALIDATE_TGEOGPOINT(b, NULL);
+  return tgeogpoint_great_circle_distance_in(a, b, H3_UNIT_KM);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant great-circle distance between two temporal
+ * geodetic points in metres, the quantity libh3 answers as
+ * greatCircleDistanceM
+ * @csqlfn #Tgeogpoint_great_circle_distance_m()
+ */
+Temporal *
+tgeogpoint_great_circle_distance_m(const Temporal *a, const Temporal *b)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TGEOGPOINT(a, NULL); VALIDATE_TGEOGPOINT(b, NULL);
+  return tgeogpoint_great_circle_distance_in(a, b, H3_UNIT_M);
+}
+
+/**
+ * @ingroup meos_h3_metrics
+ * @brief Return the per-instant great-circle distance between two temporal
+ * geodetic points in radians, the quantity libh3 answers as
+ * greatCircleDistanceRads
+ * @csqlfn #Tgeogpoint_great_circle_distance_rads()
+ */
+Temporal *
+tgeogpoint_great_circle_distance_rads(const Temporal *a, const Temporal *b)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TGEOGPOINT(a, NULL); VALIDATE_TGEOGPOINT(b, NULL);
+  return tgeogpoint_great_circle_distance_in(a, b, H3_UNIT_RADS);
 }
 
 /*****************************************************************************/

--- a/mobilitydb/sql/h3/286_th3index_metrics.in.sql
+++ b/mobilitydb/sql/h3/286_th3index_metrics.in.sql
@@ -31,14 +31,16 @@
  * @file
  * @brief Cell-metric functions for `th3index`.
  *
- * All three functions take a textual `unit` argument (`km`, `km2`,
- * `m`, `m2`, `rads`, `rads2` as in h3-pg). The unit string is
- * validated at bind time by the MEOS implementation; an invalid
- * value raises an error before any per-instant work happens.
+ * Each function names the unit it answers, the way libh3 names its own
+ * (`cellAreaKm2`, `edgeLengthM`, `greatCircleDistanceRads`), so a unit is
+ * chosen by calling the function that answers it rather than by passing a
+ * string. `cellArea` is the exception and not an omission: the square metre
+ * is the unit the DggsCellOps `cell_area` slot declares, so it carries the
+ * bare name every cell index shares.
  *
- * `greatCircleDistance(tgeogpoint, tgeogpoint, text)` is the
- * `binary_synced` form of the scalar h3-pg helper — both geodetic
- * points are synchronised over their shared time axis.
+ * The `greatCircleDistance*` functions are the `binary_synced` form of the
+ * scalar libh3 helper — both geodetic points are synchronised over their
+ * shared time axis.
  */
 
 /******************************************************************************
@@ -80,13 +82,22 @@ CREATE FUNCTION th3EdgeLengthRads(th3index)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************
- * greatCircleDistance
+ * greatCircleDistanceKm, greatCircleDistanceM and greatCircleDistanceRads
  ******************************************************************************/
 
-CREATE FUNCTION greatCircleDistance(tgeogpoint, tgeogpoint,
-  text DEFAULT 'km')
+CREATE FUNCTION greatCircleDistanceKm(tgeogpoint, tgeogpoint)
   RETURNS tfloat
-  AS 'MODULE_PATHNAME', 'Tgeogpoint_great_circle_distance'
+  AS 'MODULE_PATHNAME', 'Tgeogpoint_great_circle_distance_km'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION greatCircleDistanceM(tgeogpoint, tgeogpoint)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Tgeogpoint_great_circle_distance_m'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION greatCircleDistanceRads(tgeogpoint, tgeogpoint)
+  RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Tgeogpoint_great_circle_distance_rads'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 /******************************************************************************/

--- a/mobilitydb/src/h3/th3index_metrics.c
+++ b/mobilitydb/src/h3/th3index_metrics.c
@@ -153,26 +153,61 @@ Th3index_edge_length_rads(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
- * greatCircleDistance(tgeogpoint, tgeogpoint, text)
+ * greatCircleDistanceKm, greatCircleDistanceM and greatCircleDistanceRads
  *****************************************************************************/
 
-PGDLLEXPORT Datum Tgeogpoint_great_circle_distance(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Tgeogpoint_great_circle_distance);
+PGDLLEXPORT Datum Tgeogpoint_great_circle_distance_km(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tgeogpoint_great_circle_distance_km);
 /**
  * @ingroup mobilitydb_h3_metrics
  * @brief Return the per-instant great-circle distance between two temporal
- * geodetic points in the given unit
- * @sqlfn greatCircleDistance()
+ * geodetic points in kilometres
+ * @sqlfn greatCircleDistanceKm()
  */
 Datum
-Tgeogpoint_great_circle_distance(PG_FUNCTION_ARGS)
+Tgeogpoint_great_circle_distance_km(PG_FUNCTION_ARGS)
 {
   Temporal *a = PG_GETARG_TEMPORAL_P(0);
   Temporal *b = PG_GETARG_TEMPORAL_P(1);
-  text *unit_txt = PG_GETARG_TEXT_P(2);
-  char *unit = text_to_cstring(unit_txt);
-  Temporal *result = tgeogpoint_great_circle_distance(a, b, unit);
-  pfree(unit);
+  Temporal *result = tgeogpoint_great_circle_distance_km(a, b);
+  PG_FREE_IF_COPY(a, 0);
+  PG_FREE_IF_COPY(b, 1);
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Tgeogpoint_great_circle_distance_m(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tgeogpoint_great_circle_distance_m);
+/**
+ * @ingroup mobilitydb_h3_metrics
+ * @brief Return the per-instant great-circle distance between two temporal
+ * geodetic points in metres
+ * @sqlfn greatCircleDistanceM()
+ */
+Datum
+Tgeogpoint_great_circle_distance_m(PG_FUNCTION_ARGS)
+{
+  Temporal *a = PG_GETARG_TEMPORAL_P(0);
+  Temporal *b = PG_GETARG_TEMPORAL_P(1);
+  Temporal *result = tgeogpoint_great_circle_distance_m(a, b);
+  PG_FREE_IF_COPY(a, 0);
+  PG_FREE_IF_COPY(b, 1);
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Tgeogpoint_great_circle_distance_rads(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tgeogpoint_great_circle_distance_rads);
+/**
+ * @ingroup mobilitydb_h3_metrics
+ * @brief Return the per-instant great-circle distance between two temporal
+ * geodetic points in radians
+ * @sqlfn greatCircleDistanceRads()
+ */
+Datum
+Tgeogpoint_great_circle_distance_rads(PG_FUNCTION_ARGS)
+{
+  Temporal *a = PG_GETARG_TEMPORAL_P(0);
+  Temporal *b = PG_GETARG_TEMPORAL_P(1);
+  Temporal *result = tgeogpoint_great_circle_distance_rads(a, b);
   PG_FREE_IF_COPY(a, 0);
   PG_FREE_IF_COPY(b, 1);
   PG_RETURN_TEMPORAL_P(result);

--- a/mobilitydb/test/h3/expected/286_th3index_metrics.test.out
+++ b/mobilitydb/test/h3/expected/286_th3index_metrics.test.out
@@ -92,54 +92,54 @@ SELECT startValue(th3EdgeLengthRads(th3CellsToDirectedEdge(
  t
 (1 row)
 
-SELECT greatCircleDistance(
+SELECT greatCircleDistanceKm(
   tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  'km');
-      greatcircledistance       
+  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01');
+     greatcircledistancekm      
 --------------------------------
  0@Mon Jan 01 00:00:00 2001 PST
 (1 row)
 
-SELECT greatCircleDistance(
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(2.35 48.86)@2001-01-01',
-  'km') IS NOT NULL;
+SELECT round(startValue(greatCircleDistanceKm(
+  tgeogpoint 'POINT(0 0)@2001-01-01',
+  tgeogpoint 'POINT(1 0)@2001-01-01'))::numeric, 6);
+   round    
+------------
+ 111.195052
+(1 row)
+
+SELECT round(startValue(greatCircleDistanceM(
+  tgeogpoint 'POINT(0 0)@2001-01-01',
+  tgeogpoint 'POINT(1 0)@2001-01-01'))::numeric, 3);
+   round    
+------------
+ 111195.052
+(1 row)
+
+SELECT round(startValue(greatCircleDistanceRads(
+  tgeogpoint 'POINT(0 0)@2001-01-01',
+  tgeogpoint 'POINT(1 0)@2001-01-01'))::numeric, 9)
+  = round((pi() / 180)::numeric, 9);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT greatCircleDistance(
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(2.35 48.86)@2001-01-01',
-  'm') IS NOT NULL;
+SELECT startValue(greatCircleDistanceM(
+    tgeogpoint 'POINT(0 0)@2001-01-01', tgeogpoint 'POINT(1 0)@2001-01-01'))
+  = startValue(greatCircleDistanceKm(
+    tgeogpoint 'POINT(0 0)@2001-01-01', tgeogpoint 'POINT(1 0)@2001-01-01')) * 1000;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT greatCircleDistance(
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(2.35 48.86)@2001-01-01',
-  'rads') IS NOT NULL;
- ?column? 
-----------
- t
-(1 row)
-
-SELECT greatCircleDistance(
+SELECT greatCircleDistanceKm(
   tgeogpoint '[POINT(-73.96 40.78)@2001-01-01, POINT(2.35 48.86)@2001-01-02]',
-  tgeogpoint '[POINT(2.35 48.86)@2001-01-01, POINT(-73.96 40.78)@2001-01-02]',
-  'km') IS NOT NULL;
+  tgeogpoint '[POINT(2.35 48.86)@2001-01-01, POINT(-73.96 40.78)@2001-01-02]')
+  IS NOT NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-/* Errors */
-SELECT greatCircleDistance(
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(2.35 48.86)@2001-01-01',
-  'km2');
-ERROR:  h3_great_circle_distance: expected a length unit (km, m, rads)

--- a/mobilitydb/test/h3/queries/286_th3index_metrics.test.sql
+++ b/mobilitydb/test/h3/queries/286_th3index_metrics.test.sql
@@ -69,40 +69,38 @@ SELECT startValue(th3EdgeLengthRads(th3CellsToDirectedEdge(
     th3index '880326b88dfffff@2001-01-01')));
 
 -------------------------------------------------------------------------------
--- greatCircleDistance(tgeogpoint, tgeogpoint, text) — binary_synced
+-- greatCircleDistanceKm, greatCircleDistanceM and greatCircleDistanceRads —
+-- binary_synced
 -------------------------------------------------------------------------------
 
 -- Distance from a point to itself is 0
-SELECT greatCircleDistance(
+SELECT greatCircleDistanceKm(
   tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  'km');
+  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01');
 
--- All three valid length units
-SELECT greatCircleDistance(
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(2.35 48.86)@2001-01-01',
-  'km') IS NOT NULL;
-SELECT greatCircleDistance(
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(2.35 48.86)@2001-01-01',
-  'm') IS NOT NULL;
-SELECT greatCircleDistance(
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(2.35 48.86)@2001-01-01',
-  'rads') IS NOT NULL;
+-- One degree of longitude at the equator, in the three units libh3 names.
+-- The radian answer is pi/180 exactly, which is the oracle for the trio.
+SELECT round(startValue(greatCircleDistanceKm(
+  tgeogpoint 'POINT(0 0)@2001-01-01',
+  tgeogpoint 'POINT(1 0)@2001-01-01'))::numeric, 6);
+SELECT round(startValue(greatCircleDistanceM(
+  tgeogpoint 'POINT(0 0)@2001-01-01',
+  tgeogpoint 'POINT(1 0)@2001-01-01'))::numeric, 3);
+SELECT round(startValue(greatCircleDistanceRads(
+  tgeogpoint 'POINT(0 0)@2001-01-01',
+  tgeogpoint 'POINT(1 0)@2001-01-01'))::numeric, 9)
+  = round((pi() / 180)::numeric, 9);
+
+-- The three answer one quantity in three units
+SELECT startValue(greatCircleDistanceM(
+    tgeogpoint 'POINT(0 0)@2001-01-01', tgeogpoint 'POINT(1 0)@2001-01-01'))
+  = startValue(greatCircleDistanceKm(
+    tgeogpoint 'POINT(0 0)@2001-01-01', tgeogpoint 'POINT(1 0)@2001-01-01')) * 1000;
 
 -- Sequence form
-SELECT greatCircleDistance(
+SELECT greatCircleDistanceKm(
   tgeogpoint '[POINT(-73.96 40.78)@2001-01-01, POINT(2.35 48.86)@2001-01-02]',
-  tgeogpoint '[POINT(2.35 48.86)@2001-01-01, POINT(-73.96 40.78)@2001-01-02]',
-  'km') IS NOT NULL;
-
--- Area unit on a length function — error
-/* Errors */
-SELECT greatCircleDistance(
-  tgeogpoint 'POINT(-73.96 40.78)@2001-01-01',
-  tgeogpoint 'POINT(2.35 48.86)@2001-01-01',
-  'km2');
+  tgeogpoint '[POINT(2.35 48.86)@2001-01-01, POINT(-73.96 40.78)@2001-01-02]')
+  IS NOT NULL;
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
libh3 answers a great circle distance through greatCircleDistanceKm,
greatCircleDistanceM and greatCircleDistanceRads, three functions each naming
its unit, so the lifted surface carries the same three answers under the same
words. The names take no family stem because the operands are temporal
geodetic points rather than H3 cells, which is the spelling the bare
greatCircleDistance on master carries.

The unit helper the three share is removed with the argument that feeds it,
and the file states that a unit is chosen by calling the function answering
it.

The test reads the radian answer against pi/180, so one degree of longitude
at the equator is checked against a closed form rather than against another
of the three.
