### PR TITLE
Cluster a geometry that is not a point where the build carries no GEOS

### DIFF
--- a/meos/src/geo/geo_lwgeom_none.c
+++ b/meos/src/geo/geo_lwgeom_none.c
@@ -43,16 +43,23 @@
  *
  * That error travels the channel liblwgeom's own errors travel: MEOS installs
  * @p meos_lwerror_handler(), so it reaches the caller as a MEOS error rather
- * than ending the process. The MEOS entry points that reach these same
- * operations report them as not supported before liblwgeom is reached at all,
- * so nothing of MEOS arrives here; the definitions exist so that the set of
- * entry points the left-out files carry is answered as a whole.
+ * than ending the process.
+ *
+ * ONE of them is answered rather than refused. @p lwgeom_centroid() IS reached
+ * from MEOS: #geo_cluster_kmeans() calls @p lwgeom_cluster_kmeans(), which
+ * takes the centroid of every input that is not a point, so a build carrying
+ * no GEOS could not cluster a polygon. #meos_centroid() answers it natively,
+ * so the clustering works wherever the library does. The rest are reached only
+ * from entry points MEOS never calls, and the definitions exist so that the
+ * set of entry points the left-out files carry is answered as a whole.
  */
 
 /* PostGIS */
 #include <liblwgeom.h>
 #include <lwgeom_geos.h>
 #include <lwgeom_log.h>
+/* MEOS */
+#include "geo/geo_funcs.h"
 
 /**
  * @brief The message the geometry library's GEOS files leave for their callers
@@ -75,11 +82,15 @@ lwgeom_needs_geos(const char *name)
   return NULL;
 }
 
+/**
+ * @brief Return the centroid of a geometry
+ * @details Answered natively, because @p lwkmeans.c takes the centroid of
+ * every clustered geometry that is not a point and MEOS reaches it there
+ */
 LWGEOM *
 lwgeom_centroid(const LWGEOM *geom)
 {
-  (void) geom;
-  return lwgeom_needs_geos(__func__);
+  return meos_centroid(geom);
 }
 
 LWGEOM *

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -585,6 +585,21 @@ int main(void)
   assert(meos_errno() != 0);
   meos_errno_reset();
 
+  /* The clustering seeds itself from the CENTROID of every input that is not a
+   * point, so an array carrying a line reaches an answer a build with no GEOS
+   * has to hold on its own. The two clusters here are the pair at the origin
+   * and the point far from it */
+  int nkmeans = 0;
+  int *kmeans = geo_cluster_kmeans(cl, 4, 2, &nkmeans);
+  assert(kmeans != NULL);
+  assert(nkmeans == 4);
+  assert(kmeans[0] == kmeans[1] && kmeans[1] == kmeans[2]);
+  assert(kmeans[3] != kmeans[0]);
+  printf("clusterKMeans over a line and three points: %d %d %d %d\n",
+    kmeans[0], kmeans[1], kmeans[2], kmeans[3]);
+  free(kmeans);
+  meos_errno_reset();
+
   /* The k-means clustering reports a missing output parameter, which it reads
    * before the count of clusters is written to it */
   assert(geo_cluster_kmeans(cl, 4, 2, NULL) == NULL);

--- a/tools/scripts/liblwgeom_geos_baseline.txt
+++ b/tools/scripts/liblwgeom_geos_baseline.txt
@@ -4,7 +4,6 @@
 # shrinks: a call to an entry point it does not carry fails the
 # check. Regenerate with --rebaseline once a native answer takes
 # a call over. The library answers 125 entry points in all.
-meos/src/geo/postgis_funcs.c	lwgeom_centroid
 meos/src/geo/postgis_funcs.c	lwgeom_difference_prec
 meos/src/geo/postgis_funcs.c	lwgeom_intersection_prec
 meos/src/geo/postgis_funcs.c	lwgeom_is_simple


### PR DESCRIPTION
The k-means clustering seeds itself from the CENTROID of every input that is not a point, through the vendored `lwkmeans.c`, so it reaches an entry point of the geometry library that GEOS answers. A build configured with `-DGEOS=OFF` stubs that entry point with the error saying the operation needs GEOS, so clustering an array holding a line or a polygon raises there:

```
lwgeom_centroid: the operation is answered by the GEOS library, which
this build excludes: configure with -DGEOS=ON
```

The centroid has a native answer, so the stub gives that answer rather than the error. Clustering the same array of a line and three points reports `1 1 1 0` in both builds.

The brief of `meos/src/geo/geo_lwgeom_none.c` holds that nothing of MEOS arrives at these stubs, because the entry points reaching them report the operation as unsupported first. That is true of five stubs and false of this one: `geo_cluster_kmeans` hands the whole array to the library, which decides per component what it needs. The brief names which stub is answered and why.

`meos/test/geo_test.c` clusters a line together with three points and reads the answer. The array it parses already carries a line, and the two clustering calls over it ask only for the errors — a mixture of SRIDs, and a missing output parameter — so no successful clustering of anything but a point runs, which is how a build carrying no GEOS raises here unnoticed.

The baseline of `tools/scripts/check_liblwgeom_geos.py` loses its `lwgeom_centroid` row, which the native centroid vacates: the row goes because the call is gone, which is the direction that file allows. The library answers 125 entry points and MobilityDB calls 8 of them.

The five other stubs stand as they are. Their callers — `rt_raster_geos_spatial_relationship`, `lwgeom_wrapx`, `lwgeom_locate_between`, `lwgeom_solid_contains_lwgeom` — are entry points MobilityDB never calls, so the definitions complete the set the left-out files carry, and a native answer behind them would reach nothing.