### PR TITLE
Read the licence of the source files the repository carries

### DIFF
--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -1,5 +1,32 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# This MobilityDB code is provided under The PostgreSQL License.
+# Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+# contributors
+#
+# MobilityDB includes portions of PostGIS version 3 source code released
+# under the GNU General Public License (GPLv2 or later).
+# Copyright (c) 2001-2025, PostGIS contributors
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose, without fee, and without a written
+# agreement is hereby granted, provided that the above copyright notice and
+# this paragraph and the following two paragraphs appear in all copies.
+#
+# IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+# OF SUCH DAMAGE.
+#
+# UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+# AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+# PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+#
+
 """
 Generate MEOS smoke-test C files from any meos_<type>.h public header.
 

--- a/tools/codegen/h3pg_import/extract.py
+++ b/tools/codegen/h3pg_import/extract.py
@@ -1,4 +1,31 @@
 #!/usr/bin/env python3
+#
+# This MobilityDB code is provided under The PostgreSQL License.
+# Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+# contributors
+#
+# MobilityDB includes portions of PostGIS version 3 source code released
+# under the GNU General Public License (GPLv2 or later).
+# Copyright (c) 2001-2025, PostGIS contributors
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose, without fee, and without a written
+# agreement is hereby granted, provided that the above copyright notice and
+# this paragraph and the following two paragraphs appear in all copies.
+#
+# IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+# OF SUCH DAMAGE.
+#
+# UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+# AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+# PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+#
+
 """Transform h3-pg's PG_FUNCTION_ARGS bodies into MEOS-compatible C.
 
 Design summary: every `Datum fn(PG_FUNCTION_ARGS)` body in h3-pg's

