### PR TITLE
Say what every H3 function does in its brief

### DIFF
--- a/meos/src/h3/h3_geo.c
+++ b/meos/src/h3/h3_geo.c
@@ -72,7 +72,7 @@
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Growable accumulator of H3 cells filled by the geometry walker
  */
 typedef struct h3_buf
 {
@@ -82,7 +82,7 @@ typedef struct h3_buf
 } h3_buf;
 
 /**
- * @brief 
+ * @brief Initialize an accumulator with a starting capacity
  */
 static void
 h3_buf_init(h3_buf *buf, int initial_capacity)
@@ -93,7 +93,7 @@ h3_buf_init(h3_buf *buf, int initial_capacity)
 }
 
 /**
- * @brief 
+ * @brief Ensure that an accumulator can hold @p additional further cells
  */
 static void
 h3_buf_grow(h3_buf *buf, int additional)
@@ -108,7 +108,7 @@ h3_buf_grow(h3_buf *buf, int additional)
 }
 
 /**
- * @brief 
+ * @brief Append a cell to an accumulator, ignoring the null cell
  */
 static inline void
 h3_buf_push(h3_buf *buf, H3Index cell)
@@ -149,7 +149,7 @@ h3_buf_push_ring1(h3_buf *out, H3Index c)
 }
 
 /**
- * @brief 
+ * @brief Free the cells held by an accumulator and reset it to empty
  */
 static void
 h3_buf_free(h3_buf *buf)
@@ -169,7 +169,8 @@ h3_buf_free(h3_buf *buf)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Compare two H3 cells by index value, the ordering used to sort an
+ * accumulator
  */
 static int
 h3index_compare(const void *a, const void *b)
@@ -182,7 +183,7 @@ h3index_compare(const void *a, const void *b)
 }
 
 /**
- * @brief 
+ * @brief Return the set of the distinct cells of an accumulator, which is freed
  */
 static Set *
 h3_buf_to_set(h3_buf *buf)
@@ -215,7 +216,8 @@ h3_buf_to_set(h3_buf *buf)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the spacing in degrees at which a segment is sampled for a given
+ * resolution
  */
 double
 h3_sample_step_deg(int32 resolution)
@@ -228,7 +230,7 @@ h3_sample_step_deg(int32 resolution)
 }
 
 /**
- * @brief 
+ * @brief Return the cell of a given resolution containing a lat/lng in degrees
  */
 H3Index
 h3_latlng_deg_to_cell(double lat_deg, double lng_deg, int32 resolution)
@@ -246,7 +248,7 @@ h3_latlng_deg_to_cell(double lat_deg, double lng_deg, int32 resolution)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Push the cell containing a point into the accumulator
  */
 static void
 point_to_cells_into(const LWPOINT *lwp, int32 resolution, h3_buf *out)
@@ -317,7 +319,8 @@ linestring_to_cells_into(const LWLINE *line, int32 resolution, h3_buf *out)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Convert a point array into an H3 geoloop in radians, dropping the
+ * repeated closing vertex
  */
 static void
 pointarray_to_geoloop(const POINTARRAY *pa, GeoLoop *loop)
@@ -345,7 +348,7 @@ pointarray_to_geoloop(const POINTARRAY *pa, GeoLoop *loop)
 }
 
 /**
- * @brief 
+ * @brief Free the vertices of a geoloop and reset it to empty
  */
 static void
 geoloop_free(GeoLoop *loop)
@@ -427,7 +430,8 @@ polygon_to_cells_into(const LWPOLY *poly, int32 resolution, h3_buf *out)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Push the cells a geometry meets into the accumulator, recursing into
+ * its components
  */
 static void
 lwgeom_to_cells_into(const LWGEOM *geom, int32 resolution, h3_buf *out)
