### PR TITLE
Write the WKT of every base type the spatial predicate admits

### DIFF
--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -73,12 +73,20 @@
   #include "rgeo/trgeo_boxops.h"
 #endif
 #if H3
+  #include <h3api.h>
+  #include "h3/h3index.h"
   #include "h3/th3index_boxops.h"
 #endif
+#if POINTCLOUD
+  #include "pointcloud/pcpoint.h"
+  #include "pointcloud/pcpatch.h"
+#endif
 #if QUADBIN
+  #include <meos_quadbin.h>
   #include "quadbin/tquadbin_boxops.h"
 #endif
 #if S2CELL
+  #include <meos_s2cell.h>
   #include "s2cell/ts2cell_boxops.h"
 #endif
 
@@ -108,9 +116,19 @@ spatialbase_as_text(Datum value, MeosType type, int maxdd)
     case T_CBUFFER:
       return cbuffer_as_text(DatumGetCbufferP(value), maxdd);
 #endif
+#if H3
+    case T_H3INDEX:
+      return meos_h3index_out((H3Index) DatumGetInt64(value));
+#endif
 #if NPOINT
     case T_NPOINT:
       return npoint_as_text(DatumGetNpointP(value), maxdd);
+#endif
+#if POINTCLOUD
+    case T_PCPOINT:
+      return pcpoint_hex_out((const Pcpoint *) DatumGetPointer(value), maxdd);
+    case T_PCPATCH:
+      return pcpatch_hex_out((const Pcpatch *) DatumGetPointer(value), maxdd);
 #endif
 #if POSE
     case T_POSE:
@@ -119,6 +137,14 @@ spatialbase_as_text(Datum value, MeosType type, int maxdd)
 #if POSECHAIN
     case T_POSECHAIN:
       return posechain_as_text(DatumGetPoseChainP(value), maxdd);
+#endif
+#if QUADBIN
+    case T_QUADBIN:
+      return quadbin_index_to_string((Quadbin) DatumGetInt64(value));
+#endif
+#if S2CELL
+    case T_S2CELL:
+      return s2cell_out((S2CellId) DatumGetInt64(value));
 #endif
     default: /* Error! */
       meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -53,6 +53,9 @@
 #include <string.h>
 #include <meos.h>
 #include <meos_geo.h>
+#include <meos_h3.h>
+#include <meos_quadbin.h>
+#include <meos_s2cell.h>
 
 /* Main program */
 int main(void)
@@ -988,6 +991,42 @@ int main(void)
     ggdwkt);
   assert(strcmp(ggdwkt, "SRID=4326;MULTIPOINT(1 1,2 2)") == 0);
   free(ggd1); free(ggd2); free(ggdu); free(ggdwkt);
+  meos_errno_reset();
+
+  /* Every base type #spatial_basetype admits renders in WKT. A cell index
+   * value carries no coordinate, so the digits argument is vacuous and the
+   * text is the cell identifier -- which is what the generic output function
+   * writes for that same value, an identity independent of the session zone */
+  meos_errno_reset();
+  Temporal *cell = th3index_in("[831c02fffffffff@2001-01-01, "
+    "880326b885fffff@2001-01-02]");
+  assert(cell != NULL);
+  char *cell_text = tspatial_as_text(cell, 6);
+  char *cell_out = tspatial_out(cell, 6);
+  assert(cell_text != NULL); assert(cell_out != NULL);
+  assert(meos_errno() == 0);
+  printf("the WKT of a temporal cell index: %s\n", cell_text);
+  assert(strcmp(cell_text, cell_out) == 0);
+  free(cell_text); free(cell_out); free(cell);
+  meos_errno_reset();
+
+  /* A set reads its elements through that same renderer, and a cell set
+   * carries no timestamp, so the three grids are stated exactly */
+  Set *h3s = h3index_to_set((H3Index) 0x831c02fffffffffULL);
+  Set *qbs = quadbin_to_set((Quadbin) 5209574053332910079ULL);
+  Set *s2s = s2cell_to_set((S2CellId) 0x47c3cULL);
+  assert(h3s != NULL); assert(qbs != NULL); assert(s2s != NULL);
+  char *h3t = spatialset_as_text(h3s, 6);
+  char *qbt = spatialset_as_text(qbs, 6);
+  char *s2t = spatialset_as_text(s2s, 6);
+  assert(h3t != NULL); assert(qbt != NULL); assert(s2t != NULL);
+  assert(meos_errno() == 0);
+  printf("the WKT of a cell set: %s %s %s\n", h3t, qbt, s2t);
+  assert(strcmp(h3t, "{\"831c02fffffffff\"}") == 0);
+  assert(strcmp(qbt, "{\"484c1fffffffffff\"}") == 0);
+  assert(strcmp(s2t, "{\"0000000000047c3c\"}") == 0);
+  free(h3t); free(qbt); free(s2t);
+  free(h3s); free(qbs); free(s2s);
   meos_errno_reset();
 
   /* Finalize MEOS */


### PR DESCRIPTION
spatial_basetype() admits the three cell index base types and the two point
cloud ones, while spatialbase_as_text(), whose own assertion is that predicate,
carries an arm for none of them. A th3index, tquadbin, ts2cell, tpcpoint or
tpcpatch value, and a set of any of them, therefore reports an unknown output
function and answers NULL, which the string builders behind tspatial_as_text(),
tspatial_as_ewkt(), spatialset_as_text() and spatialset_as_ewkt() read with
strlen. Each of the five renders through the function basetype_out() already
uses for it, so a value carrying no coordinate writes its identifier and the
digits argument is vacuous. geo_test states the three cell sets exactly, whose
text carries no timestamp, and the temporal form against the generic output
function, an identity the session zone does not move.

