### PR TITLE
Read the union of an array on the dimensions its members share

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2481,8 +2481,67 @@ geom_array_mixed_union(GSERIALIZED **gsarr, int count)
 }
 
 /**
- * @ingroup meos_geo_base_spatial
- * @brief Return the union of an array of geometries
+ * @brief Return the members of an array read on the dimensions they share
+ * @details A planar union answers the point set its members cover, and the Z
+ * and M ordinates of that answer are READ from the members rather than
+ * computed: a member carrying no elevation determines none for the points it
+ * contributes, and an answer declaring one would publish a value the array
+ * does not hold. The answer therefore carries an ordinate only where EVERY
+ * member contributing points carries it. An empty member contributes none, so
+ * it does not take an ordinate away from the members that do
+ * @param[in] gsarr Array of geometries
+ * @param[in] count Number of elements in the array
+ * @return A new array holding the members read on their shared dimensions, or
+ * @p NULL where they already share them and the array itself is what the arms
+ * read. The caller releases the array and its members
+ */
+static GSERIALIZED **
+geom_array_shared_dims(GSERIALIZED **gsarr, int count)
+{
+  assert(gsarr); assert(count > 0);
+  bool hasz = true, hasm = true, mixed = false;
+  int nonempty = 0;
+  for (int i = 0; i < count; i++)
+  {
+    if (gserialized_is_empty(gsarr[i]))
+      continue;
+    nonempty++;
+    if (! gserialized_has_z(gsarr[i]))
+      hasz = false;
+    if (! gserialized_has_m(gsarr[i]))
+      hasm = false;
+  }
+  /* An array of empties carries no points to read an ordinate for */
+  if (nonempty == 0)
+    return NULL;
+  for (int i = 0; i < count && ! mixed; i++)
+  {
+    if (gserialized_is_empty(gsarr[i]))
+      continue;
+    mixed = ((bool) gserialized_has_z(gsarr[i]) != hasz ||
+      (bool) gserialized_has_m(gsarr[i]) != hasm);
+  }
+  /* Every member already carries what they share, and the array reads as it is */
+  if (! mixed)
+    return NULL;
+
+  GSERIALIZED **result = palloc(sizeof(GSERIALIZED *) * count);
+  for (int i = 0; i < count; i++)
+  {
+    LWGEOM *geom = lwgeom_from_gserialized(gsarr[i]);
+    /* The two ordinates are never both dropped: they are shared unless a
+     * member lacks one, and a member lacking both leaves nothing to force */
+    LWGEOM *shared = hasz ? lwgeom_force_3dz(geom, 0) :
+      (hasm ? lwgeom_force_3dm(geom, 0) : lwgeom_force_2d(geom));
+    result[i] = geo_serialize(shared);
+    lwgeom_free(geom); lwgeom_free(shared);
+  }
+  return result;
+}
+
+/**
+ * @brief Return the union of an array of geometries whose members share their
+ * dimensions
  * @details The function will iteratively call @p GEOSUnion on the
  * GEOS-converted versions of them and return PGIS-converted version back.
  * Changing the combination order *might* speed up performance.
@@ -2492,27 +2551,10 @@ geom_array_mixed_union(GSERIALIZED **gsarr, int count)
  * MEOS modified the PostGIS function since does not cope with geographies
  * by setting the geodetic flag for geographies.
  */
