### PR TITLE
State the group of every function that answers a SQL function

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -835,6 +835,7 @@ cbuffer_srid(const Cbuffer *cb)
 }
 
 /**
+ * @ingroup meos_internal_cbuffer_base_srid
  * @brief Set the coordinates of a circular buffer to an SRID
  * @param[in] cb Circular buffer
  * @param[in] srid SRID

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -653,6 +653,7 @@ ea_spatialrel_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
  *****************************************************************************/
 
 /**
+ * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a geometry ever/always contains a temporal circular
  * buffer, 0 if not, and -1 on error or if the geometry is empty
  * @param[in] gs Geometry
@@ -693,6 +694,7 @@ acontains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 /*****************************************************************************/
 
 /**
+ * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever/always contains a
  * geometry, 0 if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal circular buffer
@@ -884,6 +886,7 @@ acontains_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
+ * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a geometry ever/always covers a temporal circular buffer
  * 0 if not, and -1 on error or if the geometry is empty
  * @param[in] gs Geometry
@@ -939,6 +942,7 @@ acovers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 /*****************************************************************************/
 
 /**
+ * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever/always covers a
  * geometry, 0 if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal circular buffer
@@ -1821,6 +1825,7 @@ atouches_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
+ * @ingroup meos_internal_cbuffer_spatial_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry are ever/always
  * within the given distance, 0 if not, -1 on error or if the geometry is empty
  * @param[in] temp Temporal circular buffer

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -360,6 +360,7 @@ tnpoint_cumulative_length(const Temporal *temp)
  *****************************************************************************/
 
 /**
+ * @ingroup meos_internal_npoint_accessor
  * @brief Speed of a temporal network point
  * @csqlfn #Tnpoint_speed()
  */

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -898,6 +898,7 @@ tnumber_value_time_tile_init(const Temporal *temp, Datum vsize,
 }
 
 /**
+ * @ingroup meos_internal_temporal_analytics_tile
  * @brief Return the temporal boxes of a temporal number split with respect to
  * a value and possibly a time grid
  * @param[in] temp Temporal number


### PR DESCRIPTION
A function's @ingroup is what the catalog derives its api field from — public where the group exists and is not an internal one, internal otherwise — and a binding generator reads that classification to decide what to leave alone. Eight functions answer a SQL function through a @csqlfn while stating no group, so the catalog records the group as none and a generator matching the group's name rather than the derived field finds nothing marking them internal. Each states the group its declaring header and its closest sibling put it in: cbuffer_set_srid_int the internal SRID group its pose twin uses, the four ever and always contains and covers helpers the internal cbuffer relationship group their tcbuffer-to-tcbuffer sibling uses, ea_dwithin_tcbuffer_geo the spatial one its own sibling uses, tnpointseq_speed the internal npoint accessor group a sequence-level accessor belongs to, and tnumber_value_time_boxes the internal analytics group meos_internal.h declares it under. With the rigid-geometry merge pair, which states meos_rgeo_modif, no function answering a SQL function is left without a group.