### PR TITLE
Date the MEOS test programs from 2001

### DIFF
--- a/meos/test/allocator_test.c
+++ b/meos/test/allocator_test.c
@@ -106,7 +106,7 @@ counting_free(void *ptr)
 /* Main program */
 int main(void)
 {
-  const char *tint_str = "[1@2000-01-01, 2@2000-01-02, 3@2000-01-03]";
+  const char *tint_str = "[1@2001-01-01, 2@2001-01-02, 3@2001-01-03]";
 
   /* Initialize MEOS (which installs the default libc allocator) */
   meos_initialize();

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -81,10 +81,10 @@ int main(void)
   assert(meos_errno() == 0);
 
   /* A succeeding call leaves the status clear */
-  Temporal *good = tfloat_in("{77@2000-01-01}");
+  Temporal *good = tfloat_in("{77@2001-01-01}");
   assert(good != NULL);
   char *good_out = tfloat_out(good, 6);
-  printf("tfloat_in(\"{77@2000-01-01}\"): %s, errno %d\n", good_out,
+  printf("tfloat_in(\"{77@2001-01-01}\"): %s, errno %d\n", good_out,
     meos_errno());
   assert(meos_errno() == 0);
 
@@ -106,7 +106,7 @@ int main(void)
    * inside the rejected check. The count starts at a value the functions never
    * produce, so that leaving it untouched is distinguishable from setting it. */
   int count = -559038737;
-  Temporal *inst = tint_in("1@2000-01-01");
+  Temporal *inst = tint_in("1@2001-01-01");
   assert(inst != NULL);
   meos_errno_reset();
   /* temporal_segments takes a sequence (set), so an instant is rejected */
@@ -116,7 +116,7 @@ int main(void)
   assert(count == 0);
 
   count = -559038737;
-  Temporal *seq = tint_in("{1@2000-01-01, 2@2000-01-02}");
+  Temporal *seq = tint_in("{1@2001-01-01, 2@2001-01-02}");
   assert(seq != NULL);
   meos_errno_reset();
   /* a span count of zero is rejected */
@@ -136,7 +136,7 @@ int main(void)
   assert(count == 0);
 
   count = -559038737;
-  Temporal *num = tint_in("{1@2000-01-01}");
+  Temporal *num = tint_in("{1@2001-01-01}");
   assert(num != NULL);
   meos_errno_reset();
   /* the two values must share a type, so a temporal float is rejected */
@@ -208,8 +208,8 @@ int main(void)
    * an order. A geometry has a B-tree order so that it can be indexed, which is
    * not a meaning to compare over time, so the call declines */
   meos_errno_reset();
-  Temporal *tpt1 = tgeompoint_in("[Point(1 1)@2000-01-01, Point(2 2)@2000-01-02]");
-  Temporal *tpt2 = tgeompoint_in("[Point(2 2)@2000-01-01, Point(3 3)@2000-01-02]");
+  Temporal *tpt1 = tgeompoint_in("[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02]");
+  Temporal *tpt2 = tgeompoint_in("[Point(2 2)@2001-01-01, Point(3 3)@2001-01-02]");
   assert(tpt1 != NULL && tpt2 != NULL && meos_errno() == 0);
   Temporal *unordered = tlt_temporal_temporal(tpt1, tpt2);
   printf("tlt_temporal_temporal(tgeompoint, tgeompoint): %s, errno %d\n",
@@ -249,8 +249,8 @@ int main(void)
   /* A temporal pose declines them for the same reason, and a pose is the value
    * a temporal rigid geometry carries */
   meos_errno_reset();
-  Temporal *tps = tpose_in("[Pose(Point(0 0),0)@2000-01-01, "
-    "Pose(Point(2 2),0.5)@2000-01-02]");
+  Temporal *tps = tpose_in("[Pose(Point(0 0),0)@2001-01-01, "
+    "Pose(Point(2 2),0.5)@2001-01-02]");
   assert(tps != NULL && meos_errno() == 0);
   assert(temporal_minus_max(tps) == NULL);
   printf("temporal_minus_max(tpose): declined, errno %d\n", meos_errno());

--- a/meos/test/index_position_test.c
+++ b/meos/test/index_position_test.c
@@ -139,7 +139,7 @@ main(void)
   {
     int x = random_int(0, 1000), y = random_int(0, 1000);
     snprintf(buf, sizeof(buf),
-      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])",
+      "STBOX XT(((%d,%d),(%d,%d)),[2001-01-01,2001-01-02])",
       x, y, x + 20, y + 20);
     STBox *b = stbox_in(buf);
     memcpy(&boxes[i], b, sizeof(STBox));
@@ -165,7 +165,7 @@ main(void)
     {
       int x = random_int(100, 900), y = random_int(100, 900);
       snprintf(buf, sizeof(buf),
-        "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])",
+        "STBOX XT(((%d,%d),(%d,%d)),[2001-01-01,2001-01-02])",
         x, y, x + 40, y + 40);
       STBox *query = stbox_in(buf);
 

--- a/meos/test/merge_test.c
+++ b/meos/test/merge_test.c
@@ -64,8 +64,8 @@ int main(void)
   meos_initialize_noexit_error_handler();
 
   /* Two instant sets sharing a timestamp with different values */
-  Temporal *conflict1 = tfloat_in("{77@2000-01-01}");
-  Temporal *conflict2 = tfloat_in("{88@2000-01-01}");
+  Temporal *conflict1 = tfloat_in("{77@2001-01-01}");
+  Temporal *conflict2 = tfloat_in("{88@2001-01-01}");
   assert(conflict1); assert(conflict2);
 
   /* temporal_merge_array reports the conflict */
@@ -73,7 +73,7 @@ int main(void)
   meos_errno_reset();
   Temporal *merged = temporal_merge_array(conflictarr, 2);
   printf("temporal_merge_array({%s, %s}, 2): NULL, errno %d\n",
-    "{77@2000-01-01}", "{88@2000-01-01}", meos_errno());
+    "{77@2001-01-01}", "{88@2001-01-01}", meos_errno());
   assert(merged == NULL);
   assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
 
@@ -81,13 +81,13 @@ int main(void)
   meos_errno_reset();
   merged = temporal_merge(conflict1, conflict2);
   printf("temporal_merge(%s, %s): NULL, errno %d\n",
-    "{77@2000-01-01}", "{88@2000-01-01}", meos_errno());
+    "{77@2001-01-01}", "{88@2001-01-01}", meos_errno());
   assert(merged == NULL);
   assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
 
   /* A conflict on a shared timestamp of temporal points is reported alike */
-  Temporal *point1 = tgeompoint_in("SRID=4326;{POINT(1 1)@2000-01-01}");
-  Temporal *point2 = tgeompoint_in("SRID=4326;{POINT(2 2)@2000-01-01}");
+  Temporal *point1 = tgeompoint_in("SRID=4326;{POINT(1 1)@2001-01-01}");
+  Temporal *point2 = tgeompoint_in("SRID=4326;{POINT(2 2)@2001-01-01}");
   assert(point1); assert(point2);
   Temporal *pointarr[2] = {point1, point2};
   meos_errno_reset();
@@ -100,20 +100,20 @@ int main(void)
   /* Two CONTINUOUS sequences meeting at a shared instant with different
    * values. This reaches a different merge path from the instant sets above:
    * the sequences are merged as an array and assembled into a sequence set */
-  Temporal *seq1 = tfloat_in("[77@2000-01-01, 88@2000-01-03]");
-  Temporal *seq2 = tfloat_in("[99@2000-01-03, 44@2000-01-05]");
+  Temporal *seq1 = tfloat_in("[77@2001-01-01, 88@2001-01-03]");
+  Temporal *seq2 = tfloat_in("[99@2001-01-03, 44@2001-01-05]");
   assert(seq1); assert(seq2);
   meos_errno_reset();
   merged = temporal_merge(seq1, seq2);
   printf("temporal_merge(%s, %s): NULL, errno %d\n",
-    "[77@2000-01-01, 88@2000-01-03]", "[99@2000-01-03, 44@2000-01-05]",
+    "[77@2001-01-01, 88@2001-01-03]", "[99@2001-01-03, 44@2001-01-05]",
     meos_errno());
   assert(merged == NULL);
   assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
 
   /* The same conflict between two sequence SETS */
-  Temporal *ss1 = tfloat_in("{[77@2000-01-01, 88@2000-01-03]}");
-  Temporal *ss2 = tfloat_in("{[99@2000-01-03, 44@2000-01-05]}");
+  Temporal *ss1 = tfloat_in("{[77@2001-01-01, 88@2001-01-03]}");
+  Temporal *ss2 = tfloat_in("{[99@2001-01-03, 44@2001-01-05]}");
   assert(ss1); assert(ss2);
   meos_errno_reset();
   merged = temporal_merge(ss1, ss2);
@@ -124,44 +124,44 @@ int main(void)
 
   /* Two continuous sequences meeting at a shared instant that carries the
    * SAME value merge into one sequence */
-  Temporal *join1 = tfloat_in("[77@2000-01-01, 88@2000-01-03]");
-  Temporal *join2 = tfloat_in("[88@2000-01-03, 44@2000-01-05]");
+  Temporal *join1 = tfloat_in("[77@2001-01-01, 88@2001-01-03]");
+  Temporal *join2 = tfloat_in("[88@2001-01-03, 44@2001-01-05]");
   assert(join1); assert(join2);
   meos_errno_reset();
   Temporal *joined = temporal_merge(join1, join2);
   assert(joined);
   char *joined_out = tfloat_out(joined, 6);
-  printf("temporal_merge(%s, %s): %s\n", "[77@2000-01-01, 88@2000-01-03]",
-    "[88@2000-01-03, 44@2000-01-05]", joined_out);
+  printf("temporal_merge(%s, %s): %s\n", "[77@2001-01-01, 88@2001-01-03]",
+    "[88@2001-01-03, 44@2001-01-05]", joined_out);
   assert(joined_out[0] == '[');
 
   free(seq1); free(seq2); free(ss1); free(ss2);
   free(join1); free(join2); free(joined); free(joined_out);
 
   /* Merging compatible values still succeeds after the reported conflicts */
-  Temporal *ok1 = tfloat_in("{77@2000-01-01}");
-  Temporal *ok2 = tfloat_in("{88@2000-01-02}");
+  Temporal *ok1 = tfloat_in("{77@2001-01-01}");
+  Temporal *ok2 = tfloat_in("{88@2001-01-02}");
   assert(ok1); assert(ok2);
   Temporal *okarr[2] = {ok1, ok2};
   merged = temporal_merge_array(okarr, 2);
   assert(merged);
   char *merged_out = tfloat_out(merged, 6);
   printf("temporal_merge_array({%s, %s}, 2): %s\n",
-    "{77@2000-01-01}", "{88@2000-01-02}", merged_out);
+    "{77@2001-01-01}", "{88@2001-01-02}", merged_out);
   assert(strcmp(merged_out,
-    "{77@2000-01-01 00:00:00+00, 88@2000-01-02 00:00:00+00}") == 0);
+    "{77@2001-01-01 00:00:00+00, 88@2001-01-02 00:00:00+00}") == 0);
 
   /* Values sharing a timestamp with the SAME value merge into one instant */
