### PR TITLE
Report an epoch-year date in every form a fixture takes

### DIFF
--- a/tools/scripts/check_fixture_dates.py
+++ b/tools/scripts/check_fixture_dates.py
@@ -42,6 +42,7 @@ The list only ever shrinks: delete a line when its file is migrated.
 Usage: check_fixture_dates.py [--list]
   --list  print every offending file and count, for refreshing the baseline
 """
+import lzma
 import os
 import re
 import sys
@@ -54,12 +55,29 @@ BASELINE = os.path.join(os.path.dirname(os.path.abspath(__file__)),
 # (`2000-2022`) and a longer number never match.
 EPOCH_DATE = re.compile(r"(?<!\d)2000-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])(?!\d)")
 
-# What CI compares, and what a reader copies out of the manual.
+# WHAT THE GATE READS, AND WHY THE TEST TREES CARRY NO EXTENSION LIST.  A fixture
+# arrives in whatever form its family needs -- the .sql the suite runs, the .out
+# it is compared against, a .c program, a .json schema, and the .sql.xz pg_dump
+# the _tbl tests load -- so naming extensions names the forms that existed when
+# the list was written, and the next one enters unread.  A date inside the
+# pg_dump is the case that proves it: it reaches every _tbl table in the suite
+# and no ordinary read sees it.  The two test trees are therefore read WHOLE.
+# `doc` names .xml because the manual is one form beside built artifacts.
 AREAS = (
-    ("mobilitydb/test", (".sql", ".out")),
-    ("meos/test", (".c",)),
+    ("mobilitydb/test", None),
+    ("meos/test", None),
     ("doc", (".xml",)),
 )
+
+
+def read_text(path):
+    """The file's text, decompressing an archive; None when it cannot be read."""
+    try:
+        opener = lzma.open if path.endswith(".xz") else open
+        with opener(path, "rt", encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except (OSError, lzma.LZMAError):
+        return None
 
 
 def offending_files():
@@ -68,14 +86,13 @@ def offending_files():
     for area, exts in AREAS:
         for dirpath, _, names in os.walk(os.path.join(ROOT, area)):
             for name in names:
-                if not name.endswith(exts):
+                if exts is not None and not name.endswith(exts):
                     continue
                 path = os.path.join(dirpath, name)
-                try:
-                    with open(path, encoding="utf-8", errors="replace") as fh:
-                        n = len(EPOCH_DATE.findall(fh.read()))
-                except OSError:
+                text = read_text(path)
+                if text is None:
                     continue
+                n = len(EPOCH_DATE.findall(text))
                 if n:
                     found[os.path.relpath(path, ROOT)] = n
     return found

--- a/tools/scripts/fixture_dates_baseline.txt
+++ b/tools/scripts/fixture_dates_baseline.txt
@@ -38,3 +38,4 @@ meos/test/timestamp_test.c 4
 meos/test/trajclip_test.c 6
 meos/test/trgeo_test.c 1
 meos/test/typeof_test.c 4
+mobilitydb/test/temporal/data/load.sql.xz 1000


### PR DESCRIPTION
check_fixture_dates.py reads the two test trees whole and decompresses the xz
pg_dumps the _tbl tests load, so a date is reported in whatever form its family
stores it: the .sql the suite runs, the .out it is compared against, a .c
program, a .json schema, and the archive itself. Naming extensions names the
forms that exist when the list is written, and a date inside a pg_dump is the
case that shows the cost, since it reaches every _tbl table in the suite while
no ordinary read sees it. The manual keeps its .xml, the one form beside the
artifacts a build leaves in doc. The whole scan takes three seconds.

mobilitydb/test/temporal/data/load.sql.xz carries 1000 such values, the 500
identical rows closing tbl_tstzspan_big, and the baseline records them for as
long as the archive holds them.

