### PR TITLE
Name each SQL argument with one spelling across the surface and the manual

### DIFF
--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -95,8 +95,8 @@ SELECT ts2cell '{[47c3c@2001-01-01, 47c4@2001-01-02]}';
 				<para>Serializar una celda temporal como texto, como binario, como binario bien conocido hexadecimal o como MF-JSON</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 asText(tcell) → text
-asBinary(tcell,endianencoding text='') → bytea
-asHexWKB(tcell,endianencoding text='') → text
+asBinary(tcell,endian text='') → bytea
+asHexWKB(tcell,endian text='') → text
 asMFJSON(tcell) → text
 </programlisting>
 				<para>La forma binaria bien conocida hexadecimal permite que una columna de celdas temporales se transfiera de ida y vuelta mediante un <varname>COPY</varname> basado en texto. En MF-JSON la carga útil de la celda se representa como el identificador de celda int64 en el arreglo <varname>values</varname>, la misma representación que lleva <varname>tbigint</varname>.</para>

--- a/doc/es/temporal_jsonb.xml
+++ b/doc/es/temporal_jsonb.xml
@@ -227,7 +227,7 @@ SELECT jsonbset '{"{\"speed\": 10}",
 				<indexterm significance="normal"><primary><varname>jsonbsetSetLax</varname></primary></indexterm>
 				<para>Asignación en un conjunto JSONB</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-jsonbsetSet(jsonbset,path text[],val jsonb,create boolean=true) → jsonbset
+jsonbsetSet(jsonbset,path text[],val jsonb,create_missing boolean=true) → jsonbset
 jsonbsetSetLax(jsonbset,path text[],val jsonb,create boolean=true,
   handle_null text) → jsonbset
 </programlisting>
@@ -1027,8 +1027,8 @@ SELECT jsonb '{"geom": "Point(1 1)"}' &lt;@ tjsonb '{[{"geom": "Point(1 1)"}@200
 				<indexterm significance="normal"><primary><varname>tjsonbSetLax</varname></primary></indexterm>
 				<para>Asignación JSONB temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tjsonbSet(tjsonb,path text[],val jsonb,create boolean=true) → tjsonb
