### PR TITLE
Count the aggregate families the manifest declares

### DIFF
--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -309,7 +309,7 @@ Two more reference chapters carry inherited surface:
 
 | chapter → `<sect1>` | prefix | generated? | notes |
 |---|---|---|---|
-| `temporal_types_aggregation.xml` → Aggregation | `temporal_`/`tnumber_` | ✓ **GEN** | `aggregates.sql.tmpl` + `aggregate_families`, **11 entries** all `reference: true`, `whole_file: true` (temporal, cbuffer, geo, json, npoint, pointcloud, pose, rgeo, tpoint, th3index, quadbin) — tCount/extent/tMin/tMax/tSum/tAvg/merge/appendInstant; `--gaps`: 18/18, full coverage |
+| `temporal_types_aggregation.xml` → Aggregation | `temporal_`/`tnumber_` | ✓ **GEN** | `aggregates.sql.tmpl` + `aggregate_families`, **12 entries** all `reference: true`, `whole_file: true` (temporal, cbuffer, geo, json, npoint, pointcloud, pose, posechain, rgeo, tpoint, th3index, quadbin) — tCount/extent/tMin/tMax/tSum/tAvg/merge/appendInstant; `--gaps`: 19/19, full coverage |
 | → Indexing | (index) | ✓ **GEN** | GiST/SP-GiST via `gist/spgist/indexes.sql.tmpl` |
 | → Statistics and Selectivity | (selectivity) | ✗ HAND | |
 | `temporal_types_analytics.xml` → Simplification / Reduction / Similarity / Extended Kalman Filter / Splitting | `temporal_`/`tgeo_` | ✗ HAND | analytics; no template |


### PR DESCRIPTION
`INHERITANCE_MAP.md` is the authoritative scoping doc, and its
Aggregation row reads `11 entries … --gaps: 18/18` and lists temporal,
cbuffer, geo, json, npoint, pointcloud, pose, rgeo, tpoint, th3index and
quadbin. `aggregate_families.yaml` declares twelve families, the twelfth
being posechain, and `generate.py --gaps` prints
`[19/19] aggregate_families`.

The same document already states the right figure twice: the coverage
section reads `aggregate_families 19/19, full coverage`, and the section
below it names `561_tposechain_aggfuncs.in.sql` as what makes it so. The
row now agrees with them and with what the generator prints.