### PR TITLE
State the circular buffer and pose distance to a spatiotemporal box as the nearest approach

### DIFF
--- a/doc/es/introduction.xml
+++ b/doc/es/introduction.xml
@@ -502,4 +502,14 @@ SET client_min_messages TO notice;
 			Además, la API de MobilityDB y de MEOS se amplió con nuevas funcionalidades y se simplificó para mejorar su usabilidad. Por último, la versión 1.3 también habilita las últimas versiones PostgreSQL 18 y PostGIS 3.6.0. Por todas estas razones, el formato binario de los tipos temporales cambió de la versión 1.2 a la 1.3 y, por lo tanto, es necesario hacer una copia de seguridad y restaurarla para migrar a la nueva versión 1.3 de MobilityDB.
 		</para>
 	</sect1>
+
+	<sect1 xml:id="migrating_1.4">
+		<title>Migración de la versión 1.3 a la versión 1.4</title>
+		<para>
+			Todo tipo que define la distancia de aproximación más cercana con respecto a una caja espaciotemporal la expresa en la versión 1.4 mediante la función <varname>nearestApproachDistance</varname> y el operador <varname>|=|</varname>. En la versión 1.3 los tipos <varname>cbuffer</varname> y <varname>pose</varname> la expresaban mediante la función <varname>distance</varname> y el operador <varname>&lt;-&gt;</varname>, mientras que <varname>geometry</varname> y <varname>geography</varname> ya usaban la primera. Las signaturas afectadas son <varname>(cbuffer, stbox)</varname>, <varname>(stbox, cbuffer)</varname>, <varname>(pose, stbox)</varname> y <varname>(stbox, pose)</varname>.
+		</para>
+		<para>
+			Las dos funciones responden preguntas distintas, que es lo que expresa el cambio. Una caja espaciotemporal lleva un período, de modo que <varname>nearestApproachDistance</varname> responde la distancia mínima durante el tiempo que comparten sus dos argumentos, y responde el valor nulo cuando no comparten ninguno. La función <varname>distance</varname> mide sus dos argumentos como conjuntos de puntos y no lee ningún período. Las signaturas de <varname>distance</varname> cuyos argumentos no llevan período conservan el nombre.
+		</para>
+	</sect1>
 </chapter>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1383,6 +1383,9 @@
 					<listitem>
 						<para><link linkend="pose_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Devuelve la distancia</para>
 					</listitem>