-  Temporal *same1 = tfloat_in("{77@2000-01-01}");
-  Temporal *same2 = tfloat_in("{77@2000-01-01}");
+  Temporal *same1 = tfloat_in("{77@2001-01-01}");
+  Temporal *same2 = tfloat_in("{77@2001-01-01}");
   assert(same1); assert(same2);
   Temporal *samearr[2] = {same1, same2};
   Temporal *sameres = temporal_merge_array(samearr, 2);
   assert(sameres);
   char *sameres_out = tfloat_out(sameres, 6);
   printf("temporal_merge_array({%s, %s}, 2): %s\n",
-    "{77@2000-01-01}", "{77@2000-01-01}", sameres_out);
-  assert(strcmp(sameres_out, "77@2000-01-01 00:00:00+00") == 0);
+    "{77@2001-01-01}", "{77@2001-01-01}", sameres_out);
+  assert(strcmp(sameres_out, "77@2001-01-01 00:00:00+00") == 0);
 
   free(conflict1); free(conflict2);
   free(point1); free(point2);

--- a/meos/test/rtree_join_test.c
+++ b/meos/test/rtree_join_test.c
@@ -262,7 +262,7 @@ test_degenerate(void)
     rtree_join(empty1, empty2, INDEX_OVERLAPS, result) == 0);
 
   RTree *filled = rtree_create_stbox();
