### PR TITLE
Remove the declaration of a function that does not exist

### DIFF
--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -115,12 +115,6 @@ extern Datum datum_geo_round(Datum value, Datum size);
 extern GSERIALIZED *point_round(const GSERIALIZED *gs, int maxdd);
 
 /******************************************************************************
- * Functions for base types
- *****************************************************************************/
-
-extern void geo_set_srid_int(const GSERIALIZED *gs, int32_t srid);
-
-/******************************************************************************
  * Functions for box types
  *****************************************************************************/
 


### PR DESCRIPTION
meos_internal_geo.h declared geo_set_srid_int, which is defined nowhere and called
nowhere. Its signature cannot do what its name says: it returns void and takes the
geometry as a const pointer, so it could not set an SRID through it. Setting an SRID
on a geometry is geo_set_srid, which returns the geometry, and in place it is the
gserialized_set_srid that geo_set_srid itself calls.

A declaration answers for the API whether or not anything implements it: a consumer
that generates its surface from the headers binds the name and fails when the symbol
is not in the library, which is how this one surfaced. The declaration is removed,
along with the section heading it left empty.

