### PR TITLE
Answer an array whose members do not share their dimensions

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2144,6 +2144,35 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 }
 
 /**
+ * @brief Return the collection a set of geometries stands for
+ * @details #lwcollection_construct() reads the Z and M dimensions of the
+ * collection from its first member and refuses a set whose members do not
+ * share them, answering @p NULL. That is not a collection an arm can be given:
+ * the arms read their members through it, so a null one is dereferenced rather
+ * than reported. The members and the array are released with the refusal, so a
+ * caller answered @p NULL has nothing left to free
+ * @param[in] geoms Array of geometries, owned by this function
+ * @param[in] ngeoms Number of elements in the array, at least one
+ * @param[in] srid Spatial reference identifier
+ * @return The collection, which owns the array and its members, or @p NULL
+ * where the members do not share their dimensions
+ */
+static LWCOLLECTION *
+union_collection_make(LWGEOM **geoms, uint32_t ngeoms, int32_t srid)
+{
+  assert(geoms); assert(ngeoms > 0);
+  LWCOLLECTION *result = lwcollection_construct(COLLECTIONTYPE, srid, NULL,
+    ngeoms, geoms);
+  if (! result)
+  {
+    for (uint32_t i = 0; i < ngeoms; i++)
+      lwgeom_free(geoms[i]);
+    pfree(geoms);
+  }
+  return result;
+}
+
+/**
  * @brief Return the union of an array of geometries whose members are all
  * surfaces, read from their boundaries
  * @details The array is presented to #meos_areal_union() as the collection it
@@ -2170,10 +2199,12 @@ geom_array_areal_union(GSERIALIZED **gsarr, int count)
     pfree(geoms);
     return NULL;
   }
-  /* #lwcollection_construct() takes ownership of the array it is given, so
+  /* #union_collection_make() takes ownership of the array it is given, so
    * geoms must not be freed after this call */
-  LWCOLLECTION *coll = lwcollection_construct(COLLECTIONTYPE,
-    gserialized_get_srid(gsarr[0]), NULL, (uint32_t) ngeoms, geoms);
+  LWCOLLECTION *coll = union_collection_make(geoms, (uint32_t) ngeoms,
+    gserialized_get_srid(gsarr[0]));
+  if (! coll)
+    return NULL;
   LWGEOM *lwresult = meos_areal_union(lwcollection_as_lwgeom(coll));
   GSERIALIZED *result = lwresult ? geo_serialize(lwresult) : NULL;
   if (lwresult)
@@ -2233,10 +2264,12 @@ geom_array_linear_union(GSERIALIZED **gsarr, int count, bool geodetic)
     pfree(geoms);
     return NULL;
   }
-  /* #lwcollection_construct() takes ownership of the array it is given, so
+  /* #union_collection_make() takes ownership of the array it is given, so
    * geoms must not be freed after this call */
-  LWCOLLECTION *coll = lwcollection_construct(COLLECTIONTYPE,
-    gserialized_get_srid(gsarr[0]), NULL, (uint32_t) ngeoms, geoms);
+  LWCOLLECTION *coll = union_collection_make(geoms, (uint32_t) ngeoms,
+    gserialized_get_srid(gsarr[0]));
+  if (! coll)
+    return NULL;
   LWGEOM *lwresult = meos_linear_union(lwcollection_as_lwgeom(coll));
   GSERIALIZED *result = NULL;
   if (lwresult)
@@ -2340,14 +2373,27 @@ geom_array_mixed_union(GSERIALIZED **gsarr, int count)
     return NULL;
   }
 
-  /* #lwcollection_construct() takes ownership of the array it is given and of
+  /* #union_collection_make() takes ownership of the array it is given and of
    * its members, so neither is freed other than through the collection. A half
    * holding a single member is the collection of one, which each arm answers
-   * by returning that member -- there is no count the arms must be spared */
-  LWCOLLECTION *acoll = lwcollection_construct(COLLECTIONTYPE, srid, NULL,
-    nareal, areal);
-  LWCOLLECTION *ocoll = lwcollection_construct(COLLECTIONTYPE, srid, NULL,
-    nother, other);
+   * by returning that member -- there is no count the arms must be spared.
+   * A half whose members do not share their dimensions is no collection, and
+   * the other half is then released here rather than through one */
+  LWCOLLECTION *acoll = union_collection_make(areal, nareal, srid);
+  LWCOLLECTION *ocoll = acoll ?
+    union_collection_make(other, nother, srid) : NULL;
+  if (! acoll || ! ocoll)
+  {
+    if (! acoll)
+    {
+      for (uint32_t i = 0; i < nother; i++)
+        lwgeom_free(other[i]);
+      pfree(other);
+    }
+    if (acoll)
+      lwcollection_free(acoll);
+    return NULL;
+  }
   LWGEOM *lwareal = meos_areal_union(lwcollection_as_lwgeom(acoll));
   LWGEOM *lwother = lwareal ?
     meos_linear_union(lwcollection_as_lwgeom(ocoll)) : NULL;
@@ -2417,9 +2463,17 @@ geom_array_mixed_union(GSERIALIZED **gsarr, int count)
   for (int i = 0; i < nacomps; i++)
     members[nmembers++] = lwgeom_clone_deep(acomps[i]);
   pfree(dropped); pfree(ocomps); pfree(acomps);
