### PR TITLE
Hold every cell a linestring meets in its H3 cover

### DIFF
--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -513,7 +513,7 @@ SELECT geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 geoToH3IndexSet(geometry,integer) → h3indexset
 </programlisting>
-				<para>Se admite todo tipo de geometría: un <varname>POINT</varname> produce una única celda, una <varname>LINESTRING</varname> muestrea sus segmentos, un <varname>POLYGON</varname> rellena su interior, y los valores <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> devuelven la unión de sus componentes. La cobertura se presenta solo para H3: es la única cuadrícula para la que MobilityDB lleva un núcleo de cobertura de regiones, y las formas para QUADBIN y S2 aún no están implementadas.</para>
+				<para>Se admite todo tipo de geometría: un <varname>POINT</varname> produce una única celda, una <varname>LINESTRING</varname> muestrea sus segmentos y toma los vecinos de cada muestra, de modo que el conjunto contiene todas las celdas que la línea toca, un <varname>POLYGON</varname> rellena su interior, y los valores <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> devuelven la unión de sus componentes. La cobertura se presenta solo para H3: es la única cuadrícula para la que MobilityDB lleva un núcleo de cobertura de regiones, y las formas para QUADBIN y S2 aún no están implementadas.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- {"871fa4418ffffff"}

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -515,7 +515,7 @@ SELECT geoToS2Cell(geography 'SRID=4326;Point(4.35 50.85)', 10);
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 geoToH3IndexSet(geometry,integer) → h3indexset
 </programlisting>
-				<para>Every geometry type is supported: a <varname>POINT</varname> yields a single cell, a <varname>LINESTRING</varname> samples its segments, a <varname>POLYGON</varname> fills its interior, and <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> values return the union of their components. The covering is stated for H3 alone: it is the one grid MobilityDB carries a region-covering kernel for, and the QUADBIN and S2 forms are not yet implemented.</para>
+				<para>Every geometry type is supported: a <varname>POINT</varname> yields a single cell, a <varname>LINESTRING</varname> samples its segments and takes the neighbours of each sample, so that the set holds every cell the line meets, a <varname>POLYGON</varname> fills its interior, and <varname>MULTI*</varname> / <varname>GEOMETRYCOLLECTION</varname> values return the union of their components. The covering is stated for H3 alone: it is the one grid MobilityDB carries a region-covering kernel for, and the QUADBIN and S2 forms are not yet implemented.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT geoToH3IndexSet(geometry 'SRID=4326;Point(4.35 50.85)', 7);
 -- {"871fa4418ffffff"}

--- a/meos/src/h3/h3_geo.c
+++ b/meos/src/h3/h3_geo.c
@@ -120,6 +120,35 @@ h3_buf_push(h3_buf *buf, H3Index cell)
 }
 
 /**
+ * @brief Push the ring of radius one around a cell, that is the cell and the
+ * six neighbours `gridDisk(c, 1)` returns
+ * @details The ring is the unit by which both covers widen to stay
+ * conservative: #polygon_to_cells_into applies it to the cells
+ * #polygonToCells returns, which are those whose centre falls inside the
+ * polygon, and #linestring_to_cells_into applies it to the cell holding each
+ * sample of a segment. In both the omitted cell is one the geometry meets
+ * while the test that selected the cells does not see it, and in both such a
+ * cell neighbours one that was selected.
+ */
+static void
+h3_buf_push_ring1(h3_buf *out, H3Index c)
+{
+  if (c == (H3Index) 0)
+    return;
+  H3Index neighbors[7];   /* gridDisk(_, 1) returns exactly 7 cells */
+  memset(neighbors, 0, sizeof(neighbors));
+  if (gridDisk(c, 1, neighbors) != E_SUCCESS)
+  {
+    /* gridDisk failure: fall back to the centre cell */
+    h3_buf_push(out, c);
+    return;
+  }
+  for (int i = 0; i < 7; i++)
+    if (neighbors[i] != (H3Index) 0)
+      h3_buf_push(out, neighbors[i]);
+}
+
+/**
  * @brief 
  */
 static void
@@ -230,14 +259,27 @@ point_to_cells_into(const LWPOINT *lwp, int32 resolution, h3_buf *out)
 }
 
 /*****************************************************************************
- * LINESTRING — Nyquist segment sampling.
+ * LINESTRING — segment sampling, each sample expanded by one ring.
  *
- * For each adjacent pair of vertices, compute segment length in degrees
- * and sample at edge/2 spacing.  Includes endpoints.
+ * For each adjacent pair of vertices, sample the segment at half a cell edge
+ * and emit the ring around the cell holding each sample.
+ *
+ * THE RING IS WHAT MAKES THE COVER CONSERVATIVE, AND SAMPLING ALONE IS NOT.
+ * A cover is read to prune, so it holds every cell the line meets: a cell it
+ * omits is a row a caller filtering on the cover never sees. Sampling bounds
+ * the distance between consecutive samples, which is a weaker statement than
+ * "every cell the segment crosses holds a sample" — a segment clipping the
+ * corner of a cell between two samples leaves that cell unsampled, and the
+ * finer the resolution the smaller such a corner needs to be.
+ *
+ * A cell crossed between two consecutive samples lies within half an edge of
+ * one of them, so it is that sample's own cell or a neighbour of it, and the
+ * ring of radius one around each sample holds it. This is the rule
+ * #polygon_to_cells_into already applies to the cells #polygonToCells returns.
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Emit the cells a linestring meets, each sample's ring included
  */
 static void
 linestring_to_cells_into(const LWLINE *line, int32 resolution, h3_buf *out)
