### PR TITLE
Read the UTC designator of a timestamp

### DIFF
--- a/mobilitydb/test/temporal/expected/001_set.test.out
+++ b/mobilitydb/test/temporal/expected/001_set.test.out
@@ -37,6 +37,13 @@ SELECT tstzset '{2000-01-01, 2000-01-02';
 ERROR:  Could not parse tstzset value: Missing closing brace
 LINE 1: SELECT tstzset '{2000-01-01, 2000-01-02';
                        ^
+SELECT tstzset '{2000-01-01T00:00:00Z, 2000-01-02T00:00:00Z}' =
+  tstzset '{2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00}';
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT asText(floatset '{1.12345678, 2.123456789}', 6);
         astext        
 ----------------------

--- a/mobilitydb/test/temporal/expected/003_span.test.out
+++ b/mobilitydb/test/temporal/expected/003_span.test.out
@@ -19,6 +19,20 @@ SELECT tstzspan '[2000-01-01, 2000-01-02';
 ERROR:  Could not parse tstzspan value: Missing closing bracket/parenthesis
 LINE 1: SELECT tstzspan '[2000-01-01, 2000-01-02';
                         ^
+SELECT tstzspan '[2000-01-01T00:00:00Z, 2000-01-02T00:00:00Z]' =
+  tstzspan '[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tstzspan '[2000-01-01T00:00:00UTC, 2000-01-02T00:00:00UTC]' =
+  tstzspan '[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00]';
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT asText(floatspan '[1.12345678, 2.123456789]', 6);
         astext        
 ----------------------

--- a/mobilitydb/test/temporal/queries/001_set.test.sql
+++ b/mobilitydb/test/temporal/queries/001_set.test.sql
@@ -41,6 +41,11 @@ SELECT tstzset '{2000-01-01, 2000-01-02, 2000-01-03}';
 SELECT tstzset '2000-01-01, 2000-01-02';
 SELECT tstzset '{2000-01-01, 2000-01-02';
 
+-- The UTC designator of RFC 3339, which every OGC Moving Features datetime is
+-- written in, denotes the same instant as the zero offset it abbreviates
+SELECT tstzset '{2000-01-01T00:00:00Z, 2000-01-02T00:00:00Z}' =
+  tstzset '{2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00}';
+
 -- Output in WKT format
 
 SELECT asText(floatset '{1.12345678, 2.123456789}', 6);

--- a/mobilitydb/test/temporal/queries/003_span.test.sql
+++ b/mobilitydb/test/temporal/queries/003_span.test.sql
@@ -39,6 +39,13 @@ SELECT tstzspan '[2000-01-01,2000-01-02] xxx';
 SELECT tstzspan '2000-01-01, 2000-01-02';
 SELECT tstzspan '[2000-01-01, 2000-01-02';
 
+-- The UTC designator of RFC 3339, which every OGC Moving Features datetime is
+-- written in, denotes the same instant as the zero offset it abbreviates
+SELECT tstzspan '[2000-01-01T00:00:00Z, 2000-01-02T00:00:00Z]' =
+  tstzspan '[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00]';
+SELECT tstzspan '[2000-01-01T00:00:00UTC, 2000-01-02T00:00:00UTC]' =
+  tstzspan '[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00]';
+
 -- Output in WKT format
 
 SELECT asText(floatspan '[1.12345678, 2.123456789]', 6);

--- a/pgtypes/utils/datetime.c
+++ b/pgtypes/utils/datetime.c
@@ -107,6 +107,19 @@ const char *const days[] = {"Sunday", "Monday", "Tuesday", "Wednesday",
  * The static table contains no TZ, DTZ, or DYNTZ entries; rather those
  * are loaded from configuration files and stored in zoneabbrevtbl, whose
  * abbrevs[] field has the same format as the static datetktbl.
+ *
+ * MEOS: except for the universal ones, which are marked below. A server reads
+ * its abbreviations from the file the timezone_abbreviations setting names, and
+ * MEOS has neither that setting nor a configuration directory to read, so
+ * zoneabbrevtbl stays empty and every abbreviation has to come from the session
+ * zone. That leaves "Z" unreadable, because it is the designator of no zone: it
+ * is the UTC designator of RFC 3339 section 5.6, the format every OGC Moving
+ * Features datetime is written in, and PostgreSQL reads it from the ETC block
+ * of its Default set. The entries below are that block, the abbreviations
+ * PostgreSQL gives a fixed zero offset, so a MEOS build and a server agree on
+ * what they mean. They are reached only after the session zone, exactly as a
+ * loaded set would be, so an abbreviation the zone defines keeps its local
+ * meaning.
  */
 static const datetkn datetktbl[] = {
   /* token, type, value */
@@ -132,6 +145,7 @@ static const datetkn datetktbl[] = {
   {"february", MONTH, 2},
   {"fri", DOW, 5},
   {"friday", DOW, 5},
+  {"gmt", TZ, 0},  /* MEOS: universal */
   {"h", UNITS, DTK_HOUR},    /* "hour" */
   {LATE, RESERV, DTK_LATE},  /* "infinity" reserved for "late time" */
   {"isodow", UNITS, DTK_ISODOW},  /* ISO day of week, Sunday == 7 */
@@ -177,11 +191,16 @@ static const datetkn datetktbl[] = {
   {"tue", DOW, 2},
   {"tues", DOW, 2},
   {"tuesday", DOW, 2},
+  {"uct", TZ, 0},  /* MEOS: universal */
+  {"ut", TZ, 0},  /* MEOS: universal */
+  {"utc", TZ, 0},  /* MEOS: universal */
   {"wed", DOW, 3},
   {"wednesday", DOW, 3},
   {"weds", DOW, 3},
   {"y", UNITS, DTK_YEAR},    /* "year" for ISO input */
-  {YESTERDAY, RESERV, DTK_YESTERDAY}  /* yesterday midnight */
+  {YESTERDAY, RESERV, DTK_YESTERDAY}, /* yesterday midnight */
+  {"z", TZ, 0},  /* MEOS: universal */
+  {"zulu", TZ, 0}  /* MEOS: universal */
 };
 
 static const int szdatetktbl = sizeof datetktbl / sizeof datetktbl[0];


### PR DESCRIPTION
The timestamp parser reads the universal time zone abbreviations, so an input
carrying the RFC 3339 UTC designator names the instant it denotes:

  SELECT tstzspan '[2000-01-01T00:00:00Z, 2000-01-02T00:00:00Z]';

A server reads its abbreviations from the file the timezone_abbreviations
setting names, and MEOS has neither that setting nor a configuration directory
to read one from, so every abbreviation had to come from the session zone. "Z"
is the designator of no zone, so it was unreadable, and every value spelled the
way RFC 3339 section 5.6 requires -- the way an OGC Moving Features datetime is
written -- was rejected as invalid syntax. The abbreviations built in are the
ETC block of PostgreSQL's Default set, the ones it gives a fixed zero offset, so
a MEOS build and a server agree on what they mean, and they are reached only
after the session zone, so an abbreviation a zone defines keeps its local
meaning.

