### PR TITLE
Return the distance between two circular buffers as the float it is

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2053,6 +2053,14 @@
 				</itemizedlist>
 			</sect3>
 			<sect3>
+				<title>Operaciones de distancia</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="cbuffer_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Devuelve la distancia</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+			<sect3>
 				<title>Comparaciones</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -288,6 +288,32 @@ SELECT asEWKT(transformPipeline(transformPipeline(cbuffer, pipeline, 4326), pipe
 			</itemizedlist>
 		</sect2>
 
+		<sect2 xml:id="cbuffer_distance">
+			<title>Operaciones de distancia</title>
+
+			<itemizedlist>
+				<listitem xml:id="cbuffer_distance_op">
+					<indexterm significance="normal"><primary><varname>distance</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
+					<para>Devuelve la distancia</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+distance({geo,stbox,cbuffer},cbuffer) → float
+distance(cbuffer,{geo,stbox,cbuffer}) → float
+{geo,stbox,cbuffer} &lt;-&gt; cbuffer → float
+</programlisting>
+					<para>La distancia entre dos búferes circulares es la distancia entre sus puntos reducida por ambos radios, y es cero cuando los búferes se superponen. El resultado es <varname>NULL</varname> cuando la geometría está vacía.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(distance(geometry 'Point(1 0)', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+-- 2.5
+SELECT round(cbuffer 'Cbuffer(Point(0 0),0.5)' &lt;-&gt; cbuffer 'Cbuffer(Point(3 4),0.5)', 6);
+-- 4
+SELECT round(cbuffer 'Cbuffer(Point(0 0),3)' &lt;-&gt; cbuffer 'Cbuffer(Point(3 4),3)', 6);
+-- 0
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 		<sect2 xml:id="cbuffer_static_operators">
 			<title>Comparaciones</title>
 
@@ -1087,7 +1113,8 @@ SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Devuelve la distancia temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-{geo,cbuffer,tcbuffer} &lt;-&gt; {geo,cbuffer,tcbuffer} → tfloat
+{geo,cbuffer} &lt;-&gt; tcbuffer → tfloat
+tcbuffer &lt;-&gt; {geo,cbuffer,tcbuffer} → tfloat
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2059,6 +2059,14 @@
 				</itemizedlist>
 			</sect3>
 			<sect3>
+				<title>Distance Operations</title>
+				<itemizedlist>
+					<listitem>
+						<para><link linkend="cbuffer_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Return the distance</para>
+					</listitem>
+				</itemizedlist>
+			</sect3>
+			<sect3>
 				<title>Comparisons</title>
 				<itemizedlist>
 					<listitem>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -288,6 +288,32 @@ SELECT asEWKT(transformPipeline(transformPipeline(cbuffer, pipeline, 4326), pipe
 			</itemizedlist>
 		</sect2>
 
+				<sect2 xml:id="cbuffer_distance">
+			<title>Distance Operations</title>
+
+			<itemizedlist>
+				<listitem xml:id="cbuffer_distance_op">
+					<indexterm significance="normal"><primary><varname>distance</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
+					<para>Return the distance</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+distance({geo,stbox,cbuffer},cbuffer) → float
+distance(cbuffer,{geo,stbox,cbuffer}) → float
+{geo,stbox,cbuffer} &lt;-&gt; cbuffer → float
+</programlisting>
+					<para>The distance between two circular buffers is the distance between their points reduced by both radii, and is zero when the buffers overlap. The result is <varname>NULL</varname> when the geometry is empty.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(distance(geometry 'Point(1 0)', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+-- 2.5
+SELECT round(cbuffer 'Cbuffer(Point(0 0),0.5)' &lt;-&gt; cbuffer 'Cbuffer(Point(3 4),0.5)', 6);
+-- 4
+SELECT round(cbuffer 'Cbuffer(Point(0 0),3)' &lt;-&gt; cbuffer 'Cbuffer(Point(3 4),3)', 6);
+-- 0
+</programlisting>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+
 				<sect2 xml:id="cbuffer_static_operators">
 			<title>Comparisons</title>
 
@@ -1089,7 +1115,8 @@ SELECT ST_AsText(shortestLine(tcbuffer '[Cbuffer(Point(2 2), 0.3)@2001-01-01,
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Return the temporal distance</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-{geo,cbuffer,tcbuffer} &lt;-&gt; {geo,cbuffer,tcbuffer} → tfloat
+{geo,cbuffer} &lt;-&gt; tcbuffer → tfloat
+tcbuffer &lt;-&gt; {geo,cbuffer,tcbuffer} → tfloat
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tcbuffer '[Cbuffer(Point(1 1), 0.3)@2001-01-01,

--- a/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
@@ -54,7 +54,7 @@ CREATE FUNCTION distance(cbuffer, stbox)
   AS 'MODULE_PATHNAME', 'Distance_cbuffer_stbox'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION distance(cbuffer, cbuffer)
-  RETURNS tfloat
+  RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_cbuffer_cbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -1,3 +1,88 @@
+SELECT round(distance(geometry 'Point(1 0)', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+ round 
+-------
+   2.5
+(1 row)
+
+SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+ round 
+-------
+   0.5
+(1 row)
+
+SELECT round(distance(cbuffer 'Cbuffer(Point(4 0),0.5)', geometry 'Point(1 0)'), 6);
+ round 
+-------
+   2.5
+(1 row)
+
+SELECT round(distance(cbuffer 'Cbuffer(Point(4 0),0.5)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+ round 
+-------
+   0.5
+(1 row)
+
+SELECT round(distance(cbuffer 'Cbuffer(Point(0 0),0.5)', cbuffer 'Cbuffer(Point(3 4),0.5)'), 6);
+ round 
+-------
+     4
+(1 row)
+
+SELECT round(geometry 'Point(1 0)' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
+ round 
+-------
+   2.5
+(1 row)
+
+SELECT round(stbox 'STBOX X((1,-1),(3,1))' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
+ round 
+-------
+   0.5
+(1 row)
+
+SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' <-> geometry 'Point(1 0)', 6);
+ round 
+-------
+   2.5
+(1 row)
+
+SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' <-> stbox 'STBOX X((1,-1),(3,1))', 6);
+ round 
+-------
+   0.5
+(1 row)
+
+SELECT round(cbuffer 'Cbuffer(Point(0 0),0.5)' <-> cbuffer 'Cbuffer(Point(3 4),0.5)', 6);
+ round 
+-------
+     4
+(1 row)
+
+SELECT round(cbuffer 'Cbuffer(Point(0 0),3)' <-> cbuffer 'Cbuffer(Point(3 4),3)', 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(cbuffer 'Cbuffer(Point(0 0),0)' <-> cbuffer 'Cbuffer(Point(0 0),0)', 6);
+ round 
+-------
+     0
+(1 row)
+
+SELECT round(cbuffer 'SRID=5676;Cbuffer(Point(0 0),0.5)' <->
+  cbuffer 'SRID=5676;Cbuffer(Point(3 4),0.5)', 6);
+ round 
+-------
+     4
+(1 row)
+
+SELECT round(geometry 'Point empty' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
+ round 
+-------
+      
+(1 row)
+
 SELECT round(geometry 'Point(1 1)' <-> tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 6);
              round              
 --------------------------------

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -26,6 +26,31 @@
 -- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
 --
 -------------------------------------------------------------------------------
+-- distance
+-------------------------------------------------------------------------------
+
+SELECT round(distance(geometry 'Point(1 0)', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+SELECT round(distance(cbuffer 'Cbuffer(Point(4 0),0.5)', geometry 'Point(1 0)'), 6);
+SELECT round(distance(cbuffer 'Cbuffer(Point(4 0),0.5)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(distance(cbuffer 'Cbuffer(Point(0 0),0.5)', cbuffer 'Cbuffer(Point(3 4),0.5)'), 6);
+
+SELECT round(geometry 'Point(1 0)' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
+SELECT round(stbox 'STBOX X((1,-1),(3,1))' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
+SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' <-> geometry 'Point(1 0)', 6);
+SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' <-> stbox 'STBOX X((1,-1),(3,1))', 6);
+SELECT round(cbuffer 'Cbuffer(Point(0 0),0.5)' <-> cbuffer 'Cbuffer(Point(3 4),0.5)', 6);
+
+-- The radii cover the gap between the centres, so the distance is zero
+SELECT round(cbuffer 'Cbuffer(Point(0 0),3)' <-> cbuffer 'Cbuffer(Point(3 4),3)', 6);
+SELECT round(cbuffer 'Cbuffer(Point(0 0),0)' <-> cbuffer 'Cbuffer(Point(0 0),0)', 6);
+SELECT round(cbuffer 'SRID=5676;Cbuffer(Point(0 0),0.5)' <->
+  cbuffer 'SRID=5676;Cbuffer(Point(3 4),0.5)', 6);
+SELECT round(geometry 'Point empty' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
+
+-------------------------------------------------------------------------------
+-- tDistance
+-------------------------------------------------------------------------------
 
 SELECT round(geometry 'Point(1 1)' <-> tcbuffer 'Cbuffer(Point(1 1), 0.5)@2000-01-01', 6);
 SELECT round(geometry 'Point(1 1)' <-> tcbuffer '{Cbuffer(Point(1 1), 0.3)@2000-01-01, Cbuffer(Point(1 1), 0.5)@2000-01-02, Cbuffer(Point(1 1), 0.5)@2000-01-03}', 6);


### PR DESCRIPTION
The distance between two circular buffers is a number, and its wrapper returns one: Distance_cbuffer_cbuffer calls the MEOS kernel declared `double distance_cbuffer_cbuffer` and answers PG_RETURN_FLOAT8. Its SQL declaration alone among the distance functions of the extension says RETURNS tfloat, so PostgreSQL reads the returned double as a pointer to a temporal value and the backend terminates on every call — `SELECT distance(cbuffer 'Cbuffer(Point(1 1),0.5)', cbuffer 'Cbuffer(Point(4 5),0.5)')` closes the connection on 1.4.0, while its sibling `distance(cbuffer, stbox)` answers 2.3284271247461903. The declaration states float, as its four siblings in the same file and distance(pose,pose) do, and no tdistance_cbuffer_cbuffer kernel exists for tfloat to name. The circular buffer chapter gains the distance entry the pose chapter carries, so the operator that answers a number is documented as answering one, and the temporal entry states the operand pairs that do answer a tfloat. The test file covers the static forms of distance and of the <-> operator, whose absence let a call that terminates the backend ship.