### PR TITLE
Answer every SQL tag against the surface it names

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -56,6 +56,8 @@ jobs:
         run: python3 tools/scripts/check_csqlfn.py --gaps
       - name: Check every wrapper a @csqlfn tag backs is named
         run: python3 tools/scripts/check_csqlfn.py --complete
+      - name: Check every wrapper a @csqlfn tag names is one the SQL reaches
+        run: python3 tools/scripts/check_csqlfn.py --targets
 
   spatialrel_orthogonality_check:
     runs-on: ubuntu-latest
@@ -134,5 +136,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Check that every @sqlfn tag names a function the extension creates
+      - name: Check that every @sqlfn tag names a surface the extension builds
         run: python3 tools/scripts/check_sqlfn_names.py

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2834,7 +2834,6 @@ geom_array_union(GSERIALIZED **gsarr, int count)
  * question: a geodesic is not the segment joining two positions in degree
  * space, and two geodesics meet where those segments need not, so the answer
  * awaits an overlay that works on the spheroid.
- * @csqlfn #Geo_union()
  */
 GSERIALIZED *
 geog_array_union(GSERIALIZED **gsarr, int count)

--- a/meos/src/pointcloud/tpcpoint_spatialfuncs.c
+++ b/meos/src/pointcloud/tpcpoint_spatialfuncs.c
@@ -182,7 +182,6 @@ tpointcloud_to_tgeompoint(const Temporal *temp)
  * @brief Return true if the tpcpoint instant position intersects the geometry
  * @param[in] temp Temporal pointcloud value (single instant)
  * @param[in] gs Geometry
- * @csqlfn #Eintersects_tpcpoint_geo()
  */
 bool
 eintersects_tpcpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -204,7 +203,6 @@ eintersects_tpcpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] temp Temporal pointcloud value (single instant)
  * @param[in] gs Geometry
  * @return @p DBL_MAX on error (missing X/Y dimensions or NULL input)
- * @csqlfn #NAD_tpcpoint_geo()
  */
 double
 nad_tpcpoint_geo(const Temporal *temp, const GSERIALIZED *gs)

--- a/tools/scripts/check_csqlfn.py
+++ b/tools/scripts/check_csqlfn.py
@@ -13,18 +13,30 @@
 # so the binding code generators (PyMEOS / JMEOS / MEOS.NET / ...) can derive the
 # SQL function and operator for each MEOS API function.
 #
-# Usage:
-#   check_csqlfn.py --table [dir...]   print the (meos_fn, @csqlfn, @sqlfn, @sqlop) table
-#   check_csqlfn.py --gaps  [dir...]   list MEOS API functions missing the @csqlfn link
-#   check_csqlfn.py --fix   [dir...]   insert the auto-resolvable @csqlfn tags
+# A gap and a tag pointing nowhere are the two ways the link can be wrong, and
+# only the first has a shape the tag itself shows. A tag names a wrapper, and
+# the wrapper is a C symbol the extension either creates a SQL surface for or
+# does not; the tag says nothing about which. --targets asks the other side of
+# the question, so that a tag naming a wrapper the tree does not define, or one
+# the SQL reaches from nothing, is a finding rather than a comment nobody reads.
 #
-# Exit status is non-zero when --gaps finds an auto-resolvable gap (CI guard).
+# Usage:
+#   check_csqlfn.py --table   [dir...] print the (meos_fn, @csqlfn, @sqlfn, @sqlop) table
+#   check_csqlfn.py --gaps    [dir...] list MEOS API functions missing the @csqlfn link
+#   check_csqlfn.py --targets          list @csqlfn tags naming no reachable wrapper
+#   check_csqlfn.py --fix     [dir...] insert the auto-resolvable @csqlfn tags
+#
+# Exit status is non-zero when --gaps finds an auto-resolvable gap, and when
+# --targets finds a tag naming a wrapper the tree does not define or one the
+# SQL reaches from nothing that the baseline does not already carry (CI guard).
 
 import collections
 import glob
 import os
 import re
 import sys
