### PR TITLE
Name the box set operations the way the rest of the surface names them

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3255,7 +3255,7 @@
 				<title>Operaciones de conjuntos</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpcbox_union"><varname>+</varname>, <varname>*</varname></link>: Unión e intersección de dos tpcboxes</para>
+						<para><link linkend="tpcboxUnion"><varname>+</varname>, <varname>*</varname></link>: Unión e intersección de dos tpcboxes</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -414,7 +414,7 @@ SELECT SRID(setSRID(tpcbox(0, 0, 10, 10, 1, 0), 4326));
 		<sect2 xml:id="tpcbox_setops">
 			<title>Operaciones de conjuntos</title>
 			<itemizedlist>
-				<listitem xml:id="tpcbox_union">
+				<listitem xml:id="tpcboxUnion">
 					<indexterm significance="normal"><primary><varname>+</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 					<para>Unión e intersección de dos tpcboxes</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3264,7 +3264,7 @@
 				<title>Set Operations</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpcbox_union"><varname>+</varname>, <varname>*</varname></link>: Union and intersection of two tpcboxes</para>
+						<para><link linkend="tpcboxUnion"><varname>+</varname>, <varname>*</varname></link>: Union and intersection of two tpcboxes</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -416,7 +416,7 @@ SELECT SRID(setSRID(tpcbox(0, 0, 10, 10, 1, 0), 4326));
 		<sect2 xml:id="tpcbox_setops">
 			<title>Set Operations</title>
 			<itemizedlist>
-				<listitem xml:id="tpcbox_union">
+				<listitem xml:id="tpcboxUnion">
 					<indexterm significance="normal"><primary><varname>+</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>*</varname></primary></indexterm>
 					<para>Union and intersection of two tpcboxes</para>

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -2694,6 +2694,7 @@ union_stbox_stbox(const STBox *box1, const STBox *box2, bool strict)
  * @param[out] result Result
  * @note This function is equivalent to @ref intersection_stbox_stbox without
  * memory allocation
+ * @csqlfn #Intersection_stbox_stbox()
  */
 bool
 inter_stbox_stbox(const STBox *box1, const STBox *box2, STBox *result)

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -901,6 +901,7 @@ union_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2, bool strict)
  * @ingroup meos_internal_pointcloud_box_setops
  * @brief Write the intersection of two TPCBoxes into @p result.
  * @return true if the boxes intersect (result is valid); false otherwise.
+ * @csqlfn #Intersection_tpcbox_tpcbox()
  */
 bool
 inter_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2, TPCBox *result)

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -2112,6 +2112,7 @@ union_tbox_tbox(const TBox *box1, const TBox *box2, bool strict)
  * @param[out] result Resulting box
  * @note This function is equivalent to @ref intersection_tbox_tbox without
  * memory allocation
+ * @csqlfn #Intersection_tbox_tbox()
  */
 bool
 inter_tbox_tbox(const TBox *box1, const TBox *box2, TBox *result)

--- a/mobilitydb/sql/geo/051_stbox.in.sql
+++ b/mobilitydb/sql/geo/051_stbox.in.sql
@@ -634,22 +634,22 @@ CREATE OPERATOR #&> (
  * Set operators
  *****************************************************************************/
 
-CREATE FUNCTION stbox_union(stbox, stbox)
+CREATE FUNCTION stboxUnion(stbox, stbox)
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Union_stbox_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION stbox_intersection(stbox, stbox)
+CREATE FUNCTION stboxIntersection(stbox, stbox)
   RETURNS stbox
   AS 'MODULE_PATHNAME', 'Intersection_stbox_stbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR + (
-  PROCEDURE = stbox_union,
+  PROCEDURE = stboxUnion,
   LEFTARG = stbox, RIGHTARG = stbox,
   COMMUTATOR = +
 );
 CREATE OPERATOR * (
-  PROCEDURE = stbox_intersection,
+  PROCEDURE = stboxIntersection,
   LEFTARG = stbox, RIGHTARG = stbox,
   COMMUTATOR = *
 );

--- a/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
+++ b/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
@@ -217,22 +217,22 @@ CREATE FUNCTION setSRID(tpcbox, integer)
  * Set operations
  ******************************************************************************/
 
-CREATE FUNCTION tpcbox_union(tpcbox, tpcbox)
+CREATE FUNCTION tpcboxUnion(tpcbox, tpcbox)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Union_tpcbox_tpcbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tpcbox_intersection(tpcbox, tpcbox)
+CREATE FUNCTION tpcboxIntersection(tpcbox, tpcbox)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Intersection_tpcbox_tpcbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR + (
-  PROCEDURE = tpcbox_union,
+  PROCEDURE = tpcboxUnion,
   LEFTARG = tpcbox, RIGHTARG = tpcbox,
   COMMUTATOR = +
 );
 CREATE OPERATOR * (
-  PROCEDURE = tpcbox_intersection,
+  PROCEDURE = tpcboxIntersection,
   LEFTARG = tpcbox, RIGHTARG = tpcbox,
   COMMUTATOR = *
 );

