### PR TITLE
Reject an extent aggregation of boxes that are not comparable

### DIFF
--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -1604,12 +1604,10 @@ Stbox_extent_transfn(PG_FUNCTION_ARGS)
     PG_RETURN_STBOX_P(stbox_copy(box1));
 
   /* Both boxes are not null */
-  ensure_same_dimensionality(box1->flags, box2->flags);
-  if (MEOS_FLAGS_GET_X(box1->flags))
-  {
-    ensure_same_srid(stbox_srid(box1), stbox_srid(box2));
-    ensure_same_geodetic(box1->flags, box2->flags);
-  }
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
+      ! ensure_same_dimensionality(box1->flags, box2->flags))
+    PG_RETURN_NULL();
   STBox *result = palloc(sizeof(STBox));
   memcpy(result, box1, sizeof(STBox));
   stbox_expand(box2, result);
@@ -1634,7 +1632,10 @@ Stbox_extent_combinefn(PG_FUNCTION_ARGS)
   if (!box1 && box2)
     PG_RETURN_STBOX_P(box2);
   /* Both boxes are not null */
-  ensure_same_dimensionality(box1->flags, box2->flags);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
+      ! ensure_same_dimensionality(box1->flags, box2->flags))
+    PG_RETURN_NULL();
   STBox *result = stbox_copy(box1);
   stbox_expand(box2, result);
   PG_RETURN_STBOX_P(result);

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -1795,6 +1795,39 @@ SELECT extent(box) FROM test;
  STBOX XT(((1,1),(3,3)),[Mon Jan 01 00:00:00 2001 PST, Wed Jan 03 00:00:00 2001 PST])
 (1 row)
 
+SELECT stbox_extent_combinefn(stbox 'SRID=5676;STBOX X((1,1),(2,2))',
+  stbox 'SRID=5676;STBOX X((3,3),(4,4))');
+     stbox_extent_combinefn     
+--------------------------------
+ SRID=5676;STBOX X((1,1),(4,4))
+(1 row)
+
+SELECT stbox_extent_combinefn(stbox 'SRID=4326;GEODSTBOX X((1,1),(2,2))',
+  stbox 'SRID=4326;GEODSTBOX X((3,3),(4,4))');
+       stbox_extent_combinefn       
+------------------------------------
+ SRID=4326;GEODSTBOX X((1,1),(4,4))
+(1 row)
+
+SELECT stbox_extent_combinefn(stbox 'STBOX T([2001-01-01,2001-01-02])',
+  stbox 'STBOX T([2001-01-03,2001-01-04])');
+                        stbox_extent_combinefn                         
+-----------------------------------------------------------------------
+ STBOX T([Mon Jan 01 00:00:00 2001 PST, Thu Jan 04 00:00:00 2001 PST])
+(1 row)
+
+SELECT stbox_extent_combinefn(stbox 'SRID=5676;STBOX X((1,1),(2,2))',
+  stbox 'SRID=4326;STBOX X((3,3),(4,4))');
+ERROR:  Operation on mixed SRID
+SELECT stbox_extent_combinefn(stbox 'SRID=4326;STBOX X((1,1),(2,2))',
+  stbox 'SRID=4326;GEODSTBOX X((3,3),(4,4))');
+ERROR:  Operation on mixed planar and geodetic coordinates
+SELECT stbox_extent_combinefn(stbox 'SRID=5676;STBOX X((1,1),(2,2))',
+  stbox 'SRID=5676;STBOX Z((3,3,3),(4,4,4))');
+ERROR:  The arguments must be of the same dimensionality
+SELECT stbox_extent_combinefn(stbox 'SRID=5676;STBOX X((1,1),(2,2))',
+  stbox 'STBOX T([2001-01-01,2001-01-02])');
+ERROR:  The arguments must be of the same dimensionality
 set parallel_setup_cost=0;
 SET
 set parallel_tuple_cost=0;

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -517,6 +517,26 @@ WITH test(box) AS (
   SELECT NULL::stbox UNION ALL SELECT stbox 'STBOX XT(((1,1),(3,3))[2001-01-01,2001-01-03])' )
 SELECT extent(box) FROM test;
 
+-- The combine function is what a parallel plan reaches, and worker
+-- partitioning cannot be steered from a query, so it is called directly
+
+SELECT stbox_extent_combinefn(stbox 'SRID=5676;STBOX X((1,1),(2,2))',
+  stbox 'SRID=5676;STBOX X((3,3),(4,4))');
+SELECT stbox_extent_combinefn(stbox 'SRID=4326;GEODSTBOX X((1,1),(2,2))',
+  stbox 'SRID=4326;GEODSTBOX X((3,3),(4,4))');
+SELECT stbox_extent_combinefn(stbox 'STBOX T([2001-01-01,2001-01-02])',
+  stbox 'STBOX T([2001-01-03,2001-01-04])');
+
+-- Errors
+SELECT stbox_extent_combinefn(stbox 'SRID=5676;STBOX X((1,1),(2,2))',
+  stbox 'SRID=4326;STBOX X((3,3),(4,4))');
+SELECT stbox_extent_combinefn(stbox 'SRID=4326;STBOX X((1,1),(2,2))',
+  stbox 'SRID=4326;GEODSTBOX X((3,3),(4,4))');
+SELECT stbox_extent_combinefn(stbox 'SRID=5676;STBOX X((1,1),(2,2))',
+  stbox 'SRID=5676;STBOX Z((3,3,3),(4,4,4))');
+SELECT stbox_extent_combinefn(stbox 'SRID=5676;STBOX X((1,1),(2,2))',
+  stbox 'STBOX T([2001-01-01,2001-01-02])');
+
 -- encourage use of parallel plans
 set parallel_setup_cost=0;
 set parallel_tuple_cost=0;


### PR DESCRIPTION
Both entries of the extent aggregation read ensure_valid_stbox_stbox, so the combine path a parallel plan takes asks what the transition path asks, and each reads the answer of the conditions it states.

Stbox_extent_combinefn asks only that its two boxes share a dimensionality. Two boxes stating different SRIDs therefore merge, and the answer carries the SRID of the first while holding the coordinates of both: 'SRID=5676;STBOX X((1,1),(2,2))' combined with 'SRID=4326;STBOX X((3,3),(4,4))' answers 'SRID=5676;STBOX X((1,1),(4,4))'. A planar box and a geodetic one at the same SRID merge into a GEODSTBOX holding planar coordinates. The box that comes out states a reference system its contents are not in.

Stbox_extent_transfn states its conditions and discards their answers, which rests on meos_error raising through the PostgreSQL handler rather than on the return value.

Seven cases call the combine function directly, worker partitioning not being something a query states, so an aggregate over a table reaches that path only by chance. Three combine boxes that agree, on the SRID and on the geodetic flag and on carrying no X at all; four state a disagreement, one of them at a single SRID so that the geodetic flag is what differs.