### PR TITLE
Make the cast from a point cloud box to a spatiotemporal box explicit

### DIFF
--- a/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
+++ b/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
@@ -134,15 +134,19 @@ CREATE FUNCTION tpcbox(pcpoint)
 CREATE CAST (pcpatch AS tpcbox) WITH FUNCTION tpcbox(pcpatch);
 CREATE CAST (pcpoint AS tpcbox) WITH FUNCTION tpcbox(pcpoint);
 
--- Project a tpcbox to an stbox by dropping the pcid. Lets tpcbox values
--- compose into stbox-only operators (extent aggregation across mixed
--- pcids, generic spatiotemporal predicates) without manual conversion.
+-- Project a tpcbox to an stbox by dropping the pcid. Write `value::stbox` to
+-- compose a tpcbox into an stbox-only operator, as every other projection into
+-- stbox is written.
 CREATE FUNCTION stbox(tpcbox)
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Tpcbox_to_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE CAST (tpcbox AS stbox) WITH FUNCTION stbox(tpcbox) AS IMPLICIT;
+-- The cast is explicit. An implicit one lets a tpcbox reach the stbox
+-- operators with no schema comparison at all, so `tpcbox && stbox` answers
+-- where `tpcbox && tpcbox` reports the pcid mismatch, and a tpcbox assigns
+-- into an stbox column dropping its schema silently.
+CREATE CAST (tpcbox AS stbox) WITH FUNCTION stbox(tpcbox);
 
 /******************************************************************************
  * Accessors


### PR DESCRIPTION
An implicit cast from `tpcbox` to `stbox` lets a point cloud box reach the
`stbox` operators with no schema comparison at all. No `(tpcbox, stbox)`
operator is declared, so these forms resolve through the cast alone:

```
tpcbox(0,0,10,10,1,0) && tpcbox(0,0,5,5,2,0)      -- ERROR: Operation on TPCBox
                                                  --   values with different schemas: 1 vs 2
tpcbox(0,0,10,10,1,0) && stbox 'STBOX X((0,0),(5,5))'  -- t

CREATE TABLE sink (b stbox);
INSERT INTO sink SELECT tpcbox(0,0,10,10,1,0);    -- accepted
SELECT b FROM sink;                               -- STBOX X((0,0),(10,10))
```

The schema check that every `tpcbox`-vs-`tpcbox` operator applies is therefore
bypassed by writing one operand as an `stbox`, or by assigning a point cloud
box into an `stbox` column, where the pcid disappears without a word.

This declares the cast explicit, so a point cloud box reaches the `stbox`
operators by `value::stbox`, the way every other projection into `stbox`
reaches them — from `box2d`, `box3d`, `geometry`, `geography`, `geomset` and
`geogset`, all of which are explicit.

The remaining `AS IMPLICIT` casts of the SQL surface are the same-type typmod
cast, `CREATE CAST (T AS T) WITH FUNCTION T(T, integer)`, which PostgreSQL
requires to be implicit for typmod enforcement. This is the only cross-type one.
