### PR TITLE
Build every family on every PostgreSQL version the matrix names

### DIFF
--- a/.github/workflows/pgversion.yml
+++ b/.github/workflows/pgversion.yml
@@ -41,7 +41,11 @@ jobs:
     strategy:
         fail-fast: false
         matrix:
-          psql: [16, 17, 18, 19]
+          # PostgreSQL 19 leaves the matrix until apt.postgresql.org carries
+          # postgresql-19-h3 and postgresql-19-pointcloud. A job that built the
+          # families those packages carry and left the rest out would report that
+          # MobilityDB builds on 19 while building a smaller MobilityDB.
+          psql: [16, 17, 18]
           postgis: [3]
           os: ["ubuntu-24.04"]
           coverage: [0]
@@ -91,23 +95,20 @@ jobs:
           ls /usr/lib/postgresql/${{ matrix.psql }}/lib/
           xzcat --version
 
-      - name: Install coverall dependencies
-        if: matrix.coverage == '1'
+      - name: Install the family and coverage dependencies
         run: |
-          # postgresql-N-pointcloud so the coverage build can compile
-          # -DPOINTCLOUD=ON; without it, meos/src/pointcloud/* (the
-          # consumer of pgPointCloud's libpc.a) plus the cross-cutting
-          # #if POINTCLOUD blocks in temporal/* are stripped at preprocess
-          # time and never get instrumented. The runtime regression tests
-          # also need the 'pointcloud' PG extension available (CREATE
-          # EXTENSION pointcloud, pulled in before mobilitydb), provided by
-          # postgresql-${VER}-pointcloud for the supported PG versions.
+          # What ALL requires, on every job rather than the coverage one alone:
+          # a family left out is stripped at preprocess time, so the build
+          # reports on a smaller MobilityDB than the one it names. The runtime
+          # regression tests also need the 'pointcloud' and 'h3' PG extensions
+          # available (CREATE EXTENSION, pulled in before mobilitydb), provided
+          # by postgresql-${VER}-pointcloud and postgresql-${VER}-h3. lcov is
+          # what only the coverage job reads, and costs nothing elsewhere.
           sudo apt-get -y install lcov libh3-dev \
             postgresql-${{ matrix.psql }}-pointcloud \
             postgresql-${{ matrix.psql }}-h3
 
       - name: Locate libh3 on disk and pin its paths
-        if: matrix.coverage == '1'
         # The pgdg libh3-dev package layout differs between releases. Find the
         # header and library at runtime and pin -DH3_INCLUDE_DIR / -DH3_LIBRARY
         # explicitly so CMake's find_path / find_library defaults cannot miss it.
@@ -124,7 +125,6 @@ jobs:
           echo "H3_LIBRARY=$H3_LIB" >> $GITHUB_ENV
 
       - name: Install pgPointCloud build dependencies
-        if: matrix.coverage == '1'
         # meos/src/pointcloud/CMakeLists.txt builds the vendored pgPointCloud
         # static libpc.a as a by-product of the CMake build; it needs the
         # autotools plus libxml2/zlib development files.
@@ -155,7 +155,9 @@ jobs:
           # the matrix, which it does for 16 to 18 but not yet for 19, and
           # MobilityDB requires those extensions when their family is on.
           cmake -DCMAKE_BUILD_TYPE=Release -DWITH_COVERAGE=${{ matrix.coverage }} \
-            ${{ matrix.coverage == '1' && format('-DALL=ON -DCASSERT=ON -DH3_INCLUDE_DIR={0} -DH3_LIBRARY={1}', env.H3_INCLUDE_DIR, env.H3_LIBRARY) || '-DCBUFFER=ON -DNPOINT=ON -DPOSE=ON -DRGEO=ON -DQUADBIN=ON' }} \
+            -DALL=ON -DH3_INCLUDE_DIR=${{ env.H3_INCLUDE_DIR }} \
+            -DH3_LIBRARY=${{ env.H3_LIBRARY }} \
+            ${{ matrix.coverage == '1' && '-DCASSERT=ON' || '' }} \
             ..
 
       - name: Build


### PR DESCRIPTION
The family and pgPointCloud dependencies were installed for the coverage
job alone, so the version builds took five families and reported on a
smaller MobilityDB than the one they name. Every job installs them and
says -DALL=ON. PostgreSQL 19 leaves the matrix until apt.postgresql.org
carries postgresql-19-h3 and postgresql-19-pointcloud, which is what the
matrix can honestly claim to cover.

