### PR TITLE
Read the bounds of a patch in the order pgPointCloud stores them

### DIFF
--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -429,8 +429,10 @@ pcpatch_to_tpcbox(const Pcpatch *pa, int32_t srid)
   return tpcbox_make(
     /* hasx */ true, /* hasz */ false, /* hast */ false,
     /* geodetic */ false, srid, pa->pcid,
-    pa->bounds[0], pa->bounds[2],  /* xmin, xmax */
-    pa->bounds[1], pa->bounds[3],  /* ymin, ymax */
+    /* PCBOUNDS is {xmin, xmax, ymin, ymax}, the order the bounds field of
+     * struct Pcpatch states and pointcloud-pg/lib/pc_api.h defines */
+    pa->bounds[0], pa->bounds[1],  /* xmin, xmax */
+    pa->bounds[2], pa->bounds[3],  /* ymin, ymax */
     0.0, 0.0,                      /* zmin, zmax (unused) */
     &empty_period);
 }

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -116,6 +116,30 @@ SELECT SRID(tpcbox(0, 0, 10, 10, 1, 4326));
  4326
 (1 row)
 
+SELECT xmin(b), xmax(b), ymin(b), ymax(b)
+FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
+  pcpoint(1, 4.0, 5.0, 6.0))) AS b) t;
+ xmin | xmax | ymin | ymax 
+------+------+------+------
+    1 |    4 |    2 |    5
+(1 row)
+
+SELECT PC_PatchMin(p, 'X'), PC_PatchMax(p, 'X'),
+  PC_PatchMin(p, 'Y'), PC_PatchMax(p, 'Y')
+FROM (SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
+  pcpoint(1, 4.0, 5.0, 6.0)) AS p) t;
+ pc_patchmin | pc_patchmax | pc_patchmin | pc_patchmax 
+-------------+-------------+-------------+-------------
+           1 |           4 |           2 |           5
+(1 row)
+
+SELECT xmin(b), xmax(b), ymin(b), ymax(b)
+FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0))) AS b) t;
+ xmin | xmax | ymin | ymax 
+------+------+------+------
+    1 |    1 |    2 |    2
+(1 row)
+
 SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
           ?column?           
 -----------------------------

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -65,6 +65,26 @@ SELECT pcid(tpcbox(0, 0, 10, 10, 7, 0));
 SELECT SRID(tpcbox(0, 0, 10, 10, 1, 4326));
 
 -------------------------------------------------------------------------------
+-- Conversions
+--
+-- The X and Y extent of the patch below are distinct, so that reading the
+-- PCBOUNDS header of a patch in the wrong order shows in the answer. The two
+-- queries answer the same extent, the second one through pgPointCloud itself.
+-------------------------------------------------------------------------------
+
+SELECT xmin(b), xmax(b), ymin(b), ymax(b)
+FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
+  pcpoint(1, 4.0, 5.0, 6.0))) AS b) t;
+SELECT PC_PatchMin(p, 'X'), PC_PatchMax(p, 'X'),
+  PC_PatchMin(p, 'Y'), PC_PatchMax(p, 'Y')
+FROM (SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
+  pcpoint(1, 4.0, 5.0, 6.0)) AS p) t;
+
+-- The extent of a patch of a single point is that point
+SELECT xmin(b), xmax(b), ymin(b), ymax(b)
+FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0))) AS b) t;
+
+-------------------------------------------------------------------------------
 -- Set operations
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
The PCBOUNDS header of a patch states {xmin, xmax, ymin, ymax}, the order pointcloud-pg/lib/pc_api.h defines and the bounds field of struct Pcpatch documents, so the conversion of a pcpatch to a TPCBox reads bounds[1] as the maximum X and bounds[2] as the minimum Y. The extent it answers is the one PC_PatchMin and PC_PatchMax answer for the same patch, and the one the bounding box of a temporal patch carries. The X and Y extent of the patch the tpcbox test converts are distinct, so the extent the test states is the one only this order answers.