### PR TITLE
Read a deserialized aggregate state into the aggregation context

### DIFF
--- a/mobilitydb/src/temporal/skiplist.c
+++ b/mobilitydb/src/temporal/skiplist.c
@@ -154,6 +154,13 @@ Taggstate_deserialize(PG_FUNCTION_ARGS)
     .len = VARSIZE(data),
     .maxlen = VARSIZE(data)
   };
+  /* The skiplist this reads is built by #temporal_skiplist_make and
+   * #temporal_skiplist_splice, which take the aggregation context from
+   * #fetch_fcinfo. Every other entry point of the aggregate stores its own
+   * fcinfo for them to find; without it they read the one a previous call
+   * left and build the state in a context that is reset before the final
+   * function runs. */
+  store_fcinfo(fcinfo);
   SkipList *result = aggstate_read(&buf);
   PG_RETURN_SKIPLIST_P(result);
 }


### PR DESCRIPTION
The deserialization function of the temporal aggregates stores the
function call information the skiplist builders read. #aggstate_read
builds its result with #temporal_skiplist_make and
#temporal_skiplist_splice, and both take the aggregation context from
#fetch_fcinfo, as do #skiplist_alloc and #skiplist_delete beneath them.
Every other entry point of these aggregates -- each transition function,
the combine function and the window forms -- stores its own fcinfo for
them to find, and the deserialization function is the one that does not,
so the builders read whichever call stored one before it and build the
state in that call's context.

A parallel plan whose leader takes part in the aggregation is where this
is reachable: the leader deserializes a worker's partial state, and the
context that state was built in is reset before the final function walks
it, so #skiplist_temporal_values reads a SkipList whose fields no longer
describe a list. The 82 aggregates carrying this state across twelve
families share the path.

