### PR TITLE
Answer the comparability of two temporal pointcloud boxes in one place

### DIFF
--- a/meos/src/pointcloud/tpc_boxops.c
+++ b/meos/src/pointcloud/tpc_boxops.c
@@ -60,6 +60,7 @@
 #include "pointcloud/pcpoint.h"
 #include "pointcloud/pcpatch.h"
 #include "pointcloud/tpcbox.h"
+#include "geo/geo_funcs.h"    /* ensure_same_dimensionality */
 
 /*****************************************************************************
  * Single-instant → TPCBox
@@ -141,8 +142,9 @@ pcpatch_fill_tpcbox_spatial(const Pcpatch *pa, TPCBox *box)
  * @param[in] s Timestamptz span
  * @param[out] box Bounding box carrying the span and no spatial dimension
  * @note Mirrors @p tstzspan_set_stbox. The span names no schema, so @p pcid
- *   stays 0 — the "unknown" value @p ensure_same_pcid_tpcbox accepts against
- *   any schema, which is what lets a time-only query meet an indexed box.
+ *   stays 0. A box carrying no coordinates has nothing for a schema to give a
+ *   meaning to, so @p ensure_valid_tpcbox_tpcbox leaves its schema unread,
+ *   which is what lets a time-only query meet an indexed box.
  */
 void
 tstzspan_set_tpcbox(const Span *s, TPCBox *box)
@@ -271,10 +273,10 @@ tpointcloudseqarr_set_tpcbox(TSequence **sequences, int count, TPCBox *box)
  * @ingroup meos_pointcloud_box_constructor
  * @brief Transition function for the extent aggregate over tpcpoint /
  *   tpcpatch values. Folds @p temp's bounding box into @p state.
- * @return @p state (mutated) when both inputs are non-NULL with
- *   matching pcid; a freshly-palloc'd TPCBox when @p state is NULL
- *   and @p temp is non-NULL; @p NULL when both are NULL or on pcid
- *   mismatch (which raises an error).
+ * @return @p state (mutated) when both inputs are non-NULL and comparable;
+ *   a freshly-palloc'd TPCBox when @p state is NULL and @p temp is non-NULL;
+ *   @p NULL when both are NULL, or when the two boxes name different schemas
+ *   or hold different dimensions (which raises an error).
  * @csqlfn #Tpc_extent_transfn()
  */
 TPCBox *
@@ -290,17 +292,12 @@ tpcbox_extent_transfn(TPCBox *state, const Temporal *temp)
     temporal_set_bbox(temp, result);
     return result;
   }
-  /* Pcid mismatch is rejected — aggregating across schemas would
-   * produce a bbox whose dimensions are uninterpretable. */
   TPCBox tmp;
   temporal_set_bbox(temp, &tmp);
-  if (state->pcid != tmp.pcid)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "Extent aggregation across distinct pcids: state.pcid=%u vs "
-      "input.pcid=%u", state->pcid, tmp.pcid);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tpcbox_tpcbox(state, &tmp) ||
+      ! ensure_same_dimensionality(state->flags, tmp.flags))
     return NULL;
-  }
   tpcbox_expand(&tmp, state);
   return state;
 }

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -88,7 +88,7 @@ bool
 ensure_same_pcid_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  if (box1->pcid != 0 && box2->pcid != 0 && box1->pcid != box2->pcid)
+  if (box1->pcid != box2->pcid)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Operation on TPCBox values with different schemas: %u vs %u",
@@ -106,7 +106,7 @@ static bool
 ensure_same_srid_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  if (box1->srid != 0 && box2->srid != 0 && box1->srid != box2->srid)
+  if (box1->srid != box2->srid)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Operation on TPCBox values with different SRIDs: %d vs %d",
@@ -118,15 +118,23 @@ ensure_same_srid_tpcbox(const TPCBox *box1, const TPCBox *box2)
 
 /**
  * @brief Return true if two temporal pointcloud boxes are valid for operations
- * @param[in] temp1,temp2 Temporal value
+ * @details The boxes are comparable when they name the same schema, which is
+ * what gives their coordinates a meaning: a schema states the dimensions a
+ * value holds and what a stored number reads as, and it states the SRID every
+ * value carrying that pcid inherits
+ * @param[in] box1,box2 Temporal pointcloud boxes
  */
 bool
 ensure_valid_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPCBOX(box1, false); VALIDATE_TPCBOX(box2, false);
-  if (! ensure_same_pcid_tpcbox(box1, box2) ||
-      ! ensure_same_srid_tpcbox(box1, box2))
+  /* Both boxes carry coordinates here, so both name the schema those
+   * coordinates are read in. A box carrying none has nothing to interpret,
+   * so it meets a box of any schema */
+  if (MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags) &&
+      (! ensure_same_pcid_tpcbox(box1, box2) ||
+       ! ensure_same_srid_tpcbox(box1, box2)))
     return false;
   return true;
 }