@@ -513,11 +517,13 @@ geo_to_h3index_set(const GSERIALIZED *gs, int32 resolution)
 
 /**
  * @ingroup meos_h3_comp
- * @brief Returns 1 if any cell in @p cells ever appears in the value
- * sequence of @p th3idx, 0 if none, -1 on error.
- * @brief The cross-platform spatial prefilter consumed by `eIntersects`
- * SQL wrappers / Spark UDFs. Iterates the th3index value sequence (one entry
- * per distinct instant) and tests Set membership.
+ * @brief Return true if a temporal H3 cell is ever equal to a cell of an H3
+ * cell set
+ * @details Returns 1 if any cell of @p cells appears in the value sequence of
+ * @p th3idx, 0 if none does, and -1 on error. This is the cross-platform
+ * spatial prefilter the `eIntersects` SQL wrappers and Spark UDFs consume: it
+ * walks the value sequence of the temporal H3 cell, one entry per distinct
+ * instant, and tests membership of the set.
  * @param[in] cells The candidate H3 cell set (T_H3INDEX).
  * @param[in] th3idx The th3index temporal value.
  * @csqlfn #Ever_eq_h3indexset_th3index()

--- a/meos/src/h3/h3index.c
+++ b/meos/src/h3/h3index.c
@@ -241,7 +241,7 @@ h3index_cell_area(H3Index cell)
  *****************************************************************************/
 
 /**
- * @brief
+ * @brief Return the resolution of an H3 cell
  */
 Datum
 datum_h3_get_resolution(Datum d)
@@ -250,7 +250,7 @@ datum_h3_get_resolution(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return the base cell number of an H3 cell
  */
 Datum
 datum_h3_get_base_cell_number(Datum d)
@@ -259,7 +259,7 @@ datum_h3_get_base_cell_number(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return true if a value is a valid H3 cell
  */
 Datum
 datum_h3_is_valid_cell(Datum d)
@@ -268,7 +268,7 @@ datum_h3_is_valid_cell(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return true if an H3 cell has a Class III resolution
  */
 Datum
 datum_h3_is_res_class_iii(Datum d)
@@ -279,7 +279,7 @@ datum_h3_is_res_class_iii(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return true if an H3 cell is a pentagon
  */
 Datum
 datum_h3_is_pentagon(Datum d)
@@ -297,7 +297,7 @@ datum_h3_is_pentagon(Datum d)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the parent of an H3 cell at a given resolution
  */
 Datum
 datum_h3_cell_to_parent(Datum cell_d, Datum res_d)
@@ -309,7 +309,7 @@ datum_h3_cell_to_parent(Datum cell_d, Datum res_d)
 }
 
 /**
- * @brief 
+ * @brief Return the parent of an H3 cell at the next coarser resolution
  */
 Datum
 datum_h3_cell_to_parent_next(Datum cell_d)
@@ -320,7 +320,7 @@ datum_h3_cell_to_parent_next(Datum cell_d)
 }
 
 /**
- * @brief 
+ * @brief Return the center child of an H3 cell at a given resolution
  */
 Datum
 datum_h3_cell_to_center_child(Datum cell_d, Datum res_d)
@@ -332,7 +332,7 @@ datum_h3_cell_to_center_child(Datum cell_d, Datum res_d)
 }
 
 /**
- * @brief 
+ * @brief Return the center child of an H3 cell at the next finer resolution
  */
 Datum
 datum_h3_cell_to_center_child_next(Datum cell_d)
@@ -344,7 +344,8 @@ datum_h3_cell_to_center_child_next(Datum cell_d)
 }
 
 /**
- * @brief 
+ * @brief Return the position of an H3 cell among the children of its ancestor at
+ * a given resolution
  */
 Datum
 datum_h3_cell_to_child_pos(Datum cell_d, Datum parent_res_d)
@@ -358,7 +359,7 @@ datum_h3_cell_to_child_pos(Datum cell_d, Datum parent_res_d)
 }
 
 /**
- * @brief 
+ * @brief Return the child at a given position and resolution of an H3 cell
  */
 Datum
 datum_h3_child_pos_to_cell(Datum pos_d, Datum parent_d, Datum child_res_d)
@@ -375,7 +376,7 @@ datum_h3_child_pos_to_cell(Datum pos_d, Datum parent_d, Datum child_res_d)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return true if two H3 cells are neighbors
  */
 Datum
 datum_h3_are_neighbor_cells(Datum origin_d, Datum dest_d)
@@ -388,7 +389,7 @@ datum_h3_are_neighbor_cells(Datum origin_d, Datum dest_d)
 }
 
 /**
- * @brief 
+ * @brief Return the directed edge from an origin H3 cell to a destination one
  */
 Datum
 datum_h3_cells_to_directed_edge(Datum origin_d, Datum dest_d)
