### PR TITLE
Read a point against the arc at the scale its coordinates carry

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -448,8 +448,17 @@ arc_set_bbox(Edge *e)
 static inline bool
 point_on_arc(double px, double py, const Edge *e)
 {
+  /* The radial distance is read from the coordinates of the point and of the
+   * centre, so what it misses by is a property of their arithmetic and not of
+   * the arc: a few units in the last place of the largest of them. An absolute
+   * band asks a point at a projected 6.4e6 to sit on its own circle to a
+   * thousandth of what that coordinate can express, and the point the engine
+   * itself places on the arc then reads as lying off it. The edge carries the
+   * tolerance its own coordinates call for -- the same quantity
+   * #point_on_segment reads for a straight edge -- and the floor leaves the
+   * band at MEOS_GEOM_TOLERANCE where an edge carries none */
   double d = hypot(px - e->cx, py - e->cy);
-  if (fabs(d - e->radius) > MEOS_GEOM_TOLERANCE)
+  if (fabs(d - e->radius) > fmax(e->tol, MEOS_GEOM_TOLERANCE))
     return false;
   return arc_contains_angle(e, atan2(py - e->cy, px - e->cx));
 }

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -262,6 +262,37 @@ int main(void)
   free(holed_geo); free(holed_buf);
   meos_errno_reset();
 
+  /* What a radial distance misses its arc by is a property of the coordinates
+   * it is read from, so the band it is judged against is theirs. At projected
+   * coordinates the point this states lies 1.6e-11 off the circle it is placed
+   * on, which is under a tenth of what those coordinates express and far over
+   * an absolute 1e-12, so a band that does not scale reads the boundary of a
+   * disc as its exterior. The same disc at the origin answers the same way,
+   * which is what makes the case about the scale rather than the geometry */
+  const char *disc_wkt[2] = {
+    "CURVEPOLYGON(CIRCULARSTRING(-1000 0,1000 0,-1000 0))",
+    "CURVEPOLYGON(CIRCULARSTRING(6399000 4600000,6401000 4600000,"
+      "6399000 4600000))" };
+  const char *edge_wkt[2] = {
+    "POINT(707.10678118654755 707.10678118654755)",
+    "POINT(6400707.1067811865 4600707.1067811865)" };
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *disc = geom_in(disc_wkt[i], -1);
+    GSERIALIZED *edge_pt = geom_in(edge_wkt[i], -1);
+    assert(disc != NULL); assert(edge_pt != NULL);
+    meos_errno_reset();
+    char *disc_matrix = geom_relate(disc, edge_pt);
+    printf("a disc %s its own boundary point: %s\n",
+      i ? "at projected coordinates against" : "at the origin against",
+      disc_matrix);
+    assert(disc_matrix != NULL);
+    assert(strcmp(disc_matrix, "FF20F1FF2") == 0);
+    assert(meos_errno() == 0);
+    free(disc); free(edge_pt); free(disc_matrix);
+    meos_errno_reset();
+  }
+
   /* A circle is read as the two arcs between one pair of points, so a portion
    * of it is told from the complementary one by a point strictly inside it
    * and never by the endpoints alone. What locates a point against a


### PR DESCRIPTION
`point_on_arc()` judges the radial distance against the tolerance the edge
carries, `fmax(e->tol, MEOS_GEOM_TOLERANCE)`. What that distance misses the arc
by is a property of the arithmetic producing it — a few units in the last place
of the largest coordinate involved — rather than of the arc, which is the
reading `point_on_segment()` takes for a straight edge and the quantity
`edge_set_tolerance()` records on every edge the extractor emits. The floor
leaves the band at `MEOS_GEOM_TOLERANCE` for an edge that carries none.

An absolute band asks a point at a projected 6.4e6 to sit on its own circle to a
thousandth of what that coordinate expresses. The point the engine itself places
on the arc lies 7.9e-12 to 3.2e-10 off it, so `geom_relate()` of a disc against
its own boundary point answers `FF2FF10F2`, the boundary read as the exterior,
where the same disc at the origin answers `FF20F1FF2`. The divergence is the
scale rather than the geometry:

| disc | matrix against a point on its boundary |
|---|---|
| origin, r=1 and r=1000 | `FF20F1FF2` |
| projected 6.4e6, r=1, r=1000 and r=1e5 | `FF20F1FF2` |

The band and the witness that locates an interior are coupled: `relate_point_in_area`
answers boundary before interior, so a witness within the band reads as a boundary
point and the interior reports empty. That witness steps off by ten times the same
scaled tolerance, so the margin holds — a surface against itself answers
`2FFF1FFF2` with `touches()` false at both scales, and a point a millimetre, a
metre or a hundred metres off the circle reads as lying off it.

`meos/test/geo_test.c` states a disc against its own boundary point at both scales.