### PR TITLE
State the argument setSRID takes

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -619,7 +619,7 @@ SELECT round(tstzspan '[2000-01-01, 2001-01-02]'::tbox);
 				<para>Return or set the spatial reference identifier</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(stbox) → integer
-setSRID(stbox) → stbox
+setSRID(stbox,integer) → stbox
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2001-01-01,2001-01-02])');

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -606,7 +606,7 @@ SELECT round(tstzspan '[2000-01-01, 2001-01-02]'::tbox);
 </programlisting>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(stbox) → integer
-setSRID(stbox) → stbox
+setSRID(stbox,integer) → stbox
 </programlisting>
 				</listitem>
 

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -1014,7 +1014,7 @@ SELECT tprecision(tstzspanset '{[2001-12-01 08:00, 2001-12-01 09:00],
 				<para>Devuelve o especifica el identificador de referencia espacial</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(spatialset) → integer
-setSRID(spatialset) → spatialset
+setSRID(spatialset,integer) → spatialset
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(geomset '{"Point(1 1)", "Point(2 2)"}');

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -249,7 +249,7 @@ SELECT asText(round(cbuffer(ST_Point(1.123456789,1.123456789), 0.123456789), 6))
 					<para>Devuelve o establece el identificador de referencia espacial</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(cbuffer) → integer
-setSRID(cbuffer) → cbuffer
+setSRID(cbuffer,integer) → cbuffer
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(cbuffer 'Cbuffer(SRID=5676;Point(1 1), 0.3)');
@@ -875,7 +875,7 @@ SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2000-01-01,
 				<para>Devuelve o establece el identificador de referencia espacial</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(tcbuffer) → integer
-setSRID(tcbuffer) → tcbuffer
+setSRID(tcbuffer,integer) → tcbuffer
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tcbuffer 'SRID=5676;

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -124,7 +124,7 @@ SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
 				<para>Devuelve o establece el identificador de referencia espacial &Z_support; &geography_support;</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(tspatial) → integer
-setSRID(tspatial) → tspatial
+setSRID(tspatial,integer) → tspatial
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tgeompoint 'Point(0 0)@2001-01-01');

--- a/doc/set_span_types.xml
+++ b/doc/set_span_types.xml
@@ -1007,7 +1007,7 @@ SELECT tprecision(tstzspanset '{[2001-12-01 08:00, 2001-12-01 09:00],
 				<para>Return or set the spatial reference identifier</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(spatialset) → integer
-setSRID(spatialset) → spatialset
+setSRID(spatialset,integer) → spatialset
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(geomset '{"Point(1 1)", "Point(2 2)"}');

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -249,7 +249,7 @@ SELECT asText(round(cbuffer(ST_Point(1.123456789,1.123456789), 0.123456789), 6))
 					<para>Return or set the spatial reference identifier</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(cbuffer) → integer
-setSRID(cbuffer) → cbuffer
+setSRID(cbuffer,integer) → cbuffer
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(cbuffer 'Cbuffer(SRID=5676;Point(1 1), 0.3)');
@@ -876,7 +876,7 @@ SELECT asText(atStbox(tcbuffer '[Cbuffer(Point(1 1), 0.5)@2000-01-01,
 				<para>Return or set the spatial reference identifier</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(tcbuffer) → integer
-setSRID(tcbuffer) → tcbuffer
+setSRID(tcbuffer,integer) → tcbuffer
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tcbuffer 'SRID=5676;

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -123,7 +123,7 @@ SELECT astext(minusElevation(tgeompoint '[Point(1 1 1)@2001-01-01,
 				<para>Return or set the spatial reference identifier &Z_support; &geography_support;</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 SRID(tspatial) → integer
-setSRID(tspatial) → tspatial
+setSRID(tspatial,integer) → tspatial
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(tgeompoint 'Point(0 0)@2001-01-01');


### PR DESCRIPTION
Every setSRID function the extension creates takes the value and the spatial reference identifier to give it, so the signature of each of them names an integer second argument: stbox, spatialset, cbuffer, tcbuffer and tspatial join the pose, pose chain and tpcbox entries, which already name it. English and Spanish state the same signatures.