@@ -265,7 +307,7 @@ linestring_to_cells_into(const LWLINE *line, int32 resolution, h3_buf *out)
       double t = (double) s / (double) nsamples;
       double lat = p0.y + t * dy;
       double lng = p0.x + t * dx;
-      h3_buf_push(out, h3_latlng_deg_to_cell(lat, lng, resolution));
+      h3_buf_push_ring1(out, h3_latlng_deg_to_cell(lat, lng, resolution));
     }
   }
 }
@@ -312,31 +354,6 @@ geoloop_free(GeoLoop *loop)
     pfree(loop->verts);
   loop->verts    = NULL;
   loop->numVerts = 0;
-}
-
-/**
- * @brief Push the 7 cells of `gridDisk(c, 1)` (the cell + its 6 neighbors)
- * @details The 1-ring is the unit of coverage expansion used by
- * `polygon_to_cells_into` to ensure that any cell the polygon overlaps
- * appears in the output set, including cells whose centroid lies
- * outside the polygon.
- */
-static void
-h3_buf_push_ring1(h3_buf *out, H3Index c)
-{
-  if (c == (H3Index) 0)
-    return;
-  H3Index neighbors[7];   /* gridDisk(_, 1) returns exactly 7 cells */
-  memset(neighbors, 0, sizeof(neighbors));
-  if (gridDisk(c, 1, neighbors) != E_SUCCESS)
-  {
-    /* gridDisk failure: fall back to the centre cell */
-    h3_buf_push(out, c);
-    return;
-  }
-  for (int i = 0; i < 7; i++)
-    if (neighbors[i] != (H3Index) 0)
-      h3_buf_push(out, neighbors[i]);
 }
 
 /**

--- a/mobilitydb/test/h3/expected/289_h3_geo.test.out
+++ b/mobilitydb/test/h3/expected/289_h3_geo.test.out
@@ -44,6 +44,18 @@ SELECT numvalues(
  t
 (1 row)
 
+WITH line(g) AS (
+  VALUES (geometry 'SRID=4326;LINESTRING(4.30 50.80, 4.45 50.90)')),
+samples AS (
+  SELECT geoToH3Cell(ST_LineInterpolatePoint(g, i / 500.0), 11) AS cell,
+    geoToH3IndexSet(g, 11) AS cover
+  FROM line, generate_series(0, 500) AS i)
+SELECT bool_and(cell <@ cover) FROM samples;
+ bool_and 
+----------
+ t
+(1 row)
+
 SELECT numvalues(
   geoToH3IndexSet(
     geometry 'SRID=4326;POLYGON((4.34 50.84, 4.36 50.84,

--- a/mobilitydb/test/h3/queries/289_h3_geo.test.sql
+++ b/mobilitydb/test/h3/queries/289_h3_geo.test.sql
@@ -55,7 +55,7 @@ SELECT geoToH3IndexSet(geometry 'SRID=4326;POINT(4.35 50.85)', 7);
 SELECT numvalues(geoToH3IndexSet(geometry 'SRID=4326;POINT(4.35 50.85)', 7));
 
 -------------------------------------------------------------------------------
--- LINESTRING → cells along the path (Nyquist segment sampling)
+-- LINESTRING → cells along the path (sampling, each sample ringed)
 -------------------------------------------------------------------------------
 
 -- ~10 km segment across Brussels at resolution 7 (cell edge ~ 1.2 km).
@@ -68,6 +68,19 @@ SELECT numvalues(
 SELECT numvalues(
   geoToH3IndexSet(
     geometry 'SRID=4326;LINESTRING(4.30 50.80, 4.45 50.90)', 5)) >= 1;
+
+-- THE COVER HOLDS THE CELL OF EVERY POINT ON THE LINE, and sampling alone
+-- does not give that: a cell the line enters and leaves between two
+-- consecutive samples is named by neither of them. Each sample therefore
+-- contributes the ring of its own neighbours, which is what makes the cover
+-- conservative. Read at a resolution fine enough for the gap to open.
+WITH line(g) AS (
+  VALUES (geometry 'SRID=4326;LINESTRING(4.30 50.80, 4.45 50.90)')),
+samples AS (
+  SELECT geoToH3Cell(ST_LineInterpolatePoint(g, i / 500.0), 11) AS cell,
+    geoToH3IndexSet(g, 11) AS cover
+  FROM line, generate_series(0, 500) AS i)
+SELECT bool_and(cell <@ cover) FROM samples;
 
 -------------------------------------------------------------------------------
 -- POLYGON → cells covering the area


### PR DESCRIPTION
The set geoToH3IndexSet returns for a linestring holds every cell the
line meets. Each segment is sampled at half a cell edge and each sample
contributes the ring of radius one around its own cell, so a cell the
line enters and leaves between two consecutive samples lies within half
an edge of one of them and is named by that sample's ring. This is the
rule polygon_to_cells_into already applies to the cells polygonToCells
returns, and it is what makes the set a conservative prefilter. Both
manuals state the neighbours, and 289_h3_geo reads every sample of a
line at resolution 11 back out of the cover.