@@ -401,7 +402,7 @@ datum_h3_cells_to_directed_edge(Datum origin_d, Datum dest_d)
 }
 
 /**
- * @brief 
+ * @brief Return true if a value is a valid H3 directed edge
  */
 Datum
 datum_h3_is_valid_directed_edge(Datum d)
@@ -410,7 +411,7 @@ datum_h3_is_valid_directed_edge(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return the origin cell of an H3 directed edge
  */
 Datum
 datum_h3_get_directed_edge_origin(Datum d)
@@ -421,7 +422,7 @@ datum_h3_get_directed_edge_origin(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return the destination cell of an H3 directed edge
  */
 Datum
 datum_h3_get_directed_edge_destination(Datum d)
@@ -433,7 +434,7 @@ datum_h3_get_directed_edge_destination(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return the boundary of an H3 directed edge as a geometry
  */
 Datum
 datum_h3_directed_edge_to_boundary(Datum d)
@@ -449,7 +450,7 @@ datum_h3_directed_edge_to_boundary(Datum d)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return a vertex of an H3 cell given its vertex number
  */
 Datum
 datum_h3_cell_to_vertex(Datum cell_d, Datum vnum_d)
@@ -461,7 +462,7 @@ datum_h3_cell_to_vertex(Datum cell_d, Datum vnum_d)
 }
 
 /**
- * @brief 
+ * @brief Return the point of an H3 vertex
  */
 Datum
 datum_h3_vertex_to_latlng(Datum d)
@@ -473,7 +474,7 @@ datum_h3_vertex_to_latlng(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return true if a value is a valid H3 vertex
  */
 Datum
 datum_h3_is_valid_vertex(Datum d)
@@ -486,7 +487,7 @@ datum_h3_is_valid_vertex(Datum d)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the grid distance in hops between two H3 cells
  */
 Datum
 datum_h3_grid_distance(Datum origin_d, Datum dest_d)
@@ -500,7 +501,7 @@ datum_h3_grid_distance(Datum origin_d, Datum dest_d)
 }
 
 /**
- * @brief 
+ * @brief Return the local IJ coordinates of an H3 cell relative to an origin cell
  */
 Datum
 datum_h3_cell_to_local_ij(Datum origin_d, Datum cell_d)
@@ -514,7 +515,7 @@ datum_h3_cell_to_local_ij(Datum origin_d, Datum cell_d)
 }
 
 /**
- * @brief 
+ * @brief Return the H3 cell at local IJ coordinates relative to an origin cell
  */
 Datum
 datum_h3_local_ij_to_cell(Datum origin_d, Datum coord_d)
@@ -531,7 +532,7 @@ datum_h3_local_ij_to_cell(Datum origin_d, Datum coord_d)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the H3 cell of a given resolution containing a point
  */
 Datum
 datum_h3_latlng_to_cell(Datum point_d, Datum res_d)
@@ -542,7 +543,7 @@ datum_h3_latlng_to_cell(Datum point_d, Datum res_d)
 }
 
 /**
- * @brief 
+ * @brief Return the center point of an H3 cell
  */
 Datum
 datum_h3_cell_to_latlng(Datum d)
@@ -554,7 +555,7 @@ datum_h3_cell_to_latlng(Datum d)
 }
 
 /**
- * @brief 
+ * @brief Return the boundary of an H3 cell as a geometry
  */
 Datum
 datum_h3_cell_to_boundary(Datum d)
@@ -573,7 +574,7 @@ datum_h3_cell_to_boundary(Datum d)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the area of an H3 cell in a given unit
  */
 Datum
 datum_h3_cell_area(Datum cell_d, Datum unit_d)
@@ -585,7 +586,7 @@ datum_h3_cell_area(Datum cell_d, Datum unit_d)
 }
 
 /**
- * @brief 
+ * @brief Return the length of an H3 directed edge in a given unit
  */
 Datum
 datum_h3_edge_length(Datum edge_d, Datum unit_d)
@@ -597,7 +598,7 @@ datum_h3_edge_length(Datum edge_d, Datum unit_d)
 }
 
 /**
- * @brief 
+ * @brief Return the great circle distance between two points in a given unit
  */
 Datum
 datum_h3_great_circle_distance(Datum a_d, Datum b_d, Datum unit_d)

