### PR TITLE
Give each Spanish entry the identity and the blocks of its English twin

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -211,7 +211,7 @@ SELECT stboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-03]');
 SELECT geodstboxZ(1.0,2.0,3.0,1.0,2.0,3.0);
 -- Only time dimension for geodetic box
 SELECT geodstboxT(tstzspan '[2001-01-03,2001-01-03]');
---  Both value (with X, Y, and Z geodetic coordinates) and time dimensions
+-- Both value (with X, Y, and Z geodetic coordinates) and time dimensions
 SELECT geodstboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-04]');
 -- Geometry and time dimension
 SELECT stbox(geometry 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03,2001-01-05]');

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -26,38 +26,38 @@
 
 		<para>Un <varname>tbox</varname> se compone de dimensiónes de valor numérico y/o de tiempo. Para cada dimensión, se proporciona un rango, es decir, ya sea un <varname>intspan</varname> o un <varname>floatspan</varname> para la dimensión de valor y un <varname>tstzspan</varname> para la dimensión de tiempo. Ejemplos de entrada de valores <varname>tbox</varname> son los siguientes:
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Dimensiones de valor y tiempo
+-- Both value and time dimensions
 SELECT tbox 'TBOXINT XT([1,3),[2001-01-01,2001-01-02])';
 SELECT tbox 'TBOXBIGINT XT([1,3),[2001-01-01,2001-01-02])';
 SELECT tbox 'TBOXFLOAT XT([1.5,2.5],[2001-01-01,2001-01-02])';
--- Sólo dimensión de valor
+-- Only value dimension
 SELECT tbox 'TBOXINT X([1,3))';
 SELECT tbox 'TBOXBIGINT X([1,3))';
 SELECT tbox 'TBOXFLOAT X((1.5,2.5))';
--- Sólo dimensión de tiempo
+-- Only time dimension
 SELECT tbox 'TBOX T((2001-01-01,2001-01-02))';
 </programlisting>
 		</para>
 
 		<para>Un <varname>stbox</varname> se compone de dimensiónes espacial y/o temporal, donde las coordenadas de la dimensión espacial pueden ser 2D o 3D. Para la dimensión de tiempo se da un <varname>tstzspan</varname>, y para la dimensión espacial se dan los valores mínimos y máximos de las coordenadas, donde estas últimas pueden ser cartesianas (planas) o geodésicas (esféricas). Se puede especificar el SRID de las coordenadas; si no es el caso, se asume un valor de 0 (desconocido) y 4326 (correspondiente a WGS84), respectivamente, para coordenadas planas y geodésicas. Los cuadros geodésicos siempre tienen una dimensión Z para tener en cuenta la curvatura de la esfera o esferoide subyacente. Ejemplos de entrada de valores <varname>stbox</varname> son los siguientes:
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Sólo dimensión de valor con coordenadas X e Y
+-- Only value dimension with X and Y coordinates
 SELECT stbox 'STBOX X((1.0,2.0),(1.0,2.0))';
--- Sólo dimensión de valor con coordenadas X, Y y Z
+-- Only value dimension with X, Y, and Z coordinates
 SELECT stbox 'STBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
--- Dimensiones de valor (con coordenadas X e Y) y de tiempo
+-- Both value (with X and Y coordinates) and time dimensions
 SELECT stbox 'STBOX XT(((1.0,2.0),(1.0,2.0)),[2001-01-03,2001-01-03])';
--- Dimensiones de valor (con coordenadas X, Y y Z) y de tiempo
+-- Both value (with X, Y, and Z coordinates) and time dimensions
 SELECT stbox 'STBOX ZT(((1.0,2.0,3.0),(1.0,2.0,3.0)),[2001-01-01,2001-01-03])';
--- Sólo dimensión de tiempo
+-- Only time dimension
 SELECT stbox 'STBOX T([2001-01-03,2001-01-03])';
--- Sólo dimensión de valores con coordenadas geodéticas X, Y y Z
+-- Only value dimension with X, Y, and Z geodetic coordinates
 SELECT stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
--- Dimensiones de valor (con coordenadas geodéticas X, Y y Z) y de tiempo
+-- Both value (with X, Y and Z geodetic coordinates) and time dimension
 SELECT stbox 'GEODSTBOX ZT(((1.0,2.0,3.0),(1.0,2.0,3.0)),[2001-01-04,2001-01-04])';
--- Sólo dimensión temporal para cuadro geodético
+-- Only time dimension for geodetic box
 SELECT stbox 'GEODSTBOX T([2001-01-03,2001-01-03])';
--- Se indica el SRID
+-- SRID is given
 SELECT stbox 'SRID=5676;STBOX XT(((1.0,2.0),(1.0,2.0)),[2001-01-04,2001-01-04])';
 SELECT stbox 'SRID=4326;GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
 </programlisting>
@@ -153,12 +153,12 @@ tbox({timestamptz,tstzspan}) → tbox
 tbox({number,numspan},{timestamptz,tstzspan}) → tbox
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Dimensiones de valores y de tiempo
+-- Both value and time dimensions
 SELECT tbox(1.0, timestamptz '2001-01-01');
 SELECT tbox(floatspan '[1.0, 2.0)', tstzspan '[2001-01-01,2001-01-02)');
--- Sólo dimensión de valores
+-- Only value dimension
 SELECT tbox(floatspan '[1.0,2.0)');
--- Sólo dimensión de tiempo
+-- Only time dimension
 SELECT tbox(tstzspan '[2001-01-01,2001-01-02)');
 </programlisting>
 			</listitem>
@@ -195,27 +195,27 @@ stbox(geo) → stbox
 stbox(geo,{timestamptz,tstzspan}) → stbox
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Sólo dimensión de valores con coordenadas X e Y
+-- Only value dimension with X and Y coordinates
 SELECT stboxX(1.0,2.0,1.0,2.0);
--- Sólo dimensión de valores con coordenadas X, Y y Z
+-- Only value dimension with X, Y, and Z coordinates
 SELECT stboxZ(1.0,2.0,3.0,1.0,2.0,3.0);
--- Sólo dimensión de valores con coordenadas X, Y y Z con SRID
+-- Only value dimension with X, Y, and Z coordinates and SRID
 SELECT stboxZ(1.0,2.0,3.0,1.0,2.0,3.0,5676);
--- Sólo dimensión de tiempo
+-- Only time dimension
 SELECT stboxT(tstzspan '[2001-01-03,2001-01-03]');
--- Dimensiones de valor (con coordenadas X e Y) y de tiempo
+-- Both value (with X and Y coordinates) and time dimensions
 SELECT stboxXT(1.0,2.0, 1.0,2.0, tstzspan '[2001-01-03,2001-01-03]');
--- Dimensiones de valor (con coordenadas X, Y y Z) y de tiempo
+-- Both value (with X, Y, and Z coordinates) and time dimensions
 SELECT stboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-03]');
--- Sólo dimensión de valores con coordenadas geodéticas X, Y y Z
+-- Only value dimension with X, Y, and Z geodetic coordinates
 SELECT geodstboxZ(1.0,2.0,3.0,1.0,2.0,3.0);
--- Sólo dimensión de tiempo para cuadro geodético
+-- Only time dimension for geodetic box
 SELECT geodstboxT(tstzspan '[2001-01-03,2001-01-03]');
--- Dimensiones de valor (con coordenadas geodéticas X, Y y Z) y de tiempo
+-- Both value (with X, Y, and Z geodetic coordinates) and time dimensions
 SELECT geodstboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-04]');
--- Geometry and time dimensión
+-- Geometry and time dimension
 SELECT stbox(geometry 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03,2001-01-05]');
--- Geography and time dimensión
+-- Geography and time dimension
 SELECT stbox(geography 'Linestring(1 1 1,2 2 2)', tstzspan '[2001-01-03,2001-01-05]');
 </programlisting>
 			</listitem>

--- a/doc/es/data_generator.xml
+++ b/doc/es/data_generator.xml
@@ -8,7 +8,7 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 -->
-<appendix xml:id ="data_generator">
+<appendix xml:id="data_generator">
 	<title>Generador de datos sintéticos</title>
 	<para>
 		En muchas circunstancias, es necesario tener un conjunto de datos de prueba para evaluar enfoques de implementación alternativos o realizar evaluaciones comparativas. A menudo se requiere que tal conjunto de datos tenga requisitos particulares en tamaño o en las características intrínsecas de sus datos. Incluso si un conjunto de datos del mundo real pudiera estar disponible, puede que no sea ideal para tales experimentos por múltiples razones. Por lo tanto, un generador de datos sintéticos que pueda personalizarse para producir datos de acuerdo con los requisitos dados suele ser la mejor solución. Obviamente, los experimentos con datos sintéticos deben complementarse con experimentos con datos del mundo real para tener una comprensión profunda del problema en cuestión.

--- a/doc/es/introduction.xml
+++ b/doc/es/introduction.xml
@@ -490,38 +490,16 @@ SET client_min_messages TO notice;
 		</sect2>
 	</sect1>
 
-	<sect1 xml:id="migrating">
-		<title>Migración de la versión 1.0 a la versión 1.1</title>
+	<sect1 xml:id="migrating_1.3">
+		<title>Migración de la versión 1.2 a la versión 1.3</title>
 		<para>
-			MobilityDB 1.1 es una revisión importante con respecto a la versión inicial 1.0. El cambio más significativo en la version 1.1 fue extraer la funcionalidad central para la gestión de datos temporales y espaciotemporales de MobilityDB en la bibilioteca C Mobility Engine Open Source (<ulink url="http://libmeos.org">MEOS</ulink>). De esta forma, la misma funcionalidad que proporciona MobilityDB en un entorno de base de datos está disponible en un programa C para ser utilizada, por ejemplo, en un entorno de streaming. La biblioteca MEOS para la gestión de la movilidad proporciona una funcionalidad similar a la biblioteca C/C++ Geometry Engine Open Source (<ulink url="http://libgeos.org">GEOS</ulink>) para geometría computacional. Además, están disponibles contenedores para la biblioteca MEOS en otros lenguajes de programación, en particular para Python con <ulink url="https://github.com/MobilityDB/PyMEOS">PyMEOS</ulink>. Además, contenedores para C#, Java y Javascript, están en desarrollando.
+			MobilityDB 1.3 es una revisión importante con respecto a la versión 1.2. El cambio más significativo de la versión 1.3 fue habilitar nuevos tipos espaciotemporales. Mientras que la versión 1.2 definía los tipos espaciotemporales <varname>tgeompoint</varname> (punto de geometría temporal), <varname>tgeogpoint</varname> (punto de geografía temporal) y <varname>tnpoint</varname> (punto de red temporal), la versión 1.3 añadió los nuevos tipos <varname>tgeometry</varname> (geometría temporal), <varname>tgeography</varname> (geografía temporal), <varname>tcbuffer</varname> (búfer circular temporal), <varname>tpose</varname> (pose temporal) y <varname>trgeometry</varname> (geometría rígida temporal). A nivel conceptual, todos los tipos espaciotemporales se organizan en la jerarquía que muestra la <xref linkend="tspatial_fig" />.
 		</para>
 		<para>
