### PR TITLE
Answer a union whose array spans the areal boundary

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -149,6 +149,7 @@ extern bool meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2,
   const char *pattern, bool *result);
 extern bool meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
   bool *result);
+extern bool relate_is_areal(const LWGEOM *geom);
 
 /* The edges of one geometry, kept so that several relationships asked about it
  * read them once. A relationship extracts the edges of both its operands, and

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -3640,7 +3640,7 @@ de9im_match(const char matrix[10], const char pattern[10])
 /**
  * @brief Return true if a geometry contains a 2-dimensional region
  */
-static bool
+bool
 relate_is_areal(const LWGEOM *geom)
 {
   if (! geom || lwgeom_is_empty(geom))

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2254,6 +2254,179 @@ geom_array_linear_union(GSERIALIZED **gsarr, int count, bool geodetic)
 }
 
 /**
+ * @brief Return the components a union answer is read as, one entry per piece
+ * that stands on its own
+ * @details A multi-geometry stands for its members and a general collection
+ * for its components, so the answer is assembled from those rather than from
+ * the wrapper.
+ * ⛔ The test is the TYPE, not #lwgeom_is_collection(), which answers true for
+ * a curve polygon and a compound curve as well -- their rings and pieces are
+ * sub-geometries, so reading THEM as components takes a surface apart into its
+ * own boundary
+ * @param[in] geom Geometry
+ * @param[out] comps Newly allocated array of components, which the geometry
+ * keeps ownership of and which the caller releases with @p pfree()
+ * @return The number of components
+ */
+static int
+union_components(const LWGEOM *geom, const LWGEOM ***comps)
+{
+  uint8_t type = geom->type;
+  if (type == MULTIPOINTTYPE || type == MULTILINETYPE ||
+      type == MULTICURVETYPE || type == MULTIPOLYGONTYPE ||
+      type == MULTISURFACETYPE || type == COLLECTIONTYPE)
+  {
+    const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
+    const LWGEOM **result = palloc(sizeof(LWGEOM *) * coll->ngeoms);
+    for (uint32_t i = 0; i < coll->ngeoms; i++)
+      result[i] = coll->geoms[i];
+    *comps = result;
+    return (int) coll->ngeoms;
+  }
+  const LWGEOM **one = palloc(sizeof(LWGEOM *));
+  one[0] = geom;
+  *comps = one;
+  return 1;
+}
+
+/**
+ * @brief Return the union of an array of geometries whose members fall on both
+ * sides of the areal boundary
+ * @details The array is split on #relate_is_areal() and each half is answered
+ * by the arm that already answers it -- #meos_areal_union() for the surfaces,
+ * #meos_linear_union() for the linework and the points. What the two answers
+ * share is then read: a non-areal piece the surfaces COVER contributes nothing
+ * of its own and is left out, and what remains is collected beside them.
+ *
+ * A piece the surfaces cover only in PART stays whole, which is the rule the
+ * union already keeps for its linework: both spellings cover the same points,
+ * and keeping the piece whole keeps a circular arc on its own circle. That is
+ * where this answer differs from the one GEOS gives, which cuts the piece at
+ * the boundary
+ * @param[in] gsarr Array of geometries
+ * @param[in] count Number of elements in the array
+ * @return The union, or @p NULL where the array does not span the boundary, or
+ * where either half is one its arm does not answer, which leaves the caller to
+ * answer it another way
+ */
+static GSERIALIZED *
+geom_array_mixed_union(GSERIALIZED **gsarr, int count)
+{
+  assert(gsarr); assert(count > 1);
+  int32_t srid = gserialized_get_srid(gsarr[0]);
+  /* An empty member carries no points and is left out, as it is in both arms */
+  LWGEOM **areal = palloc(sizeof(LWGEOM *) * count);
+  LWGEOM **other = palloc(sizeof(LWGEOM *) * count);
+  uint32_t nareal = 0, nother = 0;
+  for (int i = 0; i < count; i++)
+  {
+    if (gserialized_is_empty(gsarr[i]))
+      continue;
+    LWGEOM *geom = lwgeom_from_gserialized(gsarr[i]);
+    if (relate_is_areal(geom))
+      areal[nareal++] = geom;
+    else
+      other[nother++] = geom;
+  }
+  /* An array that stays on one side of the boundary is what the two arms
+   * already answered, and this one has nothing to add to it */
+  if (nareal == 0 || nother == 0)
+  {
+    for (uint32_t i = 0; i < nareal; i++)
+      lwgeom_free(areal[i]);
+    for (uint32_t i = 0; i < nother; i++)
+      lwgeom_free(other[i]);
+    pfree(areal); pfree(other);
+    return NULL;
+  }
+
+  /* #lwcollection_construct() takes ownership of the array it is given and of
+   * its members, so neither is freed other than through the collection. A half
+   * holding a single member is the collection of one, which each arm answers
+   * by returning that member -- there is no count the arms must be spared */
+  LWCOLLECTION *acoll = lwcollection_construct(COLLECTIONTYPE, srid, NULL,
+    nareal, areal);
+  LWCOLLECTION *ocoll = lwcollection_construct(COLLECTIONTYPE, srid, NULL,
+    nother, other);
+  LWGEOM *lwareal = meos_areal_union(lwcollection_as_lwgeom(acoll));
+  LWGEOM *lwother = lwareal ?
+    meos_linear_union(lwcollection_as_lwgeom(ocoll)) : NULL;
+  lwcollection_free(acoll); lwcollection_free(ocoll);
+  if (! lwother)
+  {
+    if (lwareal)
+      lwgeom_free(lwareal);
+    return NULL;
+  }
+
+  /* The surfaces are asked about every piece, so their edges are extracted
+   * once and read again for each question rather than once per question */
+  void *actx = relate_ctx_make(lwareal);
+  const LWGEOM **ocomps;
+  int nocomps = union_components(lwother, &ocomps);
+  bool *dropped = palloc0(sizeof(bool) * nocomps);
+  int nkept = 0;
+  for (int i = 0; i < nocomps && actx; i++)
+  {
+    void *octx = relate_ctx_make(ocomps[i]);
+    bool covered = false;
+    if (! octx || ! meos_spatialrel_ctx(actx, octx, COVERS, &covered))
+    {
+      /* A pair the engine does not cover leaves the whole answer to the
+       * caller: a piece kept without knowing it is covered would be a
+       * component the union does not have */
+      relate_ctx_free(octx);
+      relate_ctx_free(actx);
+      actx = NULL;
+      break;
+    }
+    relate_ctx_free(octx);
+    dropped[i] = covered;
+    if (! covered)
+      nkept++;
+  }
+  if (! actx)
+  {
+    pfree(dropped); pfree(ocomps);
+    lwgeom_free(lwareal); lwgeom_free(lwother);
+    return NULL;
+  }
+  relate_ctx_free(actx);
+
+  /* Every piece is covered, so the surfaces are the whole answer and they
+   * carry their own type rather than being wrapped in a collection */
+  GSERIALIZED *result;
+  if (nkept == 0)
+  {
+    result = geo_serialize(lwareal);
+    pfree(dropped); pfree(ocomps);
+    lwgeom_free(lwareal); lwgeom_free(lwother);
+    return result;
+  }
+
+  /* The answer lists what remains before the surfaces, the order a collection
+   * is read in, and lists each piece on its own: a collection of surfaces
+   * stands for its members here, not for itself */
+  const LWGEOM **acomps;
+  int nacomps = union_components(lwareal, &acomps);
+  LWGEOM **members = palloc(sizeof(LWGEOM *) * (nkept + nacomps));
+  int nmembers = 0;
+  for (int i = 0; i < nocomps; i++)
+    if (! dropped[i])
+      members[nmembers++] = lwgeom_clone_deep(ocomps[i]);
+  for (int i = 0; i < nacomps; i++)
+    members[nmembers++] = lwgeom_clone_deep(acomps[i]);
+  pfree(dropped); pfree(ocomps); pfree(acomps);
+  /* #lwcollection_construct() takes ownership of the array it is given */
+  LWCOLLECTION *coll = lwcollection_construct(COLLECTIONTYPE, srid, NULL,
+    (uint32_t) nmembers, members);
+  result = geo_serialize(lwcollection_as_lwgeom(coll));
+  lwcollection_free(coll);
+  lwgeom_free(lwareal); lwgeom_free(lwother);
+  return result;
+}
+
+/**
  * @ingroup meos_geo_base_spatial
  * @brief Return the union of an array of geometries
  * @details The function will iteratively call @p GEOSUnion on the
@@ -2334,6 +2507,15 @@ geom_array_union(GSERIALIZED **gsarr, int count)
   if (! geodetic || geom_array_point_only(gsarr, count))
   {
     GSERIALIZED *native = geom_array_linear_union(gsarr, count, geodetic);
+    if (native)
+      return native;
+  }
+  /* An array whose members fall on BOTH sides of the areal boundary is
+   * answered by the two arms together: each half is dissolved by the arm that
+   * answers it, and a non-areal piece the surfaces cover is left out */
+  if (! geodetic)
+  {
+    GSERIALIZED *native = geom_array_mixed_union(gsarr, count);
     if (native)
       return native;
   }

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -710,6 +710,50 @@ int main(void)
   free(gg1); free(gg2); free(ggp1); free(ggp2);
   meos_errno_reset();
 
