### PR TITLE
Build the SP-GiST spatiotemporal centroid and node box through the span kernel

### DIFF
--- a/meos/src/geo/tspatial_spgist.c
+++ b/meos/src/geo/tspatial_spgist.c
@@ -196,6 +196,10 @@ stboxnode_init(const STBox *centroid, STboxNode *nodebox)
     TimestampTzGetDatum(DT_NOBEGIN);
   nodebox->left.period.upper = nodebox->right.period.upper =
     TimestampTzGetDatum(DT_NOEND);
+  nodebox->left.period.spantype = nodebox->right.period.spantype =
+    centroid->period.spantype;
+  nodebox->left.period.basetype = nodebox->right.period.basetype =
+    centroid->period.basetype;
 
   nodebox->left.srid = nodebox->right.srid = centroid->srid;
   nodebox->left.flags = nodebox->right.flags = centroid->flags;

--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -422,8 +422,9 @@ Stbox_quadtree_picksplit(PG_FUNCTION_ARGS)
     centroid->zmin = lowZs[median];
     centroid->zmax = highZs[median];
   }
-  centroid->period.lower = TimestampTzGetDatum(lowTs[median]);
-  centroid->period.upper = TimestampTzGetDatum(highTs[median]);
+  span_set(TimestampTzGetDatum(lowTs[median]),
+    TimestampTzGetDatum(highTs[median]), true, true, T_TIMESTAMPTZ,
+    T_TSTZSPAN, &centroid->period);
 
   /* Fill the output */
   out->hasPrefix = true;


### PR DESCRIPTION
The centroid a quadtree split writes takes its period from `span_set`, which names the span and base types the period holds along with its bounds, and the node box a descent starts from carries those two types into both of its corners beside the SRID and the flags it already carries. `Tbox_quadtree_picksplit` and `tboxnode_init` state this shape for the temporal number tree, so one route builds every span a spatiotemporal index key holds.

A span whose base type names nothing is answered correctly only while every reader supplies the type itself, which the spatiotemporal readers do by passing `T_TIMESTAMPTZ`. Carrying the type in the span is what the temporal number readers rely on, and it is what a reader added later reaches for.

`stboxnode_init` serves the in-memory SPTree engine beside the PostgreSQL access method, so both trees start a descent from a node box that names the span it holds.