### PR TITLE
Add the temporal S2 cell type and the S2 cell set to SQL

### DIFF
--- a/meos/include/meos_s2cell.h
+++ b/meos/include/meos_s2cell.h
@@ -189,6 +189,71 @@ extern STBox *s2cell_tstzspan_to_stbox(S2CellId cell, const Span *s);
 extern Set *s2cell_edge_neighbors_set(S2CellId cell);
 extern Set *s2cell_cell_to_children_set(S2CellId cell, int children_level);
 
+/*****************************************************************************
+ * Temporal `ts2cell` inheritance
+ *****************************************************************************/
+
+/* Input and output */
+
+extern Temporal *ts2cell_in(const char *str);
+extern TInstant *ts2cellinst_in(const char *str);
+extern TSequence *ts2cellseq_in(const char *str, interpType interp);
+extern TSequenceSet *ts2cellseqset_in(const char *str);
+
+/* Constructors */
+
+extern Temporal *ts2cell_make(S2CellId value, TimestampTz t);
+extern TInstant *ts2cellinst_make(S2CellId value, TimestampTz t);
+extern TSequence *ts2cellseq_make(const S2CellId *values,
+  const TimestampTz *times, int count, bool lower_inc, bool upper_inc);
+extern TSequenceSet *ts2cellseqset_make(const TSequence **sequences,
+  int count);
+
+/* Accessors */
+
+extern S2CellId ts2cell_start_value(const Temporal *temp);
+extern S2CellId ts2cell_end_value(const Temporal *temp);
+extern bool ts2cell_value_n(const Temporal *temp, int n, S2CellId *result);
+extern S2CellId *ts2cell_values(const Temporal *temp, int *count);
+extern bool ts2cell_value_at_timestamptz(const Temporal *temp, TimestampTz t,
+  bool strict, S2CellId *result);
+
+/* Conversions */
+
+extern Temporal *tbigint_to_ts2cell(const Temporal *temp);
+extern Temporal *ts2cell_to_tbigint(const Temporal *temp);
+
+/* Ever, always and temporal comparisons */
+
+extern int ever_eq_s2cell_ts2cell(S2CellId cell, const Temporal *temp);
+extern int ever_eq_ts2cell_s2cell(const Temporal *temp, S2CellId cell);
+extern int ever_ne_s2cell_ts2cell(S2CellId cell, const Temporal *temp);
+extern int ever_ne_ts2cell_s2cell(const Temporal *temp, S2CellId cell);
+extern int always_eq_s2cell_ts2cell(S2CellId cell, const Temporal *temp);
+extern int always_eq_ts2cell_s2cell(const Temporal *temp, S2CellId cell);
+extern int always_ne_s2cell_ts2cell(S2CellId cell, const Temporal *temp);
+extern int always_ne_ts2cell_s2cell(const Temporal *temp, S2CellId cell);
+extern int ever_eq_ts2cell_ts2cell(const Temporal *temp1,
+  const Temporal *temp2);
+extern int ever_ne_ts2cell_ts2cell(const Temporal *temp1,
+  const Temporal *temp2);
+extern int always_eq_ts2cell_ts2cell(const Temporal *temp1,
+  const Temporal *temp2);
+extern int always_ne_ts2cell_ts2cell(const Temporal *temp1,
+  const Temporal *temp2);
+extern Temporal *teq_s2cell_ts2cell(S2CellId cell, const Temporal *temp);
+extern Temporal *teq_ts2cell_s2cell(const Temporal *temp, S2CellId cell);
+extern Temporal *teq_ts2cell_ts2cell(const Temporal *temp1,
+  const Temporal *temp2);
+extern Temporal *tne_s2cell_ts2cell(S2CellId cell, const Temporal *temp);
+extern Temporal *tne_ts2cell_s2cell(const Temporal *temp, S2CellId cell);
+extern Temporal *tne_ts2cell_ts2cell(const Temporal *temp1,
+  const Temporal *temp2);
+
+/* Token conversion, which no other DGGS carries */
+
+extern Temporal *ts2cell_cell_to_token(const Temporal *temp);
+
 /*****************************************************************************/
 
 #endif /* __MEOS_S2CELL_H__ */

--- a/meos/include/s2cell/ts2cell.h
+++ b/meos/include/s2cell/ts2cell.h
@@ -1,0 +1,92 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Internal declarations for the ts2cell type-inheritance boilerplate.
+ *
+ * The analogue of `meos/include/quadbin/tquadbin.h`. It carries the extern
+ * declarations for the helpers in `ts2cell.c` that do not belong in the public
+ * `meos_s2cell.h`. The validity macro `VALIDATE_TS2CELL(temp, ret)`, used in
+ * every lifted function and public accessor, lives in the public header
+ * alongside the other type-validation macros so bindings reach it directly.
+ *
+ * An S2 cell is defined on the sphere, so the temporal point bridge answers a
+ * `tgeogpoint`, where the Web-Mercator quadbin answers a `tgeompoint`.
+ */
+
+#ifndef __TS2CELL_H__
+#define __TS2CELL_H__
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include <meos.h>
+#include <meos_s2cell.h>
+#include "temporal/meos_catalog.h"
+#include "temporal/temporal.h"
+
+/*****************************************************************************
+ * Validators (bodies in ts2cell.c)
+ *****************************************************************************/
+
+/**
+ * @brief Ensure a (ts2cell, ts2cell) operand pair is safe to combine — both
+ * are the right temptype and are synchronisable.
+ */
+extern bool ensure_valid_ts2cell_ts2cell(const Temporal *temp1,
+  const Temporal *temp2);
+
+/**
+ * @brief Ensure a (ts2cell, s2cell) pair — the bare `S2CellId` is validated
+ * for encoding a cell, zero being the canonical invalid sentinel.
+ */
+extern bool ensure_valid_ts2cell_s2cell(const Temporal *temp, S2CellId cell);
+
+/**
+ * @brief Ensure a (ts2cell, tgeogpoint) pair — used by the geodetic point
+ * bridges.
+ */
+extern bool ensure_valid_ts2cell_tgeogpoint(const Temporal *temp1,
+  const Temporal *temp2);
+
+/*****************************************************************************
+ * Low-level Datum-returning comparison primitives, used by the ts2cell
+ * comparison-operator wrappers
+ *****************************************************************************/
+
+/**
+ * @brief Compare two S2 cell Datums for equality, the per-instant comparison
+ * the ever/always dispatchers apply. Delegates to bit equality at the int64
+ * level.
+ */
+extern Datum datum2_s2cell_eq(Datum d1, Datum d2, MeosType type);
+extern Datum datum2_s2cell_ne(Datum d1, Datum d2, MeosType type);
+
+#endif /* __TS2CELL_H__ */

--- a/meos/src/s2cell/CMakeLists.txt
+++ b/meos/src/s2cell/CMakeLists.txt
@@ -2,7 +2,9 @@ set(S2CELL_SOURCES
   s2cell.c
   s2cell_geo.c
   s2cellset.c
+  ts2cell.c
   ts2cell_boxops.c
+  ts2cell_compops.c
   ts2cell_ops.c
 )
 

