### PR TITLE
Answer bounding box equality for a spatiotemporal box from stbox_eq

### DIFF
--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -138,13 +138,7 @@ temporal_bbox_eq(const void *box1, const void *box2, MeosType temptype)
     return tpcbox_eq((TPCBox *) box1, (TPCBox *) box2);
 #endif
   else if (bboxtype == T_STBOX)
-    // TODO Due to floating point precision the current statement
-    // is not equal to the next one.
-    // return stbox_eq((STBox *) box1, (STBox *) box2);
-    // Problem raised in the test file 51_tpoint_tbl.test.out
-    // Look for temp != merge in that file for 2 other cases where
-    // a problem still remains (result != 0) even with the _cmp function
-    return stbox_cmp((STBox *) box1, (STBox *) box2) == 0;
+    return stbox_eq((STBox *) box1, (STBox *) box2);
   else
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,


### PR DESCRIPTION
temporal_bbox_eq reads its STBox arm through stbox_eq, the sibling every other arm of the dispatch uses: span_eq, tbox_eq, tpcbox_eq.

stbox_cmp orders the same doubles with < and >, so it answers 0 exactly where stbox_eq answers true. A note on the arm attributes a difference between them to floating point precision; a last-bit difference in any dimension stbox_cmp reads moves stbox_cmp too.

The diff shows the bounding box dispatch commit as well as this one.