### PR TITLE
Publish the shared cell index faces over a static h3index

### DIFF
--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -505,10 +505,13 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
 				<indexterm significance="normal"><primary><varname>getResolution</varname></primary></indexterm>
 				<para>Devolver la resolución de cada celda de una trayectoria</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+getResolution(cell) → integer
 getResolution(tcell) → tint
 </programlisting>
 				<para>Devolver la resolución de una celda, como un <varname>integer</varname> desde la forma estática y como un <varname>tint</varname> de la resolución de cada celda de una trayectoria desde la temporal. QUADBIN la llama nivel de zoom y S2 nivel, y el rango pertenece a la cuadrícula: de 0 a 15 para H3, de 0 a 26 para QUADBIN, de 0 a 30 para S2.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT getResolution(h3index '831c02fffffffff');
+-- 3
 SELECT getResolution(th3index '831c02fffffffff@2001-01-01');
 -- 3@2001-01-01
 SELECT getResolution(tquadbin '48a6227affffffff@2001-01-01');
@@ -523,11 +526,14 @@ SELECT getResolution(ts2cell '47c3c@2001-01-01');
 				<indexterm significance="normal"><primary><varname>isValidCell</varname></primary></indexterm>
 				<para>Devolver un booleano temporal que indica en cada instante si el valor es una celda válida</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+isValidCell(cell) → boolean
 isValidCell(tcell) → tbool
 </programlisting>
 				<para>Un valor es una celda válida cuando su patrón de bits denota algo que su cuadrícula indexa: para QUADBIN, coordenadas de tesela dentro de los límites de la resolución que declara el identificador; para H3, una celda base y una secuencia de dígitos que lleva el icosaedro; para S2, una cara y una posición de Hilbert en un nivel entre 0 y 30.</para>
 				<para>Solo a H3 se le puede plantear la pregunta sobre un valor que responde <varname>false</varname>: su función de entrada admite cualquier patrón de bits y deja el veredicto a esta función, mientras que las funciones de entrada de QUADBIN y de S2 rechazan un patrón que no indexa nada, de modo que <varname>tquadbin '0'</varname> y <varname>ts2cell '0'</varname> provocan un error antes de que se haga la llamada.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidCell(quadbin '48a6227affffffff');
+-- t
 SELECT isValidCell(th3index '831c02fffffffff@2001-01-01');
 -- t@2001-01-01
 SELECT isValidCell(th3index '0@2001-01-01');
@@ -549,11 +555,14 @@ SELECT isValidCell(ts2cell '47c3c@2001-01-01');
 				<indexterm significance="normal"><primary><varname>cellToParent</varname></primary></indexterm>
 				<para>Devolver la celda padre temporal en la resolución dada</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+cellToParent(cell,integer) → cell
 cellToParent(tcell,integer) → tcell
 cellToParent(tcell) → tcell
 </programlisting>
 				<para>Devolver el ancestro de una celda en la resolución más gruesa dada. La forma estática toma una única <varname>cell</varname>; la forma temporal devuelve el ancestro de cada celda de una trayectoria. La forma sin argumento desciende a la resolución inmediatamente más gruesa.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT cellToParent(h3index '8a2a1072b59ffff', 5);
