### PR TITLE
Answer the static S2 cell operations from SQL

### DIFF
--- a/mobilitydb/pg_include/pg_s2cell/doxygen_mobilitydb_s2cell.h
+++ b/mobilitydb/pg_include/pg_s2cell/doxygen_mobilitydb_s2cell.h
@@ -1,0 +1,106 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief MobilityDB Documentation: Functions for temporal Google S2 cell
+ * indices
+ */
+
+/*****************************************************************************
+ * Sections of the temporal S2 cell index functions
+ *****************************************************************************/
+
+/**
+ * @defgroup mobilitydb_s2cell_base Functions for static S2 cell indices
+ * @ingroup mobilitydb_s2cell
+ * @brief Functions for static S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_accessor Accessor functions
+ * @ingroup mobilitydb_s2cell
+ * @brief Accessor functions for temporal S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_conversion Conversion functions
+ * @ingroup mobilitydb_s2cell
+ * @brief Conversion functions for temporal S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_hierarchy Hierarchy functions
+ * @ingroup mobilitydb_s2cell
+ * @brief Hierarchy functions for temporal S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_set Set functions
+ * @ingroup mobilitydb_s2cell
+ * @brief Set functions for temporal S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_comp Comparison functions
+ * @ingroup mobilitydb_s2cell
+ * @brief Comparison functions for temporal S2 cell indices
+ *
+ *   @defgroup mobilitydb_s2cell_comp_ever Ever and always comparison functions
+ *   @ingroup mobilitydb_s2cell_comp
+ *   @brief Ever and always comparison functions for temporal S2 cell indices
+ *
+ *   @defgroup mobilitydb_s2cell_comp_temp Temporal comparison functions
+ *   @ingroup mobilitydb_s2cell_comp
+ *   @brief Temporal comparison functions for temporal S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_rel Spatial relationship functions
+ * @ingroup mobilitydb_s2cell
+ * @brief Spatial relationship functions for temporal S2 cell indices
+ *
+ *   @defgroup mobilitydb_s2cell_rel_ever Ever and always spatial relationship functions
+ *   @ingroup mobilitydb_s2cell_rel
+ *   @brief Ever and always spatial relationship functions for temporal S2 cell indices
+ */
+
+/*****************************************************************************/
+
+/**
+ * @defgroup mobilitydb_s2cell_base_inout Input and output functions
+ * @ingroup mobilitydb_s2cell_base
+ * @brief Input and output functions for static S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_base_accessor Accessor functions
+ * @ingroup mobilitydb_s2cell_base
+ * @brief Accessor functions for static S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_base_comp Comparison functions
+ * @ingroup mobilitydb_s2cell_base
+ * @brief Comparison functions for static S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_base_hierarchy Hierarchy functions
+ * @ingroup mobilitydb_s2cell_base
+ * @brief Hierarchy functions for static S2 cell indices
+ *
+ * @defgroup mobilitydb_s2cell_base_conversion Conversion functions
+ * @ingroup mobilitydb_s2cell_base
+ * @brief Conversion functions for static S2 cell indices
+ */
+
+/*****************************************************************************/

--- a/mobilitydb/pg_include/pg_temporal/doxygen_mobilitydb.h
+++ b/mobilitydb/pg_include/pg_temporal/doxygen_mobilitydb.h
@@ -93,6 +93,10 @@
  * @ingroup mobilitydb_api
  * @brief Functions for temporal CARTO QUADBIN cell indices
  *
+ * @defgroup mobilitydb_s2cell Functions for temporal Google S2 cell indices
+ * @ingroup mobilitydb_api
+ * @brief Functions for temporal Google S2 cell indices
+ *
  * @defgroup mobilitydb_raster Functions for temporal rasters
  * @ingroup mobilitydb_api
  * @brief Functions for temporal rasters

