### PR TITLE
Reject a tile size that leaves the grid no dimension

### DIFF
--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -1316,7 +1316,12 @@ tgeo_space_time_tile_init(const Temporal *temp, double xsize, double ysize,
    * what differs between the families is which restriction reads the value,
    * which is the caller's to supply */
   VALIDATE_NOT_NULL(ntiles, NULL); VALIDATE_TSPATIAL(temp, NULL);
-  if ((xsize && ! ensure_positive_datum(Float8GetDatum(xsize), T_FLOAT8)) ||
+  /* A grid needs at least one dimension to be laid on, which is what the state
+   * constructor asserts. The per-size checks below are guarded by `xsize &&`, so
+   * a zero size skips its own positivity check rather than failing it; without
+   * this the value reaches the binning arithmetic and divides by that zero */
+  if (! ensure_one_tile_dimension(xsize, duration) ||
+      (xsize && ! ensure_positive_datum(Float8GetDatum(xsize), T_FLOAT8)) ||
       (xsize && ! ensure_positive_datum(Float8GetDatum(ysize), T_FLOAT8)) ||
       (xsize && ! ensure_positive_datum(Float8GetDatum(zsize), T_FLOAT8)) ||
       (xsize && (! ensure_not_empty(sorigin) || ! ensure_point_type(sorigin))) ||

--- a/mobilitydb/test/geo/expected/058_tgeo_tile.test.out
+++ b/mobilitydb/test/geo/expected/058_tgeo_tile.test.out
@@ -305,3 +305,11 @@ FROM (SELECT spaceTimeSplit(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-
 SELECT spaceTimeSplit(tgeometry 'SRID=5676;Point(1 1 1)@2000-01-01', 2.0, interval '2 days', 'SRID=3812;Point(0.5 0.5 0.5)');
 ERROR:  The tgeometry cannot have Z dimension
 CONTEXT:  SQL function "spacetimesplit" statement 1
+SELECT spaceSplit(tgeompoint 'SRID=25832;[Point(0 0)@2000-01-01, Point(1000 1000)@2000-01-01 01:00]', 0.0);
+ERROR:  At least one of the arguments xsize or duration must be given
+CONTEXT:  SQL function "spacesplit" statement 1
+SELECT spaceTimeSplit(tgeompoint 'SRID=25832;[Point(0 0)@2000-01-01, Point(1000 1000)@2000-01-01 01:00]', 0.0, NULL);
+ spacetimesplit 
+----------------
+(0 rows)
+

--- a/mobilitydb/test/geo/queries/058_tgeo_tile.test.sql
+++ b/mobilitydb/test/geo/queries/058_tgeo_tile.test.sql
@@ -140,5 +140,9 @@ FROM (SELECT spaceTimeSplit(tgeometry '{[Point(1 1)@2000-01-01, Point(2 2)@2000-
 
 /* Errors */
 SELECT spaceTimeSplit(tgeometry 'SRID=5676;Point(1 1 1)@2000-01-01', 2.0, interval '2 days', 'SRID=3812;Point(0.5 0.5 0.5)');
+-- A grid needs a dimension to be laid on: a zero spatial size with no duration
+-- leaves every dimension unset
+SELECT spaceSplit(tgeompoint 'SRID=25832;[Point(0 0)@2000-01-01, Point(1000 1000)@2000-01-01 01:00]', 0.0);
+SELECT spaceTimeSplit(tgeompoint 'SRID=25832;[Point(0 0)@2000-01-01, Point(1000 1000)@2000-01-01 01:00]', 0.0, NULL);
 
 -------------------------------------------------------------------------------


### PR DESCRIPTION
`spaceSplit` with a zero size aborts the backend. The size checks in `tgeo_space_time_tile_init` each read `xsize && ...`, so a zero size skips its own positivity check rather than failing it, and the value reaches `stbox_tile_state_make`, whose first line asserts `xsize > 0 || duration`. A build with assertions enabled dies there with signal 6, and the query reports that the server closed the connection:

```
SELECT spaceSplit(tgeompoint 'SRID=25832;[Point(0 0)@2000-01-01, Point(1000 1000)@2000-01-01 01:00]', 0.0);
server closed the connection unexpectedly
```

```
meos/src/geo/tgeo_tile.c:379: stbox_tile_state_make: Assertion `xsize > 0 || duration' failed.
server process was terminated by signal 6: Aborted
```

An internal assert firing on user input names a missing public guard, so the entry states the requirement its state constructor asserts, through the same `ensure_one_tile_dimension` that `stbox_space_time_tiles` already applies. The assert stays. A zero size with a duration remains valid, since a time-only split needs no spatial dimension, and the query now answers with an error rather than dying:

```
ERROR:  At least one of the arguments xsize or duration must be given
```

The tile test covers the zero size that is now refused and the time-only split that is still accepted.