-  STBox *box = stbox_in("STBOX XT(((0,0),(1,1)),[2000-01-01, 2000-01-02])");
+  STBox *box = stbox_in("STBOX XT(((0,0),(1,1)),[2001-01-01, 2001-01-02])");
   rtree_insert(filled, box, 0);
   check("empty joined with a filled index reports no pair",
     rtree_join(empty1, filled, INDEX_OVERLAPS, result) == 0);
@@ -273,14 +273,14 @@ test_degenerate(void)
    * report their single pair once the boxes are made to overlap */
   RTree *far = rtree_create_stbox();
   STBox *farbox = stbox_in(
-    "STBOX XT(((1000,1000),(1001,1001)),[2000-01-01, 2000-01-02])");
+    "STBOX XT(((1000,1000),(1001,1001)),[2001-01-01, 2001-01-02])");
   rtree_insert(far, farbox, 0);
   check("indexes that share no box report no pair",
     rtree_join(filled, far, INDEX_OVERLAPS, result) == 0);
 
   RTree *near = rtree_create_stbox();
   STBox *nearbox = stbox_in(
-    "STBOX XT(((0.5,0.5),(2,2)),[2000-01-01, 2000-01-02])");
+    "STBOX XT(((0.5,0.5),(2,2)),[2001-01-01, 2001-01-02])");
   rtree_insert(near, nearbox, 7);
   int n = rtree_join(filled, near, INDEX_OVERLAPS, result);
   check("a single overlapping pair is reported once", n == 1);