+  /* An array whose members fall on BOTH sides of the areal boundary is
+   * answered by the two native arms together: the surfaces are dissolved, the
+   * linework and the points are dissolved, and a piece the surfaces COVER is
+   * left out of the answer.  A piece they cover only in PART stays WHOLE,
+   * which is where the answer differs from the one GEOS gives -- both
+   * spellings cover the same points, and keeping the piece whole keeps a
+   * circular arc on its own circle */
+  const char *msq = "POLYGON((0 0,0 2,2 2,2 0,0 0))";
+  struct { const char *piece; const char *result; } mixcases[] = {
+    /* the point is outside, so it stands beside the surface */
+    { "POINT(5 5)",
+      "GEOMETRYCOLLECTION(POINT(5 5),POLYGON((0 0,0 2,2 2,2 0,0 0)))" },
+    /* the point is inside, so the surface is the whole answer */
+    { "POINT(1 1)", "POLYGON((0 0,0 2,2 2,2 0,0 0))" },
+    /* a point ON the boundary is covered as well */
+    { "POINT(0 1)", "POLYGON((0 0,0 2,2 2,2 0,0 0))" },
+    /* the line is covered, and contributes nothing of its own */
+    { "LINESTRING(0.5 0.5,1.5 1.5)", "POLYGON((0 0,0 2,2 2,2 0,0 0))" },
+    /* the line is covered only in part and stays whole */
+    { "LINESTRING(1 1,5 5)",
+      "GEOMETRYCOLLECTION(LINESTRING(1 1,5 5),POLYGON((0 0,0 2,2 2,2 0,0 0)))" },
+    /* the arc stays on its own circle rather than being linearized */
+    { "CIRCULARSTRING(5 5,6 6,7 5)",
+      "GEOMETRYCOLLECTION(CIRCULARSTRING(5 5,6 6,7 5),"
+        "POLYGON((0 0,0 2,2 2,2 0,0 0)))" },
+  };
+  for (size_t i = 0; i < sizeof(mixcases) / sizeof(mixcases[0]); i++)
+  {
+    GSERIALIZED *mx1 = geom_in(mixcases[i].piece, -1);
+    GSERIALIZED *mx2 = geom_in(msq, -1);
+    assert(mx1 != NULL); assert(mx2 != NULL);
+    GSERIALIZED *mxarr[2] = {mx1, mx2};
+    meos_errno_reset();
+    GSERIALIZED *mxu = geom_array_union(mxarr, 2);
+    assert(mxu != NULL);
+    assert(meos_errno() == 0);
+    char *mxwkt = geo_as_text(mxu, 3);
+    assert(mxwkt != NULL);
+    printf("%s united with the square: %s\n", mixcases[i].piece, mxwkt);
+    assert(strcmp(mxwkt, mixcases[i].result) == 0);
+    free(mx1); free(mx2); free(mxu); free(mxwkt);
+  }
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
An array mixing surfaces with linework and points reaches GEOS. Each of the two
native arms answers one side of the areal boundary and declines the other, so a
single member on the far side sends the whole array to `GEOSUnaryUnion_r`, even
though both halves are answerable natively.

