### PR TITLE
Union two surfaces that share a stretch of their boundaries

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -3473,10 +3473,19 @@ buffer_make_surfaces_from_pieces(const MeosArray *pieces, int32_t srid)
  *****************************************************************************/
 
 /**
- * @brief Determine whether two buffer boundaries have a proper crossing.
- * @details A proper crossing means that at least one boundary intersection
- * is an isolated point and the two surfaces overlap in their interiors.
- * A point-touch without interior overlap is NOT a crossing.
+ * @brief Determine whether two buffer boundaries meet at nodes the overlay can
+ * split them at
+ * @details Two boundaries meet either at isolated POINTS or along a CURVE, and
+ * both give the overlay something to work with: a point is a node, and a
+ * coincident stretch is bounded by two of them, which
+ * #buffer_collect_line_line_intersections() emits from the parameters of the
+ * overlap. What follows splits both boundaries at those nodes and classifies
+ * each piece, and a piece lying ON the other boundary is resolved by the side
+ * each geometry occupies -- opposite sides put the stretch INSIDE the union,
+ * so it is dropped, and the two surfaces come out as one.
+ * A point-touch without interior overlap answers true here as well; it is the
+ * boundary SELECTION that leaves such a pair as two surfaces, because every
+ * piece of both boundaries survives it.
  */
 static bool
 buffer_boundaries_cross(const LWGEOM *geom1, const LWGEOM *geom2)
@@ -3506,14 +3515,10 @@ buffer_boundaries_cross(const LWGEOM *geom1, const LWGEOM *geom2)
         continue;
       int dimension = buffer_boundary_intersection(e1, e2);
 
-      /* Dimension 1 means that the boundaries overlap over a curve.
-       * That is not a proper crossing and must be handled separately. */
-      if (dimension == 1)
-      {
-        meos_array_destroy(a1); meos_array_destroy(a2);
-        return false;
-      }
-      if (dimension == 0)
+      /* A curve the two boundaries share is bounded by two nodes, so it splits
+       * like any other meeting and the stretch between them becomes a piece of
+       * its own for the classification to place */
+      if (dimension >= 0)
         point_intersection = true;
     }
   }

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -883,10 +883,11 @@ int main(void)
       "POLYGON Z((1 1 7,1 3 7,3 3 7,3 1 7,1 1 7))",
       "POLYGON((1 2,0 2,0 0,2 0,2 1,3 1,3 3,1 3,1 2))" },
     /* two surfaces MEETING along an edge at different elevations: the shared
-     * edge is where they disagree */
+     * edge is where they disagree, and the shell is traversed counter-clockwise
+     * as #buffer_normalize_ring_orientation() leaves every shell it builds */
     { "POLYGON Z((0 0 1,0 2 1,2 2 1,2 0 1,0 0 1))",
       "POLYGON Z((2 0 7,2 2 7,4 2 7,4 0 7,2 0 7))",
-      "POLYGON((0 2,2 2,4 2,4 0,2 0,0 0,0 2))" },
+      "POLYGON((2 2,0 2,0 0,2 0,4 0,4 2,2 2))" },
     /* linework coinciding over a stretch, dissolved into one curve that keeps
      * the elevation both members carry */
     { "LINESTRING Z(0 0 1,6 6 1)", "LINESTRING Z(3 3 1,10 10 1)",


### PR DESCRIPTION
`buffer_boundaries_cross()` answers for a boundary meeting of either dimension, so the
union of two surfaces sharing a stretch of their boundaries reaches the split that
resolves it. A shared stretch is bounded by two nodes, which
`buffer_collect_line_line_intersections()` emits from the parameters of the overlap;
`buffer_split_pieces()` splits both boundaries at them; `buffer_classify_piece()` reads
the stretch as lying on the other boundary; and `buffer_classify_coincident_piece()`
places it by the side each geometry occupies, opposite sides putting it inside the union
so that it is dropped. The change is the entry test alone: every stage behind it is in
place, and a build configured with `-DGEOS=OFF` reports the case rather than falling
through to the GEOS path.

The four contact cases of two unit squares answer:

| contact | answer |
|---|---|
| share an edge | `POLYGON((1 1,0 1,0 0,1 0,2 0,2 1,1 1))` |
| share a point | a MULTIPOLYGON |
| interiors overlap | one merged surface |
| disjoint | a MULTIPOLYGON |

`meos/test/geo_test.c` states the shell of the lift case whose two surfaces meet along an
edge at elevations 1 and 7, where the disagreement leaves the answer planar. The union
path builds that shell through `buffer_make_surfaces_from_pieces()` and
`buffer_build_surfaces_from_rings()`, which run `buffer_normalize_ring_orientation()`,
whose rule is that a shell is traversed counter-clockwise and a hole clockwise. The
expectation states the counter-clockwise shell, the traversal the nine other cases of
that table also state. `geom_relate` reads `2FFF1FFF2` between it and the clockwise
spelling, one point set under both.

`geo_test` passes with `-DGEOS=ON` and with `-DGEOS=OFF`, the GEOS-free configuration
reaching the end of the file rather than its `uu2 != NULL` assertion. Over 283
protected-area polygons the buffer at radii 1, 5 and 50 answers 482 surfaces and declines
367, and the unary union of the same 283 answers all 283.