--- a/mobilitydb/src/pointcloud/tpc_aggfuncs.c
+++ b/mobilitydb/src/pointcloud/tpc_aggfuncs.c
@@ -45,6 +45,7 @@
 #include "pointcloud/tpc_boxops.h"
 #include "pointcloud/tpcbox.h"          /* PG_GETARG_TPCBOX_P, etc. */
 #include "pointcloud/pcpatch.h"
+#include "geo/geo_funcs.h"          /* ensure_same_dimensionality */
 #include "temporal/temporal.h"
 #include "temporal/skiplist.h"          /* PG_RETURN_SKIPLIST_P macro */
 #include "pg_temporal/skiplist.h"       /* INPUT_AGG_TRANS_STATE etc. */
@@ -99,10 +100,11 @@ Tpcbox_extent_transfn(PG_FUNCTION_ARGS)
   if (! box1 && ! box2) PG_RETURN_NULL();
   if (! box1) PG_RETURN_TPCBOX_P(tpcbox_copy(box2));
   if (! box2) PG_RETURN_TPCBOX_P(tpcbox_copy(box1));
-  if (box1->pcid != box2->pcid)
-    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
-      errmsg("Extent aggregation across distinct pcids: %u vs %u",
-        box1->pcid, box2->pcid)));
+  /* Both boxes are not null */
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
+      ! ensure_same_dimensionality(box1->flags, box2->flags))
+    PG_RETURN_NULL();
   TPCBox *result = tpcbox_copy(box1);
   tpcbox_expand(box2, result);
   PG_RETURN_TPCBOX_P(result);

--- a/mobilitydb/src/pointcloud/tpcbox_gist.c
+++ b/mobilitydb/src/pointcloud/tpcbox_gist.c
@@ -277,7 +277,9 @@ PG_FUNCTION_INFO_V1(Tpcbox_gist_same);
 /**
  * @ingroup mobilitydb_pointcloud_index
  * @brief GiST same method — exact equality, not the user-facing
- *   @c same_tpcbox_tpcbox (which is fuzzy on the same-pcid front)
+ *   @c same_tpcbox_tpcbox, which refuses two boxes naming different schemas
+ *   rather than answering false. An index method has to answer, so this one
+ *   reads a differing schema as one more way for two keys to differ
  * @sqlfn tpcbox_gist_same()
  */
 Datum

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -174,6 +174,10 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(50, 50, 60, 60, 1, 0);
  
 (1 row)
 
+SELECT tpcbox(0, 0, 5, 5, 0, 0) + tpcbox(3, 3, 10, 10, 1, 0);
+ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
+SELECT tpcbox(0, 0, 5, 5, 0, 0) * tpcbox(3, 3, 10, 10, 1, 0);
+ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
 SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 8, 8, 1, 0);
  ?column? 
 ----------
@@ -252,6 +256,44 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(0, 0, 5, 5, 2, 0);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 2, 0);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
+SELECT tpcbox(0, 0, 5, 5, 0, 0) && tpcbox(3, 3, 10, 10, 1, 0);
+ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
+SELECT tpcbox(0, 0, 5, 5, 0, 0) @> tpcbox(1, 1, 4, 4, 1, 0);
+ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
+SELECT tpcbox(0, 0, 5, 5, 1, 4326) && tpcbox(3, 3, 10, 10, 1, 3857);
+ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
+SELECT tpcbox(0, 0, 5, 5, 1, 4326) + tpcbox(3, 3, 10, 10, 1, 3857);
+ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
+SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) &&
+  tpcbox_t(tstzspan '[2024-01-02, 2024-01-03]', 1);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) +
+  tpcbox_t(tstzspan '[2024-01-02, 2024-01-03]', 1);
+                                  ?column?                                  
+----------------------------------------------------------------------------
+ TPCBOX(T([Mon Jan 01 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]), 1)
+(1 row)
+
+SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 0)),
+  (tpcbox(3, 3, 10, 10, 1, 0))) t(b);
+           extent            
+-----------------------------
+ TPCBOX(X((0,0),(10,10)), 1)
+(1 row)
+
+SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 0)),
+  (tpcbox(3, 3, 10, 10, 2, 0))) t(b);
+ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
+SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 0, 0)),
+  (tpcbox(3, 3, 10, 10, 1, 0))) t(b);
+ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
+SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 4326)),
+  (tpcbox(3, 3, 10, 10, 1, 3857))) t(b);
+ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
 SELECT tpcbox(0, 0, 5, 5, 1, 0) =  tpcbox(0, 0, 5, 5, 1, 0);
  ?column? 
 ----------

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -101,6 +101,11 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
 SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
 SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(50, 50, 60, 60, 1, 0);  -- NULL (disjoint)
 
+-- A box carrying coordinates states the schema they are read in, so a box
+-- naming schema 0 and one naming schema 1 have no common extent to combine
+SELECT tpcbox(0, 0, 5, 5, 0, 0) + tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcbox(0, 0, 5, 5, 0, 0) * tpcbox(3, 3, 10, 10, 1, 0);
+
 -------------------------------------------------------------------------------
 -- Topological predicates — same pcid
 -------------------------------------------------------------------------------
