### PR TITLE
Read a base value of any type from its string representation

### DIFF
--- a/meos/include/meos_internal.h
+++ b/meos/include/meos_internal.h
@@ -797,6 +797,8 @@ extern uint32 meos_random_binomial20_half(pg_prng_state *rng);
  * Generic type functions
  *****************************************************************************/
 
+extern bool basetype_in(const char *str, MeosType type, bool end,
+  Datum *result);
 extern Datum datum_ceil(Datum d);
 extern Datum datum_degrees(Datum d, Datum normalize);
 extern Datum datum_float_round(Datum value, Datum size);

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -134,6 +134,12 @@ extern LWGEOM *parse_geojson(json_object *geojson, int *hasz);
 
 /**
  * @brief Return a base value from its string representation
+ * @param[in] str String
+ * @param[in] type Base type of the value
+ * @param[in] end True when the string must end where the value ends, which
+ * the types parsing a value out of a larger string read
+ * @param[out] result Value read
+ * @return On error return @p false
  */
 bool
 #if CBUFFER || NPOINT || POSE || RGEO


### PR DESCRIPTION
`basetype_in` answers the value a string carries for the base type it is given, which is what a caller holding a type rather than a name needs. It carries a `Datum`, so it joins the generic type functions of `meos_internal.h`, beside the `datum_` functions taking the same `MeosType`, rather than the public surface.