-GSERIALIZED *
-geom_array_union(GSERIALIZED **gsarr, int count)
+static GSERIALIZED *
+geom_array_union_shared(GSERIALIZED **gsarr, int count)
 {
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gsarr, NULL);
-  if (! ensure_positive(count))
-    return NULL;
-  /* This entry answers on the plane; #geog_array_union() answers a geodetic
-   * array. The flag is read from one member, so the array is turned away
-   * before the SRID test walks all of them */
-  if (! ensure_not_geodetic_geo(gsarr[0]))
-    return NULL;
-  /* The members of the array carry one SRID */
-  if (! ensure_same_srid_geoarr((const GSERIALIZED **) gsarr, count))
-    return NULL;
-
-  /* A single member is its own union, returned as a value of its own: the
-   * array belongs to the caller, and a result aliasing a member of it is
-   * released when the caller releases the array */
-  if (count == 1)
-    return geo_copy(gsarr[0]);
+  assert(gsarr); assert(count > 1);
 
   /* An array holding nothing but empties has an empty union, which is read
    * from the array alone. It is answered here so that a build carrying no
@@ -2700,6 +2742,52 @@ geom_array_union(GSERIALIZED **gsarr, int count)
 }
 
 /**
+ * @ingroup meos_geo_base_spatial
+ * @brief Return the union of an array of geometries
+ * @details The answer covers the points the members cover, read on the
+ * dimensions they share: an array mixing a member that carries an elevation
+ * with one that does not is answered without one, since no member determines
+ * an elevation for the points the flat one contributes. That reading is what
+ * the array is answered from, so the answer does not depend on which member
+ * the array happens to list first
+ * @param[in] gsarr Array of geometries
+ * @param[in] count Number of elements in the array
+ * @return On error return @p NULL
+ */
+GSERIALIZED *
+geom_array_union(GSERIALIZED **gsarr, int count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(gsarr, NULL);
+  if (! ensure_positive(count))
+    return NULL;
+  /* This entry answers on the plane; #geog_array_union() answers a geodetic
+   * array. The flag is read from one member, so the array is turned away
+   * before the SRID test walks all of them */
+  if (! ensure_not_geodetic_geo(gsarr[0]))
+    return NULL;
+  /* The members of the array carry one SRID */
+  if (! ensure_same_srid_geoarr((const GSERIALIZED **) gsarr, count))
+    return NULL;
+
+  /* A single member is its own union, returned as a value of its own: the
+   * array belongs to the caller, and a result aliasing a member of it is
+   * released when the caller releases the array. The member carries whatever
+   * dimensions it has, since there is no other member to share them with */
+  if (count == 1)
+    return geo_copy(gsarr[0]);
+
+  GSERIALIZED **shared = geom_array_shared_dims(gsarr, count);
+  if (! shared)
+    return geom_array_union_shared(gsarr, count);
+  GSERIALIZED *result = geom_array_union_shared(shared, count);
+  for (int i = 0; i < count; i++)
+    pfree(shared[i]);
+  pfree(shared);
+  return result;
+}
+
+/**
  * @ingroup meos_geo_base_transf
  * @brief Return the union of an array of geographies
  * @param[in] gsarr Array of geographies
@@ -2738,7 +2826,18 @@ geog_array_union(GSERIALIZED **gsarr, int count)
       "The union of a geodetic array is answered for positions only");
     return NULL;
   }
-  return geom_array_linear_union(gsarr, count, true);
+
+  /* Which positions of a set are equal is read from their coordinates, and an
+   * elevation none of them carries is no more available here than on the
+   * plane, so the array is read on the dimensions its members share */
+  GSERIALIZED **shared = geom_array_shared_dims(gsarr, count);
+  if (! shared)
+    return geom_array_linear_union(gsarr, count, true);
+  GSERIALIZED *result = geom_array_linear_union(shared, count, true);
+  for (int i = 0; i < count; i++)
+    pfree(shared[i]);
+  pfree(shared);
+  return result;
 }
 
 /**

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -754,26 +754,41 @@ int main(void)
   }
   meos_errno_reset();
 
-  /* The members of an array need not share their dimensions, while the
-   * collection the arms read them through must: #lwcollection_construct()
-   * refuses a set whose members carry different Z and M flags and answers
-   * NULL, and an arm given that NULL read the geometry through it. Every arm
-   * builds one -- the surfaces, the linework, and both halves of an array
-   * spanning the areal boundary, which builds a third for the answer it
-   * assembles -- so each of them is given a mixture here */
-  const char *dimcases[][2] = {
+  /* The members of an array need not share their dimensions, and the answer is
+   * read on the ones they do: a member carrying no elevation determines none
+   * for the points it contributes, so an answer declaring one would publish a
+   * value the array does not hold. Every arm is given a mixture here -- the
+   * surfaces, the linework, and an array spanning the areal boundary -- and
+   * the answer covers the same points whichever member the array lists first */
+  const char *dimcases[][3] = {
     /* the linear arm, whose members are points */
-    { "POINT Z(0 0 1)", "POINT(1 1)" },
+    { "POINT Z(0 0 1)", "POINT(1 1)", "MULTIPOINT((0 0),(1 1))" },
+    /* the same members in the other order cover the same points: the answer
+     * is read from what the array holds, not from what it lists first */
+    { "POINT(1 1)", "POINT Z(0 0 1)", "MULTIPOINT((1 1),(0 0))" },
     /* the linear arm, whose members are curves */
-    { "LINESTRING Z(0 0 1,1 1 1)", "LINESTRING(5 5,6 6)" },
-    /* the areal arm */
+    { "LINESTRING Z(0 0 1,1 1 1)", "LINESTRING(5 5,6 6)",
+      "MULTILINESTRING((0 0,1 1),(5 5,6 6))" },
+    /* the areal arm, whose surfaces stay apart */
     { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))",
-      "POLYGON((9 9,9 11,11 11,11 9,9 9))" },
-    /* both arms together, each half uniform and the answer mixed */
-    { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))", "LINESTRING(1 1,5 5)" },
-    /* a measure is a dimension of the collection as an elevation is */
-    { "POINT ZM(0 0 1 2)", "POINT Z(1 1 1)" },
-    { "POINT M(0 0 1)", "POINT(1 1)" },
+      "POLYGON((9 9,9 11,11 11,11 9,9 9))",
+      "MULTIPOLYGON(((0 0,0 2,2 2,2 0,0 0)),((9 9,9 11,11 11,11 9,9 9)))" },
+    /* the areal arm, dissolving a pair whose interiors meet */
+    { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))",
+      "POLYGON((1 1,1 3,3 3,3 1,1 1))",
+      "POLYGON((1 2,0 2,0 0,2 0,2 1,3 1,3 3,1 3,1 2))" },
+    /* both arms together, each half sharing its dimensions and the two halves
+     * not sharing them with each other */
+    { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))", "LINESTRING(5 5,6 6)",
+      "GEOMETRYCOLLECTION(LINESTRING(5 5,6 6),"
+        "POLYGON((0 0,0 2,2 2,2 0,0 0)))" },
+    /* a measure is a dimension of the answer as an elevation is, and the two
+     * are read one by one: the elevation both members carry is kept */
+    { "POINT ZM(0 0 1 2)", "POINT Z(1 1 1)", "MULTIPOINT Z ((0 0 1),(1 1 1))" },
+    { "POINT M(0 0 1)", "POINT(1 1)", "MULTIPOINT((0 0),(1 1))" },
+    /* an EMPTY member contributes no points, so it takes no ordinate away
+     * from the members that do carry one */
+    { "POINT Z(0 0 1)", "POLYGON EMPTY", "POINT Z (0 0 1)" },
   };
   for (size_t i = 0; i < sizeof(dimcases) / sizeof(dimcases[0]); i++)
   {
@@ -783,15 +798,13 @@ int main(void)
     GSERIALIZED *dmarr[2] = {dm1, dm2};
     meos_errno_reset();
     GSERIALIZED *dmu = geom_array_union(dmarr, 2);
-    /* Which answer comes back is the arm's to give, and what is asserted here
-     * is that the array is ANSWERED: a union, or the refusal reported through
-     * the error. Reading the refused collection ended the process instead */
-    printf("union of %s with %s: %s\n", dimcases[i][0], dimcases[i][1],
-      dmu ? "answered" : "declined");
-    assert(dmu != NULL || meos_errno() != 0);
-    free(dm1); free(dm2);
-    if (dmu)
-      free(dmu);
+    assert(dmu != NULL);
+    assert(meos_errno() == 0);
+    char *dmwkt = geo_as_text(dmu, 3);
+    assert(dmwkt != NULL);
+    printf("union of %s with %s: %s\n", dimcases[i][0], dimcases[i][1], dmwkt);
+    assert(strcmp(dmwkt, dimcases[i][2]) == 0);
+    free(dm1); free(dm2); free(dmu); free(dmwkt);
     meos_errno_reset();
   }
 
