### PR TITLE
Solve two arcs where they meet in one place

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -208,6 +208,12 @@ geom_ring_is_convex(const POINTARRAY *pa)
 extern bool relate_point_on_boundary(double x, double y, Edge **edges,
   int nedges);
 extern int relate_point_in_area(double x, double y, Edge **edges, int nedges);
+/* Where two arcs meet, which the buffer overlay asks as well: solving the two
+ * circles and keeping the solutions both angular spans hold is one
+ * computation, and an intersection the two engines place differently is a
+ * defect neither of them can see from its own file */
+extern int relate_arc_arc_points(const Edge *a, const Edge *b, double x[2],
+  double y[2], bool *overlap);
 
 extern bool ensure_srid_is_latlong(int32_t srid);
 extern bool ensure_geodetic_geo(const GSERIALIZED *gs);

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -1549,38 +1549,17 @@ buffer_collect_arc_arc_intersections(const Edge *e1, const Edge *e2,
     return;
   }
 
-  /* Circles that cannot intersect */
-  if (d > r1 + r2 + MEOS_GEOM_TOLERANCE || d < fabs(r1 - r2) - MEOS_GEOM_TOLERANCE)
-    return;
-
-  /* Distance from the first centre to the radical-line foot */
-  double a = (d * d + r1 * r1 - r2 * r2) / (2.0 * d);
-  double h2 = r1 * r1 - a * a;
-  if (h2 < 0.0)
-    h2 = 0.0;
-  double h = sqrt(h2);
-  /* Unit vector from centre 1 to centre 2 */
-  double ux = dx / d;
-  double uy = dy / d;
-
-  /* Foot of the perpendicular on the radical line */
-  double mx = e1->cx + a * ux;
-  double my = e1->cy + a * uy;
-
-  /* At most two circle intersection points */
-  for (int k = 0; k < 2; k++)
-  {
-    double sign = k == 0 ? -1.0 : 1.0;
-    double x = mx + sign * h * (-uy);
-    double y = my + sign * h * ux;
-    double phi1 = atan2(y - e1->cy, x - e1->cx);
-    double phi2 = atan2(y - e2->cy, x - e2->cx);
-    if (arc_contains_angle(e1, phi1) && arc_contains_angle(e2, phi2))
-      buffer_add_intersection_point(points, x, y);
-    /* Tangency gives only one point */
-    if (h <= MEOS_GEOM_TOLERANCE)
-      break;
-  }
+  /* Two circles that are not the same circle meet where
+   * #relate_arc_arc_points() places them: the arithmetic that solves them and
+   * keeps the solutions both angular spans hold is one computation, and the
+   * overlay reads the points it answers. The coincident case above stays here,
+   * since what the two engines want of it differs -- the overlay splits at the
+   * ends of the shared stretch, the relate engine reads the stretch itself */
+  double x[2], y[2];
+  bool overlap = false;
+  int n = relate_arc_arc_points(e1, e2, x, y, &overlap);
+  for (int i = 0; i < n; i++)
+    buffer_add_intersection_point(points, x[i], y[i]);
 }
 
 /**

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -4337,7 +4337,7 @@ relate_arcs_overlap(const Edge *a, const Edge *b)
  * If the arcs overlap over a non-zero-length portion, overlap is set
  * to true and no point is required for the one-dimensional component.
  */
-static int
+int
 relate_arc_arc_points(const Edge *a, const Edge *b, double x[2], double y[2],
   bool *overlap)
 {


### PR DESCRIPTION
Two circles that are not the same circle meet where `relate_arc_arc_points()`
places them, and the buffer overlay reads the points it answers. The overlay
solved them a second time: the same radical-line foot, the same half-chord, the
same pair of candidates tested against both angular spans, written out again in
another file. An intersection the two engines place differently is a defect
neither of them can see from its own file, and the second copy carried none of
the reasoning the first states — why membership is decided by the angle alone,
and why a tangency yields one point rather than two.

The coincident case stays in the overlay, because what the two want of it
differs: the overlay splits at the ends of the stretch two arcs of one circle
share, while the relate engine answers the stretch itself through an overlap
flag its caller reads instead. Keeping that beside the call is what makes the
delegation behaviour-neutral rather than nearly so.

`relate_arc_arc_points()` joins `relate_point_on_boundary()` and
`relate_point_in_area()` as an entry the overlay reaches through `geo_funcs.h`.

The two implementations answer alike over the cases where two arcs are hard:
ordinary crossings, a span that excludes the crossing points, external and
internal tangency with spans that contain the contact, disjoint circles, one
circle inside another, concentric circles, coincident spans that overlap, that
share an endpoint and that are disjoint, a tangency within 1e-13, and each of
those at projected coordinates. The four contact cases of a union, the buffer
of a geometry of several parts, and `meos/test/geo_test.c` answer what they
answer without this change.