--- a/meos/src/s2cell/ts2cell.c
+++ b/meos/src/s2cell/ts2cell.c
@@ -1,0 +1,461 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Type-inheritance boilerplate for `ts2cell`.
+ *
+ * The analogue of `meos/src/quadbin/tquadbin.c`. Every temporal type carries
+ * this layer to specialise the generic `Temporal` machinery for its own value
+ * type:
+ *
+ *   * argument validators for every supported operand pair,
+ *   * type-specific input parsers that delegate to the generic int-8 parser
+ *     but tag the result with `T_TS2CELL`,
+ *   * type-specific constructors (`ts2cell_make`, `ts2cellinst_make`,
+ *     `ts2cellseq_make`, `ts2cellseqset_make`),
+ *   * type-specific accessors (`ts2cell_start_value`, `ts2cell_end_value`,
+ *     `ts2cell_value_n`, `ts2cell_values`, `ts2cell_value_at_timestamptz`)
+ *     that hide the Datum-packing convention from callers,
+ *   * MEOS-level conversions to and from `tbigint` for callers that want the
+ *     bit-identical representation without a SQL round trip.
+ *
+ * S2 cells are geodetic, so the temporal point bridge uses `tgeogpoint`.
+ */
+
+#include "s2cell/ts2cell.h"
+
+/* C */
+#include <assert.h>
+#include <string.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_internal.h>
+#include <meos_s2cell.h>
+#include "temporal/temporal.h"
+#include "temporal/lifting.h"
+#include "temporal/meos_catalog.h"
+#include "temporal/type_parser.h"
+#include "temporal/type_util.h"
+#include "s2cell/s2cell.h"
+
+/*****************************************************************************
+ * Validators
+ *
+ * Every binary_synced / mixed-type MEOS function calls one of these before
+ * doing any real work; failure returns false and leaves an error on the
+ * thread-local stack, matching the TQUADBIN and TH3INDEX pattern.
+ *****************************************************************************/
+
+/**
+ * @brief Ensure that a (ts2cell, ts2cell) pair is valid — both are the right
+ * temptype and share a meaningful time axis
+ * @details The synchronisation check itself happens later in
+ * `tfunc_temporal_temporal`; only the null and temptype fences are here.
+ */
+bool
+ensure_valid_ts2cell_ts2cell(const Temporal *temp1, const Temporal *temp2)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp1, false); VALIDATE_TS2CELL(temp2, false);
+  return true;
+}
+
+/**
+ * @brief Ensure that a (ts2cell, S2CellId) pair is valid
+ * @details A value of 0 is the conventional invalid sentinel, what
+ * `s2cell_is_valid_cell(0)` answers false for. It is rejected up front so a
+ * caller cannot test a trajectory for "ever equal to the invalid sentinel"
+ * without noticing.
+ */
+bool
+ensure_valid_ts2cell_s2cell(const Temporal *temp, S2CellId cell)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp, false);
+  if (! s2cell_is_valid_cell(cell))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Value %" PRIu64 " does not encode a valid S2 cell", (uint64) cell);
+    return false;
+  }
+  return true;
+}
+
+/**
+ * @brief Ensure that a (ts2cell, tgeogpoint) pair is valid
+ */
+bool
+ensure_valid_ts2cell_tgeogpoint(const Temporal *temp1, const Temporal *temp2)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp1, false);
+  if (! ensure_not_null((void *) temp2) ||
+      ! ensure_temporal_isof_type((Temporal *) temp2, T_TGEOGPOINT))
+    return false;
+  return true;
+}
+
+/*****************************************************************************
+ * Input and output
+ *
+ * The on-disk representation of a ts2cell is identical to that of a tbigint —
+ * the only distinction is the MeosType tag. The type-specific parsers delegate
+ * to the generic temporal parser.
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_s2cell_inout
+ * @brief Return a temporal S2 cell from its Well-Known Text representation
+ * @csqlfn #Temporal_in()
+ */
+Temporal *
+ts2cell_in(const char *str)
+{
+  if (! ensure_not_null((void *) str))
+    return NULL;
+  return temporal_parse(&str, T_TS2CELL);
+}
+
+/**
+ * @ingroup meos_internal_s2cell_inout
+ * @brief Return a temporal S2 cell instant from its Well-Known Text
+ * representation
+ */
+TInstant *
+ts2cellinst_in(const char *str)
+{
+  Temporal *temp = ts2cell_in(str);
+  if (! temp)
+    return NULL;
+  assert(temp->subtype == TINSTANT);
+  return (TInstant *) temp;
+}
+
+/**
+ * @ingroup meos_internal_s2cell_inout
+ * @brief Return a temporal S2 cell sequence from its Well-Known Text
+ * representation
+ * @details A ts2cell sequence always carries step interpolation, S2 cells
+ * being discrete; the @p interp argument is accepted for signature parity with
+ * the generic API and discarded.
+ */
+TSequence *
+ts2cellseq_in(const char *str, interpType interp)
+{
+  (void) interp;
+  Temporal *temp = ts2cell_in(str);
+  if (! temp)
+    return NULL;
+  assert(temp->subtype == TSEQUENCE);
+  return (TSequence *) temp;
+}
+
+/**
+ * @ingroup meos_internal_s2cell_inout
+ * @brief Return a temporal S2 cell sequence set from its Well-Known Text
+ * representation
+ */
+TSequenceSet *
+ts2cellseqset_in(const char *str)
+{
+  Temporal *temp = ts2cell_in(str);
+  if (! temp)
+    return NULL;
+  assert(temp->subtype == TSEQUENCESET);
+  return (TSequenceSet *) temp;
+}
+
+/*****************************************************************************
+ * Constructors
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_s2cell_constructor
+ * @brief Return a temporal S2 cell instant from a cell and a timestamptz
+ * @param[in] value S2 cell value
+ * @param[in] t Timestamp
+ */
+TInstant *
+ts2cellinst_make(S2CellId value, TimestampTz t)
+{
+  return tinstant_make(S2CellGetDatum(value), T_TS2CELL, t);
+}
+
+/**
+ * @ingroup meos_s2cell_constructor
+ * @brief Return a temporal S2 cell sequence from arrays of cells and
+ * timestamps, with step interpolation, S2 cells being discrete
+ * @param[in] values Array of S2 cell values
+ * @param[in] times Array of timestamps, of the same length as @p values
+ * @param[in] count Number of elements in the arrays
+ * @param[in] lower_inc Lower bound inclusivity
+ * @param[in] upper_inc Upper bound inclusivity
+ */
+TSequence *
+ts2cellseq_make(const S2CellId *values, const TimestampTz *times, int count,
+  bool lower_inc, bool upper_inc)
+{
+  if (! ensure_not_null((void *) values) ||
+      ! ensure_not_null((void *) times) ||
+      ! ensure_positive(count))
+    return NULL;
+
+  TInstant **instants = palloc(sizeof(TInstant *) * count);
+  for (int i = 0; i < count; ++i)
+    instants[i] = tinstant_make(S2CellGetDatum(values[i]), T_TS2CELL, times[i]);
+  TSequence *result = tsequence_make(instants, count, lower_inc, upper_inc,
+    STEP, NORMALIZE);
+  for (int i = 0; i < count; ++i)
+    pfree(instants[i]);
+  pfree(instants);
+  return result;
+}
+
+/**
+ * @ingroup meos_s2cell_constructor
+ * @brief Return a temporal S2 cell sequence set from an array of sequences
+ * @param[in] sequences Array of sequences, with step interpolation
+ * @param[in] count Number of sequences
+ */
+TSequenceSet *
+ts2cellseqset_make(const TSequence **sequences, int count)
+{
+  return tsequenceset_make((TSequence **) sequences, count, NORMALIZE);
+}
+
+/**
+ * @ingroup meos_s2cell_constructor
+ * @brief Return the single-instant temporal S2 cell of a cell and a
+ * timestamptz
+ */
+Temporal *
+ts2cell_make(S2CellId value, TimestampTz t)
+{
+  return (Temporal *) ts2cellinst_make(value, t);
+}
+
+/*****************************************************************************
+ * Accessors
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_s2cell_accessor
+ * @brief Return the S2 cell at the first instant of a temporal S2 cell
+ * @csqlfn #Temporal_start_value()
+ */
+S2CellId
+ts2cell_start_value(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp, (S2CellId) 0);
+  return DatumGetS2Cell(temporal_start_value(temp));
+}
+
+/**
+ * @ingroup meos_s2cell_accessor
+ * @brief Return the S2 cell at the last instant of a temporal S2 cell
+ * @csqlfn #Temporal_end_value()
+ */
+S2CellId
+ts2cell_end_value(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp, (S2CellId) 0);
+  return DatumGetS2Cell(temporal_end_value(temp));
+}
+
+/**
+ * @ingroup meos_s2cell_accessor
+ * @brief Return the nth distinct S2 cell of a temporal S2 cell, counting
+ * from one
+ * @param[in] temp Temporal value
+ * @param[in] n Number
+ * @param[out] result Value
+ * @return True on success, false when @p n is out of range
+ * @csqlfn #Temporal_value_n()
+ */
+bool
+ts2cell_value_n(const Temporal *temp, int n, S2CellId *result)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp, false);
+  if (! ensure_not_null((void *) result))
+    return false;
+  Datum d;
+  if (! temporal_value_n(temp, n, &d))
+    return false;
+  *result = DatumGetS2Cell(d);
+  return true;
+}
+
+/**
+ * @ingroup meos_s2cell_accessor
+ * @brief Return the distinct S2 cells a temporal S2 cell takes, in ascending
+ * order
+ * @param[in] temp Temporal S2 cell
+ * @param[out] count Number of distinct values
+ * @return Allocated array of @p count cells, owned by the caller
+ * @csqlfn #Temporal_valueset()
+ */
+S2CellId *
+ts2cell_values(const Temporal *temp, int *count)
+{
+  /* The out parameter is defined even when a later check fails */
+  VALIDATE_NOT_NULL(count, NULL);
+  *count = 0;
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp, NULL);
+
+  Datum *datums = temporal_values(temp, count);
+  if (datums == NULL)
+    return NULL;
+  S2CellId *result = palloc(sizeof(S2CellId) * (*count));
+  for (int i = 0; i < *count; ++i)
+    result[i] = DatumGetS2Cell(datums[i]);
+  pfree(datums);
+  return result;
+}
+
+/**
+ * @ingroup meos_s2cell_accessor
+ * @brief Return the S2 cell of a temporal S2 cell at a timestamptz
+ * @param[in] temp Temporal S2 cell
+ * @param[in] t Timestamp
+ * @param[in] strict True to require an exact instant match, false to answer
+ * the value the containing sequence carries under step interpolation
+ * @param[out] result The cell at @p t, written only on success
+ * @return True on success, false when @p t lies outside @p temp
+ * @csqlfn #Temporal_value_at_timestamptz()
+ */
+bool
+ts2cell_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
+  S2CellId *result)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp, false);
+  if (! ensure_not_null((void *) result))
+    return false;
+  Datum d;
+  if (! temporal_value_at_timestamptz(temp, t, strict, &d))
+    return false;
+  *result = DatumGetS2Cell(d);
+  return true;
+}
+
+/*****************************************************************************
+ * MEOS-level conversions between ts2cell and tbigint
+ *
+ * The int64 payload is identical between the tbigint and s2cell base types,
+ * but the embedded bounding box differs: a tbigint sequence carries a TBox
+ * while a ts2cell sequence carries an STBox. The conversion therefore lifts an
+ * identity Datum function with the target restype, so that the instant,
+ * sequence and sequence set are rebuilt at the correct shape and the box is
+ * recomputed from the new base type.
+ *****************************************************************************/
+
+/**
+ * @brief Return its argument
+ */
+static Datum
+datum_s2cell_identity(Datum d)
+{
+  return d;
+}
+
+/**
+ * @ingroup meos_s2cell_conversion
+ * @brief Return a `tbigint` converted to a `ts2cell`, owned by the caller
+ * @csqlfn #Tbigint_to_ts2cell()
+ */
+Temporal *
+tbigint_to_ts2cell(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TBIGINT(temp, NULL);
+
+  LiftedFunctionInfo lfinfo;
+  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
+  lfinfo.func = (varfunc) datum_s2cell_identity;
+  lfinfo.numparam = 0;
+  lfinfo.argtype[0] = T_TBIGINT;
+  lfinfo.restype = T_TS2CELL;
+  return tfunc_temporal(temp, &lfinfo);
+}
+
+/**
+ * @ingroup meos_s2cell_conversion
+ * @brief Return a `ts2cell` converted to a `tbigint`, owned by the caller
+ * @csqlfn #Ts2cell_to_tbigint()
+ */
+Temporal *
+ts2cell_to_tbigint(const Temporal *temp)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_TS2CELL(temp, NULL);
+
+  LiftedFunctionInfo lfinfo;
+  memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
+  lfinfo.func = (varfunc) datum_s2cell_identity;
+  lfinfo.numparam = 0;
+  lfinfo.argtype[0] = T_TS2CELL;
+  lfinfo.restype = T_TBIGINT;
+  return tfunc_temporal(temp, &lfinfo);
+}
+
+/*****************************************************************************
+ * Comparison-primitive wrappers
+ *
+ * Equality and inequality for S2 cells are bit equality at the int64 level,
+ * which the `datum2_eq` / `datum2_ne` the generic tbigint machinery uses
+ * already covers. These are the thin type-correct symbols the compops
+ * dispatcher passes through.
+ *****************************************************************************/
+
+/**
+ * @brief Return true if two S2 cell Datums are equal
+ */
+Datum
+datum2_s2cell_eq(Datum d1, Datum d2, MeosType type)
+{
+  (void) type;
+  return BoolGetDatum(DatumGetS2Cell(d1) == DatumGetS2Cell(d2));
+}
+
+/**
+ * @brief Return true if two S2 cell Datums are different
+ */
+Datum
+datum2_s2cell_ne(Datum d1, Datum d2, MeosType type)
+{
+  (void) type;
+  return BoolGetDatum(DatumGetS2Cell(d1) != DatumGetS2Cell(d2));
+}
+
+/*****************************************************************************/

