### PR TITLE
Null every slot the MEOS finalize chain releases

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -78,6 +78,11 @@ jobs:
           # SIBLING-FROM bool_test (same compile+run idiom)
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o allocator_test allocator_test.c -L/usr/local/lib -lmeos
           ./allocator_test
+          # lifecycle_test drives meos_initialize/meos_finalize twice over
+          # populated caches, which is what a host running the lifecycle per
+          # unit of work does. SIBLING-FROM allocator_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o lifecycle_test lifecycle_test.c -L/usr/local/lib -lmeos
+          ./lifecycle_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o bool_test bool_test.c -L/usr/local/lib -lmeos
           ./bool_test
           # int_test is what reads <meos.h> and <pg_int.h> in one translation

--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -172,16 +172,19 @@ GetMEOSPROJSRSCache()
 void
 meos_finalize_projsrs(void)
 {
+  /* Idempotency: only destroy a live cache, and null the slot so a
+   * second finalize call does not double-free the cache and its
+   * stored projections. */
   MEOSPROJSRSCache *cache = MEOS_PROJ_CACHE;
-  if (cache)
+  if (! cache)
+    return;
+  for (uint32_t i = 0; i < cache->PROJSRSCacheCount; i++)
   {
-    for (uint32_t i = 0; i < cache->PROJSRSCacheCount; i++)
-    {
-      if (cache->MEOSPROJSRSCache[i].projection)
-        PROJSRSDestroyPJ(cache->MEOSPROJSRSCache[i].projection);
-    }
+    if (cache->MEOSPROJSRSCache[i].projection)
+      PROJSRSDestroyPJ(cache->MEOSPROJSRSCache[i].projection);
   }
   pfree(cache);
+  MEOS_PROJ_CACHE = NULL;
   return;
 }
 

--- a/meos/test/lifecycle_test.c
+++ b/meos/test/lifecycle_test.c
@@ -1,0 +1,105 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests the idempotency of the MEOS setup lifecycle.
+ *
+ * Every finalize function in the #meos_finalize chain nulls the slot it
+ * released, so the chain is safe to run twice and a cycle can be started
+ * again on the same thread. A host that drives the lifecycle per unit of work
+ * (a stream query, a worker task) relies on both properties.
+ *
+ * Each cycle populates the caches the chain releases before releasing them,
+ * so the assertions are not vacuous: the collation cache is filled by
+ * #meos_initialize_collation, the timezone cache by #meos_initialize_timezone,
+ * and the PROJ SRS cache by a #geo_transform between two projections.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o lifecycle_test lifecycle_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <meos.h>
+#include <meos_geo.h>
+
+/* A point in WGS 84, transformed to Web Mercator so that the cycle stores a
+ * projection in the PROJ SRS cache the finalize chain then releases. */
+#define POINT_WKT "SRID=4326;POINT(4.35 50.85)"
+#define SRID_TO 3857
+
+/**
+ * @brief Fill the caches that the finalize chain releases
+ */
+static void
+populate_caches(void)
+{
+  GSERIALIZED *geom = geom_in(POINT_WKT, -1);
+  assert(geom);
+  GSERIALIZED *proj = geo_transform(geom, SRID_TO);
+  assert(proj);
+  assert(geo_srid(proj) == SRID_TO);
+  free(proj);
+  free(geom);
+}
+
+int
+main(void)
+{
+  /* A cycle that releases populated caches, then a second finalize: the
+   * chain runs on slots it has already nulled. */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  populate_caches();
+  meos_finalize();
+  meos_finalize();
+
+  /* A second cycle on the same thread: initialize finds every slot free. */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  populate_caches();
+  meos_finalize();
+
+  /* The per-cache entry points carry the same contract on their own. */
+  meos_initialize();
+  meos_finalize_collation();
+  meos_finalize_collation();
+  meos_finalize_timezone();
+  meos_finalize_timezone();
+  meos_finalize_projsrs();
+  meos_finalize_projsrs();
+  meos_finalize();
+
+  printf("lifecycle_test: OK\n");
+  return EXIT_SUCCESS;
+}

--- a/pgtypes/utils/pg_locale.c
+++ b/pgtypes/utils/pg_locale.c
@@ -1339,10 +1339,14 @@ void
 meos_finalize_collation(void)
 {
   // collation_cache_my_destroy(CollationCache);
+  /* Idempotency: null the slot after freeing it so a second finalize call
+   * does not double-free, and so meos_initialize_collation finds the slot
+   * free, as its assertion requires. */
   if (default_locale != NULL)
   {
     pfree((void *) default_locale->info.builtin.locale);
     pfree(default_locale);
+    default_locale = NULL;
   }
 }
 


### PR DESCRIPTION
Null every slot the MEOS finalize chain releases. meos_finalize_projsrs and meos_finalize_collation null the slot they release, as meos_finalize_timezone and meos_finalize_ways do, so the whole meos_finalize chain is idempotent and a cycle can start again on the same thread. meos_finalize_projsrs releases only a live cache, so a second call neither walks the freed entry array nor frees the cache twice, and meos_finalize_collation leaves the slot free for the assertion meos_initialize_collation opens with. meos/test/lifecycle_test holds the contract: it populates the collation, timezone and PROJ SRS caches, runs the chain twice, opens a second cycle on the same thread, and calls each per-cache entry point twice; the MEOS workflow builds and runs it beside allocator_test. A host that drives the lifecycle per unit of work depends on both properties: lifecycle_test segmentation-faults against a build without this change and prints OK with it.