### PR TITLE
Give each bounding box entry the signature it documents

### DIFF
--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -496,11 +496,6 @@ SELECT shiftScaleValue(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])', 
 -- TBOXFLOAT XT([3.5, 6.5],[2001-01-01, 2001-01-02])
 </programlisting>
 
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-shiftTime(box,interval) → box
-scaleTime(box,interval) → box
-shiftScaleTime(box,interval,interval) → box
-</programlisting>
 			</listitem>
 
 			<listitem xml:id="box_shiftTime">
@@ -508,6 +503,11 @@ shiftScaleTime(box,interval,interval) → box
 				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
 				<para>Desplaza y/o escalar el período de un cuadro delimitador con uno o dos intervalos</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+shiftTime(box,interval) → box
+scaleTime(box,interval) → box
+shiftScaleTime(box,interval,interval) → box
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftTime(tbox 'TBOXFLOAT XT([1.5, 2.5],[2001-01-01,2001-01-02])',
   interval '1 day');
@@ -534,22 +534,17 @@ SELECT shiftScaleTime(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-02])
 -- STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01 01:00:00, 2001-01-01 04:00:00])
 </programlisting>
 				<para>Si el ancho o el lapso de tiempo del valor de tiempo es cero (es decir, los límites inferior y superior son iguales), el resultado es el cuadro delimitador. El valor o intervalo dado debe ser estrictamente mayor que cero.</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-getSpace(stbox) → stbox
-</programlisting>
 			</listitem>
 
 			<listitem xml:id="box_getSpace">
 				<indexterm significance="normal"><primary><varname>getSpace</varname></primary></indexterm>
 				<para>Devuelve la dimensión espacial del cuadro delimitador, eliminando la dimensión temporal, si existe</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+getSpace(stbox) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getSpace(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])');
 -- STBOX Z((1,1,1),(2,2,2))
-</programlisting>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-expandValue(tbox,{integer,float}) → tbox
-expandSpace(stbox,float) → stbox
-expandTime(box,interval) → box
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -563,6 +558,11 @@ expandTime(box,interval) → box
 					<indexterm significance="normal"><primary><varname>expandSpace</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>expandTime</varname></primary></indexterm>
 					<para>Extiende la dimensión numérica, espacial o temporal del cuadro delimitador con un valor o un intervalo</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+expandValue(tbox,{integer,float}) → tbox
+expandSpace(stbox,float) → stbox
+expandTime(box,interval) → box
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT expandValue(tbox 'TBOXFLOAT XT((1,2),[2001-01-01,2001-01-03])', 1.0);
 -- TBOXFLOAT XT((0,3),[2001-01-01,2001-01-03])
@@ -587,14 +587,14 @@ SELECT expandTime(stbox 'STBOX ZT(((1,1,1),(2,2,2)),[2001-01-01,2001-01-03])',
 SELECT expandTime(tbox 'TBOX XT((1,2),[2001-01-01,2001-01-03])', interval '-2 days');
 -- NULL
 </programlisting>
-					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-round(box,integer=0) → box
-</programlisting>
 				</listitem>
 
 				<listitem xml:id="box_round">
 					<indexterm significance="normal"><primary><varname>round</varname></primary></indexterm>
 					<para>Redondea el valor o las coordenadas del cuadro delimitador a un número de decimales</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+round(box,integer=0) → box
+</programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(tbox 'TBOXFLOAT XT((1.12345,2.12345),[2001-01-01,2001-01-02])', 2);
 -- TBOXFLOAT XT((1.12,2.12),[2001-01-01, 2001-01-02])
@@ -603,10 +603,6 @@ SELECT round(stbox 'STBOX XT(((1.12345, 1.12345),(2.12345, 2.12345)),
 -- STBOX XT(((1.12,1.12),(2.12,2.12)),[2001-01-01, 2001-01-02])
 SELECT round(tstzspan '[2000-01-01, 2001-01-02]'::tbox);
 -- The tbox must have X dimension
-</programlisting>
-					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-SRID(stbox) → integer
-setSRID(stbox,integer) → stbox
 </programlisting>
 				</listitem>
 
@@ -621,6 +617,10 @@ setSRID(stbox,integer) → stbox
 				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
 				<para>Devuelve o especifica el identificador de referencia espacial</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+SRID(stbox) → integer
+setSRID(stbox,integer) → stbox
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT SRID(stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2001-01-01,2001-01-02])');
 -- 0


### PR DESCRIPTION
The Spanish bounding box chapter states the signature of shiftTime, getSpace, expandValue, round and SRID in the entry each one documents, so an entry names the function its text describes and the spatial reference system entry names one at all. Every entry of the chapter states the same signature in Spanish as in English.