### PR TITLE
State the set returning nature of quadSplit once in the Spanish manual

### DIFF
--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -688,7 +688,7 @@ SELECT quadSplit(stbox 'STBOX Z((0,0,0),(4,4,4))');
 </programlisting>
 			</listitem>
 		</itemizedlist>
-		<para>Tenga en cuenta que la función anterior es una <emphasis>función de retorno de conjuntos</emphasis> (también conocida como <emphasis>función de tabla</emphasis>) ya que normalmente devuelve más de un valor. Por lo tanto, la función está marcada con el símbolo &SRF;. Esta función se usa normalmente para cuadrículas de resolución múltiple, donde el espacio se divide en celdas de modo que las celdas tengan un número máximo de elementos. <xref linkend="berlinmod_grid" /> muestra un ejemplo del resultado de usar esta función usando trayectorias sintéticas en Bruselas.</para>
+		<para>Esta función se usa normalmente para cuadrículas de resolución múltiple, donde el espacio se divide en celdas de modo que las celdas tengan un número máximo de elementos. <xref linkend="berlinmod_grid" /> muestra un ejemplo del resultado de usar esta función usando trayectorias sintéticas en Bruselas.</para>
 		<figure xml:id="berlinmod_grid" float="start">
 			<title>Grilla multiresolución sobre datos de Bruselas obtenidos mediante el generador <ulink url="https://github.com/MobilityDB/MobilityDB-BerlinMOD">BerlinMOD</ulink>. Cada celda contiene como máximo 10.000 (izquierda) y 1.000 (derecha) instantes durante todo el período de simulación (cuatro días en este caso). A la izquierda, podemos ver la alta densidad de tráfico en el anillo alrededor de Bruselas, mientras que a la derecha podemos ver otros ejes principales de la ciudad.</title>
 			<mediaobject>


### PR DESCRIPTION
The quadSplit entry states that the function is a set returning function in the explanation below its signature, in both manuals alike. The paragraph following the list repeats that statement in Spanish only, so the Spanish reader reads it twice in consecutive paragraphs where the English reader reads it once. That paragraph opens instead on the multiresolution grid it exists to introduce, matching its English twin sentence for sentence, and the SRF symbol occurs twice in doc/box_types.xml and twice in doc/es/box_types.xml.