+					<listitem>
+						<para><link linkend="pose_nearestApproachDistance"><varname>nearestApproachDistance</varname>, <varname>|=|</varname></link>: Devuelve la distancia de aproximación más cercana</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 			<sect3>
@@ -2086,6 +2089,9 @@
 				<itemizedlist>
 					<listitem>
 						<para><link linkend="cbuffer_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Devuelve la distancia</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="cbuffer_nearestApproachDistance"><varname>nearestApproachDistance</varname>, <varname>|=|</varname></link>: Devuelve la distancia de aproximación más cercana</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -297,9 +297,9 @@ SELECT asEWKT(transformPipeline(transformPipeline(cbuffer, pipeline, 4326), pipe
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Devuelve la distancia</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-distance({geo,stbox,cbuffer},cbuffer) → float
-distance(cbuffer,{geo,stbox,cbuffer}) → float
-{geo,stbox,cbuffer} &lt;-&gt; cbuffer → float
+distance({geo,cbuffer},cbuffer) → float
+distance(cbuffer,{geo,cbuffer}) → float
+{geo,cbuffer} &lt;-&gt; cbuffer → float
 </programlisting>
 					<para>La distancia entre dos búferes circulares es la distancia entre sus puntos reducida por ambos radios, y es cero cuando los búferes se superponen. El resultado es <varname>NULL</varname> cuando la geometría está vacía.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -309,6 +309,22 @@ SELECT round(cbuffer 'Cbuffer(Point(0 0),0.5)' &lt;-&gt; cbuffer 'Cbuffer(Point(
 -- 4
 SELECT round(cbuffer 'Cbuffer(Point(0 0),3)' &lt;-&gt; cbuffer 'Cbuffer(Point(3 4),3)', 6);
 -- 0
+</programlisting>
+				</listitem>
+				<listitem xml:id="cbuffer_nearestApproachDistance">
+					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
+					<para>Devuelve la distancia de aproximación más cercana</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+nearestApproachDistance({stbox,cbuffer},{cbuffer,stbox}) → float
+{stbox,cbuffer} |=| {cbuffer,stbox} → float
+</programlisting>
+					<para>El valor es la menor distancia sobre el tiempo que comparten los dos argumentos, y es <varname>NULL</varname> cuando no comparten ninguno. Un búfer circular no lleva período, por lo que está presente en todo tiempo que abarca la caja.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+-- 0.5
+SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' |=| stbox 'STBOX X((1,-1),(3,1))', 6);
+-- 0.5
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/es/temporal_pose_types.xml
+++ b/doc/es/temporal_pose_types.xml
@@ -414,16 +414,14 @@ SELECT asEWKT(transformPipeline(transformPipeline(pose, pipeline, 4326), pipelin
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Devuelve la distancia</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-distance({geo,stbox,pose},pose) → float
-distance(pose,{geo,stbox,pose}) → float
-{geo,stbox,pose} &lt;-&gt; pose → float
+distance({geo,pose},pose) → float
+distance(pose,{geo,pose}) → float
+{geo,pose} &lt;-&gt; pose → float
 </programlisting>
 					<para>Solo se tiene en cuenta el componente de punto de la pose, la orientación se ignora. La distancia se calcula en dos dimensiones, incluso cuando los argumentos son tridimensionales. El resultado es <varname>NULL</varname> cuando la geometría está vacía.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
 -- 3
-SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
--- 1
 SELECT round(pose 'Pose(Point(0 0),0)' &lt;-&gt; pose 'Pose(Point(3 4),0)', 6);
 -- 5
 SELECT round(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)' &lt;-&gt;
@@ -431,6 +429,22 @@ SELECT round(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)' &lt;-&gt;
 -- 5
 SELECT round(geometry 'Point empty' &lt;-&gt; pose 'Pose(Point(4 0),0)', 6);
 -- NULL
+</programlisting>
+				</listitem>
+				<listitem xml:id="pose_nearestApproachDistance">
+					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
+					<para>Devuelve la distancia de aproximación más cercana</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+nearestApproachDistance({stbox,pose},{pose,stbox}) → float
+{stbox,pose} |=| {pose,stbox} → float
+</programlisting>
+					<para>El valor es la menor distancia sobre el tiempo que comparten los dos argumentos, y es <varname>NULL</varname> cuando no comparten ninguno. Una pose no lleva período, por lo que está presente en todo tiempo que abarca la caja. Solo se tiene en cuenta el componente de punto de la pose, la orientación se ignora.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
+-- 1
+SELECT round(pose 'Pose(Point(4 0),0)' |=| stbox 'STBOX X((1,-1),(3,1))', 6);
+-- 1
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/introduction.xml
+++ b/doc/introduction.xml
@@ -503,5 +503,15 @@ SET client_min_messages TO notice;
 			In addition, the API of MobilityDB and MEOS was extended with new functionality and streamlined to improve usability. Finally, version 1.3 also enables the latest versions PostgreSQL 18 and PostGIS 3.6.0. For all these reasons, the binary format of the temporal types have changed from version 1.2 to 1.3 and thus a backup and restore is needed for migrating to the newer version 1.3 of MobilityDB.
 		</para>
 	</sect1>
+
+	<sect1 xml:id="migrating_1.4">
+		<title>Migrating from Version 1.3 to Version 1.4</title>
+		<para>
+			Every type that defines the nearest approach distance against a spatiotemporal box states it in version 1.4 by the function <varname>nearestApproachDistance</varname> and the operator <varname>|=|</varname>. In version 1.3 the types <varname>cbuffer</varname> and <varname>pose</varname> stated it instead by the function <varname>distance</varname> and the operator <varname>&lt;-&gt;</varname>, where <varname>geometry</varname> and <varname>geography</varname> already used the former. The signatures concerned are <varname>(cbuffer, stbox)</varname>, <varname>(stbox, cbuffer)</varname>, <varname>(pose, stbox)</varname>, and <varname>(stbox, pose)</varname>.
+		</para>
+		<para>
+			The two functions answer different questions, which is what the change states. A spatiotemporal box carries a period, so <varname>nearestApproachDistance</varname> answers the least distance over the time that its two arguments share, and answers the null value when they share none. The function <varname>distance</varname> measures its two arguments as sets of points and reads no period. The signatures of <varname>distance</varname> whose arguments carry no period keep the name.
+		</para>
+	</sect1>
 </chapter>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1383,6 +1383,9 @@
 					<listitem>
 						<para><link linkend="pose_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Return the distance</para>
 					</listitem>
+					<listitem>
+						<para><link linkend="pose_nearestApproachDistance"><varname>nearestApproachDistance</varname>, <varname>|=|</varname></link>: Return the nearest approach distance</para>
+					</listitem>
 				</itemizedlist>
 			</sect3>
 			<sect3>
@@ -2092,6 +2095,9 @@
 				<itemizedlist>
 					<listitem>
 						<para><link linkend="cbuffer_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Return the distance</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="cbuffer_nearestApproachDistance"><varname>nearestApproachDistance</varname>, <varname>|=|</varname></link>: Return the nearest approach distance</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -297,9 +297,9 @@ SELECT asEWKT(transformPipeline(transformPipeline(cbuffer, pipeline, 4326), pipe
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Return the distance</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-distance({geo,stbox,cbuffer},cbuffer) → float
-distance(cbuffer,{geo,stbox,cbuffer}) → float
-{geo,stbox,cbuffer} &lt;-&gt; cbuffer → float
+distance({geo,cbuffer},cbuffer) → float
+distance(cbuffer,{geo,cbuffer}) → float
+{geo,cbuffer} &lt;-&gt; cbuffer → float
 </programlisting>
 					<para>The distance between two circular buffers is the distance between their points reduced by both radii, and is zero when the buffers overlap. The result is <varname>NULL</varname> when the geometry is empty.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
@@ -309,6 +309,22 @@ SELECT round(cbuffer 'Cbuffer(Point(0 0),0.5)' &lt;-&gt; cbuffer 'Cbuffer(Point(
 -- 4
 SELECT round(cbuffer 'Cbuffer(Point(0 0),3)' &lt;-&gt; cbuffer 'Cbuffer(Point(3 4),3)', 6);
 -- 0
+</programlisting>
+				</listitem>
+				<listitem xml:id="cbuffer_nearestApproachDistance">
+					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
+					<para>Return the nearest approach distance</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+nearestApproachDistance({stbox,cbuffer},{cbuffer,stbox}) → float
+{stbox,cbuffer} |=| {cbuffer,stbox} → float
+</programlisting>
+					<para>The value is the least distance over the time the two arguments share, and is <varname>NULL</varname> when they share none. A circular buffer carries no period, so it is present at every time the box spans.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+-- 0.5
+SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' |=| stbox 'STBOX X((1,-1),(3,1))', 6);
+-- 0.5
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/temporal_pose_types.xml
+++ b/doc/temporal_pose_types.xml
@@ -413,16 +413,14 @@ SELECT asEWKT(transformPipeline(transformPipeline(pose, pipeline, 4326), pipelin
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Return the distance</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-distance({geo,stbox,pose},pose) → float
-distance(pose,{geo,stbox,pose}) → float
-{geo,stbox,pose} &lt;-&gt; pose → float
+distance({geo,pose},pose) → float
+distance(pose,{geo,pose}) → float
+{geo,pose} &lt;-&gt; pose → float
 </programlisting>
 					<para>Only the point component of the pose is taken into account, the orientation is ignored. The distance is computed in two dimensions, even when the arguments are three-dimensional. The result is <varname>NULL</varname> when the geometry is empty.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
 -- 3
-SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
--- 1
 SELECT round(pose 'Pose(Point(0 0),0)' &lt;-&gt; pose 'Pose(Point(3 4),0)', 6);
 -- 5
 SELECT round(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)' &lt;-&gt;
@@ -430,6 +428,22 @@ SELECT round(pose 'Pose(Point(0 0 0), 1, 0, 0, 0)' &lt;-&gt;
 -- 5
 SELECT round(geometry 'Point empty' &lt;-&gt; pose 'Pose(Point(4 0),0)', 6);
 -- NULL
+</programlisting>
+				</listitem>
+				<listitem xml:id="pose_nearestApproachDistance">
+					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
+					<para>Return the nearest approach distance</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+nearestApproachDistance({stbox,pose},{pose,stbox}) → float
+{stbox,pose} |=| {pose,stbox} → float
+</programlisting>
+					<para>The value is the least distance over the time the two arguments share, and is <varname>NULL</varname> when they share none. A pose carries no period, so it is present at every time the box spans. Only the point component of the pose is taken into account, the orientation is ignored.</para>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
+-- 1
+SELECT round(pose 'Pose(Point(4 0),0)' |=| stbox 'STBOX X((1,-1),(3,1))', 6);
+-- 1
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -1026,7 +1026,6 @@ distance_cbuffer_geo(const Cbuffer *cb, const GSERIALIZED *gs)
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between a circular buffer and a spatiotemporal box
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_cbuffer_stbox() #Distance_stbox_cbuffer()
  */
 double
 distance_cbuffer_stbox(const Cbuffer *cb, const STBox *box)

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1657,7 +1657,7 @@ tcbufferseg_boundary_roots(const Cbuffer *cb1, const Cbuffer *cb2,
  * and a spatiotemporal box
  * @param[in] cb Circular buffer
  * @param[in] box Spatiotemporal box
- * @csqlfn #NAD_cbuffer_stbox()
+ * @csqlfn #NAD_cbuffer_stbox() #NAD_stbox_cbuffer()
  */
 double
 nad_cbuffer_stbox(const Cbuffer *cb, const STBox *box)

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -2258,7 +2258,7 @@ distance_pose_geo(const Pose *pose, const GSERIALIZED *gs)
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a spatiotemporal box
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_pose_stbox() #Distance_stbox_pose()
+ * @csqlfn #NAD_pose_stbox() #NAD_stbox_pose()
  */
 double
 distance_pose_stbox(const Pose *pose, const STBox *box)

--- a/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
+++ b/mobilitydb/sql/cbuffer/210_tcbuffer_distance.in.sql
@@ -41,17 +41,9 @@ CREATE FUNCTION distance(geometry, cbuffer)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_geo_cbuffer'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
-CREATE FUNCTION distance(stbox, cbuffer)
-  RETURNS float
-  AS 'MODULE_PATHNAME', 'Distance_stbox_cbuffer'
-  LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION distance(cbuffer, geometry)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_cbuffer_geo'
-  LANGUAGE C IMMUTABLE PARALLEL SAFE;
-CREATE FUNCTION distance(cbuffer, stbox)
-  RETURNS float
-  AS 'MODULE_PATHNAME', 'Distance_cbuffer_stbox'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 CREATE FUNCTION distance(cbuffer, cbuffer)
   RETURNS float
@@ -66,20 +58,8 @@ CREATE OPERATOR <-> (
 );
 CREATE OPERATOR <-> (
   PROCEDURE = distance,
-  LEFTARG = stbox,
-  RIGHTARG = cbuffer,
-  COMMUTATOR = <->
-);
-CREATE OPERATOR <-> (
-  PROCEDURE = distance,
   LEFTARG = cbuffer,
   RIGHTARG = geometry,
-  COMMUTATOR = <->
-);
-CREATE OPERATOR <-> (
-  PROCEDURE = distance,
-  LEFTARG = cbuffer,
-  RIGHTARG = stbox,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
@@ -172,6 +152,14 @@ CREATE FUNCTION nearestApproachInstant(tcbuffer, tcbuffer)
 
 /*****************************************************************************/
 
+CREATE FUNCTION nearestApproachDistance(cbuffer, stbox)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_cbuffer_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION nearestApproachDistance(stbox, cbuffer)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_stbox_cbuffer'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(geometry, tcbuffer)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_geo_tcbuffer'
@@ -201,6 +189,16 @@ CREATE FUNCTION nearestApproachDistance(tcbuffer, tcbuffer)
   AS 'MODULE_PATHNAME', 'NAD_tcbuffer_tcbuffer'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE OPERATOR |=| (
+  LEFTARG = cbuffer, RIGHTARG = stbox,
+  PROCEDURE = nearestApproachDistance,
+  COMMUTATOR = '|=|'
+);
+CREATE OPERATOR |=| (
+  LEFTARG = stbox, RIGHTARG = cbuffer,
+  PROCEDURE = nearestApproachDistance,
+  COMMUTATOR = '|=|'
+);
 CREATE OPERATOR |=| (
   LEFTARG = geometry, RIGHTARG = tcbuffer,
   PROCEDURE = nearestApproachDistance,

--- a/mobilitydb/sql/pose/110_tpose_distance.in.sql
+++ b/mobilitydb/sql/pose/110_tpose_distance.in.sql
@@ -40,17 +40,9 @@ CREATE FUNCTION distance(geometry, pose)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_geo_pose'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION distance(stbox, pose)
-  RETURNS float
-  AS 'MODULE_PATHNAME', 'Distance_stbox_pose'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION distance(pose, geometry)
   RETURNS float
   AS 'MODULE_PATHNAME', 'Distance_pose_geo'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION distance(pose, stbox)
-  RETURNS float
-  AS 'MODULE_PATHNAME', 'Distance_pose_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION distance(pose, pose)
   RETURNS float
@@ -65,20 +57,8 @@ CREATE OPERATOR <-> (
 );
 CREATE OPERATOR <-> (
   PROCEDURE = distance,
-  LEFTARG = stbox,
-  RIGHTARG = pose,
-  COMMUTATOR = <->
-);
-CREATE OPERATOR <-> (
-  PROCEDURE = distance,
   LEFTARG = pose,
   RIGHTARG = geometry,
-  COMMUTATOR = <->
-);
-CREATE OPERATOR <-> (
-  PROCEDURE = distance,
-  LEFTARG = pose,
-  RIGHTARG = stbox,
   COMMUTATOR = <->
 );
 CREATE OPERATOR <-> (
@@ -171,6 +151,14 @@ CREATE FUNCTION nearestApproachInstant(tpose, tpose)
 
 /*****************************************************************************/
 
+CREATE FUNCTION nearestApproachDistance(pose, stbox)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_pose_stbox'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION nearestApproachDistance(stbox, pose)
+  RETURNS float
+  AS 'MODULE_PATHNAME', 'NAD_stbox_pose'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION nearestApproachDistance(geometry, tpose)
   RETURNS float
   AS 'MODULE_PATHNAME', 'NAD_geo_tpose'
@@ -200,6 +188,16 @@ CREATE FUNCTION nearestApproachDistance(tpose, tpose)
   AS 'MODULE_PATHNAME', 'NAD_tpose_tpose'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE OPERATOR |=| (
+  LEFTARG = pose, RIGHTARG = stbox,
+  PROCEDURE = nearestApproachDistance,
+  COMMUTATOR = '|=|'
+);
+CREATE OPERATOR |=| (
+  LEFTARG = stbox, RIGHTARG = pose,
+  PROCEDURE = nearestApproachDistance,
+  COMMUTATOR = '|=|'
+);
 CREATE OPERATOR |=| (
   LEFTARG = geometry, RIGHTARG = tpose,
   PROCEDURE = nearestApproachDistance,

--- a/mobilitydb/src/cbuffer/tcbuffer_distance.c
+++ b/mobilitydb/src/cbuffer/tcbuffer_distance.c
@@ -89,46 +89,6 @@ Distance_geo_cbuffer(PG_FUNCTION_ARGS)
 
 /*****************************************************************************/
 
-PGDLLEXPORT Datum Distance_cbuffer_stbox(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Distance_cbuffer_stbox);
-/**
- * @ingroup mobilitydb_cbuffer_dist
- * @brief Return the temporal distance between a circular buffer and a
- * spatiotemporal box
- * @sqlfn distance()
- * @sqlop @p <->
- */
-Datum
-Distance_cbuffer_stbox(PG_FUNCTION_ARGS)
-{
-  Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
-  STBox *box = PG_GETARG_STBOX_P(1);
-  double result = distance_cbuffer_stbox(cb, box);
-  if (result == DBL_MAX)
-    PG_RETURN_NULL();
-  PG_RETURN_FLOAT8(result);
-}
-
-PGDLLEXPORT Datum Distance_stbox_cbuffer(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Distance_stbox_cbuffer);
-/**
- * @ingroup mobilitydb_cbuffer_dist
- * @brief Return the temporal distance between a circular buffer and a
- * spatiotemporal box
- * @sqlfn distance()
- * @sqlop @p <->
- */
-Datum
-Distance_stbox_cbuffer(PG_FUNCTION_ARGS)
-{
-  STBox *box = PG_GETARG_STBOX_P(0);
-  Cbuffer *cb = PG_GETARG_CBUFFER_P(1);
-  double result = distance_cbuffer_stbox(cb, box);
-  if (result == DBL_MAX)
-    PG_RETURN_NULL();
-  PG_RETURN_FLOAT8(result);
-}
-
 PGDLLEXPORT Datum Distance_cbuffer_cbuffer(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Distance_cbuffer_cbuffer);
 /**
@@ -377,16 +337,36 @@ PGDLLEXPORT Datum NAD_cbuffer_stbox(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(NAD_cbuffer_stbox);
 /**
  * @ingroup mobilitydb_cbuffer_dist
- * @brief Return the temporal distance between a circular buffer and a
+ * @brief Return the nearest approach distance between a circular buffer and a
  * spatiotemporal box
- * @sqlfn tDistance()
- * @sqlop @p <->
+ * @sqlfn nearestApproachDistance()
+ * @sqlop @p |=|
  */
 Datum
 NAD_cbuffer_stbox(PG_FUNCTION_ARGS)
 {
   Cbuffer *cb = PG_GETARG_CBUFFER_P(0);
   STBox *box = PG_GETARG_STBOX_P(1);
+  double result = nad_cbuffer_stbox(cb, box);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum NAD_stbox_cbuffer(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(NAD_stbox_cbuffer);
+/**
+ * @ingroup mobilitydb_cbuffer_dist
+ * @brief Return the nearest approach distance between a spatiotemporal box and
+ * a circular buffer
+ * @sqlfn nearestApproachDistance()
+ * @sqlop @p |=|
+ */
+Datum
+NAD_stbox_cbuffer(PG_FUNCTION_ARGS)
+{
+  STBox *box = PG_GETARG_STBOX_P(0);
+  Cbuffer *cb = PG_GETARG_CBUFFER_P(1);
   double result = nad_cbuffer_stbox(cb, box);
   if (result == DBL_MAX)
     PG_RETURN_NULL();

--- a/mobilitydb/src/pose/tpose_distance.c
+++ b/mobilitydb/src/pose/tpose_distance.c
@@ -89,44 +89,6 @@ Distance_geo_pose(PG_FUNCTION_ARGS)
 
 /*****************************************************************************/
 
-PGDLLEXPORT Datum Distance_pose_stbox(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Distance_pose_stbox);
-/**
- * @ingroup mobilitydb_pose_dist
- * @brief Return the distance between a pose and a spatiotemporal box
- * @sqlfn distance()
- * @sqlop @p <->
- */
-Datum
-Distance_pose_stbox(PG_FUNCTION_ARGS)
-{
-  Pose *pose = PG_GETARG_POSE_P(0);
-  STBox *box = PG_GETARG_STBOX_P(1);
-  double result = distance_pose_stbox(pose, box);
-  if (result == DBL_MAX)
-    PG_RETURN_NULL();
-  PG_RETURN_FLOAT8(result);
-}
-
-PGDLLEXPORT Datum Distance_stbox_pose(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Distance_stbox_pose);
-/**
- * @ingroup mobilitydb_pose_dist
- * @brief Return the distance between a spatiotemporal box and a pose
- * @sqlfn distance()
- * @sqlop @p <->
- */
-Datum
-Distance_stbox_pose(PG_FUNCTION_ARGS)
-{
-  STBox *box = PG_GETARG_STBOX_P(0);
-  Pose *pose = PG_GETARG_POSE_P(1);
-  double result = distance_pose_stbox(pose, box);
-  if (result == DBL_MAX)
-    PG_RETURN_NULL();
-  PG_RETURN_FLOAT8(result);
-}
-
 PGDLLEXPORT Datum Distance_pose_pose(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Distance_pose_pose);
 /**
@@ -360,6 +322,48 @@ NAI_tpose_tpose(PG_FUNCTION_ARGS)
 /*****************************************************************************
  * Nearest approach distance (NAD)
  *****************************************************************************/
+
+PGDLLEXPORT Datum NAD_pose_stbox(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(NAD_pose_stbox);
+/**
+ * @ingroup mobilitydb_pose_dist
+ * @brief Return the nearest approach distance between a pose and a
+ * spatiotemporal box
+ * @sqlfn nearestApproachDistance()
+ * @sqlop @p |=|
+ */
+Datum
+NAD_pose_stbox(PG_FUNCTION_ARGS)
+{
+  Pose *pose = PG_GETARG_POSE_P(0);
+  STBox *box = PG_GETARG_STBOX_P(1);
+  double result = distance_pose_stbox(pose, box);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum NAD_stbox_pose(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(NAD_stbox_pose);
+/**
+ * @ingroup mobilitydb_pose_dist
+ * @brief Return the nearest approach distance between a spatiotemporal box and
+ * a pose
+ * @sqlfn nearestApproachDistance()
+ * @sqlop @p |=|
+ */
+Datum
+NAD_stbox_pose(PG_FUNCTION_ARGS)
+{
+  STBox *box = PG_GETARG_STBOX_P(0);
+  Pose *pose = PG_GETARG_POSE_P(1);
+  double result = distance_pose_stbox(pose, box);
+  if (result == DBL_MAX)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+/*****************************************************************************/
 
 PGDLLEXPORT Datum NAD_geo_tpose(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(NAD_geo_tpose);

--- a/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
+++ b/mobilitydb/test/cbuffer/expected/210_tcbuffer_distance.test.out
@@ -4,7 +4,7 @@ SELECT round(distance(geometry 'Point(1 0)', cbuffer 'Cbuffer(Point(4 0),0.5)'),
    2.5
 (1 row)
 
-SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
  round 
 -------
    0.5
@@ -16,7 +16,19 @@ SELECT round(distance(cbuffer 'Cbuffer(Point(4 0),0.5)', geometry 'Point(1 0)'),
    2.5
 (1 row)
 
-SELECT round(distance(cbuffer 'Cbuffer(Point(4 0),0.5)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(nearestApproachDistance(cbuffer 'Cbuffer(Point(4 0),0.5)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+ round 
+-------
+   0.5
+(1 row)
+
+SELECT round(stbox 'STBOX X((1,-1),(3,1))' |=| cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
+ round 
+-------
+   0.5
+(1 row)
+
+SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' |=| stbox 'STBOX X((1,-1),(3,1))', 6);
  round 
 -------
    0.5
@@ -35,11 +47,10 @@ SELECT round(geometry 'Point(1 0)' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
 (1 row)
 
 SELECT round(stbox 'STBOX X((1,-1),(3,1))' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
- round 
--------
-   0.5
-(1 row)
-
+ERROR:  operator does not exist: stbox <-> cbuffer
+LINE 1: SELECT round(stbox 'STBOX X((1,-1),(3,1))' <-> cbuffer 'Cbuf...
+                                                   ^
+HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
 SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' <-> geometry 'Point(1 0)', 6);
  round 
 -------
@@ -47,11 +58,10 @@ SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' <-> geometry 'Point(1 0)', 6);
 (1 row)
 
 SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' <-> stbox 'STBOX X((1,-1),(3,1))', 6);
- round 
--------
-   0.5
-(1 row)
-
+ERROR:  operator does not exist: cbuffer <-> stbox
+LINE 1: SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' <-> stbox 'ST...
+                                                       ^
+HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
 SELECT round(cbuffer 'Cbuffer(Point(0 0),0.5)' <-> cbuffer 'Cbuffer(Point(3 4),0.5)', 6);
  round 
 -------

--- a/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
+++ b/mobilitydb/test/cbuffer/queries/210_tcbuffer_distance.test.sql
@@ -30,9 +30,11 @@
 -------------------------------------------------------------------------------
 
 SELECT round(distance(geometry 'Point(1 0)', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
-SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', cbuffer 'Cbuffer(Point(4 0),0.5)'), 6);
 SELECT round(distance(cbuffer 'Cbuffer(Point(4 0),0.5)', geometry 'Point(1 0)'), 6);
-SELECT round(distance(cbuffer 'Cbuffer(Point(4 0),0.5)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(nearestApproachDistance(cbuffer 'Cbuffer(Point(4 0),0.5)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(stbox 'STBOX X((1,-1),(3,1))' |=| cbuffer 'Cbuffer(Point(4 0),0.5)', 6);
+SELECT round(cbuffer 'Cbuffer(Point(4 0),0.5)' |=| stbox 'STBOX X((1,-1),(3,1))', 6);
 SELECT round(distance(cbuffer 'Cbuffer(Point(0 0),0.5)', cbuffer 'Cbuffer(Point(3 4),0.5)'), 6);
 
 SELECT round(geometry 'Point(1 0)' <-> cbuffer 'Cbuffer(Point(4 0),0.5)', 6);

--- a/mobilitydb/test/pose/expected/113_tpose_distance.test.out
+++ b/mobilitydb/test/pose/expected/113_tpose_distance.test.out
@@ -4,7 +4,7 @@ SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
      3
 (1 row)
 
-SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
  round 
 -------
      1
@@ -16,7 +16,19 @@ SELECT round(distance(pose 'Pose(Point(4 0),0)', geometry 'Point(1 0)'), 6);
      3
 (1 row)
 
-SELECT round(distance(pose 'Pose(Point(4 0),0)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(nearestApproachDistance(pose 'Pose(Point(4 0),0)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+ round 
+-------
+     1
+(1 row)
+
+SELECT round(stbox 'STBOX X((1,-1),(3,1))' |=| pose 'Pose(Point(4 0),0)', 6);
+ round 
+-------
+     1
+(1 row)
+
+SELECT round(pose 'Pose(Point(4 0),0)' |=| stbox 'STBOX X((1,-1),(3,1))', 6);
  round 
 -------
      1
@@ -35,11 +47,10 @@ SELECT round(geometry 'Point(1 0)' <-> pose 'Pose(Point(4 0),0)', 6);
 (1 row)
 
 SELECT round(stbox 'STBOX X((1,-1),(3,1))' <-> pose 'Pose(Point(4 0),0)', 6);
- round 
--------
-     1
-(1 row)
-
+ERROR:  operator does not exist: stbox <-> pose
+LINE 1: SELECT round(stbox 'STBOX X((1,-1),(3,1))' <-> pose 'Pose(Po...
+                                                   ^
+HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
 SELECT round(pose 'Pose(Point(4 0),0)' <-> geometry 'Point(1 0)', 6);
  round 
 -------
@@ -47,11 +58,10 @@ SELECT round(pose 'Pose(Point(4 0),0)' <-> geometry 'Point(1 0)', 6);
 (1 row)
 
 SELECT round(pose 'Pose(Point(4 0),0)' <-> stbox 'STBOX X((1,-1),(3,1))', 6);
- round 
--------
-     1
-(1 row)
-
+ERROR:  operator does not exist: pose <-> stbox
+LINE 1: SELECT round(pose 'Pose(Point(4 0),0)' <-> stbox 'STBOX X((1...
+                                               ^
+HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
 SELECT round(pose 'Pose(Point(0 0),0)' <-> pose 'Pose(Point(3 4),0)', 6);
  round 
 -------
@@ -101,11 +111,10 @@ SELECT NULL::geometry <-> pose 'Pose(Point(4 0),0)';
 (1 row)
 
 SELECT pose 'Pose(Point(4 0),0)' <-> NULL::stbox;
- ?column? 
-----------
-         
-(1 row)
-
+ERROR:  operator does not exist: pose <-> stbox
+LINE 1: SELECT pose 'Pose(Point(4 0),0)' <-> NULL::stbox;
+                                         ^
+HINT:  No operator matches the given name and argument types. You might need to add explicit type casts.
 SELECT NULL::pose <-> pose 'Pose(Point(4 0),0)';
  ?column? 
 ----------

--- a/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
+++ b/mobilitydb/test/pose/queries/113_tpose_distance.test.sql
@@ -32,9 +32,11 @@
 -------------------------------------------------------------------------------
 
 SELECT round(distance(geometry 'Point(1 0)', pose 'Pose(Point(4 0),0)'), 6);
-SELECT round(distance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
+SELECT round(nearestApproachDistance(stbox 'STBOX X((1,-1),(3,1))', pose 'Pose(Point(4 0),0)'), 6);
 SELECT round(distance(pose 'Pose(Point(4 0),0)', geometry 'Point(1 0)'), 6);
-SELECT round(distance(pose 'Pose(Point(4 0),0)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(nearestApproachDistance(pose 'Pose(Point(4 0),0)', stbox 'STBOX X((1,-1),(3,1))'), 6);
+SELECT round(stbox 'STBOX X((1,-1),(3,1))' |=| pose 'Pose(Point(4 0),0)', 6);
+SELECT round(pose 'Pose(Point(4 0),0)' |=| stbox 'STBOX X((1,-1),(3,1))', 6);
 SELECT round(distance(pose 'Pose(Point(0 0),0)', pose 'Pose(Point(3 4),0)'), 6);
 
 SELECT round(geometry 'Point(1 0)' <-> pose 'Pose(Point(4 0),0)', 6);


### PR DESCRIPTION
A spatiotemporal box is an extent rather than a value, so the distance to it is
the least distance over the time both arguments share. The signatures
(cbuffer, stbox), (stbox, cbuffer), (pose, stbox) and (stbox, pose) state this
as nearestApproachDistance and the operator |=|, under which every other type
that takes a box already answers. The signatures whose arguments carry no
period keep the name distance and the operator <->.

The wrappers NAD_cbuffer_stbox, NAD_stbox_cbuffer, NAD_pose_stbox and
NAD_stbox_pose bind the four signatures over one kernel per type, and the
manual carries the entry in both languages together with the section on
migrating from version 1.3.

