### PR TITLE
Hold the survivors alone in the data area of a filtered patch

### DIFF
--- a/meos/src/pointcloud/pcpatch_decompose.c
+++ b/meos/src/pointcloud/pcpatch_decompose.c
@@ -90,6 +90,12 @@ pcpatch_filter_per_point(const Pcpatch *pa, pcpatch_pointpred_fn pred,
   Pcpatch *result = NULL;
   if (out->npoints > 0)
   {
+    /* The data area of a serialized patch is read back by length, so it holds
+     * exactly the survivors: pc_patch_uncompressed_make sized it for the upper
+     * bound above, and only the growth path of pc_patch_uncompressed_add_point
+     * keeps that size in step with the point count. */
+    out->maxpoints = out->npoints;
+    out->datasize = (size_t) out->npoints * schema->size;
     /* Recompute extent + stats so the serialized header is consistent
      * with the survivor set (bounds matter for downstream bbox prune). */
     pc_patch_uncompressed_compute_extent(out);

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -429,8 +429,10 @@ pcpatch_to_tpcbox(const Pcpatch *pa, int32_t srid)
   return tpcbox_make(
     /* hasx */ true, /* hasz */ false, /* hast */ false,
     /* geodetic */ false, srid, pa->pcid,
-    pa->bounds[0], pa->bounds[2],  /* xmin, xmax */
-    pa->bounds[1], pa->bounds[3],  /* ymin, ymax */
+    /* PCBOUNDS is {xmin, xmax, ymin, ymax}, the order the bounds field of
+     * struct Pcpatch states and pointcloud-pg/lib/pc_api.h defines */
+    pa->bounds[0], pa->bounds[1],  /* xmin, xmax */
+    pa->bounds[2], pa->bounds[3],  /* ymin, ymax */
     0.0, 0.0,                      /* zmin, zmax (unused) */
     &empty_period);
 }

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -116,6 +116,30 @@ SELECT SRID(tpcbox(0, 0, 10, 10, 1, 4326));
  4326
 (1 row)
 
+SELECT xmin(b), xmax(b), ymin(b), ymax(b)
+FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
+  pcpoint(1, 4.0, 5.0, 6.0))) AS b) t;
+ xmin | xmax | ymin | ymax 
+------+------+------+------
+    1 |    4 |    2 |    5
+(1 row)
+
+SELECT PC_PatchMin(p, 'X'), PC_PatchMax(p, 'X'),
+  PC_PatchMin(p, 'Y'), PC_PatchMax(p, 'Y')
+FROM (SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
+  pcpoint(1, 4.0, 5.0, 6.0)) AS p) t;
+ pc_patchmin | pc_patchmax | pc_patchmin | pc_patchmax 
+-------------+-------------+-------------+-------------
+           1 |           4 |           2 |           5
+(1 row)
+
+SELECT xmin(b), xmax(b), ymin(b), ymax(b)
+FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0))) AS b) t;
+ xmin | xmax | ymin | ymax 
+------+------+------+------
+    1 |    1 |    2 |    2
+(1 row)
+
 SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
           ?column?           
 -----------------------------

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -495,6 +495,20 @@ SELECT startNumPoints(minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, AR
               1
 (1 row)
 
+SELECT PC_AsText(getValue(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 1, 1, 1,
+  tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
+         pc_astext          
+----------------------------
+ {"pcid":1,"pts":[[1,1,1]]}
+(1 row)
+
+SELECT PC_AsText(getValue(minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 1, 1, 1,
+  tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
+         pc_astext          
+----------------------------
+ {"pcid":1,"pts":[[2,2,2]]}
+(1 row)
+
 SELECT startNumPoints(atGeometry(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz),
   geometry 'Polygon((0 0, 0 3, 3 3, 3 0, 0 0))'));
  startnumpoints 
@@ -514,6 +528,20 @@ SELECT startNumPoints(minusGeometry(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRA
  startnumpoints 
 ----------------
               1
+(1 row)
+
+SELECT PC_AsText(getValue(atGeometry(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz),
+  geometry 'Polygon((0 0, 0 1.5, 1.5 1.5, 1.5 0, 0 0))')));
+         pc_astext          
+----------------------------
+ {"pcid":1,"pts":[[1,1,1]]}
+(1 row)
+
+SELECT PC_AsText(getValue(minusGeometry(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz),
+  geometry 'Polygon((0 0, 0 1.5, 1.5 1.5, 1.5 0, 0 0))')));
+         pc_astext          
+----------------------------
+ {"pcid":1,"pts":[[2,2,2]]}
 (1 row)
 
 SELECT eIntersects(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz),

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -65,6 +65,26 @@ SELECT pcid(tpcbox(0, 0, 10, 10, 7, 0));
 SELECT SRID(tpcbox(0, 0, 10, 10, 1, 4326));
 
 -------------------------------------------------------------------------------
+-- Conversions
+--
+-- The X and Y extent of the patch below are distinct, so that reading the
+-- PCBOUNDS header of a patch in the wrong order shows in the answer. The two
+-- queries answer the same extent, the second one through pgPointCloud itself.
+-------------------------------------------------------------------------------
+
+SELECT xmin(b), xmax(b), ymin(b), ymax(b)
+FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
+  pcpoint(1, 4.0, 5.0, 6.0))) AS b) t;
+SELECT PC_PatchMin(p, 'X'), PC_PatchMax(p, 'X'),
+  PC_PatchMin(p, 'Y'), PC_PatchMax(p, 'Y')
+FROM (SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
+  pcpoint(1, 4.0, 5.0, 6.0)) AS p) t;
+
+-- The extent of a patch of a single point is that point
+SELECT xmin(b), xmax(b), ymin(b), ymax(b)
+FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0))) AS b) t;
+
+-------------------------------------------------------------------------------
 -- Set operations
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -241,6 +241,13 @@ SELECT minusTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 3, 3, 3,
 SELECT startNumPoints(minusTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
 
+-- The patch a restriction that drops a point answers is read back point by
+-- point, which is what states that its data area holds the survivors alone.
+SELECT PC_AsText(getValue(atTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 1, 1, 1,
+  tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
+SELECT PC_AsText(getValue(minusTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 1, 1, 1,
+  tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
+
 -------------------------------------------------------------------------------
 -- Per-point restrictions by geometry — atGeometry / minusGeometry.
 -------------------------------------------------------------------------------
@@ -251,6 +258,10 @@ SELECT atGeometry(:inst1,
   geometry 'Polygon((10 10, 10 20, 20 20, 20 10, 10 10))') IS NULL;
 SELECT startNumPoints(minusGeometry(:inst1,
   geometry 'Polygon((0 0, 0 1.5, 1.5 1.5, 1.5 0, 0 0))'));
+SELECT PC_AsText(getValue(atGeometry(:inst1,
+  geometry 'Polygon((0 0, 0 1.5, 1.5 1.5, 1.5 0, 0 0))')));
+SELECT PC_AsText(getValue(minusGeometry(:inst1,
+  geometry 'Polygon((0 0, 0 1.5, 1.5 1.5, 1.5 0, 0 0))')));
 
 -------------------------------------------------------------------------------
 -- Spatial relationships — eIntersects(tpcpatch, geometry).


### PR DESCRIPTION
A per-point restriction of a tpcpatch sizes its output for the points it reads and keeps those a predicate answers for, so the data area it serializes holds exactly the survivors: the size a serialized patch states is the one its reader compares against the point count, and only the growth path of pc_patch_uncompressed_add_point keeps the two in step on its own. The patch atTpcboxFine, minusTpcboxFine, atGeometry and minusGeometry answer is read back point by point, by PC_AsText, by PC_Explode and by the conversion to a temporal geometry. The tpcpatch test reads back the patch each of the four answers for a restriction dropping one of two points, which states the surviving point.