### PR TITLE
Build every family in every workflow

### DIFF
--- a/.github/workflows/cppcheck.yml
+++ b/.github/workflows/cppcheck.yml
@@ -93,9 +93,8 @@ jobs:
           cmake -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
                 -DCMAKE_BUILD_TYPE=Release \
                 -DMEOS=on \
-                -DCBUFFER=on -DNPOINT=on -DPOSE=on -DRGEO=on -DQUADBIN=on \
-                -DRASTER=on -DPOINTCLOUD=on \
-                -DH3=on -DH3_INCLUDE_DIR="$H3_INCLUDE_DIR" -DH3_LIBRARY="$H3_LIBRARY" ..
+                -DALL=on \
+                -DH3_INCLUDE_DIR="$H3_INCLUDE_DIR" -DH3_LIBRARY="$H3_LIBRARY" ..
 
       - name: Run cppcheck (XML output - universally supported)
         # --project uses the same -I paths CMake records for the real

--- a/.github/workflows/fedora.yml
+++ b/.github/workflows/fedora.yml
@@ -58,7 +58,8 @@ jobs:
             postgresql-server-devel postgis \
             geos-devel proj-devel json-c-devel \
             gdal-devel h3-devel \
-            autoconf automake libtool libxml2-devel zlib-devel
+            autoconf automake libtool libxml2-devel zlib-devel which \
+            redhat-rpm-config
           gcc --version | head -1
 
       - uses: actions/checkout@v4
@@ -103,7 +104,9 @@ jobs:
         run: |
           dnf -y install gcc gcc-c++ cmake make git tar xz diffutils \
             postgresql-server postgresql-server-devel postgis \
-            geos-devel proj-devel json-c-devel gdal-devel
+            geos-devel proj-devel json-c-devel gdal-devel h3-devel \
+            autoconf automake libtool libxml2-devel zlib-devel which \
+            redhat-rpm-config
           locale
 
       - uses: actions/checkout@v4
@@ -118,12 +121,42 @@ jobs:
           useradd -m builder
           chown -R builder "$GITHUB_WORKSPACE"
 
-      - name: Configure with the families Fedora can run
+      - name: Build and install the vendored pgPointCloud
+        # POINTCLOUD maps to a PostgreSQL extension of its own, which the
+        # extension's `requires` names, so CREATE EXTENSION ... CASCADE asks
+        # the cluster for it. Fedora packages no build of pgPointCloud and the
+        # tree carries one, built here the way the repository builds it.
+        run: |
+          cd "$GITHUB_WORKSPACE/pointcloud-pg"
+          ./autogen.sh
+          ./configure --with-pgconfig="$(command -v pg_config)"
+          make -j$(nproc)
+          make install
+
+      - name: Build and install the h3 PostgreSQL extension
+        # H3 names the h3 extension in the extension's own requires clause, so
+        # CREATE EXTENSION ... CASCADE asks the cluster for it. Fedora packages
+        # the libh3 C library alone, which is a different thing, so the
+        # extension is built from the repository and tag h3-pg/H3PG_REVISION
+        # records for the bindings this tree embeds.
+        run: |
+          # h3-pg/ in the tree holds the binding sources this extension
+          # compiles into its own library, so the checkout is cloned beside it.
+          git clone --depth 1 --recurse-submodules --branch v4.2.3 \
+            https://github.com/postgis/h3-pg.git h3-pg-checkout
+          cmake -S h3-pg-checkout -B h3-pg-build -DCMAKE_BUILD_TYPE=Release
+          cmake --build h3-pg-build -j$(nproc)
+          cmake --install h3-pg-build
+          # Installing into the cluster needs root, and the configure below runs
+          # as builder and writes pointcloud-pg/lib/pc_config.h into the tree,
+          # so the workspace returns to that user.
+          chown -R builder "$GITHUB_WORKSPACE"
+
+      - name: Configure with every family
         run: |
           su builder -c "cmake -S '$GITHUB_WORKSPACE' -B '$GITHUB_WORKSPACE/build' \
             -DCMAKE_BUILD_TYPE=Release \
-            -DCBUFFER=ON -DJSON=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON \
-            -DQUADBIN=ON -DRASTER=ON"
+            -DALL=ON"
 
       - name: Build
         run: su builder -c "make -C '$GITHUB_WORKSPACE/build' -j$(nproc)"

