### PR TITLE
Convert a cell of each cell-index type into a set of that type

### DIFF
--- a/meos/include/meos_h3.h
+++ b/meos/include/meos_h3.h
@@ -243,6 +243,8 @@ extern Temporal *tgeompoint_to_th3index(const Temporal *temp, int32 resolution);
 extern Temporal *th3index_to_tgeogpoint(const Temporal *temp);
 extern Temporal *th3index_to_tgeompoint(const Temporal *temp);
 
+extern Set    *h3index_to_set(H3Index cell);
+
 /* Static geometry → H3 cell / cell set.  See meos/src/h3/h3_geo.c. */
 extern H3Index geo_to_h3index_cell(const GSERIALIZED *point, int32 resolution);
 extern Set    *geo_to_h3index_set(const GSERIALIZED *gs,    int32 resolution);

--- a/meos/include/meos_quadbin.h
+++ b/meos/include/meos_quadbin.h
@@ -216,6 +216,7 @@ extern bool tquadbin_value_at_timestamptz(const Temporal *temp, TimestampTz t,
 
 /* Conversions */
 
+extern Set *quadbin_to_set(Quadbin cell);
 extern Temporal *tbigint_to_tquadbin(const Temporal *temp);
 extern Temporal *tquadbin_to_tbigint(const Temporal *temp);
 

--- a/meos/include/meos_s2cell.h
+++ b/meos/include/meos_s2cell.h
@@ -220,6 +220,7 @@ extern bool ts2cell_value_at_timestamptz(const Temporal *temp, TimestampTz t,
 
 /* Conversions */
 
+extern Set *s2cell_to_set(S2CellId cell);
 extern Temporal *tbigint_to_ts2cell(const Temporal *temp);
 extern Temporal *ts2cell_to_tbigint(const Temporal *temp);
 

--- a/meos/src/h3/h3index_sets.c
+++ b/meos/src/h3/h3index_sets.c
@@ -471,3 +471,20 @@ meos_h3_get_icosahedron_faces(H3Index cell)
 }
 
 /*****************************************************************************/
+
+/*****************************************************************************
+ * Conversion functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_h3_set_conversion
+ * @brief Convert an H3 cell into a H3 cell set
+ * @param[in] cell Value
+ * @csqlfn #Value_to_set()
+ */
+Set *
+h3index_to_set(H3Index cell)
+{
+  Datum v = H3IndexGetDatum(cell);
+  return set_make_exp(&v, 1, 1, T_H3INDEX, ORDER_NO);
+}

--- a/meos/src/quadbin/quadbinset.c
+++ b/meos/src/quadbin/quadbinset.c
@@ -126,3 +126,20 @@ quadbin_cell_to_children_set(Quadbin origin, int children_resolution)
 }
 
 /*****************************************************************************/
+
+/*****************************************************************************
+ * Conversion functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_quadbin_set_conversion
+ * @brief Convert a quadbin cell into a quadbin cell set
+ * @param[in] cell Value
+ * @csqlfn #Value_to_set()
+ */
+Set *
+quadbin_to_set(Quadbin cell)
+{
+  Datum v = QuadbinGetDatum(cell);
+  return set_make_exp(&v, 1, 1, T_QUADBIN, ORDER_NO);
+}

--- a/meos/src/s2cell/s2cellset.c
+++ b/meos/src/s2cell/s2cellset.c
@@ -131,3 +131,20 @@ s2cell_cell_to_children_set(S2CellId cell, int children_level)
 }
 
 /*****************************************************************************/
+
+/*****************************************************************************
+ * Conversion functions
+ *****************************************************************************/
+
+/**
+ * @ingroup meos_s2cell_set_conversion
+ * @brief Convert an S2 cell into a S2 cell set
+ * @param[in] cell Value
+ * @csqlfn #Value_to_set()
+ */
+Set *
+s2cell_to_set(S2CellId cell)
+{
+  Datum v = S2CellGetDatum(cell);
+  return set_make_exp(&v, 1, 1, T_S2CELL, ORDER_NO);
+}


### PR DESCRIPTION
The fourteen other base types answer `set(value)` through a `<base>_to_set` of their own; the three cell-index types answer it through the generic wrapper alone, so a caller holding the type rather than the SQL name has nothing to call and every binding writes the constructor by hand. `quadbin_to_set`, `s2cell_to_set` and `h3index_to_set` mirror their siblings: the value packed into a `Datum` and handed to `set_make_exp` with the type of the cell. The SQL surface is unchanged — `set(quadbin)`, `set(s2cell)` and `set(h3index)` already exist, already bind the generic `Value_to_set` wrapper, and are already exercised by the pg_regress suites.
