### PR TITLE
State the PostgreSQL base types once, in a header both builds read

### DIFF
--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -379,6 +379,10 @@ if(MEOS)
 
   # Files from ${CMAKE_SOURCE_DIR}
 
+  # The base types every other header here is written against, and which the
+  # spliced <meos.h> reads as well
+  install(FILES "${CMAKE_SOURCE_DIR}/pgtypes/pg_basetypes.h"
+    DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
   install(FILES "${CMAKE_SOURCE_DIR}/pgtypes/pg_bool.h"
     DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}")
   install(FILES "${CMAKE_SOURCE_DIR}/pgtypes/pg_date.h"

--- a/meos/include/postgres_ext_defs.in.h
+++ b/meos/include/postgres_ext_defs.in.h
@@ -1,3 +1,9 @@
+/* The scalar types come from the header that states them once, so this file and
+ * every pg_*.h answer the same type for a name. It is read BEFORE POSTGRES_H is
+ * defined below, because that macro is what tells it PostgreSQL has already
+ * supplied them. */
+#include <pg_basetypes.h>
+
 #ifndef POSTGRES_H
 #define POSTGRES_H
 
@@ -7,16 +13,6 @@
 
 typedef char *Pointer;
 typedef uintptr_t Datum;
-
-typedef signed char int8;
-typedef signed short int16;
-typedef signed int int32;
-typedef int64_t int64;
-
-typedef unsigned char uint8;
-typedef unsigned short uint16;
-typedef unsigned int uint32;
-typedef uint64_t uint64;
 
 /* State vector of the PostgreSQL pseudo-random number generator, mirroring the
  * definition in <common/pg_prng.h>. Its include guard is defined here as well

--- a/pgtypes/pg_basetypes.h
+++ b/pgtypes/pg_basetypes.h
@@ -1,0 +1,65 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+
+/**
+ * @file
+ * @brief The PostgreSQL base types the pgtypes headers and the installed
+ * <meos.h> are written against
+ * @details A translation unit reaches these names either from PostgreSQL
+ * itself — the backend's `postgres.h`, or the copy this tree vendors, both of
+ * which define `POSTGRES_H` — or from here. Stating them in one place is what
+ * keeps the two readings the same type: `int64` is `long int` in PostgreSQL 17
+ * and `int64_t` here, and where those differ a second definition of the name
+ * is a redefinition with a different type rather than a harmless repetition.
+ */
+
+#ifndef __PG_BASETYPES_H__
+#define __PG_BASETYPES_H__
+
+#include <stdint.h>
+
+#ifndef POSTGRES_H
+
+typedef signed char int8;
+typedef signed short int16;
+typedef signed int int32;
+typedef int64_t int64;
+
+typedef unsigned char uint8;
+typedef unsigned short uint16;
+typedef unsigned int uint32;
+typedef uint64_t uint64;
+
+typedef float float4;
+typedef double float8;
+
+#endif /* POSTGRES_H */
+
+#endif /* __PG_BASETYPES_H__ */

--- a/pgtypes/pg_date.h
+++ b/pgtypes/pg_date.h
@@ -36,8 +36,8 @@
 #ifndef __PG_DATE_H__
 #define __PG_DATE_H__
 
-typedef int32_t int32;
-typedef int64_t int64;
+#include "pg_basetypes.h"
+
 typedef int32 DateADT;
 typedef int64 TimeADT;
 

--- a/pgtypes/pg_float.h
+++ b/pgtypes/pg_float.h
@@ -36,8 +36,7 @@
 #ifndef __PG_FLOAT_H__
 #define __PG_FLOAT_H__
 
-typedef float float4;
-typedef double float8;
+#include "pg_basetypes.h"
 
 /*****************************************************************************/
 

--- a/pgtypes/pg_int.h
+++ b/pgtypes/pg_int.h
@@ -36,21 +36,7 @@
 #ifndef __PG_INT_H__
 #define __PG_INT_H__
 
-/* A translation unit that has PostgreSQL's postgres.h already carries these
- * names, and the two spellings are the same type only from PG18 on: PG17
- * declares int64 as long int, which on a platform where int64_t is long long
- * is a redefinition with a different type and a hard error. postgres.h defines
- * POSTGRES_H, and so does the copy this tree vendors, so the guard reads as
- * "PostgreSQL's base types are already in scope" in both builds. */
-#ifndef POSTGRES_H
-typedef int16_t int16;
-typedef int32_t int32;
-typedef int64_t int64;
-typedef uint32_t uint32;
-typedef uint64_t uint64;
-typedef float float4;
-typedef double float8;
-#endif /* POSTGRES_H */
+#include "pg_basetypes.h"
 
 /*****************************************************************************/
 

--- a/pgtypes/pg_interval.h
+++ b/pgtypes/pg_interval.h
@@ -36,8 +36,7 @@
 #ifndef __PG_INTERVAL_H__
 #define __PG_INTERVAL_H__
 
-typedef float float4;
-typedef double float8;
+#include "pg_basetypes.h"
 
 struct NumericData;
 typedef struct NumericData *Numeric;

--- a/pgtypes/pg_numeric.h
+++ b/pgtypes/pg_numeric.h
@@ -14,12 +14,7 @@
 #ifndef __PG_NUMERIC_H__
 #define __PG_NUMERIC_H__
 
-typedef int8_t int8;
-typedef int16_t int16;
-typedef int32_t int32;
-typedef int64_t int64;
-typedef float float4;
-typedef double float8;
+#include "pg_basetypes.h" /* MEOS: the PostgreSQL base types, stated once */
 
 /*
  * Limits on the precision and scale specifiable in a NUMERIC typmod.  The

--- a/pgtypes/pg_text.h
+++ b/pgtypes/pg_text.h
@@ -36,13 +36,11 @@
 #ifndef __PG_TEXT_H__
 #define __PG_TEXT_H__
 
+#include "pg_basetypes.h"
+
 typedef struct varlena;
 typedef struct varlena text;
 
-typedef int8_t int8;
-typedef int16_t int16;
-typedef int32_t int32;
-typedef int64_t int64;
 typedef unsigned int Oid;
 
 /*****************************************************************************/

--- a/pgtypes/pg_time.h
+++ b/pgtypes/pg_time.h
@@ -36,9 +36,8 @@
 #ifndef __PG_TIME_H__
 #define __PG_TIME_H__
 
-typedef int32_t int32;
-typedef int64_t int64;
-typedef double float8;
+#include "pg_basetypes.h"
+
 typedef int32 DateADT;
 typedef int64 TimeADT;
 

--- a/pgtypes/pg_timestamp.h
+++ b/pgtypes/pg_timestamp.h
@@ -36,17 +36,12 @@
 #ifndef __PG_TIMESTAMP_H__
 #define __PG_TIMESTAMP_H__
 
-typedef int8_t int8;
-typedef int16_t int16;
-typedef int32_t int32;
-typedef int64_t int64;
+#include "pg_basetypes.h"
+
 typedef int32 DateADT;
 typedef int64 TimeADT;
 typedef int64 Timestamp;
 typedef int64 TimestampTz;
-
-typedef float float4;
-typedef double float8;
 
 struct NumericData;
 typedef struct NumericData *Numeric;

--- a/tools/scripts/check_int64_in_headers.sh
+++ b/tools/scripts/check_int64_in_headers.sh
@@ -43,14 +43,15 @@
 
 set -euo pipefail
 
-# meos/include/postgres_ext_defs.in.h is the ONE base-type definition template that
-# must spell int64 as `typedef int64_t int64` — it DEFINES the PG alias from the C99
-# type, exactly as the vendored pgtypes/c.h (already excluded) does. int64_t is the
-# only spelling that resolves to the same 64-bit type as the installed pg_*.h on EVERY
-# platform (long int on Linux LP64, long long on Windows LLP64 and macOS); a hardcoded
-# `long int` is 32-bit on Windows and conflicts with pg_text.h's int64_t. Exclude the
-# template like the other vendored base-type headers; the ban still covers all API
-# signatures (which must use the int64 / uint64 aliases, never int64_t directly).
+# pgtypes/pg_basetypes.h is the ONE place that DEFINES the PG aliases from the C99
+# types, and it must spell int64 as `typedef int64_t int64`: int64_t is the only
+# spelling that resolves to the same 64-bit type on EVERY platform (long int on Linux
+# LP64, long long on Windows LLP64 and macOS), whereas a hardcoded `long int` is 32-bit
+# on Windows. It sits under pgtypes/, which this check does not scan, so it needs no
+# exclusion of its own — and neither does meos/include/postgres_ext_defs.in.h, which
+# now includes it rather than restating the types. The exclusion below stays only so
+# that a template reintroducing a definition is not rejected for the right spelling.
+# The ban still covers all API signatures, which use the int64 / uint64 aliases.
 violations=$(grep -rEn '\bu?int64_t\b' \
   meos/include \
   mobilitydb/pg_include \


### PR DESCRIPTION
Nine headers each restate the scalar base types: `float4` in seven of them, `float8` in eight, `int64` in five, and only `pg_int.h` guards its copy with `POSTGRES_H`. A translation unit reaching two of them holds two typedefs for one name, and the two spellings are the same type only from PostgreSQL 18 on — PG17 declares `int64` as `long int`, so wherever `int64_t` is `long long` the second definition is a redefinition with a different type.

Two lines reproduce what that costs today, with no test involved:

```c
#include <meos.h>
#include <pg_int.h>    /* error: unknown type name 'float4' */
```

`<meos.h>` carries the splice, which defines `POSTGRES_H` and supplies the integer types only; `pg_int.h` then skips its own guarded typedefs on the premise that PostgreSQL's base types are in scope, and declares `float4_to_int64(float4)`. The premise is false for that definer.

`pgtypes/pg_basetypes.h` states the ten names once under the guard, and every `pg_*.h` includes it in place of its own copies. The splice reads the same header rather than restating the integers, placed before it defines `POSTGRES_H`, since that macro is what says PostgreSQL already supplies them.

Each header still stands alone, which is the property a one-sided check cannot see: with `POSTGRES_H` out of scope every one emits all ten typedefs exactly as before, and with it in scope every one emits none. Nothing emitted cannot clash on any platform, so the result holds by construction rather than by per-platform luck.

On a toolchain where `int64_t` is `long long`, a PG17-shaped unit including each header raises `conflicting types for 'int64'` for five of the eight — `pg_date`, `pg_numeric`, `pg_timestamp`, `pg_time`, `pg_text` — and for none of them here. `meos/test/int_test.c`, the only consumer of the `<meos.h>` + `<pg_int.h>` pair, compiles and runs.

`pg_numeric.h` is the one file of the eight carrying PostgreSQL's own header rather than MobilityDB's, so its include is marked `/* MEOS */` to keep the deviation greppable across an upstream re-sync. `tools/scripts/check_int64_in_headers.sh` names the new owner in its comment; its scope and verdict are unchanged.