@@ -292,7 +292,7 @@ test_degenerate(void)
    * STBox pair must overlap in every dimension the two boxes share */
   RTree *later = rtree_create_stbox();
   STBox *laterbox = stbox_in(
-    "STBOX XT(((0,0),(1,1)),[2001-01-01, 2001-01-02])");
+    "STBOX XT(((0,0),(1,1)),[2002-01-01, 2002-01-02])");
   rtree_insert(later, laterbox, 0);
   check("boxes apart in time only are not reported",
     rtree_join(filled, later, INDEX_OVERLAPS, result) == 0);

--- a/meos/test/rtree_load_test.c
+++ b/meos/test/rtree_load_test.c
@@ -124,7 +124,7 @@ main(void)
   {
     int x = i % 64, y = i / 64;
     snprintf(buf, sizeof(buf),
-      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])", x, y, x + 1, y + 1);
+      "STBOX XT(((%d,%d),(%d,%d)),[2001-01-01,2001-01-02])", x, y, x + 1, y + 1);
     STBox *box = stbox_in(buf);
     memcpy(&boxes[i], box, sizeof(STBox));
     free(box);
@@ -144,7 +144,7 @@ main(void)
   {
     int x = (q * 7) % 60, y = (q * 11) % 30;
     snprintf(buf, sizeof(buf),
-      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])", x, y, x + 5, y + 5);
+      "STBOX XT(((%d,%d),(%d,%d)),[2001-01-01,2001-01-02])", x, y, x + 5, y + 5);
     STBox *query = stbox_in(buf);
     int ngrown, npacked;
     int64 *g = search_sorted(grown, query, &ngrown);
@@ -174,7 +174,7 @@ main(void)
 
   /* (iii) and (iv) a window over the whole extent returns every id unchanged */
   snprintf(buf, sizeof(buf),
-    "STBOX XT(((-1,-1),(1000,1000)),[2000-01-01,2000-01-02])");
+    "STBOX XT(((-1,-1),(1000,1000)),[2001-01-01,2001-01-02])");
   STBox *whole = stbox_in(buf);
   int nall;
   int64 *got = search_sorted(packed, whole, &nall);

--- a/meos/test/sptree_join_test.c
+++ b/meos/test/sptree_join_test.c
@@ -115,7 +115,7 @@ random_stbox(double span, double minext, double maxext)
   char buf[256];
   snprintf(buf, sizeof(buf),
     "STBOX XT(((%.6f,%.6f),(%.6f,%.6f)),"
-    "[2000-01-01 00:00:00+00, 2000-01-02 00:00:00+00])", x, y, x + dx, y + dy);
+    "[2001-01-01 00:00:00+00, 2001-01-02 00:00:00+00])", x, y, x + dx, y + dy);
   return stbox_in(buf);
 }
 
@@ -321,7 +321,7 @@ test_degenerate(void)
     sptree_join(empty1, empty2, INDEX_OVERLAPS, result) == 0);
 
   SPTree *filled = sptree_create_stbox(SPTREE_QUADTREE);