--- a/mobilitydb/sql/s2cell/602_s2cell_ops.in.sql
+++ b/mobilitydb/sql/s2cell/602_s2cell_ops.in.sql
@@ -1,0 +1,135 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief Static `s2cell` cell operations.
+ *
+ * The subset of the DGGS surface every family shares — resolution,
+ * hierarchy, cell ↔ point, boundary and area — under the names the
+ * `DggsCellOps` descriptor in `meos/include/temporal/tcellindex.h`
+ * fixes, together with the operations that are S2's own: the cube
+ * face a cell sits on, the Hilbert range a cell spans, the level of
+ * the deepest cell containing two cells, and the token.
+ *
+ * A cell is a region of the WGS84 sphere, so its centre and its
+ * boundary are geographies in SRID 4326 and its area is in square
+ * metres. There is no k-ring: the Hilbert curve gives four edge
+ * neighbours and no ring of a given radius.
+ *
+ * C wrappers in `mobilitydb/src/s2cell/s2cell_ops.c`; first-party
+ * kernel in `meos/src/s2cell/s2cell.c`.
+ */
+
+CREATE FUNCTION getResolution(s2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'S2cell_get_resolution'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2GetFace(s2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'S2cell_get_face'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cellArea(s2cell)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'S2cell_cell_area'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2EdgeLength(s2cell, integer)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'S2cell_edge_length'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cellToParent(s2cell, integer)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'S2cell_cell_to_parent'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2CellToChild(s2cell, integer, integer)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'S2cell_cell_to_child'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2CellToChildren(s2cell, integer)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'S2cell_cell_to_children'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2CellContains(s2cell, s2cell)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'S2cell_cell_contains'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2CommonAncestorLevel(s2cell, s2cell)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'S2cell_common_ancestor_level'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2RangeMin(s2cell)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'S2cell_range_min'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2RangeMax(s2cell)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'S2cell_range_max'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2EdgeNeighbors(s2cell)
+  RETURNS s2cellset
+  AS 'MODULE_PATHNAME', 'S2cell_edge_neighbors'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION geoToS2Cell(geography, integer)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'S2cell_point_to_cell'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cellToPoint(s2cell)
+  RETURNS geography
+  AS 'MODULE_PATHNAME', 'S2cell_cell_to_point'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cellToBoundary(s2cell)
+  RETURNS geography
+  AS 'MODULE_PATHNAME', 'S2cell_cell_to_boundary'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2CellToToken(s2cell)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'S2cell_cell_to_token'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION s2TokenToCell(text)
+  RETURNS s2cell
+  AS 'MODULE_PATHNAME', 'S2cell_token_to_cell'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/*****************************************************************************/

--- a/mobilitydb/sql/s2cell/CMakeLists.txt
+++ b/mobilitydb/sql/s2cell/CMakeLists.txt
@@ -1,6 +1,7 @@
 SET(LOCAL_FILES
   600_s2cell
   601_s2cellset
+  602_s2cell_ops
   603_ts2cell
   )
 

--- a/mobilitydb/src/s2cell/CMakeLists.txt
+++ b/mobilitydb/src/s2cell/CMakeLists.txt
@@ -1,6 +1,13 @@
 add_library(pg_s2cell OBJECT
   s2cell.c
+  s2cell_ops.c
   ts2cell.c
+  # The subset shared with every DGGS family plus the operations that
+  # are S2's own: the cube face, the Hilbert range a cell spans, the
+  # level of the deepest common ancestor, and the token. There is no
+  # k-ring — the Hilbert curve gives four edge neighbours and no ring
+  # of a given radius.
+  #
   # 601_s2cellset.in.sql routes to the generic Set_* symbols, so the
   # set machinery needs no standalone C wrapper file.
   )

--- a/mobilitydb/src/s2cell/s2cell_ops.c
+++ b/mobilitydb/src/s2cell/s2cell_ops.c
@@ -1,0 +1,403 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief PG V1 wrappers for the static `s2cell` cell operations.
+ *
+ * Each wrapper unpacks its arguments, delegates to the first-party S2
+ * kernel declared in `meos_s2cell.h`, and returns the result. The
+ * subset shared with every DGGS family (resolution, hierarchy,
+ * point/boundary, area) is wrapped here under the names the
+ * `DggsCellOps` descriptor in `meos/include/temporal/tcellindex.h`
+ * fixes, together with the operations that are S2's own: the cube face
+ * a cell sits on, the Hilbert range a cell spans, the level of the
+ * deepest common ancestor of two cells, and the token.
+ *
+ * The centre and the boundary are geographies on the WGS84 sphere
+ * (SRID 4326), since an S2 cell is a region of the sphere and not of a
+ * projected plane, and the area is in square metres as the descriptor
+ * states. There is no k-ring: the Hilbert curve gives four edge
+ * neighbours and no ring of a given radius.
+ */
+
+/* PostgreSQL */
+#include <postgres.h>
+#include <fmgr.h>
+/* PostGIS */
+#include <liblwgeom.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_geo.h>
+#include <meos_s2cell.h>
+#include <pgtypes.h>
+#include "geo/stbox.h"
+#include "temporal/set.h"
+#include "temporal/span.h"
+#include "s2cell/s2cell.h"
+/* MobilityDB */
+#include "pg_geo/postgis.h"
+
+/*****************************************************************************
+ * Accessors
+ *****************************************************************************/
+
+PGDLLEXPORT Datum S2cell_get_resolution(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_get_resolution);
+/**
+ * @ingroup mobilitydb_s2cell_base_accessor
+ * @brief Return the resolution (level) of an S2 cell
+ * @sqlfn getResolution()
+ */
+Datum
+S2cell_get_resolution(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  PG_RETURN_INT32((int32) s2cell_get_resolution(cell));
+}
+
+PGDLLEXPORT Datum S2cell_get_face(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_get_face);
+/**
+ * @ingroup mobilitydb_s2cell_base_accessor
+ * @brief Return the cube face in `[0, 5]` an S2 cell sits on
+ * @sqlfn s2GetFace()
+ */
+Datum
+S2cell_get_face(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  PG_RETURN_INT32((int32) s2cell_get_face(cell));
+}
+
+PGDLLEXPORT Datum S2cell_cell_area(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_cell_area);
+/**
+ * @ingroup mobilitydb_s2cell_base_accessor
+ * @brief Return the area in square metres of an S2 cell
+ * @sqlfn cellArea()
+ */
+Datum
+S2cell_cell_area(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  PG_RETURN_FLOAT8(s2cell_cell_area(cell));
+}
+
+PGDLLEXPORT Datum S2cell_edge_length(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_edge_length);
+/**
+ * @ingroup mobilitydb_s2cell_base_accessor
+ * @brief Return the length in metres of an edge of an S2 cell, from the
+ * vertex of the given index to the next one counterclockwise
+ * @sqlfn s2EdgeLength()
+ */
+Datum
+S2cell_edge_length(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  int32 edge = PG_GETARG_INT32(1);
+  PG_RETURN_FLOAT8(s2cell_edge_length(cell, (uint32_t) edge));
+}
+
+/*****************************************************************************
+ * Hierarchy
+ *****************************************************************************/
+
+PGDLLEXPORT Datum S2cell_cell_to_parent(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_cell_to_parent);
+/**
+ * @ingroup mobilitydb_s2cell_base_hierarchy
+ * @brief Return the ancestor of an S2 cell at the given coarser level
+ * @sqlfn cellToParent()
+ */
+Datum
+S2cell_cell_to_parent(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  int32 level = PG_GETARG_INT32(1);
+  PG_RETURN_S2CELL(s2cell_cell_to_parent(cell, (uint32_t) level));
+}
+
+PGDLLEXPORT Datum S2cell_cell_to_child(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_cell_to_child);
+/**
+ * @ingroup mobilitydb_s2cell_base_hierarchy
+ * @brief Return the descendant of an S2 cell at the given finer level and
+ * the given position along the Hilbert curve
+ * @sqlfn s2CellToChild()
+ */
+Datum
+S2cell_cell_to_child(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  int32 level = PG_GETARG_INT32(1);
+  int32 position = PG_GETARG_INT32(2);
+  PG_RETURN_S2CELL(s2cell_cell_to_child(cell, (uint32_t) level,
+    (uint32_t) position));
+}
+
+PGDLLEXPORT Datum S2cell_cell_to_children(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_cell_to_children);
+/**
+ * @ingroup mobilitydb_s2cell_base_hierarchy
+ * @brief Return the descendants of an S2 cell at the given finer level as
+ * an s2cellset
+ * @sqlfn s2CellToChildren()
+ */
+Datum
+S2cell_cell_to_children(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  int32 level = PG_GETARG_INT32(1);
+  Set *result = s2cell_cell_to_children_set(cell, level);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_SET_P(result);
+}
+
+PGDLLEXPORT Datum S2cell_cell_contains(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_cell_contains);
+/**
+ * @ingroup mobilitydb_s2cell_base_hierarchy
+ * @brief Return true if the first S2 cell contains the second one
+ * @sqlfn s2CellContains()
+ */
+Datum
+S2cell_cell_contains(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  S2CellId other = PG_GETARG_S2CELL(1);
+  PG_RETURN_BOOL(s2cell_cell_contains(cell, other));
+}
+
+PGDLLEXPORT Datum S2cell_common_ancestor_level(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_common_ancestor_level);
+/**
+ * @ingroup mobilitydb_s2cell_base_hierarchy
+ * @brief Return the level of the deepest cell containing two S2 cells, and
+ * -1 if they lie on different cube faces
+ * @sqlfn s2CommonAncestorLevel()
+ */
+Datum
+S2cell_common_ancestor_level(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  S2CellId other = PG_GETARG_S2CELL(1);
+  PG_RETURN_INT32(s2cell_common_ancestor_level(cell, other));
+}
+
+PGDLLEXPORT Datum S2cell_range_min(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_range_min);
+/**
+ * @ingroup mobilitydb_s2cell_base_hierarchy
+ * @brief Return the first leaf cell an S2 cell contains, which is the lower
+ * bound of the contiguous Hilbert range its descendants occupy
+ * @sqlfn s2RangeMin()
+ */
+Datum
+S2cell_range_min(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  PG_RETURN_S2CELL(s2cell_range_min(cell));
+}
+
+PGDLLEXPORT Datum S2cell_range_max(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_range_max);
+/**
+ * @ingroup mobilitydb_s2cell_base_hierarchy
+ * @brief Return the last leaf cell an S2 cell contains, which is the upper
+ * bound of the contiguous Hilbert range its descendants occupy
+ * @sqlfn s2RangeMax()
+ */
+Datum
+S2cell_range_max(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  PG_RETURN_S2CELL(s2cell_range_max(cell));
+}
+
+PGDLLEXPORT Datum S2cell_edge_neighbors(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_edge_neighbors);
+/**
+ * @ingroup mobilitydb_s2cell_base_hierarchy
+ * @brief Return the four cells sharing an edge with an S2 cell as an
+ * s2cellset
+ * @sqlfn s2EdgeNeighbors()
+ */
+Datum
+S2cell_edge_neighbors(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  Set *result = s2cell_edge_neighbors_set(cell);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_SET_P(result);
+}
+
+/*****************************************************************************
+ * Conversions
+ *****************************************************************************/
+
+PGDLLEXPORT Datum S2cell_point_to_cell(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_point_to_cell);
+/**
+ * @ingroup mobilitydb_s2cell_base_conversion
+ * @brief Return the S2 cell at the given level holding a point
+ * @sqlfn geoToS2Cell()
+ */
+Datum
+S2cell_point_to_cell(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(0);
+  int32 level = PG_GETARG_INT32(1);
+  S2CellId result = geo_to_s2cell_cell(gs, level);
+  PG_FREE_IF_COPY(gs, 0);
+  PG_RETURN_S2CELL(result);
+}
+
+PGDLLEXPORT Datum S2cell_cell_to_point(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_cell_to_point);
+/**
+ * @ingroup mobilitydb_s2cell_base_conversion
+ * @brief Return the centre of an S2 cell
+ * @sqlfn cellToPoint()
+ */
+Datum
+S2cell_cell_to_point(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  GSERIALIZED *result = s2cell_cell_to_geogpoint(cell);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_GSERIALIZED_P(result);
+}
+
+PGDLLEXPORT Datum S2cell_cell_to_boundary(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_cell_to_boundary);
+/**
+ * @ingroup mobilitydb_s2cell_base_conversion
+ * @brief Return the boundary of an S2 cell as a polygon
+ * @sqlfn cellToBoundary()
+ */
+Datum
+S2cell_cell_to_boundary(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  GSERIALIZED *result = s2cell_cell_to_geog(cell);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_GSERIALIZED_P(result);
+}
+
+PGDLLEXPORT Datum S2cell_cell_to_token(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_cell_to_token);
+/**
+ * @ingroup mobilitydb_s2cell_base_conversion
+ * @brief Return the token of an S2 cell, which is its identifier in
+ * hexadecimal with the trailing zeros removed
+ * @sqlfn s2CellToToken()
+ */
+Datum
+S2cell_cell_to_token(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  char *result = s2cell_cell_to_token(cell);
+  if (! result)
+    PG_RETURN_NULL();
+  text *out = cstring_to_text(result);
+  pfree(result);
+  PG_RETURN_TEXT_P(out);
+}
+
+PGDLLEXPORT Datum S2cell_token_to_cell(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_token_to_cell);
+/**
+ * @ingroup mobilitydb_s2cell_base_conversion
+ * @brief Return the S2 cell a token denotes
+ * @sqlfn s2TokenToCell()
+ */
+Datum
+S2cell_token_to_cell(PG_FUNCTION_ARGS)
+{
+  text *token = PG_GETARG_TEXT_P(0);
+  char *str = text_to_cstring(token);
+  S2CellId result = s2cell_token_to_cell(str);
+  pfree(str);
+  PG_FREE_IF_COPY(token, 0);
+  PG_RETURN_S2CELL(result);
+}
+
+PGDLLEXPORT Datum S2cell_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_to_stbox);
+/**
+ * @ingroup mobilitydb_s2cell_base_conversion
+ * @brief Return the spatiotemporal bounding box of an S2 cell
+ * @sqlfn stbox()
+ * @sqlop @p ::
+ */
+Datum
+S2cell_to_stbox(PG_FUNCTION_ARGS)
+{
+  PG_RETURN_STBOX_P(s2cell_to_stbox(PG_GETARG_S2CELL(0)));
+}
+
+PGDLLEXPORT Datum S2cell_timestamptz_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_timestamptz_to_stbox);
+/**
+ * @ingroup mobilitydb_s2cell_base_conversion
+ * @brief Return the spatiotemporal bounding box of an S2 cell and a
+ * timestamptz
+ * @sqlfn stbox()
+ */
+Datum
+S2cell_timestamptz_to_stbox(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  TimestampTz t = PG_GETARG_TIMESTAMPTZ(1);
+  PG_RETURN_STBOX_P(s2cell_timestamptz_to_stbox(cell, t));
+}
+
+PGDLLEXPORT Datum S2cell_tstzspan_to_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(S2cell_tstzspan_to_stbox);
+/**
+ * @ingroup mobilitydb_s2cell_base_conversion
+ * @brief Return the spatiotemporal bounding box of an S2 cell and a
+ * timestamptz span
+ * @sqlfn stbox()
+ */
+Datum
+S2cell_tstzspan_to_stbox(PG_FUNCTION_ARGS)
+{
+  S2CellId cell = PG_GETARG_S2CELL(0);
+  const Span *s = PG_GETARG_SPAN_P(1);
+  PG_RETURN_STBOX_P(s2cell_tstzspan_to_stbox(cell, s));
+}
+
+/*****************************************************************************/