@@ -121,12 +126,46 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0)  -|- tpcbox(5, 0, 10, 5, 1, 0);
 SELECT adjacent(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(5, 0, 10, 5, 1, 0));
 
 -------------------------------------------------------------------------------
--- Topological predicates — pcid mismatch always returns false
+-- Topological predicates — the schema decides what a coordinate means
 -------------------------------------------------------------------------------
 
+-- Two schemas give the same number two meanings, so the boxes are not
+-- comparable and the predicate has no answer to give
 SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 8, 8, 2, 0);
 SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(0, 0, 5, 5, 2, 0);
 SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 2, 0);
+
+-- Schema 0 is a schema like any other once a box carries coordinates
+SELECT tpcbox(0, 0, 5, 5, 0, 0) && tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcbox(0, 0, 5, 5, 0, 0) @> tpcbox(1, 1, 4, 4, 1, 0);
+
+-- The SRID is read on the same terms: one schema, two reference systems, so
+-- the same pair of numbers denotes two different places
+SELECT tpcbox(0, 0, 5, 5, 1, 4326) && tpcbox(3, 3, 10, 10, 1, 3857);
+SELECT tpcbox(0, 0, 5, 5, 1, 4326) + tpcbox(3, 3, 10, 10, 1, 3857);
+
+-- A box carrying no coordinates names no schema, so it meets a box of any
+-- schema: this is the shape a time-only query box takes against an index
+SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) &&
+  tpcbox_t(tstzspan '[2024-01-02, 2024-01-03]', 1);
+SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) +
+  tpcbox_t(tstzspan '[2024-01-02, 2024-01-03]', 1);
+
+-------------------------------------------------------------------------------
+-- Extent aggregation
+-------------------------------------------------------------------------------
+
+-- The aggregate answers the extent of the boxes it folds, so it is bounded by
+-- the same comparability the operators are: an extent spanning two schemas, or
+-- two reference systems, states a region no schema can read
+SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 0)),
+  (tpcbox(3, 3, 10, 10, 1, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 0)),
+  (tpcbox(3, 3, 10, 10, 2, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 0, 0)),
+  (tpcbox(3, 3, 10, 10, 1, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 4326)),
+  (tpcbox(3, 3, 10, 10, 1, 3857))) t(b);
 
 -------------------------------------------------------------------------------
 -- Comparison operators


### PR DESCRIPTION
A TPCBox names a pgpointcloud schema, and that schema is what gives the
box's coordinates a meaning: it states the dimensions a value holds, what
a stored number reads as, and the SRID every value carrying that pcid
inherits. Two boxes drawn from different schemas measure different
quantities and have no common extent, which is the same sentence as an
STBox in metres against one in feet.

Two entries answer that question independently, and they disagree.

The validator reads a pcid of 0 as a wildcard matching any schema, so a
box carrying coordinates but naming no schema combines with one that
does:

  SELECT tpcbox(0, 0, 5, 5, 0, 0) + tpcbox(3, 3, 10, 10, 1, 0);
   TPCBOX(X((0,0),(10,10)), 1)

The answer states schema 1 for an extent half of which nothing reads in
schema 1.

The wildcard carries a second job, which is why removing it alone is not
the fix: a time-only query box names no schema, so it has to meet an
indexed box of any schema for the index to stay usable. What makes that
box meet is not an unknown schema, but that it carries no coordinates,
leaving nothing for a schema to give a meaning to. Testing that condition
keeps the index path and closes the hole, and lets the two identity
checks be the plain comparisons they state.

The extent aggregate hand-rolls the same question and names only half of
it:

  if (box1->pcid != box2->pcid)
    ereport(ERROR, ...);

so two boxes of one schema in different reference systems fold together,
and the answer states one of the two for the whole extent:

  SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 4326)),
    (tpcbox(3, 3, 10, 10, 1, 3857))) t(b);
   SRID=4326;TPCBOX(X((0,0),(10,10)), 1)

while the operator answering the same question on the same pair refuses.
Both transition functions read the validator instead, paired with the
shared dimensionality primitive as the STBox sibling does, so the
aggregate refuses exactly what the operators refuse and the diagnostics
are the family's own rather than a second wording.

None of these rejections carried a test. They do now, beside the cases
that keep answering: the extent of two boxes of one schema, and a
time-only box meeting a box of any schema.

Three comments describe the behaviour this changes and are corrected with
it. tpc_boxops.c names the pcid-0 wildcard as what lets a time-only query
meet an indexed box; tpcbox_gist.c calls same_tpcbox_tpcbox "fuzzy on the
same-pcid front"; and 410_tpcbox.test.sql's section header reads "pcid
mismatch always returns false" while its expected output holds three
ERROR lines.

This applies section 5 of doc/contributing/bbox_validation_design_notes.md:
frame values absorb at input and are strict at comparison.