+
+import check_sqlfn_names
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 KW = {'if', 'for', 'while', 'return', 'sizeof', 'switch', 'else', 'do', 'assert',
@@ -349,6 +361,57 @@ def overtagged():
     return rows, sum(t - d for _, t, d in rows)
 
 
+# A tag names a wrapper, so the wrapper is where the tag is answered. The
+# extension defines a wrapper with PG_FUNCTION_INFO_V1 and reaches it from a
+# CREATE FUNCTION, or from a CREATE OPERATOR, CREATE AGGREGATE, CREATE OPERATOR
+# CLASS or CREATE CAST naming the function that binds it; a wrapper reached that
+# way is a legitimate target and is NOT a finding. A tag naming a wrapper the
+# tree defines nowhere names nothing at all, and one naming a wrapper the SQL
+# reaches from nothing names a symbol that has no callable surface. The
+# generators read the tag either way and publish the name it states.
+def pg_defined():
+    """Map every PG wrapper symbol to the file registering it."""
+    out = {}
+    for path in glob.glob(f'{ROOT}/mobilitydb/src/**/*.c', recursive=True):
+        for m in re.finditer(r'PG_FUNCTION_INFO_V1\((\w+)\)', read_text(path)):
+            out[m.group(1)] = os.path.relpath(path, ROOT)
+    return out
+
+
+def csqlfn_tags():
+    """List of (target, meos_fn, file, line) for every @csqlfn reference."""
+    rows = []
+    for path in sorted(glob.glob(f'{ROOT}/meos/src/**/*.c', recursive=True)):
+        rel = os.path.relpath(path, ROOT)
+        lines = read_text(path).split('\n')
+        for i, ln in enumerate(lines):
+            if '@csqlfn' not in ln:
+                continue
+            fn = ''
+            for k in range(i + 1, min(i + 12, len(lines))):
+                mm = re.match(r'^([a-z][A-Za-z0-9_]+)\s*\(', lines[k])
+                if mm:
+                    fn = mm.group(1)
+                    break
+            for target in CSQLFN_REF.findall(ln):
+                rows.append((target, fn, rel, i + 1))
+    return rows
+
+
+def targets():
+    """Return (missing, unreachable): @csqlfn tags naming no reachable wrapper."""
+    defined = pg_defined()
+    declared_of = check_sqlfn_names.sql_names()
+    backed = check_sqlfn_names.sql_backed()
+    missing, unreachable = [], []
+    for target, fn, rel, line in csqlfn_tags():
+        if target not in defined:
+            missing.append((target, fn, rel, line, ''))
+        elif target not in declared_of and target not in backed:
+            unreachable.append((target, fn, rel, line, defined[target]))
+    return missing, unreachable
+
+
 def main():
     """Dispatch on the mode argument and report the @csqlfn coverage."""
     mode = sys.argv[1] if len(sys.argv) > 1 else '--gaps'
@@ -372,6 +435,26 @@ def main():
         print(f'\n{bare} bare "AS \'MODULE_PATHNAME\'" bindings carry no wrapper '
               f'symbol and are outside this check')
         sys.exit(1 if commuted else 0)
+    elif mode == '--targets':
+        missing, unreachable = targets()
+        # The unreachable wrapper is the finding check_sqlfn_names.py already
+        # states and baselines, so its baseline answers here too: one wrapper,
+        # one grandfathering, and a tag added toward it fails on both sides.
+        tag_of = {sym: tag for sym, tag, _p, _s in check_sqlfn_names.wrappers()}
+        baseline = check_sqlfn_names.read_baseline()
+        fresh = [r for r in unreachable
+                 if check_sqlfn_names.baseline_key(r[0], tag_of.get(r[0], ''))
+                 not in baseline]
+        print(f'@csqlfn tags naming a wrapper the tree does not define: '
+              f'{len(missing)}')
+        for target, fn, rel, line, _w in missing:
+            print(f'  {rel}:{line}: {fn or "?"} -> #{target}()')
+        print(f'\n@csqlfn tags naming a wrapper the SQL reaches from nothing: '
+              f'{len(unreachable)} ({len(fresh)} outside the baseline)')
+        for target, fn, rel, line, wrapper in unreachable:
+            print(f'  {rel}:{line}: {fn or "?"} -> #{target}()  defined in '
+                  f'{wrapper}')
+        sys.exit(1 if missing or fresh else 0)
     elif mode == '--overtagged':
         rows, excess = overtagged()
         print(f'wrappers carrying more @csqlfn tags than SQL declarations: '

--- a/tools/scripts/check_sqlfn_names.py
+++ b/tools/scripts/check_sqlfn_names.py
@@ -25,9 +25,21 @@ names both the SQL function and the C symbol it binds:
       AS 'MODULE_PATHNAME', 'Contains_tstzspan_temporal'
 
 so the SQL name of the wrapper `Contains_tstzspan_temporal` is `contains`,
-and its tag must say so.  A wrapper is checked only when the SQL binds it;
-one reached solely through an operator or an aggregate has no CREATE FUNCTION
-to answer for it and is left alone.
+and its tag must say so.
+
+A wrapper the SQL binds is answered against the name it is bound to.  A
+wrapper the SQL binds to nothing has no name to compare, and the tag is
+answered by the weaker question the tree can settle: does the extension
+reach the wrapper at all?  A wrapper named by a CREATE OPERATOR, a CREATE
+AGGREGATE, a CREATE OPERATOR CLASS or a CREATE CAST is reached and is left
+alone; a wrapper nothing names is reached from nothing, its `@sqlfn` states
+a SQL surface the extension never builds, and the generators publish that
+surface anyway.  Such a tag is the one shape nothing else in the tree
+disagrees with: it is usually copied from the block above it, so it names a
+plausible function of the family, the extension compiles and passes its
+tests without the wrapper, and the tag reads as settled.  The wrappers the
+tree already carries this way are listed in
+tools/scripts/sqlfn_unreachable_baseline.txt.
 
 An aggregate's transition, combine and final wrappers each back a CREATE
 FUNCTION nobody calls while implementing a CREATE AGGREGATE everybody does.
@@ -60,10 +72,13 @@ accepted rather than reported:
               backing-only by the catalog the generators read.
 
 Usage:
-  check_sqlfn_names.py            report every tag that names no SQL function
-  check_sqlfn_names.py --fix      rewrite each reported tag to the SQL name
+  check_sqlfn_names.py              report every tag that names no SQL function
+  check_sqlfn_names.py --fix        rewrite each reported tag to the SQL name
+  check_sqlfn_names.py --rebaseline write the unreachable wrappers as the
+                                    new baseline
 
-Exit status is non-zero when a tag names no SQL function (CI guard).
+Exit status is non-zero when a tag names no SQL function, or when a wrapper
+carrying a tag is reached from nothing and is not in the baseline (CI guard).
 """
 
 import glob
@@ -72,6 +87,21 @@ import re
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# The wrappers reached from nothing that the tree already carries. The list
+# only shrinks: a new one fails the check. Keyed by wrapper and tag so that an
+# edit above a finding does not read as a new one, in the shape of
+# tools/scripts/error_sentinels_baseline.txt.
+BASELINE_PATH = os.path.join(ROOT, 'tools', 'scripts',
+                             'sqlfn_unreachable_baseline.txt')
+BASELINE_HEADER = (
+    '# Wrappers carrying an @sqlfn tag that tools/scripts/check_sqlfn_names.py\n'
+    '# finds the extension reaches from nothing: no CREATE FUNCTION binds them\n'
+    '# and no CREATE OPERATOR, CREATE AGGREGATE, CREATE OPERATOR CLASS or\n'
+    '# CREATE CAST names them. Grandfathered in, keyed by wrapper and tag so\n'
+    '# that an edit above a finding does not read as a new one. The list only\n'
+    '# shrinks: a new unreachable wrapper fails the check. Regenerate with\n'
+    '# --rebaseline after a fix.\n')
 
 # The bounding-box topological tags: a family of MobilityDB's own, exposed
 # through `@>`/`<@`/`&&`/`-|-`/`~=` and their bare aliases rather than under
@@ -85,6 +115,24 @@ BBOX_TAGS = {'contains_bbox', 'contained_bbox', 'overlaps_bbox',
 CREATE_FN = re.compile(r'CREATE\s+(?:OR\s+REPLACE\s+)?FUNCTION\s+([\w"]+)\s*\(',
                        re.IGNORECASE)
 MODULE_SYM = re.compile(r"MODULE_PATHNAME'\s*,\s*'(\w+)'")
+
+# `AS 'MODULE_PATHNAME'` without a symbol takes the SQL name as the symbol, so
+# the statement names its wrapper too and the wrapper is bound.  Six selectivity
+# debugging functions use the form; a wrapper written that way answers this
+# guard rather than reading as reached from nothing.
+BARE_SYM = re.compile(r"AS 'MODULE_PATHNAME'\s*$", re.M)
+
+# The clauses that name a callable without calling it by name: an operator's
+# implementation, an aggregate's transition, combine, serial, deserial, final
+# and moving-aggregate members, an operator class support function and a cast's
+# conversion function.  A wrapper one of these names is reached; a wrapper none
+# of them names, and no CREATE FUNCTION binds, is reached from nothing.
+BACKING = re.compile(
+    r'\b(?:PROCEDURE|FUNCTION|SFUNC|COMBINEFUNC|SERIALFUNC|DESERIALFUNC|'
+    r'FINALFUNC|MSFUNC|MINVFUNC|MFINALFUNC)\s*=\s*([\w"]+)', re.IGNORECASE)
+OPCLASS_FN = re.compile(r'\bFUNCTION\s+\d+\s+(?:\([\w\s,]+\)\s*)?([\w"]+)\s*\(',
+                        re.IGNORECASE)
+CAST_FN = re.compile(r'\bWITH\s+FUNCTION\s+([\w"]+)\s*\(', re.IGNORECASE)
 
 # A tag names its functions with empty parentheses, and may name several.
 TAG_NAME = re.compile(r'([A-Za-z_]\w*)\s*\(\)')
@@ -109,10 +157,32 @@ def sql_names():
         src = read_text(path)
         for mt in CREATE_FN.finditer(src):
             end = src.find(';', mt.end())
-            sym = MODULE_SYM.search(src[mt.end():end if end > 0 else len(src)])
+            stmt = src[mt.end():end if end > 0 else len(src)]
+            sql = mt.group(1).strip('"')
+            sym = MODULE_SYM.search(stmt)
             if sym:
-                names.setdefault(sym.group(1), set()).add(mt.group(1).strip('"'))
+                names.setdefault(sym.group(1), set()).add(sql)
+            elif BARE_SYM.search(stmt):
+                names.setdefault(sql, set()).add(sql)
     return names
+
+
+def sql_backed():
+    """The callables a CREATE OPERATOR, AGGREGATE, OPERATOR CLASS or CAST names.
+
+    A wrapper is not called by these clauses directly — each names a SQL
+    function, and the SQL function is what a CREATE FUNCTION binds to the
+    wrapper — so a wrapper reached this way is already bound.  The set is read
+    all the same, and a symbol in it is reached: it is what tells a wrapper the
+    SQL exposes only through an operator or an aggregate apart from a wrapper
+    the SQL exposes not at all, and the two must not be reported together.
+    """
+    backed = set()
+    for path in glob.glob(f'{ROOT}/mobilitydb/sql/**/*.in.sql', recursive=True):
+        src = read_text(path)
+        for pat in (BACKING, OPCLASS_FN, CAST_FN):
+            backed |= {m.strip('"') for m in pat.findall(src)}
+    return backed
 
 
 def wrappers():
@@ -142,14 +212,69 @@ def accepted(tagged, declared):
     return len(declared) > 1
 
 
-def report(fix):
+def baseline_key(sym, tag):
+    """The baseline line of one unreachable wrapper: the wrapper and its tag."""
+    return '%s %s' % (sym, tag)
+
+
+def read_baseline():
+    """The grandfathered unreachable wrappers, keyed by wrapper and tag."""
+    if not os.path.exists(BASELINE_PATH):
+        return set()
+    return {ln for ln in read_text(BASELINE_PATH).splitlines()
+            if ln and not ln.startswith('#')}
+
+
+def write_baseline(unreachable):
+    """Write the unreachable wrappers as the new baseline."""
+    keys = sorted(baseline_key(sym, tag) for sym, tag, _p in unreachable)
+    with open(BASELINE_PATH, 'w', encoding='utf-8') as fp:
+        fp.write(BASELINE_HEADER + '\n'.join(keys) + '\n')
+    print('wrote %d wrapper(s) to %s'
+          % (len(keys), os.path.relpath(BASELINE_PATH, ROOT)))
+
+
+def report_unreachable(unreachable):
+    """Print the unreachable wrappers outside the baseline; return their count."""
+    baseline = read_baseline()
+    fresh = [r for r in unreachable
+             if baseline_key(r[0], r[1]) not in baseline]
+    for sym, tag, path in sorted(fresh, key=lambda r: (r[2], r[0])):
+        print('%s: %s\n    @sqlfn %s\n    the extension reaches this wrapper from '
+              'nothing: no CREATE FUNCTION binds it and no CREATE OPERATOR, '
+              'AGGREGATE, OPERATOR CLASS or CAST names it'
+              % (os.path.relpath(path, ROOT), sym, tag))
+
+    # A baseline listing wrappers the tree no longer carries is out of date, not
+    # broken: the invariant is that no NEW unreachable wrapper appears, so the
+    # shrink is a notice and happens with the next --rebaseline.
+    gone = sorted(baseline - {baseline_key(r[0], r[1]) for r in unreachable})
+    if gone:
+        print('\n%d baselined wrapper(s) are no longer unreachable. Run '
+              'tools/scripts/check_sqlfn_names.py --rebaseline to shrink the '
+              'baseline:' % len(gone))
+        for key in gone:
+            print('  %s' % key)
+    if fresh:
+        print('\n%d wrapper(s) carry an @sqlfn tag the extension reaches from '
+              'nothing.' % len(fresh))
+    return len(fresh)
+
+
+def report(fix, rebaseline=False):
     """Report (and optionally repair) every tag naming no SQL function."""
     declared_of = sql_names()
-    bad = []
+    backed = sql_backed()
+    bad, unreachable = [], []
     for sym, tag, path, span in wrappers():
         declared = declared_of.get(sym)
         if not declared:
-            continue                    # reached through an operator or aggregate
+            # No CREATE FUNCTION binds the wrapper. Reached through an operator
+            # or an aggregate it is bound all the same; named by nothing, its
+            # tag states a surface the extension never builds.
+            if sym not in backed:
+                unreachable.append((sym, tag, path))
+            continue
         tagged = set(TAG_NAME.findall(tag))
         if tagged & declared or accepted(tagged, declared):
             continue
@@ -169,6 +294,10 @@ def report(fix):
               'laggard; the tag names what it is to become)'
               % (os.path.relpath(path, ROOT), sym, tag, ', '.join(declared)))
 
+    if rebaseline:
+        write_baseline(unreachable)
+        return 0
+
     if fix:
         for path in {r[3] for r in stale}:
             src = read_text(path)
@@ -182,6 +311,8 @@ def report(fix):
               % (len(stale), len({r[3] for r in stale}), len(laggard)))
         return 0
 
+    fresh = report_unreachable(unreachable)
+
     if laggard:
         print('\n%d SQL name(s) carry an underscore their tag does not; the rename is '
               'theirs to make, so they do not fail this check.' % len(laggard))
@@ -189,8 +320,11 @@ def report(fix):
         print('\n%d @sqlfn tag(s) name a function the extension does not create.'
               % len(stale))
         print('Run tools/scripts/check_sqlfn_names.py --fix to state the SQL name.')
-    return 1 if stale else 0
+    if not stale and not fresh:
+        print('sqlfn-names: clean (%d unreachable wrapper(s) baselined).'
+              % len(unreachable))
+    return 1 if stale or fresh else 0
 
 
 if __name__ == '__main__':
-    sys.exit(report('--fix' in sys.argv[1:]))
+    sys.exit(report('--fix' in sys.argv[1:], '--rebaseline' in sys.argv[1:]))

--- a/tools/scripts/sqlfn_unreachable_baseline.txt
+++ b/tools/scripts/sqlfn_unreachable_baseline.txt
@@ -1,0 +1,26 @@
+# Wrappers carrying an @sqlfn tag that tools/scripts/check_sqlfn_names.py
+# finds the extension reaches from nothing: no CREATE FUNCTION binds them
+# and no CREATE OPERATOR, CREATE AGGREGATE, CREATE OPERATOR CLASS or
+# CREATE CAST names them. Grandfathered in, keyed by wrapper and tag so
+# that an edit above a finding does not read as a new one. The list only
+# shrinks: a new unreachable wrapper fails the check. Regenerate with
+# --rebaseline after a fix.
+Cbufferarr_round round()
+Jsonb_as_text text()
+NAD_cbuffer_stbox tDistance()
+Posearr_round round()
+Posechain_from_text posechainFromText()
+Teq_th3index_th3index tEq()
+Teq_tnpoint_tnpoint tEq()
+Teq_tpose_tpose tEq()
+Teq_tposechain_tposechain tEq()
+Teq_tquadbin_tquadbin tEq()
+Teq_trgeometry_trgeometry tEq()
+Teq_ts2cell_ts2cell tEq()
+Tne_th3index_th3index tNe()
+Tne_tnpoint_tnpoint tNe()
+Tne_tpose_tpose tNe()
+Tne_tposechain_tposechain tNe()
+Tne_tquadbin_tquadbin tNe()
+Tne_trgeometry_trgeometry tNe()
+Tne_ts2cell_ts2cell tNe()


### PR DESCRIPTION
A `@sqlfn` tag names the SQL function the extension creates for a PG wrapper
and a `@csqlfn` tag names the wrapper a MEOS function is bound through, and
the binding code generators publish each function under the name the pair
states, so a tag naming a surface the extension does not build makes every
generated binding publish a name no user can call.

`check_csqlfn.py --targets` reads the wrapper side of every `@csqlfn`
reference: a tag naming a symbol no `PG_FUNCTION_INFO_V1` registers names
nothing at all and fails the check, and a tag naming a wrapper the SQL
reaches from nothing is listed against the baseline that grandfathers the
wrappers the tree carries.

`check_sqlfn_names.py` answers the wrapper a CREATE FUNCTION binds against
the name it is bound to, and the wrapper nothing binds against whether the
extension reaches it at all. A wrapper named by a CREATE OPERATOR, a CREATE
AGGREGATE, a CREATE OPERATOR CLASS or a CREATE CAST is reached and is
legitimate; a wrapper none of them names and no CREATE FUNCTION binds is
reached from nothing, and its tag states a surface the extension never
builds. The nineteen such wrappers are listed in
tools/scripts/sqlfn_unreachable_baseline.txt, which only shrinks:
`--rebaseline` writes it, a new unreachable wrapper fails the check, and a
baselined wrapper the tree has since bound is a notice. The bare
`AS 'MODULE_PATHNAME'` form takes the SQL name as its symbol and binds its
wrapper like the explicit form.

`geog_array_union`, `eintersects_tpcpoint_geo` and `nad_tpcpoint_geo` are
MEOS entry points the extension gives no wrapper, and carry no `@csqlfn`
link.
