### PR TITLE
Keep the region a cell covers when its box is composed with a time

### DIFF
--- a/meos/src/h3/th3index_boxops.c
+++ b/meos/src/h3/th3index_boxops.c
@@ -186,7 +186,9 @@ h3index_timestamptz_to_stbox(H3Index cell, TimestampTz t)
   STBox box;
   if (! h3index_set_stbox(cell, &box))
     return NULL;
-  timestamptz_set_stbox(t, &box);
+  span_set(TimestampTzGetDatum(t), TimestampTzGetDatum(t), true, true,
+    T_TIMESTAMPTZ, T_TSTZSPAN, &box.period);
+  MEOS_FLAGS_SET_T(box.flags, true);
   return stbox_copy(&box);
 }
 
@@ -207,7 +209,8 @@ h3index_tstzspan_to_stbox(H3Index cell, const Span *s)
   STBox box;
   if (! h3index_set_stbox(cell, &box))
     return NULL;
-  tstzspan_set_stbox(s, &box);
+  memcpy(&box.period, s, sizeof(Span));
+  MEOS_FLAGS_SET_T(box.flags, true);
   return stbox_copy(&box);
 }
 

--- a/meos/src/quadbin/tquadbin_boxops.c
+++ b/meos/src/quadbin/tquadbin_boxops.c
@@ -137,7 +137,9 @@ quadbin_timestamptz_to_stbox(Quadbin cell, TimestampTz t)
   STBox box;
   if (! quadbin_set_stbox(cell, &box))
     return NULL;
-  timestamptz_set_stbox(t, &box);
+  span_set(TimestampTzGetDatum(t), TimestampTzGetDatum(t), true, true,
+    T_TIMESTAMPTZ, T_TSTZSPAN, &box.period);
+  MEOS_FLAGS_SET_T(box.flags, true);
   return stbox_copy(&box);
 }
 
@@ -158,7 +160,8 @@ quadbin_tstzspan_to_stbox(Quadbin cell, const Span *s)
   STBox box;
   if (! quadbin_set_stbox(cell, &box))
     return NULL;
-  tstzspan_set_stbox(s, &box);
+  memcpy(&box.period, s, sizeof(Span));
+  MEOS_FLAGS_SET_T(box.flags, true);
   return stbox_copy(&box);
 }
 