+-- 852a1073fffffff
 SELECT getResolution(cellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
 -- 5@2001-01-01
 SELECT getResolution(cellToParent(tquadbin
@@ -592,11 +601,14 @@ SELECT getResolution(th3index(tgeompoint
 				<indexterm significance="normal"><primary><varname>tgeompoint</varname></primary></indexterm>
 				<para>Devolver el centroide geodésico temporal de cada celda de una trayectoria</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+cellToPoint(cell) → geometry
 cellToPoint(tcell) → tgeogpoint
 tgeompoint(tcell) → tgeompoint
 </programlisting>
 				<para>La forma <varname>tgeompoint</varname> responde el mismo centroide como un punto plano en SRID 4326, y H3 es la única cuadrícula que publica ambas formas. La operación se llama <varname>cellToPoint</varname> para todas las cuadrículas, siendo la ranura <varname>cell_to_point</varname> del descriptor lo que lo fija.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(cellToPoint(h3index '871fa44a8ffffff'), 6);
+-- POINT(4.297401 50.8043)
 SELECT asText(cellToPoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
 SELECT asText(tgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
@@ -612,10 +624,13 @@ SELECT asText(cellToPoint(ts2cell '47c3c@2001-01-01'), 6);
 				<indexterm significance="normal"><primary><varname>cellToBoundary</varname></primary></indexterm>
 				<para>Devolver la frontera poligonal temporal de cada celda de una trayectoria, como una geografía temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+cellToBoundary(cell) → geometry
 cellToBoundary(tcell) → tgeography
 </programlisting>
 				<para>Devolver la frontera poligonal de una celda en el SRID 4326. La forma estática toma una única <varname>cell</varname>; la forma temporal devuelve la frontera de cada celda de una trayectoria. El anillo se cierra sobre su primer vértice, de modo que un hexágono H3 lleva siete puntos y un cuadrado QUADBIN o un cuadrilátero esférico S2 cinco.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_NPoints(cellToBoundary(h3index '871fa44a8ffffff'));
+-- 7
 SELECT ST_GeometryType(getValue(cellToBoundary(th3index
   '871fa44a8ffffff@2001-01-01'))::geometry);
 -- ST_Polygon

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -505,10 +505,13 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7) ?=
 				<indexterm significance="normal"><primary><varname>getResolution</varname></primary></indexterm>
 				<para>Return the resolution of each cell in a trajectory</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+getResolution(cell) → integer
 getResolution(tcell) → tint
 </programlisting>
 				<para>Return the resolution of a cell, as an <varname>integer</varname> from the static form and as a <varname>tint</varname> of the resolution of each cell in a trajectory from the temporal one. QUADBIN calls it a zoom level and S2 a level, and the range belongs to the grid: 0 to 15 for H3, 0 to 26 for QUADBIN, 0 to 30 for S2.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT getResolution(h3index '831c02fffffffff');
+-- 3
 SELECT getResolution(th3index '831c02fffffffff@2001-01-01');
 -- 3@2001-01-01
 SELECT getResolution(tquadbin '48a6227affffffff@2001-01-01');
@@ -523,11 +526,14 @@ SELECT getResolution(ts2cell '47c3c@2001-01-01');
 				<indexterm significance="normal"><primary><varname>isValidCell</varname></primary></indexterm>
 				<para>Return a temporal boolean stating at each instant whether the value is a valid cell</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+isValidCell(cell) → boolean
 isValidCell(tcell) → tbool
 </programlisting>
 				<para>A value is a valid cell when its bit pattern denotes something its grid indexes: for QUADBIN, tile coordinates within the bounds of the resolution the identifier states; for H3, a base cell and digit sequence the icosahedron carries; for S2, a face and a Hilbert position at a level between 0 and 30.</para>
 				<para>Only H3 can be asked the question of a value that answers <varname>false</varname>: its input function admits any bit pattern and leaves the verdict to this function, while the QUADBIN and the S2 input functions reject a pattern that indexes nothing, so <varname>tquadbin '0'</varname> and <varname>ts2cell '0'</varname> raise an error before the call is made.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT isValidCell(quadbin '48a6227affffffff');
+-- t
 SELECT isValidCell(th3index '831c02fffffffff@2001-01-01');
 -- t@2001-01-01
 SELECT isValidCell(th3index '0@2001-01-01');
@@ -549,11 +555,14 @@ SELECT isValidCell(ts2cell '47c3c@2001-01-01');
 				<indexterm significance="normal"><primary><varname>cellToParent</varname></primary></indexterm>
 				<para>Return the temporal parent cell at the given resolution</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+cellToParent(cell,integer) → cell
 cellToParent(tcell,integer) → tcell
 cellToParent(tcell) → tcell
 </programlisting>
 				<para>Return the ancestor of a cell at the given coarser resolution. The static form takes a single <varname>cell</varname>; the temporal form returns the ancestor of each cell in a trajectory. The no-argument form drops to the next-coarser resolution.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT cellToParent(h3index '8a2a1072b59ffff', 5);
+-- 852a1073fffffff
 SELECT getResolution(cellToParent(th3index '8a2a1072b59ffff@2001-01-01', 5));
 -- 5@2001-01-01
 SELECT getResolution(cellToParent(tquadbin
@@ -592,11 +601,14 @@ SELECT getResolution(th3index(tgeompoint
 				<indexterm significance="normal"><primary><varname>tgeompoint</varname></primary></indexterm>
 				<para>Return the temporal geodetic centroid of each cell in a trajectory</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+cellToPoint(cell) → geometry
 cellToPoint(tcell) → tgeogpoint
 tgeompoint(tcell) → tgeompoint
 </programlisting>
 				<para>The <varname>tgeompoint</varname> form answers the same centroid as an SRID-4326 planar point, and H3 is the one grid publishing both forms. The operation is named <varname>cellToPoint</varname> for every grid, the <varname>cell_to_point</varname> slot of the descriptor being what fixes it.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_AsText(cellToPoint(h3index '871fa44a8ffffff'), 6);
+-- POINT(4.297401 50.8043)
 SELECT asText(cellToPoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
 -- POINT(4.297401 50.8043)@2001-01-01
 SELECT asText(tgeompoint(th3index '871fa44a8ffffff@2001-01-01'), 6);
@@ -612,10 +624,13 @@ SELECT asText(cellToPoint(ts2cell '47c3c@2001-01-01'), 6);
 				<indexterm significance="normal"><primary><varname>cellToBoundary</varname></primary></indexterm>
 				<para>Return the temporal polygon boundary of each cell in a trajectory, as a temporal geography</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+cellToBoundary(cell) → geometry
 cellToBoundary(tcell) → tgeography
 </programlisting>
 				<para>Return the polygon boundary of a cell in SRID 4326. The static form takes a single <varname>cell</varname>; the temporal form returns the boundary of each cell in a trajectory. The ring closes on its first vertex, so an H3 hexagon carries seven points and a QUADBIN square or an S2 spherical quadrilateral five.</para>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT ST_NPoints(cellToBoundary(h3index '871fa44a8ffffff'));
+-- 7
 SELECT ST_GeometryType(getValue(cellToBoundary(th3index
   '871fa44a8ffffff@2001-01-01'))::geometry);
 -- ST_Polygon

--- a/meos/include/h3/doxygen_meos_h3.h
+++ b/meos/include/h3/doxygen_meos_h3.h
@@ -117,6 +117,22 @@
  * @defgroup meos_h3_base_comp Comparison functions
  * @ingroup meos_h3_base
  * @brief Comparison functions for static H3 cell indices
+ *
+ * @defgroup meos_h3_base_inspection Index-inspection functions
+ * @ingroup meos_h3_base
+ * @brief Index-inspection functions for static H3 cell indices
+ *
+ * @defgroup meos_h3_base_hierarchy Hierarchy functions
+ * @ingroup meos_h3_base
+ * @brief Hierarchy functions for static H3 cell indices
+ *
+ * @defgroup meos_h3_base_latlng Lat/Lng-conversion functions
+ * @ingroup meos_h3_base
+ * @brief Lat/Lng-conversion functions for static H3 cell indices
+ *
+ * @defgroup meos_h3_base_metrics Metric functions
+ * @ingroup meos_h3_base
+ * @brief Metric functions for static H3 cell indices
  */
 
 /*****************************************************************************/

--- a/meos/include/h3/th3index_internal.h
+++ b/meos/include/h3/th3index_internal.h
@@ -84,8 +84,6 @@ typedef enum
  *****************************************************************************/
 
 /* Point / polygon conversions — bodies in th3index_latlng.c. */
-extern GSERIALIZED *h3_cell_to_geompoint(H3Index cell);
-extern GSERIALIZED *h3_cell_to_geom(H3Index cell);
 
 /* Shared helper: build a geodetic SRID 4326 LWPOLY from a libh3
  * CellBoundary and serialise. Primary definition in

--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -135,6 +135,23 @@ extern char *h3index_as_hexwkb(H3Index cell, uint8_t variant, size_t *size_out);
  * declared in h3_ext_defs.in.h spliced above: their bare names collide
  * with the C symbols of the h3-pg PostgreSQL extension. */
 
+/* Inspection */
+
+extern uint32_t h3index_get_resolution(H3Index cell);
+
+/* Hierarchy */
+
+extern H3Index h3index_cell_to_parent(H3Index cell, uint32_t parent_resolution);
+
+/* Geometry (lon/lat, SRID 4326) */
+
+extern GSERIALIZED *h3index_cell_to_point(H3Index cell);
+extern GSERIALIZED *h3index_cell_to_boundary(H3Index cell);
+
+/* Metrics */
+
+extern double h3index_cell_area(H3Index cell);
+
 /*****************************************************************************
  * Type inheritance (analogue of meos_cbuffer.h's tcbuffer section)
  *****************************************************************************/

--- a/meos/src/h3/h3index.c
+++ b/meos/src/h3/h3index.c
@@ -175,6 +175,68 @@ ensure_h3index_vertex(H3Index vertex)
 }
 
 /*****************************************************************************
+ * Scalar MEOS API for the shared DggsCellOps faces
+ *
+ * The faces every grid publishes, spelled as `quadbin_*` and `s2cell_*` spell
+ * them, over the h3-pg imports of `h3_generated.h`. The unit is the one the
+ * `DggsCellOps` descriptor fixes: an area is square metres, so the unit
+ * argument `h3_cell_area_meos()` carries does not reach this surface.
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_h3_base_inspection
+ * @brief Return the resolution of an H3 cell
+ * @param[in] cell H3 cell
+ * @csqlfn #H3index_get_resolution()
+ */
+uint32_t
+h3index_get_resolution(H3Index cell)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_h3index_cell(cell))
+    return 0;
+  return (uint32_t) h3_get_resolution_meos(cell);
+}
+
+/**
+ * @ingroup meos_h3_base_hierarchy
+ * @brief Return the parent of an H3 cell at a coarser resolution
+ * @param[in] cell H3 cell
+ * @param[in] parent_resolution Target resolution (<= resolution of @p cell)
+ * @return The parent cell, or 0 on error
+ * @csqlfn #H3index_cell_to_parent()
+ */
+H3Index
+h3index_cell_to_parent(H3Index cell, uint32_t parent_resolution)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_h3index_cell(cell))
+    return 0;
+  if (parent_resolution > (uint32_t) h3_get_resolution_meos(cell))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The parent resolution must not be finer than the resolution of the cell");
+    return 0;
+  }
+  return h3_cell_to_parent_meos(cell, (int32) parent_resolution);
+}
+
+/**
+ * @ingroup meos_h3_base_metrics
+ * @brief Return the area in square metres of an H3 cell
+ * @param[in] cell H3 cell
+ * @csqlfn #H3index_cell_area()
+ */
+double
+h3index_cell_area(H3Index cell)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_h3index_cell(cell))
+    return 0.0;
+  return h3_cell_area_meos(cell, H3_UNIT_M2);
+}
+
+/*****************************************************************************
  * Datum wrappers for inspection
  *****************************************************************************/
 
@@ -487,7 +549,7 @@ datum_h3_cell_to_latlng(Datum d)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_H3INDEX_CELL(DatumGetH3Index(d), (Datum) 0);
-  GSERIALIZED *gs = h3_cell_to_geompoint(DatumGetH3Index(d));
+  GSERIALIZED *gs = h3index_cell_to_point(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
 
@@ -499,7 +561,7 @@ datum_h3_cell_to_boundary(Datum d)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_H3INDEX_CELL(DatumGetH3Index(d), (Datum) 0);
-  GSERIALIZED *gs = h3_cell_to_geom(DatumGetH3Index(d));
+  GSERIALIZED *gs = h3index_cell_to_boundary(DatumGetH3Index(d));
   return PointerGetDatum(gs);
 }
 

--- a/meos/src/h3/th3index_edges.c
+++ b/meos/src/h3/th3index_edges.c
@@ -73,7 +73,7 @@ h3_directed_edge_to_gs_boundary(H3Index edge)
    * as cells), swapping lat/lng in the process — a known upstream
    * quirk. We emit a closed POLYGON too so consumers see a uniform
    * shape, but keep x = lng, y = lat as in
-   * `h3_cell_to_geom`. */
+   * `h3index_cell_to_boundary`. */
   return cell_boundary_to_gs(&bnd);
 }
 

--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -33,7 +33,7 @@
  * adapter bodies that back them.
  *
  * The static h3 conversions `geo_to_h3index_cell`,
- * `h3_cell_to_geompoint`, and `h3_cell_to_geom` live here
+ * `h3index_cell_to_point`, and `h3index_cell_to_boundary` live here
  * alongside the lifted entries that consume them. Point reads use
  * the MobilityDB peek macro `GSERIALIZED_POINT2D_P` rather than
  * `lwgeom_from_gserialized` — approved by the PostGIS team and a
@@ -90,10 +90,13 @@ geo_to_h3index_cell(const GSERIALIZED *point, int32 resolution)
 }
 
 /**
- * @brief 
+ * @ingroup meos_h3_base_latlng
+ * @brief Return the centroid of an H3 cell as a geometry point
+ * @param[in] cell H3 cell
+ * @csqlfn #H3index_cell_to_point()
  */
 GSERIALIZED *