--- a/meos/src/s2cell/ts2cell_compops.c
+++ b/meos/src/s2cell/ts2cell_compops.c
@@ -1,0 +1,320 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Ever, always and temporal comparisons for the temporal S2 cell type.
+ *
+ * Equality of S2 cells is bit equality of the identifier, so every entry point
+ * here is a thin type-correct dispatcher over the generic comparison machinery,
+ * as the quadbin and h3index twins are. Each comparison stands in three forms:
+ * the ever form, true when it holds at some instant; the always form, true when
+ * it holds at every instant; and the temporal form, a tbool of the result at
+ * each instant.
+ */
+
+#include "s2cell/ts2cell.h"
+
+/* MEOS */
+#include <meos.h>
+#include <meos_internal.h>
+#include <meos_s2cell.h>
+#include "temporal/temporal.h"
+#include "temporal/temporal_compops.h"
+#include "temporal/type_util.h"
+#include "s2cell/s2cell.h"
+
+/*****************************************************************************
+ * Internal dispatchers
+ *****************************************************************************/
+
+/**
+ * @brief Return true if a temporal S2 cell and a bare S2 cell satisfy the
+ * ever or always comparison
+ * @param[in] temp Temporal S2 cell
+ * @param[in] cell Bare S2 cell
+ * @param[in] func Per-instant comparison primitive
+ * @param[in] ever True for ever semantics, false for always
+ */
+static int
+eacomp_ts2cell_s2cell(const Temporal *temp, S2CellId cell,
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
+{
+  /* Ensure the validity of the arguments */
+  assert(func);
+  if (! ensure_valid_ts2cell_s2cell(temp, cell))
+    return -1;
+  return eacomp_temporal_base(temp, S2CellGetDatum(cell), func, ever);
+}
+
+/**
+ * @brief Return true if two temporal S2 cells satisfy the ever or always
+ * comparison
+ */
+static int
+eacomp_ts2cell_ts2cell(const Temporal *temp1, const Temporal *temp2,
+  Datum (*func)(Datum, Datum, MeosType), bool ever)
+{
+  /* Ensure the validity of the arguments */
+  assert(func);
+  if (! ensure_valid_ts2cell_ts2cell(temp1, temp2))
+    return -1;
+  return eacomp_temporal_temporal(temp1, temp2, func, ever);
+}
+
+/*****************************************************************************
+ * Ever and always comparisons
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if a temporal S2 cell is ever equal to a bare S2 cell
+ * @csqlfn #Ever_eq_ts2cell_s2cell()
+ */
+int
+ever_eq_ts2cell_s2cell(const Temporal *temp, S2CellId cell)
+{
+  return eacomp_ts2cell_s2cell(temp, cell, &datum2_eq, true);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if a bare S2 cell is ever equal to a temporal S2 cell
+ * @csqlfn #Ever_eq_s2cell_ts2cell()
+ */
+int
+ever_eq_s2cell_ts2cell(S2CellId cell, const Temporal *temp)
+{
+  return eacomp_ts2cell_s2cell(temp, cell, &datum2_eq, true);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if a temporal S2 cell is always equal to a bare S2 cell
+ * @csqlfn #Always_eq_ts2cell_s2cell()
+ */
+int
+always_eq_ts2cell_s2cell(const Temporal *temp, S2CellId cell)
+{
+  return eacomp_ts2cell_s2cell(temp, cell, &datum2_eq, false);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if a bare S2 cell is always equal to a temporal S2 cell
+ * @csqlfn #Always_eq_s2cell_ts2cell()
+ */
+int
+always_eq_s2cell_ts2cell(S2CellId cell, const Temporal *temp)
+{
+  return eacomp_ts2cell_s2cell(temp, cell, &datum2_eq, false);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if two temporal S2 cells are ever equal to one another
+ * @csqlfn #Ever_eq_ts2cell_ts2cell()
+ */
+int
+ever_eq_ts2cell_ts2cell(const Temporal *temp1, const Temporal *temp2)
+{
+  return eacomp_ts2cell_ts2cell(temp1, temp2, &datum2_eq, true);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if two temporal S2 cells are always equal to one another
+ * @csqlfn #Always_eq_ts2cell_ts2cell()
+ */
+int
+always_eq_ts2cell_ts2cell(const Temporal *temp1, const Temporal *temp2)
+{
+  return eacomp_ts2cell_ts2cell(temp1, temp2, &datum2_eq, false);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if a temporal S2 cell is ever different from a bare S2 cell
+ * @csqlfn #Ever_ne_ts2cell_s2cell()
+ */
+int
+ever_ne_ts2cell_s2cell(const Temporal *temp, S2CellId cell)
+{
+  return eacomp_ts2cell_s2cell(temp, cell, &datum2_ne, true);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if a bare S2 cell is ever different from a temporal S2 cell
+ * @csqlfn #Ever_ne_s2cell_ts2cell()
+ */
+int
+ever_ne_s2cell_ts2cell(S2CellId cell, const Temporal *temp)
+{
+  return eacomp_ts2cell_s2cell(temp, cell, &datum2_ne, true);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if a temporal S2 cell is always different from a bare S2 cell
+ * @csqlfn #Always_ne_ts2cell_s2cell()
+ */
+int
+always_ne_ts2cell_s2cell(const Temporal *temp, S2CellId cell)
+{
+  return eacomp_ts2cell_s2cell(temp, cell, &datum2_ne, false);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if a bare S2 cell is always different from a temporal S2 cell
+ * @csqlfn #Always_ne_s2cell_ts2cell()
+ */
+int
+always_ne_s2cell_ts2cell(S2CellId cell, const Temporal *temp)
+{
+  return eacomp_ts2cell_s2cell(temp, cell, &datum2_ne, false);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if two temporal S2 cells are ever different from one another
+ * @csqlfn #Ever_ne_ts2cell_ts2cell()
+ */
+int
+ever_ne_ts2cell_ts2cell(const Temporal *temp1, const Temporal *temp2)
+{
+  return eacomp_ts2cell_ts2cell(temp1, temp2, &datum2_ne, true);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_ever
+ * @brief Return true if two temporal S2 cells are always different from one another
+ * @csqlfn #Always_ne_ts2cell_ts2cell()
+ */
+int
+always_ne_ts2cell_ts2cell(const Temporal *temp1, const Temporal *temp2)
+{
+  return eacomp_ts2cell_ts2cell(temp1, temp2, &datum2_ne, false);
+}
+
+/*****************************************************************************
+ * Temporal comparisons
+ *****************************************************************************/
+
+/**
+ * @brief Return the per-instant comparison of a temporal S2 cell against a
+ * bare S2 cell
+ * @details Equality and inequality are commutative, so the two argument orders
+ * share one implementation.
+ */
+static Temporal *
+tcomp_ts2cell_s2cell(const Temporal *temp, S2CellId cell,
+  Datum (*func)(Datum, Datum, MeosType))
+{
+  /* Ensure the validity of the arguments */
+  assert(func);
+  if (! ensure_valid_ts2cell_s2cell(temp, cell))
+    return NULL;
+  return tcomp_temporal_base(temp, S2CellGetDatum(cell), func);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_temp
+ * @brief Return the temporal equality of a temporal S2 cell and a bare S2 cell
+ * @csqlfn #Teq_ts2cell_s2cell()
+ */
+Temporal *
+teq_ts2cell_s2cell(const Temporal *temp, S2CellId cell)
+{
+  return tcomp_ts2cell_s2cell(temp, cell, &datum2_eq);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_temp
+ * @brief Return the temporal equality of a bare S2 cell and a temporal S2 cell
+ * @csqlfn #Teq_s2cell_ts2cell()
+ */
+Temporal *
+teq_s2cell_ts2cell(S2CellId cell, const Temporal *temp)
+{
+  return tcomp_ts2cell_s2cell(temp, cell, &datum2_eq);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_temp
+ * @brief Return the temporal equality of two temporal S2 cells across the time
+ * they share
+ * @csqlfn #Teq_ts2cell_ts2cell()
+ */
+Temporal *
+teq_ts2cell_ts2cell(const Temporal *temp1, const Temporal *temp2)
+{
+  if (! ensure_valid_ts2cell_ts2cell(temp1, temp2))
+    return NULL;
+  return tcomp_temporal_temporal(temp1, temp2, &datum2_eq);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_temp
+ * @brief Return the temporal inequality of a temporal S2 cell and a bare S2 cell
+ * @csqlfn #Tne_ts2cell_s2cell()
+ */
+Temporal *
+tne_ts2cell_s2cell(const Temporal *temp, S2CellId cell)
+{
+  return tcomp_ts2cell_s2cell(temp, cell, &datum2_ne);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_temp
+ * @brief Return the temporal inequality of a bare S2 cell and a temporal S2 cell
+ * @csqlfn #Tne_s2cell_ts2cell()
+ */
+Temporal *
+tne_s2cell_ts2cell(S2CellId cell, const Temporal *temp)
+{
+  return tcomp_ts2cell_s2cell(temp, cell, &datum2_ne);
+}
+
+/**
+ * @ingroup meos_s2cell_comp_temp
+ * @brief Return the temporal inequality of two temporal S2 cells across the time
+ * they share
+ * @csqlfn #Tne_ts2cell_ts2cell()
+ */
+Temporal *
+tne_ts2cell_ts2cell(const Temporal *temp1, const Temporal *temp2)
+{
+  if (! ensure_valid_ts2cell_ts2cell(temp1, temp2))
+    return NULL;
+  return tcomp_temporal_temporal(temp1, temp2, &datum2_ne);
+}
+
+/*****************************************************************************/

--- a/mobilitydb/sql/s2cell/601_s2cellset.in.sql
+++ b/mobilitydb/sql/s2cell/601_s2cellset.in.sql
@@ -1,0 +1,465 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief `s2cellset` SQL type — set of s2cell values, mirrors
+ * the bigintset structure over the s2cell base type.
+ *
+ * Every C call routes to a generic `Set_*` symbol. The dispatch
+ * arms in `type_in.c` / `type_out.c` (the basetype_in and
+ * basetype_out cases for T_S2CELL) make the generic Set parser
+ * and formatter read and write an element with s2cell_parse and
+ * s2cell_out.
+ */
+
+/******************************************************************************
+ * Type plumbing
+ ******************************************************************************/
+
+CREATE TYPE s2cellset;
+
+CREATE FUNCTION s2cellset_in(cstring)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Set_in'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2cellset_out(s2cellset)
+  RETURNS cstring
+  AS 'MODULE_PATHNAME', 'Set_out'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2cellset_recv(internal)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Set_recv'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2cellset_send(s2cellset)
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Set_send'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE TYPE s2cellset (
+  internallength = variable,
+  input = s2cellset_in,
+  output = s2cellset_out,
+  receive = s2cellset_recv,
+  send = s2cellset_send,
+  alignment = double,
+  storage = extended
+  -- , analyze = geoset_analyze
+);
+
+/******************************************************************************
+ * WKB / HexWKB helpers
+ ******************************************************************************/
+
+CREATE FUNCTION s2cellsetFromBinary(bytea)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Set_from_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2cellsetFromHexWKB(text)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Set_from_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asText(s2cellset)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Set_as_text'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asBinary(s2cellset, endianenconding text DEFAULT '')
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Set_as_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexWKB(s2cellset, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Constructors
+ ******************************************************************************/
+
+CREATE FUNCTION set(s2cell[])
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Set_constructor'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- Singleton constructor: `set(basetype)` is the cross-set convention
+-- (matches set(bigint), set(text), etc.).
+CREATE FUNCTION set(s2cell)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Value_to_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (s2cell AS s2cellset) WITH FUNCTION set(s2cell);
+
+/******************************************************************************
+ * Accessors
+ ******************************************************************************/
+
+CREATE FUNCTION memSize(s2cellset)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Set_mem_size'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION numValues(s2cellset)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Set_num_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startValue(s2cellset)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'Set_start_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endValue(s2cellset)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'Set_end_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION valueN(s2cellset, integer)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'Set_value_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION getValues(s2cellset)
+  RETURNS s2cell[]
+  AS 'MODULE_PATHNAME', 'Set_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Comparison operators + btree / hash opclasses
+ ******************************************************************************/
+
+CREATE FUNCTION eq(s2cellset, s2cellset)
+  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_eq'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ne(s2cellset, s2cellset)
+  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_ne'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION lt(s2cellset, s2cellset)
+  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_lt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION le(s2cellset, s2cellset)
+  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_le'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ge(s2cellset, s2cellset)
+  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_ge'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION gt(s2cellset, s2cellset)
+  RETURNS boolean AS 'MODULE_PATHNAME', 'Set_gt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION cmp(s2cellset, s2cellset)
+  RETURNS integer AS 'MODULE_PATHNAME', 'Set_cmp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION hash(s2cellset)
+  RETURNS integer AS 'MODULE_PATHNAME', 'Set_hash'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION hashExtended(s2cellset, bigint)
+  RETURNS bigint AS 'MODULE_PATHNAME', 'Set_hash_extended'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR = (LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  PROCEDURE = eq, COMMUTATOR = =, NEGATOR = <>,
+  RESTRICT = eqsel, JOIN = eqjoinsel, HASHES, MERGES);
+CREATE OPERATOR <> (LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  PROCEDURE = ne, COMMUTATOR = <>, NEGATOR = =,
+  RESTRICT = neqsel, JOIN = neqjoinsel);
+CREATE OPERATOR < (LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  PROCEDURE = lt, COMMUTATOR = >, NEGATOR = >=,
+  RESTRICT = span_sel, JOIN = span_joinsel);
+CREATE OPERATOR <= (LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  PROCEDURE = le, COMMUTATOR = >=, NEGATOR = >,
+  RESTRICT = span_sel, JOIN = span_joinsel);
+CREATE OPERATOR > (LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  PROCEDURE = gt, COMMUTATOR = <, NEGATOR = <=,
+  RESTRICT = span_sel, JOIN = span_joinsel);
+CREATE OPERATOR >= (LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  PROCEDURE = ge, COMMUTATOR = <=, NEGATOR = <,
+  RESTRICT = span_sel, JOIN = span_joinsel);
+
+CREATE OPERATOR CLASS s2cellset_btree_ops
+  DEFAULT FOR TYPE s2cellset USING btree AS
+    OPERATOR  1  <,
+    OPERATOR  2  <=,
+    OPERATOR  3  =,
+    OPERATOR  4  >=,
+    OPERATOR  5  >,
+    FUNCTION  1  cmp(s2cellset, s2cellset);
+
+CREATE OPERATOR CLASS s2cellset_hash_ops
+  DEFAULT FOR TYPE s2cellset USING hash AS
+    OPERATOR  1  =,
+    FUNCTION  1  hash(s2cellset),
+    FUNCTION  2  hashExtended(s2cellset, bigint);
+
+/******************************************************************************
+ * unnest — SETOF expansion
+ ******************************************************************************/
+
+CREATE FUNCTION unnest(s2cellset)
+  RETURNS SETOF s2cell
+  AS 'MODULE_PATHNAME', 'Set_unnest'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * setUnion aggregate
+ *
+ * Two aggregate overloads, matching the pattern every other *set
+ * ships with: one that aggregates scalars into a set
+ * (`setUnion(s2cell)`), one that aggregates sets into a set
+ * (`setUnion(s2cellset)`). Both share the same finalfn.
+ ******************************************************************************/
+
+-- The transition function is not STRICT
+CREATE FUNCTION set_union_transfn(internal, s2cell)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Value_union_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION set_union_transfn(internal, s2cellset)
+  RETURNS internal
+  AS 'MODULE_PATHNAME', 'Set_union_transfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION s2cellset_union_finalfn(internal)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Set_union_finalfn'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE AGGREGATE setUnion(s2cell) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+  FINALFUNC = s2cellset_union_finalfn,
+  PARALLEL = safe
+);
+
+CREATE AGGREGATE setUnion(s2cellset) (
+  SFUNC = set_union_transfn,
+  STYPE = internal,
+  COMBINEFUNC = array_agg_combine,
+  SERIALFUNC = array_agg_serialize,
+  DESERIALFUNC = array_agg_deserialize,
+  FINALFUNC = s2cellset_union_finalfn,
+  PARALLEL = safe
+);
+
+/******************************************************************************/
+
+/******************************************************************************
+ * Set-theoretic operators
+ *
+ * The value-dim ordering operators (`<<`, `&<`, `>>`, `&>`) that other
+ * `*set` types ship are intentionally NOT declared: S2 cell ids have
+ * no meaningful total order — the int64 comparison that the framework would
+ * use for "strictly-left" queries has no spatial or hierarchical meaning
+ * (same rationale as the bbox-operator pruning for `ts2cell`).
+ *
+ * All C implementations behind these operators (`Contains_set_*`,
+ * `Overlaps_set_set`, `Union_*`, `Minus_*`, `Intersection_*`) are
+ * type-generic — they dispatch on the operand's MeosType and route through
+ * `datum_cmp` / `datum_eq` from `type_util.c`, where `T_S2` is already
+ * wired.
+ ******************************************************************************/
+
+/******************************************************************************
+ * contains @>
+ ******************************************************************************/
+
+CREATE FUNCTION contains(s2cellset, s2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Contains_set_value'
+  SUPPORT span_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION contains(s2cellset, s2cellset)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Contains_set_set'
+  SUPPORT span_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR @> (
+  PROCEDURE = contains,
+  LEFTARG = s2cellset, RIGHTARG = s2cell,
+  COMMUTATOR = <@,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+CREATE OPERATOR @> (
+  PROCEDURE = contains,
+  LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  COMMUTATOR = <@,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+
+/******************************************************************************
+ * contained by <@
+ ******************************************************************************/
+
+CREATE FUNCTION contained(s2cell, s2cellset)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Contained_value_set'
+  SUPPORT span_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION contained(s2cellset, s2cellset)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Contained_set_set'
+  SUPPORT span_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR <@ (
+  PROCEDURE = contained,
+  LEFTARG = s2cell, RIGHTARG = s2cellset,
+  COMMUTATOR = @>,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+CREATE OPERATOR <@ (
+  PROCEDURE = contained,
+  LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  COMMUTATOR = @>,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+
+/******************************************************************************
+ * overlaps &&
+ ******************************************************************************/
+
+CREATE FUNCTION overlaps(s2cellset, s2cellset)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Overlaps_set_set'
+  SUPPORT span_supportfn
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR && (
+  PROCEDURE = overlaps,
+  LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  COMMUTATOR = &&,
+  RESTRICT = span_sel, JOIN = span_joinsel
+);
+
+/******************************************************************************
+ * Set union +
+ ******************************************************************************/
+
+CREATE FUNCTION setUnion(s2cell, s2cellset)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Union_value_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setUnion(s2cellset, s2cell)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Union_set_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setUnion(s2cellset, s2cellset)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Union_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR + (
+  PROCEDURE = setUnion,
+  LEFTARG = s2cell, RIGHTARG = s2cellset,
+  COMMUTATOR = +
+);
+CREATE OPERATOR + (
+  PROCEDURE = setUnion,
+  LEFTARG = s2cellset, RIGHTARG = s2cell,
+  COMMUTATOR = +
+);
+CREATE OPERATOR + (
+  PROCEDURE = setUnion,
+  LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  COMMUTATOR = +
+);
+
+/******************************************************************************
+ * Set difference -
+ ******************************************************************************/
+
+CREATE FUNCTION setMinus(s2cell, s2cellset)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Minus_value_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setMinus(s2cellset, s2cell)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Minus_set_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setMinus(s2cellset, s2cellset)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Minus_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR - (
+  PROCEDURE = setMinus,
+  LEFTARG = s2cell, RIGHTARG = s2cellset
+);
+CREATE OPERATOR - (
+  PROCEDURE = setMinus,
+  LEFTARG = s2cellset, RIGHTARG = s2cell
+);
+CREATE OPERATOR - (
+  PROCEDURE = setMinus,
+  LEFTARG = s2cellset, RIGHTARG = s2cellset
+);
+
+/******************************************************************************
+ * Set intersection *
+ ******************************************************************************/
+
+CREATE FUNCTION setIntersection(s2cell, s2cellset)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Intersection_value_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setIntersection(s2cellset, s2cell)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Intersection_set_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION setIntersection(s2cellset, s2cellset)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Intersection_set_set'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR * (
+  PROCEDURE = setIntersection,
+  LEFTARG = s2cell, RIGHTARG = s2cellset,
+  COMMUTATOR = *
+);
+CREATE OPERATOR * (
+  PROCEDURE = setIntersection,
+  LEFTARG = s2cellset, RIGHTARG = s2cell,
+  COMMUTATOR = *
+);
+CREATE OPERATOR * (
+  PROCEDURE = setIntersection,
+  LEFTARG = s2cellset, RIGHTARG = s2cellset,
+  COMMUTATOR = *
+);

--- a/mobilitydb/sql/s2cell/603_ts2cell.in.sql
+++ b/mobilitydb/sql/s2cell/603_ts2cell.in.sql
@@ -1,0 +1,685 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Type plumbing for `ts2cell`, a temporal type carrying Google
+ * S2 cell indices as a function of time.
+ *
+ * On-disk representation is the same Temporal structure used by
+ * every other temporal type; the basetype is the dedicated
+ * `s2cell`, not `int8`, and the catalog entry
+ * `{T_TS2CELL, T_S2CELL}` drives dispatch. ts2cell is classified
+ * as a geodetic `tspatial_type` — an S2 cell is a region of the
+ * WGS84 sphere, so the bounding box is a geodetic `stbox` (X/Y + T
+ * dimensions, GEODETIC flag set, SRID 4326), matching `tgeogpoint`
+ * where the Web-Mercator `tquadbin` carries a planar box.
+ *
+ * Casts to / from `tbigint` are ASSIGNMENT-only — the user must
+ * spell out the cast, mistakes surface as a clear binder error
+ * rather than silently reinterpreting an arbitrary int64
+ * trajectory as a stream of s2cell cells. The two types share the
+ * int64 payload but carry different bbox shapes, so the casts go
+ * through a real function — see below.
+ */
+
+-- GENERATED-IO-BEGIN s2cell — tools/codegen/inherited/generate.py from templates/comparisons.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.d/io_families.yaml and re-run.
+CREATE TYPE ts2cell;
+
+/******************************************************************************
+ * Input / Output
+ ******************************************************************************/
+
+CREATE FUNCTION ts2cell_in(cstring, oid, integer)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_in'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION ts2cell_recv(internal, oid, integer)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_recv'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION temporal_out(ts2cell)
+  RETURNS cstring
+  AS 'MODULE_PATHNAME', 'Temporal_out'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION temporal_send(ts2cell)
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Temporal_send'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE TYPE ts2cell (
+  internallength = variable,
+  input = ts2cell_in,
+  output = temporal_out,
+  send = temporal_send,
+  receive = ts2cell_recv,
+  typmod_in = temporal_typmod_in,
+  typmod_out = temporal_typmod_out,
+  storage = extended,
+  alignment = double,
+  analyze = tspatial_analyze
+);
+
+-- GENERATED-IO-END s2cell
+
+-- GENERATED-REPRESENTATIONS-BEGIN s2cell — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.d/representation_families.yaml and re-run.
+/******************************************************************************
+ * Text and (Hex)WKB I/O (mirrors the tcbuffer / tnpoint / tpose plug-in types)
+ ******************************************************************************/
+
+CREATE FUNCTION asText(ts2cell)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_text'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asBinary(ts2cell, endianenconding text DEFAULT '')
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexWKB(ts2cell, endianenconding text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asMFJSON(temp ts2cell, options integer DEFAULT 0,
+    flags integer DEFAULT 0, maxdecimaldigits integer DEFAULT 15)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION ts2cellFromBinary(bytea)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_from_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION ts2cellFromHexWKB(text)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_from_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION ts2cellFromMFJSON(text)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_from_mfjson'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END s2cell
+
+/******************************************************************************
+ * Typmod enforcer + self-cast (mirrors tbigint / tint / tfloat / ttext)
+ ******************************************************************************/
+
+CREATE FUNCTION ts2cell(ts2cell, integer)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_enforce_typmod'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (ts2cell AS ts2cell) WITH FUNCTION ts2cell(ts2cell, integer)
+  AS IMPLICIT;
+
+/******************************************************************************
+ * Conversions
+ *
+ * The int64 payload is shared, but ts2cell sequences carry a geodetic
+ * STBox bbox while tbigint sequences carry a TBox; a binary coercion
+ * would leave the wrong bbox shape in place and the wrong temptype byte
+ * inside the Temporal header. The cast therefore goes through a real
+ * function that lifts an identity Datum function so the result is
+ * rebuilt at the correct shape. The cast is declared `AS ASSIGNMENT`
+ * so the user must spell out `::ts2cell` or `::tbigint` — mistakes
+ * surface as a clear binder error rather than silently reinterpreting
+ * an arbitrary int64 trajectory as a stream of s2cell cells.
+ ******************************************************************************/
+
+CREATE FUNCTION ts2cell(tbigint)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Tbigint_to_ts2cell'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tbigint(ts2cell)
+  RETURNS tbigint
+  AS 'MODULE_PATHNAME', 'Ts2cell_to_tbigint'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE CAST (tbigint AS ts2cell) WITH FUNCTION ts2cell(tbigint) AS ASSIGNMENT;
+CREATE CAST (ts2cell AS tbigint) WITH FUNCTION tbigint(ts2cell) AS ASSIGNMENT;
+
+/******************************************************************************
+ * Constructors
+ *
+ * Inherited Temporal<T> surface wired to the generic constructor symbols
+ * (the value Datum carries the s2cell cell, dispatch is on the base oid).
+ * `ts2cell` has step interpolation only, so the from-span and array
+ * constructors take no interpolation argument / default to `'step'`, and a
+ * cell has no scalar-distance metric so `ts2cellSeqSetGaps` exposes only the
+ * time gap (the `tbigint` / `ttext` form, not the continuous `tcbuffer` one).
+ ******************************************************************************/
+
+CREATE FUNCTION ts2cell(s2cell, timestamptz)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Tinstant_constructor'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ts2cell(s2cell, tstzset)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Tsequence_from_base_tstzset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ts2cell(s2cell, tstzspan)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Tsequence_from_base_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ts2cell(s2cell, tstzspanset)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Tsequenceset_from_base_tstzspanset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- The inclusivity parameters are spelled `lowerInc` / `upperInc`, the
+-- spelling `022_temporal.in.sql` gives the base temporal type and the one
+-- `th3index` and `tquadbin` give the sibling cell indexes. The spatial
+-- families spell the same two parameters `lower_inc` / `upper_inc`, so a
+-- named-argument call does not carry across families; that split is a
+-- property of the published surface, not of this file.
+CREATE FUNCTION ts2cellSeq(ts2cell[], text DEFAULT 'step',
+    lowerInc boolean DEFAULT true, upperInc boolean DEFAULT true)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Tsequence_constructor'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ts2cellSeqSet(ts2cell[])
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Tsequenceset_constructor'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- The function is not strict
+CREATE FUNCTION ts2cellSeqSetGaps(ts2cell[], maxt interval DEFAULT NULL)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Tsequenceset_constructor_gaps'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+/******************************************************************************
+ * Transformations
+ ******************************************************************************/
+
+CREATE FUNCTION ts2cellInst(ts2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_as_tinstant'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- The function is not strict
+CREATE FUNCTION ts2cellSeq(ts2cell, text DEFAULT NULL)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequence'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+-- The function is not strict
+CREATE FUNCTION ts2cellSeqSet(ts2cell, text DEFAULT NULL)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_as_tsequenceset'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+CREATE FUNCTION setInterp(ts2cell, text)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_set_interp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION appendInstant(ts2cell, ts2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_append_tinstant'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION appendSequence(ts2cell, ts2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_append_tsequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- The function is not strict
+CREATE FUNCTION merge(ts2cell, ts2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_merge'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+CREATE FUNCTION merge(ts2cell[])
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_merge_array'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION shiftTime(ts2cell, interval)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_shift_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION scaleTime(ts2cell, interval)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_scale_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION shiftScaleTime(ts2cell, interval, interval)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_shift_scale_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tprecision(ts2cell, duration interval,
+  origin timestamptz DEFAULT '2000-01-03')
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_tprecision'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tsample(ts2cell, duration interval,
+  origin timestamptz DEFAULT '2000-01-03', interp text DEFAULT 'discrete')
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_tsample'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Accessor functions
+ *
+ * The lifted cell operations live in `355_ts2cell_spatialfuncs.in.sql`.
+ ******************************************************************************/
+
+-- GENERATED-ACCESSORS-BEGIN s2cell — tools/codegen/inherited/generate.py from templates/accessors.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.d/accessor_families.yaml and re-run.
+
+CREATE FUNCTION tempSubtype(ts2cell)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_subtype'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION tempBasetype(ts2cell)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_basetype_name'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION interp(ts2cell)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Temporal_interp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION memSize(ts2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_mem_size'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- value is a reserved word in SQL
+CREATE FUNCTION getValue(ts2cell)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'Tinstant_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timestamp is a reserved word in SQL
+CREATE FUNCTION getTimestamp(ts2cell)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Tinstant_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- values is a reserved word in SQL
+CREATE FUNCTION getValues(ts2cell)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'Temporal_valueset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- time is a reserved word in SQL
+CREATE FUNCTION getTime(ts2cell)
+  RETURNS tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_time'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- timeSpan is the bounding period, the tstzspan extent of the temporal value
+CREATE FUNCTION timeSpan(ts2cell)
+  RETURNS tstzspan
+  AS 'MODULE_PATHNAME', 'Temporal_to_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startValue(ts2cell)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'Temporal_start_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endValue(ts2cell)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'Temporal_end_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION valueN(ts2cell, int)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'Temporal_value_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION valueAtTimestamp(ts2cell, timestamptz)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'Temporal_value_at_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION duration(ts2cell, boundspan boolean DEFAULT FALSE)
+  RETURNS interval
+  AS 'MODULE_PATHNAME', 'Temporal_duration'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION lowerInc(ts2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_lower_inc'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION upperInc(ts2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_upper_inc'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION numInstants(ts2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_instants'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startInstant(ts2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_start_instant'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endInstant(ts2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_end_instant'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION instantN(ts2cell, integer)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_instant_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION instants(ts2cell)
+  RETURNS ts2cell[]
+  AS 'MODULE_PATHNAME', 'Temporal_instants'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION numTimestamps(ts2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_timestamps'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startTimestamp(ts2cell)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Temporal_start_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endTimestamp(ts2cell)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Temporal_end_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION timestampN(ts2cell, integer)
+  RETURNS timestamptz
+  AS 'MODULE_PATHNAME', 'Temporal_timestamptz_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION timestamps(ts2cell)
+  RETURNS timestamptz[]
+  AS 'MODULE_PATHNAME', 'Temporal_timestamps'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION numSequences(ts2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_num_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION startSequence(ts2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_start_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION endSequence(ts2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_end_sequence'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sequenceN(ts2cell, integer)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_sequence_n'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION sequences(ts2cell)
+  RETURNS ts2cell[]
+  AS 'MODULE_PATHNAME', 'Temporal_sequences'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION segments(ts2cell)
+  RETURNS ts2cell[]
+  AS 'MODULE_PATHNAME', 'Temporal_segments'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+-- GENERATED-ACCESSORS-END s2cell
+
+-- The tstzspan cast is backed by the generated timeSpan accessor.
+CREATE CAST (ts2cell AS tstzspan) WITH FUNCTION timeSpan(ts2cell);
+
+/******************************************************************************
+ * Unnest
+ ******************************************************************************/
+
+CREATE TYPE s2cell_tstzspanset AS (
+  value s2cell,
+  time tstzspanset
+);
+
+CREATE FUNCTION unnest(ts2cell)
+  RETURNS SETOF s2cell_tstzspanset
+  AS 'MODULE_PATHNAME', 'Temporal_unnest'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Restriction functions
+ ******************************************************************************/
+
+CREATE FUNCTION atValue(ts2cell, s2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_at_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusValue(ts2cell, s2cell)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_minus_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atValues(ts2cell, s2cellset)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_at_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusValues(ts2cell, s2cellset)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_minus_values'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION atTime(ts2cell, timestamptz)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_at_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusTime(ts2cell, timestamptz)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_minus_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atTime(ts2cell, tstzset)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_at_tstzset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusTime(ts2cell, tstzset)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_minus_tstzset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atTime(ts2cell, tstzspan)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_at_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusTime(ts2cell, tstzspan)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_minus_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION atTime(ts2cell, tstzspanset)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_at_tstzspanset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION minusTime(ts2cell, tstzspanset)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_minus_tstzspanset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION beforeTimestamp(ts2cell, timestamptz, strict boolean DEFAULT TRUE)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_before_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION afterTimestamp(ts2cell, timestamptz, strict boolean DEFAULT TRUE)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_after_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Modification functions
+ ******************************************************************************/
+
+CREATE FUNCTION insert(ts2cell, ts2cell, connect boolean DEFAULT TRUE)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_insert'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION update(ts2cell, ts2cell, connect boolean DEFAULT TRUE)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_update'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(ts2cell, timestamptz, connect boolean DEFAULT TRUE)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_delete_timestamptz'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(ts2cell, tstzset, connect boolean DEFAULT TRUE)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(ts2cell, tstzspan, connect boolean DEFAULT TRUE)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzspan'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION deleteTime(ts2cell, tstzspanset, connect boolean DEFAULT TRUE)
+  RETURNS ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_delete_tstzspanset'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE TYPE time_ts2cell AS (
+  time timestamptz,
+  temp ts2cell
+);
+
+CREATE FUNCTION timeSplit(ts2cell, bin_width interval,
+    origin timestamptz DEFAULT '2000-01-03')
+  RETURNS setof time_ts2cell
+  AS 'MODULE_PATHNAME', 'Temporal_time_split'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Comparison functions and B-tree / hash indexing
+ *
+ * All ts2cell values share the exact same on-disk layout as every
+ * other temporal type, so the generic Temporal_* dispatch in the
+ * backend is enough — no ts2cell-specific wrappers required.
+ ******************************************************************************/
+
+CREATE FUNCTION lt(ts2cell, ts2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_lt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION le(ts2cell, ts2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_le'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION eq(ts2cell, ts2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_eq'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ne(ts2cell, ts2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_ne'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION ge(ts2cell, ts2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_ge'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION gt(ts2cell, ts2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Temporal_gt'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION cmp(ts2cell, ts2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_cmp'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR < (
+  LEFTARG = ts2cell, RIGHTARG = ts2cell,
+  PROCEDURE = lt,
+  COMMUTATOR = >, NEGATOR = >=,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
+);
+CREATE OPERATOR <= (
+  LEFTARG = ts2cell, RIGHTARG = ts2cell,
+  PROCEDURE = le,
+  COMMUTATOR = >=, NEGATOR = >,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
+);
+CREATE OPERATOR = (
+  LEFTARG = ts2cell, RIGHTARG = ts2cell,
+  PROCEDURE = eq,
+  COMMUTATOR = =, NEGATOR = <>,
+  RESTRICT = eqsel, JOIN = eqjoinsel
+);
+CREATE OPERATOR <> (
+  LEFTARG = ts2cell, RIGHTARG = ts2cell,
+  PROCEDURE = ne,
+  COMMUTATOR = <>, NEGATOR = =,
+  RESTRICT = neqsel, JOIN = neqjoinsel
+);
+CREATE OPERATOR >= (
+  LEFTARG = ts2cell, RIGHTARG = ts2cell,
+  PROCEDURE = ge,
+  COMMUTATOR = <=, NEGATOR = <,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
+);
+CREATE OPERATOR > (
+  LEFTARG = ts2cell, RIGHTARG = ts2cell,
+  PROCEDURE = gt,
+  COMMUTATOR = <, NEGATOR = <=,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
+);
+
+CREATE OPERATOR CLASS ts2cell_btree_ops
+  DEFAULT FOR TYPE ts2cell USING btree AS
+    OPERATOR  1 <,
+    OPERATOR  2 <=,
+    OPERATOR  3 =,
+    OPERATOR  4 >=,
+    OPERATOR  5 >,
+    FUNCTION  1 cmp(ts2cell, ts2cell);
+
+/******************************************************************************/
+
+CREATE FUNCTION hash(ts2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Temporal_hash'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION hashExtended(ts2cell, bigint)
+  RETURNS bigint
+  AS 'MODULE_PATHNAME', 'Temporal_hash_extended'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE OPERATOR CLASS ts2cell_hash_ops
+  DEFAULT FOR TYPE ts2cell USING hash AS
+    OPERATOR    1   = ,
+    FUNCTION    1   hash(ts2cell),
+    FUNCTION    2   hashExtended(ts2cell, bigint);
+
+/******************************************************************************/

--- a/mobilitydb/sql/s2cell/CMakeLists.txt
+++ b/mobilitydb/sql/s2cell/CMakeLists.txt
@@ -1,5 +1,7 @@
 SET(LOCAL_FILES
   600_s2cell
+  601_s2cellset
+  603_ts2cell
   )
 
 foreach (f ${LOCAL_FILES})

--- a/mobilitydb/src/s2cell/CMakeLists.txt
+++ b/mobilitydb/src/s2cell/CMakeLists.txt
@@ -1,3 +1,6 @@
 add_library(pg_s2cell OBJECT
   s2cell.c
-)
+  ts2cell.c
+  # 601_s2cellset.in.sql routes to the generic Set_* symbols, so the
+  # set machinery needs no standalone C wrapper file.
+  )

--- a/mobilitydb/src/s2cell/ts2cell.c
+++ b/mobilitydb/src/s2cell/ts2cell.c
@@ -1,0 +1,84 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief PG V1 wrappers for the temporal `ts2cell` type.
+ *
+ * Every operation of the temporal type routes to a generic
+ * `Temporal_*` symbol; the two conversions below are the whole
+ * family-specific surface, because `ts2cell` and `tbigint` share the
+ * int64 payload while carrying different bounding boxes.
+ */
+
+/* PostgreSQL */
+#include <postgres.h>
+#include <fmgr.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_s2cell.h>
+#include "temporal/temporal.h"
+/* MobilityDB */
+#include "pg_temporal/temporal.h"
+
+PGDLLEXPORT Datum Tbigint_to_ts2cell(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Tbigint_to_ts2cell);
+/**
+ * @ingroup mobilitydb_s2cell_conversion
+ * @brief Convert a temporal big integer into a temporal S2 cell
+ * @sqlfn ts2cell()
+ * @sqlop @p ::
+ */
+Datum
+Tbigint_to_ts2cell(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Temporal *result = tbigint_to_ts2cell(temp);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+PGDLLEXPORT Datum Ts2cell_to_tbigint(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Ts2cell_to_tbigint);
+/**
+ * @ingroup mobilitydb_s2cell_conversion
+ * @brief Convert a temporal S2 cell into a temporal big integer
+ * @sqlfn tbigint()
+ * @sqlop @p ::
+ */
+Datum
+Ts2cell_to_tbigint(PG_FUNCTION_ARGS)
+{
+  Temporal *temp = PG_GETARG_TEMPORAL_P(0);
+  Temporal *result = ts2cell_to_tbigint(temp);
+  PG_FREE_IF_COPY(temp, 0);
+  PG_RETURN_TEMPORAL_P(result);
+}
+
+/*****************************************************************************/

--- a/mobilitydb/test/s2cell/expected/601_s2cellset.test.out
+++ b/mobilitydb/test/s2cell/expected/601_s2cellset.test.out
@@ -1,0 +1,118 @@
+SELECT s2cellset '{47c3c444c000000c, 47c3c444c0000004}';
+                s2cellset                 
+------------------------------------------
+ {"47c3c444c0000004", "47c3c444c000000c"}
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004, 47c3c444c0000004}';
+      s2cellset       
+----------------------
+ {"47c3c444c0000004"}
+(1 row)
+
+SELECT s2cell '47c3c444c0000008';
+ERROR:  s2cell value "47c3c444c0000008" does not encode a valid S2 cell
+LINE 1: SELECT s2cell '47c3c444c0000008';
+                      ^
+SELECT set(ARRAY[s2cell '47c3c444c000000c', s2cell '47c3c444c0000004']);
+                   set                    
+------------------------------------------
+ {"47c3c444c0000004", "47c3c444c000000c"}
+(1 row)
+
+SELECT numValues(s2cellset '{47c3c444c000000c, 47c3c444c0000004}');
+ numvalues 
+-----------
+         2
+(1 row)
+
+SELECT startValue(s2cellset '{47c3c444c000000c, 47c3c444c0000004}');
+    startvalue    
+------------------
+ 47c3c444c0000004
+(1 row)
+
+SELECT endValue(s2cellset '{47c3c444c000000c, 47c3c444c0000004}');
+     endvalue     
+------------------
+ 47c3c444c000000c
+(1 row)
+
+SELECT valueN(s2cellset '{47c3c444c000000c, 47c3c444c0000004}', 1);
+      valuen      
+------------------
+ 47c3c444c0000004
+(1 row)
+
+SELECT valueN(s2cellset '{47c3c444c000000c, 47c3c444c0000004}', 3);
+ valuen 
+--------
+ 
+(1 row)
+
+SELECT (s2cell '47c3c444c0000004')::s2cellset;
+      s2cellset       
+----------------------
+ {"47c3c444c0000004"}
+(1 row)
+
+SELECT s2cell '47c3c444c0000004' <@ s2cellset '{47c3c444c0000004, 47c3c444c000000c}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT s2cell '47c3c444c0000014' <@ s2cellset '{47c3c444c0000004, 47c3c444c000000c}';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004}' @> s2cell '47c3c444c0000004';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004}' + s2cellset '{47c3c444c000000c}';
+                 ?column?                 
+------------------------------------------
+ {"47c3c444c0000004", "47c3c444c000000c"}
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004, 47c3c444c000000c}' * s2cellset '{47c3c444c000000c}';
+       ?column?       
+----------------------
+ {"47c3c444c000000c"}
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004, 47c3c444c000000c}' - s2cellset '{47c3c444c000000c}';
+       ?column?       
+----------------------
+ {"47c3c444c0000004"}
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004}' && s2cellset '{47c3c444c0000004, 47c3c444c000000c}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004}' && s2cellset '{47c3c444c0000014}';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004}' = s2cellset '{47c3c444c0000004}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT s2cellset '{47c3c444c0000004}' < s2cellset '{47c3c444c000000c}';
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/s2cell/expected/603_ts2cell.test.out
+++ b/mobilitydb/test/s2cell/expected/603_ts2cell.test.out
@@ -1,0 +1,181 @@
+SELECT asText(ts2cell '47c3c3@2000-01-01');
+               astext                
+-------------------------------------
+ 47c3c3@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(ts2cell '{47c3c3@2000-01-01, 54b5c9@2000-01-02}');
+                                   astext                                   
+----------------------------------------------------------------------------
+ {47c3c3@Sat Jan 01 00:00:00 2000 PST, 54b5c9@Sun Jan 02 00:00:00 2000 PST}
+(1 row)
+
+SELECT asText(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+                                   astext                                   
+----------------------------------------------------------------------------
+ [47c3c3@Sat Jan 01 00:00:00 2000 PST, 54b5c9@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(ts2cell '{[47c3c3@2000-01-01, 54b5c9@2000-01-02],[47c3c3@2000-01-03]}');
+                                                       astext                                                        
+---------------------------------------------------------------------------------------------------------------------
+ {[47c3c3@Sat Jan 01 00:00:00 2000 PST, 54b5c9@Sun Jan 02 00:00:00 2000 PST], [47c3c3@Mon Jan 03 00:00:00 2000 PST]}
+(1 row)
+
+SELECT interp(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+ interp 
+--------
+ Step
+(1 row)
+
+SELECT interp(ts2cell '{47c3c3@2000-01-01, 54b5c9@2000-01-02}');
+  interp  
+----------
+ Discrete
+(1 row)
+
+SELECT asText(ts2cell 'Interp=Step;[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+                                   astext                                   
+----------------------------------------------------------------------------
+ [47c3c3@Sat Jan 01 00:00:00 2000 PST, 54b5c9@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(ts2cell(s2cell '47c3c3', timestamptz '2000-01-01'));
+               astext                
+-------------------------------------
+ 47c3c3@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(ts2cellInst(ts2cell '[47c3c3@2000-01-01]'));
+               astext                
+-------------------------------------
+ 47c3c3@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+SELECT asText(ts2cellSeq(ARRAY[ts2cell '47c3c3@2000-01-01', ts2cell '54b5c9@2000-01-02']));
+                                   astext                                   
+----------------------------------------------------------------------------
+ [47c3c3@Sat Jan 01 00:00:00 2000 PST, 54b5c9@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(ts2cell(s2cell '47c3c3', tstzspan '[2000-01-01, 2000-01-02]'));
+                                   astext                                   
+----------------------------------------------------------------------------
+ [47c3c3@Sat Jan 01 00:00:00 2000 PST, 47c3c3@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT tempSubtype(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+ tempsubtype 
+-------------
+ Sequence
+(1 row)
+
+SELECT tempBasetype(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+ tempbasetype 
+--------------
+ s2cell
+(1 row)
+
+SELECT startValue(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+ startvalue 
+------------
+ 47c3c3
+(1 row)
+
+SELECT endValue(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+ endvalue 
+----------
+ 54b5c9
+(1 row)
+
+SELECT getValues(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+      getvalues       
+----------------------
+ {"47c3c3", "54b5c9"}
+(1 row)
+
+SELECT numInstants(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+ numinstants 
+-------------
+           2
+(1 row)
+
+SELECT valueAtTimestamp(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]', '2000-01-01 12:00');
+ valueattimestamp 
+------------------
+ 47c3c3
+(1 row)
+
+SELECT duration(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+ duration 
+----------
+ 1 day
+(1 row)
+
+SELECT asText(atValue(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]', s2cell '47c3c3'));
+                                    astext                                    
+------------------------------------------------------------------------------
+ {[47c3c3@Sat Jan 01 00:00:00 2000 PST, 47c3c3@Sun Jan 02 00:00:00 2000 PST)}
+(1 row)
+
+SELECT asText(minusValue(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]', s2cell '47c3c3'));
+                 astext                  
+-----------------------------------------
+ {[54b5c9@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atTime(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]', tstzspan '[2000-01-01, 2000-01-01 12:00]'));
+                                   astext                                   
+----------------------------------------------------------------------------
+ [47c3c3@Sat Jan 01 00:00:00 2000 PST, 47c3c3@Sat Jan 01 12:00:00 2000 PST]
+(1 row)
+
+SELECT asText(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]'::tbigint);
+                                                astext                                                
+------------------------------------------------------------------------------------------------------
+ [5171191201918877696@Sat Jan 01 00:00:00 2000 PST, 6104005871807758336@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT asText(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]'::tbigint::ts2cell);
+                                   astext                                   
+----------------------------------------------------------------------------
+ [47c3c3@Sat Jan 01 00:00:00 2000 PST, 54b5c9@Sun Jan 02 00:00:00 2000 PST]
+(1 row)
+
+SELECT ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]'::tbigint::ts2cell
+  = ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ts2cell '[47c3c3@2000-01-01]' = ts2cell '[47c3c3@2000-01-01]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ts2cell '[47c3c3@2000-01-01]' <> ts2cell '[54b5c9@2000-01-01]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cmp(ts2cell '[47c3c3@2000-01-01]', ts2cell '[47c3c3@2000-01-01]');
+ cmp 
+-----
+   0
+(1 row)
+
+SELECT s2cell '47c3c3' < s2cell '54b5c9';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cmp(ts2cell '[47c3c3@2000-01-01]', ts2cell '[54b5c9@2000-01-01]');
+ cmp 
+-----
+   1
+(1 row)
+

--- a/mobilitydb/test/s2cell/queries/601_s2cellset.test.sql
+++ b/mobilitydb/test/s2cell/queries/601_s2cellset.test.sql
@@ -1,0 +1,81 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Static s2cellset SQL type: parser, output, constructor, accessors, the cast
+-- from a single cell, set operations, and the btree opclass.
+--
+-- Every cell here is at level 29, whose level bit sits at position 2, so the
+-- literals end in 4, c and 14. A token ending in 8 sets bit 3, which is odd
+-- and encodes no level, and the type rejects it.
+
+-------------------------------------------------------------------------------
+-- Input and output
+--
+-- A set prints its elements in ascending identifier order, which is Hilbert
+-- order, and duplicates collapse.
+-------------------------------------------------------------------------------
+
+SELECT s2cellset '{47c3c444c000000c, 47c3c444c0000004}';
+SELECT s2cellset '{47c3c444c0000004, 47c3c444c0000004}';
+SELECT s2cell '47c3c444c0000008';
+
+-------------------------------------------------------------------------------
+-- Constructor and accessors
+-------------------------------------------------------------------------------
+
+SELECT set(ARRAY[s2cell '47c3c444c000000c', s2cell '47c3c444c0000004']);
+SELECT numValues(s2cellset '{47c3c444c000000c, 47c3c444c0000004}');
+SELECT startValue(s2cellset '{47c3c444c000000c, 47c3c444c0000004}');
+SELECT endValue(s2cellset '{47c3c444c000000c, 47c3c444c0000004}');
+SELECT valueN(s2cellset '{47c3c444c000000c, 47c3c444c0000004}', 1);
+SELECT valueN(s2cellset '{47c3c444c000000c, 47c3c444c0000004}', 3);
+
+-------------------------------------------------------------------------------
+-- The cast from a single cell, and set membership
+-------------------------------------------------------------------------------
+
+SELECT (s2cell '47c3c444c0000004')::s2cellset;
+SELECT s2cell '47c3c444c0000004' <@ s2cellset '{47c3c444c0000004, 47c3c444c000000c}';
+SELECT s2cell '47c3c444c0000014' <@ s2cellset '{47c3c444c0000004, 47c3c444c000000c}';
+SELECT s2cellset '{47c3c444c0000004}' @> s2cell '47c3c444c0000004';
+
+-------------------------------------------------------------------------------
+-- Set operations
+-------------------------------------------------------------------------------
+
+SELECT s2cellset '{47c3c444c0000004}' + s2cellset '{47c3c444c000000c}';
+SELECT s2cellset '{47c3c444c0000004, 47c3c444c000000c}' * s2cellset '{47c3c444c000000c}';
+SELECT s2cellset '{47c3c444c0000004, 47c3c444c000000c}' - s2cellset '{47c3c444c000000c}';
+SELECT s2cellset '{47c3c444c0000004}' && s2cellset '{47c3c444c0000004, 47c3c444c000000c}';
+SELECT s2cellset '{47c3c444c0000004}' && s2cellset '{47c3c444c0000014}';
+
+-------------------------------------------------------------------------------
+-- Comparison, which the btree operator class carries
+-------------------------------------------------------------------------------
+
+SELECT s2cellset '{47c3c444c0000004}' = s2cellset '{47c3c444c0000004}';
+SELECT s2cellset '{47c3c444c0000004}' < s2cellset '{47c3c444c000000c}';
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/s2cell/queries/603_ts2cell.test.sql
+++ b/mobilitydb/test/s2cell/queries/603_ts2cell.test.sql
@@ -1,0 +1,113 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- The temporal S2 cell index type: input and output, the constructors, the
+-- accessors, the restrictions, the conversions to and from tbigint, and the
+-- bounding box.
+--
+-- A cell literal here is a token the type accepts; `47c3c3` is the level-10
+-- cell over Brussels and `54b5c9` a level-10 cell over San Francisco, so the
+-- two lie on different cube faces and a value spanning them spans the globe.
+
+-------------------------------------------------------------------------------
+-- Input and output
+-------------------------------------------------------------------------------
+
+SELECT asText(ts2cell '47c3c3@2000-01-01');
+SELECT asText(ts2cell '{47c3c3@2000-01-01, 54b5c9@2000-01-02}');
+SELECT asText(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+SELECT asText(ts2cell '{[47c3c3@2000-01-01, 54b5c9@2000-01-02],[47c3c3@2000-01-03]}');
+
+-------------------------------------------------------------------------------
+-- Interpolation
+--
+-- A cell index is discrete, so a sequence is step interpolated and asking for
+-- a linear one is refused.
+-------------------------------------------------------------------------------
+
+SELECT interp(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+SELECT interp(ts2cell '{47c3c3@2000-01-01, 54b5c9@2000-01-02}');
+SELECT asText(ts2cell 'Interp=Step;[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+
+-------------------------------------------------------------------------------
+-- Constructors
+-------------------------------------------------------------------------------
+
+SELECT asText(ts2cell(s2cell '47c3c3', timestamptz '2000-01-01'));
+SELECT asText(ts2cellInst(ts2cell '[47c3c3@2000-01-01]'));
+SELECT asText(ts2cellSeq(ARRAY[ts2cell '47c3c3@2000-01-01', ts2cell '54b5c9@2000-01-02']));
+SELECT asText(ts2cell(s2cell '47c3c3', tstzspan '[2000-01-01, 2000-01-02]'));
+
+-------------------------------------------------------------------------------
+-- Accessors
+-------------------------------------------------------------------------------
+
+SELECT tempSubtype(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+SELECT tempBasetype(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+SELECT startValue(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+SELECT endValue(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+SELECT getValues(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+SELECT numInstants(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+SELECT valueAtTimestamp(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]', '2000-01-01 12:00');
+SELECT duration(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]');
+
+-------------------------------------------------------------------------------
+-- Restrictions
+-------------------------------------------------------------------------------
+
+SELECT asText(atValue(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]', s2cell '47c3c3'));
+SELECT asText(minusValue(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]', s2cell '47c3c3'));
+SELECT asText(atTime(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]', tstzspan '[2000-01-01, 2000-01-01 12:00]'));
+
+-------------------------------------------------------------------------------
+-- Conversions
+--
+-- The int64 payload survives the round trip through tbigint, and the cast is
+-- ASSIGNMENT so it must be spelled out.
+-------------------------------------------------------------------------------
+
+SELECT asText(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]'::tbigint);
+SELECT asText(ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]'::tbigint::ts2cell);
+SELECT ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]'::tbigint::ts2cell
+  = ts2cell '[47c3c3@2000-01-01, 54b5c9@2000-01-02]';
+
+-------------------------------------------------------------------------------
+-- Comparisons
+--
+-- A ts2cell is a spatiotemporal type, so `temporal_cmp` reads the bounding
+-- box before the cell identifier and only falls through to the identifier
+-- where the boxes are equal. Two cells on different cube faces are therefore
+-- ordered by their extents, which need not agree with the order the static
+-- s2cell comparison gives them, and the tquadbin sibling behaves the same
+-- way.
+-------------------------------------------------------------------------------
+
+SELECT ts2cell '[47c3c3@2000-01-01]' = ts2cell '[47c3c3@2000-01-01]';
+SELECT ts2cell '[47c3c3@2000-01-01]' <> ts2cell '[54b5c9@2000-01-01]';
+SELECT cmp(ts2cell '[47c3c3@2000-01-01]', ts2cell '[47c3c3@2000-01-01]');
+SELECT s2cell '47c3c3' < s2cell '54b5c9';
+SELECT cmp(ts2cell '[47c3c3@2000-01-01]', ts2cell '[54b5c9@2000-01-01]');
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -688,7 +688,7 @@ its last edit:
   reads a patch as the `MULTIPOINT` of the positions its points occupy, and
   `tpcpatch_to_tgeometry` lifts that over time — so the manifest line rests on a
   MEOS entry rather than on a cast chain that already existed.
-- `distance_families`, **10/15** of the value-domain types: `posechainset`,
+- `distance_families`, **10/16** of the value-domain types: `posechainset`,
   `h3indexset`, `quadbinset`, `s2cellset`, `pcpointset`, `pcpatchset`. `posechainset` is
   deliberate and `setfamilies.yaml` says so in place — a pose chain has no
   distance function, so the set deploys none.
@@ -906,7 +906,7 @@ column names the `manifest.d/` key) · ✗ HAND = hand-maintained.
 | BBox Ops · Topological (:1014) | ✓ GEN | ✓ GEN | ✓ GEN | `manifest.d/topop_families.yaml` · `span_families` (005/009) |
 | BBox Ops · Position (:1082) | ✓ GEN (ordered sets only) | ✓ GEN | ✓ GEN | `manifest.d/posop_families.yaml` · `span_families` (005/009) |
 | BBox Ops · Splitting (:1162) | ✓ GEN (`spans`/`splitNSpans`/`splitEachNSpans` live in `003_span.in.sql`) | ✓ GEN | ✓ GEN | `span_families` (003/007 entries) |
-| Distance (:1219) | ✓ GEN (metric sets only) — `--gaps` 10/13, missing `posechainset`, `h3indexset`, `quadbinset`; the denominator is `numset` ∪ `timeset` ∪ `spatialset`, and the spatial families answer through the `SpatialSet<T>` override of §9.1b | ✓ GEN | ✓ GEN | `manifest.d/distance_families.yaml` · `span_families` (005/009) |
+| Distance (:1219) | ✓ GEN (metric sets only) — `--gaps` 10/16, missing `posechainset`, `h3indexset`, `quadbinset`, `s2cellset`, `pcpointset`, `pcpatchset`; the denominator is `numset` ∪ `timeset` ∪ `spatialset`, and the spatial families answer through the `SpatialSet<T>` override of §9.1b | ✓ GEN | ✓ GEN | `manifest.d/distance_families.yaml` · `span_families` (005/009) |
 | Comparisons (:1248) | ✓ GEN | ✓ GEN | ✓ GEN | `manifest.d/comparison_families.yaml` (`set` family entries) + `manifest.d/hash_families.yaml` · `span_families` (003/007) |
 | Aggregations (:1306) | ✓ GEN — the `extent` aggregates over sets in `015_span_aggfuncs.in.sql`, `setUnion` in `001_set.in.sql`, and the per-family `setUnion` regions | ✓ GEN | ✓ GEN | `span_families` (015 entry + `set_aggregations` + the per-family `*set_setunion` entries) |
 | Indexing (:1389) | ✓ GEN (span-basetype sets only, §9.2) | ✓ GEN | ✓ GEN | `span_families` (011/012/013 entries) |

--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -5,7 +5,7 @@
 # land unnoticed. The list is a ratchet: it may only shrink. Bring a file
 # under the manifest, then delete its line here.
 #
-# 97 of 206 files remain.
+# 99 of 208 files remain.
 
 mobilitydb/sql/cbuffer/204_tcbuffer_compops.in.sql
 mobilitydb/sql/cbuffer/205_tcbuffer_spatialfuncs.in.sql
@@ -90,6 +90,8 @@ mobilitydb/sql/rgeo/170_trgeo_spatialrels.in.sql
 mobilitydb/sql/rgeo/175_trgeo_geom_clip.in.sql
 mobilitydb/sql/rgeo/176_trgeo_vclip.in.sql
 mobilitydb/sql/s2cell/600_s2cell.in.sql
+mobilitydb/sql/s2cell/601_s2cellset.in.sql
+mobilitydb/sql/s2cell/603_ts2cell.in.sql
 mobilitydb/sql/temporal/019_geo_constructors.in.sql
 mobilitydb/sql/temporal/021_tbox.in.sql
 mobilitydb/sql/temporal/028_tbool_boolops.in.sql

--- a/tools/codegen/inherited/manifest.d/setfamilies.yaml
+++ b/tools/codegen/inherited/manifest.d/setfamilies.yaml
@@ -46,6 +46,7 @@ setfamilies:
   - {set: jsonbset,   base: jsonb,       ordered: false,                         metric: false, spatial: false}
   - {set: h3indexset, base: h3index,     ordered: false,                         metric: false, spatial: true}
   - {set: quadbinset, base: quadbin,     ordered: false,                         metric: false, spatial: true}
+  - {set: s2cellset,  base: s2cell,      ordered: false,                         metric: false, spatial: true}
   # pointcloud sets ARE spatialset_type() — their elements carry an SRID — and
   # carry no bounding box, which is what this column states: the dimensions of
   # a pcpoint need the schema XML keyed by pcid, which MEOS cannot read.


### PR DESCRIPTION
The generic Temporal machinery reaches `ts2cell` through the layer every
temporal type carries: validators for each operand pair, parsers that tag
the generic int-8 parse with the S2 temporal type, constructors over cells
and timestamps with the step interpolation a discrete cell demands,
accessors that answer cells rather than Datums, and the zero-cost
conversions to and from a temporal bigint, which lift an identity so the
bounding box is rebuilt as a spatiotemporal one.

Equality of S2 cells is bit equality of the identifier, so each comparison
entry point is a thin type-correct dispatcher over the generic comparison
machinery. Every comparison stands in three forms — true at some instant,
true at every instant, and a temporal boolean of the result at each
instant — and in the three operand orders a bare cell and a temporal cell
admit.

A set of S2 cells is an `s2cellset`, declared beside its element type. It
carries the input and output functions, the constructor, the accessors,
the cast from a single cell, the set operations, the comparison operators
and the btree operator class, each bound to the generic `Set_*` wrapper:
the dispatch arms for `T_S2CELL` make the shared parser and formatter read
and write an element with `s2cell_parse` and `s2cell_out`, so the family
adds no C symbol of its own and `setfamilies.yaml` records the row the
manifest keeps for every set type. Its regression test states the set in
Hilbert order with duplicates collapsed, the accessors, membership, the
four set operations and the comparison; its cells sit at level 29, whose
level bit is at position 2, and it states that a token ending in 8 sets an
odd bit, encodes no level and is rejected.

The extension declares `ts2cell` over that surface, so the type MEOS
parses and the type SQL declares are the one type. Its constructors spell
the inclusivity parameters `lowerInc` / `upperInc`, the spelling
`022_temporal.in.sql` gives the base temporal type and the one `th3index`
and `tquadbin` give the sibling cell indexes.

`601` and `603` are hand-written, so `coverage_exceptions.txt` lists them
beside the `600` their family already holds and the analogous h3 and
quadbin entries.