--- a/meos/src/h3/th3index.c
+++ b/meos/src/h3/th3index.c
@@ -133,7 +133,7 @@ ensure_valid_th3index_tgeogpoint(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return true if two H3 cells are equal
  */
 Datum
 datum2_h3index_eq(Datum d1, Datum d2, MeosType type)
@@ -143,7 +143,7 @@ datum2_h3index_eq(Datum d1, Datum d2, MeosType type)
 }
 
 /**
- * @brief 
+ * @brief Return true if two H3 cells are different
  */
 Datum
 datum2_h3index_ne(Datum d1, Datum d2, MeosType type)
@@ -429,7 +429,8 @@ th3index_value_at_timestamptz(const Temporal *temp, TimestampTz t,
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return a value unchanged, the value function of the casts between
+ * tbigint and th3index, which share the same representation
  */
 static Datum
 datum_h3index_identity(Datum d)

--- a/meos/src/h3/th3index_compops.c
+++ b/meos/src/h3/th3index_compops.c
@@ -269,7 +269,7 @@ tcomp_th3index_h3index(const Temporal *temp, H3Index cell,
 }
 
 /**
- * @brief
+ * @brief Return the temporal comparison of an H3 cell and a temporal H3 cell
  */
 static Temporal *
 tcomp_h3index_th3index(H3Index cell, const Temporal *temp,

--- a/meos/src/h3/th3index_edges.c
+++ b/meos/src/h3/th3index_edges.c
@@ -58,7 +58,7 @@
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the boundary of an H3 directed edge as a geometry
  */
 GSERIALIZED *
 h3_directed_edge_to_gs_boundary(H3Index edge)

--- a/meos/src/h3/th3index_hierarchy.c
+++ b/meos/src/h3/th3index_hierarchy.c
@@ -59,7 +59,7 @@
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the parent of an H3 cell at the next coarser resolution
  */
 H3Index
 h3_cell_to_parent_next_meos(H3Index cell)
@@ -75,7 +75,7 @@ h3_cell_to_parent_next_meos(H3Index cell)
 }
 
 /**
- * @brief 
+ * @brief Return the center child of an H3 cell at the next finer resolution
  */
 H3Index
 h3_cell_to_center_child_next_meos(H3Index cell)

--- a/meos/src/h3/th3index_metrics.c
+++ b/meos/src/h3/th3index_metrics.c
@@ -63,7 +63,7 @@
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the area of an H3 cell in a given unit
  */
 double
 h3_cell_area_meos(H3Index cell, H3Unit unit)
@@ -89,7 +89,7 @@ h3_cell_area_meos(H3Index cell, H3Unit unit)
 }
 
 /**
- * @brief 
+ * @brief Return the length of an H3 directed edge in a given unit
  */
 double
 h3_edge_length_meos(H3Index edge, H3Unit unit)
@@ -115,7 +115,7 @@ h3_edge_length_meos(H3Index edge, H3Unit unit)
 }
 
 /**
- * @brief 
+ * @brief Return the great circle distance between two points in a given unit
  */
 double
 h3_gs_great_circle_distance_meos(const GSERIALIZED *a, const GSERIALIZED *b,

--- a/meos/src/h3/th3index_traversal.c
+++ b/meos/src/h3/th3index_traversal.c
@@ -77,7 +77,7 @@ h3_cell_to_local_ij_meos(H3Index origin, H3Index cell)
 }
 
 /**
- * @brief 
+ * @brief Return the H3 cell at local IJ coordinates relative to an origin cell
  */
 H3Index
 h3_local_ij_to_cell_meos(H3Index origin, const GSERIALIZED *coord)

--- a/meos/src/h3/th3index_vertices.c
+++ b/meos/src/h3/th3index_vertices.c
@@ -55,7 +55,7 @@
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return the point of an H3 vertex
  */
 GSERIALIZED *
 h3_vertex_to_gs_point(H3Index vertex)


### PR DESCRIPTION
Every function, type and Datum wrapper in the H3 family carries a brief
that names the quantity it returns, in the phrasing the sibling families
use. The fifty-four briefs that stood empty are filled: the geometry
walker's accumulator and its helpers in h3_geo.c, the twenty-nine Datum
wrappers over the libh3 primitives in h3index.c, the two cell comparison
functions and the identity the tbigint casts lift, and the parent, child,
area, length, distance, edge, vertex and local-IJ primitives their
wrappers call. The ever-equal prefilter states its subject once and gives
its three return values, its walk over the value sequence and its callers
as details, so the brief doxygen renders for it is the sentence that names
what it answers.

