### PR TITLE
State the SQL function each @sqlfn tag names

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -128,3 +128,11 @@ jobs:
         uses: actions/checkout@v4
       - name: Validate the GeoPose documents against the OGC schemas
         run: python3 tools/scripts/check_geopose_conformance.py
+
+  sqlfn_names_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Check that every @sqlfn tag names a function the extension creates
+        run: python3 tools/scripts/check_sqlfn_names.py

--- a/mobilitydb/src/cbuffer/cbuffer.c
+++ b/mobilitydb/src/cbuffer/cbuffer.c
@@ -234,7 +234,7 @@ PG_FUNCTION_INFO_V1(Cbuffer_from_hexwkb);
  * @ingroup mobilitydb_cbuffer_base_inout
  * @brief Return a circular buffer from its ASCII hex-encoded Well-Known Binary
  * (HexWKB) representation
- * @sqlfn cbufferFromHexWKB()
+ * @sqlfn cbufferFromHexEWKB()
  */
 Datum
 Cbuffer_from_hexwkb(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/cbuffer/tcbuffer.c
+++ b/mobilitydb/src/cbuffer/tcbuffer.c
@@ -147,7 +147,7 @@ PG_FUNCTION_INFO_V1(Tcbuffer_constructor);
  * @ingroup mobilitydb_cbuffer_constructor
  * @brief Construct a temporal circular buffer from a temporal point and a
  * temporal float
- * @sqlfn tcbuffer_constructor()
+ * @sqlfn tcbuffer()
  */
 Datum
 Tcbuffer_constructor(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/cbuffer/tcbuffer_distance.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_distance.c
@@ -52,7 +52,7 @@ PG_FUNCTION_INFO_V1(Distance_cbuffer_geo);
  * @ingroup mobilitydb_cbuffer_dist
  * @brief Return the temporal distance between a circular buffer and a
  * geometry
- * @sqlfn tDistance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -95,7 +95,7 @@ PG_FUNCTION_INFO_V1(Distance_cbuffer_stbox);
  * @ingroup mobilitydb_cbuffer_dist
  * @brief Return the temporal distance between a circular buffer and a
  * spatiotemporal box
- * @sqlfn tDistance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -115,7 +115,7 @@ PG_FUNCTION_INFO_V1(Distance_stbox_cbuffer);
  * @ingroup mobilitydb_cbuffer_dist
  * @brief Return the temporal distance between a circular buffer and a
  * spatiotemporal box
- * @sqlfn tDistance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum
@@ -134,7 +134,7 @@ PG_FUNCTION_INFO_V1(Distance_cbuffer_cbuffer);
 /**
  * @ingroup mobilitydb_cbuffer_dist
  * @brief Return the temporal distance between two circular buffers
- * @sqlfn tDistance()
+ * @sqlfn distance()
  * @sqlop @p <->
  */
 Datum

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -290,7 +290,7 @@ PG_FUNCTION_INFO_V1(Stbox_constructor_x);
 /**
  * @ingroup mobilitydb_geo_box_constructor
  * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn stbox()
+ * @sqlfn stboxX()
  */
 inline Datum
 Stbox_constructor_x(PG_FUNCTION_ARGS)
@@ -303,7 +303,7 @@ PG_FUNCTION_INFO_V1(Stbox_constructor_z);
 /**
  * @ingroup mobilitydb_geo_box_constructor
  * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn stbox_z()
+ * @sqlfn stboxZ()
  */
 inline Datum
 Stbox_constructor_z(PG_FUNCTION_ARGS)
@@ -316,7 +316,7 @@ PG_FUNCTION_INFO_V1(Stbox_constructor_t);
 /**
  * @ingroup mobilitydb_geo_box_constructor
  * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn stbox_t()
+ * @sqlfn stboxT()
  */
 inline Datum
 Stbox_constructor_t(PG_FUNCTION_ARGS)
@@ -329,7 +329,7 @@ PG_FUNCTION_INFO_V1(Stbox_constructor_xt);
 /**
  * @ingroup mobilitydb_geo_box_constructor
  * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn stbox_xt()
+ * @sqlfn stboxXT()
  */
 inline Datum
 Stbox_constructor_xt(PG_FUNCTION_ARGS)
@@ -342,7 +342,7 @@ PG_FUNCTION_INFO_V1(Stbox_constructor_zt);
 /**
  * @ingroup mobilitydb_geo_box_constructor
  * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn stbox_zt()
+ * @sqlfn stboxZT()
  */
 inline Datum
 Stbox_constructor_zt(PG_FUNCTION_ARGS)
@@ -358,7 +358,7 @@ PG_FUNCTION_INFO_V1(Geodstbox_constructor_z);
 /**
  * @ingroup mobilitydb_geo_box_constructor
  * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn geodstbox_z()
+ * @sqlfn geodstboxZ()
  */
 inline Datum
 Geodstbox_constructor_z(PG_FUNCTION_ARGS)
@@ -371,7 +371,7 @@ PG_FUNCTION_INFO_V1(Geodstbox_constructor_t);
 /**
  * @ingroup mobilitydb_geo_box_constructor
  * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn geodstbox_t()
+ * @sqlfn geodstboxT()
  */
 inline Datum
 Geodstbox_constructor_t(PG_FUNCTION_ARGS)
@@ -384,7 +384,7 @@ PG_FUNCTION_INFO_V1(Geodstbox_constructor_zt);
 /**
  * @ingroup mobilitydb_geo_box_constructor
  * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn geodstbox_zt()
+ * @sqlfn geodstboxZT()
  */
 inline Datum
 Geodstbox_constructor_zt(PG_FUNCTION_ARGS)
@@ -1028,7 +1028,7 @@ PG_FUNCTION_INFO_V1(Stbox_expand_time);
  * @ingroup mobilitydb_geo_box_transf
  * @brief Return a spatiotemporal box with the time span expanded/shrinked by
  * an interval
- * @sqlfn Stbox_expand_time()
+ * @sqlfn expandTime()
  */
 Datum
 Stbox_expand_time(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/geo/tgeo_spatialfuncs.c
+++ b/mobilitydb/src/geo/tgeo_spatialfuncs.c
@@ -843,7 +843,7 @@ PG_FUNCTION_INFO_V1(Tgeo_at_elevation);
 /**
  * @ingroup mobilitydb_geo_restrict
  * @brief Return a temporal geo restricted to an elevation span
- * @sqlfn atGeometry()
+ * @sqlfn atElevation()
  */
 inline Datum
 Tgeo_at_elevation(PG_FUNCTION_ARGS)
@@ -856,7 +856,7 @@ PG_FUNCTION_INFO_V1(Tgeo_minus_elevation);
 /**
  * @ingroup mobilitydb_geo_restrict
  * @brief Return a temporal geo restricted to the complement an elevation span
- * @sqlfn minusGeometry()
+ * @sqlfn minusElevation()
  */
 inline Datum
 Tgeo_minus_elevation(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/geo/tgeo_tile.c
+++ b/mobilitydb/src/geo/tgeo_tile.c
@@ -298,7 +298,7 @@ PG_FUNCTION_INFO_V1(Stbox_get_time_tile);
 /**
  * @brief @ingroup mobilitydb_geo_tile
  * @brief Return a tile in the temporal grid of a spatiotemporal box
- * @sqlfn getTimeTile()
+ * @sqlfn getStboxTimeTile()
  */
 inline Datum
 Stbox_get_time_tile(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/npoint/npoint.c
+++ b/mobilitydb/src/npoint/npoint.c
@@ -240,7 +240,7 @@ PG_FUNCTION_INFO_V1(Npoint_from_hexwkb);
  * @ingroup mobilitydb_npoint_base_inout
  * @brief Return a network point from its ASCII hex-encoded Well-Known Binary
  * (HexWKB) representation
- * @sqlfn npointFromHexWKB()
+ * @sqlfn npointFromHexEWKB()
  */
 Datum
 Npoint_from_hexwkb(PG_FUNCTION_ARGS)
@@ -324,7 +324,7 @@ PG_FUNCTION_INFO_V1(Npoint_as_ewkb);
 /**
  * @ingroup mobilitydb_pose_base_inout
  * @brief Return the Well-Known Binary (WKB) representation of a network point
- * @sqlfn asBinary()
+ * @sqlfn asEWKB()
  */
 Datum
 Npoint_as_ewkb(PG_FUNCTION_ARGS)
@@ -580,7 +580,7 @@ PG_FUNCTION_INFO_V1(Npoint_position);
 /**
  * @ingroup mobilitydb_npoint_base_accessor
  * @brief Return the position of a network point
- * @sqlfn position()
+ * @sqlfn getPosition()
  */
 Datum
 Npoint_position(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/pose/pose.c
+++ b/mobilitydb/src/pose/pose.c
@@ -181,7 +181,7 @@ PG_FUNCTION_INFO_V1(Pose_from_hexwkb);
  * @ingroup mobilitydb_pose_base_inout
  * @brief Return a pose from its ASCII hex-encoded Well-Known Binary (HexWKB)
  * representation
- * @sqlfn poseFromHexWKB()
+ * @sqlfn poseFromHexEWKB()
  */
 Datum
 Pose_from_hexwkb(PG_FUNCTION_ARGS)
@@ -265,7 +265,7 @@ PG_FUNCTION_INFO_V1(Pose_as_ewkb);
 /**
  * @ingroup mobilitydb_pose_base_inout
  * @brief Return the Well-Known Binary (WKB) representation of a pose
- * @sqlfn asBinary()
+ * @sqlfn asEWKB()
  */
 Datum
 Pose_as_ewkb(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/posechain/posechain.c
+++ b/mobilitydb/src/posechain/posechain.c
@@ -233,7 +233,7 @@ PG_FUNCTION_INFO_V1(Posechain_from_hexwkb);
  * @ingroup mobilitydb_posechain_base_inout
  * @brief Return a pose chain from its ASCII hex-encoded Well-Known Binary
  * (HexWKB) representation
- * @sqlfn posechainFromHexWKB()
+ * @sqlfn posechainFromHexEWKB()
  */
 Datum
 Posechain_from_hexwkb(PG_FUNCTION_ARGS)
@@ -672,7 +672,7 @@ PG_FUNCTION_INFO_V1(Posechain_eq);
 /**
  * @ingroup mobilitydb_posechain_base_comp
  * @brief Return true if the first pose chain is equal to the second one
- * @sqlfn posechain_eq()
+ * @sqlfn eq()
  * @sqlop @p =
  */
 Datum
@@ -688,7 +688,7 @@ PG_FUNCTION_INFO_V1(Posechain_ne);
 /**
  * @ingroup mobilitydb_posechain_base_comp
  * @brief Return true if the first pose chain is not equal to the second one
- * @sqlfn posechain_ne()
+ * @sqlfn ne()
  * @sqlop @p <>
  */
 Datum
@@ -705,7 +705,7 @@ PG_FUNCTION_INFO_V1(Posechain_cmp);
  * @ingroup mobilitydb_posechain_base_comp
  * @brief Return -1, 0, or 1 depending on whether the first pose chain is
  * less than, equal to, or greater than the second one
- * @sqlfn posechain_cmp()
+ * @sqlfn cmp()
  */
 Datum
 Posechain_cmp(PG_FUNCTION_ARGS)
@@ -720,7 +720,7 @@ PG_FUNCTION_INFO_V1(Posechain_lt);
 /**
  * @ingroup mobilitydb_posechain_base_comp
  * @brief Return true if the first pose chain is less than the second one
- * @sqlfn posechain_lt()
+ * @sqlfn lt()
  * @sqlop @p <
  */
 Datum
@@ -737,7 +737,7 @@ PG_FUNCTION_INFO_V1(Posechain_le);
  * @ingroup mobilitydb_posechain_base_comp
  * @brief Return true if the first pose chain is less than or equal to the
  * second one
- * @sqlfn posechain_le()
+ * @sqlfn le()
  * @sqlop @p <=
  */
 Datum
@@ -754,7 +754,7 @@ PG_FUNCTION_INFO_V1(Posechain_ge);
  * @ingroup mobilitydb_posechain_base_comp
  * @brief Return true if the first pose chain is greater than or equal to the
  * second one
- * @sqlfn posechain_ge()
+ * @sqlfn ge()
  * @sqlop @p >=
  */
 Datum
@@ -770,7 +770,7 @@ PG_FUNCTION_INFO_V1(Posechain_gt);
 /**
  * @ingroup mobilitydb_posechain_base_comp
  * @brief Return true if the first pose chain is greater than the second one
- * @sqlfn posechain_gt()
+ * @sqlfn gt()
  * @sqlop @p >
  */
 Datum

--- a/mobilitydb/src/rgeo/trgeo.c
+++ b/mobilitydb/src/rgeo/trgeo.c
@@ -256,7 +256,7 @@ PG_FUNCTION_INFO_V1(Trgeometry_inst_constructor);
  * @ingroup mobilitydb_rgeo_constructor
  * @brief Construct a temporal rigid geometry instant from a geometry, a pose,
  * and a timestamptz
- * @sqlfn trgeometryInst()
+ * @sqlfn trgeometry()
  */
 Datum
 Trgeometry_inst_constructor(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/span.c
+++ b/mobilitydb/src/temporal/span.c
@@ -230,7 +230,7 @@ PG_FUNCTION_INFO_V1(Span_constructor);
 /**
  * @ingroup mobilitydb_setspan_constructor
  * @brief Return a span from the bounds
- * @sqlfn intspan(), floatspan(), ...
+ * @sqlfn span()
  */
 Datum
 Span_constructor(PG_FUNCTION_ARGS)
@@ -407,7 +407,7 @@ PG_FUNCTION_INFO_V1(Span_to_range);
 /**
  * @ingroup mobilitydb_setspan_conversion
  * @brief Convert a span into a range
- * @sqlfn int4range(), tstzrange()
+ * @sqlfn range()
  * @sqlop @p ::
  */
 Datum
@@ -461,7 +461,7 @@ PG_FUNCTION_INFO_V1(Range_to_span);
 /**
  * @ingroup mobilitydb_setspan_conversion
  * @brief Convert a PostgreSQL range into a span
- * @sqlfn intspan(), tstzspan()
+ * @sqlfn span()
  * @sqlop @p ::
  */
 Datum

--- a/mobilitydb/src/temporal/spanset.c
+++ b/mobilitydb/src/temporal/spanset.c
@@ -260,7 +260,7 @@ PG_FUNCTION_INFO_V1(Value_to_spanset);
 /**
  * @ingroup mobilitydb_setspan_conversion
  * @brief Convert a value into a span set
- * @sqlfn intspanset(), floatspanset(), ...
+ * @sqlfn spanset()
  */
 Datum
 Value_to_spanset(PG_FUNCTION_ARGS)
@@ -275,7 +275,7 @@ PG_FUNCTION_INFO_V1(Set_to_spanset);
 /**
  * @ingroup mobilitydb_setspan_conversion
  * @brief Convert a set into a span set
- * @sqlfn intspanset(), floatspanset(), ...
+ * @sqlfn spanset()
  */
 Datum
 Set_to_spanset(PG_FUNCTION_ARGS)
@@ -409,7 +409,7 @@ PG_FUNCTION_INFO_V1(Spanset_to_multirange);
 /**
  * @ingroup mobilitydb_setspan_conversion
  * @brief Convert a span set into a multirange
- * @sqlfn int4range(), tstzrange()
+ * @sqlfn multirange()
  * @sqlop @p ::
  */
 Datum
@@ -428,7 +428,7 @@ PG_FUNCTION_INFO_V1(Multirange_to_spanset);
 /**
  * @ingroup mobilitydb_setspan_conversion
  * @brief Convert a multirange into a span set
- * @sqlfn intspanset(), tstzspanset()
+ * @sqlfn spanset()
  * @sqlop @p ::
  */
 Datum
@@ -510,7 +510,7 @@ PG_FUNCTION_INFO_V1(Spanset_lower_inc);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return true if the lower bound of a span set is inclusive
- * @sqlfn lower_inc()
+ * @sqlfn lowerInc()
  */
 Datum
 Spanset_lower_inc(PG_FUNCTION_ARGS)
@@ -526,7 +526,7 @@ PG_FUNCTION_INFO_V1(Spanset_upper_inc);
 /**
  * @ingroup mobilitydb_setspan_accessor
  * @brief Return true if the upper bound of a span set is inclusive
- * @sqlfn lower_inc()
+ * @sqlfn upperInc()
  */
 Datum
 Spanset_upper_inc(PG_FUNCTION_ARGS)
@@ -908,7 +908,7 @@ PG_FUNCTION_INFO_V1(Numspanset_shift_scale);
  * @ingroup mobilitydb_setspan_transf
  * @brief Return a number span set shifted and scaled by two values
  * @note This function is also used for `datespanset`
- * @sqlfn shiftTscale()
+ * @sqlfn shiftScale()
  */
 Datum
 Numspanset_shift_scale(PG_FUNCTION_ARGS)
@@ -926,7 +926,7 @@ PG_FUNCTION_INFO_V1(Tstzspanset_shift_scale);
 /**
  * @ingroup mobilitydb_setspan_transf
  * @brief Return a timestamptz span set shifted and scaled by two intervals
- * @sqlfn shiftTscale()
+ * @sqlfn shiftScale()
  */
 Datum
 Tstzspanset_shift_scale(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/tbool_ops.c
+++ b/mobilitydb/src/temporal/tbool_ops.c
@@ -50,7 +50,7 @@ PG_FUNCTION_INFO_V1(Tand_bool_tbool);
 /**
  * @ingroup mobilitydb_temporal_bool
  * @brief Return the boolean and of a boolean and a temporal boolean
- * @sqlfn temporal_and()
+ * @sqlfn tAnd()
  * @sqlop @p &
  */
 Datum
@@ -68,7 +68,7 @@ PG_FUNCTION_INFO_V1(Tand_tbool_bool);
 /**
  * @ingroup mobilitydb_temporal_bool
  * @brief Return the boolean and of a temporal boolean and a boolean
- * @sqlfn temporal_and()
+ * @sqlfn tAnd()
  * @sqlop @p &
  */
 Datum
@@ -86,7 +86,7 @@ PG_FUNCTION_INFO_V1(Tand_tbool_tbool);
 /**
  * @ingroup mobilitydb_temporal_bool
  * @brief Return the boolean and of two temporal booleans
- * @sqlfn temporal_and()
+ * @sqlfn tAnd()
  * @sqlop @p &
  */
 Datum
@@ -111,7 +111,7 @@ PG_FUNCTION_INFO_V1(Tor_bool_tbool);
 /**
  * @ingroup mobilitydb_temporal_bool
  * @brief Return the boolean or of a boolean and the temporal boolean
- * @sqlfn temporal_or()
+ * @sqlfn tOr()
  * @sqlop @p |
  */
 Datum
@@ -129,7 +129,7 @@ PG_FUNCTION_INFO_V1(Tor_tbool_bool);
 /**
  * @ingroup mobilitydb_temporal_bool
  * @brief Return the boolean or of a temporal boolean and a boolean
- * @sqlfn temporal_or()
+ * @sqlfn tOr()
  * @sqlop @p |
  */
 Datum
@@ -147,7 +147,7 @@ PG_FUNCTION_INFO_V1(Tor_tbool_tbool);
 /**
  * @ingroup mobilitydb_temporal_bool
  * @brief Return the boolean or of two temporal booleans
- * @sqlfn temporal_or()
+ * @sqlfn tOr()
  * @sqlop @p |
  */
 Datum
@@ -172,7 +172,7 @@ PG_FUNCTION_INFO_V1(Tnot_tbool);
 /**
  * @ingroup mobilitydb_temporal_bool
  * @brief Return the boolean not of a temporal boolean
- * @sqlfn temporal_not()
+ * @sqlfn tNot()
  * @sqlop @p ~
  */
 Datum

--- a/mobilitydb/src/temporal/tbox.c
+++ b/mobilitydb/src/temporal/tbox.c
@@ -427,7 +427,7 @@ PG_FUNCTION_INFO_V1(Tbox_to_intspan);
 /**
  * @ingroup mobilitydb_box_conversion
  * @brief Convert a temporal box into an integer span
- * @sqlfn floatspan()
+ * @sqlfn intspan()
  */
 Datum
 Tbox_to_intspan(PG_FUNCTION_ARGS)
@@ -706,7 +706,7 @@ PG_FUNCTION_INFO_V1(Tbox_shift_scale_value);
  * @ingroup mobilitydb_box_transf
  * @brief Return a temporal box with the value span shifted and scaled by two
  * values
- * @sqlfn scaleValue()
+ * @sqlfn shiftScaleValue()
  */
 Datum
 Tbox_shift_scale_value(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/temporal.c
+++ b/mobilitydb/src/temporal/temporal.c
@@ -420,7 +420,7 @@ PG_FUNCTION_INFO_V1(Temporal_out);
 /**
  * @ingroup mobilitydb_temporal_inout
  * @brief Return the Well-Known Text (WKT) representation of a temporal value
- * @sqlfn tint_out(), tfloat_out(), ...
+ * @sqlfn temporal_out()
  */
 Datum
 Temporal_out(PG_FUNCTION_ARGS)
@@ -493,7 +493,7 @@ PG_FUNCTION_INFO_V1(Temporal_send);
 /**
  * @ingroup mobilitydb_temporal_inout
  * @brief Return the Well-Known Binary (WKB) representation of a temporal value
- * @sqlfn tint_send(), tfloat_send(), ...
+ * @sqlfn temporal_send()
  */
 Datum
 Temporal_send(PG_FUNCTION_ARGS)
@@ -712,7 +712,7 @@ PG_FUNCTION_INFO_V1(Temporal_from_text);
  * @note This just does the same thing as the SQL function #Temporal_in, except
  * it has to handle a 'text' input. First, unwrap the text into a cstring, then
  * do as Temporal_in
- * @sqlfn tboolFromText(), tintFromText(),
+ * @sqlfn tjsonbFromText()
  */
 Datum
 Temporal_from_text(PG_FUNCTION_ARGS)
@@ -1648,7 +1648,7 @@ PG_FUNCTION_INFO_V1(Temporalarr_round);
  * @ingroup mobilitydb_temporal_transf
  * @brief Return an array of temporal floats with the precision of the values
  * set to a number of decimal places
- * @sqlfn asText()
+ * @sqlfn round()
  */
 Datum
 Temporalarr_round(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/temporal_analytics.c
+++ b/mobilitydb/src/temporal/temporal_analytics.c
@@ -61,7 +61,7 @@ PG_FUNCTION_INFO_V1(Timestamptz_tprecision);
  * @ingroup mobilitydb_temporal_analytics_reduction
  * @brief Return the initial timestamptz of the bin in which a timestamptz
  * falls
- * @sqlfn tPrecision()
+ * @sqlfn tprecision()
  */
 Datum
 Timestamptz_tprecision(PG_FUNCTION_ARGS)
@@ -77,7 +77,7 @@ PG_FUNCTION_INFO_V1(Tstzset_tprecision);
 /**
  * @ingroup mobilitydb_temporal_analytics_reduction
  * @brief Return a tstzset with the precision set to time bins
- * @sqlfn tPrecision()
+ * @sqlfn tprecision()
  */
 Datum
 Tstzset_tprecision(PG_FUNCTION_ARGS)
@@ -93,7 +93,7 @@ PG_FUNCTION_INFO_V1(Tstzspan_tprecision);
 /**
  * @ingroup mobilitydb_temporal_analytics_reduction
  * @brief Return a tstzspan with the precision set to time bins
- * @sqlfn tPrecision()
+ * @sqlfn tprecision()
  */
 Datum
 Tstzspan_tprecision(PG_FUNCTION_ARGS)
@@ -109,7 +109,7 @@ PG_FUNCTION_INFO_V1(Tstzspanset_tprecision);
 /**
  * @ingroup mobilitydb_temporal_analytics_reduction
  * @brief Return a tstzspanset value with the precision set to time bins
- * @sqlfn tPrecision()
+ * @sqlfn tprecision()
  */
 Datum
 Tstzspanset_tprecision(PG_FUNCTION_ARGS)
@@ -131,7 +131,7 @@ PG_FUNCTION_INFO_V1(Temporal_tprecision);
 /**
  * @ingroup mobilitydb_temporal_analytics_reduction
  * @brief Return a temporal value with the precision set to time bins
- * @sqlfn tPrecision()
+ * @sqlfn tprecision()
  */
 Datum
 Temporal_tprecision(PG_FUNCTION_ARGS)
@@ -149,7 +149,7 @@ PG_FUNCTION_INFO_V1(Temporal_tsample);
 /**
  * @ingroup mobilitydb_temporal_analytics_reduction
  * @brief Return a temporal value sampled at time bins
- * @sqlfn tSample()
+ * @sqlfn tsample()
  */
 Datum
 Temporal_tsample(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/temporal_tile.c
+++ b/mobilitydb/src/temporal/temporal_tile.c
@@ -116,7 +116,7 @@ PG_FUNCTION_INFO_V1(Value_bin);
 /**
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return a span bin in a bin list for number spans
- * @sqlfn getValueBin()
+ * @sqlfn getBin()
  */
 Datum
 Value_bin(PG_FUNCTION_ARGS)
@@ -136,7 +136,7 @@ PG_FUNCTION_INFO_V1(Date_bin);
 /**
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return a span bin in a bin list for date spans
- * @sqlfn getTimeBin()
+ * @sqlfn getBin()
  */
 Datum
 Date_bin(PG_FUNCTION_ARGS)
@@ -157,7 +157,7 @@ PG_FUNCTION_INFO_V1(Timestamptz_bin);
 /**
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return a span bin in a bin list for timestamptz spans
- * @sqlfn getTimeBin()
+ * @sqlfn getBin()
  */
 Datum
 Timestamptz_bin(PG_FUNCTION_ARGS)
@@ -181,7 +181,7 @@ PG_FUNCTION_INFO_V1(Temporal_time_bins);
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return the value spans of a temporal number split with respect to
  * value bins
- * @sqlfn timeSpans()
+ * @sqlfn timeBins()
  */
 Datum
 Temporal_time_bins(PG_FUNCTION_ARGS)
@@ -205,7 +205,7 @@ PG_FUNCTION_INFO_V1(Tnumber_value_bins);
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return the value spans of a temporal number split with respect to
  * value bins
- * @sqlfn valueSpans()
+ * @sqlfn valueBins()
  */
 Datum
 Tnumber_value_bins(PG_FUNCTION_ARGS)
@@ -315,7 +315,7 @@ PG_FUNCTION_INFO_V1(Tbox_value_tiles);
 /**
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return the tile list of a temporal box
- * @sqlfn valueTimeTiles()
+ * @sqlfn valueTiles()
  */
 inline Datum
 Tbox_value_tiles(PG_FUNCTION_ARGS)
@@ -328,7 +328,7 @@ PG_FUNCTION_INFO_V1(Tbox_time_tiles);
 /**
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return the tile list of a temporal box
- * @sqlfn valueTimeTiles()
+ * @sqlfn timeTiles()
  */
 inline Datum
 Tbox_time_tiles(PG_FUNCTION_ARGS)
@@ -390,7 +390,7 @@ PG_FUNCTION_INFO_V1(Tbox_get_value_tile);
 /**
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return a tile in a multidimensional grid for temporal numbers
- * @sqlfn tile()
+ * @sqlfn getValueTile()
  */
 inline Datum
 Tbox_get_value_tile(PG_FUNCTION_ARGS)
@@ -403,7 +403,7 @@ PG_FUNCTION_INFO_V1(Tbox_get_time_tile);
 /**
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return a tile in a multidimensional grid for temporal numbers
- * @sqlfn tile()
+ * @sqlfn getTBoxTimeTile()
  */
 inline Datum
 Tbox_get_time_tile(PG_FUNCTION_ARGS)
@@ -416,7 +416,7 @@ PG_FUNCTION_INFO_V1(Tbox_get_value_time_tile);
 /**
  * @ingroup mobilitydb_temporal_analytics_tile
  * @brief Return a tile in a multidimensional grid for temporal numbers
- * @sqlfn tile()
+ * @sqlfn getValueTimeTile()
  */
 inline Datum
 Tbox_get_value_time_tile(PG_FUNCTION_ARGS)

--- a/tools/scripts/check_sqlfn_names.py
+++ b/tools/scripts/check_sqlfn_names.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: PostgreSQL
+#
+# BINDING-HEADER-PARSE-OK: CI source guard under tools/scripts/, in the
+# shape of check_csqlfn.py. It reads mobilitydb/src/**.c and
+# mobilitydb/sql/**.in.sql to compare a wrapper's @sqlfn tag with the SQL
+# function the extension creates for that wrapper; it extracts no API surface
+# and generates nothing.
+#
+"""Report an @sqlfn tag that names something the extension does not create.
+
+The @sqlfn tag is the only statement of a PG wrapper's SQL name.  The binding
+code generators read it to publish the function under the name MobilityDB
+publishes, so a tag naming something the extension never creates makes every
+generated binding publish a name no MobilityDB user can call, and the C
+sources document a dialect the extension does not speak.  Nothing else
+detects it: the tag is a comment, so the extension builds, installs and
+passes its tests while the tag says whatever it says.
+
+The oracle is mechanical and lives in the same tree.  Each CREATE FUNCTION
+names both the SQL function and the C symbol it binds:
+
+    CREATE FUNCTION contains(tcbuffer, tstzspan)
+      RETURNS boolean
+      AS 'MODULE_PATHNAME', 'Contains_tstzspan_temporal'
+
+so the SQL name of the wrapper `Contains_tstzspan_temporal` is `contains`,
+and its tag must say so.  A wrapper is checked only when the SQL binds it;
+one reached solely through an operator or an aggregate has no CREATE FUNCTION
+to answer for it and is left alone.
+
+Three shapes name the SQL correctly without repeating its spelling, and are
+accepted rather than reported:
+
+  AGGREGATE   The SQL name is a `_transfn` / `_combinefn` / `_finalfn`, an
+              internal of an aggregate no user calls.  The tag names the
+              aggregate itself (`tCount`), which is the name to document.
+
+  PER TYPE    The symbol serves a FAMILY of SQL functions, each carrying its
+              own type (`intspan_in`, `floatspan_in`, ... for one `Span_in`),
+              so there is no single name for the tag to state and the tag
+              names the family.  What such a tag should say is a question of
+              its own; this guard asks only the one with a mechanical answer,
+              and leaves a symbol bound to several names alone.
+
+  LAGGARD     The SQL name carries an underscore and the tag does not.  The
+              public SQL API is camelCase without underscores, so `cbuffer_same`
+              and `tbox_union` are names awaiting a rename and the tag already
+              says what they are to become.  Reported so the disagreement is
+              visible, never repaired here: stating the laggard in the tag
+              would walk the dialect backwards, and renaming the function is a
+              change to the public API, not to a comment.
+
+  BOUNDING    The five bounding-box topological tags below.  MobilityDB
+  BOX         exposes these through their operator and its bare alias, and
+              the `_bbox` suffix distinguishes the three families that share
+              a name (`contains`, `contains_bbox`, `contains_rid`) in the
+              tag namespace.  Kept deliberately, and classified as
+              backing-only by the catalog the generators read.
+
+Usage:
+  check_sqlfn_names.py            report every tag that names no SQL function
+  check_sqlfn_names.py --fix      rewrite each reported tag to the SQL name
+
+Exit status is non-zero when a tag names no SQL function (CI guard).
+"""
+
+import glob
+import os
+import re
+import sys
+
+ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# The bounding-box topological tags: a family of MobilityDB's own, exposed
+# through `@>`/`<@`/`&&`/`-|-`/`~=` and their bare aliases rather than under
+# the tag's spelling.  The catalog carries them as backing-only names.
+BBOX_TAGS = {'contains_bbox', 'contained_bbox', 'overlaps_bbox',
+             'adjacent_bbox', 'same_bbox'}
+
+# An aggregate's internals are CREATE FUNCTIONed under names no user calls;
+# the tag names the aggregate they serve.
+AGGREGATE_INTERNAL = re.compile(r'_(transfn|combinefn|finalfn)$')
+
+# The name and C symbol of one CREATE FUNCTION statement.  The statement ends
+# at its first semicolon: reading past it walks into the next statement and
+# credits this function with the next one's symbol.
+CREATE_FN = re.compile(r'CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([\w"]+)\s*\(',
+                       re.IGNORECASE)
+MODULE_SYM = re.compile(r"MODULE_PATHNAME'\s*,\s*'(\w+)'")
+
+# A tag names its functions with empty parentheses, and may name several.
+TAG_NAME = re.compile(r'([A-Za-z_]\w*)\s*\(\)')
+
+# The wrapper the doxygen block documents is the one PG_FUNCTION_INFO_V1
+# registers just above it.  Reading forward to the definition instead would
+# have to know every qualifier a definition carries (`inline Datum`), and a
+# missed qualifier silently pairs the block with the NEXT wrapper.
+WRAPPER = re.compile(r'PG_FUNCTION_INFO_V1\((\w+)\);\s*\n(/\*\*.*?\*/)', re.S)
+
+
+def read_text(path):
+    """Read a source file as UTF-8 text."""
+    with open(path, encoding='utf-8') as fp:
+        return fp.read()
+
+
+def sql_names():
+    """Map each C symbol to the SQL function names the extension creates for it."""
+    names = {}
+    for path in glob.glob(f'{ROOT}/mobilitydb/sql/**/*.in.sql', recursive=True):
+        src = read_text(path)
+        for mt in CREATE_FN.finditer(src):
+            end = src.find(';', mt.end())
+            sym = MODULE_SYM.search(src[mt.end():end if end > 0 else len(src)])
+            if sym:
+                names.setdefault(sym.group(1), set()).add(mt.group(1).strip('"'))
+    return names
+
+
+def wrappers():
+    """List of (symbol, tag text, path, span) for every wrapper carrying an @sqlfn.
+
+    The span locates the tag's names inside the file, so a repair edits the
+    block of the wrapper that is wrong.  A file states one tag many times —
+    `@sqlfn tDistance()` reads ten times in tcbuffer_distance.c, on four
+    wrappers that are wrong and five that are right — and a rewrite keyed on
+    the tag's TEXT would edit whichever comes first."""
+    rows = []
+    for path in glob.glob(f'{ROOT}/mobilitydb/src/**/*.c', recursive=True):
+        src = read_text(path)
+        for mt in WRAPPER.finditer(src):
+            tag = re.search(r'@sqlfn\s+(.+)', mt.group(2))
+            if tag:
+                at = mt.start(2) + tag.start(1)
+                rows.append((mt.group(1), tag.group(1).strip(), path,
+                             (at, at + len(tag.group(1)))))
+    return rows
+
+
+def accepted(tagged, declared):
+    """True if the tag names the SQL correctly without repeating its spelling."""
+    if tagged & BBOX_TAGS:
+        return True
+    return len(declared) > 1 or AGGREGATE_INTERNAL.search(next(iter(declared)))
+
+
+def report(fix):
+    """Report (and optionally repair) every tag naming no SQL function."""
+    declared_of = sql_names()
+    bad = []
+    for sym, tag, path, span in wrappers():
+        declared = declared_of.get(sym)
+        if not declared:
+            continue                    # reached through an operator or aggregate
+        tagged = set(TAG_NAME.findall(tag))
+        if tagged & declared or accepted(tagged, declared):
+            continue
+        bad.append((sym, tag, sorted(declared), path, span))
+
+    # A SQL name carrying an underscore the tag does not is the laggard side:
+    # the tag already holds the camelCase name the rename is heading for.
+    laggard = [r for r in bad if all('_' in n for n in r[2])
+               and not any('_' in t for t in TAG_NAME.findall(r[1]))]
+    stale = [r for r in bad if r not in laggard]
+
+    for sym, tag, declared, path, _s in sorted(stale, key=lambda r: (r[3], r[0])):
+        print('%s: %s\n    @sqlfn %s\n    SQL creates %s'
+              % (os.path.relpath(path, ROOT), sym, tag, ', '.join(declared)))
+    for sym, tag, declared, path, _s in sorted(laggard, key=lambda r: (r[3], r[0])):
+        print('%s: %s\n    @sqlfn %s\n    SQL creates %s  (the SQL name is the '
+              'laggard; the tag names what it is to become)'
+              % (os.path.relpath(path, ROOT), sym, tag, ', '.join(declared)))
+
+    if fix:
+        for path in {r[3] for r in stale}:
+            src = read_text(path)
+            # back to front, so an earlier edit does not move a later span
+            for _sym, _tag, declared, _p, (lo, hi) in sorted(
+                    (r for r in stale if r[3] == path), key=lambda r: -r[4][0]):
+                src = src[:lo] + '%s()' % declared[0] + src[hi:]
+            with open(path, 'w', encoding='utf-8') as fp:
+                fp.write(src)
+        print('\nrewrote %d tag(s) in %d file(s); left %d whose SQL name is the laggard'
+              % (len(stale), len({r[3] for r in stale}), len(laggard)))
+        return 0
+
+    if laggard:
+        print('\n%d SQL name(s) carry an underscore their tag does not; the rename is '
+              'theirs to make, so they do not fail this check.' % len(laggard))
+    if stale:
+        print('\n%d @sqlfn tag(s) name a function the extension does not create.'
+              % len(stale))
+        print('Run tools/scripts/check_sqlfn_names.py --fix to state the SQL name.')
+    return 1 if stale else 0
+
+
+if __name__ == '__main__':
+    sys.exit(report('--fix' in sys.argv[1:]))


### PR DESCRIPTION
The @sqlfn tag is the only statement of a PG wrapper's SQL name, and the binding code generators publish a function under the name it gives, so a tag naming something the extension never creates publishes a name no MobilityDB user can call while the C sources document a dialect the extension does not speak. A tag is a comment, so nothing in a build or a test run answers for it. Each tag names the function the SQL creates for its own wrapper: tAnd rather than temporal_and, shiftScale rather than shiftTscale, atElevation rather than atGeometry on Tgeo_at_elevation, upperInc rather than a second lower_inc, and in the point cloud box the name its template leaves unfilled. tools/scripts/check_sqlfn_names.py reads the CREATE FUNCTION statement that binds each wrapper and reports a tag naming none of the SQL names its symbol carries, as its own job of the Check code workflow, with --fix to state the SQL name. Four shapes answer for the SQL without repeating its spelling: a symbol serving a family of per-type functions, one whose SQL name is an aggregate internal, the five bounding-box topological tags MobilityDB exposes through their operator and its bare alias, and a SQL name carrying an underscore its tag does not, where the tag names the camelCase the rename is heading for and repairing it would walk the dialect backwards. The last is reported and left, since renaming the function changes the public API rather than a comment.