### PR TITLE
Answer the comparability of two spatiotemporal boxes in one validator

### DIFF
--- a/meos/include/geo/stbox.h
+++ b/meos/include/geo/stbox.h
@@ -52,6 +52,12 @@
 
 /*****************************************************************************/
 
+/* Validity of a pair of spatiotemporal boxes */
+
+extern bool ensure_valid_stbox_stbox(const STBox *box1, const STBox *box2);
+
+/*****************************************************************************/
+
 /* Set an STBox from a <Type> */
 
 extern void point_get_coords(const GSERIALIZED *point, bool hasz,

--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -104,8 +104,6 @@ extern bool ensure_valid_tspatial_geo(const Temporal *temp,
   const GSERIALIZED *gs);
 extern bool ensure_valid_tspatial_tspatial(const Temporal *temp1,
   const Temporal *temp2);
-extern bool ensure_valid_spatial_stbox_stbox(const STBox *box1,
-  const STBox *box2);
 extern bool ensure_valid_tgeo_stbox(const Temporal *temp, const STBox *box);
 extern bool ensure_valid_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs);
 extern bool ensure_valid_tgeo_tgeo(const Temporal *temp1,

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1859,14 +1859,8 @@ topo_stbox_stbox_init(const STBox *box1, const STBox *box2, bool *hasx,
   bool *hasz, bool *hast, bool *geodetic)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
-  if (! ensure_common_dimension(box1->flags, box2->flags))
-    return false;
-  /* Both boxes carry X here, so reading the SRID through the validating
-   * accessor would only repeat the test the condition has just made */
-  if (MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags) &&
-     (! ensure_same_geodetic(box1->flags, box2->flags) ||
-      ! ensure_same_srid(box1->srid, box2->srid)))
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
+      ! ensure_common_dimension(box1->flags, box2->flags))
     return false;
   stbox_stbox_flags(box1, box2, hasx, hasz, hast, geodetic);
   return true;
@@ -2100,14 +2094,19 @@ adjacent_stbox_stbox(const STBox *box1, const STBox *box2)
  *****************************************************************************/
 
 /**
- * @brief Verify the conditions for a position operator
+ * @brief Return true if two spatiotemporal boxes are valid for operations
+ * @details The boxes are comparable when they state the same spatial
+ * reference system, which for a spatiotemporal box is its SRID together with
+ * whether its coordinates are geodetic. A box carrying no X states neither,
+ * so the pair is comparable whatever the other box holds. Which dimensions an
+ * operation needs is the operation's own question, asked after this one
  * @param[in] box1,box2 Spatiotemporal boxes
  */
-static bool
-ensure_valid_pos_stbox_stbox_x(const STBox *box1, const STBox *box2)
+bool
+ensure_valid_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, NULL); VALIDATE_NOT_NULL(box2, NULL);
+  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
   /* Both boxes carry X here, so reading the SRID through the validating
    * accessor would only repeat the test the condition has just made */
   if (MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags) && (
@@ -2143,7 +2142,7 @@ bool
 left_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
@@ -2177,7 +2176,7 @@ bool
 overleft_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
@@ -2211,7 +2210,7 @@ bool
 right_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
@@ -2245,7 +2244,7 @@ bool
 overright_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
@@ -2277,7 +2276,7 @@ bool
 below_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
@@ -2311,7 +2310,7 @@ bool
 overbelow_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
@@ -2343,7 +2342,7 @@ bool
 above_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
@@ -2377,7 +2376,7 @@ bool
 overabove_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_X(T_STBOX, box1->flags) ||
       ! ensure_has_X(T_STBOX, box2->flags))
     return false;
@@ -2411,7 +2410,7 @@ bool
 front_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_Z(T_STBOX, box1->flags) ||
       ! ensure_has_Z(T_STBOX, box2->flags))
     return false;
@@ -2445,7 +2444,7 @@ bool
 overfront_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_Z(T_STBOX, box1->flags) ||
       ! ensure_has_Z(T_STBOX, box2->flags))
     return false;
@@ -2479,7 +2478,7 @@ bool
 back_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_Z(T_STBOX, box1->flags) ||
       ! ensure_has_Z(T_STBOX, box2->flags))
     return false;
@@ -2513,7 +2512,7 @@ bool
 overback_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_pos_stbox_stbox_x(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
       ! ensure_has_Z(T_STBOX, box1->flags) ||
       ! ensure_has_Z(T_STBOX, box2->flags))
     return false;