--- a/.github/workflows/meos-smoke.yml
+++ b/.github/workflows/meos-smoke.yml
@@ -40,14 +40,21 @@ jobs:
             libgeos-dev \
             libproj-dev \
             libjson-c-dev \
+            libgdal-dev \
+            libh3-dev \
+            libxml2-dev \
+            zlib1g-dev \
             valgrind
 
       - name: Build and install MEOS
         run: |
           mkdir build
           cd build
-          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on \
-            -DRGEO=on -DPOSE=on -DCBUFFER=on -DNPOINT=on ..
+          # ALL enables every optional family, as in meos.yml, so a family added
+          # later is smoke-tested here without editing this workflow: the list in
+          # CMakeLists.txt decides. A family left out installs no public header,
+          # and the suite generated from that header is then skipped in silence
+          cmake -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DALL=on ..
           make -j $(nproc)
           sudo make install
           sudo ldconfig

--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -289,13 +289,18 @@ jobs:
           sudo apt-get install -y \
             libgeos-dev \
             libproj-dev \
-            libjson-c-dev
+            libjson-c-dev \
+            libgdal-dev \
+            libh3-dev \
+            libxml2-dev \
+            zlib1g-dev \
+            autoconf automake libtool
 
       # Install into a local prefix rather than /usr/local, so the link test
       # below cannot silently resolve against a system-installed libmeos.
       - name: Build the static library
         run: |
-          cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DCBUFFER=on -DJSON=on \
+          cmake -B build -S . -DCMAKE_BUILD_TYPE=Debug -DMEOS=on -DALL=on \
             -DBUILD_SHARED_LIBS=OFF -DCMAKE_INSTALL_PREFIX="$PWD/prefix"
           cmake --build build -j $(nproc)
           cmake --install build

--- a/.github/workflows/meos_locale.yml
+++ b/.github/workflows/meos_locale.yml
@@ -55,6 +55,7 @@ jobs:
           sudo apt-get install -y \
             cmake ninja-build \
             libgeos++-dev libproj-dev libjson-c-dev \
+            libgdal-dev libh3-dev libxml2-dev zlib1g-dev \
             locales
           sudo locale-gen de_DE.UTF-8
           sudo update-locale
@@ -67,7 +68,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
             -DMEOS=ON \
-            -DCBUFFER=ON -DNPOINT=ON
+            -DALL=ON
 
       - name: Build libmeos
         run: cmake --build build-meos -j

--- a/.github/workflows/meos_macos.yml
+++ b/.github/workflows/meos_macos.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Install dependencies (Homebrew)
         run: |
-          brew install json-c geos proj cmake ninja
+          brew install json-c geos proj cmake ninja h3 gdal libxml2 zlib
 
       - name: Configure (MEOS=ON, no PostgreSQL extension)
         run: |
@@ -52,7 +52,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
             -DCMAKE_PREFIX_PATH="$BREW_PREFIX" \
             -DMEOS=ON \
-            -DCBUFFER=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON
+            -DALL=ON
 
       - name: Build libmeos.dylib
         run: cmake --build build-meos -j

--- a/.github/workflows/meos_utf8_smoke.yml
+++ b/.github/workflows/meos_utf8_smoke.yml
@@ -59,7 +59,8 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake ninja-build \
-            libgeos++-dev libproj-dev libjson-c-dev
+            libgeos++-dev libproj-dev libjson-c-dev \
+            libgdal-dev libh3-dev libxml2-dev zlib1g-dev
 
       - name: Configure standalone MEOS
         run: |
@@ -68,7 +69,7 @@ jobs:
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
             -DMEOS=ON \
-            -DCBUFFER=ON -DNPOINT=ON
+            -DALL=ON
 
       - name: Build libmeos
         run: cmake --build build-meos -j

--- a/.github/workflows/windows_msys2_meos.yml
+++ b/.github/workflows/windows_msys2_meos.yml
@@ -56,6 +56,7 @@ jobs:
           msystem: UCRT64
           update: true
           install: >-
