### PR TITLE
Record no epoch-year date for the archive that carries none

### DIFF
--- a/tools/scripts/fixture_dates_baseline.txt
+++ b/tools/scripts/fixture_dates_baseline.txt
@@ -27,4 +27,3 @@ meos/test/tbl_temporal.c 1
 meos/test/tbl_temporal_value.c 1
 meos/test/tbl_value_value.c 1
 meos/test/timestamp_test.c 4
-mobilitydb/test/temporal/data/load.sql.xz 1000


### PR DESCRIPTION
fixture_dates_baseline.txt lists what each file holds, and
mobilitydb/test/temporal/data/load.sql.xz holds none, so it leaves the list. An
entry above a file's true count is a standing permission to date that many
values in 2000 again, and this is the archive every _tbl table in the suite
loads.

The list now records 14 files and 79 values: the bin origin 2000-01-03 in the
signature listings that state a tprecision, tsample or timeSplit default, and
the December answers a bin or an expanded span reaching one step back from a
2001 instant returns.

