### PR TITLE
Tag the box accessor the SQL function reaches, and see the ones it does not

### DIFF
--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -915,7 +915,6 @@ tbox_xmin(const TBox *box, double *result)
  * @param[in] box Box
  * @param[out] result Result
  * @return On error return false, otherwise return true
- * @csqlfn #Tbox_xmin()
  */
 bool
 tboxint_xmin(const TBox *box, int *result)
@@ -935,7 +934,6 @@ tboxint_xmin(const TBox *box, int *result)
  * @param[in] box Box
  * @param[out] result Result
  * @return On error return false, otherwise return true
- * @csqlfn #Tbox_xmin()
  */
 bool
 tboxbigint_xmin(const TBox *box, int64 *result)
@@ -955,7 +953,6 @@ tboxbigint_xmin(const TBox *box, int64 *result)
  * @param[in] box Box
  * @param[out] result Result
  * @return On error return false, otherwise return true
- * @csqlfn #Tbox_xmin()
  */
 bool
 tboxfloat_xmin(const TBox *box, double *result)
@@ -1022,7 +1019,6 @@ tbox_xmax(const TBox *box, double *result)
  * @param[in] box Box
  * @param[out] result Result
  * @return On error return false, otherwise return true
- * @csqlfn #Tbox_xmax()
  */
 bool
 tboxint_xmax(const TBox *box, int *result)
@@ -1042,7 +1038,6 @@ tboxint_xmax(const TBox *box, int *result)
  * @param[in] box Box
  * @param[out] result Result
  * @return On error return false, otherwise return true
- * @csqlfn #Tbox_xmax()
  */
 bool
 tboxbigint_xmax(const TBox *box, int64 *result)
@@ -1062,7 +1057,6 @@ tboxbigint_xmax(const TBox *box, int64 *result)
  * @param[in] box Box
  * @param[out] result Result
  * @return On error return false, otherwise return true
- * @csqlfn #Tbox_xmax()
  */
 bool
 tboxfloat_xmax(const TBox *box, double *result)

--- a/tools/scripts/check_csqlfn.py
+++ b/tools/scripts/check_csqlfn.py
@@ -20,6 +20,7 @@
 #
 # Exit status is non-zero when --gaps finds an auto-resolvable gap (CI guard).
 
+import collections
 import glob
 import os
 import re
@@ -319,6 +320,35 @@ def incomplete(dirs):
     return commuted, mistagged, dispatch, bare
 
 
+# A wrapper is bound by one CREATE FUNCTION per SQL overload, and each overload
+# is answered by at most one MEOS function, so a wrapper carrying MORE @csqlfn
+# tags than it has SQL declarations has tags naming no callable surface. That is
+# not cosmetic: a binding generating from the catalog registers one function per
+# tag, and DuckDB, which cannot overload on return type, answers
+# `Could not choose a best candidate function for the function call "Xmax(tbox)"`
+# once the int and bigint accessors register beside the float one -- a function
+# that works today becomes uncallable, and the surface diff reports it as a
+# clean addition.
+#
+# The invariant only names CANDIDATES. A wrapper that dispatches on subtype
+# reaches several MEOS functions through one declaration legitimately, so each
+# row is read before its tag is touched, exactly as the gap side is.
+def overtagged():
+    """Return (rows, excess): wrappers carrying more @csqlfn tags than SQL declarations."""
+    tags = collections.Counter()
+    for path in glob.glob(f'{ROOT}/meos/src/**/*.c', recursive=True):
+        for m in re.finditer(r'@csqlfn\s+([^\n*]*)', read_text(path)):
+            for w in re.findall(r'#(\w+)\(\)', m.group(1)):
+                tags[w] += 1
+    decl = collections.Counter()
+    for path in glob.glob(f'{ROOT}/mobilitydb/sql/**/*.in.sql', recursive=True):
+        for w in re.findall(r"MODULE_PATHNAME'\s*,\s*'(\w+)'", read_text(path)):
+            decl[w] += 1
+    rows = [(w, t, decl.get(w, 0)) for w, t in tags.items() if t > decl.get(w, 0)]
+    rows.sort(key=lambda r: (-(r[1] - r[2]), r[0]))
+    return rows, sum(t - d for _, t, d in rows)
+
+
 def main():
     """Dispatch on the mode argument and report the @csqlfn coverage."""
     mode = sys.argv[1] if len(sys.argv) > 1 else '--gaps'
@@ -342,6 +372,13 @@ def main():
         print(f'\n{bare} bare "AS \'MODULE_PATHNAME\'" bindings carry no wrapper '
               f'symbol and are outside this check')
         sys.exit(1 if commuted else 0)
+    elif mode == '--overtagged':
+        rows, excess = overtagged()
+        print(f'wrappers carrying more @csqlfn tags than SQL declarations: '
+              f'{len(rows)} ({excess} excess tags)')
+        for w, t, d in rows:
+            print(f'  {w:38s} tags={t:<3} declarations={d}')
+        sys.exit(0)
     elif mode == '--fix':
         n = 0
         for fn, pg, f, _how in auto:


### PR DESCRIPTION
Tbox_xmax reads tbox_xmax and returns a float, and xMax(tbox) is the one
SQL declaration binding it, so the tags on tboxint_xmax, tboxbigint_xmax
and tboxfloat_xmax name a call that wrapper does not make; xMin carries
the same four-way shape. A binding generating from the catalog registers
one function per tag, and a host that cannot overload on return type then
answers "Could not choose a best candidate function" for a call that
works today.

A wrapper is bound by one CREATE FUNCTION per SQL overload and each
overload is answered by at most one MEOS function, so carrying more tags
than declarations names a surface no caller can reach. The checker
reports that count, which it could not see before: it looked only for
tags that are missing. The rows it names are candidates whose wrapper is
read before a tag is touched, so it reports and exits zero.

