### PR TITLE
Report a base type that has no round function instead of calling none

### DIFF
--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -785,6 +785,13 @@ set_round(const Set *s, int maxdd)
   Datum *values = palloc(sizeof(Datum) * s->count);
   Datum size = Int32GetDatum(maxdd);
   datum_func2 func = round_fn(s->basetype);
+  /* A base type carrying no decimal has no round function and #round_fn
+   * reports it, so the decline is propagated rather than called */
+  if (! func)
+  {
+    pfree(values);
+    return NULL;
+  }
   for (int i = 0; i < s->count; i++)
     values[i] = func(SET_VAL_N(s, i), size);
   return set_make_free(values, s->count, s->basetype, ORDER);

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -1438,6 +1438,14 @@ temporal_round(const Temporal *temp, int maxdd)
   LiftedFunctionInfo lfinfo;
   memset(&lfinfo, 0, sizeof(LiftedFunctionInfo));
   lfinfo.func = (varfunc) round_fn(temptype_basetype(work->temptype));
+  /* A base type carrying no decimal has no round function and #round_fn
+   * reports it, so the decline is propagated rather than lifted */
+  if (! lfinfo.func)
+  {
+    if (work != temp)
+      pfree(work);
+    return NULL;
+  }
   lfinfo.numparam = 1;
   lfinfo.param[0] = Int32GetDatum(maxdd);
   lfinfo.argtype[0] = work->temptype;

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -48,8 +48,10 @@
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <meos.h>
 #include <meos_geo.h>
+#include <meos_h3.h>
 #include <meos_pose.h>
 
 /* Main program */
@@ -263,6 +265,37 @@ int main(void)
   assert(meos_errno() == 0);
   printf("temporal_at_max(tint): answered, errno %d\n", meos_errno());
   free(extremum);
+
+  /* A base type carrying no decimal has no round function, and the two
+   * entries that lift one report the decline instead of calling it: a cell
+   * index identifier is an integer with nothing to round */
+  meos_errno_reset();
+  Set *cellset = h3index_to_set((H3Index) 0x831c02fffffffffULL);
+  assert(cellset != NULL && meos_errno() == 0);
+  assert(set_round(cellset, 2) == NULL);
+  printf("set_round(h3indexset): declined, errno %d\n", meos_errno());
+  assert(meos_errno() == MEOS_ERR_INTERNAL_TYPE_ERROR);
+  free(cellset);
+
+  meos_errno_reset();
+  Temporal *cell = th3index_in("[831c02fffffffff@2001-01-01]");
+  assert(cell != NULL && meos_errno() == 0);
+  assert(temporal_round(cell, 2) == NULL);
+  printf("temporal_round(th3index): declined, errno %d\n", meos_errno());
+  assert(meos_errno() == MEOS_ERR_INTERNAL_TYPE_ERROR);
+  free(cell);
+
+  /* A set of floats rounds, so the two declines discriminate */
+  meos_errno_reset();
+  Set *fset = floatset_in("{1.234567, 2.345678}");
+  assert(fset != NULL);
+  Set *frounded = set_round(fset, 2);
+  assert(frounded != NULL && meos_errno() == 0);
+  char *ftext = floatset_out(frounded, 6);
+  printf("set_round(floatset): answered %s\n", ftext);
+  assert(strcmp(ftext, "{1.23, 2.35}") == 0);
+  free(ftext); free(frounded); free(fset);
+  meos_errno_reset();
 
   free(tpt1); free(tpt2);
 


### PR DESCRIPTION
round_fn() answers the function that rounds a base type and reports a base type
carrying no decimal, which a cell index identifier is. set_round() assigns that
answer to a datum_func2 and calls it, and temporal_round() stores it in the
lifted function info, so round over an h3indexset, a quadbinset, an s2cellset or
any of their temporal forms calls a null pointer. Both entries test the answer
and propagate the decline, releasing the values array and the stripped working
value. error_test asserts both declines beside a float set that rounds, which
discriminates them.