--- a/mobilitydb/test/h3/expected/259_th3index_boxops.test.out
+++ b/mobilitydb/test/h3/expected/259_th3index_boxops.test.out
@@ -64,3 +64,35 @@ SELECT round(stbox(th3index '[8001fffffffffff@2001-01-01, 801ffffffffffff@2001-0
  SRID=4326;GEODSTBOX XT(((-180,37.523712),(180,90)),[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST])
 (1 row)
 
+SELECT round(stbox(h3index '8001fffffffffff', timestamptz '2001-01-01'), 6);
+                                                      round                                                       
+------------------------------------------------------------------------------------------------------------------
+ SRID=4326;GEODSTBOX XT(((-180,68.929958),(180,90)),[Mon Jan 01 00:00:00 2001 PST, Mon Jan 01 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(stbox(h3index '8001fffffffffff', tstzspan '[2001-01-01, 2001-01-02]'), 6);
+                                                      round                                                       
+------------------------------------------------------------------------------------------------------------------
+ SRID=4326;GEODSTBOX XT(((-180,68.929958),(180,90)),[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(stbox(h3index '8001fffffffffff', timestamptz '2001-01-01')::stbox, 6)
+  && round(stbox(h3index '8001fffffffffff'), 6);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT hasX(stbox(h3index '8001fffffffffff', timestamptz '2001-01-01')),
+  hasT(stbox(h3index '8001fffffffffff', timestamptz '2001-01-01'));
+ hasx | hast 
+------+------
+ t    | t
+(1 row)
+
+SELECT SRID(stbox(h3index '8001fffffffffff', tstzspan '[2001-01-01, 2001-01-02]'));
+ srid 
+------
+ 4326
+(1 row)
+

--- a/mobilitydb/test/h3/queries/259_th3index_boxops.test.sql
+++ b/mobilitydb/test/h3/queries/259_th3index_boxops.test.sql
@@ -73,3 +73,20 @@ SELECT round(stbox(th3index '[8001fffffffffff@2001-01-01, 801ffffffffffff@2001-0
 -- `stbox(child) <@ stbox(parent)` is false for H3 by construction and says
 -- nothing about this box.
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- A cell composed with a time keeps the space it covers
+--
+-- `stbox(cell)` and `stbox(cell, <time>)` bound the same region; the second
+-- adds the period and nothing else, so its X and Y are those of the first.
+-------------------------------------------------------------------------------
+
+SELECT round(stbox(h3index '8001fffffffffff', timestamptz '2001-01-01'), 6);
+SELECT round(stbox(h3index '8001fffffffffff', tstzspan '[2001-01-01, 2001-01-02]'), 6);
+SELECT round(stbox(h3index '8001fffffffffff', timestamptz '2001-01-01')::stbox, 6)
+  && round(stbox(h3index '8001fffffffffff'), 6);
+SELECT hasX(stbox(h3index '8001fffffffffff', timestamptz '2001-01-01')),
+  hasT(stbox(h3index '8001fffffffffff', timestamptz '2001-01-01'));
+SELECT SRID(stbox(h3index '8001fffffffffff', tstzspan '[2001-01-01, 2001-01-02]'));
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/quadbin/expected/356_quadbin_ops.test.out
+++ b/mobilitydb/test/quadbin/expected/356_quadbin_ops.test.out
@@ -198,3 +198,35 @@ SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');
  1202021322
 (1 row)
 
+SELECT round(stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01'), 6);
+                                                            round                                                            
+-----------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;STBOX XT(((4.21875,50.736455),(4.570313,50.958427)),[Mon Jan 01 00:00:00 2001 PST, Mon Jan 01 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(stbox(quadbin '48a6227affffffff', tstzspan '[2001-01-01, 2001-01-02]'), 6);
+                                                            round                                                            
+-----------------------------------------------------------------------------------------------------------------------------
+ SRID=4326;STBOX XT(((4.21875,50.736455),(4.570313,50.958427)),[Mon Jan 01 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST])
+(1 row)
+
+SELECT round(stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01')::stbox, 6)
+  && round(stbox(quadbin '48a6227affffffff'), 6);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT hasX(stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01')),
+  hasT(stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01'));
+ hasx | hast 
+------+------
+ t    | t
+(1 row)
+
+SELECT SRID(stbox(quadbin '48a6227affffffff', tstzspan '[2001-01-01, 2001-01-02]'));
+ srid 
+------
+ 4326
+(1 row)
+

--- a/mobilitydb/test/quadbin/queries/356_quadbin_ops.test.sql
+++ b/mobilitydb/test/quadbin/queries/356_quadbin_ops.test.sql
@@ -126,3 +126,20 @@ SELECT quadbinCellToQuadkey(quadbin '48427fffffffffff');  -- '0213'
 SELECT quadbinCellToQuadkey(quadbin '48a6227affffffff');  -- '1202021322'
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- A cell composed with a time keeps the space it covers
+--
+-- `stbox(cell)` and `stbox(cell, <time>)` bound the same region; the second
+-- adds the period and nothing else, so its X and Y are those of the first.
+-------------------------------------------------------------------------------
+
+SELECT round(stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01'), 6);
+SELECT round(stbox(quadbin '48a6227affffffff', tstzspan '[2001-01-01, 2001-01-02]'), 6);
+SELECT round(stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01')::stbox, 6)
+  && round(stbox(quadbin '48a6227affffffff'), 6);
+SELECT hasX(stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01')),
+  hasT(stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01'));
+SELECT SRID(stbox(quadbin '48a6227affffffff', tstzspan '[2001-01-01, 2001-01-02]'));
+
+-------------------------------------------------------------------------------


### PR DESCRIPTION
`stbox(cell, timestamptz)` and `stbox(cell, tstzspan)` answer a box
carrying the period and nothing else: no X, no Y, no SRID.
`stbox(quadbin '48a6227affffffff')` reads
`SRID=4326;STBOX X((4.21875,50.736455),(4.570312,50.958427))` while
`stbox(quadbin '48a6227affffffff', timestamptz '2001-01-01')` reads
`STBOX T([Mon Jan 01 00:00:00 2001 PST, Mon Jan 01 00:00:00 2001 PST])`,
and h3 answers the same way.

Both families fill the box from the cell and then call
`timestamptz_set_stbox` / `tstzspan_set_stbox`, which open with
`memset(box, 0, sizeof(STBox))` because their own contract is to build a
box FROM a time rather than to add one to a box already filled. They now
set the period and the T flag directly, as `geo_timestamptz_to_stbox` and
`geo_tstzspan_to_stbox` do. Every other spatial family already composes
correctly through its own `<type>_timestamptz_set_stbox`, and `cbuffer` is
the witness: it answers `STBOX XT(((-1,-1),(3,3)),[...])` throughout.

No expected output moves: 16 h3 and quadbin suites regenerate
byte-identically, because no fixture called either signature. The two
suites gain the witness, and it fails on the code it replaces: `hasX`
reads `f` and the two round calls raise `The stbox must have X dimension`.