+            git
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-ninja
@@ -63,8 +64,48 @@ jobs:
             mingw-w64-ucrt-x86_64-geos
             mingw-w64-ucrt-x86_64-proj
             mingw-w64-ucrt-x86_64-tzdata
+            mingw-w64-ucrt-x86_64-gdal
+            mingw-w64-ucrt-x86_64-libxml2
+            mingw-w64-ucrt-x86_64-zlib
 
       - uses: ./.github/actions/msys2-toolchain-report
+
+      - name: Build libh3 from source
+        # MSYS2 packages no h3, and H3=ON asks CMake for the library by name,
+        # so the family is unbuildable here until the library exists. The MEOS
+        # build needs the C library alone: the h3 PostgreSQL extension the
+        # control file names is a requirement of the extension target, which
+        # this job does not build.
+        run: |
+          git clone --depth 1 --branch v4.2.1 https://github.com/uber/h3.git h3-src
+          cmake -S h3-src -B h3-build \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$PWD/h3-install" \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_TESTING=OFF \
+            -DENABLE_DOCS=OFF \
+            -DBUILD_BENCHMARKS=OFF \
+            -DBUILD_FILTERS=OFF \
+            -DBUILD_GENERATORS=OFF
+          cmake --build h3-build -j
+          cmake --install h3-build
+
+      - name: Pin the libh3 paths the configure step reads
+        # The same read cppcheck.yml makes of the packaged library, against the
+        # tree this job just installed: name the header and the library outright
+        # so a layout change is a loud failure rather than a silent H3=OFF.
+        run: |
+          H3_INC=$(find "$PWD/h3-install" -name 'h3api.h' | head -1)
+          H3_LIB=$(find "$PWD/h3-install" -name 'libh3*.dll.a' -o -name 'libh3*.a' \
+            -o -name 'libh3*.dll' | head -1)
+          if [ -z "$H3_INC" ] || [ -z "$H3_LIB" ]; then
+            find "$PWD/h3-install" -name 'libh3*' -o -name 'h3api.h'
+            echo "::error::could not locate the libh3 headers/library just built"
+            exit 1
+          fi
+          echo "H3_INCLUDE_DIR=$(dirname "$H3_INC")" >> "$GITHUB_ENV"
+          echo "H3_LIBRARY=$H3_LIB" >> "$GITHUB_ENV"
 
       - name: Resolve native timezone data path
         run: |
@@ -76,15 +117,14 @@ jobs:
 
       - name: Configure (MEOS=ON, no PostgreSQL extension)
         run: |
-          # POSE pulls in RGEO via CMAKE_DEPENDENT_OPTION; RGEO stays off
-          # because rgeo's compilation on Windows depends on PostGIS
-          # build-tree generated headers that are not available there.
           cmake -S . -B build-meos \
             -G Ninja \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX="$PWD/meos-install" \
             -DMEOS=ON \
-            -DCBUFFER=ON -DNPOINT=ON -DPOSE=OFF -DRGEO=OFF \
+            -DALL=ON \
+            -DH3_LIBRARY="$H3_LIBRARY" \
+            -DH3_INCLUDE_DIR="$H3_INCLUDE_DIR" \
             -DMEOS_TZDATA_DIR="$MEOS_TZDATA_WIN"
 
       - name: Build libmeos
@@ -109,5 +149,5 @@ jobs:
             -o meos-install/temporal_test.exe \
             meos/test/temporal_test.c \
             -lmeos
-          PATH="$PWD/meos-install/bin:$PWD/meos-install/lib:$PWD/build-meos:$PATH" ./meos-install/temporal_test.exe \
+          PATH="$PWD/meos-install/bin:$PWD/meos-install/lib:$PWD/build-meos:$PWD/h3-install/bin:$PATH" ./meos-install/temporal_test.exe \
             || (echo "temporal_test.exe failed at runtime"; exit 1)


### PR DESCRIPTION
Eight workflows named their own families, so the set was defined in nine
places and a family added to CMakeLists.txt joined none of them. The
cppcheck job asked in prose for every optional feature so their sources
land in compile_commands.json, and analysed eight of eleven, leaving the
JSON, pose chain and S2 cell sources read by nobody. Each installs what
ALL requires and says -DALL=ON, which is the one definition.