-h3_cell_to_geompoint(H3Index cell)
+h3index_cell_to_point(H3Index cell)
 {
   LatLng ll;
   if (cellToLatLng(cell, &ll) != E_SUCCESS)
@@ -141,10 +144,13 @@ cell_boundary_to_gs(const CellBoundary *bnd)
 }
 
 /**
- * @brief 
+ * @ingroup meos_h3_base_latlng
+ * @brief Return the boundary of an H3 cell as a geometry polygon
+ * @param[in] cell H3 cell
+ * @csqlfn #H3index_cell_to_boundary()
  */
 GSERIALIZED *
-h3_cell_to_geom(H3Index cell)
+h3index_cell_to_boundary(H3Index cell)
 {
   CellBoundary bnd;
   if (cellToBoundary(cell, &bnd) != E_SUCCESS)
@@ -421,7 +427,7 @@ th3index_to_tgeogpoint(const Temporal *temp)
 /*****************************************************************************
  * cellToPoint (planar output, SRID 4326 overload)
  *
- * Both overloads share the same static adapter `h3_cell_to_geompoint`,
+ * Both overloads share the same static adapter `h3index_cell_to_point`,
  * which emits an SRID-4326 point. The geography-vs-geometry nature
  * of the result is disambiguated at the lifting layer via the
  * `restype` setting — downstream consumers see the intended type.

--- a/meos/src/h3/th3index_metrics.c
+++ b/meos/src/h3/th3index_metrics.c
@@ -77,7 +77,7 @@ h3_cell_area_meos(H3Index cell, H3Unit unit)
     case H3_UNIT_RADS2: err = cellAreaRads2(cell, &area); break;
     default:
       meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-        "h3_cell_area: expected an area unit (km2, m2, rads2)");
+        "h3_cell_area_meos: expected an area unit (km2, m2, rads2)");
       return 0.0;
   }
   if (err != E_SUCCESS)

--- a/mobilitydb/pg_include/pg_h3/doxygen_mobilitydb_h3.h
+++ b/mobilitydb/pg_include/pg_h3/doxygen_mobilitydb_h3.h
@@ -131,6 +131,22 @@
  * @defgroup mobilitydb_h3_base_comp Comparison functions
  * @ingroup mobilitydb_h3_base
  * @brief Comparison functions for static H3 cell indices
+ *
+ * @defgroup mobilitydb_h3_base_inspection Index-inspection functions
+ * @ingroup mobilitydb_h3_base
+ * @brief Index-inspection functions for static H3 cell indices
+ *
+ * @defgroup mobilitydb_h3_base_hierarchy Hierarchy functions
+ * @ingroup mobilitydb_h3_base
+ * @brief Hierarchy functions for static H3 cell indices
+ *
+ * @defgroup mobilitydb_h3_base_latlng Lat/Lng-conversion functions
+ * @ingroup mobilitydb_h3_base
+ * @brief Lat/Lng-conversion functions for static H3 cell indices
+ *
+ * @defgroup mobilitydb_h3_base_metrics Metric functions
+ * @ingroup mobilitydb_h3_base
+ * @brief Metric functions for static H3 cell indices
  */
 
 /*****************************************************************************/

--- a/mobilitydb/sql/h3/252_h3index_ops.in.sql
+++ b/mobilitydb/sql/h3/252_h3index_ops.in.sql
@@ -45,6 +45,55 @@
  */
 
 /******************************************************************************
+ * Resolution
+ ******************************************************************************/
+
+CREATE FUNCTION getResolution(h3index)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'H3index_get_resolution'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Hierarchy
+ *
+ * `cellToParent` drops to the requested coarser resolution;
+ * `h3CellToChildren` returns the seven child cells at the requested
+ * finer resolution as an `h3indexset`.
+ ******************************************************************************/
+
+CREATE FUNCTION cellToParent(h3index, integer)
+  RETURNS h3index
+  AS 'MODULE_PATHNAME', 'H3index_cell_to_parent'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Lat/Lng
+ ******************************************************************************/
+
+CREATE FUNCTION cellToPoint(h3index)
+  RETURNS geometry
+  AS 'MODULE_PATHNAME', 'H3index_cell_to_point'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION cellToBoundary(h3index)
+  RETURNS geometry
+  AS 'MODULE_PATHNAME', 'H3index_cell_to_boundary'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
+ * Metrics
+ *
+ * The unit is the square metre, the one the `DggsCellOps` descriptor
+ * fixes for `cell_area`. The two other units libh3 publishes are the
+ * H3-only `th3CellAreaKm2` / `th3CellAreaRads2`.
+ ******************************************************************************/
+
+CREATE FUNCTION cellArea(h3index)
+  RETURNS double precision
+  AS 'MODULE_PATHNAME', 'H3index_cell_area'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/******************************************************************************
  * Static geometry → H3 cell (POINT only) / cell set (any geometry)
  ******************************************************************************/
 

--- a/mobilitydb/src/h3/CMakeLists.txt
+++ b/mobilitydb/src/h3/CMakeLists.txt
@@ -1,5 +1,8 @@
 add_library(pg_h3 OBJECT
   h3index.c
+  # The DggsCellOps faces shared with quadbin and s2cell, wrapped where
+  # quadbin_ops.c and s2cell_ops.c wrap theirs.
+  h3index_ops.c
   h3index_sets.c
   th3index.c
   th3index_inspection.c

--- a/mobilitydb/src/h3/h3index_ops.c
+++ b/mobilitydb/src/h3/h3index_ops.c
@@ -1,0 +1,160 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief PG V1 wrappers for the static `h3index` cell operations.
+ *
+ * Each wrapper unpacks its arguments, delegates to the first-party H3
+ * kernel declared in `meos_h3.h`, and returns the result. The file holds
+ * the faces the `DggsCellOps` descriptor shares across every DGGS family
+ * — resolution, hierarchy, cell centroid and boundary, area — spelled
+ * with the bare slot names `quadbin` and `s2cell` already publish, so a
+ * query reads the same whichever grid holds the cell.
+ *
+ * `isValidCell` is the sixth face and lives in `h3index.c` beside the
+ * type plumbing, as `Quadbin_is_valid_cell` and `S2cell_is_valid_cell`
+ * live beside theirs. The hexagon-only surface (directed edges, vertices,
+ * pentagon / base-cell / class-III inspection, local-IJ traversal,
+ * great-circle metrics) has no counterpart in a square or a spherical
+ * quadrilateral grid and is wrapped in the `th3index_*` files.
+ *
+ * The cell centroid and boundary geometries are emitted as lon/lat
+ * (SRID 4326), matching the `h3_cellops` descriptor in
+ * `meos/src/h3/th3index_ops.c`.
+ */
+
+/* PostgreSQL */
+#include <postgres.h>
+#include <fmgr.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_geo.h>
+#include <meos_h3.h>
+#include "h3/h3index.h"
+/* MobilityDB */
+#include "pg_geo/postgis.h"
+
+/* DatumGetH3Index / H3IndexGetDatum live in h3index.h.
+ * PG_GETARG_H3INDEX / PG_RETURN_H3INDEX are the fmgr-layer
+ * conveniences defined locally here because fmgr.h is a
+ * MobilityDB-side dependency. */
+#define PG_GETARG_H3INDEX(n) DatumGetH3Index(PG_GETARG_DATUM(n))
+#define PG_RETURN_H3INDEX(x) PG_RETURN_DATUM(H3IndexGetDatum(x))
+
+/*****************************************************************************
+ * Resolution
+ *****************************************************************************/
+
+PGDLLEXPORT Datum H3index_get_resolution(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(H3index_get_resolution);
+/**
+ * @ingroup mobilitydb_h3_base_inspection
+ * @brief Return the resolution of an H3 cell
+ * @sqlfn getResolution()
+ */
+Datum
+H3index_get_resolution(PG_FUNCTION_ARGS)
+{
+  PG_RETURN_INT32((int32) h3index_get_resolution(PG_GETARG_H3INDEX(0)));
+}
+
+/*****************************************************************************
+ * Hierarchy
+ *****************************************************************************/
+
+PGDLLEXPORT Datum H3index_cell_to_parent(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(H3index_cell_to_parent);
+/**
+ * @ingroup mobilitydb_h3_base_hierarchy
+ * @brief Return the parent cell at the given coarser resolution
+ * @sqlfn cellToParent()
+ */
+Datum
+H3index_cell_to_parent(PG_FUNCTION_ARGS)
+{
+  H3Index cell = PG_GETARG_H3INDEX(0);
+  int32 resolution = PG_GETARG_INT32(1);
+  PG_RETURN_H3INDEX(h3index_cell_to_parent(cell, (uint32_t) resolution));
+}
+
+/*****************************************************************************
+ * Lat/Lng
+ *****************************************************************************/
+
+PGDLLEXPORT Datum H3index_cell_to_point(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(H3index_cell_to_point);
+/**
+ * @ingroup mobilitydb_h3_base_latlng
+ * @brief Return the centroid of an H3 cell
+ * @sqlfn cellToPoint()
+ */
+Datum
+H3index_cell_to_point(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *result = h3index_cell_to_point(PG_GETARG_H3INDEX(0));
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_GSERIALIZED_P(result);
+}
+
+PGDLLEXPORT Datum H3index_cell_to_boundary(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(H3index_cell_to_boundary);
+/**
+ * @ingroup mobilitydb_h3_base_latlng
+ * @brief Return the boundary of an H3 cell
+ * @sqlfn cellToBoundary()
+ */
+Datum
+H3index_cell_to_boundary(PG_FUNCTION_ARGS)
+{
+  GSERIALIZED *result = h3index_cell_to_boundary(PG_GETARG_H3INDEX(0));
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_GSERIALIZED_P(result);
+}
+
+/*****************************************************************************
+ * Metrics
+ *****************************************************************************/
+
+PGDLLEXPORT Datum H3index_cell_area(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(H3index_cell_area);
+/**
+ * @ingroup mobilitydb_h3_base_metrics
+ * @brief Return the area in square metres of an H3 cell
+ * @sqlfn cellArea()
+ */
+Datum
+H3index_cell_area(PG_FUNCTION_ARGS)
+{
+  PG_RETURN_FLOAT8(h3index_cell_area(PG_GETARG_H3INDEX(0)));
+}
+
+/*****************************************************************************/

--- a/mobilitydb/test/h3/expected/252_h3index_ops.test.out
+++ b/mobilitydb/test/h3/expected/252_h3index_ops.test.out
@@ -1,0 +1,141 @@
+SELECT getResolution(h3index '831c02fffffffff');
+ getresolution 
+---------------
+             3
+(1 row)
+
+SELECT getResolution(h3index '871fa44a8ffffff');
+ getresolution 
+---------------
+             7
+(1 row)
+
+SELECT getResolution(h3index '8a2a1072b59ffff');
+ getresolution 
+---------------
+            10
+(1 row)
+
+SELECT isValidCell(h3index '831c02fffffffff');
+ isvalidcell 
+-------------
+ t
+(1 row)
+
+SELECT isValidCell(h3index '0');
+ isvalidcell 
+-------------
+ f
+(1 row)
+
+SELECT getResolution(cellToParent(h3index '8a2a1072b59ffff', 5));
+ getresolution 
+---------------
+             5
+(1 row)
+
+SELECT cellToParent(h3index '8a2a1072b59ffff', 5);
+  celltoparent   
+-----------------
+ 852a1073fffffff
+(1 row)
+
+SELECT cellToParent(h3index '871fa44a8ffffff', 7) = h3index '871fa44a8ffffff';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cellToParent(h3index '831c02fffffffff', 7);
+ERROR:  The parent resolution must not be finer than the resolution of the cell
+SELECT round(ST_X(cellToPoint(h3index '871fa44a8ffffff'))::numeric, 6);
+  round   
+----------
+ 4.297401
+(1 row)
+
+SELECT round(ST_Y(cellToPoint(h3index '871fa44a8ffffff'))::numeric, 6);
+   round   
+-----------
+ 50.804300
+(1 row)
+
+SELECT ST_SRID(cellToPoint(h3index '871fa44a8ffffff'));
+ st_srid 
+---------
+    4326
+(1 row)
+
+SELECT ST_GeometryType(cellToBoundary(h3index '871fa44a8ffffff'));
+ st_geometrytype 
+-----------------
+ ST_Polygon
+(1 row)
+
+SELECT ST_SRID(cellToBoundary(h3index '871fa44a8ffffff'));
+ st_srid 
+---------
+    4326
+(1 row)
+
+SELECT ST_NPoints(cellToBoundary(h3index '871fa44a8ffffff'));
+ st_npoints 
+------------
+          7
+(1 row)
+
+SELECT ST_Contains(
+  cellToBoundary(h3index '871fa44a8ffffff'),
+  cellToPoint(h3index '871fa44a8ffffff'));
+ st_contains 
+-------------
+ t
+(1 row)
+
+SELECT geoToH3Cell(cellToPoint(h3index '871fa44a8ffffff'), 7)
+  = h3index '871fa44a8ffffff';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT round(cellArea(h3index '871fa44a8ffffff')::numeric, 0);
+  round  
+---------
+ 4441914
+(1 row)
+
+SELECT cellArea(h3index '8a2a1072b59ffff') < cellArea(h3index '831c02fffffffff');
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT abs(cellArea(h3index '871fa44a8ffffff') / 1e6
+  - getValue(th3CellAreaKm2(th3index '871fa44a8ffffff@2001-01-01'))) < 1e-9;
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT getResolution(h3index '831c02fffffffff')
+  = getValue(getResolution(th3index '831c02fffffffff@2001-01-01'));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT cellArea(h3index '871fa44a8ffffff')
+  = getValue(cellArea(th3index '871fa44a8ffffff@2001-01-01'));
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT ST_AsBinary(cellToBoundary(h3index '871fa44a8ffffff'))
+  = ST_AsBinary(getValue(cellToBoundary(th3index '871fa44a8ffffff@2001-01-01'))::geometry);
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/h3/queries/252_h3index_ops.test.sql
+++ b/mobilitydb/test/h3/queries/252_h3index_ops.test.sql
@@ -1,0 +1,113 @@
+-------------------------------------------------------------------------------
+--
+-- This MobilityDB code is provided under The PostgreSQL License.
+-- Copyright (c) 2016-2025, Université libre de Bruxelles and MobilityDB
+-- contributors
+--
+-- Permission to use, copy, modify, and distribute this software and its
+-- documentation for any purpose, without fee, and without a written
+-- agreement is hereby granted, provided that the above copyright notice and
+-- this paragraph and the following two paragraphs appear in all copies.
+--
+-- IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+-- DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+-- LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+-- EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+-- OF SUCH DAMAGE.
+--
+-- UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+-- INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+-- AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+-- AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+-- PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+--
+-------------------------------------------------------------------------------
+
+-- Static h3index cell operations: the six faces every DGGS family publishes
+-- under the bare DggsCellOps slot names — resolution, validity, hierarchy,
+-- cell centroid and boundary, and area. The H3-only surface (directed edges,
+-- vertices, pentagon / base-cell / class-III inspection, grid traversal,
+-- great-circle metrics) is exercised by the 28x files.
+
+-------------------------------------------------------------------------------
+-- Resolution
+-------------------------------------------------------------------------------
+
+SELECT getResolution(h3index '831c02fffffffff');  -- res 3
+SELECT getResolution(h3index '871fa44a8ffffff');  -- res 7
+SELECT getResolution(h3index '8a2a1072b59ffff');  -- res 10
+
+-------------------------------------------------------------------------------
+-- Validity
+-------------------------------------------------------------------------------
+
+SELECT isValidCell(h3index '831c02fffffffff');
+SELECT isValidCell(h3index '0');
+
+-------------------------------------------------------------------------------
+-- Hierarchy: parent
+-------------------------------------------------------------------------------
+
+SELECT getResolution(cellToParent(h3index '8a2a1072b59ffff', 5));
+SELECT cellToParent(h3index '8a2a1072b59ffff', 5);
+
+-- The parent of a cell at its own resolution is the cell itself
+SELECT cellToParent(h3index '871fa44a8ffffff', 7) = h3index '871fa44a8ffffff';
+
+-- A parent resolution finer than the cell's own is an error
+SELECT cellToParent(h3index '831c02fffffffff', 7);
+
+-------------------------------------------------------------------------------
+-- Lat/Lng: centroid and boundary
+-------------------------------------------------------------------------------
+
+SELECT round(ST_X(cellToPoint(h3index '871fa44a8ffffff'))::numeric, 6);
+SELECT round(ST_Y(cellToPoint(h3index '871fa44a8ffffff'))::numeric, 6);
+SELECT ST_SRID(cellToPoint(h3index '871fa44a8ffffff'));
+
+SELECT ST_GeometryType(cellToBoundary(h3index '871fa44a8ffffff'));
+SELECT ST_SRID(cellToBoundary(h3index '871fa44a8ffffff'));
+
+-- A hexagon's ring closes on its first vertex, so it carries seven points
+SELECT ST_NPoints(cellToBoundary(h3index '871fa44a8ffffff'));
+
+-- The centroid lies inside the boundary
+SELECT ST_Contains(
+  cellToBoundary(h3index '871fa44a8ffffff'),
+  cellToPoint(h3index '871fa44a8ffffff'));
+
+-- The cell containing the centroid is the cell itself
+SELECT geoToH3Cell(cellToPoint(h3index '871fa44a8ffffff'), 7)
+  = h3index '871fa44a8ffffff';
+
+-------------------------------------------------------------------------------
+-- Metrics: area
+-------------------------------------------------------------------------------
+
+-- The unit is the square metre, the one the DggsCellOps descriptor fixes.
+-- The value is bounded to whole square metres: six fractional digits on a
+-- magnitude of 4.4e6 pins thirteen significant digits, which drifts between
+-- builds.
+SELECT round(cellArea(h3index '871fa44a8ffffff')::numeric, 0);
+
+-- A finer cell covers less ground than a coarser one
+SELECT cellArea(h3index '8a2a1072b59ffff') < cellArea(h3index '831c02fffffffff');
+
+-- The square-metre face and the H3-only square-kilometre one agree
+SELECT abs(cellArea(h3index '871fa44a8ffffff') / 1e6
+  - getValue(th3CellAreaKm2(th3index '871fa44a8ffffff@2001-01-01'))) < 1e-9;
+
+-------------------------------------------------------------------------------
+-- The static face and its temporal lift answer the same value
+-------------------------------------------------------------------------------
+
+SELECT getResolution(h3index '831c02fffffffff')
+  = getValue(getResolution(th3index '831c02fffffffff@2001-01-01'));
+
+SELECT cellArea(h3index '871fa44a8ffffff')
+  = getValue(cellArea(th3index '871fa44a8ffffff@2001-01-01'));
+
+SELECT ST_AsBinary(cellToBoundary(h3index '871fa44a8ffffff'))
+  = ST_AsBinary(getValue(cellToBoundary(th3index '871fa44a8ffffff@2001-01-01'))::geometry);
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/h3/queries/282_th3index_latlng.test.sql
+++ b/mobilitydb/test/h3/queries/282_th3index_latlng.test.sql
@@ -7,8 +7,8 @@
 -------------------------------------------------------------------------------
 
 -- §1.1 Lat/Lng conversions — five lifts, all backed by adapters in
--- th3index_latlng.c (geo_to_h3index_cell / h3_cell_to_geompoint /
--- h3_cell_to_geom). Round-trip identities are the most
+-- th3index_latlng.c (geo_to_h3index_cell / h3index_cell_to_point /
+-- h3index_cell_to_boundary). Round-trip identities are the most
 -- robust assertions because they hold without us hard-coding any
 -- specific lat/lng coordinates.
 --


### PR DESCRIPTION
h3index answers the six DggsCellOps faces quadbin and s2cell answer:
getResolution, isValidCell, cellToParent, cellToPoint, cellToBoundary and
cellArea, under the bare slot names, so a query reads the same whichever grid
holds the cell. MEOS publishes them in meos_h3.h as h3index_get_resolution,
h3index_cell_to_parent, h3index_cell_to_point, h3index_cell_to_boundary and
h3index_cell_area, the prefix h3index_from_wkb and h3index_to_stbox already
carry; mobilitydb/src/h3/h3index_ops.c wraps them where quadbin_ops.c and
s2cell_ops.c wrap theirs, and isValidCell stays in the base file beside its
quadbin and s2cell twins.

The h3index_ prefix is what keeps the surface loadable. The h3-pg extension
library exports h3_get_resolution, h3_cell_to_parent and h3_cell_area as PG V1
functions, so a MEOS entry point of that name binds to h3-pg at load time and a
call through it terminates the backend with SIGSEGV. h3_cell_to_geompoint and
h3_cell_to_geom carried a prefix h3-pg does not claim and are renamed to the
same h3index_ spelling, leaving one prefix for the whole static surface.

The four doxygen groups each side pair with the temporal groups they mirror, as
the ten meos_cbuffer_base_ groups pair with theirs.

252_h3index_ops.test.sql states 23 cases: each face over its own cell, the
parent resolution that is finer than the cell's own, the centroid inside the
boundary and the cell that contains the centroid, the square metre against the
H3-only square kilometre, and each static face against the value its temporal
lift answers, the boundary bit for bit. The chapter states the static form in
every shared slot's signature, as cellArea already states it, with one harvested
example each: 198 of 201 result comments agree against a live server, the
remainder being two illustrative CREATE INDEX statements and the empty quadkey.

