### PR TITLE
Read an aggregate transition value through PG_ARGISNULL

### DIFF
--- a/mobilitydb/src/geo/tgeo_aggfuncs.c
+++ b/mobilitydb/src/geo/tgeo_aggfuncs.c
@@ -142,7 +142,11 @@ PG_FUNCTION_INFO_V1(Tpoint_tcentroid_finalfn);
 Datum
 Tpoint_tcentroid_finalfn(PG_FUNCTION_ARGS)
 {
-  SkipList *state = (SkipList *) PG_GETARG_POINTER(0);
+  /* See the note in Temporal_tagg_finalfn */
+  SkipList *state = PG_ARGISNULL(0) ? NULL : (SkipList *) PG_GETARG_POINTER(0);
+  if (! state)
+    PG_RETURN_NULL();
+
   Temporal *result = tpoint_tcentroid_finalfn(state);
   if (! result)
     PG_RETURN_NULL();

--- a/mobilitydb/src/temporal/temporal_aggfuncs.c
+++ b/mobilitydb/src/temporal/temporal_aggfuncs.c
@@ -107,8 +107,14 @@ PG_FUNCTION_INFO_V1(Temporal_tagg_finalfn);
 Datum
 Temporal_tagg_finalfn(PG_FUNCTION_ARGS)
 {
+  /* The transition value is null for a group that aggregated no rows, and
+   * PG_GETARG_POINTER of a null argument is an arbitrary pointer rather than
+   * NULL, so the state is read through PG_ARGISNULL */
+  SkipList *state = PG_ARGISNULL(0) ? NULL : (SkipList *) PG_GETARG_POINTER(0);
+  if (! state)
+    PG_RETURN_NULL();
+
   MemoryContext ctx = set_aggregation_context(fcinfo);
-  SkipList *state = (SkipList *) PG_GETARG_POINTER(0);
   Temporal *result = temporal_tagg_finalfn(state);
   unset_aggregation_context(ctx);
   if (! result)
@@ -754,7 +760,11 @@ PG_FUNCTION_INFO_V1(Tnumber_tavg_finalfn);
 Datum
 Tnumber_tavg_finalfn(PG_FUNCTION_ARGS)
 {
-  SkipList *state = (SkipList *) PG_GETARG_POINTER(0);
+  /* See the note in Temporal_tagg_finalfn */
+  SkipList *state = PG_ARGISNULL(0) ? NULL : (SkipList *) PG_GETARG_POINTER(0);
+  if (! state)
+    PG_RETURN_NULL();
+
   Temporal *result = tnumber_tavg_finalfn(state);
   if (! result)
     PG_RETURN_NULL();
@@ -905,6 +915,10 @@ PG_FUNCTION_INFO_V1(Temporal_append_finalfn);
 Datum
 Temporal_append_finalfn(PG_FUNCTION_ARGS)
 {
+  /* See the note in Temporal_tagg_finalfn */
+  if (PG_ARGISNULL(0))
+    PG_RETURN_NULL();
+
   MemoryContext ctx = set_aggregation_context(fcinfo);
   Temporal *state = PG_GETARG_TEMPORAL_P(0);
   Temporal *result = temporal_compact(state);


### PR DESCRIPTION
A `GROUP BY` over a temporal aggregate crashes the backend on PostgreSQL 16 and 17 when a group aggregates no rows:

```sql
SELECT k%10, numInstants(tand(inst)) FROM tbl_tbool_inst GROUP BY k%10 ORDER BY k%10;
```
```
temporal.c:942: temporal_copy: Assertion `temp' failed.
LOG:  server process terminated by signal 6: Aborted
```

The transition value of such a group is null, and `PG_GETARG_POINTER` of a null argument yields an arbitrary pointer rather than NULL. Four final functions read it directly, so the state they pass on is recycled memory. A core taken at the assertion shows it plainly: `key_size` and `value_size` hold pointer values and `comp_fn` and `merge_fn` are null, which is not a live `SkipList`. The internal `if (! state ...)` guard cannot catch this, because the pointer it tests is not null.

This reads the state through `PG_ARGISNULL` and returns null when it is absent — the form `Span_union_finalfn` and `Set_union_finalfn` already use:

```c
SkipList *state = PG_ARGISNULL(0) ? NULL : (SkipList *) PG_GETARG_POINTER(0);
if (! state)
  PG_RETURN_NULL();
```

It applies to the four final functions that lack the guard — `Temporal_tagg_finalfn`, `Tnumber_tavg_finalfn`, `Tpoint_tcentroid_finalfn` and `Temporal_append_finalfn` — leaving all six in agreement.

The crash reaches every aggregate those functions serve: `tAnd`, `tOr`, `tCount`, `tMin`, `tMax`, `tSum`, `merge`, `tAvg`, `tCentroid` and `appendInstant`. It needs only a group that contributes no rows.

`040_temporal_aggfuncs_tbl` fails on PostgreSQL 16 without this change and passes with it; the full suite is 322 of 322 on the same build.