### PR TITLE
Read the direction an edge runs in as a direction

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -3829,21 +3829,51 @@ buffer_offset_edge(const Edge *edge, double radius, bool left,
 }
 
 /**
+ * @brief Return the direction an edge runs in at one of its ends
+ * @details A direction, so of unit length at both ends of both kinds of edge.
+ * The tangent of an arc is a sine and a cosine and is already of unit length;
+ * the chord of a straight edge is as long as the edge, and the turn between
+ * two directions is read as a cross product, so leaving it unnormalized makes
+ * that turn an area where two straight edges meet, a length where a straight
+ * edge meets an arc, and a sine where two arcs do. Only the last is what the
+ * one tolerance the turn is judged against can bound, so the other two shrink
+ * with the geometry and a genuine turn between small edges reads as tangent.
+ * @param[in] edge Edge
+ * @param[in] at_start True for the direction it leaves its start point in,
+ * false for the direction it arrives at its end point in
+ * @param[out] dx,dy Direction, of unit length, or zero for an edge of no
+ * length, which runs in no direction
+ */
+static void
+buffer_edge_tangent(const Edge *edge, bool at_start, double *dx, double *dy)
+{
+  assert(edge); assert(dx); assert(dy);
+  if (edge->etype == EDGE_POLYARC || edge->etype == EDGE_LINEARC)
+  {
+    double theta = at_start ? edge->theta0 : edge->theta1;
+    double s = sin(theta), c = cos(theta);
+    *dx = edge->ccw ? -s : s;
+    *dy = edge->ccw ? c : -c;
+    return;
+  }
+  double ex = edge->x2 - edge->x1, ey = edge->y2 - edge->y1;
+  double len = hypot(ex, ey);
+  if (len <= 0.0)
+  {
+    *dx = *dy = 0.0;
+    return;
+  }
+  *dx = ex / len;
+  *dy = ey / len;
+}
+
+/**
  * @brief Return the direction an edge leaves its start point in
  */
 static void
 buffer_edge_start_tangent(const Edge *edge, double *dx, double *dy)
 {
-  assert(edge); assert(dx); assert(dy);
-  if (edge->etype == EDGE_POLYARC || edge->etype == EDGE_LINEARC)
-  {
-    double s = sin(edge->theta0), c = cos(edge->theta0);
-    *dx = edge->ccw ? -s : s;
-    *dy = edge->ccw ? c : -c;
-    return;
-  }
-  *dx = edge->x2 - edge->x1;
-  *dy = edge->y2 - edge->y1;
+  buffer_edge_tangent(edge, true, dx, dy);
 }
 
 /**
@@ -3852,16 +3882,7 @@ buffer_edge_start_tangent(const Edge *edge, double *dx, double *dy)
 static void
 buffer_edge_end_tangent(const Edge *edge, double *dx, double *dy)
 {
-  assert(edge); assert(dx); assert(dy);
-  if (edge->etype == EDGE_POLYARC || edge->etype == EDGE_LINEARC)
-  {
-    double s = sin(edge->theta1), c = cos(edge->theta1);
-    *dx = edge->ccw ? -s : s;
-    *dy = edge->ccw ? c : -c;
-    return;
-  }
-  *dx = edge->x2 - edge->x1;
-  *dy = edge->y2 - edge->y1;
+  buffer_edge_tangent(edge, false, dx, dy);
 }
 
 /**

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -357,6 +357,44 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* The junction between two offsets is settled from the cross product of the
+   * directions the two edges meeting there run in, and that product is a sine
+   * only where both directions are of unit length. An arc answers a sine and
+   * a cosine and is; a straight edge answered its whole chord and was not, so
+   * the product was a length where a straight edge met an arc and an area
+   * where two straight edges met, and both shrink with the geometry until a
+   * genuine turn falls under the tolerance and reads as one edge continuing
+   * into the next. The witness is a compound curve of a straight run closing
+   * through an arc, whose junctions are exactly those two kinds. A buffer is
+   * the same shape wherever the geometry sits and whatever its size, so the
+   * two copies below answer the same surface scaled: the copy at unit size,
+   * where every tolerance is far from its limits, is what the small one is
+   * read against. Before the directions were normalized the small copy lost
+   * both junctions and its buffer read zero wide */
+  const char *turning[] = {
+    "CompoundCurve((0 0,10 0),CircularString(10 0,5 2,0 0))",
+    "CompoundCurve((0 0,1e-06 0),CircularString(1e-06 0,5e-07 2e-07,0 0))"
+  };
+  const double turning_radius[] = {1.0, 1e-07};
+  char turning_patt[10] = "T*****FF*";
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *g = geom_in(turning[i], -1);
+    assert(g != NULL);
+    meos_errno_reset();
+    GSERIALIZED *b = geom_buffer(g, turning_radius[i], "");
+    printf("geom_buffer(a curve turning twice, %s): answered %d, errno %d\n",
+      i ? "a millionth the size" : "at unit size", b != NULL, meos_errno());
+    assert(b != NULL);
+    assert(meos_errno() == 0);
+    bool covers = geom_relate_pattern(b, g, turning_patt);
+    printf("  it covers the geometry it is taken of: %d\n", covers);
+    assert(covers == true);
+    assert(meos_errno() == 0);
+    free(b); free(g);
+    meos_errno_reset();
+  }
+
   /* A boundary piece kept by the resolve lies AT the buffer distance, and the
    * distance deciding that is read from the coordinates, so what it is rounded
    * to is the size of THEIR last bits and not of the radius. At a projected


### PR DESCRIPTION
An edge answers the direction it runs in at either end through one body, of unit length whichever kind of edge it is.

`buffer_offset_edges` classifies the junction between two offsets from the cross product of the two directions meeting there, judged against `MEOS_GEOM_TOLERANCE`. That product is a sine only where both directions are of unit length. An arc answers a sine and a cosine and is; a straight edge answering its whole chord is not, which leaves the product

* a **sine** where two arcs meet, the only one an absolute constant can bound,
* a **length** where a straight edge meets an arc,
* an **area** where two straight edges meet.

Two of the three shrink with the geometry, so below about 1e-6 a genuine turn falls under the tolerance and reads as two edges continuing into each other. In lon/lat that size is ordinary: 1e-6 degrees is about 11 cm.

The other caller of these helpers, the square end cap, divides by `hypot(dx, dy)` itself, so a unit direction leaves that division a no-op and the cap unchanged.

## What it is worth

The oracle needs no reference engine: a buffer is the same shape wherever the geometry sits and whatever its size, so the same shape scaled by `s` and buffered by `r * s` answers a bounding box `s` times as large. Measured on `CompoundCurve((0 0,10 0),CircularString(10 0,5 2,0 0))` at radius = scale:

| scale | master, bbox/scale | with this change | covers its own input |
|---|---|---|---|
| 1, 1e-2, 1e-4 | 12 x 4 | 12 x 4 | 1 -> 1 |
| 1e-7 | **0 x 2** | 10.74 x 3.93 | **0 -> 1** |
| 1e-8 | 10 x 3.93 | 10.74 x 4.15 | **0 -> 1** |

A buffer reading zero wide at 1e-7 is what losing both junctions costs. Three answers stop violating the containment invariant and none starts.

A plain circularstring, whose junctions are arc against arc, serves as the control: its directions are unit vectors already, and only its 1e-8 answer moves, where the arc through three nearly collinear points decomposes to a straight edge.

## The test

`meos/test/geo_test.c` buffers that curve at unit size and at a millionth of it and reads that each covers the geometry it is taken of. Built against master's kernel it aborts at `assert(covers == true)`; with this change it passes.

## What this leaves open

Scale invariance holds at 1e-7 and 1e-8 and not at 1e-5 and 1e-6, where the arc-to-arc block loses it as well, so at least one more absolute constant governs this path. The same turn test also has a second copy in the straight-polygon path, which reads it from raw chords; that copy reaches every polygon buffer and belongs in its own change with its own adjudication.