### PR TITLE
[comment-only] Name the S2 wrappers on the shared cell-index kernels

### DIFF
--- a/meos/src/temporal/tcellindex.c
+++ b/meos/src/temporal/tcellindex.c
@@ -186,7 +186,7 @@ tcellindex_lift_param1(const Temporal *temp, Datum (*func)(Datum, Datum),
 /**
  * @ingroup meos_cellindex
  * @brief Return the temporal resolution (tint) of a temporal cell index.
- * @csqlfn #Tquadbin_get_resolution(), #Th3index_get_resolution()
+ * @csqlfn #Tquadbin_get_resolution(), #Th3index_get_resolution(), #Ts2cell_get_resolution()
  */
 Temporal *
 tcellindex_get_resolution(const Temporal *temp)
@@ -203,7 +203,7 @@ tcellindex_get_resolution(const Temporal *temp)
  * @ingroup meos_cellindex
  * @brief Return a tbool stating at each instant whether the value is a valid
  * cell.
- * @csqlfn #Tquadbin_is_valid_cell(), #Th3index_is_valid_cell()
+ * @csqlfn #Tquadbin_is_valid_cell(), #Th3index_is_valid_cell(), #Ts2cell_is_valid_cell()
  */
 Temporal *
 tcellindex_is_valid_cell(const Temporal *temp)
@@ -219,7 +219,7 @@ tcellindex_is_valid_cell(const Temporal *temp)
 /**
  * @ingroup meos_cellindex
  * @brief Return the temporal parent cell at the given resolution.
- * @csqlfn #Tquadbin_cell_to_parent(), #Th3index_cell_to_parent()
+ * @csqlfn #Tquadbin_cell_to_parent(), #Th3index_cell_to_parent(), #Ts2cell_cell_to_parent()
  */
 Temporal *
 tcellindex_cell_to_parent(const Temporal *temp, int32 resolution)
@@ -236,7 +236,7 @@ tcellindex_cell_to_parent(const Temporal *temp, int32 resolution)
  * @ingroup meos_cellindex
  * @brief Return the temporal cell centroid as a temporal point (geodetic for
  * H3/S2, Web-Mercator for quadbin).
- * @csqlfn #Tquadbin_cell_to_point()
+ * @csqlfn #Tquadbin_cell_to_point(), #Ts2cell_cell_to_point()
  */
 Temporal *
 tcellindex_cell_to_point(const Temporal *temp)
@@ -252,7 +252,7 @@ tcellindex_cell_to_point(const Temporal *temp)
 /**
  * @ingroup meos_cellindex
  * @brief Return the temporal cell boundary as a temporal (multi)polygon.
- * @csqlfn #Tquadbin_cell_to_boundary(), #Th3index_cell_to_boundary()
+ * @csqlfn #Tquadbin_cell_to_boundary(), #Th3index_cell_to_boundary(), #Ts2cell_cell_to_boundary()
  */
 Temporal *
 tcellindex_cell_to_boundary(const Temporal *temp)
@@ -270,7 +270,7 @@ tcellindex_cell_to_boundary(const Temporal *temp)
 /**
  * @ingroup meos_cellindex
  * @brief Return the temporal cell area in square meters (tfloat).
- * @csqlfn #Tquadbin_cell_area(), #Th3index_cell_area()
+ * @csqlfn #Tquadbin_cell_area(), #Th3index_cell_area(), #Ts2cell_cell_area()
  */
 Temporal *
 tcellindex_cell_area(const Temporal *temp)


### PR DESCRIPTION
**Comment-only PR** — Doxygen `@csqlfn` tags only, no code or behavior change; the 12 changed lines all sit inside `/** */` blocks in `meos/src/temporal/tcellindex.c`.

The six generic cell-index entry points serve every DGGS family, and each family's PG wrapper delegates to them: `Ts2cell_get_resolution`, `_is_valid_cell`, `_cell_to_parent`, `_cell_to_point`, `_cell_to_boundary` and `_cell_area` each call the kernel of the same name. The kernels name the quadbin and h3 wrappers, so the catalog attaches those families' SQL overloads alone and the S2 surface — `getResolution`, `isValidCell`, `cellArea`, `cellToParent`, `cellToPoint` and `cellToBoundary` over `ts2cell` — reaches no binding that generates from the catalog. The `cell_to_point` kernel names quadbin and S2 only, h3 answering that slot geodetically from `th3index_to_tgeogpoint`.

Deriving the MEOS-API catalog from this tree gives each kernel its ts2cell overload: `tcellindex_get_resolution` reads `[tquadbin] [th3index] [ts2cell]`, `cell_to_parent` reads `[tquadbin,integer] [th3index,integer] [ts2cell,integer]`, and `cell_to_point` reads `[tquadbin] [ts2cell]`.