### PR TITLE
Carry the ordinates the members of an overlay determine

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -143,6 +143,8 @@ angle_normalize(double a)
 extern LWGEOM *meos_oriented_envelope(const LWGEOM *geom);
 extern LWGEOM *meos_areal_union(const LWGEOM *geom);
 extern LWGEOM *meos_linear_union(const LWGEOM *geom);
+extern LWGEOM *meos_lift_ordinates(const LWGEOM *geom, const LWGEOM **geoms,
+  int count);
 extern bool meos_is_simple(const LWGEOM *geom, bool *result);
 extern bool meos_relate(const LWGEOM *g1, const LWGEOM *g2, char result[10]);
 extern bool meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2,

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -8195,4 +8195,443 @@ meos_linear_union(const LWGEOM *geom)
   return lwcollection_as_lwgeom(result);
 }
 
+/*****************************************************************************
+ * Lifting a planar answer back to the ordinates its inputs carry
+ *****************************************************************************/
+
+/**
+ * @brief Structure keeping what the inputs of an overlay determine at one
+ * point of its answer
+ */
+typedef struct
+{
+  bool found;      /**< An input determines the ordinates there */
+  bool zconflict;  /**< Two inputs determine different elevations there */
+  bool mconflict;  /**< Two inputs determine different measures there */
+  double z;        /**< Elevation the inputs determine */
+  double m;        /**< Measure the inputs determine */
+} LiftPoint;
+
+/**
+ * @brief Return the angle swept from one angle to another in a direction
+ * @param[in] theta0,theta1 Angles of the ends of the sweep
+ * @param[in] ccw True where the sweep runs counterclockwise
+ */
+static double
+arc_angle_swept(double theta0, double theta1, bool ccw)
+{
+  return angle_normalize(ccw ? theta1 - theta0 : theta0 - theta1);
+}
+
+/**
+ * @brief Return the ordinates an arc determines at a point of it
+ * @details A geometry carrying a Z or an M is a planar figure together with a
+ * LIFT: the ordinates are given at the vertices and read between them along
+ * the curve joining them, which for an arc is read by ANGLE rather than by the
+ * chord. The middle control point carries its own ordinates, so the lift is
+ * linear over each of the two halves of the sweep
+ * @param[in] p0,p1,p2 Control points of the arc
+ * @param[in] px,py Point
+ * @param[out] z,m Ordinates the arc determines there
+ * @return True if the point lies on the arc, which is what determines them
+ */
+static bool
+arc_ordinates_at(const POINT4D *p0, const POINT4D *p1, const POINT4D *p2,
+  double px, double py, double *z, double *m)
+{
+  assert(p0); assert(p1); assert(p2); assert(z); assert(m);
+  POINT2D a = { p0->x, p0->y }, b = { p1->x, p1->y }, c = { p2->x, p2->y };
+  POINT2D centre;
+  double radius = lw_arc_center(&a, &b, &c, &centre);
+  /* Three collinear points draw a segment, which the caller reads as one */
+  if (radius < 0)
+    return false;
+
+  /* The point lies on the circle */
+  double tol = fmax(
+    coordinate_tolerance(centre.x - radius, centre.x + radius),
+    coordinate_tolerance(centre.y - radius, centre.y + radius));
+  if (fabs(hypot(px - centre.x, py - centre.y) - radius) > tol)
+    return false;
+
+  /* The sweep runs from the first control point through the second, which is
+   * the direction the three of them turn in */
+  bool ccw = cross_product(&a, &b, &c) > 0;
+  double t0 = atan2(a.y - centre.y, a.x - centre.x);
+  double total = arc_angle_swept(t0,
+    atan2(c.y - centre.y, c.x - centre.x), ccw);
+  double mid = arc_angle_swept(t0,
+    atan2(b.y - centre.y, b.x - centre.x), ccw);
+  double here = arc_angle_swept(t0, atan2(py - centre.y, px - centre.x), ccw);
+  /* A full circle sweeps from a point back to itself, which reads as no sweep
+   * at all: its two halves are what the middle control point separates */
+  if (total <= 0)
+    total = 2 * M_PI;
+  /* The point is on the circle but outside the span the arc occupies */
+  if (here > total + MEOS_GEOM_TOLERANCE)
+    return false;
+
+  double f = here / total, fmid = mid / total;
+  if (fmid <= 0 || fmid >= 1)
+  {
+    /* The middle point determines nothing of its own, so the lift runs from
+     * one end of the arc to the other */
+    *z = p0->z + f * (p2->z - p0->z);
+    *m = p0->m + f * (p2->m - p0->m);
+    return true;
+  }
+  if (f <= fmid)
+  {
+    double g = f / fmid;
+    *z = p0->z + g * (p1->z - p0->z);
+    *m = p0->m + g * (p1->m - p0->m);
+  }
+  else
+  {
+    double g = (f - fmid) / (1 - fmid);
+    *z = p1->z + g * (p2->z - p1->z);
+    *m = p1->m + g * (p2->m - p1->m);
+  }
+  return true;
+}
+
+/**
+ * @brief Return the ordinates a point array determines at a point
+ * @details A vertex of the array determines its own ordinates, and a point
+ * between two of them reads them along the curve that joins them
+ * @param[in] pa Point array
+ * @param[in] circular True where the array reads as arcs rather than segments
+ * @param[in] px,py Point
+ * @param[out] z,m Ordinates the array determines there
+ * @return True if the point lies on what the array draws
+ */
+static bool
+ptarray_ordinates_at(const POINTARRAY *pa, bool circular, double px, double py,
+  double *z, double *m)
+{
+  assert(pa); assert(z); assert(m);
+  /* A vertex carries its ordinates rather than reading them from a curve, and
+   * an answer keeps the vertices of its inputs, so this is where the walk ends
+   * for all but the nodes an overlay adds */
+  for (uint32_t i = 0; i < pa->npoints; i++)
+  {
+    POINT4D p;
+    getPoint4d_p(pa, i, &p);
+    if (fabs(p.x - px) <= coordinate_tolerance(p.x, px) &&
+        fabs(p.y - py) <= coordinate_tolerance(p.y, py))
+    {
+      *z = p.z; *m = p.m;
+      return true;
+    }
+  }
+
+  if (circular)
+  {
+    /* An arc is read from three points, the last of one being the first of the
+     * next */
+    for (uint32_t i = 0; i + 2 < pa->npoints; i += 2)
+    {
+      POINT4D p0, p1, p2;
+      getPoint4d_p(pa, i, &p0);
+      getPoint4d_p(pa, i + 1, &p1);
+      getPoint4d_p(pa, i + 2, &p2);
+      if (arc_ordinates_at(&p0, &p1, &p2, px, py, z, m))
+        return true;
+    }
+    return false;
+  }
+
+  for (uint32_t i = 0; i + 1 < pa->npoints; i++)
+  {
+    POINT4D p0, p1;
+    getPoint4d_p(pa, i, &p0);
+    getPoint4d_p(pa, i + 1, &p1);
+    if (! point_on_segment(px, py, p0.x, p0.y, p1.x, p1.y))
+      continue;
+    POINT2D q = { px, py }, a = { p0.x, p0.y }, b = { p1.x, p1.y }, closest;
+    double f = (double) closest_point2d_on_segment_ratio(&q, &a, &b, &closest);
+    *z = p0.z + f * (p1.z - p0.z);
+    *m = p0.m + f * (p1.m - p0.m);
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Read what a point array determines at a point into what the arrays
+ * already read determine there
+ * @details The first array to determine the ordinates gives them, and one
+ * determining others reports the conflict, which is separate for each of the
+ * two: two surfaces meeting at one elevation may carry different measures
+ * @param[in] pa Point array
+ * @param[in] circular True where the array reads as arcs rather than segments
+ * @param[in] px,py Point
+ * @param[in,out] state Ordinates determined at the point
+ */
+static void
+lift_point_read(const POINTARRAY *pa, bool circular, double px, double py,
+  LiftPoint *state)
+{
+  assert(pa); assert(state);
+  double z, m;
+  if (! ptarray_ordinates_at(pa, circular, px, py, &z, &m))
+    return;
+  if (! state->found)
+  {
+    state->found = true;
+    state->z = z; state->m = m;
+    return;
+  }
+  if (fabs(z - state->z) > coordinate_tolerance(z, state->z))
+    state->zconflict = true;
+  if (fabs(m - state->m) > coordinate_tolerance(m, state->m))
+    state->mconflict = true;
+  return;
+}
+
+/**
+ * @brief Read the ordinates a geometry determines at a point into what the
+ * geometries read before it determined
+ * @details Where two of them determine DIFFERENT ordinates at one point --
+ * two surfaces crossing at different elevations -- the point has none that the
+ * inputs give, and a value chosen between them would be one no input carries.
+ * The conflict is reported rather than resolved
+ * @param[in] geom Geometry
+ * @param[in] px,py Point
+ * @param[in,out] state Ordinates the geometries already read determine there,
+ * which this one adds what it determines to
+ */
+static void
+geom_ordinates_at(const LWGEOM *geom, double px, double py,
+  LiftPoint *state)
+{
+  assert(geom); assert(state);
+  const POINTARRAY *pa = NULL;
+  bool circular = false;
+  switch (geom->type)
+  {
+    case POINTTYPE:
+      pa = ((const LWPOINT *) geom)->point;
+      break;
+    case LINETYPE:
+      pa = ((const LWLINE *) geom)->points;
+      break;
+    case CIRCSTRINGTYPE:
+      pa = ((const LWCIRCSTRING *) geom)->points;
+      circular = true;
+      break;
+    case TRIANGLETYPE:
+      pa = ((const LWTRIANGLE *) geom)->points;
+      break;
+    case POLYGONTYPE:
+    {
+      const LWPOLY *poly = (const LWPOLY *) geom;
+      for (uint32_t i = 0; i < poly->nrings; i++)
+        lift_point_read(poly->rings[i], false, px, py, state);
+      return;
+    }
+    /* ⛔ A CURVEPOLYGON and a COMPOUNDCURVE hold their rings and their pieces
+     * in @p geoms, and each of those is a geometry of its own that says
+     * whether it reads as arcs. They are walked HERE rather than through
+     * #lwgeom_is_collection(), which answers true for both */
+    case CURVEPOLYTYPE:
+    case COMPOUNDTYPE:
+    case MULTIPOINTTYPE:
+    case MULTILINETYPE:
+    case MULTICURVETYPE:
+    case MULTIPOLYGONTYPE:
+    case MULTISURFACETYPE:
+    case POLYHEDRALSURFACETYPE:
+    case TINTYPE:
+    case COLLECTIONTYPE:
+    {
+      const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
+      for (uint32_t i = 0; i < coll->ngeoms; i++)
+        geom_ordinates_at(coll->geoms[i], px, py, state);
+      return;
+    }
+    default:
+      return;
+  }
+  lift_point_read(pa, circular, px, py, state);
+  return;
+}
+
+/**
+ * @brief Collect the point arrays of a geometry in the order a walk of it
+ * visits them
+ * @details Two geometries drawing the same figure list the same arrays with
+ * the same number of points in the same order, which is what lets the
+ * ordinates read for the vertices of one be written to the other
+ * @param[in] geom Geometry
+ * @param[in,out] arrays Array of point arrays
+ */
+static void
+geom_ptarrays(const LWGEOM *geom, MeosArray *arrays)
+{
+  assert(geom); assert(arrays);
+  POINTARRAY *pa = NULL;
+  switch (geom->type)
+  {
+    case POINTTYPE:
+      pa = ((const LWPOINT *) geom)->point;
+      break;
+    case LINETYPE:
+      pa = ((const LWLINE *) geom)->points;
+      break;
+    case CIRCSTRINGTYPE:
+      pa = ((const LWCIRCSTRING *) geom)->points;
+      break;
+    case TRIANGLETYPE:
+      pa = ((const LWTRIANGLE *) geom)->points;
+      break;
+    case POLYGONTYPE:
+    {
+      const LWPOLY *poly = (const LWPOLY *) geom;
+      for (uint32_t i = 0; i < poly->nrings; i++)
+        meos_array_add(arrays, &poly->rings[i]);
+      return;
+    }
+    /* ⛔ The rings of a CURVEPOLYGON and the pieces of a COMPOUNDCURVE are
+     * geometries in @p geoms, walked here rather than through
+     * #lwgeom_is_collection(), which answers true for both */
+    case CURVEPOLYTYPE:
+    case COMPOUNDTYPE:
+    case MULTIPOINTTYPE:
+    case MULTILINETYPE:
+    case MULTICURVETYPE:
+    case MULTIPOLYGONTYPE:
+    case MULTISURFACETYPE:
+    case POLYHEDRALSURFACETYPE:
+    case TINTYPE:
+    case COLLECTIONTYPE:
+    {
+      const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
+      for (uint32_t i = 0; i < coll->ngeoms; i++)
+        geom_ptarrays(coll->geoms[i], arrays);
+      return;
+    }
+    default:
+      return;
+  }
+  meos_array_add(arrays, &pa);
+  return;
+}
+
+/**
+ * @ingroup meos_internal_geo_base_spatial
+ * @brief Return a planar answer carrying the ordinates its inputs determine
+ * @details A union, a difference or an intersection is computed on the PLANE,
+ * while the Z and M its inputs carry are a lift of that plane: the ordinates
+ * are given at the vertices of the inputs and read between them along the
+ * curve joining them. Every vertex of such an answer lies on the boundary of
+ * an input -- the boundary of a union is part of the boundaries it is built
+ * from -- so the inputs determine an ordinate there, EXCEPT where two of them
+ * determine different ones, as two surfaces crossing at different elevations
+ * do. The answer therefore carries an ordinate exactly where the lift is
+ * unique, and is the plain planar figure where it is not: a value chosen
+ * between two the inputs carry, such as the mean, is one no input holds.
+ * @param[in] geom Answer of a planar overlay
+ * @param[in] geoms Geometries the answer is read from
+ * @param[in] count Number of geometries, at least one
+ * @return A new geometry carrying the ordinates the inputs determine
+ * @note The two ordinates are decided one by one: an answer whose elevations
+ * agree keeps them where its measures conflict
+ */
+LWGEOM *
+meos_lift_ordinates(const LWGEOM *geom, const LWGEOM **geoms, int count)
+{
+  assert(geom); assert(geoms); assert(count > 0);
+  /* The answer carries what the inputs do, and the inputs share it */
+  bool hasz = FLAGS_GET_Z(geoms[0]->flags);
+  bool hasm = FLAGS_GET_M(geoms[0]->flags);
+  if (! hasz && ! hasm)
+    return lwgeom_force_2d(geom);
+
+  /* The vertices of the answer, read in the order a walk of it visits them */
+  MeosArray *arrays = meos_array_create(sizeof(POINTARRAY *));
+  geom_ptarrays(geom, arrays);
+  int nvertices = 0;
+  for (int i = 0; i < meos_array_count(arrays); i++)
+    nvertices += (int) (*(POINTARRAY **) meos_array_get(arrays, i))->npoints;
+
+  /* The extent of each geometry, read once for the whole walk. A vertex
+   * outside one lies on nothing it draws, so the geometries a handful of
+   * comparisons rule out are never walked for it */
+  GBOX *boxes = palloc(sizeof(GBOX) * count);
+  bool *hasbox = palloc(sizeof(bool) * count);
+  for (int i = 0; i < count; i++)
+    hasbox[i] = (lwgeom_calculate_gbox(geoms[i], &boxes[i]) == LW_SUCCESS);
+
+  LiftPoint *lifted = palloc(sizeof(LiftPoint) * Max(nvertices, 1));
+  bool zok = hasz, mok = hasm;
+  int nvertex = 0;
+  for (int i = 0; i < meos_array_count(arrays); i++)
+  {
+    const POINTARRAY *pa = *(POINTARRAY **) meos_array_get(arrays, i);
+    for (uint32_t j = 0; j < pa->npoints; j++)
+    {
+      POINT4D p;
+      getPoint4d_p(pa, j, &p);
+      LiftPoint *state = &lifted[nvertex++];
+      state->found = false; state->zconflict = false; state->mconflict = false;
+      state->z = state->m = 0;
+      for (int k = 0; k < count; k++)
+      {
+        /* The extent is grown by the tolerance the coordinates call for, so a
+         * vertex ON the boundary of one is read rather than ruled out */
+        if (hasbox[k])
+        {
+          double tol = fmax(coordinate_tolerance(boxes[k].xmin, boxes[k].xmax),
+            coordinate_tolerance(boxes[k].ymin, boxes[k].ymax));
+          if (p.x < boxes[k].xmin - tol || p.x > boxes[k].xmax + tol ||
+              p.y < boxes[k].ymin - tol || p.y > boxes[k].ymax + tol)
+            continue;
+        }
+        geom_ordinates_at(geoms[k], p.x, p.y, state);
+      }
+      /* A vertex no input determines an ordinate for leaves the answer with
+       * none, as a conflict does: the answer is a figure of one dimension or
+       * of another, never of one at some of its vertices */
+      if (! state->found || state->zconflict)
+        zok = false;
+      if (! state->found || state->mconflict)
+        mok = false;
+    }
+  }
+  meos_array_destroy(arrays);
+  pfree(boxes); pfree(hasbox);
+
+  LWGEOM *result = lwgeom_force_dims(geom, zok ? 1 : 0, mok ? 1 : 0, 0, 0);
+  if (! zok && ! mok)
+  {
+    pfree(lifted);
+    return result;
+  }
+
+  /* The forced answer draws the same figure, so its vertices are visited in
+   * the same order and take the ordinates read for them */
+  MeosArray *outarrays = meos_array_create(sizeof(POINTARRAY *));
+  geom_ptarrays(result, outarrays);
+  nvertex = 0;
+  for (int i = 0; i < meos_array_count(outarrays); i++)
+  {
+    POINTARRAY *pa = *(POINTARRAY **) meos_array_get(outarrays, i);
+    for (uint32_t j = 0; j < pa->npoints; j++)
+    {
+      POINT4D p;
+      getPoint4d_p(pa, j, &p);
+      if (zok)
+        p.z = lifted[nvertex].z;
+      if (mok)
+        p.m = lifted[nvertex].m;
+      ptarray_set_point4d(pa, j, &p);
+      nvertex++;
+    }
+  }
+  meos_array_destroy(outarrays);
+  pfree(lifted);
+  return result;
+}
+
 /*****************************************************************************/

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2742,6 +2742,42 @@ geom_array_union_shared(GSERIALIZED **gsarr, int count)
 }
 
 /**
+ * @brief Return the answer of an overlay carrying the ordinates its members
+ * determine
+ * @details The answer of an overlay is computed on the PLANE while its Z and M
+ * are a lift of that plane, so the ordinates are read back from the members
+ * once the planar figure is known -- see #meos_lift_ordinates(). An answer of
+ * members carrying neither ordinate is already the whole answer, and is left
+ * untouched rather than walked
+ * @param[in] result Answer of the overlay, owned by this function
+ * @param[in] gsarr Array of geometries the answer is read from
+ * @param[in] count Number of elements in the array
+ * @return The answer carrying the ordinates its members determine, or @p NULL
+ * where the overlay gave none
+ */
+static GSERIALIZED *
+union_lifted(GSERIALIZED *result, GSERIALIZED **gsarr, int count)
+{
+  assert(gsarr); assert(count > 0);
+  if (! result)
+    return NULL;
+  if (! gserialized_has_z(gsarr[0]) && ! gserialized_has_m(gsarr[0]))
+    return result;
+
+  const LWGEOM **geoms = palloc(sizeof(LWGEOM *) * count);
+  for (int i = 0; i < count; i++)
+    geoms[i] = lwgeom_from_gserialized(gsarr[i]);
+  LWGEOM *lwresult = lwgeom_from_gserialized(result);
+  LWGEOM *lifted = meos_lift_ordinates(lwresult, geoms, count);
+  GSERIALIZED *answer = geo_serialize(lifted);
+  for (int i = 0; i < count; i++)
+    lwgeom_free((LWGEOM *) geoms[i]);
+  pfree(geoms);
+  lwgeom_free(lwresult); lwgeom_free(lifted); pfree(result);
+  return answer;
+}
+
+/**
  * @ingroup meos_geo_base_spatial
  * @brief Return the union of an array of geometries
  * @details The answer covers the points the members cover, read on the
@@ -2778,12 +2814,15 @@ geom_array_union(GSERIALIZED **gsarr, int count)
     return geo_copy(gsarr[0]);
 
   GSERIALIZED **shared = geom_array_shared_dims(gsarr, count);
-  if (! shared)
-    return geom_array_union_shared(gsarr, count);
-  GSERIALIZED *result = geom_array_union_shared(shared, count);
-  for (int i = 0; i < count; i++)
-    pfree(shared[i]);
-  pfree(shared);
+  GSERIALIZED **members = shared ? shared : gsarr;
+  GSERIALIZED *result = union_lifted(geom_array_union_shared(members, count),
+    members, count);
+  if (shared)
+  {
+    for (int i = 0; i < count; i++)
+      pfree(shared[i]);
+    pfree(shared);
+  }
   return result;
 }
 
@@ -2892,8 +2931,14 @@ geom_unary_union(const GSERIALIZED *gs, double prec)
     return NULL;
 #endif /* GEOS */
   }