-tjsonbSetLax(tjsonb,path text[],val jsonb,create boolean=true,handle_null text) → tjsonb
+tjsonbSet(tjsonb,path text[],val jsonb,create_missing boolean=true) → tjsonb
+tjsonbSetLax(tjsonb,path text[],val jsonb,create_missing boolean=true,handle_null text) → tjsonb
 </programlisting>
 				<para>Devuelve el valor <varname>tjsonb</varname> con el elemento especificado por la ruta reemplazado por <varname>jsonb</varname>, o añadido si <varname>create</varname> es verdadero y el elemento no existe. Todos los pasos anteriores de la ruta deben existir, o se devuelve el objetivo sin cambios. Como ocurre con los operadores orientados a rutas, los enteros negativos que aparecen en la ruta cuentan desde el final de los arreglos JSON. Si el último paso de la ruta es un índice de arreglo que está fuera de rango, y create_if_missing es verdadero, el nuevo valor se añade al principio del arreglo si el índice es negativo, o al final del arreglo si es positivo. La función <varname>tjsonbSetLax</varname> se comporta de forma idéntica a <varname>tjsonbSet</varname> si el valor dado no es NULL; de lo contrario, se comporta según el valor de <varname>handle_null</varname>, que debe ser uno de <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname> o <varname>'return_source'</varname>. Como se indicó anteriormente, mantuvimos el comportamiento de PostgreSQL para esta función habilitando el valor <varname>'return_source'</varname>, mientras que para todas las demás operaciones de <emphasis>consulta</emphasis>, este valor se ha reemplazado por <varname>'return_null'</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -946,7 +946,7 @@ SELECT (un).time FROM (SELECT unnest(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Fragmenta un tpcpoint en fragmentos, uno por cada intervalo de tiempo</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-timeSplit(tpcpoint,bin_width interval,
+timeSplit(tpcpoint,duration interval,
   origin timestamptz='2000-01-03') → {(time,tpcpoint)}
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1727,7 +1727,7 @@ SELECT (un).time FROM (SELECT unnest(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Fragmenta un tpcpatch en fragmentos, uno por cada intervalo de tiempo</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-timeSplit(tpcpatch,bin_width interval,
+timeSplit(tpcpatch,duration interval,
   origin timestamptz='2000-01-03') → {(time,tpcpatch)}
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -211,7 +211,7 @@ JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8)) GROUP BY t.tripid
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<para>Devuelve la representación binaria conocida (WKB) de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asBinary(raquet,endianencoding text='') → bytea
+asBinary(raquet,endian text='') → bytea
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
@@ -223,7 +223,7 @@ SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'u
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Devuelve la representación hexadecimal binaria conocida (HexWKB) de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asHexWKB(raquet,endianencoding text='') → text
+asHexWKB(raquet,endian text='') → text
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));

--- a/doc/es/temporal_spatial_p1.xml
+++ b/doc/es/temporal_spatial_p1.xml
@@ -856,8 +856,8 @@ SELECT asEWKT(rotate(temp, -pi()/3, ST_Centroid(traversedArea(temp))),
 				<indexterm significance="normal"><primary><varname>scale</varname></primary></indexterm>
 				<para>Devuelve un punto temporal escalado por factores dados &Z_support;</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-scale(tgeo,Xfactor float,Yfactor float,Zfactor float) → tgeo
-scale(tgeo,Xfactor float,Yfactor float) → tgeo
+scale(tgeo,xfactor float,yfactor float,zfactor float) → tgeo
+scale(tgeo,xfactor float,yfactor float) → tgeo
 scale(tgeo,factor geometry) → tgeo
 scale(tgeo,factor geometry,origin geometry) → tgeo
 </programlisting>

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -792,7 +792,7 @@ SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 da
 					<para>Devuelve una matriz de rangos de valores o de tiempo obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores o de tiempo</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 valueBins(tnumber,vsize number,vorigin number=0) → numspan[]
-timeBins(temp,duration interval,torigin timestamptz='2000-01-03') → tstzspan[]
+timeBins(temp,tsize interval,torigin timestamptz='2000-01-03') → tstzspan[]
 </programlisting>
 					<para>La elección entre instantes o segmentos depende de si la interpolación es discreta o continua. Si no se especifica el origen de los valores, se establece por defecto en 0 para los rangos de valores y en el lunes 3 de enero de 2000 para los rangos de tiempo.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -820,8 +820,8 @@ SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
 					<indexterm significance="normal"><primary><varname>valueTimeBoxes</varname></primary></indexterm>
 					<para>Devuelve una matriz de cuadros temporales obtenidos a partir de los instantes o segmentos de un número temporal con respecto a un mosaico de valores y/o tiempo</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-valueBoxes(tnumber,size number,vorigin number=0) → tbox[]
-timeBoxes(tnumber,duration interval,torigin timestamptz='2000-01-03') → tbox[]
+valueBoxes(tnumber,vsize number,vorigin number=0) → tbox[]
+timeBoxes(tnumber,tsize interval,torigin timestamptz='2000-01-03') → tbox[]
 valueTimeBoxes(tnumber,vsize number,tsize interval,vorigin number=0,
   torigin timestamptz='2000-01-03') → tbox[]
 </programlisting>
@@ -996,7 +996,7 @@ spaceSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
   [ysize float,zsize float,]
   origin geompoint='Point(0 0 0)',bitmatrix boolean=true,
   borderInc boolean=true) → {(point,tpoint)}
-timeSplit(tpoint,duration interval,torigin timestamptz='2000-01-03') → {(time,tpoint)}
+timeSplit(tpoint,duration interval,origin timestamptz='2000-01-03') → {(time,tpoint)}
 spaceTimeSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
   [ysize float,zsize float,]
   duration interval,sorigin geompoint='Point(0 0 0)',

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -95,8 +95,8 @@ SELECT ts2cell '{[47c3c@2001-01-01, 47c4@2001-01-02]}';
 				<para>Serialize a temporal cell as text, as binary, as hexadecimal well-known binary, or as MF-JSON</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 asText(tcell) → text
-asBinary(tcell,endianencoding text='') → bytea
-asHexWKB(tcell,endianencoding text='') → text
+asBinary(tcell,endian text='') → bytea
+asHexWKB(tcell,endian text='') → text
 asMFJSON(tcell) → text
 </programlisting>
 				<para>The hexadecimal well-known binary form lets a temporal cell column round-trip through a text-based <varname>COPY</varname>. In MF-JSON the cell payload renders as the int64 cell identifier in the <varname>values</varname> array, the same representation <varname>tbigint</varname> carries.</para>

--- a/doc/temporal_jsonb.xml
+++ b/doc/temporal_jsonb.xml
@@ -227,7 +227,7 @@ SELECT jsonbset '{"{\"speed\": 10}",
 				<indexterm significance="normal"><primary><varname>jsonbsetSetLax</varname></primary></indexterm>
 				<para>JSONB set assignment</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-jsonbsetSet(jsonbset,path text[],val jsonb,create boolean=true) → jsonbset
+jsonbsetSet(jsonbset,path text[],val jsonb,create_missing boolean=true) → jsonbset
 jsonbsetSetLax(jsonbset,path text[],val jsonb,create boolean=true,
   handle_null text) → jsonbset
 </programlisting>
@@ -1027,8 +1027,8 @@ SELECT jsonb '{"geom": "Point(1 1)"}' &lt;@ tjsonb '{[{"geom": "Point(1 1)"}@200
 				<indexterm significance="normal"><primary><varname>tjsonbSetLax</varname></primary></indexterm>
 				<para>Temporal JSONB set</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tjsonbSet(tjsonb,path text[],val jsonb,create boolean=true) → tjsonb
-tjsonbSetLax(tjsonb,path text[],val jsonb,create boolean=true,handle_null text) → tjsonb
+tjsonbSet(tjsonb,path text[],val jsonb,create_missing boolean=true) → tjsonb
+tjsonbSetLax(tjsonb,path text[],val jsonb,create_missing boolean=true,handle_null text) → tjsonb
 </programlisting>
 				<para>Return the <varname>tjsonb</varname> value with the item specified by path replaced by <varname>jsonb</varname>, or added if <varname>create</varname> is true and the item does not exist. All earlier steps in the path must exist, or the target is returned unchanged. As with the path oriented operators, negative integers that appear in the path count from the end of JSON arrays. If the last path step is an array index that is out of range, and create_if_missing is true, the new value is added at the beginning of the array if the index is negative, or at the end of the array if it is positive. Function <varname>tjsonbSetLax</varname> behaves identically to <varname>tjsonbSet</varname> if the given value is not NULL, Otherwise, it behaves according to the value of <varname>handle_null</varname>, which must be one of <varname>'raise_exception'</varname>, <varname>'use_json_null'</varname>, <varname>'delete_key'</varname>, or <varname>'return_source'</varname>. As stated above, we kept PostgreSQL behavior for this function enabling the value <varname>'return_source'</varname> whereas for all other <emphasis>query</emphasis> operations, this value has been replaced with <varname>'return_null'</varname>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -946,7 +946,7 @@ SELECT (un).time FROM (SELECT unnest(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Split a tpcpoint into fragments, one per time bin</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-timeSplit(tpcpoint,bin_width interval,
+timeSplit(tpcpoint,duration interval,
   origin timestamptz='2000-01-03') → {(time,tpcpoint)}
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -1727,7 +1727,7 @@ SELECT (un).time FROM (SELECT unnest(tpcpatchSeq(ARRAY[
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
 					<para>Split a tpcpatch into fragments, one per time bin</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-timeSplit(tpcpatch,bin_width interval,
+timeSplit(tpcpatch,duration interval,
   origin timestamptz='2000-01-03') → {(time,tpcpatch)}
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -211,7 +211,7 @@ JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8)) GROUP BY t.tripid
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
 				<para>Return the Well-Known Binary (WKB) representation of a Raquet tile</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asBinary(raquet,endianencoding text='') → bytea
+asBinary(raquet,endian text='') → bytea
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
@@ -223,7 +223,7 @@ SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'u
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
 				<para>Return the Hexadecimal Well-Known Binary (HexWKB) representation of a Raquet tile</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asHexWKB(raquet,endianencoding text='') → text
+asHexWKB(raquet,endian text='') → text
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));

--- a/doc/temporal_spatial_p1.xml
+++ b/doc/temporal_spatial_p1.xml
@@ -857,8 +857,8 @@ SELECT asEWKT(rotate(temp, -pi()/3, ST_Centroid(traversedArea(temp))),
 				<indexterm significance="normal"><primary><varname>scale</varname></primary></indexterm>
 				<para>Return a temporal point scaled by given factors &Z_support;</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-scale(tgeo,Xfactor float,Yfactor float,Zfactor float) → tgeo
-scale(tgeo,Xfactor float,Yfactor float) → tgeo
+scale(tgeo,xfactor float,yfactor float,zfactor float) → tgeo
+scale(tgeo,xfactor float,yfactor float) → tgeo
 scale(tgeo,factor geometry) → tgeo
 scale(tgeo,factor geometry,origin geometry) → tgeo
 </programlisting>

--- a/doc/temporal_types_analytics.xml
+++ b/doc/temporal_types_analytics.xml
@@ -810,7 +810,7 @@ SELECT getSpaceTimeTile(geometry 'Point(1 1)', '2001-01-01', 2.0, interval '2 da
 					<para>Return an array of value or time spans obtained from the instants or segments of a temporal number with respect to a value or time grid</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 valueBins(tnumber,vsize number,vorigin number=0) → numspan[]
-timeBins(temp,duration interval,torigin timestamptz='2000-01-03') → tstzspan[]
+timeBins(temp,tsize interval,torigin timestamptz='2000-01-03') → tstzspan[]
 </programlisting>
 					<para>The choice between instants or segments depends on whether the interpolation is discrete or continuous. If the origin of values or time is not specified, it is set by default to 0 for value spans or to Monday, January 3, 2000 for time spans.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -838,8 +838,8 @@ SELECT timeBins(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03, 4@2000-01-04,
 					<indexterm significance="normal"><primary><varname>valueTimeBoxes</varname></primary></indexterm>
 					<para>Return an array of temporal boxes obtained from the instants or segments of a temporal number with respect to a value and/or time grid</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-valueBoxes(tnumber,size number,vorigin number=0) → tbox[]
-timeBoxes(tnumber,duration interval,torigin timestamptz='2000-01-03') → tbox[]
+valueBoxes(tnumber,vsize number,vorigin number=0) → tbox[]
+timeBoxes(tnumber,tsize interval,torigin timestamptz='2000-01-03') → tbox[]
 valueTimeBoxes(tnumber,vsize number,tsize interval,vorigin number=0,
   torigin timestamptz='2000-01-03') → tbox[]
 </programlisting>
@@ -1016,7 +1016,7 @@ spaceSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
   [ysize float,zsize float,]
   origin geompoint='Point(0 0 0)',bitmatrix boolean=true,
   borderInc boolean=true) → {(point,tpoint)}
-timeSplit(tpoint,duration interval,torigin timestamptz='2000-01-03') → {(time,tpoint)}
+timeSplit(tpoint,duration interval,origin timestamptz='2000-01-03') → {(time,tpoint)}
 spaceTimeSplit({tgeompoint,tgeometry,tpose,tpcpoint},xsize float,
   [ysize float,zsize float,]
   duration interval,sorigin geompoint='Point(0 0 0)',

--- a/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
@@ -121,22 +121,22 @@ CREATE FUNCTION asEWKT(cbuffer[], maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(cbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(cbuffer, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Cbuffer_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(cbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(cbuffer, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Cbuffer_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(cbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(cbuffer, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Cbuffer_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(cbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(cbuffer, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Cbuffer_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
+++ b/mobilitydb/sql/cbuffer/201_cbufferset.in.sql
@@ -80,19 +80,19 @@ CREATE FUNCTION cbuffersetFromHexWKB(text)
   AS 'MODULE_PATHNAME', 'Set_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(cbufferset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(cbufferset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(cbufferset, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(cbufferset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(cbufferset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(cbufferset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(cbufferset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(cbufferset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spatialset_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -147,22 +147,22 @@ CREATE FUNCTION asMFJSON(tcbuffer, options integer DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tcbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tcbuffer, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(tcbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(tcbuffer, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tcbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tcbuffer, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(tcbuffer, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(tcbuffer, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -653,7 +653,7 @@ CREATE TYPE time_tcbuffer AS (
   temp tcbuffer
 );
 
-CREATE FUNCTION timeSplit(tcbuffer, bin_width interval,
+CREATE FUNCTION timeSplit(tcbuffer, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tcbuffer
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/geo/050_geoset.in.sql
+++ b/mobilitydb/sql/geo/050_geoset.in.sql
@@ -166,36 +166,36 @@ CREATE FUNCTION asEWKT(geogset, maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(geomset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(geomset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(geomset, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(geomset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(geomset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(geomset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(geomset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(geomset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spatialset_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(geogset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(geogset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(geogset, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(geogset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(geogset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(geogset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(geogset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(geogset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spatialset_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/geo/051_stbox.in.sql
+++ b/mobilitydb/sql/geo/051_stbox.in.sql
@@ -81,12 +81,12 @@ CREATE FUNCTION asText(stbox, maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Stbox_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(stbox, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(stbox, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Stbox_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(stbox, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(stbox, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Stbox_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/geo/052_tgeo.in.sql
+++ b/mobilitydb/sql/geo/052_tgeo.in.sql
@@ -861,12 +861,12 @@ CREATE TYPE time_tgeog AS (
   tgeog tgeography
 );
 
-CREATE FUNCTION timeSplit(tgeometry, bin_width interval,
+CREATE FUNCTION timeSplit(tgeometry, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tgeom
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSplit(tgeography, bin_width interval,
+CREATE FUNCTION timeSplit(tgeography, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tgeog
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/geo/052_tpoint.in.sql
+++ b/mobilitydb/sql/geo/052_tpoint.in.sql
@@ -862,12 +862,12 @@ CREATE TYPE time_tgeogpoint AS (
   temp tgeogpoint
 );
 
-CREATE FUNCTION timeSplit(tgeompoint, bin_width interval,
+CREATE FUNCTION timeSplit(tgeompoint, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tgeompoint
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSplit(tgeogpoint, bin_width interval,
+CREATE FUNCTION timeSplit(tgeogpoint, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tgeogpoint
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/geo/053_tgeo_inout.in.sql
+++ b/mobilitydb/sql/geo/053_tgeo_inout.in.sql
@@ -144,38 +144,38 @@ CREATE FUNCTION asMFJSON(tgeography, options integer DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tgeometry, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tgeography, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tgeography, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(tgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(tgeometry, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(tgeography, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(tgeography, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tgeometry, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tgeography, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tgeography, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(tgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(tgeometry, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(tgeography, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(tgeography, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/geo/053_tpoint_inout.in.sql
+++ b/mobilitydb/sql/geo/053_tpoint_inout.in.sql
@@ -176,42 +176,42 @@ CREATE FUNCTION asMFJSON(tgeogpoint, options integer DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tgeompoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tgeompoint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tgeogpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tgeogpoint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(tgeompoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(tgeompoint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(tgeogpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(tgeogpoint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- asHexWKB: base hex-WKB (variant 0, no SRID) — portable RFC #861 name,
 -- byte-for-byte identical to MobilityDuck asHexWKB and MobilitySpark asHexWKB.
-CREATE FUNCTION asHexWKB(tgeompoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tgeompoint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tgeogpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tgeogpoint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- asHexEWKB: extended hex-WKB (WKB_EXTENDED flag, includes SRID) —
 -- mirrors asEWKB() and is consistent with MobilityDuck asHexEWKB.
-CREATE FUNCTION asHexEWKB(tgeompoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(tgeompoint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(tgeogpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(tgeogpoint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/geo/058_tgeo_tile.in.sql
+++ b/mobilitydb/sql/geo/058_tgeo_tile.in.sql
@@ -103,7 +103,7 @@ CREATE FUNCTION spaceSplit(tgeometry, size float,
   RETURNS SETOF point_tgeo
   AS 'SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4)'
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spaceSplit(tgeometry, sizeX float, sizeY float,
+CREATE FUNCTION spaceSplit(tgeometry, xsize float, ysize float,
     sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
     borderInc boolean DEFAULT TRUE)
   RETURNS SETOF point_tgeo

--- a/mobilitydb/sql/geo/058_tpoint_tile.in.sql
+++ b/mobilitydb/sql/geo/058_tpoint_tile.in.sql
@@ -247,7 +247,7 @@ CREATE FUNCTION spaceSplit(tgeompoint, size float,
   RETURNS SETOF point_tpoint
   AS 'SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4)'
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION spaceSplit(tgeompoint, sizeX float, sizeY float,
+CREATE FUNCTION spaceSplit(tgeompoint, xsize float, ysize float,
     sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
     borderInc boolean DEFAULT TRUE)
   RETURNS SETOF point_tpoint

--- a/mobilitydb/sql/h3/250_h3index.in.sql
+++ b/mobilitydb/sql/h3/250_h3index.in.sql
@@ -124,12 +124,12 @@ CREATE FUNCTION h3indexFromHexWKB(text)
   AS 'MODULE_PATHNAME', 'H3index_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(h3index, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(h3index, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'H3index_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(h3index, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(h3index, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'H3index_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/h3/251_h3indexset.in.sql
+++ b/mobilitydb/sql/h3/251_h3indexset.in.sql
@@ -94,12 +94,12 @@ CREATE FUNCTION asText(h3indexset)
   AS 'MODULE_PATHNAME', 'Set_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(h3indexset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(h3indexset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(h3indexset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(h3indexset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/h3/253_th3index.in.sql
+++ b/mobilitydb/sql/h3/253_th3index.in.sql
@@ -103,12 +103,12 @@ CREATE FUNCTION asText(th3index)
   AS 'MODULE_PATHNAME', 'Temporal_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(th3index, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(th3index, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(th3index, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(th3index, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -568,7 +568,7 @@ CREATE TYPE time_th3index AS (
   temp th3index
 );
 
-CREATE FUNCTION timeSplit(th3index, bin_width interval,
+CREATE FUNCTION timeSplit(th3index, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_th3index
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/json/450_jsonbset.in.sql
+++ b/mobilitydb/sql/json/450_jsonbset.in.sql
@@ -85,12 +85,12 @@ CREATE FUNCTION asText(jsonbset)
   AS 'MODULE_PATHNAME', 'Set_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(jsonbset, endianencoding text DEFAULT '')
+CREATE FUNCTION asBinary(jsonbset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(jsonbset, endianencoding text DEFAULT '')
+CREATE FUNCTION asHexWKB(jsonbset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/json/452_tjsonb.in.sql
+++ b/mobilitydb/sql/json/452_tjsonb.in.sql
@@ -127,12 +127,12 @@ CREATE FUNCTION asMFJSON(temp tjsonb, options integer DEFAULT 0, flags integer D
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tjsonb, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tjsonb, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tjsonb, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tjsonb, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -583,7 +583,7 @@ CREATE TYPE time_tjsonb AS (
   temp tjsonb
 );
 
-CREATE FUNCTION timeSplit(tjsonb, bin_width interval,
+CREATE FUNCTION timeSplit(tjsonb, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tjsonb
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/npoint/300_npoint.in.sql
+++ b/mobilitydb/sql/npoint/300_npoint.in.sql
@@ -148,22 +148,22 @@ CREATE FUNCTION asEWKT(npoint[], maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(npoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(npoint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Npoint_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(npoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(npoint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Npoint_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(npoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(npoint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Npoint_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(npoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(npoint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Npoint_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/npoint/301_npointset.in.sql
+++ b/mobilitydb/sql/npoint/301_npointset.in.sql
@@ -101,19 +101,19 @@ CREATE FUNCTION asEWKT(npointset, maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(npointset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(npointset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(npointset, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(npointset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(npointset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(npointset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(npointset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(npointset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spatialset_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/npoint/302_tnpoint.in.sql
+++ b/mobilitydb/sql/npoint/302_tnpoint.in.sql
@@ -111,12 +111,12 @@ CREATE FUNCTION asText(tnpoint[], maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialarr_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tnpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tnpoint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tnpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tnpoint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -596,7 +596,7 @@ CREATE TYPE time_tnpoint AS (
   temp tnpoint
 );
 
-CREATE FUNCTION timeSplit(tnpoint, bin_width interval,
+CREATE FUNCTION timeSplit(tnpoint, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tnpoint
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/pointcloud/400_pcset.in.sql
+++ b/mobilitydb/sql/pointcloud/400_pcset.in.sql
@@ -353,19 +353,19 @@ CREATE FUNCTION pcpointsetFromHexWKB(text)
   RETURNS pcpointset
   AS 'MODULE_PATHNAME', 'Set_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(pcpointset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(pcpointset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(pcpointset, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(pcpointset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(pcpointset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(pcpointset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(pcpointset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(pcpointset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spatialset_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -733,19 +733,19 @@ CREATE FUNCTION pcpatchsetFromHexWKB(text)
   RETURNS pcpatchset
   AS 'MODULE_PATHNAME', 'Set_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(pcpatchset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(pcpatchset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(pcpatchset, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(pcpatchset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(pcpatchset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(pcpatchset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(pcpatchset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(pcpatchset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spatialset_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
+++ b/mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -118,11 +118,11 @@ CREATE FUNCTION tpcpointFromHexWKB(text)
   RETURNS tpcpoint
   AS 'MODULE_PATHNAME', 'Temporal_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tpcpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tpcpoint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tpcpoint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tpcpoint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -627,7 +627,7 @@ CREATE TYPE time_tpcpoint AS (
   temp tpcpoint
 );
 
-CREATE FUNCTION timeSplit(tpcpoint, bin_width interval,
+CREATE FUNCTION timeSplit(tpcpoint, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tpcpoint
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
+++ b/mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -108,11 +108,11 @@ CREATE FUNCTION tpcpatchFromHexWKB(text)
   RETURNS tpcpatch
   AS 'MODULE_PATHNAME', 'Temporal_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tpcpatch, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tpcpatch, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tpcpatch, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tpcpatch, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -654,7 +654,7 @@ CREATE TYPE time_tpcpatch AS (
   temp tpcpatch
 );
 
-CREATE FUNCTION timeSplit(tpcpatch, bin_width interval,
+CREATE FUNCTION timeSplit(tpcpatch, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tpcpatch
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/pointcloud/446_tpcpoint_tile.in.sql
+++ b/mobilitydb/sql/pointcloud/446_tpcpoint_tile.in.sql
@@ -125,7 +125,7 @@ CREATE FUNCTION spaceSplit(tpcpoint, size float,
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4, $5)
   $$;
-CREATE FUNCTION spaceSplit(tpcpoint, sizeX float, sizeY float,
+CREATE FUNCTION spaceSplit(tpcpoint, xsize float, ysize float,
     sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
     borderInc boolean DEFAULT TRUE)
   RETURNS SETOF point_tpcpoint

--- a/mobilitydb/sql/pose/100_pose.in.sql
+++ b/mobilitydb/sql/pose/100_pose.in.sql
@@ -148,22 +148,22 @@ CREATE FUNCTION asEWKT(pose[], maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(pose, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(pose, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Pose_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(pose, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(pose, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Pose_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(pose, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(pose, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Pose_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(pose, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(pose, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Pose_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/pose/101_poseset.in.sql
+++ b/mobilitydb/sql/pose/101_poseset.in.sql
@@ -101,19 +101,19 @@ CREATE FUNCTION asEWKT(poseset, maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(poseset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(poseset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(poseset, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(poseset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(poseset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(poseset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(poseset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(poseset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spatialset_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/pose/102_tpose.in.sql
+++ b/mobilitydb/sql/pose/102_tpose.in.sql
@@ -194,22 +194,22 @@ CREATE FUNCTION asMFJSON(tpose, options integer DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tpose, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tpose, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(tpose, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(tpose, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tpose, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tpose, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(tpose, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(tpose, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -715,7 +715,7 @@ CREATE TYPE time_tpose AS (
   temp tpose
 );
 
-CREATE FUNCTION timeSplit(tpose, bin_width interval,
+CREATE FUNCTION timeSplit(tpose, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tpose
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/pose/119_tpose_tile.in.sql
+++ b/mobilitydb/sql/pose/119_tpose_tile.in.sql
@@ -125,7 +125,7 @@ CREATE FUNCTION spaceSplit(tpose, size float,
   LANGUAGE SQL IMMUTABLE STRICT PARALLEL SAFE AS $$
     SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4, $5)
   $$;
-CREATE FUNCTION spaceSplit(tpose, sizeX float, sizeY float,
+CREATE FUNCTION spaceSplit(tpose, xsize float, ysize float,
     sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,
     borderInc boolean DEFAULT TRUE)
   RETURNS SETOF point_tpose

--- a/mobilitydb/sql/posechain/550_posechain.in.sql
+++ b/mobilitydb/sql/posechain/550_posechain.in.sql
@@ -119,22 +119,22 @@ CREATE FUNCTION asEWKT(posechain[], maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialarr_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(posechain, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(posechain, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Posechain_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(posechain, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(posechain, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Posechain_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(posechain, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(posechain, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Posechain_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(posechain, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(posechain, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Posechain_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/posechain/551_posechainset.in.sql
+++ b/mobilitydb/sql/posechain/551_posechainset.in.sql
@@ -101,19 +101,19 @@ CREATE FUNCTION asEWKT(posechainset, maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(posechainset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(posechainset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asEWKB(posechainset, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(posechainset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spatialset_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(posechainset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(posechainset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexEWKB(posechainset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(posechainset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spatialset_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/posechain/552_tposechain.in.sql
+++ b/mobilitydb/sql/posechain/552_tposechain.in.sql
@@ -168,22 +168,22 @@ CREATE FUNCTION asMFJSON(tposechain, options integer DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tposechain, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tposechain, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(tposechain, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(tposechain, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tposechain, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tposechain, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(tposechain, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(tposechain, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -651,7 +651,7 @@ CREATE TYPE time_tposechain AS (
   temp tposechain
 );
 
-CREATE FUNCTION timeSplit(tposechain, bin_width interval,
+CREATE FUNCTION timeSplit(tposechain, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tposechain
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/quadbin/351_quadbinset.in.sql
+++ b/mobilitydb/sql/quadbin/351_quadbinset.in.sql
@@ -94,12 +94,12 @@ CREATE FUNCTION asText(quadbinset)
   AS 'MODULE_PATHNAME', 'Set_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(quadbinset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(quadbinset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(quadbinset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(quadbinset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/quadbin/353_tquadbin.in.sql
+++ b/mobilitydb/sql/quadbin/353_tquadbin.in.sql
@@ -103,12 +103,12 @@ CREATE FUNCTION asText(tquadbin)
   AS 'MODULE_PATHNAME', 'Temporal_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tquadbin, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tquadbin, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tquadbin, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tquadbin, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -570,7 +570,7 @@ CREATE TYPE time_tquadbin AS (
   temp tquadbin
 );
 
-CREATE FUNCTION timeSplit(tquadbin, bin_width interval,
+CREATE FUNCTION timeSplit(tquadbin, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_tquadbin
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -110,12 +110,12 @@ CREATE FUNCTION raquetFromHexWKB(text)
   AS 'MODULE_PATHNAME', 'Raquet_from_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(raquet, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(raquet, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Raquet_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(raquet, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(raquet, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Raquet_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/rgeo/150_trgeo.in.sql
+++ b/mobilitydb/sql/rgeo/150_trgeo.in.sql
@@ -147,22 +147,22 @@ CREATE FUNCTION asMFJSON(trgeometry, options integer DEFAULT 0,
   AS 'MODULE_PATHNAME', 'Temporal_as_mfjson'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(trgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(trgeometry, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asEWKB(trgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asEWKB(trgeometry, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tspatial_as_ewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(trgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(trgeometry, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexEWKB(trgeometry, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexEWKB(trgeometry, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tspatial_as_hexewkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -657,7 +657,7 @@ CREATE TYPE time_trgeometry AS (
   temp trgeometry
 );
 
-CREATE FUNCTION timeSplit(trgeometry, bucket_width interval,
+CREATE FUNCTION timeSplit(trgeometry, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_trgeometry
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/s2cell/601_s2cellset.in.sql
+++ b/mobilitydb/sql/s2cell/601_s2cellset.in.sql
@@ -95,12 +95,12 @@ CREATE FUNCTION asText(s2cellset)
   AS 'MODULE_PATHNAME', 'Set_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(s2cellset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(s2cellset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(s2cellset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(s2cellset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/s2cell/603_ts2cell.in.sql
+++ b/mobilitydb/sql/s2cell/603_ts2cell.in.sql
@@ -103,12 +103,12 @@ CREATE FUNCTION asText(ts2cell)
   AS 'MODULE_PATHNAME', 'Temporal_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(ts2cell, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(ts2cell, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(ts2cell, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(ts2cell, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -576,7 +576,7 @@ CREATE TYPE time_ts2cell AS (
   temp ts2cell
 );
 
-CREATE FUNCTION timeSplit(ts2cell, bin_width interval,
+CREATE FUNCTION timeSplit(ts2cell, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS setof time_ts2cell
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/mobilitydb/sql/temporal/001_set.in.sql
+++ b/mobilitydb/sql/temporal/001_set.in.sql
@@ -293,52 +293,52 @@ CREATE FUNCTION asText(tstzset)
   AS 'MODULE_PATHNAME', 'Set_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(intset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(intset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(bigintset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(bigintset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(floatset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(floatset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(textset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(textset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(dateset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(dateset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tstzset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tstzset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Set_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(intset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(intset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(bigintset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(bigintset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(floatset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(floatset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(textset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(textset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(dateset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(dateset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tstzset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tstzset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Set_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/temporal/003_span.in.sql
+++ b/mobilitydb/sql/temporal/003_span.in.sql
@@ -250,44 +250,44 @@ CREATE FUNCTION asText(tstzspan)
   AS 'MODULE_PATHNAME', 'Span_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(intspan, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(intspan, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Span_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(bigintspan, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(bigintspan, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Span_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(floatspan, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(floatspan, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Span_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(datespan, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(datespan, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Span_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tstzspan, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tstzspan, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Span_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(intspan, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(intspan, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Span_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(bigintspan, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(bigintspan, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Span_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(floatspan, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(floatspan, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Span_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(datespan, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(datespan, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Span_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tstzspan, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tstzspan, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Span_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/temporal/007_spanset.in.sql
+++ b/mobilitydb/sql/temporal/007_spanset.in.sql
@@ -244,44 +244,44 @@ CREATE FUNCTION asText(tstzspanset)
   AS 'MODULE_PATHNAME', 'Spanset_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(intspanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(intspanset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spanset_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(bigintspanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(bigintspanset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spanset_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(floatspanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(floatspanset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spanset_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(datespanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(datespanset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spanset_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tstzspanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tstzspanset, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Spanset_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(intspanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(intspanset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spanset_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(bigintspanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(bigintspanset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spanset_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(floatspanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(floatspanset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spanset_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(datespanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(datespanset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spanset_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tstzspanset, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tstzspanset, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Spanset_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/temporal/021_tbox.in.sql
+++ b/mobilitydb/sql/temporal/021_tbox.in.sql
@@ -81,12 +81,12 @@ CREATE FUNCTION asText(tbox, maxdecimaldigits integer DEFAULT 15)
   AS 'MODULE_PATHNAME', 'Tbox_as_text'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asBinary(tbox, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tbox, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Tbox_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tbox, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tbox, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Tbox_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/temporal/023_temporal_inout.in.sql
+++ b/mobilitydb/sql/temporal/023_temporal_inout.in.sql
@@ -181,44 +181,44 @@ CREATE FUNCTION asMFJSON(temp ttext, options integer DEFAULT 0,
 
 /*****************************************************************************/
 
-CREATE FUNCTION asBinary(tbool, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tbool, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tint, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tbigint, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tbigint, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(tfloat, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(tfloat, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asBinary(ttext, endianenconding text DEFAULT '')
+CREATE FUNCTION asBinary(ttext, endian text DEFAULT '')
   RETURNS bytea
   AS 'MODULE_PATHNAME', 'Temporal_as_wkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION asHexWKB(tbool, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tbool, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tbigint, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tbigint, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(tfloat, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(tfloat, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION asHexWKB(ttext, endianenconding text DEFAULT '')
+CREATE FUNCTION asHexWKB(ttext, endian text DEFAULT '')
   RETURNS text
   AS 'MODULE_PATHNAME', 'Temporal_as_hexwkb'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;

--- a/mobilitydb/sql/temporal/025_temporal_tile.in.sql
+++ b/mobilitydb/sql/temporal/025_temporal_tile.in.sql
@@ -103,11 +103,11 @@ CREATE FUNCTION getBin("value" float, size float, origin float DEFAULT 0.0)
   AS 'MODULE_PATHNAME', 'Value_bin'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION getBin(date, interval, date DEFAULT '2000-01-03')
+CREATE FUNCTION getBin(date, duration interval, origin date DEFAULT '2000-01-03')
   RETURNS datespan
   AS 'MODULE_PATHNAME', 'Date_bin'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION getBin(timestamptz, interval, timestamptz DEFAULT '2000-01-03')
+CREATE FUNCTION getBin(timestamptz, duration interval, origin timestamptz DEFAULT '2000-01-03')
   RETURNS tstzspan
   AS 'MODULE_PATHNAME', 'Timestamptz_bin'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -301,27 +301,27 @@ CREATE TYPE time_ttext AS (
   temp ttext
 );
 
-CREATE FUNCTION timeSplit(tbool, size interval,
+CREATE FUNCTION timeSplit(tbool, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS SETOF time_tbool
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSplit(tint, size interval,
+CREATE FUNCTION timeSplit(tint, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS SETOF time_tint
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSplit(tbigint, size interval,
+CREATE FUNCTION timeSplit(tbigint, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS SETOF time_tbigint
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSplit(tfloat, size interval,
+CREATE FUNCTION timeSplit(tfloat, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS SETOF time_tfloat
   AS 'MODULE_PATHNAME', 'Temporal_time_split'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION timeSplit(ttext, size interval,
+CREATE FUNCTION timeSplit(ttext, duration interval,
     origin timestamptz DEFAULT '2000-01-03')
   RETURNS SETOF time_ttext
   AS 'MODULE_PATHNAME', 'Temporal_time_split'

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -478,7 +478,7 @@ separate `io_repr.sql.tmpl`; the generic block renderer covers both shapes.
 EWKT/EWKB are **TSpatial<T>-level**, the `E` = carries the SRID
 ([[ewkt-ewkb-tspatial-srid-representation]]). Conventions to reproduce verbatim:
 `maxdecimaldigits integer DEFAULT 15` on float/coordinate-bearing types only;
-`endianenconding text DEFAULT ''` (canonical misspelling) on `asBinary`/`asHexWKB`.
+`endian text DEFAULT ''` on `asBinary`/`asHexWKB`.
 
 Governed by `templates/representations.sql.tmpl` + `representation_families`,
 **12 entries** all `reference: true` (temporal, cbuffer, geo, h3, json, npoint,

--- a/tools/codegen/inherited/generate.py
+++ b/tools/codegen/inherited/generate.py
@@ -952,9 +952,9 @@ def bootstrap_io_type(filetext: str, fam: dict, rendered: str) -> str:
 #     not a class rule.
 #   * text form : pointcloud (tpcpoint/tpcpatch) withholds asText/FromText/FromMFJSON
 #     (a base-type capability); such a family simply omits those ops from its sequence.
-# The canonical MISSPELLING `endianenconding text DEFAULT ''` (asBinary/asEWKB/
-# asHexWKB/asHexEWKB) and `maxdecimaldigits integer DEFAULT 15` (only float/coordinate-
-# bearing types, per-type via the `maxdd` token) are reproduced verbatim.
+# The endian argument `endian text DEFAULT ''` (asBinary/asEWKB/asHexWKB/asHexEWKB) and
+# `maxdecimaldigits integer DEFAULT 15` (only float/coordinate-bearing types, per-type
+# via the `maxdd` token) are reproduced verbatim.
 #
 # Region markers for the eventual Phase-2 emit (mirroring _io_markers); Phase-1
 # --validate extracts the committed hand block by section-header ANCHORS instead, so
@@ -968,7 +968,7 @@ def _representations_markers(family: str):
 
 
 # From-constructor argument types and the as-output return types (the invariant
-# structure of each op; the varying part — symbol, maxdecimaldigits/endianenconding
+# structure of each op; the varying part — symbol, maxdecimaldigits/endian
 # presence — is computed below or overridden per family).
 _REPR_FROM_ARG = {
     "FromText": "text", "FromEWKT": "text", "FromMFJSON": "text",
@@ -1026,9 +1026,9 @@ def _repr_fn(op: str, t: dict, fam: dict, array: bool) -> str:
         sym = fam.get("syms", {}).get(op, _REPR_DEFAULT_SYM[op])
         return _repr_skeleton(_repr_mfjson_sig(t, fam), "text", sym)
     # as<Fmt>(temp[, tail]) output.  maxdecimaldigits only on maxdd types (text/ewkt);
-    # endianenconding on the (E/Hex)WKB ops; both reproduced verbatim.
+    # endian on the (E/Hex)WKB ops; both reproduced verbatim.
     if op in _REPR_ENDIAN_OPS:
-        tail = ", endianenconding text DEFAULT ''"
+        tail = ", endian text DEFAULT ''"
     elif op in _REPR_ARRAY_OPS and t.get("maxdd"):
         tail = ", maxdecimaldigits integer DEFAULT 15"
     else:

--- a/tools/codegen/inherited/manifest.d/span_families.yaml
+++ b/tools/codegen/inherited/manifest.d/span_families.yaml
@@ -40,9 +40,9 @@ span_families:
   - {sig: "asText({sp}, maxdecimaldigits integer DEFAULT 15)", ret: "text", sym: Span_as_text, only: [float]}
   - {sig: "asText({sp})", ret: "text", sym: Span_as_text, only: [date, tstz]}
   - lit: "\n"
-  - {sig: "asBinary({sp}, endianenconding text DEFAULT '')", ret: "bytea", sym: Span_as_wkb}
+  - {sig: "asBinary({sp}, endian text DEFAULT '')", ret: "bytea", sym: Span_as_wkb}
   - lit: "\n"
-  - {sig: "asHexWKB({sp}, endianenconding text DEFAULT '')", ret: "text", sym: Span_as_hexwkb}
+  - {sig: "asHexWKB({sp}, endian text DEFAULT '')", ret: "text", sym: Span_as_hexwkb}
   - lit: "\n/******************************************************************************\n * Constructor functions\n ******************************************************************************/\n\n"
   - {sig: "span({v}, {v}, boolean DEFAULT true, boolean DEFAULT false)", ret: "{sp}", sym: Span_constructor}
   - lit: "\n/******************************************************************************\n * Conversion functions\n ******************************************************************************/\n\n"
@@ -198,9 +198,9 @@ span_families:
   - {sig: "asText({ss}, maxdecimaldigits integer DEFAULT 15)", ret: "text", sym: Spanset_as_text, only: [float]}
   - {sig: "asText({ss})", ret: "text", sym: Spanset_as_text, only: [date, tstz]}
   - lit: "\n"
-  - {sig: "asBinary({ss}, endianenconding text DEFAULT '')", ret: "bytea", sym: Spanset_as_wkb}
+  - {sig: "asBinary({ss}, endian text DEFAULT '')", ret: "bytea", sym: Spanset_as_wkb}
   - lit: "\n"
-  - {sig: "asHexWKB({ss}, endianenconding text DEFAULT '')", ret: "text", sym: Spanset_as_hexwkb}
+  - {sig: "asHexWKB({ss}, endian text DEFAULT '')", ret: "text", sym: Spanset_as_hexwkb}
   - lit: "\n/******************************************************************************\n * Constructor functions\n ******************************************************************************/\n\n"
   - {sig: "spanset({sp}[])", ret: "{ss}", sym: Spanset_constructor}
   - lit: "\n/******************************************************************************\n * Conversion functions\n ******************************************************************************/\n\n"
@@ -2747,9 +2747,9 @@ span_families:
   - {sig: "asText({vs}, maxdecimaldigits integer DEFAULT 15)", ret: "text", sym: Set_as_text, only: [float]}
   - {sig: "asText({vs})", ret: "text", sym: Set_as_text, only: [text, date, tstz]}
   - lit: "\n"
-  - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
   - lit: "\n"
-  - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
   - lit: "\n"
 
 - family: geoset_io
@@ -2793,10 +2793,10 @@ span_families:
     sep: "\n"
   - lit: "\n"
   - group:
-    - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
-    - {sig: "asEWKB({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
-    - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
-    - {sig: "asHexEWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
+    - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+    - {sig: "asEWKB({vs}, endian text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
+    - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+    - {sig: "asHexEWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
     sep: "\n"
   - lit: "\n"
 
@@ -2829,10 +2829,10 @@ span_families:
   - {sig: "asText({vs}, maxdecimaldigits integer DEFAULT 15)", ret: "text", sym: Spatialset_as_text}
   - {sig: "asEWKT({vs}, maxdecimaldigits integer DEFAULT 15)", ret: "text", sym: Spatialset_as_ewkt}
   - lit: "\n"
-  - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
-  - {sig: "asEWKB({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
-  - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
-  - {sig: "asHexEWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asEWKB({vs}, endian text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexEWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
   - lit: "\n"
 
 - family: npointset_io
@@ -2864,10 +2864,10 @@ span_families:
   - {sig: "asText({vs}, maxdecimaldigits integer DEFAULT 15)", ret: "text", sym: Set_as_text}
   - {sig: "asEWKT({vs}, maxdecimaldigits integer DEFAULT 15)", ret: "text", sym: Spatialset_as_ewkt}
   - lit: "\n"
-  - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
-  - {sig: "asEWKB({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
-  - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
-  - {sig: "asHexEWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asEWKB({vs}, endian text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexEWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
   - lit: "\n"
 
 - family: cbufferset_io
@@ -2893,10 +2893,10 @@ span_families:
   - lit: "\n"
   - {sig: "{vs}FromHexWKB(text)", ret: "{vs}", sym: Set_from_hexwkb}
   - lit: "\n"
-  - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
-  - {sig: "asEWKB({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
-  - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
-  - {sig: "asHexEWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asEWKB({vs}, endian text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexEWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
   - lit: "\n"
   - {sig: "asText({vs}, maxdecimaldigits integer DEFAULT 15)", ret: "text", sym: Spatialset_as_text}
   - lit: "\n"
@@ -2929,9 +2929,9 @@ span_families:
   - lit: "\n"
   - {sig: "asText({vs})", ret: "text", sym: Set_as_text}
   - lit: "\n"
-  - {sig: "asBinary({vs}, endianencoding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
   - lit: "\n"
-  - {sig: "asHexWKB({vs}, endianencoding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
   - lit: "\n"
 
 - family: h3indexset_io
@@ -2962,9 +2962,9 @@ span_families:
   - lit: "\n"
   - {sig: "asText({vs})", ret: "text", sym: Set_as_text}
   - lit: "\n"
-  - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
   - lit: "\n"
-  - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
   - lit: "\n"
 
 - family: quadbinset_io
@@ -2995,9 +2995,9 @@ span_families:
   - lit: "\n"
   - {sig: "asText({vs})", ret: "text", sym: Set_as_text}
   - lit: "\n"
-  - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
   - lit: "\n"
-  - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
   - lit: "\n"
 
 - family: pcpointset_io
@@ -3021,10 +3021,10 @@ span_families:
   - lit: "\n"
   - {sig: "{vs}FromBinary(bytea)", ret: "{vs}", sym: Set_from_wkb}
   - {sig: "{vs}FromHexWKB(text)", ret: "{vs}", sym: Set_from_hexwkb}
-  - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
-  - {sig: "asEWKB({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
-  - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
-  - {sig: "asHexEWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asEWKB({vs}, endian text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexEWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
   - lit: "\n"
 
 - family: pcpatchset_io
@@ -3048,10 +3048,10 @@ span_families:
   - lit: "\n"
   - {sig: "{vs}FromBinary(bytea)", ret: "{vs}", sym: Set_from_wkb}
   - {sig: "{vs}FromHexWKB(text)", ret: "{vs}", sym: Set_from_hexwkb}
-  - {sig: "asBinary({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
-  - {sig: "asEWKB({vs}, endianenconding text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
-  - {sig: "asHexWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
-  - {sig: "asHexEWKB({vs}, endianenconding text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
+  - {sig: "asBinary({vs}, endian text DEFAULT '')", ret: "bytea", sym: Set_as_wkb}
+  - {sig: "asEWKB({vs}, endian text DEFAULT '')", ret: "bytea", sym: Spatialset_as_ewkb}
+  - {sig: "asHexWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Set_as_hexwkb}
+  - {sig: "asHexEWKB({vs}, endian text DEFAULT '')", ret: "text", sym: Spatialset_as_hexewkb}
   - lit: "\n"
 - family: geoset_srs
   file: mobilitydb/sql/geo/050_geoset.in.sql

--- a/tools/codegen/inherited/manifest.d/tiling_families.yaml
+++ b/tools/codegen/inherited/manifest.d/tiling_families.yaml
@@ -8,8 +8,8 @@ tiling_families:
   blocks:
   - lit: "/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tgeom AS (\n  time timestamptz,\n  tgeom tgeometry\n);\nCREATE TYPE time_tgeog AS (\n  time timestamptz,\n  tgeog tgeography\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tgeometry, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tgeom", sym: "Temporal_time_split"}
-    - {sig: "timeSplit(tgeography, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tgeog", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tgeometry, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tgeom", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tgeography, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tgeog", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: tpoint
   file: mobilitydb/sql/geo/052_tpoint.in.sql
@@ -19,8 +19,8 @@ tiling_families:
   blocks:
   - lit: "/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tgeompoint AS (\n  time timestamptz,\n  temp tgeompoint\n);\nCREATE TYPE time_tgeogpoint AS (\n  time timestamptz,\n  temp tgeogpoint\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tgeompoint, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tgeompoint", sym: "Temporal_time_split"}
-    - {sig: "timeSplit(tgeogpoint, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tgeogpoint", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tgeompoint, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tgeompoint", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tgeogpoint, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tgeogpoint", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: cbuffer
   file: mobilitydb/sql/cbuffer/202_tcbuffer.in.sql
@@ -30,7 +30,7 @@ tiling_families:
   blocks:
   - lit: "/*****************************************************************************\n * Multidimensional tiling\n *****************************************************************************/\n\nCREATE TYPE time_tcbuffer AS (\n  time timestamptz,\n  temp tcbuffer\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tcbuffer, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tcbuffer", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tcbuffer, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tcbuffer", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: json
   file: mobilitydb/sql/json/452_tjsonb.in.sql
@@ -40,7 +40,7 @@ tiling_families:
   blocks:
   - lit: "/*****************************************************************************\n * Multidimensional tiling\n *****************************************************************************/\n\nCREATE TYPE time_tjsonb AS (\n  time timestamptz,\n  temp tjsonb\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tjsonb, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tjsonb", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tjsonb, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tjsonb", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: json_boxops
   file: mobilitydb/sql/json/459_tjsonb_boxops.in.sql
@@ -57,7 +57,7 @@ tiling_families:
   blocks:
   - lit: "/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tnpoint AS (\n  time timestamptz,\n  temp tnpoint\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tnpoint, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tnpoint", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tnpoint, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tnpoint", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: tpcpoint
   file: mobilitydb/sql/pointcloud/420_tpcpoint.in.sql
@@ -67,7 +67,7 @@ tiling_families:
   blocks:
   - lit: "/******************************************************************************\n * Unnest\n ******************************************************************************/\n\nCREATE TYPE pcpoint_tstzspanset AS (\n  value pcpoint,\n  time tstzspanset\n);\n\nCREATE FUNCTION unnest(tpcpoint)\n  RETURNS SETOF pcpoint_tstzspanset\n  AS 'MODULE_PATHNAME', 'Temporal_unnest'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tpcpoint AS (\n  time timestamptz,\n  temp tpcpoint\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tpcpoint, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tpcpoint", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tpcpoint, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tpcpoint", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: tpcpatch
   file: mobilitydb/sql/pointcloud/430_tpcpatch.in.sql
@@ -77,7 +77,7 @@ tiling_families:
   blocks:
   - lit: "/******************************************************************************\n * Unnest\n ******************************************************************************/\n\nCREATE TYPE pcpatch_tstzspanset AS (\n  value pcpatch,\n  time tstzspanset\n);\n\nCREATE FUNCTION unnest(tpcpatch)\n  RETURNS SETOF pcpatch_tstzspanset\n  AS 'MODULE_PATHNAME', 'Temporal_unnest'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tpcpatch AS (\n  time timestamptz,\n  temp tpcpatch\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tpcpatch, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tpcpatch", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tpcpatch, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tpcpatch", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: tpc_boxops
   file: mobilitydb/sql/pointcloud/435_tpc_boxops.in.sql
@@ -94,7 +94,7 @@ tiling_families:
   blocks:
   - lit: "/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tpose AS (\n  time timestamptz,\n  temp tpose\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tpose, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tpose", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tpose, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tpose", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: posechain
   file: mobilitydb/sql/posechain/552_tposechain.in.sql
@@ -104,7 +104,7 @@ tiling_families:
   blocks:
   - lit: "/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_tposechain AS (\n  time timestamptz,\n  temp tposechain\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tposechain, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tposechain", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tposechain, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tposechain", sym: "Temporal_time_split"}
   - lit: "\n"
 
 - family: rgeo
@@ -115,7 +115,7 @@ tiling_families:
   blocks:
   - lit: "/******************************************************************************\n * Multidimensional tiling\n ******************************************************************************/\n\nCREATE TYPE time_trgeometry AS (\n  time timestamptz,\n  temp trgeometry\n);\n\n"
   - fns:
-    - {sig: "timeSplit(trgeometry, bucket_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_trgeometry", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(trgeometry, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_trgeometry", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: tgeo_tile
   file: mobilitydb/sql/geo/058_tgeo_tile.in.sql
@@ -140,7 +140,7 @@ tiling_families:
   - fns:
     - {sig: "spaceSplit(tgeometry, xsize float, ysize float, zsize float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tgeo", sym: "Tgeo_space_split"}
     - {sig: "spaceSplit(tgeometry, size float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tgeo", sql: "SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4)"}
-    - {sig: "spaceSplit(tgeometry, sizeX float, sizeY float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tgeo", sql: "SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5)"}
+    - {sig: "spaceSplit(tgeometry, xsize float, ysize float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tgeo", sql: "SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5)"}
   - lit: "\nCREATE TYPE point_time_tgeo AS (\n  point geometry,\n  time timestamptz,\n  tgeo tgeometry\n);\n\n"
   - fns:
     - {sig: "spaceTimeSplit(tgeometry, xsize float, ysize float,\n    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',\n    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_time_tgeo", sym: "Tgeo_space_time_split"}
@@ -230,7 +230,7 @@ tiling_families:
   - fns:
     - {sig: "spaceSplit(tgeompoint, xsize float, ysize float, zsize float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpoint", sym: "Tgeo_space_split"}
     - {sig: "spaceSplit(tgeompoint, size float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpoint", sql: "SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4)"}
-    - {sig: "spaceSplit(tgeompoint, sizeX float, sizeY float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpoint", sql: "SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5)"}
+    - {sig: "spaceSplit(tgeompoint, xsize float, ysize float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpoint", sql: "SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5)"}
   - lit: "\nCREATE TYPE point_time_tpoint AS (\n  point geometry,\n  time timestamptz,\n  tpoint tgeompoint\n);\n\n"
   - fns:
     - {sig: "spaceTimeSplit(tgeompoint, xsize float, ysize float,\n    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',\n    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_time_tpoint", sym: "Tgeo_space_time_split"}
@@ -260,7 +260,7 @@ tiling_families:
   - fns:
     - {sig: "spaceSplit(tpose, xsize float, ysize float, zsize float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpose", body: "    SELECT r.point, @extschema@.atTime($1, @extschema@.getTime(r.tpoint))\n    FROM @extschema@.spaceSplit(\n      $1::@extschema@.tgeompoint, $2, $3, $4, $5, $6, $7) AS r"}
     - {sig: "spaceSplit(tpose, size float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpose", body: "    SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4, $5)"}
-    - {sig: "spaceSplit(tpose, sizeX float, sizeY float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpose", body: "    SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5, $6)"}
+    - {sig: "spaceSplit(tpose, xsize float, ysize float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpose", body: "    SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5, $6)"}
   - lit: "\nCREATE TYPE point_time_tpose AS (\n  point geometry,\n  time timestamptz,\n  tpose tpose\n);\n\n"
   - fns:
     - {sig: "spaceTimeSplit(tpose, xsize float, ysize float,\n    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',\n    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_time_tpose", body: "    SELECT r.point, r.time, @extschema@.atTime($1, @extschema@.getTime(r.tpoint))\n    FROM @extschema@.spaceTimeSplit(\n      $1::@extschema@.tgeompoint, $2, $3, $4, $5, $6, $7, $8, $9) AS r"}
@@ -290,7 +290,7 @@ tiling_families:
   - fns:
     - {sig: "spaceSplit(tpcpoint, xsize float, ysize float, zsize float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpcpoint", body: "    SELECT r.point, @extschema@.atTime($1, @extschema@.getTime(r.tpoint))\n    FROM @extschema@.spaceSplit(\n      $1::@extschema@.tgeompoint, $2, $3, $4, $5, $6, $7) AS r"}
     - {sig: "spaceSplit(tpcpoint, size float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpcpoint", body: "    SELECT @extschema@.spaceSplit($1, $2, $2, $2, $3, $4, $5)"}
-    - {sig: "spaceSplit(tpcpoint, sizeX float, sizeY float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpcpoint", body: "    SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5, $6)"}
+    - {sig: "spaceSplit(tpcpoint, xsize float, ysize float,\n    sorigin geometry DEFAULT 'Point(0 0 0)', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_tpcpoint", body: "    SELECT @extschema@.spaceSplit($1, $2, $3, $2, $4, $5, $6)"}
   - lit: "\nCREATE TYPE point_time_tpcpoint AS (\n  point geometry,\n  time timestamptz,\n  tpcpoint tpcpoint\n);\n\n"
   - fns:
     - {sig: "spaceTimeSplit(tpcpoint, xsize float, ysize float,\n    zsize float, interval, sorigin geometry DEFAULT 'Point(0 0 0)',\n    torigin timestamptz DEFAULT '2000-01-03', bitmatrix boolean DEFAULT TRUE,\n    borderInc boolean DEFAULT TRUE)", ret: "SETOF point_time_tpcpoint", body: "    SELECT r.point, r.time, @extschema@.atTime($1, @extschema@.getTime(r.tpoint))\n    FROM @extschema@.spaceTimeSplit(\n      $1::@extschema@.tgeompoint, $2, $3, $4, $5, $6, $7, $8, $9) AS r"}
@@ -309,7 +309,7 @@ tiling_families:
   - {temp: tfloat, base: float, basefull: float, span: floatspan, vdef: "0.0"}
   - {temp: ttext}
   blocks:
-  - lit: "/**\n * @file\n * @brief Bin and tile functions for temporal types\n * @note The time bin function are inspired from TimescaleDB\n * https://docs.timescale.com/api/latest/hyperfunctions/time_bucket/\n */\n\n/*****************************************************************************\n * Bins\n *****************************************************************************/\n\nCREATE FUNCTION bins(intspan, vsize int, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(bigintspan, vsize bigint, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(floatspan, vsize float, vorigin float DEFAULT 0.0)\n  RETURNS floatspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION bins(datespan, tsize interval,\n    torigin date DEFAULT '2000-01-01')\n  RETURNS datespan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(tstzspan, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/\n\nCREATE FUNCTION bins(intspanset, vsize int, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(bigintspanset, vsize bigint, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(floatspanset, vsize float, vorigin float DEFAULT 0.0)\n  RETURNS floatspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION bins(datespanset, tsize interval,\n    torigin date DEFAULT '2000-01-01')\n  RETURNS datespan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(tstzspanset, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/\n\nCREATE FUNCTION getBin(\"value\" integer, size integer, origin integer DEFAULT 0)\n  RETURNS intspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(\"value\" bigint, size bigint, origin bigint DEFAULT 0)\n  RETURNS bigintspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(\"value\" float, size float, origin float DEFAULT 0.0)\n  RETURNS floatspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION getBin(date, interval, date DEFAULT '2000-01-03')\n  RETURNS datespan\n  AS 'MODULE_PATHNAME', 'Date_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(timestamptz, interval, timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan\n  AS 'MODULE_PATHNAME', 'Timestamptz_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/\n\n"
+  - lit: "/**\n * @file\n * @brief Bin and tile functions for temporal types\n * @note The time bin function are inspired from TimescaleDB\n * https://docs.timescale.com/api/latest/hyperfunctions/time_bucket/\n */\n\n/*****************************************************************************\n * Bins\n *****************************************************************************/\n\nCREATE FUNCTION bins(intspan, vsize int, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(bigintspan, vsize bigint, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(floatspan, vsize float, vorigin float DEFAULT 0.0)\n  RETURNS floatspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION bins(datespan, tsize interval,\n    torigin date DEFAULT '2000-01-01')\n  RETURNS datespan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(tstzspan, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Span_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/\n\nCREATE FUNCTION bins(intspanset, vsize int, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(bigintspanset, vsize bigint, vorigin int DEFAULT 0)\n  RETURNS intspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(floatspanset, vsize float, vorigin float DEFAULT 0.0)\n  RETURNS floatspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION bins(datespanset, tsize interval,\n    torigin date DEFAULT '2000-01-01')\n  RETURNS datespan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION bins(tstzspanset, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan[]\n  AS 'MODULE_PATHNAME', 'Spanset_bins'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/\n\nCREATE FUNCTION getBin(\"value\" integer, size integer, origin integer DEFAULT 0)\n  RETURNS intspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(\"value\" bigint, size bigint, origin bigint DEFAULT 0)\n  RETURNS bigintspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(\"value\" float, size float, origin float DEFAULT 0.0)\n  RETURNS floatspan\n  AS 'MODULE_PATHNAME', 'Value_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\nCREATE FUNCTION getBin(date, duration interval, origin date DEFAULT '2000-01-03')\n  RETURNS datespan\n  AS 'MODULE_PATHNAME', 'Date_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\nCREATE FUNCTION getBin(timestamptz, duration interval, origin timestamptz DEFAULT '2000-01-03')\n  RETURNS tstzspan\n  AS 'MODULE_PATHNAME', 'Timestamptz_bin'\n  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;\n\n/*****************************************************************************/\n\n"
   - gen: {sig: "timeBins({TEMP}, tsize interval,\n    torigin timestamptz DEFAULT '2000-01-03')", ret: "tstzspan[]", sym: Temporal_time_bins}
   - lit: "\n"
   - gen: {sig: "valueBins({TEMP}, vsize {BASE}, vorigin {BASE} DEFAULT {VDEF})", ret: "{SPAN}[]", sym: Tnumber_value_bins, presence: numeric}
@@ -322,7 +322,7 @@ tiling_families:
   - lit: "\n/*****************************************************************************\n * Splitting\n *****************************************************************************/\n\nCREATE TYPE number_tint AS (\n  number integer,\n  tnumber tint\n);\nCREATE TYPE number_tbigint AS (\n  number bigint,\n  tnumber tbigint\n);\nCREATE TYPE number_tfloat AS (\n  number float,\n  tnumber tfloat\n);\n\n"
   - gen: {sig: "valueSplit({TEMP}, size {BASEFULL}, origin {BASEFULL} DEFAULT {VDEF})", ret: "SETOF number_{TEMP}", sym: Tnumber_value_split, presence: numeric}
   - lit: "\n/*****************************************************************************/\n\nCREATE TYPE time_tbool AS (\n  time timestamptz,\n  temp tbool\n);\nCREATE TYPE time_tint AS (\n  time timestamptz,\n  temp tint\n);\nCREATE TYPE time_tbigint AS (\n  time timestamptz,\n  temp tbigint\n);\nCREATE TYPE time_tfloat AS (\n  time timestamptz,\n  temp tfloat\n);\nCREATE TYPE time_ttext AS (\n  time timestamptz,\n  temp ttext\n);\n\n"
-  - gen: {sig: "timeSplit({TEMP}, size interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "SETOF time_{TEMP}", sym: Temporal_time_split}
+  - gen: {sig: "timeSplit({TEMP}, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "SETOF time_{TEMP}", sym: Temporal_time_split}
   - lit: "\n/*****************************************************************************/\n\nCREATE TYPE number_time_tint AS (\n  number integer,\n  time timestamptz,\n  tnumber tint\n);\nCREATE TYPE number_time_tbigint AS (\n  number bigint,\n  time timestamptz,\n  tnumber tbigint\n);\nCREATE TYPE number_time_tfloat AS (\n  number float,\n  time timestamptz,\n  tnumber tfloat\n);\n\n"
   - gen: {sig: "valueTimeSplit({TEMP}, size {BASEFULL}, duration interval,\n    vorigin {BASEFULL} DEFAULT {VDEF}, torigin timestamptz DEFAULT '2000-01-03')", ret: "SETOF number_time_{TEMP}", sym: Tnumber_value_time_split, presence: numeric}
   - lit: "\n/*****************************************************************************/\n\n\n"
@@ -335,7 +335,7 @@ tiling_families:
   blocks:
   - lit: "CREATE TYPE time_th3index AS (\n  time timestamptz,\n  temp th3index\n);\n\n"
   - fns:
-    - {sig: "timeSplit(th3index, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_th3index", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(th3index, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_th3index", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: th3index_boxops
   file: mobilitydb/sql/h3/257_th3index_boxops.in.sql
@@ -354,7 +354,7 @@ tiling_families:
   blocks:
   - lit: "CREATE TYPE time_tquadbin AS (\n  time timestamptz,\n  temp tquadbin\n);\n\n"
   - fns:
-    - {sig: "timeSplit(tquadbin, bin_width interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tquadbin", sym: "Temporal_time_split"}
+    - {sig: "timeSplit(tquadbin, duration interval,\n    origin timestamptz DEFAULT '2000-01-03')", ret: "setof time_tquadbin", sym: "Temporal_time_split"}
   - lit: "\n"
 - family: quadbin_boxops
   file: mobilitydb/sql/quadbin/357_tquadbin_boxops.in.sql


### PR DESCRIPTION
Every argument of a function family carries one name, and it is the name the manual prints. The WKB endianness argument is endian, so a named call such as asBinary(s, endian => 'NDR') resolves for every type; the surface spells it endianenconding in 150 declarations and endianencoding in two, and the manual a third way, so no named call is portable across the family surface. The interval of timeSplit is duration against bin_width for fifteen families, bucket_width for trgeometry and size for the five alphanumeric base types. The two axes of spaceSplit are xsize and ysize, the spelling nine of its ten overloads and every manual signature carry. The date and timestamptz overloads of getBin name their arguments duration and origin, as their three numeric siblings name theirs.

The generator is where the names live: tools/codegen/inherited/generate.py and its manifests emit these declarations, so the spellings are stated there and INHERITANCE_MAP.md states the argument the representation behaviours carry. generate.py --validate reads 318 targets up to date.

Both manuals state the same names in their signature blocks. Erasing argument names from the 178 changed declaration lines makes every one of them identical to the line it replaces, so the surface differs in argument names alone.