### PR TITLE
Read a big integer temporal value as the integer it is

### DIFF
--- a/meos/src/temporal/tnumber_mathfuncs.c
+++ b/meos/src/temporal/tnumber_mathfuncs.c
@@ -228,8 +228,28 @@ tnumberinst_abs(const TInstant *inst)
   assert(tnumber_basetype(basetype));
   Datum value = tinstant_value_p(inst);
   Datum absvalue;
+  /* The most negative value of a two's complement integer has no positive
+   * counterpart, which is why PostgreSQL's own abs reports it out of range */
   if (basetype == T_INT4)
-    absvalue = Int32GetDatum(abs(DatumGetInt32(value)));
+  {
+    int32 i = DatumGetInt32(value);
+    if (i == PG_INT32_MIN)
+    {
+      meos_error(ERROR, MEOS_ERR_VALUE_OUT_OF_RANGE, "Integer out of range");
+      return NULL;
+    }
+    absvalue = Int32GetDatum(abs(i));
+  }
+  else if (basetype == T_INT8)
+  {
+    int64 i = DatumGetInt64(value);
+    if (i == PG_INT64_MIN)
+    {
+      meos_error(ERROR, MEOS_ERR_VALUE_OUT_OF_RANGE, "Bigint out of range");
+      return NULL;
+    }
+    absvalue = Int64GetDatum(llabs(i));
+  }
   else /* basetype == T_FLOAT8 */
     absvalue = Float8GetDatum(fabs(DatumGetFloat8(value)));
   return tinstant_make(absvalue, inst->temptype, inst->t);
@@ -245,7 +265,17 @@ tnumberseq_iter_abs(const TSequence *seq)
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
   TInstant **instants = palloc(sizeof(TInstant *) * seq->count);
   for (int i = 0; i < seq->count; i++)
+  {
     instants[i] = tnumberinst_abs(TSEQUENCE_INST_N(seq, i));
+    /* An instant whose absolute value the type cannot represent reports the
+     * range error and answers NULL, which an error handler installed by a
+     * MEOS program returns through, so the instants built here are released */
+    if (! instants[i])
+    {
+      pfree_array((void **) instants, i);
+      return NULL;
+    }
+  }
   return tsequence_make_free(instants, seq->count,
     seq->period.lower_inc, seq->period.upper_inc, interp, NORMALIZE);
 }
@@ -331,6 +361,11 @@ tnumberseqset_abs(const TSequenceSet *ss)
     const TSequence *seq = TSEQUENCESET_SEQ_N(ss, i);
     sequences[i] = linear ?
       tnumberseq_linear_abs(seq) : tnumberseq_iter_abs(seq);
+    if (! sequences[i])
+    {
+      pfree_array((void **) sequences, i);
+      return NULL;
+    }
   }
   return tsequenceset_make_free(sequences, ss->count, NORMALIZE);
 }
@@ -372,6 +407,8 @@ delta_value(Datum value1, Datum value2, MeosType basetype)
   assert(basetype == T_INT4 || basetype == T_INT8 || basetype == T_FLOAT8);
   if (basetype == T_INT4)
     return Int32GetDatum(DatumGetInt32(value2) - DatumGetInt32(value1));
+  else if (basetype == T_INT8)
+    return Int64GetDatum(DatumGetInt64(value2) - DatumGetInt64(value1));
   else /* basetype == T_FLOAT8 */
     return Float8GetDatum(DatumGetFloat8(value2) - DatumGetFloat8(value1));
 }

