### PR TITLE
Name every wrapper a cell-index function answers

### DIFF
--- a/meos/src/temporal/tcellindex.c
+++ b/meos/src/temporal/tcellindex.c
@@ -186,7 +186,7 @@ tcellindex_lift_param1(const Temporal *temp, Datum (*func)(Datum, Datum),
 /**
  * @ingroup meos_cellindex
  * @brief Return the temporal resolution (tint) of a temporal cell index.
- * @csqlfn #Tquadbin_get_resolution()
+ * @csqlfn #Tquadbin_get_resolution(), #Th3index_get_resolution()
  */
 Temporal *
 tcellindex_get_resolution(const Temporal *temp)
@@ -203,7 +203,7 @@ tcellindex_get_resolution(const Temporal *temp)
  * @ingroup meos_cellindex
  * @brief Return a tbool stating at each instant whether the value is a valid
  * cell.
- * @csqlfn #Tquadbin_is_valid_cell()
+ * @csqlfn #Tquadbin_is_valid_cell(), #Th3index_is_valid_cell()
  */
 Temporal *
 tcellindex_is_valid_cell(const Temporal *temp)
@@ -219,7 +219,7 @@ tcellindex_is_valid_cell(const Temporal *temp)
 /**
  * @ingroup meos_cellindex
  * @brief Return the temporal parent cell at the given resolution.
- * @csqlfn #Tquadbin_cell_to_parent()
+ * @csqlfn #Tquadbin_cell_to_parent(), #Th3index_cell_to_parent()
  */
 Temporal *
 tcellindex_cell_to_parent(const Temporal *temp, int32 resolution)
@@ -252,7 +252,7 @@ tcellindex_cell_to_point(const Temporal *temp)
 /**
  * @ingroup meos_cellindex
  * @brief Return the temporal cell boundary as a temporal (multi)polygon.
- * @csqlfn #Tquadbin_cell_to_boundary()
+ * @csqlfn #Tquadbin_cell_to_boundary(), #Th3index_cell_to_boundary()
  */
 Temporal *
 tcellindex_cell_to_boundary(const Temporal *temp)
@@ -270,7 +270,7 @@ tcellindex_cell_to_boundary(const Temporal *temp)
 /**
  * @ingroup meos_cellindex
  * @brief Return the temporal cell area in square meters (tfloat).
- * @csqlfn #Tquadbin_cell_area()
+ * @csqlfn #Tquadbin_cell_area(), #Th3index_cell_area()
  */
 Temporal *
 tcellindex_cell_area(const Temporal *temp)


### PR DESCRIPTION
One tcellindex_* body serves every temporal cell index type that binds it: Th3index_cell_area and Tquadbin_cell_area each call tcellindex_cell_area, and MobilityDB creates cellArea(th3index) and cellArea(tquadbin) over them. The @csqlfn names only the quadbin wrapper, so the catalog resolves the function to one of its SQL surfaces and a binding generated from it registers that one alone. Five of the six name each wrapper that answers them, the shape the catalog reads as the two declared operand types where it reads one: regenerating from this tree turns the declared arg types of tcellindex_get_resolution and tcellindex_is_valid_cell from ['tquadbin'] into ['th3index', 'tquadbin']. cell_to_point keeps its single reference, the h3 surface declaring no cellToPoint. A DGGS added to the family names its wrapper here the same way.