--- a/mobilitydb/sql/temporal/021_tbox.in.sql
+++ b/mobilitydb/sql/temporal/021_tbox.in.sql
@@ -555,22 +555,22 @@ CREATE OPERATOR #&> (
  * Set operators
  *****************************************************************************/
 
-CREATE FUNCTION tbox_union(tbox, tbox)
+CREATE FUNCTION tboxUnion(tbox, tbox)
   RETURNS tbox
   AS 'MODULE_PATHNAME', 'Union_tbox_tbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION tbox_intersection(tbox, tbox)
+CREATE FUNCTION tboxIntersection(tbox, tbox)
   RETURNS tbox
   AS 'MODULE_PATHNAME', 'Intersection_tbox_tbox'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR + (
-  PROCEDURE = tbox_union,
+  PROCEDURE = tboxUnion,
   LEFTARG = tbox, RIGHTARG = tbox,
   COMMUTATOR = +
 );
 CREATE OPERATOR * (
-  PROCEDURE = tbox_intersection,
+  PROCEDURE = tboxIntersection,
   LEFTARG = tbox, RIGHTARG = tbox,
   COMMUTATOR = *
 );

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -1525,7 +1525,7 @@ PG_FUNCTION_INFO_V1(Union_stbox_stbox);
 /**
  * @ingroup mobilitydb_geo_box_set
  * @brief Return the union of two spatiotemporal boxes
- * @sqlfn stbox_union()
+ * @sqlfn stboxUnion()
  * @sqlop @p +
  */
 Datum
@@ -1541,7 +1541,7 @@ PG_FUNCTION_INFO_V1(Intersection_stbox_stbox);
 /**
  * @ingroup mobilitydb_geo_box_set
  * @brief Return the intersection of two spatiotemporal boxes
- * @sqlfn stbox_intersection()
+ * @sqlfn stboxIntersection()
  * @sqlop @p *
  */
 Datum

--- a/mobilitydb/src/pointcloud/tpcbox.c
+++ b/mobilitydb/src/pointcloud/tpcbox.c
@@ -545,7 +545,7 @@ PG_FUNCTION_INFO_V1(Union_tpcbox_tpcbox);
 /**
  * @ingroup mobilitydb_pointcloud_box_setops
  * @brief Return the union of two TPCBox values (must share pcid)
- * @sqlfn union()
+ * @sqlfn tpcboxUnion()
  * @sqlop @p +
  */
 Datum
@@ -564,7 +564,7 @@ PG_FUNCTION_INFO_V1(Intersection_tpcbox_tpcbox);
  * @ingroup mobilitydb_pointcloud_box_setops
  * @brief Return the intersection of two TPCBox values; NULL if disjoint
  *   or pcid mismatch
- * @sqlfn intersection()
+ * @sqlfn tpcboxIntersection()
  * @sqlop @p *
  */
 Datum

--- a/mobilitydb/src/temporal/tbox.c
+++ b/mobilitydb/src/temporal/tbox.c
@@ -1017,7 +1017,7 @@ PG_FUNCTION_INFO_V1(Union_tbox_tbox);
 /**
  * @ingroup mobilitydb_box_set
  * @brief Return the union of two temporal boxes
- * @sqlfn union()
+ * @sqlfn tboxUnion()
  * @sqlop @p +
  */
 Datum
@@ -1033,7 +1033,7 @@ PG_FUNCTION_INFO_V1(Intersection_tbox_tbox);
 /**
  * @ingroup mobilitydb_box_set
  * @brief Return the intersection of two temporal boxes
- * @sqlfn intersection()
+ * @sqlfn tboxIntersection()
  * @sqlop @p *
  */
 Datum


### PR DESCRIPTION
The union and intersection of two boxes are the last underscored names on
a surface that spells everything else in camelCase: setUnion and
setIntersection appear 54 times each, spanUnion and spansetUnion 20 each,
against one occurrence apiece of stbox_union, tbox_union, tpcbox_union
and their intersection twins. The three box types agree with each other,
which reads as a convention until the whole surface is counted.

The catalog is further from the dialect than the SQL is, in two ways.

Four of the six entries name something other than what PostgreSQL
publishes. tbox and tpcbox tag their union as union() and their
intersection as intersection(), while the deployed functions are
tbox_union and tpcbox_intersection. union is a reserved keyword, so that
tag names something no unquoted CREATE FUNCTION can be called.

The other two name nothing at all. The three intersection kernels carry
no @csqlfn, so the catalog cannot reach the wrapper that states their SQL
name and records none, although PostgreSQL publishes one. All three union
kernels carry theirs, which is what makes the omission visible.

Both halves of a pair take the type prefix. A reserved word blocks the
bare form for union and not for intersection, and splitting one pair
across two shapes leaves an exception to memorise; the prefix clears the
reserved word and reads the same on either side. It is what the set, span
and spanset families already do, for the same reason.

Each name moves in three places, the catalog being the source of truth
the bindings read and the SQL its projection: the @sqlfn on the wrapper,
the CREATE FUNCTION, and the PROCEDURE clause of the + and * operators.
The tests reach these through their operators, so the expected output
does not move.