### PR TITLE
Measure the GiST penalty of a spatiotemporal box as the volume its insertion adds

### DIFF
--- a/mobilitydb/src/geo/tspatial_gist.c
+++ b/mobilitydb/src/geo/tspatial_gist.c
@@ -204,30 +204,6 @@ Tspatial_gist_compress(PG_FUNCTION_ARGS)
  *****************************************************************************/
 
 /**
- * @brief Calculate the union of two spatiotemporal boxes
- * @param[in] a,b Input boxes
- * @param[out] new Resulting box
- */
-static void
-stbox_union_gist(const STBox *a, const STBox *b, STBox *new)
-{
-  memset(new, 0, sizeof(STBox));
-  new->xmin = FLOAT8_MIN(a->xmin, b->xmin);
-  new->xmax = FLOAT8_MAX(a->xmax, b->xmax);
-  new->ymin = FLOAT8_MIN(a->ymin, b->ymin);
-  new->ymax = FLOAT8_MAX(a->ymax, b->ymax);
-  new->zmin = FLOAT8_MIN(a->zmin, b->zmin);
-  new->zmax = FLOAT8_MAX(a->zmax, b->zmax);
-  TimestampTz tmin = Min(DatumGetTimestampTz(a->period.lower),
-    DatumGetTimestampTz(b->period.lower));
-  TimestampTz tmax = Max(DatumGetTimestampTz(a->period.upper),
-    DatumGetTimestampTz(b->period.upper));
-  new->period.lower = TimestampTzGetDatum(tmin);
-  new->period.upper = TimestampTzGetDatum(tmax);
-  return;
-}
-
-/**
  * @brief Return the size of a spatiotemporal box for penalty calculation
  * @note The result can be +Infinity, but not NaN
  */
@@ -266,7 +242,7 @@ stbox_size(const STBox *box)
   {
     result_size *= (box->xmax - box->xmin) * (box->ymax - box->ymin);
     if (hasz)
-      result_size *= (box->xmax - box->xmin) * (box->ymax - box->ymin);
+      result_size *= (box->zmax - box->zmin);
   }
   if (hast)
     /* Expressed in seconds */
@@ -286,7 +262,8 @@ stbox_penalty(void *bbox1, void *bbox2)
   const STBox *original = (STBox *) bbox1;
   const STBox *new = (STBox *) bbox2;
   STBox unionbox;
-  stbox_union_gist(original, new, &unionbox);
+  memcpy(&unionbox, original, sizeof(STBox));
+  stbox_adjust(&unionbox, (void *) new);
   return stbox_size(&unionbox) - stbox_size(original);
 }
 


### PR DESCRIPTION
The penalty copies the original box, which carries the flags naming the dimensions it holds, and grows the copy through `stbox_adjust`, so the size of the union reads the same dimensions as the size of the original and their difference is the volume the insertion adds. `tpcbox_penalty` states this shape for the point cloud box. The Z extent of a box is the side between its zmin and its zmax.

A box built by zeroed memory names no dimension, so every union takes the size of a box with no extent, the penalty of an insertion into a node reads as a constant of that node, and `gistchoose` orders the candidate children by their own volume rather than by the growth each would take.

`stbox_gist_penalty` is the penalty support function of the tgeo, tpoint, tcbuffer, tpose, trgeo, th3index, tquadbin and stbox operator classes.

Measured on PostgreSQL 18.3 over `tbl_tgeompoint3d_big`, 20200 rows and 101 query boxes, with the insert build that the penalty serves: the index reads 6208 buffers over 193 pages, where a penalty whose union names no dimension reads 66693 over 249. Both readings answer 1607 rows under an index scan and under a sequential scan, so the difference is the clustering the index builds and not the rows it returns.