--- a/mobilitydb/test/temporal/expected/026_tnumber_mathfuncs.test.out
+++ b/mobilitydb/test/temporal/expected/026_tnumber_mathfuncs.test.out
@@ -1991,6 +1991,24 @@ SELECT round(deltaValue(tfloat '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2
  Interp=Step;{[1@Sat Jan 01 00:00:00 2000 PST, -1@Sun Jan 02 00:00:00 2000 PST, -1@Mon Jan 03 00:00:00 2000 PST), [0@Tue Jan 04 00:00:00 2000 PST, 0@Wed Jan 05 00:00:00 2000 PST)}
 (1 row)
 
+SELECT deltaValue(tint '[5@2000-01-01, 2@2000-01-02]');
+                             deltavalue                             
+--------------------------------------------------------------------
+ [-3@Sat Jan 01 00:00:00 2000 PST, -3@Sun Jan 02 00:00:00 2000 PST)
+(1 row)
+
+SELECT deltaValue(tbigint '[5@2000-01-01, 2@2000-01-02]');
+                             deltavalue                             
+--------------------------------------------------------------------
+ [-3@Sat Jan 01 00:00:00 2000 PST, -3@Sun Jan 02 00:00:00 2000 PST)
+(1 row)
+
+SELECT deltaValue(tbigint '[-3@2000-01-01, 4@2000-01-02]');
+                            deltavalue                            
+------------------------------------------------------------------
+ [7@Sat Jan 01 00:00:00 2000 PST, 7@Sun Jan 02 00:00:00 2000 PST)
+(1 row)
+
 /* NULL */
 SELECT round(deltaValue(tfloat '1@2000-01-01'), 6);
  round 
@@ -2248,3 +2266,29 @@ SELECT abs(tfloat '[-1@2000-01-01,1@2000-01-02]');
  [1@Sat Jan 01 00:00:00 2000 PST, 0@Sat Jan 01 12:00:00 2000 PST, 1@Sun Jan 02 00:00:00 2000 PST]
 (1 row)
 
+SELECT abs(tint '{-2@2000-01-01, 5@2000-01-02, -7@2000-01-03}');
+                                               abs                                                
+--------------------------------------------------------------------------------------------------
+ {2@Sat Jan 01 00:00:00 2000 PST, 5@Sun Jan 02 00:00:00 2000 PST, 7@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT abs(tbigint '{-2@2000-01-01, 5@2000-01-02, -7@2000-01-03}');
+                                               abs                                                
+--------------------------------------------------------------------------------------------------
+ {2@Sat Jan 01 00:00:00 2000 PST, 5@Sun Jan 02 00:00:00 2000 PST, 7@Mon Jan 03 00:00:00 2000 PST}
+(1 row)
+
+SELECT abs(tbigint '-9223372036854775807@2000-01-01');
+                       abs                        
+--------------------------------------------------
+ 9223372036854775807@Sat Jan 01 00:00:00 2000 PST
+(1 row)
+
+/* Errors */
+-- The most negative value of each integer type has no positive counterpart
+SELECT abs(tint '-2147483648@2000-01-01');
+ERROR:  Integer out of range
+SELECT abs(tbigint '-9223372036854775808@2000-01-01');
+ERROR:  Bigint out of range
+SELECT abs(tint '{-2147483648@2000-01-01, 5@2000-01-02}');
+ERROR:  Integer out of range

--- a/mobilitydb/test/temporal/queries/026_tnumber_mathfuncs.test.sql
+++ b/mobilitydb/test/temporal/queries/026_tnumber_mathfuncs.test.sql
@@ -457,6 +457,11 @@ SELECT round(radians(tfloat '{[1.5@2000-01-01, 2.5@2000-01-02, 1.5@2000-01-03],[
 SELECT round(deltaValue(tfloat '{1@2000-01-01, 2@2000-01-02, 1@2000-01-03}'), 6);
 SELECT round(deltaValue(tfloat '[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]'), 6);
 SELECT round(deltaValue(tfloat '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-04, 3@2000-01-05]}'), 6);
+-- A big integer answers as its integer twin does. A rising pair alone cannot
+-- witness the base type, so a falling one and one crossing zero stand beside it
+SELECT deltaValue(tint '[5@2000-01-01, 2@2000-01-02]');
+SELECT deltaValue(tbigint '[5@2000-01-01, 2@2000-01-02]');
+SELECT deltaValue(tbigint '[-3@2000-01-01, 4@2000-01-02]');
 /* NULL */
 SELECT round(deltaValue(tfloat '1@2000-01-01'), 6);
 SELECT round(deltaValue(tfloat 'Interp=Step;[1@2000-01-01, 2@2000-01-02, 1@2000-01-03]'), 6);
@@ -526,6 +531,16 @@ SELECT round(tan(tfloat '{[1@2000-01-01, 2@2000-01-02, 1@2000-01-03],[3@2000-01-
 -------------------------------------------------------------------------------
 
 SELECT abs(tfloat '[-1@2000-01-01,1@2000-01-02]');
+-- A big integer answers as its integer twin does, the two named side by side
+-- because the value is read through the base type the temporal type declares
+SELECT abs(tint '{-2@2000-01-01, 5@2000-01-02, -7@2000-01-03}');
+SELECT abs(tbigint '{-2@2000-01-01, 5@2000-01-02, -7@2000-01-03}');
+SELECT abs(tbigint '-9223372036854775807@2000-01-01');
+/* Errors */
+-- The most negative value of each integer type has no positive counterpart
+SELECT abs(tint '-2147483648@2000-01-01');
+SELECT abs(tbigint '-9223372036854775808@2000-01-01');
+SELECT abs(tint '{-2147483648@2000-01-01, 5@2000-01-02}');
 
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
abs(tbigint) and deltaValue(tbigint) answer the bit pattern of a double where
their tint twins answer the value. tnumberinst_abs and delta_value each
dispatch on the base type in two arms, an integer one testing T_INT4 and a
float one whose comment names T_FLOAT8, while the assert above admits T_INT8
as well, so a big integer takes the float arm: its datum is read as a double,
fabs clears the sign bit or the subtraction is done on two denormals, and the
result is written back under the integer type. abs(tbigint '-2@...') answers
9223372036854775806, which is the bit pattern of -2 with its sign bit cleared,
and deltaValue over a falling pair answers -9223372036854775805 where -3 is the
value. A rising pair of small positive big integers answers correctly, since
their bit patterns are denormals whose difference is exact, which is why the
defect reads as absent from a single ascending case.

Each function gains the T_INT8 arm its assert already admits, the abs one over
llabs as span_ops.c reads a big integer distance. The three-arm shape is the one
tnumber_spgist.c states for the same three base types.

026_tnumber_mathfuncs states each new case beside its tint twin, since the twin
is the oracle: the falling pair and the pair crossing zero for deltaValue, a
sequence mixing signs and the most negative representable value for abs.

Neither integer arm could answer the most negative value of its type, which has
no positive counterpart: abs(tint '-2147483648@...') answered that value back
and the big integer one answered 0, where PostgreSQL's own abs of the same
integer reports it out of range. Both arms report it, and the sequence and
sequence set release the values they hold and answer NULL, since an error
handler installed by a MEOS program returns to them.

