### PR TITLE
State the instants the trajectory clip answers

### DIFF
--- a/meos/test/trajclip_test.c
+++ b/meos/test/trajclip_test.c
@@ -101,7 +101,10 @@ main(void)
     "POLYGON((50 50,50 100,100 100,100 50,50 50))",
     "{[POINT(69.790369 81.452098)@2000-01-01 00:00:00+00,"
     " POINT(55.752648 78.953813)@2000-01-02 00:00:00+00,"
-    " POINT(50 77.980799)@2000-01-02 19:37:41.053145+00]}");
+    /* The segment reaches x = 50 at 0.81783626209040821... of the way from the
+     * first instant, which is 70661.053044611... seconds into the day, and a
+     * timestamp holds whole microseconds */
+    " POINT(50 77.980799)@2000-01-02 19:37:41.053044+00]}");
 
   /* Multi-path open-path output where each output path is two crossings on
    * the same segment (no input vertex inside the path). The earlier
@@ -128,7 +131,9 @@ main(void)
     "{[POINT(82.963951 12.089449)@2001-03-29 10:26:39.347482+00,"
     " POINT(81.280652 6.48016)@2001-03-29 10:26:56.129728+00],"
     " [POINT(78.038715 6.519277)@2001-03-29 10:27:11.429509+00,"
-    " POINT(34.666556 26.774361)@2001-03-29 10:30:05.13933+00]}");
+    /* The last segment meets the edge at 5.1393297419... seconds past the
+     * minute, and a timestamp holds whole microseconds */
+    " POINT(34.666556 26.774361)@2001-03-29 10:30:05.139329+00]}");
 
   meos_finalize();
   printf("\n%d failure(s)\n", fails);


### PR DESCRIPTION
Two of the seven cases in `meos/test/trajclip_test.c` assert an instant the clip does not answer. Nothing in the workflow runs the program, so neither expectation has ever been read; both are wrong against the geometry itself, and the library is right.

**The slanted segment.** It reaches `x = 50` at 0.81783626209040821… of the way from its first instant, which is 70661.053044611… seconds into the day. The case asserts `19:37:41.053145` — a hundred microseconds past that. The clip answers `19:37:41.053044`, the whole microseconds the value holds.

**The multi-path case.** Its last segment meets the edge from `(44.539342168718576 6.923481728881598)` at 5.1393297419… seconds past the minute. The case asserts `05.13933`, that value *rounded*; the clip answers `05.139329`, that value in whole microseconds.

Each expectation is corrected to what the truncating library produces, with the analytic fraction recorded in a comment beside it so the next reader can check the number rather than trust it. The program then passes 7/7.

The oracle here is the closed-form crossing parameter, not the program's own output — a test corrected to whatever the code prints asserts nothing.