### PR TITLE
Restrict a spatial temporal value to every set element within its extent

### DIFF
--- a/meos/src/temporal/temporal_restrict.c
+++ b/meos/src/temporal/temporal_restrict.c
@@ -244,7 +244,13 @@ temporal_bbox_restrict_set(const Temporal *temp, const Set *s)
   {
     STBox box;
     tspatial_set_stbox(temp, &box);
-    return contains_stbox_stbox(&box, (STBox *) SET_BBOX_PTR(s));
+    /* The set bounds every value the restriction may match, so what excludes
+     * the temporal value is the two boxes standing apart, exactly as the
+     * numeric branch above reads it. Asking the temporal box to CONTAIN the
+     * set box makes one set element lying outside the temporal extent discard
+     * the elements that do lie inside it, and a restriction to a larger set
+     * answers less than a restriction to a smaller one */
+    return overlaps_stbox_stbox(&box, (STBox *) SET_BBOX_PTR(s));
   }
   return true;
 }

--- a/mobilitydb/test/geo/expected/052_tgeo.test.out
+++ b/mobilitydb/test/geo/expected/052_tgeo.test.out
@@ -3666,6 +3666,18 @@ SELECT asText(atValues(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02
  {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(1 1)@Sun Jan 02 00:00:00 2000 PST), [POINT(1 1)@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(atValues(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(1 1)", "Point(9 9)"}'));
+                                        astext                                        
+--------------------------------------------------------------------------------------
+ {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(1 1)@Sun Jan 02 00:00:00 2000 PST)}
+(1 row)
+
+SELECT asText(minusValues(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(1 1)", "Point(9 9)"}'));
+                   astext                    
+---------------------------------------------
+ {[POINT(2 2)@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT asText(atValues(tgeography 'Point(1.5 1.5)@2000-01-01', geogset '{"Point(1.5 1.5)"}'));
                    astext                    
 ---------------------------------------------

--- a/mobilitydb/test/geo/expected/052_tpoint.test.out
+++ b/mobilitydb/test/geo/expected/052_tpoint.test.out
@@ -3784,6 +3784,24 @@ SELECT asText(atValues(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-0
  {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST], [POINT(1 1)@Mon Jan 03 00:00:00 2000 PST]}
 (1 row)
 
+SELECT asText(atValues(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(1 1)", "Point(9 9)"}'));
+                   astext                    
+---------------------------------------------
+ {[POINT(1 1)@Sat Jan 01 00:00:00 2000 PST]}
+(1 row)
+
+SELECT asText(atValues(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(9 9)", "Point(8 8)"}'));
+ astext 
+--------
+ 
+(1 row)
+
+SELECT asText(minusValues(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(1 1)", "Point(9 9)"}'));
+                                        astext                                        
+--------------------------------------------------------------------------------------
+ {(POINT(1 1)@Sat Jan 01 00:00:00 2000 PST, POINT(2 2)@Sun Jan 02 00:00:00 2000 PST]}
+(1 row)
+
 SELECT asText(atValues(tgeogpoint 'Point(1.5 1.5)@2000-01-01', geogset '{"Point(1.5 1.5)"}'));
                    astext                    
 ---------------------------------------------

--- a/mobilitydb/test/geo/queries/052_tgeo.test.sql
+++ b/mobilitydb/test/geo/queries/052_tgeo.test.sql
@@ -1098,6 +1098,10 @@ SELECT asText(atValues(tgeometry 'Point(1 1)@2000-01-01', geomset '{"Point(1 1)"
 SELECT asText(atValues(tgeometry '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', geomset '{"Point(1 1)"}'));
 SELECT asText(atValues(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', geomset '{"Point(1 1)"}'));
 SELECT asText(atValues(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}', geomset '{"Point(1 1)"}'));
+-- A set element outside the extent of the temporal geometry must not discard
+-- the elements inside it
+SELECT asText(atValues(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(1 1)", "Point(9 9)"}'));
+SELECT asText(minusValues(tgeometry '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(1 1)", "Point(9 9)"}'));
 SELECT asText(atValues(tgeography 'Point(1.5 1.5)@2000-01-01', geogset '{"Point(1.5 1.5)"}'));
 SELECT asText(atValues(tgeography '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}', geogset '{"Point(1.5 1.5)"}'));
 SELECT asText(atValues(tgeography '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]', geogset '{"Point(1.5 1.5)"}'));

--- a/mobilitydb/test/geo/queries/052_tpoint.test.sql
+++ b/mobilitydb/test/geo/queries/052_tpoint.test.sql
@@ -1153,6 +1153,11 @@ SELECT asText(atValues(tgeompoint 'Point(1 1)@2000-01-01', geomset '{"Point(1 1)
 SELECT asText(atValues(tgeompoint '{Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03}', geomset '{"Point(1 1)"}'));
 SELECT asText(atValues(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03]', geomset '{"Point(1 1)"}'));
 SELECT asText(atValues(tgeompoint '{[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02, Point(1 1)@2000-01-03],[Point(3 3)@2000-01-04, Point(3 3)@2000-01-05]}', geomset '{"Point(1 1)"}'));
+-- A set element outside the extent of the temporal point must not discard the
+-- elements inside it: a restriction to a larger set answers at least as much
+SELECT asText(atValues(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(1 1)", "Point(9 9)"}'));
+SELECT asText(atValues(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(9 9)", "Point(8 8)"}'));
+SELECT asText(minusValues(tgeompoint '[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]', geomset '{"Point(1 1)", "Point(9 9)"}'));
 SELECT asText(atValues(tgeogpoint 'Point(1.5 1.5)@2000-01-01', geogset '{"Point(1.5 1.5)"}'));
 SELECT asText(atValues(tgeogpoint '{Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03}', geogset '{"Point(1.5 1.5)"}'));
 SELECT asText(atValues(tgeogpoint '[Point(1.5 1.5)@2000-01-01, Point(2.5 2.5)@2000-01-02, Point(1.5 1.5)@2000-01-03]', geogset '{"Point(1.5 1.5)"}'));

--- a/mobilitydb/test/npoint/expected/302_tnpoint_tbl.test.out
+++ b/mobilitydb/test/npoint/expected/302_tnpoint_tbl.test.out
@@ -475,7 +475,14 @@ SELECT COUNT(*) FROM tbl_tnpoint,
 WHERE atValues(temp, s) IS NOT NULL;
  count 
 -------
-     0
+    30
+(1 row)
+
+SELECT COUNT(*) FROM tbl_tnpoint t
+WHERE EXISTS (SELECT 1 FROM tbl_npoint n WHERE atValue(t.temp, n.np) IS NOT NULL);
+ count 
+-------
+    30
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tnpoint,

--- a/mobilitydb/test/npoint/queries/302_tnpoint_tbl.test.sql
+++ b/mobilitydb/test/npoint/queries/302_tnpoint_tbl.test.sql
@@ -218,6 +218,10 @@ WHERE minusValue(temp, np) IS NOT NULL;
 SELECT COUNT(*) FROM tbl_tnpoint,
 ( SELECT setUnion(np) AS s FROM tbl_npoint) tmp
 WHERE atValues(temp, s) IS NOT NULL;
+-- Restricting to a set answers what restricting to its elements one by one
+-- answers, so the two counts are the same number
+SELECT COUNT(*) FROM tbl_tnpoint t
+WHERE EXISTS (SELECT 1 FROM tbl_npoint n WHERE atValue(t.temp, n.np) IS NOT NULL);
 
 SELECT COUNT(*) FROM tbl_tnpoint,
 ( SELECT setUnion(np) AS s FROM tbl_npoint) tmp


### PR DESCRIPTION
The box a value set stores bounds every element the restriction may match, so what excludes the temporal value is the two boxes standing apart, exactly as the numeric branch of the same test reads it. Asking the temporal box to contain the set box lets one element lying outside the temporal extent discard the elements lying inside it, so a restriction to a larger set answers less than a restriction to a smaller one, and over a whole table it answers nothing: `atValues(temp, s)` against the set of every network point in `tbl_npoint` matched no row of `tbl_tnpoint` where restricting to those points one at a time matches thirty. The npoint test states that equivalence as the two counts it compares, and the geo tests carry the cases where one element of the set lies outside the temporal value's extent. Every spatial temporal type reads the same test — tgeompoint, tgeometry, tcbuffer, tnpoint, tpose and trgeometry — and a set of one element is answered by the singleton path before the box test runs.