-  STBox *box = stbox_in("STBOX XT(((0,0),(1,1)),[2000-01-01, 2000-01-02])");
+  STBox *box = stbox_in("STBOX XT(((0,0),(1,1)),[2001-01-01, 2001-01-02])");
   sptree_insert(filled, box, 0);
   check("empty joined with a filled index reports no pair",
     sptree_join(empty1, filled, INDEX_OVERLAPS, result) == 0);
@@ -332,14 +332,14 @@ test_degenerate(void)
    * report their single pair once the boxes are made to overlap */
   SPTree *far = sptree_create_stbox(SPTREE_KDTREE);
   STBox *farbox = stbox_in(
-    "STBOX XT(((1000,1000),(1001,1001)),[2000-01-01, 2000-01-02])");
+    "STBOX XT(((1000,1000),(1001,1001)),[2001-01-01, 2001-01-02])");
   sptree_insert(far, farbox, 0);
   check("indexes that share no box report no pair",
     sptree_join(filled, far, INDEX_OVERLAPS, result) == 0);
 
   SPTree *near = sptree_create_stbox(SPTREE_KDTREE);
   STBox *nearbox = stbox_in(
-    "STBOX XT(((0.5,0.5),(2,2)),[2000-01-01, 2000-01-02])");
+    "STBOX XT(((0.5,0.5),(2,2)),[2001-01-01, 2001-01-02])");
   sptree_insert(near, nearbox, 7);
   int n = sptree_join(filled, near, INDEX_OVERLAPS, result);
   check("a single overlapping pair is reported once", n == 1);
@@ -351,7 +351,7 @@ test_degenerate(void)
    * STBox pair must overlap in every dimension the two boxes share */
   SPTree *later = sptree_create_stbox(SPTREE_QUADTREE);
   STBox *laterbox = stbox_in(
-    "STBOX XT(((0,0),(1,1)),[2001-01-01, 2001-01-02])");
+    "STBOX XT(((0,0),(1,1)),[2002-01-01, 2002-01-02])");
   sptree_insert(later, laterbox, 0);
   check("boxes apart in time only are not reported",
     sptree_join(filled, later, INDEX_OVERLAPS, result) == 0);
@@ -375,7 +375,7 @@ test_refused(void)
   SPTree *stboxtree = sptree_create_stbox(SPTREE_QUADTREE);
   SPTree *other = sptree_create_stbox(SPTREE_KDTREE);
   SPTree *tboxtree = sptree_create_tbox(SPTREE_QUADTREE);
-  STBox *box = stbox_in("STBOX XT(((0,0),(1,1)),[2000-01-01, 2000-01-02])");
+  STBox *box = stbox_in("STBOX XT(((0,0),(1,1)),[2001-01-01, 2001-01-02])");
   sptree_insert(stboxtree, box, 0);
   sptree_insert(other, box, 1);
 

--- a/meos/test/sptree_load_test.c
+++ b/meos/test/sptree_load_test.c
@@ -381,7 +381,7 @@ test_stbox(SPTreeKind kind, const char *kindname)
   {
     int x = random_int(0, 1000), y = random_int(0, 1000);
     snprintf(buf, sizeof(buf),
-      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])",
+      "STBOX XT(((%d,%d),(%d,%d)),[2001-01-01,2001-01-02])",
       x, y, x + 20, y + 20);
     STBox *box = stbox_in(buf);
     memcpy(&boxes[i], box, sizeof(STBox));
@@ -397,7 +397,7 @@ test_stbox(SPTreeKind kind, const char *kindname)
   {
     int x = random_int(0, 1000), y = random_int(0, 1000);
     snprintf(buf, sizeof(buf),
-      "STBOX XT(((%d,%d),(%d,%d)),[2000-01-01,2000-01-02])",
+      "STBOX XT(((%d,%d),(%d,%d)),[2001-01-01,2001-01-02])",
       x, y, x + 60, y + 60);
     STBox *query = stbox_in(buf);
 

--- a/meos/test/tbl_temporal.c
+++ b/meos/test/tbl_temporal.c
@@ -35,7 +35,7 @@
  * The corresponding SQL query would be, for each temporal type in turn,
  * @code
  * SELECT k, numInstants(tprecision(temp, interval '5 minutes', timestamptz
-     '2000-01-01'))
+     '2000-01-03'))
    FROM tbl_tfloat;
  * @endcode
  *

