### PR TITLE
Publish the merge of a rigid geometry

### DIFF
--- a/meos/include/meos_rgeo.h
+++ b/meos/include/meos_rgeo.h
@@ -151,6 +151,8 @@ extern Temporal *trgeometry_delete_timestamptz(const Temporal *temp, TimestampTz
 extern Temporal *trgeometry_delete_tstzset(const Temporal *temp, const Set *s, bool connect);
 extern Temporal *trgeometry_delete_tstzspan(const Temporal *temp, const Span *s, bool connect);
 extern Temporal *trgeometry_delete_tstzspanset(const Temporal *temp, const SpanSet *ss, bool connect);
+extern Temporal *trgeometry_merge(const Temporal *temp1, const Temporal *temp2);
+extern Temporal *trgeometry_merge_array(Temporal **temparr, int count);
 extern Temporal *trgeometry_round(const Temporal *temp, int maxdd);
 extern Temporal *trgeometry_set_interp(const Temporal *temp, interpType interp);
 extern TInstant *trgeometry_as_tinstant(const Temporal *temp);

--- a/meos/include/rgeo/trgeo.h
+++ b/meos/include/rgeo/trgeo.h
@@ -82,12 +82,6 @@ extern Temporal *geo_tpose_to_trgeo(const GSERIALIZED *gs,
 extern bool trgeo_value_at_timestamptz(const Temporal *temp, TimestampTz t,
   bool strict, Datum *result);
 
-/* Modification functions */
-
-extern Temporal *trgeometry_merge(const Temporal *temp1,
-  const Temporal *temp2);
-extern Temporal *trgeometry_merge_array(Temporal **temparr, int count);
-
 /* Restriction functions */
 
 extern Temporal *trgeometry_restrict_value(const Temporal *temp, Datum value,

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -962,6 +962,7 @@ geo_tpose_to_trgeo(const GSERIALIZED *gs, const Temporal *temp)
 }
 
 /**
+ * @ingroup meos_rgeo_modif
  * @brief Return two temporal rigid geometries merged into one
  * @param[in] temp1,temp2 Temporal rigid geometries
  * @details A temporal rigid geometry is a temporal pose carrying a reference
@@ -1008,6 +1009,7 @@ trgeometry_merge(const Temporal *temp1, const Temporal *temp2)
 }
 
 /**
+ * @ingroup meos_rgeo_modif
  * @brief Return the temporal rigid geometries of an array merged into one
  * @param[in] temparr Array of temporal rigid geometries
  * @param[in] count Number of elements in the array


### PR DESCRIPTION
A temporal rigid geometry merges through trgeometry_merge, which answers the SQL merge() and states so with a @csqlfn. The pair carries no @ingroup, so the catalog records the group as none and a generator reading the group to decide what is internal finds nothing to exclude; it emits a call while the declaration sits in the private rgeo/trgeo.h, and the binding fails to compile on a symbol the public surface never offers — MobilityDuck run 33159507103 stops on an undeclared trgeometry_merge. Both members state meos_rgeo_modif, the group their delete and append siblings state, and both are declared in meos_rgeo.h, which declares the other 83 public rigid-geometry functions and repeats none of them in a private header. The callers reach the declaration through rgeo/trgeo_spatialfuncs.h, which includes meos_rgeo.h for exactly this.