@@ -2670,10 +2669,8 @@ STBox *
 union_stbox_stbox(const STBox *box1, const STBox *box2, bool strict)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, NULL); VALIDATE_NOT_NULL(box2, NULL);
-  if (! ensure_same_geodetic(box1->flags, box2->flags) ||
-      ! ensure_same_dimensionality(box1->flags, box2->flags) ||
-      ! ensure_same_srid(box1->srid, box2->srid))
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
+      ! ensure_same_dimensionality(box1->flags, box2->flags))
     return NULL;
   /* If the strict parameter is true, we need to ensure that the boxes
    * intersect, otherwise their union cannot be represented by a box */
@@ -2754,10 +2751,8 @@ STBox *
 intersection_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, NULL); VALIDATE_NOT_NULL(box2, NULL);
-  if (! ensure_same_geodetic(box1->flags, box2->flags) ||
-      // ! ensure_same_dimensionality(box1->flags, box2->flags) ||
-      ! ensure_same_srid(box1->srid, box2->srid))
+  // ! ensure_same_dimensionality(box1->flags, box2->flags) is not asked here
+  if (! ensure_valid_stbox_stbox(box1, box2))
     return NULL;
 
   STBox *result = palloc(sizeof(STBox));

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2745,8 +2745,9 @@ double
 nad_stbox_stbox(const STBox *box1, const STBox *box2)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, DBL_MAX); VALIDATE_NOT_NULL(box2, DBL_MAX);
-  if (! ensure_valid_spatial_stbox_stbox(box1, box2) ||
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
+      ! ensure_has_X(T_STBOX, box1->flags) ||
+      ! ensure_has_X(T_STBOX, box2->flags) ||
       ! ensure_same_spatial_dimensionality(box1->flags, box2->flags))
     return DBL_MAX;
 

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -692,20 +692,6 @@ ensure_valid_tspatial_geo(const Temporal *temp, const GSERIALIZED *gs)
   return true;
 }
 
-/**
- * @brief Ensure the validity of a spatiotemporal boxes
- */
-bool
-ensure_valid_spatial_stbox_stbox(const STBox *box1, const STBox *box2)
-{
-  VALIDATE_NOT_NULL(box1, false); VALIDATE_NOT_NULL(box2, false);
-  if (! ensure_has_X(T_STBOX, box1->flags) ||
-      ! ensure_has_X(T_STBOX, box2->flags) ||
-      ! ensure_same_srid(stbox_srid(box1), stbox_srid(box2)) ||
-      ! ensure_same_geodetic(box1->flags, box2->flags))
-    return false;
-  return true;
-}
 
 /**
  * @brief Ensure the validity of a temporal geo and a spatiotemporal box

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -1107,15 +1107,15 @@ SELECT stbox 'STBOX X((1,1),(5,5))' -|- stbox 'STBOX X((5,5),(9,9))';
 
 /* Errors */
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' && stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' @> stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' <@ stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' -|- stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' ~= stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' && stbox 'STBOX T([2001-01-01, 2001-01-02])';
 ERROR:  The temporal values must have at least one common dimension
 SELECT stbox 'STBOX X((1.0,1.0),(2.0,2.0))' @> stbox 'STBOX T([2001-01-01, 2001-01-02])';
@@ -1542,7 +1542,7 @@ ERROR:  The arguments must be of the same dimensionality
 SELECT stbox 'GEODSTBOX T([2001-01-03,2001-01-03])' + stbox 'GEODSTBOX ZT(((1.0,2.0,3.0),(1.0,2.0,3.0)),[2001-01-03,2001-01-04])';
 ERROR:  The arguments must be of the same dimensionality
 SELECT stbox 'STBOX X((1.0,2.0),(3.0,4.0))' + stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT stbox 'STBOX X((1.0,2.0),(3.0,4.0))' * stbox 'STBOX X((1.0,2.0),(3.0,4.0))';
        ?column?       
 ----------------------
@@ -1773,7 +1773,7 @@ SELECT stbox 'STBOX ZT(((1.0,2.0,3.0),(4.0,5.0,6.0)),[2001-01-01,2001-01-02])' *
 
 /* Errors */
 SELECT stbox 'STBOX X((1.0,2.0),(3.0,4.0))' * stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT MAX(xmax(t1.b + t2.b)) FROM tbl_stbox t1, tbl_stbox t2 WHERE t1.b && t2.b;
     max     
 ------------

