### PR TITLE
Compile the raster and point cloud families on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,6 +402,14 @@ endif()
 # Added to build on Windows to avoid the error 'M_PI': undeclared identifier
 add_compile_definitions(_USE_MATH_DEFINES)
 
+# The Windows GDI header defines PC_NONE as a palette constant, which is also
+# the first enumerator of the pgPointCloud compression enum, so a translation
+# unit reading both parses "0 = 0," in place of the enumerator. NOGDI keeps the
+# drawing interface out of windows.h, which no target here draws through.
+if(WIN32)
+  add_compile_definitions(NOGDI)
+endif()
+
 # Set default compile flags and code coverage for GCC
 if(CMAKE_COMPILER_IS_GNUCC)
   # MobilityDB compiler flags valid for both C and C++

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -38,6 +38,19 @@
  * demand.
  */
 
+/* librtcore.h reads GDAL, which reads <sys/stat.h> under its own name, while
+ * PostgreSQL's win32_port.h renames stat away and states the condition itself:
+ * "We must pull in sys/stat.h before this part, else our overrides lose". The
+ * header is therefore read RENAMED here first, which is PostgreSQL's own
+ * prologue (pgtypes/port/win32_port.h), so its struct stat is the only one. */
+#ifdef _WIN32
+#define fstat microsoft_native_fstat
+#define stat microsoft_native_stat
+#include <sys/stat.h>
+#undef fstat
+#undef stat
+#endif
+
 #include "librtcore.h"
 
 /* C */


### PR DESCRIPTION
librtcore.h reads GDAL, which reads `<sys/stat.h>` under its own name, so on Windows the struct stat
it defines stands where PostgreSQL's win32_port.h expects its own, and that header states the
condition itself: sys/stat.h is pulled in before its overrides or the overrides lose. raster_rtcore.c
reads the header renamed ahead of librtcore.h, which is PostgreSQL's own prologue. The Windows GDI
header separately defines PC_NONE as a palette constant while pgPointCloud names its first
compression enumerator the same, so a translation unit reading both parses an integer where an
identifier belongs; the build defines NOGDI on Windows, leaving the drawing interface out of
windows.h for every target, none of which draws through it. With both, a `-DALL=ON` MEOS build under
MSYS2 UCRT64 runs 409 of 409 steps with no failed target and links `libmeos.dll`, carrying the point
cloud, raster, pose, rigid geometry and H3 families that the platform otherwise turns away.