-  GSERIALIZED *result = geo_serialize(lwresult);
-  lwgeom_free(lwgeom); lwgeom_free(lwresult);
+  /* The dissolve is computed on the plane, and the ordinates the components
+   * carry are read back onto it: two of them crossing at one elevation give
+   * the answer that elevation, and two crossing at different ones leave the
+   * point with none */
+  const LWGEOM *inputs[1] = { lwgeom };
+  LWGEOM *lifted = meos_lift_ordinates(lwresult, inputs, 1);
+  GSERIALIZED *result = geo_serialize(lifted);
+  lwgeom_free(lwgeom); lwgeom_free(lwresult); lwgeom_free(lifted);
   return result;
 }
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -822,6 +822,123 @@ int main(void)
   free(dmz1); free(dmz2); free(dmzu); free(dmzwkt);
   meos_errno_reset();
 
+  /* A union is computed on the PLANE while the Z and M its members carry are a
+   * lift of that plane: the ordinates are given at their vertices and read
+   * between them along the curve joining them. Every vertex of the answer lies
+   * on the boundary of a member, so a member determines an ordinate there --
+   * unless two of them determine DIFFERENT ones, as two surfaces crossing at
+   * different elevations do, when the point has none the members give. The
+   * answer therefore carries an ordinate exactly where that lift is unique */
+  struct { const char *first; const char *second; const char *result; }
+    liftcases[] = {
+    /* two surfaces crossing on ONE plane: the nodes the overlay adds are
+     * elevated by the edges carrying them, which agree */
+    { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))",
+      "POLYGON Z((1 1 1,1 3 1,3 3 1,3 1 1,1 1 1))",
+      "POLYGON Z ((1 2 1,0 2 1,0 0 1,2 0 1,2 1 1,3 1 1,3 3 1,1 3 1,1 2 1))" },
+    /* the same pair on the sloping plane Z = x, which the added nodes are
+     * read onto: (1 2) takes 1 and (2 1) takes 2 */
+    { "POLYGON Z((0 0 0,0 2 0,2 2 2,2 0 2,0 0 0))",
+      "POLYGON Z((1 1 1,1 3 1,3 3 3,3 1 3,1 1 1))",
+      "POLYGON Z ((1 2 1,0 2 0,0 0 0,2 0 2,2 1 2,3 1 3,3 3 3,1 3 1,1 2 1))" },
+    /* two surfaces crossing at DIFFERENT elevations: the nodes have none, so
+     * the answer is the planar figure rather than one carrying a mean */
+    { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))",
+      "POLYGON Z((1 1 7,1 3 7,3 3 7,3 1 7,1 1 7))",
+      "POLYGON((1 2,0 2,0 0,2 0,2 1,3 1,3 3,1 3,1 2))" },
+    /* two surfaces MEETING along an edge at different elevations: the shared
+     * edge is where they disagree */
+    { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))",
+      "POLYGON Z((2 0 7,2 2 7,4 2 7,4 0 7,2 0 7))",
+      "POLYGON((0 2,2 2,4 2,4 0,2 0,0 0,0 2))" },
+    /* linework coinciding over a stretch, dissolved into one curve that keeps
+     * the elevation both members carry */
+    { "LINESTRING Z(0 0 1,6 6 1)", "LINESTRING Z(3 3 1,10 10 1)",
+      "LINESTRING Z (0 0 1,6 6 1,10 10 1)" },
+    /* the elevations agree and the measures do not, so the answer keeps the
+     * one that is determined and drops the one that is not */
+    { "POLYGON ZM((0 0 1 5,0 2 1 5,2 2 1 5,2 0 1 5,0 0 1 5))",
+      "POLYGON ZM((1 1 1 9,1 3 1 9,3 3 1 9,3 1 1 9,1 1 1 9))",
+      "POLYGON Z ((1 2 1,0 2 1,0 0 1,2 0 1,2 1 1,3 1 1,3 3 1,1 3 1,1 2 1))" },
+    /* and the other way round */
+    { "POLYGON ZM((0 0 1 5,0 2 1 5,2 2 1 5,2 0 1 5,0 0 1 5))",
+      "POLYGON ZM((1 1 7 5,1 3 7 5,3 3 7 5,3 1 7 5,1 1 7 5))",
+      "POLYGON M ((1 2 5,0 2 5,0 0 5,2 0 5,2 1 5,3 1 5,3 3 5,1 3 5,1 2 5))" },
+  };
+  for (size_t i = 0; i < sizeof(liftcases) / sizeof(liftcases[0]); i++)
+  {
+    GSERIALIZED *lf1 = geom_in(liftcases[i].first, -1);
+    GSERIALIZED *lf2 = geom_in(liftcases[i].second, -1);
+    assert(lf1 != NULL); assert(lf2 != NULL);
+    GSERIALIZED *lfarr[2] = {lf1, lf2};
+    meos_errno_reset();
+    GSERIALIZED *lfu = geom_array_union(lfarr, 2);
+    assert(lfu != NULL);
+    assert(meos_errno() == 0);
+    char *lfwkt = geo_as_text(lfu, 3);
+    assert(lfwkt != NULL);
+    printf("%s united with %s: %s\n", liftcases[i].first, liftcases[i].second,
+      lfwkt);
+    assert(strcmp(lfwkt, liftcases[i].result) == 0);
+    free(lf1); free(lf2); free(lfu); free(lfwkt);
+    meos_errno_reset();
+  }
+
+  /* An arc is a curve, and the lift along it is read by ANGLE rather than by
+   * the chord joining its ends. These two discs are mirror images about the
+   * line through the points where they cross, and each carries elevations
+   * linear in the angle around its own centre, so the two determine the SAME
+   * elevation at each crossing node -- 0.2301, the node's 41.41 degrees over
+   * 180 -- and the answer carries it. Read along the chord, one disc gives
+   * 0.209 there and the other 0.25: they would conflict and the answer would
+   * come back flat, so its dimension is what this asserts */
+  GSERIALIZED *dsc1 = geom_in(
+    "CURVEPOLYGON(CIRCULARSTRING Z(0 0 1,2 2 0.5,4 0 0,2 -2 0.5,0 0 1))", -1);
+  GSERIALIZED *dsc2 = geom_in(
+    "CURVEPOLYGON(CIRCULARSTRING Z(3 0 0,5 2 0.5,7 0 1,5 -2 0.5,3 0 0))", -1);
+  assert(dsc1 != NULL); assert(dsc2 != NULL);
+  GSERIALIZED *dscarr[2] = {dsc1, dsc2};
+  meos_errno_reset();
+  GSERIALIZED *dscu = geom_array_union(dscarr, 2);
+  assert(dscu != NULL);
+  assert(meos_errno() == 0);
+  char *dscwkt = geo_as_text(dscu, 4);
+  printf("two mirrored discs elevated by the angle: %s\n", dscwkt);
+  assert(strcmp(dscwkt,
+    "CURVEPOLYGON Z (COMPOUNDCURVE Z ("
+    "CIRCULARSTRING Z (3.5 1.3229 0.2301,1.2929 1.8708 0.615,0 0 1),"
+    "CIRCULARSTRING Z (0 0 1,1.2929 -1.8708 0.615,3.5 -1.3229 0.2301),"
+    "CIRCULARSTRING Z (3.5 -1.3229 0.2301,5.7071 -1.8708 0.615,7 0 1),"
+    "CIRCULARSTRING Z (7 0 1,5.7071 1.8708 0.615,3.5 1.3229 0.2301)))") == 0);
+  free(dsc1); free(dsc2); free(dscu); free(dscwkt);
+  meos_errno_reset();
+
+  /* The dissolve of ONE geometry reads its ordinates back the same way: its
+   * components determine them where they agree and leave the answer planar
+   * where they do not */
+  GSERIALIZED *uz1 = geom_in(
+    "MULTISURFACE(POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1)),"
+    "POLYGON Z((1 1 1,1 3 1,3 3 1,3 1 1,1 1 1)))", -1);
+  GSERIALIZED *uz2 = geom_in(
+    "MULTISURFACE(POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1)),"
+    "POLYGON Z((1 1 7,1 3 7,3 3 7,3 1 7,1 1 7)))", -1);
+  assert(uz1 != NULL); assert(uz2 != NULL);
+  GSERIALIZED *uzu1 = geom_unary_union(uz1, -1);
+  GSERIALIZED *uzu2 = geom_unary_union(uz2, -1);
+  assert(uzu1 != NULL); assert(uzu2 != NULL);
+  assert(meos_errno() == 0);
+  char *uzwkt1 = geo_as_text(uzu1, 3);
+  char *uzwkt2 = geo_as_text(uzu2, 3);
+  printf("the dissolve of two surfaces at one elevation: %s\n", uzwkt1);
+  printf("the dissolve of two surfaces at two elevations: %s\n", uzwkt2);
+  assert(strcmp(uzwkt1,
+    "POLYGON Z ((1 2 1,0 2 1,0 0 1,2 0 1,2 1 1,3 1 1,3 3 1,1 3 1,1 2 1))")
+    == 0);
+  assert(strcmp(uzwkt2,
+    "POLYGON((1 2,0 2,0 0,2 0,2 1,3 1,3 3,1 3,1 2))") == 0);
+  free(uz1); free(uz2); free(uzu1); free(uzu2); free(uzwkt1); free(uzwkt2);
+  meos_errno_reset();
+
   /* Which positions of a set are equal is read from their coordinates, on the
    * spheroid as on the plane, and an elevation one of them does not carry is
    * no more available there: the geodetic entry reads the shared dimensions


### PR DESCRIPTION
A geometry carrying a Z or an M is a planar figure together with a LIFT: the ordinates are given at its vertices and read between them along the curve joining them. An overlay is computed on the plane, and the arms that rebuild a boundary from it answer the planar figure alone, while the GEOS arm answers with values no member holds:

```
two squares crossing on the single plane Z=1        ->  POLYGON((1 2,0 2,...))      flat
two lines dissolved over the stretch they share     ->  LINESTRING(0 0,6 6,10 10)   flat
four crossing bars framing a hole, at Z=1 and Z=7   ->  hole ring (1 1 4,9 1 4,...) 4 = the mean
```

The boundary of a union is part of the boundaries it is built from, so every vertex of the answer lies on a member and that member determines its ordinates: its own where the vertex is one of its vertices, and the reading along the segment or the arc that carries it otherwise. The answer carries an ordinate exactly where that lift is UNIQUE, and is the plain planar figure where two members determine different ones — two surfaces crossing at different elevations give their crossing point none, and a value chosen between them is one no member carries.

`meos_lift_ordinates()` reads them back onto the answer of an overlay, after the arms have drawn the planar figure and whichever arm drew it, so a GEOS-free build and a GEOS build agree. It walks nothing where the members carry neither ordinate, which is what a planar array costs, and the extent of each member rules out the ones a vertex cannot lie on. The lift along an arc is read by ANGLE, since that is the curve the arc draws, and the two ordinates are decided one by one: an answer whose elevations agree keeps them where its measures conflict.

The array union and the unary union both read them, so the dissolve of a collection answers as the union of its members does.

The cases added to `meos/test/geo_test.c` state each answer as its exact spelling. The two mirrored discs elevated by the angle around their own centres are what separates the lift along the arc from one along the chord: they agree on 0.2301 at each crossing node, 41.41 degrees over 180, while a chord reading gives 0.209 on one disc and 0.25 on the other, conflicts, and answers a flat figure — so the assertion is the dimension of the answer.

The first two commits on this branch are the null-collection guard and the shared-dimension reading, opened separately; review those first.