### PR TITLE
Build the vendored pgPointCloud against PostgreSQL 19

### DIFF
--- a/pointcloud-pg/pgsql/pc_access.c
+++ b/pointcloud-pg/pgsql/pc_access.c
@@ -126,7 +126,7 @@ Datum pcpoint_get_values(PG_FUNCTION_ARGS)
   PG_RETURN_ARRAYTYPE_P(result);
 }
 
-static inline bool array_get_isnull(const bits8 *nullbitmap, int offset)
+static inline bool array_get_isnull(const uint8 *nullbitmap, int offset)
 {
   if (nullbitmap == NULL)
   {
@@ -147,7 +147,7 @@ pcpatch_from_point_array(ArrayType *array, FunctionCallInfo fcinfo)
 #endif
 {
   int nelems;
-  bits8 *bitmap;
+  uint8 *bitmap;
   size_t offset = 0;
   int i;
   uint32 pcid = 0;
@@ -222,7 +222,7 @@ pcpatch_from_patch_array(ArrayType *array, FunctionCallInfo fcinfo)
 #endif
 {
   int nelems;
-  bits8 *bitmap;
+  uint8 *bitmap;
   size_t offset = 0;
   int i;
   uint32 pcid = 0;
@@ -1127,7 +1127,7 @@ const char **array_to_cstring_array(ArrayType *array, int *size)
   int i, j, offset = 0;
   int nelems = ArrayGetNItems(ARR_NDIM(array), ARR_DIMS(array));
   const char **cstring = nelems ? pcalloc(nelems * sizeof(char *)) : NULL;
-  bits8 *bitmap = ARR_NULLBITMAP(array);
+  uint8 *bitmap = ARR_NULLBITMAP(array);
   for (i = j = 0; i < nelems; ++i)
   {
     text *array_text;

--- a/pointcloud-pg/pgsql/pc_pgsql.c
+++ b/pointcloud-pg/pgsql/pc_pgsql.c
@@ -52,9 +52,13 @@ static Oid pointcloud_get_full_version_schema()
 #if PGSQL_VERSION < 140
   FuncCandidateList clist =
       FuncnameGetCandidates(names, -1, NIL, false, false, false);
-#else
+#elif PGSQL_VERSION < 190
   FuncCandidateList clist =
       FuncnameGetCandidates(names, -1, NIL, false, false, false, false);
+#else
+  /* PostgreSQL 19 adds an output flags argument, which is not read here */
+  FuncCandidateList clist =
+      FuncnameGetCandidates(names, -1, NIL, false, false, false, false, NULL);
 #endif
   if (!clist)
     return InvalidOid;


### PR DESCRIPTION
The vendored pgPointCloud does not compile against PostgreSQL 19, which is one
of the two reasons `pgversion.yml` leaves 19 out of its matrix. Two
incompatibilities, both in `pointcloud-pg/pgsql/`:

- **`bits8` does not exist in PostgreSQL 19.** Four sites use it as the element
  type of a byte buffer. `uint8` names the same unsigned byte on every supported
  version, so the change is portable across 16-19 rather than version-gated.

- **`FuncnameGetCandidates` takes an eighth argument in PostgreSQL 19.** The call
  is already version-branched; this adds the `>= 190000` arm passing `NULL` for
  the new parameter and leaves the existing arms untouched.

Neither hunk is conditional on 19 alone: the `bits8` change is a spelling
correction valid on every version, and the new `FuncnameGetCandidates` arm is
selected by the same `PGSQL_VERSION` ladder the surrounding code uses.

Restoring PostgreSQL 19 to the CI matrix also needs `postgresql-19-h3` and
`postgresql-19-pointcloud` in apt, so this is a prerequisite rather than the
whole story.