-			Fueron necesarios varios cambios con respecto a la versión 1.0 de MobilityDB para habilitar lo anterior. Uno importante fue la definición de nuevos tipos de datos <varname>span</varname> y <varname>spanset</varname>, que brindan una funcionalidad similar a los tipos de datos de PostgreSQL <varname>range</varname> y <varname>multirange</varname> pero también se puede usar en varios lenguajes de programación independientemente de PostgreSQL. Estos son <emphasis>tipos de plantilla</emphasis>, lo que significa que son contenedores de otros tipos, de forma similar a como las listas y matrices contienen valores de otros tipos. Además, también se agregó un nuevo tipo de datos de plantilla <varname>set</varname>. Por lo tanto, los tipos <varname>timestampset</varname>, <varname>period</varname> y <varname>periodset</varname> en la versión 1.0 se reemplazan por los tipos <varname>tstzset</varname>, <varname>tstzspan</varname> y <varname>tstzspanset</varname> en la versión 1.1. El nombre de las funciones constructoras para estos tipos se modificó en consecuencia.
+			Para habilitar lo anterior fue necesaria una refactorización del código. Todos los tipos que proporcionaba la versión 1.2, además de los nuevos tipos <varname>tgeometry</varname> y <varname>tgeography</varname>, se definen como tipos centrales y, por lo tanto, se incluyen siempre en el proceso de construcción. Cada uno de los demás tipos espaciotemporales se puede incluir en el proceso de construcción indicando su bandera de compilación correspondiente. Por ejemplo, al añadir <varname>-DCBUFFER=1</varname> se incluyen en el proceso de construcción los tipos construidos sobre el tipo base <varname>cbuffer</varname>, es decir <varname>cbuffer</varname>, <varname>cbufferset</varname> y <varname>tcbuffer</varname>. La posibilidad de seleccionar los tipos que se incluyen en el programa ejecutable es importante en particular para el procesamiento de flujos, dada la capacidad limitada de los dispositivos de borde. Tenga en cuenta que los nuevos tipos <varname>tcbuffer</varname>, <varname>tpose</varname> y <varname>trgeometry</varname> están todavía en desarrollo y se finalizarán en una versión próxima.
 		</para>
 		<para>
-			Finalmente, se simplificó la API de MEOS y MobilityDB para mejorar la usabilidad. Detallamos a continuación los cambios más importantes en la API.
+			Además, la API de MobilityDB y de MEOS se amplió con nuevas funcionalidades y se simplificó para mejorar su usabilidad. Por último, la versión 1.3 también habilita las últimas versiones PostgreSQL 18 y PostGIS 3.6.0. Por todas estas razones, el formato binario de los tipos temporales cambió de la versión 1.2 a la 1.3 y, por lo tanto, es necesario hacer una copia de seguridad y restaurarla para migrar a la nueva versión 1.3 de MobilityDB.
 		</para>
-		<itemizedlist>
-			<listitem>
-				<para>Las funciones <varname>atTimestamp</varname>, <varname>atTimestampSet</varname>, <varname>atPeriod</varname>, and <varname>atPeriodSet</varname> fueron renombradas a <varname>atTime</varname>.
-				</para>
-			</listitem>
-			<listitem>
-				<para>Las funciones <varname>minusTimestamp</varname>, <varname>minusTimestampSet</varname>, <varname>minusPeriod</varname> y <varname>minusPeriodSet</varname> fueron renombradas a <varname>minusTime</varname>.
-				</para>
-			</listitem>
-			<listitem>
-				<para>Las funciones <varname>atValue</varname>, <varname>atValues</varname>, <varname>atRange</varname> y <varname>atRanges</varname> fueron renombradas a <varname>atValues</varname>.
-				</para>
-			</listitem>
-			<listitem>
-				<para>Las funciones <varname>minusValue</varname>, <varname>minusValues</varname>, <varname>minusRange</varname> y <varname>minusRanges</varname> fueron renombradas a <varname>minusValues</varname>.
-				</para>
-			</listitem>
-			<listitem>
-				<para>Las funciones <varname>contains</varname>, <varname>disjoint</varname>, <varname>dwithin</varname>, <varname>intersects</varname> y <varname>touches</varname> fueron renombradas, respectivamente, a <varname>eContains</varname>, <varname>eDisjoint</varname>, <varname>eDwithin</varname>, <varname>eIntersects</varname> y <varname>eTouches</varname>.
-			</para>
-			</listitem>
-		</itemizedlist>
 	</sect1>
 </chapter>

--- a/doc/es/portable_sql.xml
+++ b/doc/es/portable_sql.xml
@@ -28,60 +28,60 @@
 				</row>
 			</thead>
 			<tbody>
