### PR TITLE
Tell a portion of a circle from the complementary one

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -6106,11 +6106,21 @@ relate_same_portion(const Edge *a, const Edge *b)
 {
   if (a->etype != b->etype)
     return false;
-  if (a->etype == EDGE_POLYARC &&
-      (fabs(a->cx - b->cx) > MEOS_GEOM_TOLERANCE ||
-       fabs(a->cy - b->cy) > MEOS_GEOM_TOLERANCE ||
-       fabs(a->radius - b->radius) > MEOS_GEOM_TOLERANCE))
-    return false;
+  if (a->etype == EDGE_POLYARC)
+  {
+    if (fabs(a->cx - b->cx) > MEOS_GEOM_TOLERANCE ||
+        fabs(a->cy - b->cy) > MEOS_GEOM_TOLERANCE ||
+        fabs(a->radius - b->radius) > MEOS_GEOM_TOLERANCE)
+      return false;
+    /* Two endpoints do not determine an arc of a circle: the two arcs a full
+     * circle is read as carry the same pair and bow to opposite sides, so a
+     * portion is told from its complement by a point strictly inside it */
+    double amx, amy, bmx, bmy;
+    relate_area_edge_point(a, 0.5, &amx, &amy);
+    relate_area_edge_point(b, 0.5, &bmx, &bmy);
+    if (! relate_same_point(amx, amy, bmx, bmy))
+      return false;
+  }
   /* The two components may traverse the portion in opposite directions */
   return (relate_same_point(a->x1, a->y1, b->x1, b->y1) &&
       relate_same_point(a->x2, a->y2, b->x2, b->y2)) ||

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -262,6 +262,33 @@ int main(void)
   free(holed_geo); free(holed_buf);
   meos_errno_reset();
 
+  /* A circle is read as the two arcs between one pair of points, so a portion
+   * of it is told from the complementary one by a point strictly inside it
+   * and never by the endpoints alone. What locates a point against a
+   * collection of two or more surfaces is the union of their boundaries, and
+   * a circle contributing one half of itself there bounds nothing: every
+   * point of the surface reads as lying outside it. The buffer of a geometry
+   * of several parts is such a collection, each part bounded by a circle */
+  char pair_covers_patt[10] = "T*****FF*";
+  GSERIALIZED *pair_geo = geom_in("MULTIPOINT(0 0,10 0)", -1);
+  assert(pair_geo != NULL);
+  meos_errno_reset();
+  GSERIALIZED *pair_buf = geom_buffer(pair_geo, 1.0, "");
+  printf("geom_buffer(a geometry of two points): %d, errno %d\n",
+    pair_buf != NULL, meos_errno());
+  assert(pair_buf != NULL);
+  assert(meos_errno() == 0);
+  bool pair_covers = geom_relate_pattern(pair_buf, pair_geo, pair_covers_patt);
+  printf("  it covers the geometry it is taken of: %d\n", pair_covers);
+  assert(pair_covers == true);
+  char *pair_matrix = geom_relate(pair_buf, pair_geo);
+  printf("  its matrix against the two points: %s\n", pair_matrix);
+  assert(pair_matrix != NULL);
+  assert(strcmp(pair_matrix, "0F2FF1FF2") == 0);
+  assert(meos_errno() == 0);
+  free(pair_geo); free(pair_buf); free(pair_matrix);
+  meos_errno_reset();
+
   /* Two computations of one node read as one node when they lie nearer than
    * the tolerance the buffer allows a node, and that tolerance takes the
    * square root of the machine epsilon and scales it by the COORDINATES. The


### PR DESCRIPTION
A collection carrying two or more surfaces places every point of itself outside
itself where a member is bounded by a circle. `geom_relate()` of

    MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(-1 0,1 0,-1 0)),
                 CURVEPOLYGON(CIRCULARSTRING(9 0,11 0,9 0)))

against `POINT(0 0)`, the centre of its first member, answers `FF2FF10F2` — the
matrix it also answers for a point ninety-nine units away — while the same two
surfaces spelled as plain polygons answer `0F2FF1FF2`. `errno` stays 0, so the
answer carries no sign of it.

What locates a point against a collection is the union of the boundaries of its
surfaces, and a portion two components bound alike is kept once so that a ray
crosses it once. `relate_same_portion()` reads a portion from its endpoints,
which the two arcs a circle is read as carry alike: they run between one pair of
points and bow to opposite sides. One half of every circle is therefore
discarded as a repeat, and a boundary that closes nothing bounds no interior.
The `ncomp < 2` short-circuit ahead of that walk is why a lone curve polygon
answers correctly, and why the case needs a collection of two or more surfaces
to appear at all.

An arc is told from its complement by a point strictly inside it. Two portions
that genuinely coincide carry that point alike as well, so the repeat a
collection does contribute is still bounded once: two identical discs in one
collection, and two squares sharing an edge, answer as they do without the
change, for a point inside and for a point outside alike.

The buffer of a geometry of several parts is such a collection, each part
bounded by a circle, so `geo_test` states that one covers the geometry it is
taken of and that its matrix against the two points is `0F2FF1FF2`.