--- a/tools/pin/smoke-resolved/gen_smoketest.py
+++ b/tools/pin/smoke-resolved/gen_smoketest.py
@@ -1,5 +1,32 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
+#
+# This MobilityDB code is provided under The PostgreSQL License.
+# Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+# contributors
+#
+# MobilityDB includes portions of PostGIS version 3 source code released
+# under the GNU General Public License (GPLv2 or later).
+# Copyright (c) 2001-2025, PostGIS contributors
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose, without fee, and without a written
+# agreement is hereby granted, provided that the above copyright notice and
+# this paragraph and the following two paragraphs appear in all copies.
+#
+# IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+# OF SUCH DAMAGE.
+#
+# UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+# AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+# PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+#
+
 """
 Generate MEOS smoke-test C files from any meos_<type>.h public header.
 

--- a/tools/scripts/license_other_projects.txt
+++ b/tools/scripts/license_other_projects.txt
@@ -1,0 +1,16 @@
+# Source files under the first-party trees that state another project's licence,
+# so test_license.sh does not ask them for MobilityDB's banner. Each line is a
+# path git lists, matched whole.
+#
+# The three *_ext_defs.in.h are read by meos/CMakeLists.txt into a generated
+# header and hold the declarations of the projects they name; postgres_int_defs.h
+# includes four of the vendored pgtypes headers; and pc_stringbuffer_shim.c holds
+# the pgPointCloud utilities PostGIS does not export.
+#
+# A file leaves this list by moving to the top-level directory of the project it
+# comes from, which is where the tree keeps vendored code.
+meos/include/h3_ext_defs.in.h
+meos/include/postgis_ext_defs.in.h
+meos/include/postgres_ext_defs.in.h
+meos/include/postgres_int_defs.h
+meos/src/pointcloud/pc_stringbuffer_shim.c

--- a/tools/scripts/test_license.sh
+++ b/tools/scripts/test_license.sh
@@ -2,8 +2,13 @@
 
 # This test checks that all source files correctly have license headers
 
-EXCLUDE_LIST="control.in|\.out|\.xz|\.cmake|\.md|\.txt|\.sh|\.control"
 DOC_EXCLUDE_LIST="\.png|\.svg|\.po|\.pot|\.pdf|\.sh|\.sty|\.vsdx|\.xsl|\.tx|\.md"
+
+# The first-party trees, and the extensions that carry code. A file holding
+# data -- a .csv fixture, a .json schema -- states no licence of its own and
+# the repository's licence covers it.
+SOURCE_TREES="meos mobilitydb tools"
+SOURCE_EXTENSIONS='\.(c|h|cpp|sql|py)$'
 
 mylicensecheck() {
   licensecheck -r -l 30 --tail 0 -i "$1" "$2"
@@ -11,13 +16,43 @@ mylicensecheck() {
 
 DIR=$(git rev-parse --show-toplevel)
 
+# WITHOUT THE READER THERE IS NO READING. licensecheck absent leaves every file
+# unexamined while the run still prints no finding and exits 0, which is the
+# answer a clean tree gives — the same silence this check was rewritten to stop
+# giving. Say what is missing instead.
+if ! command -v licensecheck > /dev/null; then
+  echo " *** licensecheck is not installed, so the licence of no file was read"
+  echo " *** install it (apt-get install licensecheck) and run this again"
+  exit 1
+fi
+
 pushd "${DIR}" > /dev/null || exit
-missing=$(! { mylicensecheck ${EXCLUDE_LIST} include & mylicensecheck ${EXCLUDE_LIST} src & mylicensecheck ${EXCLUDE_LIST} sql & mylicensecheck ${EXCLUDE_LIST} test; } | grep "No copyright\|UNKNOWN")
+# ASK GIT WHICH FILES THE REPOSITORY CARRIES, NEVER THE DIRECTORY. The four
+# names this read carried -- include, src, sql, test -- are not directories of
+# this tree, whose sources live under meos/ and mobilitydb/, so it matched
+# nothing: the check passed on empty input while sixty files carried no banner,
+# which is the whole reason it exists. Reading git also keeps out what a build
+# leaves behind, such as a __pycache__ .pyc or a staged install prefix.
+sources=$(git ls-files ${SOURCE_TREES} |
+  grep -E "${SOURCE_EXTENSIONS}" |
+  grep -vxF -f tools/scripts/license_other_projects.txt)
+read_count=$(printf '%s\n' "${sources}" | grep -c .)
+missing=$(printf '%s\n' "${sources}" | xargs -r licensecheck -l 30 --tail 0 |
+  grep "No copyright\|UNKNOWN")
 missing1=$(mylicensecheck ${DOC_EXCLUDE_LIST} doc | grep "No copyright")
 missing2=$(find doc -type f -name "*.xml" -exec grep -H -i -c 'Creative Commons' {} \; | grep :0$ | cut -d':' -f1)
 popd > /dev/null || exit
 
 error=0
+# THE CHECK STATES ITS OWN DENOMINATOR. A run that reads nothing prints no
+# finding and exits 0, which is what a run over a clean tree prints too, and
+# that is how a read of four directories this tree does not have went unnoticed.
+# Saying how many files were read tells the two apart at a glance.
+echo "license: read ${read_count} source file(s) under ${SOURCE_TREES// /, }"
+if [[ ${read_count} -eq 0 ]]; then
+  echo " *** The licence check read no file at all, so it asserts nothing"
+  error=1
+fi
 if [[ $missing ]]; then
   echo " ****************************************************"
   echo " *** Found source files without valid license headers"


### PR DESCRIPTION
test_license.sh asks git for the files under meos, mobilitydb and tools that
carry code, and reads each one: 1229 of them. The four names it read before —
include, src, sql and test — are not directories of this tree, whose sources
live under meos and mobilitydb, so the read matched nothing and the check
answered for an empty input. Asking git also keeps out what a build leaves
behind, a __pycache__ .pyc among it.

The check states how many files it read, and fails when that is none. A run
that reads nothing reports no finding and exits 0, which is what a run over a
clean tree reports too, and telling those apart is what the count is for.

license_other_projects.txt names the five source files under those trees that
state another project's licence: the three *_ext_defs.in.h that
meos/CMakeLists.txt reads into a generated header, postgres_int_defs.h, and the
pgPointCloud utilities pc_stringbuffer_shim.c holds. A file leaves that list by
moving to the top-level directory of the project it comes from, which is where
the tree keeps vendored code.

Three generators state the banner they emit into their output as a string, and
now state one of their own at the top, where a reader and the thirty lines
licensecheck reads both meet it.

Without licensecheck the run reads nothing and still prints no finding, which
is the answer a clean tree gives, so the check says what is missing and stops.