--- a/meos/test/trajclip_test.c
+++ b/meos/test/trajclip_test.c
@@ -95,16 +95,16 @@ main(void)
    * 056_tpoint_spatialfuncs_tbl, 087_tnpoint_spatialfuncs and
    * 087_tnpoint_spatialfuncs_tbl on PR #18's CI. */
   fails += run_case("quantised exit on slanted segment",
-    "[POINT(69.790369 81.452098)@2000-01-01,"
-    " POINT(55.752648 78.953813)@2000-01-02,"
-    " POINT(48.718663 77.764071)@2000-01-03]",
+    "[POINT(69.790369 81.452098)@2001-01-01,"
+    " POINT(55.752648 78.953813)@2001-01-02,"
+    " POINT(48.718663 77.764071)@2001-01-03]",
     "POLYGON((50 50,50 100,100 100,100 50,50 50))",
-    "{[POINT(69.790369 81.452098)@2000-01-01 00:00:00+00,"
-    " POINT(55.752648 78.953813)@2000-01-02 00:00:00+00,"
+    "{[POINT(69.790369 81.452098)@2001-01-01 00:00:00+00,"
+    " POINT(55.752648 78.953813)@2001-01-02 00:00:00+00,"
     /* The segment reaches x = 50 at 0.81783626209040821... of the way from the
      * first instant, which is 70661.053044611... seconds into the day, and a
      * timestamp holds whole microseconds */
-    " POINT(50 77.980799)@2000-01-02 19:37:41.053044+00]}");
+    " POINT(50 77.980799)@2001-01-02 19:37:41.053044+00]}");
 
   /* Multi-path open-path output where each output path is two crossings on
    * the same segment (no input vertex inside the path). The earlier

--- a/meos/test/trgeo_test.c
+++ b/meos/test/trgeo_test.c
@@ -67,7 +67,7 @@ int main(void)
   /* Well-formed trgeometry value: a reference geometry followed by the
    * ';'-delimited temporal (pose) part */
   const char *trgeo1_in =
-    "Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 2),0.5)@2000-01-01";
+    "Polygon((1 1,2 2,3 1,1 1));Pose(Point(1 2),0.5)@2001-01-01";
 
   /* Temporal *trgeometry_in(const char *str); */
   Temporal *trgeo1 = trgeometry_in(trgeo1_in);

--- a/meos/test/typeof_test.c
+++ b/meos/test/typeof_test.c
@@ -70,14 +70,14 @@ int main(void)
   meos_initialize_timezone("UTC");
 
   /* Self-describing serializations: the concrete type is recovered */
