### PR TITLE
Answer the precision of a big integer as the average it is

### DIFF
--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -737,7 +737,10 @@ tsequence_tprecision(const TSequence *seq, const Interval *duration,
   lower = lower_bin;
   upper = lower_bin + tunits;
   interpType interp = MEOS_FLAGS_GET_INTERP(seq->flags);
-  MeosType temptype_out = (seq->temptype == T_TINT) ? T_TFLOAT : seq->temptype;
+  /* The value of a bin is a time-weighted average, which an integer type does
+   * not carry, so both of them answer it as the float it is */
+  MeosType temptype_out = (seq->temptype == T_TINT ||
+    seq->temptype == T_TBIGINT) ? T_TFLOAT : seq->temptype;
   /* Determine whether we are computing the twAvg or the twCentroid */
   bool twavg = tnumber_type(seq->temptype);
 #if RGEO
@@ -947,7 +950,10 @@ tsequenceset_tprecision(const TSequenceSet *ss, const Interval *duration,
   lower = lower_bin;
   upper = lower_bin + tunits;
   interpType interp = MEOS_FLAGS_GET_INTERP(ss->flags);
-  MeosType temptype_out = (ss->temptype == T_TINT) ? T_TFLOAT : ss->temptype;
+  /* The value of a bin is a time-weighted average, which an integer type does
+   * not carry, so both of them answer it as the float it is */
+  MeosType temptype_out = (ss->temptype == T_TINT ||
+    ss->temptype == T_TBIGINT) ? T_TFLOAT : ss->temptype;
   MeosType basetype_out = temptype_basetype(temptype_out);
   /* Determine whether we are computing the twAvg or the twCentroid */
   bool twavg = tnumber_type(ss->temptype);

--- a/mobilitydb/test/temporal/expected/022_temporal.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal.test.out
@@ -8022,6 +8022,24 @@ SELECT tprecision(tint '{54@2001-02-27 16:21:00, 52@2001-02-27 16:29:00}', '15 m
  {53@Tue Feb 27 16:15:00 2001 PST}
 (1 row)
 
+SELECT tprecision(tint '[-4@2000-01-01, -4@2000-01-03]', interval '1 day');
+                                   tprecision                                   
+--------------------------------------------------------------------------------
+ Interp=Step;[-4@Sat Jan 01 00:00:00 2000 PST, -4@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT tprecision(tbigint '[-4@2000-01-01, -4@2000-01-03]', interval '1 day');
+                                   tprecision                                   
+--------------------------------------------------------------------------------
+ Interp=Step;[-4@Sat Jan 01 00:00:00 2000 PST, -4@Mon Jan 03 00:00:00 2000 PST]
+(1 row)
+
+SELECT tprecision(tbigint '{54@2001-02-27 16:21:00, 52@2001-02-27 16:29:00}', '15 minutes', '2001-01-01');
+            tprecision             
+-----------------------------------
+ {53@Tue Feb 27 16:15:00 2001 PST}
+(1 row)
+
 SELECT d, getTime(tprecision(tfloat '[1@2001-01-01, 5@2001-01-05, 1@2001-01-09)', d, '2001-01-01'))
   <@ getTime(tfloat '[1@2001-01-01, 5@2001-01-05, 1@2001-01-09)') AS covered
 FROM (VALUES (interval '1 day'), (interval '2 days'), (interval '4 days'),

--- a/mobilitydb/test/temporal/queries/022_temporal.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal.test.sql
@@ -1907,6 +1907,11 @@ SELECT tprecision(tfloat '[1@2001-01-01, 5@2001-01-05, 1@2001-01-09]', '1 day', 
 -- A bin can start before the sequence does, which is every bin holding a
 -- discrete sequence whose instants sit inside it
 SELECT tprecision(tint '{54@2001-02-27 16:21:00, 52@2001-02-27 16:29:00}', '15 minutes', '2001-01-01');
+-- A big integer answers the bin average as its integer twin does, the two named
+-- side by side because the average is a float neither integer type carries
+SELECT tprecision(tint '[-4@2000-01-01, -4@2000-01-03]', interval '1 day');
+SELECT tprecision(tbigint '[-4@2000-01-01, -4@2000-01-03]', interval '1 day');
+SELECT tprecision(tbigint '{54@2001-02-27 16:21:00, 52@2001-02-27 16:29:00}', '15 minutes', '2001-01-01');
 
 -- Which bin ends on the bound follows from the bin width, so the containment
 -- holds over a sweep of widths rather than at one of them


### PR DESCRIPTION
tprecision over a tbigint answers -4607182418800017408 where its tint twin
answers -4 for the same input. The value of a bin is a time-weighted average,
which tnumberseq_twavg computes as a double, and the instant holding it takes
the temptype temptype_out names. That name reads T_TFLOAT for a temporal
integer and the value's own type otherwise, so a temporal big integer stores a
double under a type whose output function reads it as an integer.

A big integer carries a time-weighted average no more than an integer does, so
both name T_TFLOAT. The declarations stand untouched: a temporal value carries
its own temptype, which is what its output function reads, so tprecision(tint)
answers a float value under a tint signature and the big integer form answers
one under a tbigint signature.

022_temporal states each case beside its tint twin, and the two answer alike:
Interp=Step;[-4@..., -4@...] for the constant sequence, carrying the value and
the interpolation the twin carries, and {53@...} for the discrete pair, the
average of 54 and 52.