-				<row><entry>Topología</entry><entry>&amp;&amp;</entry><entry>overlaps(a, b)</entry></row>
-				<row><entry></entry><entry>@&gt;</entry><entry>contains(a, b)</entry></row>
-				<row><entry></entry><entry>&lt;@</entry><entry>contained(a, b)</entry></row>
-				<row><entry></entry><entry>-|-</entry><entry>adjacent(a, b)</entry></row>
-				<row><entry>Posición temporal</entry><entry>&lt;&lt;#</entry><entry>before(a, b)</entry></row>
-				<row><entry></entry><entry>#&gt;&gt;</entry><entry>after(a, b)</entry></row>
-				<row><entry></entry><entry>&amp;&lt;#</entry><entry>overbefore(a, b)</entry></row>
-				<row><entry></entry><entry>#&amp;&gt;</entry><entry>overafter(a, b)</entry></row>
-				<row><entry>Espacio, eje X</entry><entry>&lt;&lt;</entry><entry>left(a, b)</entry></row>
-				<row><entry></entry><entry>&gt;&gt;</entry><entry>right(a, b)</entry></row>
-				<row><entry></entry><entry>&amp;&lt;</entry><entry>overleft(a, b)</entry></row>
-				<row><entry></entry><entry>&amp;&gt;</entry><entry>overright(a, b)</entry></row>
-				<row><entry>Espacio, eje Y</entry><entry>&lt;&lt;|</entry><entry>below(a, b)</entry></row>
-				<row><entry></entry><entry>|&gt;&gt;</entry><entry>above(a, b)</entry></row>
-				<row><entry></entry><entry>&amp;&lt;|</entry><entry>overbelow(a, b)</entry></row>
-				<row><entry></entry><entry>|&amp;&gt;</entry><entry>overabove(a, b)</entry></row>
-				<row><entry>Espacio, eje Z</entry><entry>&lt;&lt;/</entry><entry>front(a, b)</entry></row>
-				<row><entry></entry><entry>/&gt;&gt;</entry><entry>back(a, b)</entry></row>
-				<row><entry></entry><entry>&amp;&lt;/</entry><entry>overfront(a, b)</entry></row>
-				<row><entry></entry><entry>/&amp;&gt;</entry><entry>overback(a, b)</entry></row>
-				<row><entry>Comparación temporal</entry><entry>#=</entry><entry>tEq(a, b)</entry></row>
-				<row><entry></entry><entry>#&lt;&gt;</entry><entry>tNe(a, b)</entry></row>
-				<row><entry></entry><entry>#&lt;</entry><entry>tLt(a, b)</entry></row>
-				<row><entry></entry><entry>#&lt;=</entry><entry>tLe(a, b)</entry></row>
-				<row><entry></entry><entry>#&gt;</entry><entry>tGt(a, b)</entry></row>
-				<row><entry></entry><entry>#&gt;=</entry><entry>tGe(a, b)</entry></row>
-				<row><entry>Distancia</entry><entry>&lt;-&gt;</entry><entry>tDistance(a, b)</entry></row>
-				<row><entry></entry><entry>|=|</entry><entry>nearestApproachDistance(a, b)</entry></row>
-				<row><entry>Igual</entry><entry>~=</entry><entry>same(a, b)</entry></row>
-				<row><entry>Comparación tradicional</entry><entry>=</entry><entry>eq(a, b)</entry></row>
-				<row><entry></entry><entry>&lt;&gt;</entry><entry>ne(a, b)</entry></row>
-				<row><entry></entry><entry>&lt;</entry><entry>lt(a, b)</entry></row>
-				<row><entry></entry><entry>&lt;=</entry><entry>le(a, b)</entry></row>
-				<row><entry></entry><entry>&gt;</entry><entry>gt(a, b)</entry></row>
-				<row><entry></entry><entry>&gt;=</entry><entry>ge(a, b)</entry></row>
-				<row><entry>Comparación alguna vez</entry><entry>?=</entry><entry>eEq(a, b)</entry></row>
-				<row><entry></entry><entry>?&lt;&gt;</entry><entry>eNe(a, b)</entry></row>
-				<row><entry></entry><entry>?&lt;</entry><entry>eLt(a, b)</entry></row>
-				<row><entry></entry><entry>?&lt;=</entry><entry>eLe(a, b)</entry></row>
-				<row><entry></entry><entry>?&gt;</entry><entry>eGt(a, b)</entry></row>
-				<row><entry></entry><entry>?&gt;=</entry><entry>eGe(a, b)</entry></row>
-				<row><entry>Comparación siempre</entry><entry>%=</entry><entry>aEq(a, b)</entry></row>
-				<row><entry></entry><entry>%&lt;&gt;</entry><entry>aNe(a, b)</entry></row>
-				<row><entry></entry><entry>%&lt;</entry><entry>aLt(a, b)</entry></row>
-				<row><entry></entry><entry>%&lt;=</entry><entry>aLe(a, b)</entry></row>
-				<row><entry></entry><entry>%&gt;</entry><entry>aGt(a, b)</entry></row>
-				<row><entry></entry><entry>%&gt;=</entry><entry>aGe(a, b)</entry></row>
-				<row><entry>Booleano (booleano temporales)</entry><entry>&amp;</entry><entry>tAnd(a, b)</entry></row>
-				<row><entry></entry><entry>|</entry><entry>tOr(a, b)</entry></row>
+				<row><entry>Topología</entry><entry>&amp;&amp;</entry><entry><indexterm significance="normal"><primary><varname>overlaps</varname></primary></indexterm>overlaps(a, b)</entry></row>
+				<row><entry></entry><entry>@&gt;</entry><entry><indexterm significance="normal"><primary><varname>contains</varname></primary></indexterm>contains(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;@</entry><entry><indexterm significance="normal"><primary><varname>contained</varname></primary></indexterm>contained(a, b)</entry></row>
+				<row><entry></entry><entry>-|-</entry><entry><indexterm significance="normal"><primary><varname>adjacent</varname></primary></indexterm>adjacent(a, b)</entry></row>
+				<row><entry>Posición temporal</entry><entry>&lt;&lt;#</entry><entry><indexterm significance="normal"><primary><varname>before</varname></primary></indexterm>before(a, b)</entry></row>
+				<row><entry></entry><entry>#&gt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>after</varname></primary></indexterm>after(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&lt;#</entry><entry><indexterm significance="normal"><primary><varname>overbefore</varname></primary></indexterm>overbefore(a, b)</entry></row>
+				<row><entry></entry><entry>#&amp;&gt;</entry><entry><indexterm significance="normal"><primary><varname>overafter</varname></primary></indexterm>overafter(a, b)</entry></row>
+				<row><entry>Espacio, eje X</entry><entry>&lt;&lt;</entry><entry><indexterm significance="normal"><primary><varname>left</varname></primary></indexterm>left(a, b)</entry></row>
+				<row><entry></entry><entry>&gt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>right</varname></primary></indexterm>right(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&lt;</entry><entry><indexterm significance="normal"><primary><varname>overleft</varname></primary></indexterm>overleft(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&gt;</entry><entry><indexterm significance="normal"><primary><varname>overright</varname></primary></indexterm>overright(a, b)</entry></row>
+				<row><entry>Espacio, eje Y</entry><entry>&lt;&lt;|</entry><entry><indexterm significance="normal"><primary><varname>below</varname></primary></indexterm>below(a, b)</entry></row>
+				<row><entry></entry><entry>|&gt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>above</varname></primary></indexterm>above(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&lt;|</entry><entry><indexterm significance="normal"><primary><varname>overbelow</varname></primary></indexterm>overbelow(a, b)</entry></row>
+				<row><entry></entry><entry>|&amp;&gt;</entry><entry><indexterm significance="normal"><primary><varname>overabove</varname></primary></indexterm>overabove(a, b)</entry></row>
+				<row><entry>Espacio, eje Z</entry><entry>&lt;&lt;/</entry><entry><indexterm significance="normal"><primary><varname>front</varname></primary></indexterm>front(a, b)</entry></row>
+				<row><entry></entry><entry>/&gt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>back</varname></primary></indexterm>back(a, b)</entry></row>
+				<row><entry></entry><entry>&amp;&lt;/</entry><entry><indexterm significance="normal"><primary><varname>overfront</varname></primary></indexterm>overfront(a, b)</entry></row>
+				<row><entry></entry><entry>/&amp;&gt;</entry><entry><indexterm significance="normal"><primary><varname>overback</varname></primary></indexterm>overback(a, b)</entry></row>
+				<row><entry>Comparación temporal</entry><entry>#=</entry><entry><indexterm significance="normal"><primary><varname>tEq</varname></primary></indexterm>tEq(a, b)</entry></row>
+				<row><entry></entry><entry>#&lt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>tNe(a, b)</entry></row>
+				<row><entry></entry><entry>#&lt;</entry><entry><indexterm significance="normal"><primary><varname>tLt</varname></primary></indexterm>tLt(a, b)</entry></row>
+				<row><entry></entry><entry>#&lt;=</entry><entry><indexterm significance="normal"><primary><varname>tLe</varname></primary></indexterm>tLe(a, b)</entry></row>
+				<row><entry></entry><entry>#&gt;</entry><entry><indexterm significance="normal"><primary><varname>tGt</varname></primary></indexterm>tGt(a, b)</entry></row>
+				<row><entry></entry><entry>#&gt;=</entry><entry><indexterm significance="normal"><primary><varname>tGe</varname></primary></indexterm>tGe(a, b)</entry></row>
+				<row><entry>Distancia</entry><entry>&lt;-&gt;</entry><entry><indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>tDistance(a, b)</entry></row>
+				<row><entry></entry><entry>|=|</entry><entry><indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>nearestApproachDistance(a, b)</entry></row>
+				<row><entry>Igual</entry><entry>~=</entry><entry><indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>same(a, b)</entry></row>
+				<row><entry>Comparación tradicional</entry><entry>=</entry><entry><indexterm significance="normal"><primary><varname>eq</varname></primary></indexterm>eq(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>ne</varname></primary></indexterm>ne(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;</entry><entry><indexterm significance="normal"><primary><varname>lt</varname></primary></indexterm>lt(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;=</entry><entry><indexterm significance="normal"><primary><varname>le</varname></primary></indexterm>le(a, b)</entry></row>
+				<row><entry></entry><entry>&gt;</entry><entry><indexterm significance="normal"><primary><varname>gt</varname></primary></indexterm>gt(a, b)</entry></row>
+				<row><entry></entry><entry>&gt;=</entry><entry><indexterm significance="normal"><primary><varname>ge</varname></primary></indexterm>ge(a, b)</entry></row>
+				<row><entry>Comparación alguna vez</entry><entry>?=</entry><entry><indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>eEq(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>eNe</varname></primary></indexterm>eNe(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;</entry><entry><indexterm significance="normal"><primary><varname>eLt</varname></primary></indexterm>eLt(a, b)</entry></row>
+				<row><entry></entry><entry>?&lt;=</entry><entry><indexterm significance="normal"><primary><varname>eLe</varname></primary></indexterm>eLe(a, b)</entry></row>
+				<row><entry></entry><entry>?&gt;</entry><entry><indexterm significance="normal"><primary><varname>eGt</varname></primary></indexterm>eGt(a, b)</entry></row>
+				<row><entry></entry><entry>?&gt;=</entry><entry><indexterm significance="normal"><primary><varname>eGe</varname></primary></indexterm>eGe(a, b)</entry></row>
+				<row><entry>Comparación siempre</entry><entry>%=</entry><entry><indexterm significance="normal"><primary><varname>aEq</varname></primary></indexterm>aEq(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>aNe</varname></primary></indexterm>aNe(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;</entry><entry><indexterm significance="normal"><primary><varname>aLt</varname></primary></indexterm>aLt(a, b)</entry></row>
+				<row><entry></entry><entry>%&lt;=</entry><entry><indexterm significance="normal"><primary><varname>aLe</varname></primary></indexterm>aLe(a, b)</entry></row>
+				<row><entry></entry><entry>%&gt;</entry><entry><indexterm significance="normal"><primary><varname>aGt</varname></primary></indexterm>aGt(a, b)</entry></row>
+				<row><entry></entry><entry>%&gt;=</entry><entry><indexterm significance="normal"><primary><varname>aGe</varname></primary></indexterm>aGe(a, b)</entry></row>
+				<row><entry>Booleano (booleano temporales)</entry><entry>&amp;</entry><entry><indexterm significance="normal"><primary><varname>tAnd</varname></primary></indexterm>tAnd(a, b)</entry></row>
+				<row><entry></entry><entry>|</entry><entry><indexterm significance="normal"><primary><varname>tOr</varname></primary></indexterm>tOr(a, b)</entry></row>
 				<row><entry></entry><entry>~</entry><entry>tNot(a)</entry></row>
-				<row><entry>Aritmética (números temporales)</entry><entry>+</entry><entry>tAdd(a, b)</entry></row>
-				<row><entry></entry><entry>-</entry><entry>tSub(a, b)</entry></row>
-				<row><entry></entry><entry>*</entry><entry>tMul(a, b)</entry></row>
-				<row><entry></entry><entry>/</entry><entry>tDiv(a, b)</entry></row>
+				<row><entry>Aritmética (números temporales)</entry><entry>+</entry><entry><indexterm significance="normal"><primary><varname>tAdd</varname></primary></indexterm>tAdd(a, b)</entry></row>
+				<row><entry></entry><entry>-</entry><entry><indexterm significance="normal"><primary><varname>tSub</varname></primary></indexterm>tSub(a, b)</entry></row>
+				<row><entry></entry><entry>*</entry><entry><indexterm significance="normal"><primary><varname>tMul</varname></primary></indexterm>tMul(a, b)</entry></row>
+				<row><entry></entry><entry>/</entry><entry><indexterm significance="normal"><primary><varname>tDiv</varname></primary></indexterm>tDiv(a, b)</entry></row>
 				<row><entry>Unión (set / span / span set)</entry><entry>+</entry><entry>setUnion / spanUnion / spansetUnion (a, b)</entry></row>
 				<row><entry>Intersección (set / span / span set)</entry><entry>*</entry><entry>setIntersection / spanIntersection / spansetIntersection (a, b)</entry></row>
 				<row><entry>Diferencia (set / span / span set)</entry><entry>-</entry><entry>setMinus / spanMinus / spansetMinus (a, b)</entry></row>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -679,7 +679,7 @@
 					<para><link linkend="ttype_startInstant"><varname>startInstant</varname>, <varname>endInstant</varname>, <varname>instantN</varname></link>: Devuelve el instante inicial, final o enésimo</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="ttype_numTimestamps"><varname>timestamps</varname>, <varname>numTimestamps</varname></link>: Devuelve el número o las marcas de tiempo diferentes</para>
+					<para><link linkend="ttype_numTimestamps"><varname>numTimestamps</varname>, <varname>timestamps</varname></link>: Devuelve el número o las marcas de tiempo diferentes</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="ttype_startTimestamp"><varname>startTimestamp</varname>, <varname>endTimestamp</varname>, <varname>timestampN</varname></link>: Devuelve la marca de tiempo inicial, final o enésima</para>
@@ -705,10 +705,10 @@
 					<para><link linkend="ttype_setInterp"><varname>setInterp</varname></link>: Transforma un valor temporal a otra interpolación</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="ttype_shiftTime"><varname>shiftTime</varname>, <varname>scaleTime</varname>, <varname>shiftScaleTime</varname></link>: Desplaza y/o escalear el intervalo de tiempo de un valor temporal a uno o dos intervalos</para>
+					<para><link linkend="ttype_segmentMinDuration"><varname>segmentMinDuration</varname>, <varname>segmentMaxDuration</varname></link>: Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="ttype_segmentMinDuration"><varname>segmentMinDuration</varname>, <varname>segmentMaxDuration</varname></link>: Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada</para>
+					<para><link linkend="ttype_shiftTime"><varname>shiftTime</varname>, <varname>scaleTime</varname>, <varname>shiftScaleTime</varname></link>: Desplaza y/o escalear el intervalo de tiempo de un valor temporal a uno o dos intervalos</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="ttype_unnest"><varname>unnest</varname></link>: Transforma un valor temporal no lineal en un conjunto de filas, cada una es una pareja compuesta de un valor de base y un conjunto de períodos durante el cual el valor temporal tiene el valor de base &SRF;</para>
@@ -1274,7 +1274,7 @@
 						<para><link linkend="tnumber_valueSplit"><varname>valueSplit</varname>, <varname>timeSplit</varname>, <varname>valueTimeSplit</varname></link>: Fragmenta un número temporal con respecto a intervalos de valores y/o de tiempo &SRF;</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tspatial_spaceSplit"><varname>spaceSplit</varname>, <varname>spaceTimeSplit</varname>, <varname>timeSplit</varname></link>: Fragmenta un punto temporal con respecto a una malla espacial o espacio-temporal &Z_support; &SRF;</para>
+						<para><link linkend="tspatial_spaceSplit"><varname>spaceSplit</varname>, <varname>timeSplit</varname>, <varname>spaceTimeSplit</varname></link>: Fragmenta un punto temporal con respecto a una malla espacial o espacio-temporal &Z_support; &SRF;</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1977,7 +1977,7 @@
 			<title>Comparaciones</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tnpoint_comp"><varname>::</varname></link>: Comparaciones tradicionales</para>
+					<para><link linkend="tnpoint_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tnpoint_ever_always"><varname>?=</varname>, <varname>?&lt;&gt;</varname>, <varname>%=</varname>, <varname>%&lt;&gt;</varname></link>: Comparaciones alguna vez y siempre</para>
@@ -2263,7 +2263,7 @@
 			<title>Relaciones siempre y alguna vez</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="tcbuffer_eContains"><varname>eContains</varname>, <varname>aContains</varname>, <varname>eDisjoint</varname>, <varname>aDisjoint</varname>, <varname>eDwithin</varname>, <varname>aDwithin</varname>, <varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>aTouches</varname>, <varname>eCovers</varname>, <varname>aCovers</varname></link>: Relaciones alguna vez y siempre</para>
+					<para><link linkend="tcbuffer_eContains"><varname>eContains</varname>, <varname>aContains</varname>, <varname>eCovers</varname>, <varname>aCovers</varname>, <varname>eDisjoint</varname>, <varname>aDisjoint</varname>, <varname>eDwithin</varname>, <varname>aDwithin</varname>, <varname>eIntersects</varname>, <varname>aIntersects</varname>, <varname>eTouches</varname>, <varname>aTouches</varname></link>: Relaciones alguna vez y siempre</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3698,9 +3698,6 @@
 					<para><link linkend="raquet_asHexWKB"><varname>asHexWKB</varname></link>: Devuelve la representación hexadecimal binaria conocida (HexWKB) de una tesela Raquet</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_pixels"><varname>pixels</varname></link>: Devuelve los bytes de píxeles de un mosaico Raquet</para>
-				</listitem>
-				<listitem>
 					<para><link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link>: Devuelve una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
 				</listitem>
 				<listitem>
@@ -3725,6 +3722,9 @@
 				</listitem>
 				<listitem>
 					<para><link linkend="raquet_pixtype"><varname>pixtype</varname></link>: Devuelve el nombre del tipo de dato de píxel de una tesela Raquet</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raquet_pixels"><varname>pixels</varname></link>: Devuelve los bytes de píxeles de un mosaico Raquet</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="raquet_to_stbox"><varname>stbox</varname></link>: Convierte una tesela Raquet en una caja espaciotemporal</para>

--- a/doc/es/set_span_types.xml
+++ b/doc/es/set_span_types.xml
@@ -119,13 +119,13 @@ spans @&gt; {spans,base} → boolean
 		</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tstzset '{2001-01-01 08:00:00, 2001-01-03 09:30:00}';
--- Conjunto unitario
+-- Singleton set
 SELECT textset '{"highway"}';
--- Conjunto erróneo: elementos desordenados
+-- Erroneous set: unordered elements
 SELECT floatset '{3.5, 1.2}';
--- Conjunto erróneo: elementos duplicados
+-- Erroneous set: duplicate elements
 SELECT geomset '{"Point(1 1)", "Point(1 1)"}';
--- Conjunto de búferes circulares: cada elemento es un cbuffer en WKT
+-- Circular-buffer set: each element is a cbuffer WKT
 SELECT cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),1.0)"}';
 </programlisting>
 		<para>
@@ -139,13 +139,13 @@ SELECT cbufferset '{"Cbuffer(Point(1 1),0.5)", "Cbuffer(Point(2 2),1.0)"}';
 SELECT intspan '[1, 3)';
 SELECT floatspan '[1.5, 3.5]';
 SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-03 09:30:00)';
--- Rangos instantáneos
+-- Instant spans
 SELECT intspan '[1, 1]';
 SELECT floatspan '[1.5, 1.5]';
 SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-01 08:00:00]';
--- Rango erróneo: límites inválidos
+-- Erroneous span: invalid bounds
 SELECT tstzspan '[2001-01-01 08:10:00, 2001-01-01 08:00:00]';
--- Rango erróneo: rango vacío
+-- Erroneous span: empty span
 SELECT tstzspan '[2001-01-01 08:00:00, 2001-01-01 08:00:00)';
 </programlisting>
 		<para>
@@ -1461,7 +1461,7 @@ SELECT cmp(intspanset '{[1, 4)}', intspanset '{[1, 5), [6, 7)}');
 		<itemizedlist>
 			<listitem><para>La función <varname>extent</varname> devuelve el rango o período delimitador que engloba un conjunto de valores de rango o de tiempo.</para></listitem>
 			<listitem><para>La unión es una operación muy útil para los tipos de conjunto y de rango. Como hemos visto en la <xref linkend="setspan_set_ops" />, podemos calcular la unión de dos valores de conjunto o de rango usando el operador <varname>+</varname>. Sin embargo, también es muy útil tener una versión agregada del operador de unión para combinar un número arbitrario de valores. Las funciones <varname>setUnion</varname> y <varname>spanUnion</varname> se pueden utilizar para este propósito.</para></listitem>
-			<listitem><para>La función <varname>tCount</varname> generaliza la función de agregación tradicional <varname>count</varname>. El conteo temporal se puede utilizar para calcular en cada momento el número de objetos disponibles (por ejemplo, el número of períodos). La función <varname>tCount</varname> devuelve un entero temporal (ver el <xref linkend="ttype_aggregation" />). La función tiene dos parámetros opcionales que especifican la granularidad (un <varname>interval</varname>) y el origen del tiempo (un <varname>timestamptz</varname>). Cuando se dan estos parámetros, el conteo temporal se calcula en rangos de tiempo de la granularidad dada (ver <xref linkend="ttype_tiling" />)</para></listitem>
+			<listitem><para>La función <varname>tCount</varname> generaliza la función de agregación tradicional <varname>count</varname>. El conteo temporal se puede utilizar para calcular en cada momento el número de objetos disponibles (por ejemplo, el número of períodos). La función <varname>tCount</varname> devuelve un entero temporal (ver el <xref linkend="ttype_p1" />). La función tiene dos parámetros opcionales que especifican la granularidad (un <varname>interval</varname>) y el origen del tiempo (un <varname>timestamptz</varname>). Cuando se dan estos parámetros, el conteo temporal se calcula en rangos de tiempo de la granularidad dada (ver <xref linkend="ttype_tiling" />)</para></listitem>
 		</itemizedlist>
 
 		<itemizedlist>

--- a/doc/es/temporal_alpha.xml
+++ b/doc/es/temporal_alpha.xml
@@ -8,7 +8,7 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 -->
-<chapter xml:id="talpha">
+<chapter xml:id="temporal_types_alpha">
 	<title>Tipos alfanuméricos temporales</title>
 
 	<sect1 xml:id="talpha_notation">
@@ -81,22 +81,6 @@ SELECT tfloat '(1@2001-01-01, 3@2001-01-03, 2@2001-01-05]'::tbox;
 				<indexterm significance="normal"><primary><varname>tint</varname></primary></indexterm>
 				<para>Convierte entre un booleano temporal y un entero temporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-valueSpan(tnumber) → numspan
-</programlisting>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT valueSpan(tint '{1@2001-01-01, 5@2001-01-02, 3@2001-01-03}');
--- [1, 6)
-SELECT valueSpan(tfloat '[1.5@2001-01-01, 4.5@2001-01-03]');
--- [1.5, 4.5]
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="tint_tfloat">
-				<indexterm significance="normal"><primary><varname>tnumber</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>tnumber(tnumber)</varname></primary></indexterm>
-				<para>Convierte entre enteros temporales, enteros grandes temporales y flotantes temporales</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tbool::tint
 tint(tbool) → tint
 </programlisting>
@@ -105,15 +89,12 @@ SELECT tbool '[true@2001-01-01, false@2001-01-03]'::tint;
 -- [1@2001-01-01, 0@2001-01-03]
 </programlisting>
 			</listitem>
-		</itemizedlist>
-	</sect1>
 
-	<sect1 xml:id="talpha_accessors">
-		<title>Accessores</title>
-		<itemizedlist>
-			<listitem xml:id="talpha_valueSpan">
-				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
-				<para>Devuelve el intervalo de valores ignorando las brechas potenciales</para>
+			<listitem xml:id="tint_tfloat">
+				<indexterm significance="normal"><primary><varname>tnumber</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tnumber(tnumber)</varname></primary></indexterm>
+				<para>Convierte entre enteros temporales, enteros grandes temporales y flotantes temporales</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tnumber::tnumber
 tnumber(tnumber) → tnumber
@@ -127,6 +108,25 @@ SELECT tfloat 'Interp=Step;[1.5@2001-01-01, 2.5@2001-01-03]'::tint;
 -- [1@2001-01-01, 2@2001-01-03]
 SELECT tint(tfloat '[1.5@2001-01-01, 2.5@2001-01-03]');
 -- ERROR:  Cannot cast temporal float with linear interpolation to temporal integer
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="talpha_accessors">
+		<title>Accessores</title>
+		<itemizedlist>
+			<listitem xml:id="talpha_valueSpan">
+				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
+				<para>Devuelve el intervalo de valores ignorando las brechas potenciales</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+valueSpan(tnumber) → numspan
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT valueSpan(tint '{1@2001-01-01, 5@2001-01-02, 3@2001-01-03}');
+-- [1, 6)
+SELECT valueSpan(tfloat '[1.5@2001-01-01, 4.5@2001-01-03]');
+-- [1.5, 4.5]
 </programlisting>
 			</listitem>
 

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -37,11 +37,11 @@ SELECT cbuffer 'Cbuffer(Point(1 1), 10.0)';
 
 		<para>Los valores del tipo de búfer circular deben satisfacer varias restricciones para que estén bien definidos. Ejemplos de valores incorrectos del tipo de búfer circular son los siguientes.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Valor de punto incorrecto
+-- Incorrect point value
 SELECT cbuffer 'Cbuffer(Linestring(1 1,2 2), 1.0)';
--- punto 3D incorrecto
+-- Incorrect 3D point
 SELECT cbuffer 'Cbuffer(Point Z(1 1 1), 1.0)';
--- valor de radio incorrecto
+-- Incorrect radius value
 SELECT cbuffer 'Cbuffer(Point(1 1), -2.0)';
 </programlisting>
 		<para>A continuación damos las funciones y operadores para el tipo de búfer circular.</para>
@@ -391,10 +391,10 @@ SELECT asText(tcbuffer '{[Cbuffer(Point(1 1), 0.2)@2001-01-01,
 
 		<para>Los valores de búfer circular temporal deben satisfacer las restricciones especificadas en la <xref linkend="ttype_validity"/> para que estén bien definidos. Se genera un error cuando no se cumple una de estas restricciones. Ejemplos de valores incorrectos son los siguientes.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- No se permiten valores nulos
+-- Null values are not allowed
 SELECT tcbuffer 'NULL@2001-01-01 08:05:00';
 SELECT tcbuffer 'Point(0 0)@NULL';
--- El tipo base no es un búfer circular
+-- Base type is not a circular buffer
 SELECT tcbuffer 'Point(0 0)@2001-01-01 08:05:00';
 </programlisting>
 		<para>A continuación damos las funciones y operadores para el búfer circular temporal. La mayoría de las funciones y operadores para tipos temporales descritos en los capítulos precedentes se pueden aplicar para los tipos de búfer circular temporal. Por lo tanto, en las firmas de las funciones, la notación <varname>base</varname> representa un <varname>cbuffer</varname> y las notaciones <varname>ttype</varname>, <varname>tpoint</varname> y <varname>tgeompoint</varname> también representan un <varname>tcbuffer</varname>. Además, las funciones que tienen un argumento de tipo <varname>geometry</varname> aceptan además un argumento de tipo <varname>cbuffer</varname>. Para evitar la redundancia, a continuación solo presentamos algunos ejemplos de estas funciones y operadores para búferes circulares temporales.</para>
@@ -1157,6 +1157,8 @@ SELECT g, minDistance(t1.Noise, t2.Noise) FROM Vessel v1, VesselTrip t1, Vessel 
 			<listitem xml:id="tcbuffer_eContains">
 				<indexterm significance="normal"><primary><varname>eContains</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aContains</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>eCovers</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>aCovers</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>eDisjoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aDisjoint</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>eDwithin</varname></primary></indexterm>
@@ -1165,8 +1167,6 @@ SELECT g, minDistance(t1.Noise, t2.Noise) FROM Vessel v1, VesselTrip t1, Vessel 
 				<indexterm significance="normal"><primary><varname>aIntersects</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>eTouches</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>aTouches</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>eCovers</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>aCovers</varname></primary></indexterm>
 				<para>Relaciones alguna vez y siempre</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 eContains({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -77,11 +77,11 @@ SELECT npoint(76, 0.33)::nsegment;
 		</itemizedlist>
 		<para>Ejemplos de valores de tipo de red estática incorrectos son los siguientes.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Valor rid incorrecto
+-- Incorrect rid value
 SELECT npoint 'Npoint(87.5, 1.0)';
--- Valor de posición incorrecto
+-- Incorrect position value
 SELECT npoint 'Npoint(87, 2.0)';
--- Valor rid inexistente en la table ways
+-- rid value not found in the ways table
 SELECT npoint 'Npoint(99999999, 1.0)';
 </programlisting>
 		<para>Damos a continuación las funciones y operadores para los tipos de redes estáticas.</para>
@@ -430,12 +430,12 @@ SELECT tnpoint '{[NPoint(1, 0.2)@2001-01-01, NPoint(1, 0.3)@2001-01-02,
 		<title>Validez de los puntos de red temporal</title>
 		<para>Los valores de los puntos de red temporal deben satisfacer las restricciones especificadas en la <xref linkend="ttype_validity" /> para que estén bien definidos. Se genera un error cuando no se cumple una de estas restricciones. Ejemplos de valores incorrectos son los siguientes.</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- No se permiten valores nulos
+-- Null values are not allowed
 SELECT tnpoint 'NULL@2001-01-01 08:05:00';
 SELECT tnpoint 'Point(0 0)@NULL';
--- El tipo base no es un punto de red
+-- Base type is not a network point
 SELECT tnpoint 'Point(0 0)@2001-01-01 08:05:00';
--- Múltiples rutas en una secuencia
+-- Multiple routes in a continuous sequence
 SELECT tnpoint '[Npoint(1, 0.2)@2001-01-01 09:00:00, Npoint(2, 0.2)@2001-01-01 09:05:00)';
 </programlisting>
 		<para>Damos a continuación las funciones y operadores para los tipos de puntos de red. La mayoría de las funciones para tipos temporales descritas en los capítulos precendentes se pueden aplicar para tipos de puntos de red temporales. Por lo tanto, en las firmas de las funciones, la notación <varname>base</varname> también representa un <varname>npoint</varname> y las notaciones <varname>ttype</varname>, <varname>tpoint</varname> y <varname>tgeompoint</varname> también representan un <varname>tnpoint</varname>. Además, las funciones que tienen un argumento de tipo <varname>geometry</varname> aceptan además un argumento de tipo <varname>npoint</varname>. Para evitar la redundancia, a continuación solo presentamos algunos ejemplos de estas funciones y operadores para puntos de red temporales.</para>
@@ -1069,7 +1069,12 @@ SELECT tDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]'
 		<title>Comparaciones</title>
 		<itemizedlist>
 			<listitem xml:id="tnpoint_comp">
-				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<para>Comparaciones tradicionales</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tnpoint {=, &lt;&gt;, &lt;, &gt;, &lt;=, &gt;=} tnpoint → boolean

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -36,7 +36,7 @@ rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
 </programlisting>
 				<para>Evalúa el píxel de la <varname>band</varname> en cada instante de <varname>traj</varname> usando muestreo bilineal-vecino más próximo (<varname>ST_Value</varname> con <varname>resample=false</varname>). Devuelve un <varname>tfloat</varname> de conjunto de instantes cuyos valores se redondean a cuatro decimales. Devuelve <varname>NULL</varname> cuando ningún instante se interseca con el ráster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Build a 3×3 synthetic elevation raster (SRID 4326, 1° pixels)
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
 WITH rast AS (
   SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
     4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
@@ -148,10 +148,10 @@ raquet(bytea,width integer,height integer,quadbin bigint,pixtype text,
 </programlisting>
 				<para>Empaqueta un arreglo de píxeles <varname>pixels</varname> de banda única en orden de fila mayor de <varname>width</varname> × <varname>height</varname> píxeles de tipo <varname>pixtype</varname> (uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>), georreferenciado por la celda <varname>quadbin</varname>, en un único valor <varname>raquet</varname> autodescriptivo. El argumento <varname>nodata</varname> es opcional; cuando se omite (<varname>NULL</varname>) la tesela no lleva valor centinela de nodata. Se genera un error cuando el arreglo <varname>pixels</varname> es menor que <varname>width</varname> × <varname>height</varname> × el tamaño del píxel. Los píxeles de más de un byte son little-endian, que es el orden de bytes que les da la especificación RaQuet sea cual sea el orden de bytes del servidor, de modo que una tesela conserva sus valores cuando se lee en otra máquina. Un <varname>raquet</varname> es un valor de longitud variable, libre de GDAL, con una representación portátil en texto Hex-WKB y binaria, distinto de y coexistente con el tipo <varname>raster</varname> de PostGIS usado por <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Empaquetar las columnas sueltas de una tabla Raquet en valores raquet
+-- Package the loose tile columns of a Raquet table into raquet values
 SELECT raquet(band_data, width, height, quadbin, 'float32',
   nodata) AS tile FROM elevation_raquet;
--- Una tesela UINT8 de 2 x 2 sin nodata
+-- A 2 x 2 UINT8 tile with no nodata
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 </programlisting>
 			</listitem>
@@ -164,9 +164,9 @@ raquetRead(bytea,quadbin bigint) → raquet
 </programlisting>
 				<para>Lee los bytes de <varname>rasterfile</varname>, un ráster en cualquier formato compatible con GDAL (GeoTIFF, PNG, …), a través del sistema de archivos virtual <varname>/vsimem/</varname> de GDAL, y empaqueta su primera banda, en orden de fila mayor, en un único valor <varname>raquet</varname> autodescriptivo georreferenciado por la celda <varname>quadbin</varname>. El tipo de datos de la banda debe ser uno de <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname> o <varname>Float64</varname>; el valor de nodata de la banda, cuando está definido, se traslada a la tesela. Como el archivo se suministra como bytes, no se requiere acceso a archivos del lado del servidor. GDAL realiza la decodificación, por lo que el controlador de formato del ráster debe estar permitido por la configuración <varname>postgis.gdal_enabled_drivers</varname> de PostGIS (que deshabilita todos los controladores de forma predeterminada); habilítelo con, por ejemplo, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. Esta es la contraparte de ingesta del constructor <link linkend="raquet"><varname>raquet</varname></link>, que construye una tesela a partir de bytes de píxeles ya decodificados. Cuando se omite <varname>quadbin</varname> o es <varname>NULL</varname>, el identificador de la tesela se deriva de la georreferenciación del ráster: el ráster debe llevar una referencia espacial <varname>EPSG:3857</varname> (Web-Mercator) y una geotransformación alineada con los ejes que describa una única tesela QUADBIN. Un ráster sin referencia espacial, uno que no esté en <varname>EPSG:3857</varname>, o una geotransformación rotada o no alineada con la cuadrícula de teselas provoca un error en lugar de ser forzado.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Decodificar un GeoTIFF almacenado en una columna bytea en una tesela raquet
+-- Decode a GeoTIFF stored in a bytea column into a raquet tile
 SELECT raquetRead(file_bytes, quadbin) AS tile FROM elevation_files;
--- Derivar la celda QUADBIN de la georreferenciación de un GeoTIFF EPSG:3857
+-- Derive the QUADBIN cell from an EPSG:3857 GeoTIFF's georeferencing
 SELECT raquetRead(file_bytes) AS tile FROM elevation_files;
 </programlisting>
 			</listitem>
@@ -179,7 +179,7 @@ rasterTileValue(tgeompoint,rast raquet) → tfloat
 </programlisting>
 				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Muestrear teselas raquet preempaquetadas a lo largo de trayectorias de barcos
+-- Sample pre-packaged raquet tiles along ship trajectories
 SELECT t.tripid, rasterTileValue(t.trip, r.tile)
 FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
 </programlisting>
@@ -193,7 +193,7 @@ rasterTileValue(tgeompoint,rast raquet[]) → tfloat
 </programlisting>
 				<para>Evalúa cada tesela de <varname>rast</varname> en cada instante de <varname>traj</varname> (SRID 4326) y devuelve los valores de píxel muestreados como un único <varname>tfloat</varname>. Una trayectoria que sale de una tesela queda cubierta por varias, y cada una aporta los instantes que caen dentro de ella. Las teselas de un mismo nivel de zoom particionan el plano, de modo que aportan instantes disjuntos. Las teselas de niveles de zoom distintos se solapan, y cuando dos de ellas muestrean el mismo instante se conserva el valor de la tesela de mayor zoom, que es la que tiene la resolución más fina. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de una tesela o sobrevive al filtrado de nodata.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Muestrear una trayectoria en todas las teselas que cruza, en un solo valor
+-- Sample a trajectory across every tile it crosses, in one value
 SELECT t.tripid, rasterTileValue(t.trip, array_agg(r.tile)) FROM trips t
 JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8)) GROUP BY t.tripid, t.trip;
 </programlisting>
@@ -231,28 +231,15 @@ SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'u
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="raquet_pixels">
-				<indexterm significance="normal"><primary><varname>pixels</varname></primary></indexterm>
-				<para>Devuelve los bytes de píxeles de un mosaico Raquet</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetFromBinary(bytea) → raquet
-</programlisting>
-				<para>Los bytes están en orden de fila mayor y empaquetados, <varname>width</varname> × <varname>height</varname> píxeles del tamaño de <varname>pixtype</varname> cada uno, en little-endian cuando un píxel ocupa más de un byte, que es la disposición que aceptan los constructores. Por lo tanto, un mosaico se reconstruye a través de sus propios accesores.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
-  'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
--- true
-</programlisting>
-			</listitem>
 
 			<listitem xml:id="raquetFromBinary">
 				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
 				<para>Devuelve una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetFromHexWKB(text) → raquet
+raquetFromBinary(bytea) → raquet
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
+SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 -- true
 </programlisting>
@@ -262,11 +249,12 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265
 				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
 				<para>Devuelve una tesela Raquet a partir de su representación hexadecimal binaria conocida (HexWKB)</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-quadbin(raquet) → bigint
+raquetFromHexWKB(text) → raquet
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
--- 5193776270265024512
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
+  'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
+-- true
 </programlisting>
 			</listitem>
 		</itemizedlist>
@@ -284,6 +272,18 @@ SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Devuelve la celda QUADBIN de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+quadbin(raquet) → bigint
+</programlisting>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
+-- 5193776270265024512
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raquet_width">
+				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
+				<para>Devuelve el ancho en píxeles de una tesela Raquet</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 width(raquet) → integer
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -292,9 +292,9 @@ SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="raquet_width">
-				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
-				<para>Devuelve el ancho en píxeles de una tesela Raquet</para>
+			<listitem xml:id="raquet_height">
+				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
+				<para>Devuelve el alto en píxeles de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 height(raquet) → integer
 </programlisting>
@@ -304,9 +304,9 @@ SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="raquet_height">
-				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
-				<para>Devuelve el alto en píxeles de una tesela Raquet</para>
+			<listitem xml:id="raquet_nodata">
+				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
+				<para>Devuelve el valor centinela nodata de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 nodata(raquet) → float8
 </programlisting>
@@ -319,33 +319,33 @@ SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="raquet_nodata">
-				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
-				<para>Devuelve el valor centinela nodata de una tesela Raquet</para>
+			<listitem xml:id="raquet_pixtype">
+				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
+				<para>Devuelve el nombre del tipo de dato de píxel de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 pixtype(raquet) → text
 </programlisting>
-							<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Leer la disposición de una tesela empaquetada
+				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que el nombre que el ráster de PostGIS da a un tipo de píxel pasa a ellos tal cual; el nombre devuelto aquí es la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela, por lo que se compara igual a ese campo tal cual.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Read back the layout of a packaged tile
 SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
 FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS tile) t;
 -- 5193776270265024512 | 2 | 2 | uint8 | 0
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="raquet_pixtype">
-				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
-				<para>Devuelve el nombre del tipo de dato de píxel de una tesela Raquet</para>
+			<listitem xml:id="raquet_pixels">
+				<indexterm significance="normal"><primary><varname>pixels</varname></primary></indexterm>
+				<para>Devuelve los bytes de píxeles de un mosaico Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 pixels(raquet) → bytea
 </programlisting>
-				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que el nombre que el ráster de PostGIS da a un tipo de píxel pasa a ellos tal cual; el nombre devuelto aquí es la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela, por lo que se compara igual a ese campo tal cual.</para>
+				<para>Los bytes están en orden de fila mayor y empaquetados, <varname>width</varname> × <varname>height</varname> píxeles del tamaño de <varname>pixtype</varname> cada uno, en little-endian cuando un píxel ocupa más de un byte, que es la disposición que aceptan los constructores. Por lo tanto, un mosaico se reconstruye a través de sus propios accesores.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- \x01020304
 </programlisting>
 			</listitem>
-
 			<listitem xml:id="raquet_to_stbox">
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Convierte una tesela Raquet en una caja espaciotemporal</para>
@@ -388,11 +388,11 @@ raquet {=, &lt;&gt;, &lt;, &lt;=, &gt;=, &gt;} raquet → boolean
 </programlisting>
 				<para>Las funciones que respaldan estos operadores son <varname>eq</varname>, <varname>ne</varname>, <varname>lt</varname>, <varname>le</varname>, <varname>ge</varname> y <varname>gt</varname>, junto con <varname>cmp(raquet,raquet) → integer</varname>, que devuelve -1, 0 o 1.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Dos teselas con la misma celda, disposición y píxeles son iguales
+-- Two tiles with the same cell, layout and pixels are equal
 SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512,
   'uint8') = raquet('\x0102'::bytea, 2, 1, 5193776270265024512, 'uint8');
 -- true
--- Deduplicar teselas, lo que permiten las clases de operadores btree y hash
+-- Deduplicate tiles, which the btree and hash operator classes support
 SELECT DISTINCT tile FROM elevation_tiles;
 </programlisting>
 			</listitem>

--- a/doc/es/temporal_types_aggregation.xml
+++ b/doc/es/temporal_types_aggregation.xml
@@ -232,7 +232,7 @@ SELECT * FROM Trips WHERE Trip &amp;&amp;
 		<para>Para acelerar algunas de las funciones de los tipos temporales, se puede agregar en la cláusula <varname>WHERE</varname> de las consultas una comparación de cuadro delimitador que hace uso de los índices disponibles. Por ejemplo, este sería típicamente el caso de las funciones que proyectan los tipos temporales a las dimensiones de valor/espacio y/o tiempo. Esto filtrará las tuplas con un índice como se muestra en la siguiente consulta.
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atTime(T.Trip, tstzspan '[2001-01-01, 2001-01-02)') FROM Trips T
--- Filtro de índice con cuadro delimitador
+-- Bounding box index filtering
 WHERE T.Trip &amp;&amp; tstzspan '[2001-01-01, 2001-01-02)';
 </programlisting>
 		</para>
@@ -240,7 +240,7 @@ WHERE T.Trip &amp;&amp; tstzspan '[2001-01-01, 2001-01-02)';
 		<para>En el caso de los geometrías temporales, todas las relaciones espaciales con la semántica alguna vez o siempre (ver la <xref linkend="tgeo_spatiotemp_rel" />) incluyen automáticamente una comparación de cuadro delimitador que hará uso de cualquier índice que esté disponible en los puntos temporales. Por esta razón, la primera versión de las relaciones se usa típicamente para filtrar las tuplas con la ayuda de un índice al calcular las relaciones temporales como se muestra en la siguiente consulta.
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(T.Trip, R.Geom) FROM Trips T, Regions R
--- Filtro de índice con cuadro delimitador
+-- Bounding box index filtering
 WHERE eIntersects(T.Trip, R.Geom);
 </programlisting>
 		</para>

--- a/doc/es/temporal_types_analytics.xml
+++ b/doc/es/temporal_types_analytics.xml
@@ -8,7 +8,7 @@
     Alike 3.0 License: https://creativecommons.org/licenses/by-sa/3.0/
    ****************************************************************************
 -->
-<chapter xml:id="ttype_analytics">
+<chapter xml:id="temporal_types_analytics">
 	<title>Tipos temporales: Operaciones de análisis</title>
 
 	<sect1 xml:id="ttype_simplification">
@@ -987,8 +987,8 @@ SELECT (sp).number, (sp).time,
 
 				<listitem xml:id="tspatial_spaceSplit">
 					<indexterm significance="normal"><primary><varname>spaceSplit</varname></primary></indexterm>
-					<indexterm significance="normal"><primary><varname>spaceTimeSplit</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>timeSplit</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>spaceTimeSplit</varname></primary></indexterm>
 					<para>Fragmenta un punto temporal con respecto a una malla espacial o espacio-temporal &Z_support;
  &SRF;</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_types_p1.xml
+++ b/doc/es/temporal_types_p1.xml
@@ -37,13 +37,13 @@ SELECT tfloat '17@2018-01-01 08:00:00';
 		Un valor temporal de subtipo <emphasis>secuencia</emphasis> (brevemente, un <emphasis>valor de secuencia</emphasis>) representa la evolución del valor durante una secuencia de instantes de tiempo, donde los valores entre estos instantes se interpolan usando una función discreta, escalonada, o lineal (ver arriba). Un ejemplo es el siguiente:
 	</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Interpolación discreta
+-- Discrete interpolation
 SELECT tfloat '{17@2018-01-01 08:00:00, 17.5@2018-01-01 08:05:00,
   18@2018-01-01 08:10:00}';
--- Interpolación escalonada
+-- Step interpolation
 SELECT tfloat 'Interp=Step;
   (10@2018-01-01 08:00:00, 20@2018-01-01 08:05:00, 15@2018-01-01 08:10:00]';
--- Interpolación lineal
+-- Linear interpolation
 SELECT tfloat '(10@2018-01-01 08:00:00, 20@2018-01-01 08:05:00, 15@2018-01-01 08:10:00]';
 </programlisting>
 
@@ -171,23 +171,23 @@ CREATE TABLE Temperature(RoomNo integer, Temp tfloat);
 INSERT INTO Temperature VALUES
   (1001, tfloat '{18.5@2001-01-01 08:00:00, 20.0@2001-01-01 08:10:00}'),
   (2001, tfloat '{19.0@2001-01-01 08:00:00, 22.5@2001-01-01 08:10:00}');
--- Valor en una marca de tiempo
+-- Value at a timestamp
 SELECT RoomNo, valueAtTimestamp(Temp, '2001-01-01 08:10:00') FROM temperature;
 -- 1001 | 20
 -- 2001 | 22.5
--- Restricción a un valor
+-- Restriction to a value
 SELECT DeptNo, atValue(NoEmps, 10) FROM Department;
 -- 10 | [10@2001-01-01, 10@2001-04-01)
 -- 20 |
--- Restricción a un período
+-- Restriction to a period
 SELECT DeptNo, atTime(NoEmps, tstzspan '[2001-01-01, 2001-04-01]') FROM Department;
 -- 10 | [10@2001-01-01, 12@2001-04-01]
 -- 20 | [4@2001-02-01, 4@2001-04-01]
--- Comparación temporal
+-- Temporal comparison
 SELECT DeptNo, NoEmps #&lt;= 10 FROM Department;
 -- 10 | [t@2001-01-01, f@2001-04-01, f@2001-08-01)
 -- 20 | [t@2001-02-01, t@2001-10-01)
--- Agregación temporal
+-- Temporal aggregation
 SELECT tsum(NoEmps) FROM Department;
 /* {[10@2001-01-01, 14@2001-02-01, 16@2001-04-01,
    18@2001-06-01, 6@2001-08-01, 6@2001-10-01)} */
@@ -200,21 +200,21 @@ INSERT INTO Trips VALUES
 Point(2 1)@2001-01-01 08:15:00)}'),
   (20, 1, tgeompoint '{[Point(0 0)@2001-01-01 08:05:00, Point(1 1)@2001-01-01 08:10:00,
   Point(3 3)@2001-01-01 08:20:00)}');
--- Valor en una marca de tiempo
+-- Value at a given timestamp
 SELECT CarId,
   ST_AsText(valueAtTimestamp(Trip, timestamptz '2001-01-01 08:10:00')) FROM Trips;
 -- 10 | POINT(2 0)
 -- 20 | POINT(1 1)
--- Restricción a un valor
+-- Restriction to a value
 SELECT CarId, asText(atValue(Trip, geometry 'Point(2 0)')) FROM Trips;
 -- 10 | {"[POINT(2 0)@2001-01-01 08:10:00]"}
 -- 20 | 
--- Restricción a un período
+-- Restriction to a period
 SELECT CarId,
   asText(atTime(Trip, tstzspan '[2001-01-01 08:05:00,2001-01-01 08:10:00]')) FROM Trips;
 -- 10 | {[POINT(1 0)@2001-01-01 08:05:00, POINT(2 0)@2001-01-01 08:10:00]}
 -- 20 | {[POINT(0 0)@2001-01-01 08:05:00, POINT(1 1)@2001-01-01 08:10:00]}
--- Distancia temporal
+-- Temporal distance
 SELECT T1.CarId, T2.CarId, T1.Trip &lt;-&gt; T2.Trip FROM Trips T1,
   Trips T2 WHERE T1.CarId &lt; T2.CarId;
 /* 10 | 20 | {[1@2001-01-01 08:05:00, 1.4142135623731@2001-01-01 08:10:00,
@@ -261,27 +261,27 @@ SELECT T1.CarId, T2.CarId, T1.Trip &lt;-&gt; T2.Trip FROM Trips T1,
 			Se genera un error cuando no se satisface una de estas restricciones. Ejemplos de valores temporales incorrectos son los siguientes.
 		</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Valor del tipo de base incorrecto
+-- Incorrect value for base type
 SELECT tbool '1.5@2001-01-01 08:00:00';
--- Valor del tipo base no es un punto
+-- Base type value is not a point
 SELECT tgeompoint 'Linestring(0 0,1 1)@2001-01-01 08:05:00';
--- Marca de tiempo incorrecta
+-- Incorrect timestamp
 SELECT tint '2@2001-02-31 08:00:00';
--- Secuencia vacía
+-- Empty sequence
 SELECT tint '';
--- Límites incorrectos para la secuencia instantánea
+-- Incorrect bounds for instantaneous sequence
 SELECT tint '[1@2001-01-01 09:00:00)';
--- Marcas de tiempo duplicadas
+-- Duplicate timestamps
 SELECT tint '[1@2001-01-01 08:00:00, 2@2001-01-01 08:00:00]';
--- Marcas de tiempo desordenadas
+-- Unordered timestamps
 SELECT tint '[1@2001-01-01 08:10:00, 2@2001-01-01 08:00:00]';
--- Valor final incorrecto para interpolación escalonada
+-- Incorrect end value for step interpolation
 SELECT tint '[1@2001-01-01 08:00:00, 2@2001-01-01 08:10:00)';
--- Conjunto de secuencias vacío
+-- Empty sequence set
 SELECT tint '{[]}';
--- Marcas de tiempo duplicadas
+-- Duplicate timestamps
 SELECT tint '{1@2001-01-01 08:00:00, 2@2001-01-01 08:00:00}';
--- Períodos superpuestos
+-- Overlapping periods
 SELECT tint '{[1@2001-01-01 08:00:00, 1@2001-01-01 10:00:00),
   [2@2001-01-01 09:00:00, 2@2001-01-01 11:00:00)}';
 </programlisting>
@@ -294,19 +294,19 @@ SELECT tint '{[1@2001-01-01 08:00:00, 1@2001-01-01 10:00:00),
 			Una forma común de generalizar las operaciones tradicionales a los tipos temporales es aplicar la operación en <emphasis>cada instante</emphasis>, lo que da un valor temporal como resultado. En ese caso, la operación sólo se define en la intersección de las extensiones temporales de los operandos; si las extensiones temporales son disjuntas, el resultado es nulo. Por ejemplo, los operadores de comparación temporal, como <varname>#&lt;</varname>, determinan si los valores tomados por sus operandos en cada instante satisfacen la condición y devuelven un booleano temporal. A continuación se dan ejemplos de las diversas generalizaciones de los operadores.
 		</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Comparación temporal
+-- Temporal comparison
 SELECT tfloat '[2@2001-01-01, 2@2001-01-03)' #&lt; tfloat '[1@2001-01-01, 3@2001-01-03)';
 -- {[f@2001-01-01, f@2001-01-02], (t@2001-01-02, t@2001-01-03)}
 SELECT tfloat '[1@2001-01-01, 3@2001-01-03)' #&lt; tfloat '[3@2001-01-03, 1@2001-01-05)';
 -- NULL
--- Adición temporal
+-- Temporal addition
 SELECT tint '[1@2001-01-01, 1@2001-01-03)' + tint '[2@2001-01-02, 2@2001-01-05)';
 -- [3@2001-01-02, 3@2001-01-03)
--- Intersección temporal
+-- Temporal intersects
 SELECT tIntersects(tgeompoint '[Point(0 1)@2001-01-01, Point(3 1)@2001-01-04)',
   geometry 'Polygon((1 0,1 2,2 2,2 0,1 0))');
 -- {[f@2001-01-01, t@2001-01-02, t@2001-01-03], (f@2001-01-03, f@2001-01-04]}
--- Distancia temporal
+-- Temporal distance
 SELECT tgeompoint '[Point(0 0)@2001-01-01 08:00:00, Point(0 1)@2001-01-03 08:10:00)' &lt;-&gt;
   tgeompoint '[Point(0 0)@2001-01-02 08:05:00, Point(1 1)@2001-01-05 08:15:00)';
 -- [0.5@2001-01-02 08:05:00, 0.745184033794557@2001-01-03 08:10:00)
@@ -316,19 +316,19 @@ SELECT tgeompoint '[Point(0 0)@2001-01-01 08:00:00, Point(0 1)@2001-01-03 08:10:
 			Otro requisito común es determinar si los operandos satisfacen <emphasis>alguna vez</emphasis> o <emphasis>siempre</emphasis> una condición con respecto a una operación. Estos se pueden obtener aplicando los operadores de comparación alguna vez o siempre. Estos operadores se indican anteponiendo los operadores de comparación tradicionales con, respectivamente, <varname>?</varname> (alguna vez) y <varname>%</varname> (siempre). A continuación se dan ejemplos de operadores de comparación alguna vez y siempre.
 		</para>
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- ¿Se cruzan los operandos alguna vez?
+-- Does the operands ever intersect?
 SELECT eIntersects(tgeompoint '[Point(0 1)@2001-01-01, Point(3 1)@2001-01-04)',
   geometry 'Polygon((1 0,1 2,2 2,2 0,1 0))') ?= true;
 -- true
--- ¿Se cruzan los operandos siempre?
+-- Does the operands always intersect?
 SELECT aIntersects(tgeompoint '[Point(0 1)@2001-01-01, Point(3 1)@2001-01-04)',
   geometry 'Polygon((0 0,0 2,4 2,4 0,0 0))') %= true;
 -- true
--- ¿Es el operando izquierdo alguna vez menor que el derecho?
+-- Is the left operand ever less than the right one ?
 SELECT (tfloat '[1@2001-01-01, 3@2001-01-03)' #&lt;
   tfloat '[3@2001-01-01, 1@2001-01-03)') ?= true;
 -- true
--- ¿Es el operando izquierdo siempre menor que el derecho?
+-- Is the left operand always less than the right one ?
 SELECT (tfloat '[1@2001-01-01, 3@2001-01-03)' #&lt;
   tfloat '[2@2001-01-01, 4@2001-01-03)') %= true;
 -- true
@@ -1068,8 +1068,8 @@ SELECT instantN(tfloat '{[1@2001-01-01, 2@2001-01-02), (2@2001-01-02, 3@2001-01-
 			</listitem>
 
 			<listitem xml:id="ttype_numTimestamps">
-				<indexterm significance="normal"><primary><varname>timestamps</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>numTimestamps</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>timestamps</varname></primary></indexterm>
 				<para>Devuelve el número o las marcas de tiempo diferentes</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 numTimestamps(ttype) → integer
@@ -1193,7 +1193,6 @@ SELECT tfloatSeqSet(tfloat '{2.5@2001-01-01, 1.5@2001-01-02, 3.5@2001-01-03}');
 -- {[2.5@2001-01-01],[1.5@2001-01-02],[3.5@2001-01-03]}
 </programlisting>
 			</listitem>
-
 			<listitem xml:id="ttype_setInterp">
 				<indexterm significance="normal"><primary><varname>setInterp</varname></primary></indexterm>
 				<para>Transforma un valor temporal a otra interpolación</para>
@@ -1218,17 +1217,15 @@ SELECT setInterp(tgeometry '[Point(1 1)@2001-01-01, Linestring(1 1,2 2)@2001-01-
 -- ERROR:  The temporal type cannot have linear interpolation
 </programlisting>
 			</listitem>
-
-			<listitem xml:id="ttype_shiftTime">
-				<indexterm significance="normal"><primary><varname>shiftTime</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
-				<para>Desplaza y/o escalear el intervalo de tiempo de un valor temporal a uno o dos intervalos</para>
+			<listitem xml:id="ttype_segmentMinDuration">
+				<indexterm significance="normal"><primary><varname>segmentMinDuration</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>segmentMaxDuration</varname></primary></indexterm>
+				<para>Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 segmentMinDuration(temp,interval,strict boolean=true) → tbool
 segmentMaxDuration(temp,interval,strict boolean=true) → tbool
 </programlisting>
-				<para>Cuando se escalea, si el rango de valores o el intervalo de tiempo del valor temporal es cero (por ejemplo, para un instante temporal), el resultado es el valor temporal. Igualmente, el ancho o intervalo dado debe ser estrictamente mayor que cero.</para>
+				<para>Si el argumento <varname>strict</varname> no se especifica, se asume el valor <varname>true</varname> por defecto y, por lo tanto, la función verifica si la duración del segmento es estrictamente menor o mayor que el intervalo. Si el argumento es <varname>false</varname>, la función verifica si la duración del segmento es menor/mayor o <emphasis>igual</emphasis> que el intervalo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT segmentMinDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
   -1@2001-01-06]', '1 day');
@@ -1244,17 +1241,17 @@ SELECT segmentMaxDuration(tfloat '[1@2001-01-01, 0@2001-01-03, -1@2001-01-04,
 -- {[f@2001-01-01, t@2001-01-03, f@2001-01-04, f@2001-01-06)}
 </programlisting>
 			</listitem>
-
-			<listitem xml:id="ttype_segmentMinDuration">
-				<indexterm significance="normal"><primary><varname>segmentMinDuration</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>segmentMaxDuration</varname></primary></indexterm>
-				<para>Devuelve un valor booleano temporal que indica si cada segmento de una secuencia (o conjunto de sequencias) temporal(es) continua tiene, respectivamente, al menos o como máximo una duración determinada</para>
+			<listitem xml:id="ttype_shiftTime">
+				<indexterm significance="normal"><primary><varname>shiftTime</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>scaleTime</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>shiftScaleTime</varname></primary></indexterm>
+				<para>Desplaza y/o escalear el intervalo de tiempo de un valor temporal a uno o dos intervalos</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 shiftTime(ttype,interval) → ttype
 scaleTime(ttype,interval) → ttype
 shiftScaleTime(ttype,interval,interval) → ttype
 </programlisting>
-				<para>Si el argumento <varname>strict</varname> no se especifica, se asume el valor <varname>true</varname> por defecto y, por lo tanto, la función verifica si la duración del segmento es estrictamente menor o mayor que el intervalo. Si el argumento es <varname>false</varname>, la función verifica si la duración del segmento es menor/mayor o <emphasis>igual</emphasis> que el intervalo.</para>
+				<para>Cuando se escalea, si el rango de valores o el intervalo de tiempo del valor temporal es cero (por ejemplo, para un instante temporal), el resultado es el valor temporal. Igualmente, el ancho o intervalo dado debe ser estrictamente mayor que cero.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT shiftTime(tint '{1@2001-01-01, 2@2001-01-03, 1@2001-01-05}', '1 day');
 -- {1@2001-01-02, 2@2001-01-04, 1@2001-01-06}
@@ -1291,7 +1288,6 @@ SELECT asText(shiftScaleTime(tgeometry '{[Point(1 1)@2001-01-01,
    POLYGON((1 1,2 2,3 1,1 1))@2001-01-03 00:00:00]} */
 </programlisting>
 			</listitem>
-
 			<listitem xml:id="ttype_unnest">
 				<indexterm significance="normal"><primary><varname>unnest</varname></primary></indexterm>
 				<para>Transforma un valor temporal no lineal en un conjunto de filas, cada una es una pareja compuesta de un valor de base y un conjunto de períodos durante el cual el valor temporal tiene el valor de base &SRF;</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -801,9 +801,6 @@
 					<para><link linkend="tnumber_bbox"><varname>::</varname>, <varname>valueSpan(tnumber)</varname>, <varname>timeSpan(tnumber)</varname>, <varname>tbox(tnumber)</varname>, <varname>valueSpan</varname>, <varname>timeSpan</varname>, <varname>tbox</varname></link>: Convert a temporal number to a span or to a temporal bounding box</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="talpha_valueSpan"><varname>valueSpan</varname></link>: Return the span of values, ignoring any gaps</para>
-				</listitem>
-				<listitem>
 					<para><link linkend="tbool_tint"><varname>::</varname>, <varname>tint(tbool)</varname>, <varname>tint</varname></link>: Convert between a temporal Boolean and a temporal integer</para>
 				</listitem>
 				<listitem>
@@ -814,6 +811,9 @@
 		<sect2>
 			<title>Accessors</title>
 			<itemizedlist>
+				<listitem>
+					<para><link linkend="talpha_valueSpan"><varname>valueSpan</varname></link>: Return the span of values, ignoring any gaps</para>
+				</listitem>
 				<listitem>
 					<para><link linkend="talpha_valueSet"><varname>valueSet</varname></link>: Return the values of a temporal number as a set</para>
 				</listitem>
@@ -1827,7 +1827,7 @@
 				<title>Comparisons</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="npoint_eq"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&lt;=</varname>, <varname>&gt;</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
+						<para><link linkend="npoint_eq"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1982,7 +1982,7 @@
 				<title>Comparisons</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tnpoint_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;,</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
+						<para><link linkend="tnpoint_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="tnpoint_ever_always"><varname>?=</varname>, <varname>?&lt;&gt;</varname>, <varname>%=</varname>, <varname>%&lt;&gt;</varname></link>: Ever and always comparisons</para>

--- a/doc/temporal_alpha.xml
+++ b/doc/temporal_alpha.xml
@@ -74,19 +74,6 @@ SELECT tfloat '(1@2001-01-01, 3@2001-01-03, 2@2001-01-05]'::tbox;
 </programlisting>
 			</listitem>
 
-			<listitem xml:id="talpha_valueSpan">
-				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
-				<para>Return the span of values, ignoring any gaps</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-valueSpan(tnumber) → numspan
-</programlisting>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT valueSpan(tint '{1@2001-01-01, 5@2001-01-02, 3@2001-01-03}');
--- [1, 6)
-SELECT valueSpan(tfloat '[1.5@2001-01-01, 4.5@2001-01-03]');
--- [1.5, 4.5]
-</programlisting>
-			</listitem>
 
 			<listitem xml:id="tbool_tint">
 				<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
@@ -129,6 +116,19 @@ SELECT tint(tfloat '[1.5@2001-01-01, 2.5@2001-01-03]');
 	<sect1 xml:id="talpha_accessors">
 		<title>Accessors</title>
 		<itemizedlist>
+			<listitem xml:id="talpha_valueSpan">
+				<indexterm significance="normal"><primary><varname>valueSpan</varname></primary></indexterm>
+				<para>Return the span of values, ignoring any gaps</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+valueSpan(tnumber) → numspan
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT valueSpan(tint '{1@2001-01-01, 5@2001-01-02, 3@2001-01-03}');
+-- [1, 6)
+SELECT valueSpan(tfloat '[1.5@2001-01-01, 4.5@2001-01-03]');
+-- [1.5, 4.5]
+</programlisting>
+			</listitem>
 			<listitem xml:id="talpha_valueSet">
 				<indexterm significance="normal"><primary><varname>valueSet</varname></primary></indexterm>
 				<para>Return the values of a temporal number as a set</para>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -1185,7 +1185,7 @@ aIntersects({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
 eTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
 aTouches({geometry,cbuffer,tcbuffer},{geometry,cbuffer,tcbuffer}) → boolean
 </programlisting>
-				<para>The <emphasis>ever</emphasis> and <emphasis>always</emphasis> relationships determine whether the topological or distance relationship is ever or always satisfied and return a <varname>boolean</varname></para>
+				<para>The <emphasis>ever</emphasis> and <emphasis>always</emphasis> relationships determine whether the topological or distance relationship is ever or always satisfied (see <xref linkend="ever_always_comparison"/>) and return a <varname>boolean</varname></para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT eContains(geometry 'Polygon((0 0,0 50,50 50,50 0,0 0))',
   tcbuffer '[Cbuffer(Point(1 1), 0.1)@2001-01-01, Cbuffer(Point(1 1), 0.3)@2001-01-03)');

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -79,7 +79,7 @@ SELECT npoint(76, 0.33)::nsegment;
 		<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Incorrect rid value
 SELECT npoint 'Npoint(87.5, 1.0)';
--- incorrect position value
+-- Incorrect position value
 SELECT npoint 'Npoint(87, 2.0)';
 -- rid value not found in the ways table
 SELECT npoint 'Npoint(99999999, 1.0)';
@@ -359,8 +359,8 @@ SELECT equals(npoint(1, f1), npoint(2, f2)) FROM fractions;
 					<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;</varname></primary></indexterm>
-					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 					<para>Traditional comparisons</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -1073,7 +1073,7 @@ SELECT tDwithin(tnpoint '[Npoint(1, 0.3)@2001-01-01, Npoint(1, 0.5)@2001-01-03]'
 				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>&gt;,</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>&gt;</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&gt;=</varname></primary></indexterm>
 				<para>Traditional comparisons</para>

--- a/doc/temporal_types_aggregation.xml
+++ b/doc/temporal_types_aggregation.xml
@@ -232,7 +232,7 @@ SELECT * FROM Trips WHERE Trip &amp;&amp;
 		<para>In order to speed up several of the functions for temporal types, we can add in the <varname>WHERE</varname> clause of queries a bounding box comparison that make uses of the available indexes. For example, this would be typically the case for the functions that project the temporal types to the value/spatial and/or time dimensions. This will filter out the tuples with an index as shown in the following query.
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT atTime(T.Trip, tstzspan '[2001-01-01, 2001-01-02)') FROM Trips T
--- Bouding box index filtering
+-- Bounding box index filtering
 WHERE T.Trip &amp;&amp; tstzspan '[2001-01-01, 2001-01-02)';
 </programlisting>
 		</para>
@@ -240,7 +240,7 @@ WHERE T.Trip &amp;&amp; tstzspan '[2001-01-01, 2001-01-02)';
 		<para>In the case of temporal points, all spatial relationships with the ever and always semantics (see <xref linkend="tgeo_spatiotemp_rel"/>) automatically include a bounding box comparison that will make use of any indexes that are available on the temporal points. For this reason, the first version of the relationships is typically used for filtering the tuples with the help of an index when computing the temporal relationships as shown in the following query.
 			<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tIntersects(T.Trip, R.Geom) FROM Trips T, Regions R
--- Bouding box index filtering
+-- Bounding box index filtering
 WHERE eIntersects(T.Trip, R.Geom);
 </programlisting>
 		</para>


### PR DESCRIPTION
A Spanish chapter translates prose alone: its titles and paragraphs are Spanish, and its xml:ids, signature blocks, example blocks, indexterms and linkends are those of its English twin, byte for byte. Across the 23 chapter pairs that identity holds on all five axes — 983 example blocks, 757 signature blocks, 1087 xml:ids, 1613 indexterms and 858 linkends.

The identity is load-bearing rather than tidiness. tools/doc/check_icon_parity.py finds an entry by its xml:id in each language, so an id that differs in one language drops that entry from the check instead of failing it, and tools/doc/gen_reference.py projects both appendices through linkend, so the two languages line up only while the ids do. Thirteen entries carry another entry's signature and example in Spanish, in temporal_alpha, temporal_raster and temporal_types_p1: the Spanish conversion entry reading Convierte entre un booleano temporal y un entero temporal states valueSpan(tnumber) as its signature. Keying the derivation by xml:id rather than by position is what states each entry's own blocks, since where the two languages file an entry differently the n-th Spanish block belongs to a different entry.

An entry is filed by what its one-liner says, which settles the two whose section differs between the languages: talpha_valueSpan returns the span of values and raquet_pixels returns the pixel bytes, so both are accessors. portable_sql carries its 53 indexterms in both languages, the Spanish introduction documents the 1.2 to 1.3 migration its English twin documents, and an xml:id written with a space before its equals sign is spelled so that an id-matching scan reaches it. The reference appendix is regenerated from the chapters.