@@ -807,6 +820,24 @@ int main(void)
   printf("union of two elevated positions: %s\n", dmzwkt);
   assert(strcmp(dmzwkt, "MULTIPOINT Z ((0 0 1),(1 1 1))") == 0);
   free(dmz1); free(dmz2); free(dmzu); free(dmzwkt);
+  meos_errno_reset();
+
+  /* Which positions of a set are equal is read from their coordinates, on the
+   * spheroid as on the plane, and an elevation one of them does not carry is
+   * no more available there: the geodetic entry reads the shared dimensions
+   * as the planar one does */
+  GSERIALIZED *ggd1 = geog_in("POINT Z(1 1 1)", -1);
+  GSERIALIZED *ggd2 = geog_in("POINT(2 2)", -1);
+  assert(ggd1 != NULL); assert(ggd2 != NULL);
+  GSERIALIZED *ggdarr[2] = {ggd1, ggd2};
+  GSERIALIZED *ggdu = geog_array_union(ggdarr, 2);
+  assert(ggdu != NULL);
+  assert(meos_errno() == 0);
+  char *ggdwkt = geo_as_ewkt(ggdu, 6);
+  printf("the union of an elevated geography position with a flat one: %s\n",
+    ggdwkt);
+  assert(strcmp(ggdwkt, "SRID=4326;MULTIPOINT(1 1,2 2)") == 0);
+  free(ggd1); free(ggd2); free(ggdu); free(ggdwkt);
   meos_errno_reset();
 
   /* Finalize MEOS */


### PR DESCRIPTION
A planar union answers the point set its members cover, and the Z and M ordinates of the answer are read from those members rather than computed. A member that carries no elevation determines none for the points it contributes, so an answer declaring one publishes a value the array does not hold.

That is what an array of mixed dimensions is answered with: the native arms decline it and GEOS answers, giving the flat member of `POINT Z(0 0 1)` with `POINT(1 1)` the elevation 1, while the same two members listed in the other order are answered without one:

```
union of POINT Z(0 0 1) with POINT(1 1)   ->  MULTIPOINT Z ((0 0 1),(1 1 1))
union of POINT(1 1) with POINT Z(0 0 1)   ->  MULTIPOINT((0 0),(1 1))
```

This adds `geom_array_shared_dims()`, which reads the array on the dimensions its members share before any arm sees it. An ordinate survives where every member contributing points carries it, and an empty member contributes none, so it does not take an elevation away from the members that do. The two ordinates are read one by one: an array holding a measure only some members carry keeps the elevation they all do.

The geodetic entry reads them the same way. Which positions of a set are equal is read from their coordinates on the spheroid as on the plane, and an elevation the array does not hold is no more available there.

The mixture therefore never reaches the collection the arms are given, the answer is the native one on both sides of the areal boundary, and it does not depend on which member the array lists first. The cases added to `meos/test/geo_test.c` state each answer as its exact spelling, with the two orders of one array among them.

The first commit on this branch is the null-collection guard opened separately; review that one first.