### PR TITLE
Read the value span of a temporal box through the base type it names

### DIFF
--- a/mobilitydb/src/temporal/tnumber_gist.c
+++ b/mobilitydb/src/temporal/tnumber_gist.c
@@ -213,37 +213,16 @@ Tnumber_gist_compress(PG_FUNCTION_ARGS)
  *****************************************************************************/
 
 /**
- * @brief Calculates the union of two temporal boxes
- * @param[in] a,b Input boxes
- * @param[out] new Resulting box
- * @note This function uses NaN-aware comparisons
- */
-static void
-tbox_union_rt(const TBox *a, const TBox *b, TBox *new)
-{
-  memset(new, 0, sizeof(TBox));
-  double xmin = FLOAT8_MIN(DatumGetFloat8(a->span.lower),
-    DatumGetFloat8(b->span.lower));
-  double xmax = FLOAT8_MAX(DatumGetFloat8(a->span.upper),
-    DatumGetFloat8(b->span.upper));
-  new->span.lower = Float8GetDatum(xmin);
-  new->span.upper = Float8GetDatum(xmax);
-  TimestampTz tmin = Min(DatumGetTimestampTz(a->period.lower),
-    DatumGetTimestampTz(b->period.lower));
-  TimestampTz tmax = Max(DatumGetTimestampTz(a->period.upper),
-    DatumGetTimestampTz(b->period.upper));
-  new->period.lower = TimestampTzGetDatum(tmin);
-  new->period.upper = TimestampTzGetDatum(tmax);
-  return;
-}
-
-/**
  * @brief Return the size of a temporal box for penalty-calculation purposes
  * @note The result can be +Infinity, but not NaN
  */
 static double
 tbox_size(const TBox *box)
 {
+  double result_size = 1;
+  bool hasx = MEOS_FLAGS_GET_X(box->flags),
+       hast = MEOS_FLAGS_GET_T(box->flags);
+
   /*
    * Check for zero-width cases.  Note that we define the size of a zero-
    * by-infinity box as zero.  It's important to special-case this somehow,
@@ -251,9 +230,9 @@ tbox_size(const TBox *box)
    *
    * The less-than cases should not happen, but if they do, say "zero".
    */
-  if (FLOAT8_LE(DatumGetFloat8(box->span.upper),
-        DatumGetFloat8(box->span.lower)) ||
-      datum_le(box->period.upper, box->period.lower, T_TIMESTAMPTZ))
+  if ((hasx && datum_le(box->span.upper, box->span.lower,
+        box->span.basetype)) ||
+      (hast && datum_le(box->period.upper, box->period.lower, T_TIMESTAMPTZ)))
     return 0.0;
 
   /*
@@ -261,11 +240,19 @@ tbox_size(const TBox *box)
    * and a non-NaN is infinite.  Note the previous check eliminated the
    * possibility that the low fields are NaNs.
    */
-  if (isnan(DatumGetFloat8(box->span.upper)))
+  if (hasx && box->span.basetype == T_FLOAT8 &&
+      isnan(DatumGetFloat8(box->span.upper)))
     return get_float8_infinity();
-  return (DatumGetFloat8(box->span.upper) - DatumGetFloat8(box->span.lower)) *
-    (DatumGetTimestampTz(box->period.upper) -
+
+  /* The value span of a tint box holds integers, so its width is read
+   * through the base type the span names */
+  if (hasx)
+    result_size *= distance_double(distance_value_value(box->span.lower,
+      box->span.upper, box->span.basetype), box->span.basetype);
+  if (hast)
+    result_size *= (double) (DatumGetTimestampTz(box->period.upper) -
       DatumGetTimestampTz(box->period.lower));
+  return result_size;
 }
 
 /**
@@ -279,7 +266,8 @@ tbox_penalty(void *bbox1, void *bbox2)
   const TBox *original = (TBox *) bbox1;
   const TBox *new = (TBox *) bbox2;
   TBox unionbox;
-  tbox_union_rt(original, new, &unionbox);
+  memcpy(&unionbox, original, sizeof(TBox));
+  tbox_adjust(&unionbox, (void *) new);
   return tbox_size(&unionbox) - tbox_size(original);
 }
 


### PR DESCRIPTION
The value span of a tint box holds integers, so its width is the distance between its bounds under the base type the span names, which is the reading `Span_gist_penalty` gives a span of any numeric type. Reading that span as a double takes the bit pattern of an integer Datum for a floating point value.

The penalty copies the original box, which carries the flags naming the dimensions it holds, and grows the copy through `tbox_adjust`, so the size of the union reads the same dimensions as the size of the original and their difference is the area the insertion adds. Each dimension enters the size only where the box holds it. `tpcbox_penalty` states this shape for the point cloud box.

Measured on PostgreSQL 18.3 over `tbl_tint_big`, 20000 rows and 50 query boxes, with the insert build that the penalty serves: the index reads 985 buffers over 135 pages, where a value span read as a double reads 17937 over 184. Both readings answer 135 rows under an index scan and under a sequential scan, so the difference is the clustering the index builds and not the rows it returns.