### PR TITLE
Run the meos test programs the workflow only ever compiled

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -112,6 +112,23 @@ jobs:
           ./merge_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o geo_test geo_test.c -L/usr/local/lib -lmeos
           ./geo_test
+          # Every program under meos/test is a check of the installed library, and
+          # one that is compiled nowhere is a check nobody makes: it keeps calling
+          # whatever it called when it was written while the surface moves under it.
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o date_test date_test.c -L/usr/local/lib -lmeos
+          ./date_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o float_test float_test.c -L/usr/local/lib -lmeos
+          ./float_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o interval_test interval_test.c -L/usr/local/lib -lmeos
+          ./interval_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o timestamp_test timestamp_test.c -L/usr/local/lib -lmeos
+          ./timestamp_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o npoint_test npoint_test.c -L/usr/local/lib -lmeos
+          ./npoint_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o trajclip_test trajclip_test.c -L/usr/local/lib -lmeos
+          ./trajclip_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o threaded_geos_test threaded_geos_test.c -L/usr/local/lib -lmeos
+          ./threaded_geos_test
           # The raster input and output functions are the only way a caller
           # outside PostgreSQL reaches a Raster, so they are exercised here
           # rather than through the PostgreSQL suite. The RASTER family is

--- a/meos/test/trajclip_test.c
+++ b/meos/test/trajclip_test.c
@@ -101,7 +101,10 @@ main(void)
     "POLYGON((50 50,50 100,100 100,100 50,50 50))",
     "{[POINT(69.790369 81.452098)@2000-01-01 00:00:00+00,"
     " POINT(55.752648 78.953813)@2000-01-02 00:00:00+00,"
-    " POINT(50 77.980799)@2000-01-02 19:37:41.053145+00]}");
+    /* The segment reaches x = 50 at 0.81783626209040821... of the way from the
+     * first instant, which is 70661.053044611... seconds into the day, and a
+     * timestamp holds whole microseconds */
+    " POINT(50 77.980799)@2000-01-02 19:37:41.053044+00]}");
 
   /* Multi-path open-path output where each output path is two crossings on
    * the same segment (no input vertex inside the path). The earlier
@@ -128,7 +131,9 @@ main(void)
     "{[POINT(82.963951 12.089449)@2001-03-29 10:26:39.347482+00,"
     " POINT(81.280652 6.48016)@2001-03-29 10:26:56.129728+00],"
     " [POINT(78.038715 6.519277)@2001-03-29 10:27:11.429509+00,"
-    " POINT(34.666556 26.774361)@2001-03-29 10:30:05.13933+00]}");
+    /* The last segment meets the edge at 5.1393297419... seconds past the
+     * minute, and a timestamp holds whole microseconds */
+    " POINT(34.666556 26.774361)@2001-03-29 10:30:05.139329+00]}");
 
   meos_finalize();
   printf("\n%d failure(s)\n", fails);


### PR DESCRIPTION
`meos/test` holds 51 programs and `.github/workflows/meos.yml` names 33 of them, so 21 are neither compiled nor run by any job. A program nothing compiles is a check nobody makes: it keeps calling whatever it called when it is written while the surface moves under it, and it stays green by never running.

This wires seven of them — `date_test`, `float_test`, `interval_test`, `timestamp_test`, `npoint_test`, `trajclip_test` and `threaded_geos_test` — with the same compile-and-run pair the job already uses for the other 33. All seven pass.

`trajclip_test` shows what the gap costs: two of its seven cases assert an instant the library does not answer, and neither is ever read. The correction is a separate branch, and this one carries it as its first commit, so the two are reviewed in order.

What stays unwired, and why:

- **`int_test`** does not compile. It includes `<meos.h>` and then `<pg_int.h>`; the installed `<meos.h>` defines `POSTGRES_H` while supplying only the integer types, so `pg_int.h` skips its own guarded typedefs and `float4` is undeclared. That is a header defect rather than a wiring one, and it has a branch of its own.
- **The 11 `tbl_*` programs** read CSV fixtures the repository does not carry, so a data decision comes before a workflow line.
- **`geo_op_diff` and `relate_diff`** are comparison drivers rather than self-checking tests: they print two engines' answers for a human to read and hold no pass or fail of their own.