--- a/mobilitydb/test/s2cell/expected/602_s2cell_ops.test.out
+++ b/mobilitydb/test/s2cell/expected/602_s2cell_ops.test.out
@@ -1,0 +1,201 @@
+SELECT getResolution(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+ getresolution 
+---------------
+            10
+(1 row)
+
+SELECT getResolution(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 20));
+ getresolution 
+---------------
+            20
+(1 row)
+
+SELECT s2GetFace(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+ s2getface 
+-----------
+         2
+(1 row)
+
+SELECT s2GetFace(geoToS2Cell(geography 'SRID=4326;Point(-122.4 37.8)', 10));
+ s2getface 
+-----------
+         4
+(1 row)
+
+SELECT getResolution(cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15), 8));
+ getresolution 
+---------------
+             8
+(1 row)
+
+SELECT s2CellContains(cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15), 8),
+  geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15));
+ s2cellcontains 
+----------------
+ t
+(1 row)
+
+SELECT s2CellContains(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15),
+  cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15), 8));
+ s2cellcontains 
+----------------
+ f
+(1 row)
+
+SELECT s2CommonAncestorLevel(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15),
+  cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15), 8));
+ s2commonancestorlevel 
+-----------------------
+                     8
+(1 row)
+
+SELECT s2CommonAncestorLevel(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10),
+  geoToS2Cell(geography 'SRID=4326;Point(-122.4 37.8)', 10));
+ s2commonancestorlevel 
+-----------------------
+                    -1
+(1 row)
+
+SELECT getResolution(s2CellToChild(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 9, 0));
+ getresolution 
+---------------
+             9
+(1 row)
+
+SELECT s2CellContains(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8),
+  s2CellToChild(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 9, 2));
+ s2cellcontains 
+----------------
+ t
+(1 row)
+
+SELECT s2CellToChild(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 10, 0);
+ERROR:  The child level 10 must be exactly one finer than the cell level 8
+SELECT numValues(s2CellToChildren(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 9));
+ numvalues 
+-----------
+         4
+(1 row)
+
+SELECT numValues(s2CellToChildren(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 10));
+ numvalues 
+-----------
+        16
+(1 row)
+
+SELECT s2RangeMin(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))
+  <= geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT s2RangeMax(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))
+  >= geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 20)
+  BETWEEN s2RangeMin(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))
+  AND s2RangeMax(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT getResolution(s2RangeMin(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)));
+ getresolution 
+---------------
+            30
+(1 row)
+
+SELECT numValues(s2EdgeNeighbors(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)));
+ numvalues 
+-----------
+         4
+(1 row)
+
+SELECT geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)
+  <@ s2EdgeNeighbors(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT geoToS2Cell(cellToPoint(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)), 10)
+  = geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ST_SRID(cellToPoint(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))::geometry);
+ st_srid 
+---------
+    4326
+(1 row)
+
+SELECT ST_GeometryType(cellToBoundary(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))::geometry);
+ st_geometrytype 
+-----------------
+ ST_Polygon
+(1 row)
+
+SELECT ST_NPoints(cellToBoundary(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))::geometry);
+ st_npoints 
+------------
+          5
+(1 row)
+
+SELECT ST_SRID(cellToBoundary(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))::geometry);
+ st_srid 
+---------
+    4326
+(1 row)
+
+SELECT round(cellArea(cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10), 0)) / 1e12, 3);
+ round  
+--------
+ 85.011
+(1 row)
+
+SELECT round(cellArea(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))
+  / cellArea(cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10), 6)), 4);
+ round 
+-------
+ 0.004
+(1 row)
+
+SELECT round(s2EdgeLength(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10), 0) / 1000, 3);
+ round 
+-------
+  9.27
+(1 row)
+
+SELECT round(s2EdgeLength(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10), 2) / 1000, 3);
+ round 
+-------
+  9.27
+(1 row)
+
+SELECT s2CellToToken(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+ s2celltotoken 
+---------------
+ 47c3c3
+(1 row)
+
+SELECT s2CellToToken(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 20));
+ s2celltotoken 
+---------------
+ 47c3c38705f
+(1 row)
+
+SELECT s2TokenToCell(s2CellToToken(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)))
+  = geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/s2cell/queries/602_s2cell_ops.test.sql
+++ b/mobilitydb/test/s2cell/queries/602_s2cell_ops.test.sql
@@ -1,0 +1,130 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Static s2cell cell operations: resolution, the cube face, hierarchy, the
+-- Hilbert range, the centre and boundary geographies, area and edge length,
+-- and the token.
+--
+-- Every cell here is derived by geoToS2Cell from a point, so the answers
+-- cross-check against the level asked for rather than against a literal.
+
+-------------------------------------------------------------------------------
+-- Resolution and face
+-------------------------------------------------------------------------------
+
+SELECT getResolution(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+SELECT getResolution(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 20));
+SELECT s2GetFace(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+SELECT s2GetFace(geoToS2Cell(geography 'SRID=4326;Point(-122.4 37.8)', 10));
+
+-------------------------------------------------------------------------------
+-- Hierarchy
+--
+-- A parent contains every cell it is the parent of, and the level of the
+-- deepest cell containing a cell and its own parent is the parent's level.
+-------------------------------------------------------------------------------
+
+SELECT getResolution(cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15), 8));
+SELECT s2CellContains(cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15), 8),
+  geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15));
+SELECT s2CellContains(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15),
+  cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15), 8));
+SELECT s2CommonAncestorLevel(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15),
+  cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 15), 8));
+SELECT s2CommonAncestorLevel(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10),
+  geoToS2Cell(geography 'SRID=4326;Point(-122.4 37.8)', 10));
+SELECT getResolution(s2CellToChild(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 9, 0));
+SELECT s2CellContains(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8),
+  s2CellToChild(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 9, 2));
+-- A child is exactly one level finer than the cell it is a child of.
+SELECT s2CellToChild(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 10, 0);
+SELECT numValues(s2CellToChildren(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 9));
+SELECT numValues(s2CellToChildren(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 8), 10));
+
+-------------------------------------------------------------------------------
+-- The Hilbert range
+--
+-- A cell spans a contiguous run of leaf cells, so its own identifier lies
+-- between the two bounds and a descendant does too.
+-------------------------------------------------------------------------------
+
+SELECT s2RangeMin(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))
+  <= geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
+SELECT s2RangeMax(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))
+  >= geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
+SELECT geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 20)
+  BETWEEN s2RangeMin(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))
+  AND s2RangeMax(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+SELECT getResolution(s2RangeMin(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)));
+
+-------------------------------------------------------------------------------
+-- Edge neighbours
+-------------------------------------------------------------------------------
+
+SELECT numValues(s2EdgeNeighbors(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)));
+SELECT geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)
+  <@ s2EdgeNeighbors(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+
+-------------------------------------------------------------------------------
+-- Centre and boundary
+--
+-- The centre lies in the cell it comes from, and the boundary is a polygon of
+-- four corners closed back on the first.
+-------------------------------------------------------------------------------
+
+SELECT geoToS2Cell(cellToPoint(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)), 10)
+  = geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
+SELECT ST_SRID(cellToPoint(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))::geometry);
+SELECT ST_GeometryType(cellToBoundary(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))::geometry);
+SELECT ST_NPoints(cellToBoundary(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))::geometry);
+SELECT ST_SRID(cellToBoundary(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))::geometry);
+
+-------------------------------------------------------------------------------
+-- Area and edge length
+--
+-- The whole sphere is the six face cells, so a face cell covers a sixth of
+-- the WGS84 area of 510 065 621 sq km, and a cell four levels finer covers
+-- about a 256th of its parent.
+-------------------------------------------------------------------------------
+
+SELECT round(cellArea(cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10), 0)) / 1e12, 3);
+SELECT round(cellArea(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10))
+  / cellArea(cellToParent(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10), 6)), 4);
+SELECT round(s2EdgeLength(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10), 0) / 1000, 3);
+SELECT round(s2EdgeLength(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10), 2) / 1000, 3);
+
+-------------------------------------------------------------------------------
+-- The token
+--
+-- The token is the identifier in hexadecimal with the trailing zeros removed,
+-- and it round-trips.
+-------------------------------------------------------------------------------
+
+SELECT s2CellToToken(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10));
+SELECT s2CellToToken(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 20));
+SELECT s2TokenToCell(s2CellToToken(geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10)))
+  = geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -552,7 +552,7 @@ The generic inherited Tcell API (declared in the umbrella header
 | C implementation | **unified once** via `DggsCellOps` — the `Tcell` C surface is effectively "generated" (single generic body, per-DGGS descriptor) |
 | catalog predicate `tcellindex_type()` | **both cell families** (`#if H3 → T_TH3INDEX`, `#if QUADBIN → T_TQUADBIN`, `tcellindex.c:66-76`) |
 | descriptor registered | `h3_cellops` (`meos/src/h3/th3index_ops.c:79`), `quadbin_cellops` (`meos/src/quadbin/tquadbin_ops.c:132`) and `s2_cellops` (`meos/src/s2cell/ts2cell_ops.c:146`), all dispatched from `dggs_cellops()` |
-| SQL wrappers (cellResolution/isValidCell/cellToParent/cellToPoint/cellToBoundary/cellArea) | **per-family HAND** in the `spatialfuncs` slot: h3 `255_th3index_spatialfuncs`, quadbin `355_tquadbin_spatialfuncs`; names are the bare DggsCellOps slot names overloaded by argument type — a second, independent surface from the generic `tcellindex_*` descriptor path above, not sourced from it |
+| SQL wrappers (getResolution/isValidCell/cellToParent/cellToPoint/cellToBoundary/cellArea) | **per-family HAND** in the `spatialfuncs` slot: h3 `255_th3index_spatialfuncs`, quadbin `355_tquadbin_spatialfuncs`; names are the bare DggsCellOps slot names overloaded by argument type — a second, independent surface from the generic `tcellindex_*` descriptor path above, not sourced from it |
 | cell→boundary hook | the key inherited hook: `spatialrels.sql.tmpl` cast-delegates via `cellToBoundary($n)::tgeometry`, the bare DggsCellOps slot name — this IS generated (§6, h3 262 / quadbin 362) |
 
 ⇒ **Remaining opportunity**: both DGGS families are wired onto `DggsCellOps` and

--- a/tools/codegen/inherited/coverage_exceptions.txt
+++ b/tools/codegen/inherited/coverage_exceptions.txt
@@ -5,7 +5,7 @@
 # land unnoticed. The list is a ratchet: it may only shrink. Bring a file
 # under the manifest, then delete its line here.
 #
-# 99 of 208 files remain.
+# 100 of 209 files remain.
 
 mobilitydb/sql/cbuffer/204_tcbuffer_compops.in.sql
 mobilitydb/sql/cbuffer/205_tcbuffer_spatialfuncs.in.sql
@@ -91,6 +91,7 @@ mobilitydb/sql/rgeo/175_trgeo_geom_clip.in.sql
 mobilitydb/sql/rgeo/176_trgeo_vclip.in.sql
 mobilitydb/sql/s2cell/600_s2cell.in.sql
 mobilitydb/sql/s2cell/601_s2cellset.in.sql
+mobilitydb/sql/s2cell/602_s2cell_ops.in.sql
 mobilitydb/sql/s2cell/603_ts2cell.in.sql
 mobilitydb/sql/temporal/019_geo_constructors.in.sql
 mobilitydb/sql/temporal/021_tbox.in.sql


### PR DESCRIPTION
`602_s2cell_ops.in.sql` declares the seventeen operations on a static cell
over the wrappers in `mobilitydb/src/s2cell/s2cell_ops.c`.

The operations the `DggsCellOps` descriptor in
`meos/include/temporal/tcellindex.h` fixes for every DGGS family carry the
bare slot name, overloaded by argument type, as h3 and quadbin declare
them: `getResolution`, `cellToParent`, `cellToPoint`, `cellToBoundary`
and `cellArea`, beside the `isValidCell` the type already publishes.
`geoToS2Cell` carries the family stem as `geoToQuadbinCell` and
`geoToH3Cell` do, because it names the grid it maps a geometry into.

Beside them stand the operations that are S2's own, and those keep the
stem because no sibling publishes them: `s2GetFace`, `s2CellToChild`,
`s2CellToChildren`, `s2CellContains`, `s2CommonAncestorLevel`,
`s2RangeMin`, `s2RangeMax`, `s2EdgeNeighbors`, `s2EdgeLength`,
`s2CellToToken` and `s2TokenToCell`. There is no k-ring: the Hilbert
curve gives four edge neighbours and no ring of a given radius.

`mobilitydb/pg_include/pg_s2cell/doxygen_mobilitydb_s2cell.h` defines the
groups those wrappers file under, mirroring
`pg_quadbin/doxygen_mobilitydb_quadbin.h`, since doxygen renders a
function only where its group is defined.

`602` is hand-written, so `coverage_exceptions.txt` lists it beside the
family's `600` and `601` and the analogous h3 and quadbin entries.