-  /* #lwcollection_construct() takes ownership of the array it is given */
-  LWCOLLECTION *coll = lwcollection_construct(COLLECTIONTYPE, srid, NULL,
-    (uint32_t) nmembers, members);
+  /* #union_collection_make() takes ownership of the array it is given. The two
+   * halves are each a collection, and yet what they draw together need not be:
+   * a surface carrying Z and a line that does not are two answers no single
+   * collection holds, and that array is left to the caller as the halves were */
+  LWCOLLECTION *coll = union_collection_make(members, (uint32_t) nmembers,
+    srid);
+  if (! coll)
+  {
+    lwgeom_free(lwareal); lwgeom_free(lwother);
+    return NULL;
+  }
   result = geo_serialize(lwcollection_as_lwgeom(coll));
   lwcollection_free(coll);
   lwgeom_free(lwareal); lwgeom_free(lwother);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -754,6 +754,61 @@ int main(void)
   }
   meos_errno_reset();
 
+  /* The members of an array need not share their dimensions, while the
+   * collection the arms read them through must: #lwcollection_construct()
+   * refuses a set whose members carry different Z and M flags and answers
+   * NULL, and an arm given that NULL read the geometry through it. Every arm
+   * builds one -- the surfaces, the linework, and both halves of an array
+   * spanning the areal boundary, which builds a third for the answer it
+   * assembles -- so each of them is given a mixture here */
+  const char *dimcases[][2] = {
+    /* the linear arm, whose members are points */
+    { "POINT Z(0 0 1)", "POINT(1 1)" },
+    /* the linear arm, whose members are curves */
+    { "LINESTRING Z(0 0 1,1 1 1)", "LINESTRING(5 5,6 6)" },
+    /* the areal arm */
+    { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))",
+      "POLYGON((9 9,9 11,11 11,11 9,9 9))" },
+    /* both arms together, each half uniform and the answer mixed */
+    { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))", "LINESTRING(1 1,5 5)" },
+    /* a measure is a dimension of the collection as an elevation is */
+    { "POINT ZM(0 0 1 2)", "POINT Z(1 1 1)" },
+    { "POINT M(0 0 1)", "POINT(1 1)" },
+  };
+  for (size_t i = 0; i < sizeof(dimcases) / sizeof(dimcases[0]); i++)
+  {
+    GSERIALIZED *dm1 = geom_in(dimcases[i][0], -1);
+    GSERIALIZED *dm2 = geom_in(dimcases[i][1], -1);
+    assert(dm1 != NULL); assert(dm2 != NULL);
+    GSERIALIZED *dmarr[2] = {dm1, dm2};
+    meos_errno_reset();
+    GSERIALIZED *dmu = geom_array_union(dmarr, 2);
+    /* Which answer comes back is the arm's to give, and what is asserted here
+     * is that the array is ANSWERED: a union, or the refusal reported through
+     * the error. Reading the refused collection ended the process instead */
+    printf("union of %s with %s: %s\n", dimcases[i][0], dimcases[i][1],
+      dmu ? "answered" : "declined");
+    assert(dmu != NULL || meos_errno() != 0);
+    free(dm1); free(dm2);
+    if (dmu)
+      free(dmu);
+    meos_errno_reset();
+  }
+
+  /* The control is the same array with its members sharing one dimension,
+   * which is answered exactly as before */
+  GSERIALIZED *dmz1 = geom_in("POINT Z(0 0 1)", -1);
+  GSERIALIZED *dmz2 = geom_in("POINT Z(1 1 1)", -1);
+  GSERIALIZED *dmzarr[2] = {dmz1, dmz2};
+  GSERIALIZED *dmzu = geom_array_union(dmzarr, 2);
+  assert(dmzu != NULL);
+  assert(meos_errno() == 0);
+  char *dmzwkt = geo_as_text(dmzu, 3);
+  printf("union of two elevated positions: %s\n", dmzwkt);
+  assert(strcmp(dmzwkt, "MULTIPOINT Z ((0 0 1),(1 1 1))") == 0);
+  free(dmz1); free(dmz2); free(dmzu); free(dmzwkt);
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
`lwcollection_construct()` reads the Z and M dimensions of a collection from its first member and refuses a set whose members carry different ones, answering `NULL`. The arms of the union build their collection with it and read the geometry through the answer without looking, so `geom_array_union()` of an array mixing a member that carries an elevation with one that does not reaches `meos_areal_union()` with a null geometry and dereferences it.

Under the error handler that returns rather than ends the process — the one a MEOS program installs with `meos_initialize_noexit_error_handler()`, and the one `meos/test/geo_test.c` runs under — the union of `POINT Z(0 0 1)` with `POINT(1 1)` ends in a segmentation fault, `rdi` holding 0 at the instruction that reads the type of the geometry:

```
Program received signal SIGSEGV, Segmentation fault.
0x00007ffff7ad97f5 in meos_areal_union () from libmeos.so
    called from geom_array_union ()
rdi            0x0                 0
=> 0x7ffff7ad97f5 <meos_areal_union+21>:	movzbl 0x16(%rdi),%ebx
```

This adds `union_collection_make()`, which builds the collection, releases the members and the array with a refusal, and answers `NULL`. Each of the four places that builds one reports that refusal instead of reading it: the areal arm, the linear arm, and both halves of the arm that spans the areal boundary, whose answer is assembled into a third collection that a surface carrying Z and a line that does not mix in turn. An array the arms decline is left to the caller as any other they do not answer.

The cases added to `meos/test/geo_test.c` cover every arm that builds a collection, and the array of two elevated positions is the control for the answer where the members do share their dimensions. The added cases segfault the test binary against the library without this change and pass with it.