-  check("tint", temporal_as_hexwkb(tint_in("1@2000-01-01"), 0, &sz), T_TINT);
-  check("tfloat", temporal_as_hexwkb(tfloat_in("1.5@2000-01-01"), 0, &sz),
+  check("tint", temporal_as_hexwkb(tint_in("1@2001-01-01"), 0, &sz), T_TINT);
+  check("tfloat", temporal_as_hexwkb(tfloat_in("1.5@2001-01-01"), 0, &sz),
     T_TFLOAT);
   check("intspan", span_as_hexwkb(intspan_in("[1, 3]"), 0, &sz), T_INTSPAN);
   check("floatspan", span_as_hexwkb(floatspan_in("[1.0, 3.0]"), 0, &sz),
     T_FLOATSPAN);
   check("tstzspan",
-    span_as_hexwkb(tstzspan_in("[2000-01-01, 2000-01-02]"), 0, &sz),
+    span_as_hexwkb(tstzspan_in("[2001-01-01, 2001-01-02]"), 0, &sz),
     T_TSTZSPAN);
   check("intset", set_as_hexwkb(intset_in("{1, 2, 3}"), 0, &sz), T_INTSET);
   check("intspanset", spanset_as_hexwkb(intspanset_in("{[1,2],[4,5]}"), 0, &sz),

--- a/tools/scripts/check_fixture_dates.py
+++ b/tools/scripts/check_fixture_dates.py
@@ -45,6 +45,7 @@ Usage: check_fixture_dates.py [--list]
 import lzma
 import os
 import re
+import subprocess
 import sys
 
 ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -70,6 +71,29 @@ AREAS = (
 )
 
 
+def tracked_files(area):
+    """The repo-relative paths git tracks under `area`.
+
+    THE SUBJECT IS WHAT THE REPOSITORY CARRIES, so the list comes from git and
+    not from the directory.  Reading the directory reads whatever a BUILD has
+    left in it, and both test trees are written into: `meos/test/.gitignore`
+    ignores `csv/`, the table fixtures tools/gen_test_csv.py exports from the
+    same pg_dumps, and the smoke-test sources gen_smoketest.py writes from the
+    installed headers.  Those carry the archives' own dates, so a directory walk
+    reports a file that is not in the repository, cannot be migrated, and cannot
+    be baselined either -- the check passes on a clean checkout and fails on the
+    same commit once its tests have run.
+    """
+    out = subprocess.run(["git", "-C", ROOT, "ls-files", "-z", "--", area],
+                         capture_output=True, text=True)
+    if out.returncode:
+        print("check_fixture_dates: git does not list " + area + "; the check "
+              "reads tracked files and cannot run outside a checkout",
+              file=sys.stderr)
+        sys.exit(2)
+    return [p for p in out.stdout.split("\0") if p]
+
+
 def read_text(path):
     """The file's text, decompressing an archive; None when it cannot be read."""
     try:
@@ -84,17 +108,15 @@ def offending_files():
     """{repo-relative path: count} for every file carrying an epoch-year date."""
     found = {}
     for area, exts in AREAS:
-        for dirpath, _, names in os.walk(os.path.join(ROOT, area)):
-            for name in names:
-                if exts is not None and not name.endswith(exts):
-                    continue
-                path = os.path.join(dirpath, name)
-                text = read_text(path)
-                if text is None:
-                    continue
-                n = len(EPOCH_DATE.findall(text))
-                if n:
-                    found[os.path.relpath(path, ROOT)] = n
+        for rel in tracked_files(area):
+            if exts is not None and not rel.endswith(exts):
+                continue
+            text = read_text(os.path.join(ROOT, rel))
+            if text is None:
+                continue
+            n = len(EPOCH_DATE.findall(text))
+            if n:
+                found[rel] = n
     return found
 
 

--- a/tools/scripts/fixture_dates_baseline.txt
+++ b/tools/scripts/fixture_dates_baseline.txt
@@ -3,6 +3,10 @@
 # count above the one recorded, so a migrated area is protected the day it is
 # clean while the rest cannot drift further. The list only shrinks: delete a line
 # when its file is migrated.
+#
+# The four meos/test entries are the bin origin 2000-01-03, the first Monday of
+# 2000 and the default every tprecision and tsample signature declares, so they
+# name a reference point rather than a fixture instant and stay as they are.
 doc/box_types.xml 2
 doc/es/box_types.xml 2
 doc/es/set_span_types.xml 10
@@ -23,19 +27,8 @@ doc/temporal_raster.xml 11
 doc/temporal_rigid_geometries.xml 22
 doc/temporal_spatial_p1.xml 10
 doc/temporal_types_analytics.xml 454
-meos/test/allocator_test.c 3
-meos/test/error_test.c 12
-meos/test/index_position_test.c 4
-meos/test/merge_test.c 39
-meos/test/rtree_join_test.c 6
-meos/test/rtree_load_test.c 6
-meos/test/sptree_join_test.c 10
-meos/test/sptree_load_test.c 4
 meos/test/tbl_temporal.c 1
 meos/test/tbl_temporal_value.c 1
 meos/test/tbl_value_value.c 1
 meos/test/timestamp_test.c 4
-meos/test/trajclip_test.c 6
-meos/test/trgeo_test.c 1
-meos/test/typeof_test.c 4
 mobilitydb/test/temporal/data/load.sql.xz 1000


### PR DESCRIPTION
The programs under meos/test read their instants from 2001, the year the
fixtures the suite loads carry, so a value a program parses sits clear of
2000-01-01, the instant PostgreSQL counts timestamps from and the one a
positive-offset zone places before the epoch.

The two join programs separate their boxes by a year: the box an index holds
opens in 2001 and the box overlapping it in space alone opens in 2002, so
"boxes apart in time only are not reported" asks what its name says.

The four files that keep an epoch-year date name 2000-01-03 as a bin origin,
the first Monday of 2000 and the default every tprecision and tsample
signature declares; tbl_temporal.c states that origin in the SQL its comment
shows, as its siblings' code does. fixture_dates_baseline.txt records what
still carries such a date, so the eleven migrated files leave it.


Stacked on #2436.