This splits the array on `relate_is_areal` — which the header publishes beside
the other relate helpers, so the partition reads the classifier the engine
already has rather than carrying a second answer to the same question — and
sends each half to the arm that answers it. What the two answers share is then
read: a non-areal piece the surfaces `COVER` contributes nothing of its own and
is left out, and what remains is listed before them, the order a collection is
read in.

Each half is presented as the collection it stands for, so a half holding a
single member is answered by that member and neither arm is reached with a
count it does not take. The surfaces are asked about every remaining piece, so
their edges are extracted once into a relate context and read again per
question rather than once per question.

### Where this differs from GEOS, and why

A piece the surfaces cover only in **part** stays **whole**, the rule the union
already keeps for its linework: both spellings cover the same points, and
keeping the piece whole keeps a circular arc on its own circle.

| array | GEOS | this |
|---|---|---|
| `LINESTRING(1 1,5 5)` + the unit square | `GC(POLYGON(…),LINESTRING(2 2,5 5))` — clipped at the boundary | `GC(LINESTRING(1 1,5 5),POLYGON(…))` — whole |
| `CIRCULARSTRING(5 5,6 6,7 5)` + the square | the arc replaced by a 61-vertex chain | `GC(CIRCULARSTRING(5 5,6 6,7 5),POLYGON(…))` |

Everything else in the acceptance set matches what ships: a point outside
stands beside the surface, a point inside or on the boundary is absorbed, a
covered line contributes nothing, and the surviving pieces are listed flat and
first, as GEOS lists them.

### Coverage

`meos/test/geo_test.c` gains six cases asserting the exact WKT of each of those
answers, including both divergences.

A `-DGEOS=OFF` library — which declines precisely the arrays that reach the GEOS
arm — answers every planar case of that set identically to the GEOS build.
