### PR TITLE
State the aggregate a wrapper serves in its own tag

### DIFF
--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -274,7 +274,9 @@ TAB_SIZE               = 4
 # @} or use a double escape (\\{ and \\})
 
 ALIASES                = "csqlfn=@par C-SQL Function:^^" \
+                         "csqlaggfn=@par C-SQL Aggregate Role:^^" \
                          "sqlfn=@par SQL Function:^^" \
+                         "sqlaggfn=@par SQL Aggregate:^^" \
                          "sqlop=@par SQL Operator:^^"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -1586,7 +1586,8 @@ PGDLLEXPORT Datum Stbox_extent_transfn(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Stbox_extent_transfn);
 /**
  * @brief Transition function for extent aggregation of spatiotemporal boxes
- */
+  * @sqlaggfn extent()
+*/
 Datum
 Stbox_extent_transfn(PG_FUNCTION_ARGS)
 {
@@ -1619,7 +1620,8 @@ PGDLLEXPORT Datum Stbox_extent_combinefn(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Stbox_extent_combinefn);
 /**
  * @brief Combine function for extent aggregation of spatiotemporal boxes
- */
+  * @sqlaggfn extent()
+*/
 Datum
 Stbox_extent_combinefn(PG_FUNCTION_ARGS)
 {

--- a/mobilitydb/src/geo/tgeo_aggfuncs.c
+++ b/mobilitydb/src/geo/tgeo_aggfuncs.c
@@ -56,7 +56,8 @@ PG_FUNCTION_INFO_V1(Tspatial_extent_transfn);
  * @ingroup mobilitydb_geo_agg
  * @brief Transition function for temporal extent aggregation of temporal 
  * spatial values
- * @sqlfn extent()
+ * @sqlfn tspatial_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Tspatial_extent_transfn(PG_FUNCTION_ARGS)
@@ -79,7 +80,8 @@ PG_FUNCTION_INFO_V1(Tpoint_tcentroid_transfn);
  * @ingroup mobilitydb_geo_agg
  * @brief Transition function for temporal centroid aggregation of temporal
  * points
- * @sqlfn tCentroid()
+ * @sqlfn tcentroid_transfn()
+ * @sqlaggfn tCentroid()
  */
 Datum
 Tpoint_tcentroid_transfn(PG_FUNCTION_ARGS)
@@ -102,7 +104,8 @@ PG_FUNCTION_INFO_V1(Tpoint_tcentroid_combinefn);
 /**
  * @ingroup mobilitydb_geo_agg
  * @brief Combine function for temporal centroid aggregation of temporal points
- * @sqlfn tCentroid()
+ * @sqlfn tcentroid_combinefn()
+ * @sqlaggfn tCentroid()
  */
 Datum
 Tpoint_tcentroid_combinefn(PG_FUNCTION_ARGS)
@@ -133,7 +136,8 @@ PG_FUNCTION_INFO_V1(Tpoint_tcentroid_finalfn);
 /**
  * @ingroup mobilitydb_geo_agg
  * @brief Final function for temporal centroid aggregation of temporal points
- * @sqlfn tCentroid()
+ * @sqlfn tcentroid_finalfn()
+ * @sqlaggfn tCentroid()
  */
 Datum
 Tpoint_tcentroid_finalfn(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/geo/tgeo_distance.c
+++ b/mobilitydb/src/geo/tgeo_distance.c
@@ -462,7 +462,8 @@ PG_FUNCTION_INFO_V1(Mindistance_transfn);
  * @brief Aggregate transition function for the 2-ary `minDistance`
  * aggregate: threads the running min as the threshold into the
  * per-pair plane-sweep kernel
- * @sqlfn minDistance()
+ * @sqlfn minDistance_transfn()
+ * @sqlaggfn minDistance()
  */
 Datum
 Mindistance_transfn(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/npoint/tnpoint_aggfuncs.c
+++ b/mobilitydb/src/npoint/tnpoint_aggfuncs.c
@@ -52,7 +52,8 @@ PG_FUNCTION_INFO_V1(Tnpoint_tcentroid_transfn);
  * @ingroup mobilitydb_npoint_agg
  * @brief Transition function for temporal centroid aggregation of temporal
  * network points
- * @sqlfn tCentroid()
+ * @sqlfn tcentroid_transfn()
+ * @sqlaggfn tCentroid()
  */
 Datum
 Tnpoint_tcentroid_transfn(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/pointcloud/tpc_aggfuncs.c
+++ b/mobilitydb/src/pointcloud/tpc_aggfuncs.c
@@ -68,7 +68,8 @@ PG_FUNCTION_INFO_V1(Tpc_extent_transfn);
  * @ingroup mobilitydb_pointcloud_agg
  * @brief Transition function for the extent aggregate over tpcpoint /
  *   tpcpatch values.
- * @sqlfn extent()
+ * @sqlfn tpc_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Tpc_extent_transfn(PG_FUNCTION_ARGS)
@@ -87,7 +88,8 @@ PG_FUNCTION_INFO_V1(Tpcbox_extent_transfn);
  * @ingroup mobilitydb_pointcloud_agg
  * @brief Transition function for the extent aggregate over tpcbox values.
  *   Doubles as the parallel combine function for the temporal variants.
- * @sqlfn extent()
+ * @sqlfn tpcbox_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Tpcbox_extent_transfn(PG_FUNCTION_ARGS)
@@ -144,7 +146,8 @@ PG_FUNCTION_INFO_V1(Tpcpatch_tnpoints_transfn);
  * @ingroup mobilitydb_pointcloud_agg
  * @brief Transition function for tnpoints(tpcpatch) — temporal running
  *   sum of per-instant pcpatch->npoints.
- * @sqlfn tnpoints()
+ * @sqlfn tnpoints_transfn()
+ * @sqlaggfn tnpoints()
  */
 Datum
 Tpcpatch_tnpoints_transfn(PG_FUNCTION_ARGS)
@@ -214,7 +217,8 @@ PG_FUNCTION_INFO_V1(Tpcpatch_tdensity_transfn);
  * @ingroup mobilitydb_pointcloud_agg
  * @brief Transition function for tdensity(tpcpatch) — temporal running
  *   sum of per-instant density (npoints / xy-bbox-area).
- * @sqlfn tdensity()
+ * @sqlfn tdensity_transfn()
+ * @sqlaggfn tdensity()
  */
 Datum
 Tpcpatch_tdensity_transfn(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/set_aggfuncs.c
+++ b/mobilitydb/src/temporal/set_aggfuncs.c
@@ -58,7 +58,8 @@ PG_FUNCTION_INFO_V1(Value_union_transfn);
  * @brief Transition function for union aggregation of sets
  * @note We simply gather the input values into an array so that the final
  * function can sort and combine them
- * @sqlfn union()
+ * @sqlfn set_union_transfn()
+ * @sqlaggfn setUnion()
  */
 Datum
 Value_union_transfn(PG_FUNCTION_ARGS)
@@ -90,7 +91,8 @@ PG_FUNCTION_INFO_V1(Set_union_transfn);
  * @brief Transition function for union aggregation of sets
  * @note We simply gather the input values into an array so that the final
  * function can sort and combine them
- * @sqlfn union()
+ * @sqlfn set_union_transfn()
+ * @sqlaggfn setUnion()
  */
 Datum
 Set_union_transfn(PG_FUNCTION_ARGS)
@@ -129,6 +131,7 @@ PG_FUNCTION_INFO_V1(Set_union_finalfn);
  * @ingroup mobilitydb_setspan_agg
  * @brief Final function for union aggregation of sets
  * @sqlfn union()
+ * @sqlaggfn setUnion()
  */
 Datum
 Set_union_finalfn(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/span_aggfuncs.c
+++ b/mobilitydb/src/temporal/span_aggfuncs.c
@@ -54,7 +54,8 @@ PG_FUNCTION_INFO_V1(Span_extent_transfn);
 /**
  * @ingroup mobilitydb_setspan_agg
  * @brief Transition function for extent aggregation of spans
- * @sqlfn extent()
+ * @sqlfn span_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Span_extent_transfn(PG_FUNCTION_ARGS)
@@ -73,6 +74,7 @@ PG_FUNCTION_INFO_V1(Span_extent_combinefn);
  * @ingroup mobilitydb_setspan_agg
  * @brief Combine function for extent aggregation of spans
  * @sqlfn extent()
+ * @sqlaggfn extent()
  */
 Datum
 Span_extent_combinefn(PG_FUNCTION_ARGS)
@@ -96,7 +98,8 @@ PG_FUNCTION_INFO_V1(Spanbase_extent_transfn);
 /**
  * @ingroup mobilitydb_setspan_agg
  * @brief Transition function for extent aggregation of span base values
- * @sqlfn extent()
+ * @sqlfn span_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Spanbase_extent_transfn(PG_FUNCTION_ARGS)
@@ -116,7 +119,8 @@ PG_FUNCTION_INFO_V1(Set_extent_transfn);
 /**
  * @ingroup mobilitydb_setspan_agg
  * @brief Transition function for extent aggregation of sets
- * @sqlfn extent()
+ * @sqlfn set_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Set_extent_transfn(PG_FUNCTION_ARGS)
@@ -135,7 +139,8 @@ PG_FUNCTION_INFO_V1(Spanset_extent_transfn);
 /**
  * @ingroup mobilitydb_setspan_agg
  * @brief Transition function for extent aggregation of span sets
- * @sqlfn extent()
+ * @sqlfn spanset_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Spanset_extent_transfn(PG_FUNCTION_ARGS)
@@ -169,7 +174,8 @@ PG_FUNCTION_INFO_V1(Spanset_union_transfn);
  * @brief Transition function for union aggregation of span sets
  * @note We simply gather the input values into an array so that the final
  * function can sort and combine them
- * @sqlfn union()
+ * @sqlfn spanset_union_transfn()
+ * @sqlaggfn spansetUnion()
  */
 Datum
 Spanset_union_transfn(PG_FUNCTION_ARGS)
@@ -208,6 +214,7 @@ PG_FUNCTION_INFO_V1(Span_union_finalfn);
  * @brief Final function for union aggregation of spans.
  * @note Shared for both spans and span sets
  * @sqlfn union()
+ * @sqlaggfn spanUnion(), spansetUnion()
  */
 Datum
 Span_union_finalfn(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/tbox.c
+++ b/mobilitydb/src/temporal/tbox.c
@@ -1055,7 +1055,8 @@ PGDLLEXPORT Datum Tbox_extent_transfn(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tbox_extent_transfn);
 /**
  * @brief Transition function for extent aggregation for boxes
- */
+  * @sqlaggfn extent()
+*/
 Datum
 Tbox_extent_transfn(PG_FUNCTION_ARGS)
 {
@@ -1088,7 +1089,8 @@ PGDLLEXPORT Datum Tbox_extent_combinefn(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tbox_extent_combinefn);
 /**
  * @brief Combine function for extent aggregation for temporal boxes
- */
+  * @sqlaggfn extent()
+*/
 Datum
 Tbox_extent_combinefn(PG_FUNCTION_ARGS)
 {

--- a/mobilitydb/src/temporal/temporal_aggfuncs.c
+++ b/mobilitydb/src/temporal/temporal_aggfuncs.c
@@ -102,6 +102,7 @@ PG_FUNCTION_INFO_V1(Temporal_tagg_finalfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Generic final function for temporal aggregation
  * @sqlfn tCount(), merge(), ...
+ * @sqlaggfn merge(), mergeAgg(), tAnd(), tCount(), tMax(), tMaxAgg(), tMin(), tMinAgg(), tOr(), tSum(), tdensity(), tnpoints(), wCount(), wMax(), wMin(), wSum()
  */
 Datum
 Temporal_tagg_finalfn(PG_FUNCTION_ARGS)
@@ -150,7 +151,8 @@ PG_FUNCTION_INFO_V1(Timestamptz_tcount_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal count aggregate of timestamptz values
- * @sqlfn tCount()
+ * @sqlfn tcount_transfn()
+ * @sqlaggfn tCount()
  */
 Datum
 Timestamptz_tcount_transfn(PG_FUNCTION_ARGS)
@@ -170,7 +172,8 @@ PG_FUNCTION_INFO_V1(Tstzset_tcount_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal count aggregate of timestamptz sets
- * @sqlfn tCount()
+ * @sqlfn tcount_transfn()
+ * @sqlaggfn tCount()
  */
 Datum
 Tstzset_tcount_transfn(PG_FUNCTION_ARGS)
@@ -191,7 +194,8 @@ PG_FUNCTION_INFO_V1(Tstzspan_tcount_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal count aggregate of timestamptz spans
- * @sqlfn tCount()
+ * @sqlfn tcount_transfn()
+ * @sqlaggfn tCount()
  */
 Datum
 Tstzspan_tcount_transfn(PG_FUNCTION_ARGS)
@@ -212,7 +216,8 @@ PG_FUNCTION_INFO_V1(Tstzspanset_tcount_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal count aggregate of timestamptz span
  * sets
- * @sqlfn tCount()
+ * @sqlfn tcount_transfn()
+ * @sqlaggfn tCount()
  */
 Datum
 Tstzspanset_tcount_transfn(PG_FUNCTION_ARGS)
@@ -235,7 +240,8 @@ PG_FUNCTION_INFO_V1(Temporal_tcount_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal count aggregation of temporal values
- * @sqlfn tCount()
+ * @sqlfn tcount_transfn()
+ * @sqlaggfn tCount()
  */
 Datum
 Temporal_tcount_transfn(PG_FUNCTION_ARGS)
@@ -256,7 +262,8 @@ PG_FUNCTION_INFO_V1(Temporal_tcount_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal count aggregation of temporal values
- * @sqlfn tCount()
+ * @sqlfn tcount_combinefn()
+ * @sqlaggfn tCount(), tdensity(), tnpoints()
  */
 Datum
 Temporal_tcount_combinefn(PG_FUNCTION_ARGS)
@@ -274,7 +281,8 @@ PG_FUNCTION_INFO_V1(Temporal_extent_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for extent aggregation of temporal booleans and
  * temporal texts
- * @sqlfn extent()
+ * @sqlfn temporal_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Temporal_extent_transfn(PG_FUNCTION_ARGS)
@@ -295,7 +303,8 @@ PG_FUNCTION_INFO_V1(Tnumber_extent_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for extent aggregation for temporal numbers
- * @sqlfn extent()
+ * @sqlfn tnumber_extent_transfn()
+ * @sqlaggfn extent()
  */
 Datum
 Tnumber_extent_transfn(PG_FUNCTION_ARGS)
@@ -318,7 +327,8 @@ PG_FUNCTION_INFO_V1(Tbool_tand_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal and aggregation of temporal booleans
- * @sqlfn tAnd()
+ * @sqlfn tbool_tand_transfn()
+ * @sqlaggfn tAnd()
  */
 Datum
 Tbool_tand_transfn(PG_FUNCTION_ARGS)
@@ -331,7 +341,8 @@ PG_FUNCTION_INFO_V1(Tbool_tand_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal and aggregation of temporal booleans
- * @sqlfn tAnd()
+ * @sqlfn tbool_tand_combinefn()
+ * @sqlaggfn tAnd()
  */
 Datum
 Tbool_tand_combinefn(PG_FUNCTION_ARGS)
@@ -344,7 +355,8 @@ PG_FUNCTION_INFO_V1(Tbool_tor_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal or aggregation of temporal booleans
- * @sqlfn tOr()
+ * @sqlfn tbool_tor_transfn()
+ * @sqlaggfn tOr()
  */
 Datum
 Tbool_tor_transfn(PG_FUNCTION_ARGS)
@@ -357,7 +369,8 @@ PG_FUNCTION_INFO_V1(Tbool_tor_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal or aggregation of temporal booleans
- * @sqlfn tOr()
+ * @sqlfn tbool_tor_combinefn()
+ * @sqlaggfn tOr()
  */
 Datum
 Tbool_tor_combinefn(PG_FUNCTION_ARGS)
@@ -373,7 +386,8 @@ PG_FUNCTION_INFO_V1(Tint_tmin_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal minimum aggregation of temporal
  * integers
- * @sqlfn tMin()
+ * @sqlfn tint_tmin_transfn()
+ * @sqlaggfn tMin(), tMinAgg()
  */
 Datum
 Tint_tmin_transfn(PG_FUNCTION_ARGS)
@@ -387,7 +401,8 @@ PG_FUNCTION_INFO_V1(Tint_tmin_combinefn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal minimum aggregation of temporal
  * integers
- * @sqlfn tMin()
+ * @sqlfn tint_tmin_combinefn()
+ * @sqlaggfn tMin(), tMinAgg(), wMin()
  */
 Datum
 Tint_tmin_combinefn(PG_FUNCTION_ARGS)
@@ -401,7 +416,8 @@ PG_FUNCTION_INFO_V1(Tint_tmax_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal maximum aggregation of temporal
  * integers
- * @sqlfn tMax()
+ * @sqlfn tint_tmax_transfn()
+ * @sqlaggfn tMax(), tMaxAgg()
  */
 Datum
 Tint_tmax_transfn(PG_FUNCTION_ARGS)
@@ -415,7 +431,8 @@ PG_FUNCTION_INFO_V1(Tint_tmax_combinefn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal maximum aggregation of temporal
  * integers
- * @sqlfn tMax()
+ * @sqlfn tint_tmax_combinefn()
+ * @sqlaggfn tMax(), tMaxAgg(), wMax()
  */
 Datum
 Tint_tmax_combinefn(PG_FUNCTION_ARGS)
@@ -428,7 +445,8 @@ PG_FUNCTION_INFO_V1(Tint_tsum_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal sum aggregation of temporal integers
- * @sqlfn tSum()
+ * @sqlfn tint_tsum_transfn()
+ * @sqlaggfn tSum()
  */
 Datum
 Tint_tsum_transfn(PG_FUNCTION_ARGS)
@@ -441,7 +459,8 @@ PG_FUNCTION_INFO_V1(Tint_tsum_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal sum aggregation of temporal integers
- * @sqlfn tSum()
+ * @sqlfn tint_tsum_combinefn()
+ * @sqlaggfn tSum(), wCount(), wSum()
  */
 Datum
 Tint_tsum_combinefn(PG_FUNCTION_ARGS)
@@ -457,7 +476,8 @@ PG_FUNCTION_INFO_V1(Tbigint_tmin_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal minimum aggregation of temporal
  * big integers
- * @sqlfn tMin()
+ * @sqlfn tbigint_tmin_transfn()
+ * @sqlaggfn tMin(), tMinAgg()
  */
 Datum
 Tbigint_tmin_transfn(PG_FUNCTION_ARGS)
@@ -471,7 +491,8 @@ PG_FUNCTION_INFO_V1(Tbigint_tmin_combinefn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal minimum aggregation of temporal
  * big integers
- * @sqlfn tMin()
+ * @sqlfn tbigint_tmin_combinefn()
+ * @sqlaggfn tMin(), tMinAgg(), wMin()
  */
 Datum
 Tbigint_tmin_combinefn(PG_FUNCTION_ARGS)
@@ -485,7 +506,8 @@ PG_FUNCTION_INFO_V1(Tbigint_tmax_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal maximum aggregation of temporal
  * big integers
- * @sqlfn tMax()
+ * @sqlfn tbigint_tmax_transfn()
+ * @sqlaggfn tMax(), tMaxAgg()
  */
 Datum
 Tbigint_tmax_transfn(PG_FUNCTION_ARGS)
@@ -499,7 +521,8 @@ PG_FUNCTION_INFO_V1(Tbigint_tmax_combinefn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal maximum aggregation of temporal
  * big integers
- * @sqlfn tMax()
+ * @sqlfn tbigint_tmax_combinefn()
+ * @sqlaggfn tMax(), tMaxAgg(), wMax()
  */
 Datum
 Tbigint_tmax_combinefn(PG_FUNCTION_ARGS)
@@ -513,7 +536,8 @@ PG_FUNCTION_INFO_V1(Tbigint_tsum_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal sum aggregation of temporal big
  * integers
- * @sqlfn tSum()
+ * @sqlfn tbigint_tsum_transfn()
+ * @sqlaggfn tSum()
  */
 Datum
 Tbigint_tsum_transfn(PG_FUNCTION_ARGS)
@@ -527,7 +551,8 @@ PG_FUNCTION_INFO_V1(Tbigint_tsum_combinefn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal sum aggregation of temporal big
  * integers
- * @sqlfn tSum()
+ * @sqlfn tbigint_tsum_combinefn()
+ * @sqlaggfn tSum(), wCount(), wSum()
  */
 Datum
 Tbigint_tsum_combinefn(PG_FUNCTION_ARGS)
@@ -543,7 +568,8 @@ PG_FUNCTION_INFO_V1(Tfloat_tmin_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal minimum aggregation of temporal
  * floats
- * @sqlfn tMin()
+ * @sqlfn tfloat_tmin_transfn()
+ * @sqlaggfn tMin(), tMinAgg()
  */
 Datum
 Tfloat_tmin_transfn(PG_FUNCTION_ARGS)
@@ -556,7 +582,8 @@ PG_FUNCTION_INFO_V1(Tfloat_tmin_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal minimum aggregation of temporal floats
- * @sqlfn tMin()
+ * @sqlfn tfloat_tmin_combinefn()
+ * @sqlaggfn tMin(), tMinAgg(), wMin()
  */
 Datum
 Tfloat_tmin_combinefn(PG_FUNCTION_ARGS)
@@ -570,7 +597,8 @@ PG_FUNCTION_INFO_V1(Tfloat_tmax_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal maximum aggregation of temporal
  * floats
- * @sqlfn tMax()
+ * @sqlfn tfloat_tmax_transfn()
+ * @sqlaggfn tMax(), tMaxAgg()
  */
 Datum
 Tfloat_tmax_transfn(PG_FUNCTION_ARGS)
@@ -584,7 +612,8 @@ PG_FUNCTION_INFO_V1(Tfloat_tmax_combinefn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal maximum aggregation of temporal floats
  * values
- * @sqlfn tMax()
+ * @sqlfn tfloat_tmax_combinefn()
+ * @sqlaggfn tMax(), tMaxAgg(), wMax()
  */
 Datum
 Tfloat_tmax_combinefn(PG_FUNCTION_ARGS)
@@ -597,7 +626,8 @@ PG_FUNCTION_INFO_V1(Tfloat_tsum_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal sum aggregation of temporal floats
- * @sqlfn tSum()
+ * @sqlfn tfloat_tsum_transfn()
+ * @sqlaggfn tSum()
  */
 Datum
 Tfloat_tsum_transfn(PG_FUNCTION_ARGS)
@@ -610,7 +640,8 @@ PG_FUNCTION_INFO_V1(Tfloat_tsum_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal sum aggregation of temporal floats
- * @sqlfn tSum()
+ * @sqlfn tfloat_tsum_combinefn()
+ * @sqlaggfn tSum(), wSum()
  */
 Datum
 Tfloat_tsum_combinefn(PG_FUNCTION_ARGS)
@@ -625,7 +656,8 @@ PG_FUNCTION_INFO_V1(Ttext_tmin_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal minimum aggregation of temporal texts
- * @sqlfn tMin()
+ * @sqlfn ttext_tmin_transfn()
+ * @sqlaggfn tMin(), tMinAgg()
  */
 Datum
 Ttext_tmin_transfn(PG_FUNCTION_ARGS)
@@ -638,7 +670,8 @@ PG_FUNCTION_INFO_V1(Ttext_tmin_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal minimum aggregation of temporal texts
- * @sqlfn tMin()
+ * @sqlfn ttext_tmin_combinefn()
+ * @sqlaggfn tMin(), tMinAgg()
  */
 Datum
 Ttext_tmin_combinefn(PG_FUNCTION_ARGS)
@@ -651,7 +684,8 @@ PG_FUNCTION_INFO_V1(Ttext_tmax_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal maximum aggregation of temporal texts
- * @sqlfn tMax()
+ * @sqlfn ttext_tmax_transfn()
+ * @sqlaggfn tMax(), tMaxAgg()
  */
 Datum
 Ttext_tmax_transfn(PG_FUNCTION_ARGS)
@@ -664,7 +698,8 @@ PG_FUNCTION_INFO_V1(Ttext_tmax_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal maximum aggregation of temporal texts
- * @sqlfn tMax()
+ * @sqlfn ttext_tmax_combinefn()
+ * @sqlaggfn tMax(), tMaxAgg()
  */
 Datum
 Ttext_tmax_combinefn(PG_FUNCTION_ARGS)
@@ -682,7 +717,8 @@ PG_FUNCTION_INFO_V1(Tnumber_tavg_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for temporal average aggregation of temporal
  * numbers
- * @sqlfn tAvg()
+ * @sqlfn tavg_transfn()
+ * @sqlaggfn tAvg()
  */
 Datum
 Tnumber_tavg_transfn(PG_FUNCTION_ARGS)
@@ -697,7 +733,8 @@ PG_FUNCTION_INFO_V1(Tnumber_tavg_combinefn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for temporal average aggregation of temporal
  * numbers
- * @sqlfn tAvg()
+ * @sqlfn tavg_combinefn()
+ * @sqlaggfn tAvg(), wAvg()
  */
 Datum
 Tnumber_tavg_combinefn(PG_FUNCTION_ARGS)
@@ -711,7 +748,8 @@ PG_FUNCTION_INFO_V1(Tnumber_tavg_finalfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Final function for temporal average aggregation of temporal
  * numbers
- * @sqlfn tAvg()
+ * @sqlfn tavg_finalfn()
+ * @sqlaggfn tAvg(), wAvg()
  */
 Datum
 Tnumber_tavg_finalfn(PG_FUNCTION_ARGS)
@@ -730,7 +768,8 @@ PG_FUNCTION_INFO_V1(Temporal_merge_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for merge aggregate of temporal values
- * @sqlfn merge()
+ * @sqlfn temporal_merge_transfn()
+ * @sqlaggfn merge(), mergeAgg()
  */
 Datum
 Temporal_merge_transfn(PG_FUNCTION_ARGS)
@@ -743,7 +782,8 @@ PG_FUNCTION_INFO_V1(Temporal_merge_combinefn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Combine function for merge aggregate of temporal values
- * @sqlfn merge()
+ * @sqlfn temporal_merge_combinefn()
+ * @sqlaggfn merge(), mergeAgg()
  */
 Datum
 Temporal_merge_combinefn(PG_FUNCTION_ARGS)
@@ -760,7 +800,8 @@ PG_FUNCTION_INFO_V1(Temporal_app_tinst_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for append temporal instant aggregate
- * @sqlfn appendInstant()
+ * @sqlfn temporal_app_tinst_transfn()
+ * @sqlaggfn appendInstant(), appendInstantAgg()
  */
 Datum
 Temporal_app_tinst_transfn(PG_FUNCTION_ARGS)
@@ -828,7 +869,8 @@ PG_FUNCTION_INFO_V1(Temporal_app_tseq_transfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for append temporal sequence aggregate
- * @sqlfn appendSequence()
+ * @sqlfn temporal_app_tseq_transfn()
+ * @sqlaggfn appendSequence(), appendSequenceAgg()
  */
 Datum
 Temporal_app_tseq_transfn(PG_FUNCTION_ARGS)
@@ -857,7 +899,8 @@ PG_FUNCTION_INFO_V1(Temporal_append_finalfn);
 /**
  * @ingroup mobilitydb_temporal_agg
  * @brief Final function for append temporal instant/sequence aggregate
- * @sqlfn appendInstant(), appendSequence()
+ * @sqlfn temporal_append_finalfn()
+ * @sqlaggfn appendInstant(), appendInstantAgg(), appendSequence(), appendSequenceAgg()
  */
 Datum
 Temporal_append_finalfn(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/temporal/temporal_waggfuncs.c
+++ b/mobilitydb/src/temporal/temporal_waggfuncs.c
@@ -124,7 +124,8 @@ PG_FUNCTION_INFO_V1(Tint_wmin_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window minimun aggregation for
  * temporal integers
- * @sqlfn wMin()
+ * @sqlfn tint_wmin_transfn()
+ * @sqlaggfn wMin()
  */
 inline Datum
 Tint_wmin_transfn(PG_FUNCTION_ARGS)
@@ -138,7 +139,8 @@ PG_FUNCTION_INFO_V1(Tbigint_wmin_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window minimun aggregation for
  * temporal integers
- * @sqlfn wMin()
+ * @sqlfn tbigint_wmin_transfn()
+ * @sqlaggfn wMin()
  */
 inline Datum
 Tbigint_wmin_transfn(PG_FUNCTION_ARGS)
@@ -152,7 +154,8 @@ PG_FUNCTION_INFO_V1(Tfloat_wmin_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window minimun aggregation for
  * temporal floats
- * @sqlfn wMin()
+ * @sqlfn tfloat_wmin_transfn()
+ * @sqlaggfn wMin()
  */
 inline Datum
 Tfloat_wmin_transfn(PG_FUNCTION_ARGS)
@@ -166,7 +169,8 @@ PG_FUNCTION_INFO_V1(Tint_wmax_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window maximun aggregation for
  * temporal integers
- * @sqlfn wMax()
+ * @sqlfn tint_wmax_transfn()
+ * @sqlaggfn wMax()
  */
 inline Datum
 Tint_wmax_transfn(PG_FUNCTION_ARGS)
@@ -180,7 +184,8 @@ PG_FUNCTION_INFO_V1(Tbigint_wmax_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window maximun aggregation for
  * temporal integers
- * @sqlfn wMax()
+ * @sqlfn tbigint_wmax_transfn()
+ * @sqlaggfn wMax()
  */
 inline Datum
 Tbigint_wmax_transfn(PG_FUNCTION_ARGS)
@@ -194,7 +199,8 @@ PG_FUNCTION_INFO_V1(Tfloat_wmax_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window maximun aggregation for
  * temporal floats
- * @sqlfn wMax()
+ * @sqlfn tfloat_wmax_transfn()
+ * @sqlaggfn wMax()
  */
 inline Datum
 Tfloat_wmax_transfn(PG_FUNCTION_ARGS)
@@ -208,7 +214,8 @@ PG_FUNCTION_INFO_V1(Tint_wsum_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window sum aggregation for temporal
  * integers
- * @sqlfn wSum()
+ * @sqlfn tint_wsum_transfn()
+ * @sqlaggfn wSum()
  */
 inline Datum
 Tint_wsum_transfn(PG_FUNCTION_ARGS)
@@ -222,7 +229,8 @@ PG_FUNCTION_INFO_V1(Tbigint_wsum_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window sum aggregation for temporal
  * integers
- * @sqlfn wSum()
+ * @sqlfn tbigint_wsum_transfn()
+ * @sqlaggfn wSum()
  */
 inline Datum
 Tbigint_wsum_transfn(PG_FUNCTION_ARGS)
@@ -236,7 +244,8 @@ PG_FUNCTION_INFO_V1(Tfloat_wsum_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window sum aggregation for temporal
  * floats
- * @sqlfn wSum()
+ * @sqlfn tfloat_wsum_transfn()
+ * @sqlaggfn wSum()
  */
 inline Datum
 Tfloat_wsum_transfn(PG_FUNCTION_ARGS)
@@ -250,7 +259,8 @@ PG_FUNCTION_INFO_V1(Temporal_wcount_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window count aggregation for temporal
  * values
- * @sqlfn wCount()
+ * @sqlfn wcount_transfn()
+ * @sqlaggfn wCount()
  */
 inline Datum
 Temporal_wcount_transfn(PG_FUNCTION_ARGS)
@@ -265,7 +275,8 @@ PG_FUNCTION_INFO_V1(Tnumber_wavg_transfn);
  * @ingroup mobilitydb_temporal_agg
  * @brief Transition function for moving window average aggregation for
  * temporal numbers
- * @sqlfn wAvg()
+ * @sqlfn wavg_transfn()
+ * @sqlaggfn wAvg()
  */
 inline Datum
 Tnumber_wavg_transfn(PG_FUNCTION_ARGS)

--- a/tools/scripts/check_sqlfn_names.py
+++ b/tools/scripts/check_sqlfn_names.py
@@ -29,14 +29,15 @@ and its tag must say so.  A wrapper is checked only when the SQL binds it;
 one reached solely through an operator or an aggregate has no CREATE FUNCTION
 to answer for it and is left alone.
 
+An aggregate's transition, combine and final wrappers each back a CREATE
+FUNCTION nobody calls while implementing a CREATE AGGREGATE everybody does.
+The tag states the first and @sqlaggfn the second, so an aggregate member
+answers this guard like any other wrapper and needs no exemption.
+
 Three shapes name the SQL correctly without repeating its spelling, and are
 accepted rather than reported:
 
-  AGGREGATE   The SQL name is a `_transfn` / `_combinefn` / `_finalfn`, an
-              internal of an aggregate no user calls.  The tag names the
-              aggregate itself (`tCount`), which is the name to document.
-
-  PER TYPE    The symbol serves a FAMILY of SQL functions, each carrying its
+  PER TYPE   The symbol serves a FAMILY of SQL functions, each carrying its
               own type (`intspan_in`, `floatspan_in`, ... for one `Span_in`),
               so there is no single name for the tag to state and the tag
               names the family.  What such a tag should say is a question of
@@ -77,10 +78,6 @@ ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)
 # the tag's spelling.  The catalog carries them as backing-only names.
 BBOX_TAGS = {'contains_bbox', 'contained_bbox', 'overlaps_bbox',
              'adjacent_bbox', 'same_bbox'}
-
-# An aggregate's internals are CREATE FUNCTIONed under names no user calls;
-# the tag names the aggregate they serve.
-AGGREGATE_INTERNAL = re.compile(r'_(transfn|combinefn|finalfn)$')
 
 # The name and C symbol of one CREATE FUNCTION statement.  The statement ends
 # at its first semicolon: reading past it walks into the next statement and
@@ -142,7 +139,7 @@ def accepted(tagged, declared):
     """True if the tag names the SQL correctly without repeating its spelling."""
     if tagged & BBOX_TAGS:
         return True
-    return len(declared) > 1 or AGGREGATE_INTERNAL.search(next(iter(declared)))
+    return len(declared) > 1
 
 
 def report(fix):


### PR DESCRIPTION
An aggregate's transition, combine and final wrappers each back a CREATE FUNCTION nobody calls and implement a CREATE AGGREGATE everybody does, and @sqlfn holds one name. Where the aggregate name takes that slot the tag states a name no CREATE FUNCTION carries, a consumer separates an aggregate from a function by the C symbol's suffix, and the aggregate a member serves is whatever the tag happens to say — for 33 of the 78 members that is fewer aggregates than the SQL gives them, tMin for a combine function CREATE AGGREGATE names under tMin, tMinAgg and wMin alike. Each wrapper states the function it backs in @sqlfn and the aggregates it serves in @sqlaggfn, both read from the SQL: the CREATE FUNCTION that binds the wrapper, and every CREATE AGGREGATE naming that function as a transition, combine or final member. The doxygen aliases define @sqlaggfn beside @sqlfn, and @csqlaggfn, which meos/src states twelve times and no alias defines. check_sqlfn_names.py drops its aggregate exemption: a member names its CREATE FUNCTION like every other wrapper, so the guard reads it the same way. The MEOS-API catalog carries the tag as its sqlAgg field.