### PR TITLE
Count the files the coverage ratchet still excepts

### DIFF
--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -5,7 +5,7 @@
 # land unnoticed. The list is a ratchet: it may only shrink. Bring a file
 # under the manifest, then delete its line here.
 #
-# 125 of 185 files remain.
+# 96 of 205 files remain.
 
 mobilitydb/sql/cbuffer/204_tcbuffer_compops.in.sql
 mobilitydb/sql/cbuffer/205_tcbuffer_spatialfuncs.in.sql


### PR DESCRIPTION
`coverage_exceptions.txt` is the ratchet the inherited generator checks a
new hand-written surface against, and its header reads `125 of 185 files
remain`. The list holds 96 paths, and `generate.py --coverage` prints
`109/205 governed, 96 still excepted`.

The header now states the two figures the run prints, so a reader
measuring progress against the ratchet reads the same numbers the check
does.