--- a/mobilitydb/test/geo/expected/060_tgeo_topops.test.out
+++ b/mobilitydb/test/geo/expected/060_tgeo_topops.test.out
@@ -1505,7 +1505,7 @@ SELECT stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))' && tgeography '{[Point(1
 
 /* Errors */
 SELECT stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))' && tgeometry 'Point(1 1 1)@2001-01-01';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT stbox 'STBOX Z((1.0,2.0,2.0),(1.0,2.0,2.0))' && tgeometry 'Point(1 1 1)@2001-01-01';
  ?column? 
 ----------
@@ -1950,7 +1950,7 @@ ERROR:  Operation on mixed SRID
 SELECT stbox 'SRID=5676;STBOX XT(((1,1),(2,2)),[2002-01-01,2002-01-02])' && stbox 'STBOX XT(((1,1),(2,2)),[2002-01-01,2002-01-02])';
 ERROR:  Operation on mixed SRID
 SELECT stbox 'GEODSTBOX ZT(((1,1,1),(2,2,2)),[2002-01-01,2002-01-02])' && stbox 'STBOX XT(((1,1),(2,2)),[2002-01-01,2002-01-02])';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT tgeometry 'SRID=5676;Point(1 1)@2001-01-01' && stbox 'STBOX XT(((1,1),(2,2)),[2002-01-01,2002-01-02])';
 ERROR:  Operation on mixed SRID
 SELECT tstzspan '[2001-01-01,2001-01-02]' @> tgeometry 'Point(1 1)@2001-01-01';

--- a/mobilitydb/test/geo/expected/060_tpoint_topops.test.out
+++ b/mobilitydb/test/geo/expected/060_tpoint_topops.test.out
@@ -1732,7 +1732,7 @@ SELECT stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))' && tgeogpoint '{[Point(1
 
 /* Errors */
 SELECT stbox 'GEODSTBOX Z((1.0,2.0,3.0),(1.0,2.0,3.0))' && tgeompoint 'Point(1 1 1)@2001-01-01';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT stbox 'STBOX Z((1.0,2.0,2.0),(1.0,2.0,2.0))' && tgeompoint 'Point(1 1 1)@2001-01-01';
  ?column? 
 ----------
@@ -2177,7 +2177,7 @@ ERROR:  Operation on mixed SRID
 SELECT stbox 'SRID=5676;STBOX XT(((1,1),(2,2)),[2002-01-01,2002-01-02])' && stbox 'STBOX XT(((1,1),(2,2)),[2002-01-01,2002-01-02])';
 ERROR:  Operation on mixed SRID
 SELECT stbox 'GEODSTBOX ZT(((1,1,1),(2,2,2)),[2002-01-01,2002-01-02])' && stbox 'STBOX XT(((1,1),(2,2)),[2002-01-01,2002-01-02])';
-ERROR:  Operation on mixed planar and geodetic coordinates
+ERROR:  Operation on mixed SRID
 SELECT tgeompoint 'SRID=5676;Point(1 1)@2001-01-01' && stbox 'STBOX XT(((1,1),(2,2)),[2002-01-01,2002-01-02])';
 ERROR:  Operation on mixed SRID
 SELECT tstzspan '[2001-01-01,2001-01-02]' @> tgeompoint 'Point(1 1)@2001-01-01';


### PR DESCRIPTION
ensure_valid_stbox_stbox holds what makes two spatiotemporal boxes comparable, the same SRID and the same geodetic reading of their coordinates, and every operation on a pair of them calls it first. Which dimensions an operation needs is its own question, asked after that one from the primitives shared across box types. stbox.c names ensure_same_srid and ensure_same_geodetic in that one function and nowhere else.

The name states the pair it relates, as ensure_valid_span_span and ensure_valid_tbox_tbox do. An operation-shaped name invites a second validator for the next operation class, which is how the rule comes to stand in five places: behind a position-shaped name, behind a spatial-shaped one that also asks for the X dimension, and inline in the topological initializer, the union and the intersection.

Those spellings disagree on which condition they read first, so a pair differing in BOTH the SRID and the geodetic flag reports one error through a position operator and another through a topological one. The pair validators of tgeo_spatialfuncs.c read the SRID first, all seven of them, so eleven expected lines across three files carry that message.

VALIDATE_NOT_NULL in the position validator answers a bool function with NULL. The dimensionality condition intersection_stbox_stbox carries commented out stays commented out.