### PR TITLE
Refuse a big integer box bound that no double represents exactly

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -388,7 +388,7 @@ SELECT zMin(stbox 'STBOX Z((1.0,2.0,3.0),(4.0,5.0,6.0))');
 SELECT tMin(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 -- 2001-01-01
 </programlisting>
-				<para>Notice that for <varname>tbox</varname> the result value for <varname>xMin</varname> and <varname>xMin</varname> is converted to a <varname>float</varname> for the temporal boxes with an integer span.</para>
+				<para>Notice that for <varname>tbox</varname> the result value for <varname>xMin</varname> and <varname>xMax</varname> is converted to a <varname>float</varname> for the temporal boxes with an integer span. A big integer bound that no <varname>float</varname> represents exactly is refused rather than rounded; read such a bound from <varname>bigintspan(box)</varname>.</para>
 			</listitem>
 
 			<listitem xml:id="box_xMax">
@@ -413,7 +413,7 @@ SELECT zMax(stbox 'STBOX Z((1.0,2.0,3.0),(4.0,5.0,6.0))');
 SELECT tMax(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 -- 2001-01-03
 </programlisting>
-				<para>Notice that for <varname>tbox</varname> the result value for <varname>xMin</varname> and <varname>xMin</varname> is converted to a <varname>float</varname> for the temporal boxes with an integer span.</para>
+				<para>Notice that for <varname>tbox</varname> the result value for <varname>xMin</varname> and <varname>xMax</varname> is converted to a <varname>float</varname> for the temporal boxes with an integer span. A big integer bound that no <varname>float</varname> represents exactly is refused rather than rounded; read such a bound from <varname>bigintspan(box)</varname>.</para>
 			</listitem>
 
 			<listitem xml:id="tbox_xMinInc">

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -388,6 +388,7 @@ SELECT zMin(stbox 'STBOX Z((1.0,2.0,3.0),(4.0,5.0,6.0))');
 SELECT tMin(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 -- 2001-01-01
 </programlisting>
+				<para>Observe que para <varname>tbox</varname> el valor resultante de <varname>xMin</varname> y <varname>xMax</varname> se convierte a <varname>float</varname> para las cajas temporales con un span de enteros. Un límite de entero grande que ningún <varname>float</varname> representa exactamente se rechaza en lugar de redondearse; lea ese límite de <varname>bigintspan(box)</varname>.</para>
 			</listitem>
 
 			<listitem xml:id="box_xMax">
@@ -412,6 +413,7 @@ SELECT zMax(stbox 'STBOX Z((1.0,2.0,3.0),(4.0,5.0,6.0))');
 SELECT tMax(stbox 'GEODSTBOX T([2001-01-01,2001-01-03))');
 -- 2001-01-03
 </programlisting>
+				<para>Observe que para <varname>tbox</varname> el valor resultante de <varname>xMin</varname> y <varname>xMax</varname> se convierte a <varname>float</varname> para las cajas temporales con un span de enteros. Un límite de entero grande que ningún <varname>float</varname> representa exactamente se rechaza en lugar de redondearse; lea ese límite de <varname>bigintspan(box)</varname>.</para>
 			</listitem>
 
 			<listitem xml:id="tbox_xMinInc">

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -890,6 +890,32 @@ tbox_hast(const TBox *box)
 }
 
 /**
+ * @brief Return in the last argument a big integer bound of a temporal box as
+ * a double
+ * @details A double holds every 32-bit integer and every float bound exactly,
+ * but only the big integers up to 2^53. Narrowing a larger one answers a
+ * neighbouring value, so it is refused and the exact bound is read from the
+ * value span of the box instead.
+ * @param[in] i Bound
+ * @param[out] result Result
+ * @return On error return false, otherwise return true
+ */
+static bool
+tbox_bigint_bound_double(int64 i, double *result)
+{
+  double d = (double) i;
+  if ((int64) d != i)
+  {
+    meos_error(ERROR, MEOS_ERR_VALUE_OUT_OF_RANGE,
+      "The big integer bound of the box is not representable as a double. "
+      "Received: " INT64_FORMAT ". Read it from bigintspan(box) instead", i);
+    return false;
+  }
+  *result = d;
+  return true;
+}
+
+/**
  * @ingroup meos_box_accessor
  * @brief Return in the last argument the minimum X value of a temporal box as
  * a double
@@ -905,6 +931,8 @@ tbox_xmin(const TBox *box, double *result)
   VALIDATE_NOT_NULL(box, false); VALIDATE_NOT_NULL(result, false);
   if (! MEOS_FLAGS_GET_X(box->flags))
     return false;
+  if (box->span.basetype == T_INT8)
+    return tbox_bigint_bound_double(DatumGetInt64(box->span.lower), result);
   *result = datum_double(box->span.lower, box->span.basetype);
   return true;
 }
@@ -1007,7 +1035,7 @@ tbox_xmax(const TBox *box, double *result)
     *result = (double) (DatumGetInt32(box->span.upper) - 1);
   else if (box->span.basetype == T_INT8)
     /* Integer spans are canonicalized, i.e., the upper bound is exclusive */
-    *result = (double) (DatumGetInt64(box->span.upper) - 1);
+    return tbox_bigint_bound_double(DatumGetInt64(box->span.upper) - 1, result);
   else
     *result = DatumGetFloat8(box->span.upper);
   return true;

--- a/mobilitydb/test/temporal/expected/021_tbox.test.out
+++ b/mobilitydb/test/temporal/expected/021_tbox.test.out
@@ -587,6 +587,22 @@ SELECT Xmax(tbox 'TBOXBIGINT XT([1,2],[2001-01-01,2001-01-02])');
     2
 (1 row)
 
+SELECT Xmin(tbox 'TBOXBIGINT XT([9007199254740993,9007199254740995],[2001-01-01,2001-01-02])');
+ERROR:  The big integer bound of the box is not representable as a double. Received: 9007199254740993. Read it from bigintspan(box) instead
+SELECT Xmax(tbox 'TBOXBIGINT XT([9007199254740993,9007199254740995],[2001-01-01,2001-01-02])');
+ERROR:  The big integer bound of the box is not representable as a double. Received: 9007199254740995. Read it from bigintspan(box) instead
+SELECT lower(bigintspan(tbox 'TBOXBIGINT XT([9007199254740993,9007199254740995],[2001-01-01,2001-01-02])'));
+      lower       
+------------------
+ 9007199254740993
+(1 row)
+
+SELECT upper(bigintspan(tbox 'TBOXBIGINT XT([9007199254740993,9007199254740995],[2001-01-01,2001-01-02])'));
+      upper       
+------------------
+ 9007199254740996
+(1 row)
+
 SELECT Tmin(tbox 'TBOXBIGINT XT([1,2],[2001-01-01,2001-01-02])');
              tmin             
 ------------------------------

--- a/mobilitydb/test/temporal/queries/021_tbox.test.sql
+++ b/mobilitydb/test/temporal/queries/021_tbox.test.sql
@@ -186,6 +186,12 @@ SELECT Tmax(tbox 'TBOX T([2001-01-01,2001-01-02])');
 
 SELECT Xmin(tbox 'TBOXBIGINT XT([1,2],[2001-01-01,2001-01-02])');
 SELECT Xmax(tbox 'TBOXBIGINT XT([1,2],[2001-01-01,2001-01-02])');
+-- A big integer bound above 2^53 has no exact float, so the double accessor
+-- refuses it rather than answering a neighbouring value; bigintspan reads it
+SELECT Xmin(tbox 'TBOXBIGINT XT([9007199254740993,9007199254740995],[2001-01-01,2001-01-02])');
+SELECT Xmax(tbox 'TBOXBIGINT XT([9007199254740993,9007199254740995],[2001-01-01,2001-01-02])');
+SELECT lower(bigintspan(tbox 'TBOXBIGINT XT([9007199254740993,9007199254740995],[2001-01-01,2001-01-02])'));
+SELECT upper(bigintspan(tbox 'TBOXBIGINT XT([9007199254740993,9007199254740995],[2001-01-01,2001-01-02])'));
 SELECT Tmin(tbox 'TBOXBIGINT XT([1,2],[2001-01-01,2001-01-02])');
 SELECT Tmax(tbox 'TBOXBIGINT XT([1,2],[2001-01-01,2001-01-02])');
 


### PR DESCRIPTION
The X bound accessors of a temporal box answer a double, which holds every 32-bit integer and every
float bound exactly but only the big integers up to 2^53. A larger bound is refused, naming the value
and the bigintspan of the box that the exact bound is read from, so a box whose value span carries a
big integer beyond that point reports the limit instead of a neighbouring value: `xMax` of
`TBOXBIGINT XT([1, 9007199254740993],[2000-01-01,2000-01-02])` answers 9007199254740992 without the
refusal, while `upper(bigintspan(...))` answers 9007199254740996 exactly. The int and float spans are
untouched, every 32-bit bound being exactly representable. The manual states the refusal in both
languages, in the sentence describing the conversion, which names xMax beside xMin, and 021_tbox
covers the refused bounds together with the exact route.
