### PR TITLE
Name the temporal pointcloud box constructors after their dimensions

### DIFF
--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -261,16 +261,16 @@ SELECT numValues(set(ARRAY[pcpoint(1, 10.0, 20.0, 30.0),
 					<indexterm significance="normal"><primary><varname>tpcbox_zt</varname></primary></indexterm>
 					<para>Construye un tpcbox a partir de límites X/Y/Z/T explícitos y un pcid</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tpcbox(xmin,ymin,xmax,ymax,pcid,srid integer=0) → tpcbox
-tpcbox_z(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid integer=0) → tpcbox
-tpcbox_t(period,pcid) → tpcbox
-tpcbox_xt(xmin,ymin,xmax,ymax,period,pcid,srid integer=0) → tpcbox
-tpcbox_zt(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid integer=0) → tpcbox
+tpcboxX(xmin,ymin,xmax,ymax,pcid,srid integer=0) → tpcbox
+tpcboxZ(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid integer=0) → tpcbox
+tpcboxT(period,pcid) → tpcbox
+tpcboxXT(xmin,ymin,xmax,ymax,period,pcid,srid integer=0) → tpcbox
+tpcboxZT(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid integer=0) → tpcbox
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0);
 -- TPCBOX(X((0,0),(10,10)), 1)
-SELECT tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+SELECT tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
 -- TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-02]), 1)
 </programlisting>
 				</listitem>
@@ -322,7 +322,7 @@ hasZ(tpcbox) → boolean
 hasT(tpcbox) → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1, 0) AS b)
   SELECT hasX(b), hasZ(b) FROM b;
 -- t | f
 </programlisting>
@@ -345,7 +345,7 @@ zmin(tpcbox) → float
 zmax(tpcbox) → float
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1, 0) AS b)
   SELECT xmin(b), xmax(b) FROM b;
 -- 0 | 10
 </programlisting>
@@ -360,7 +360,7 @@ tmin(tpcbox) → timestamptz
 tmax(tpcbox) → timestamptz
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tmin(tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1));
+SELECT tmin(tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1));
 -- 2024-01-01
 </programlisting>
 				</listitem>
@@ -374,7 +374,7 @@ pcid(tpcbox) → integer
 SRID(tpcbox) → integer
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcbox(0, 0, 10, 10, 7, 4326) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 7, 4326) AS b)
   SELECT pcid(b), SRID(b) FROM b;
 -- 7 | 4326
 </programlisting>
@@ -392,7 +392,7 @@ WITH b AS (SELECT tpcbox(0, 0, 10, 10, 7, 4326) AS b)
 round(tpcbox,integer=0) → tpcbox
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT round(tpcbox(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
+SELECT round(tpcboxX(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
 -- TPCBOX(X((0.12,1.23),(2.35,3.46)), 1)
 </programlisting>
 				</listitem>
@@ -405,7 +405,7 @@ setSRID(tpcbox,integer) → tpcbox
 </programlisting>
 					<para>No reproyecta las coordenadas, para ello, proyecte primero el tpcpoint subyacente y tome la caja delimitadora del resultado</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT SRID(setSRID(tpcbox(0, 0, 10, 10, 1, 0), 4326));
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1, 0), 4326));
 -- 4326
 </programlisting>
 				</listitem>
@@ -423,9 +423,9 @@ tpcbox {+, *} tpcbox → tpcbox
 </programlisting>
 					<para>Ambos operandos deben compartir el mismo <varname>pcid</varname>, y la intersección es NULL cuando las dos cajas son disjuntas.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
 -- TPCBOX(X((0,0),(10,10)), 1)
-SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
 -- TPCBOX(X((3,3),(5,5)), 1)
 </programlisting>
 				</listitem>
@@ -448,17 +448,17 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
 tpcbox {&amp;&amp;, @&gt;, &lt;@, ~=, -|-} tpcbox → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 10, 10, 1, 0) @&gt; tpcbox(2, 2, 8, 8, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0) @&gt; tpcboxX(2, 2, 8, 8, 1, 0);
 -- t
-SELECT tpcbox(2, 2, 8, 8, 1, 0) &lt;@ tpcbox(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(2, 2, 8, 8, 1, 0) &lt;@ tpcboxX(0, 0, 10, 10, 1, 0);
 -- t
-SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) &amp;&amp; tpcboxX(3, 3, 10, 10, 1, 0);
 -- t
-SELECT tpcbox(0, 0, 2, 2) ~= tpcbox(0, 0, 2, 2);
+SELECT tpcboxX(0, 0, 2, 2) ~= tpcboxX(0, 0, 2, 2);
 -- t
-SELECT tpcbox(0, 0, 2, 2) -|- tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) -|- tpcboxX(5, 5, 7, 7);
 -- f
-SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) &amp;&amp; tpcboxX(0, 0, 5, 5, 2, 0);
 -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 </programlisting>
 				</listitem>
@@ -495,14 +495,14 @@ tpcbox {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} tpcbox → boolean
 </programlisting>
 					<para>Los cuatro grupos prueban el eje X, el eje Y, el eje Z y el eje temporal, y cada uno indica, en orden, estrictamente antes, no se extiende después, estrictamente después y no se extiende antes a lo largo de su eje.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 2, 2) &lt;&lt; tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&lt; tpcboxX(5, 5, 7, 7);
 -- t
-SELECT tpcbox(0, 0, 2, 2) &lt;&lt;| tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;| tpcboxX(5, 5, 7, 7);
 -- t
 -- Neither box carries a z dimension or a time span, so those tests are false.
-SELECT tpcbox(0, 0, 2, 2) &lt;&lt;/ tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;/ tpcboxX(5, 5, 7, 7);
 -- f
-SELECT tpcbox(0, 0, 2, 2) &lt;&lt;# tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;# tpcboxX(5, 5, 7, 7);
 -- f
 </programlisting>
 				</listitem>
@@ -525,11 +525,11 @@ tpcbox {=, &lt;&gt;, &lt;, &lt;=, &gt;, &gt;=} tpcbox → boolean
 </programlisting>
 					<para>La función compara en el orden siguiente: pcid, srid, flags, período y a continuación límites espaciales en orden XYZ-min/max)</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 2, 2) = tpcbox(0, 0, 2, 2);
+SELECT tpcboxX(0, 0, 2, 2) = tpcboxX(0, 0, 2, 2);
 -- t
-SELECT tpcbox(0, 0, 2, 2) &lt;&gt; tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&gt; tpcboxX(5, 5, 7, 7);
 -- t
-SELECT tpcbox(0, 0, 2, 2) &lt; tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt; tpcboxX(5, 5, 7, 7);
 -- t
 </programlisting>
 				</listitem>
@@ -890,13 +890,13 @@ minusTpcbox(tpcpoint,tpcbox,border_inc boolean=true) → tpcpoint
 SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz), tpcpoint(pcpoint(1, 2, 2, 2), '2001-01-02'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]),
-  tpcbox_zt(0, 0, 0, 2, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxZT(0, 0, 0, 2, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 2
 -- The box does not intersect the tpcpoint, so nothing is removed.
 SELECT numInstants(minusTpcbox(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz), tpcpoint(pcpoint(1, 2, 2, 2), '2001-01-02'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]),
-  tpcbox_zt(10, 10, 10, 12, 12, 12, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxZT(10, 10, 10, 12, 12, 12, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 3
 </programlisting>
 				</listitem>
@@ -1015,7 +1015,7 @@ SELECT tpcpointSeq(ARRAY[
 SELECT tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]) @&gt;
-  tpcbox_z(1, 1, 1, 2, 2, 2, 1);
+  tpcboxZ(1, 1, 1, 2, 2, 2, 1);
 -- true
 </programlisting>
 				</listitem>
@@ -1037,7 +1037,7 @@ SELECT tpcpointSeq(ARRAY[
 SELECT tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]) &lt;&lt;
-  tpcbox_z(10, 10, 10, 12, 12, 12, 1);
+  tpcboxZ(10, 10, 10, 12, 12, 12, 1);
 -- true
 SELECT tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1069,7 +1069,7 @@ SELECT round(nearestApproachDistance( tpcpoint(pcpoint(1, 1, 1, 1),
 SELECT round(nearestApproachDistance(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz), tpcpoint(pcpoint(1, 2, 2, 2), '2001-01-02'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]),
-  tpcbox_z(10, 10, 10, 12, 12, 12, 1))::numeric, 4);
+  tpcboxZ(10, 10, 10, 12, 12, 12, 1))::numeric, 4);
 -- 12.1244
 SELECT round((tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz) |=|
   tpcpoint(pcpoint(1, 10, 10, 10), '2001-01-01'::timestamptz))::numeric, 4);
@@ -1621,7 +1621,7 @@ SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[ tpcpatch(pcpatch(pcpoint(1, 1, 1,
   pcpoint(1, 2, 2, 2)), '2001-01-01'::timestamptz),
   tpcpatch(pcpatch(pcpoint(1, 3, 3, 3),
   pcpoint(1, 4, 4, 4)), '2001-01-02'::timestamptz)]),
-  tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxXT(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
 -- The dropped patch stays present on the open interval before its instant,
 -- so the complement keeps two instants.
@@ -1629,7 +1629,7 @@ SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[ tpcpatch(pcpatch(pcpoint(1, 1,
   pcpoint(1, 2, 2, 2)), '2001-01-01'::timestamptz),
   tpcpatch(pcpatch(pcpoint(1, 3, 3, 3),
   pcpoint(1, 4, 4, 4)), '2001-01-02'::timestamptz)]),
-  tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxXT(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 2
 </programlisting>
 				</listitem>
@@ -1647,7 +1647,7 @@ SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[ tpcpatch(pcpatch(pcpoint(1, 1
   pcpoint(1, 2, 2, 2)), '2001-01-01'::timestamptz),
   tpcpatch(pcpatch(pcpoint(1, 3, 3, 3),
   pcpoint(1, 4, 4, 4)), '2001-01-02'::timestamptz)]),
-  tpcbox_xt(0, 0, 1, 1, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxXT(0, 0, 1, 1, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
 </programlisting>
 				</listitem>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -262,16 +262,16 @@ SELECT numValues(set(ARRAY[pcpoint(1, 10.0, 20.0, 30.0),
 					<indexterm significance="normal"><primary><varname>tpcbox_zt</varname></primary></indexterm>
 					<para>Construct a tpcbox from explicit X/Y/Z/T bounds and a pcid</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tpcbox(xmin,ymin,xmax,ymax,pcid,srid integer=0) → tpcbox
-tpcbox_z(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid integer=0) → tpcbox
-tpcbox_t(period,pcid) → tpcbox
-tpcbox_xt(xmin,ymin,xmax,ymax,period,pcid,srid integer=0) → tpcbox
-tpcbox_zt(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid integer=0) → tpcbox
+tpcboxX(xmin,ymin,xmax,ymax,pcid,srid integer=0) → tpcbox
+tpcboxZ(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid integer=0) → tpcbox
+tpcboxT(period,pcid) → tpcbox
+tpcboxXT(xmin,ymin,xmax,ymax,period,pcid,srid integer=0) → tpcbox
+tpcboxZT(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid integer=0) → tpcbox
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0);
 -- TPCBOX(X((0,0),(10,10)), 1)
-SELECT tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+SELECT tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
 -- TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-02]), 1)
 </programlisting>
 				</listitem>
@@ -323,7 +323,7 @@ hasZ(tpcbox) → boolean
 hasT(tpcbox) → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1, 0) AS b)
   SELECT hasX(b), hasZ(b) FROM b;
 -- t | f
 </programlisting>
@@ -346,7 +346,7 @@ zmin(tpcbox) → float
 zmax(tpcbox) → float
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcbox(0, 0, 10, 10, 1, 0) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1, 0) AS b)
   SELECT xmin(b), xmax(b) FROM b;
 -- 0 | 10
 </programlisting>
@@ -361,7 +361,7 @@ tmin(tpcbox) → timestamptz
 tmax(tpcbox) → timestamptz
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tmin(tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1));
+SELECT tmin(tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1));
 -- 2024-01-01
 </programlisting>
 				</listitem>
@@ -375,7 +375,7 @@ pcid(tpcbox) → integer
 SRID(tpcbox) → integer
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcbox(0, 0, 10, 10, 7, 4326) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 7, 4326) AS b)
   SELECT pcid(b), SRID(b) FROM b;
 -- 7 | 4326
 </programlisting>
@@ -393,7 +393,7 @@ WITH b AS (SELECT tpcbox(0, 0, 10, 10, 7, 4326) AS b)
 round(tpcbox,integer=0) → tpcbox
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT round(tpcbox(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
+SELECT round(tpcboxX(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
 -- TPCBOX(X((0.12,1.23),(2.35,3.46)), 1)
 </programlisting>
 				</listitem>
@@ -406,7 +406,7 @@ setSRID(tpcbox,integer) → tpcbox
 </programlisting>
 					<para>Does not reproject coordinates, for that, project the underlying tpcpoint first and take the bbox of the result</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT SRID(setSRID(tpcbox(0, 0, 10, 10, 1, 0), 4326));
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1, 0), 4326));
 -- 4326
 </programlisting>
 				</listitem>
@@ -425,9 +425,9 @@ tpcbox {+, *} tpcbox → tpcbox
 </programlisting>
 					<para>Both operands must share the same <varname>pcid</varname>, and the intersection is NULL when the two boxes are disjoint.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
 -- TPCBOX(X((0,0),(10,10)), 1)
-SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
 -- TPCBOX(X((3,3),(5,5)), 1)
 </programlisting>
 				</listitem>
@@ -450,17 +450,17 @@ SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
 tpcbox {&amp;&amp;, @&gt;, &lt;@, ~=, -|-} tpcbox → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 10, 10, 1, 0) @&gt; tpcbox(2, 2, 8, 8, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0) @&gt; tpcboxX(2, 2, 8, 8, 1, 0);
 -- t
-SELECT tpcbox(2, 2, 8, 8, 1, 0) &lt;@ tpcbox(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(2, 2, 8, 8, 1, 0) &lt;@ tpcboxX(0, 0, 10, 10, 1, 0);
 -- t
-SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) &amp;&amp; tpcboxX(3, 3, 10, 10, 1, 0);
 -- t
-SELECT tpcbox(0, 0, 2, 2) ~= tpcbox(0, 0, 2, 2);
+SELECT tpcboxX(0, 0, 2, 2) ~= tpcboxX(0, 0, 2, 2);
 -- t
-SELECT tpcbox(0, 0, 2, 2) -|- tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) -|- tpcboxX(5, 5, 7, 7);
 -- f
-SELECT tpcbox(0, 0, 5, 5, 1, 0) &amp;&amp; tpcbox(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) &amp;&amp; tpcboxX(0, 0, 5, 5, 2, 0);
 -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 </programlisting>
 				</listitem>
@@ -497,14 +497,14 @@ tpcbox {&lt;&lt;#, &amp;&lt;#, #&gt;&gt;, #&amp;&gt;} tpcbox → boolean
 </programlisting>
 					<para>The four groups test the X, the Y, the Z and the time axis, and each states, in order, strictly before, does not extend after, strictly after, and does not extend before along its axis.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 2, 2) &lt;&lt; tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&lt; tpcboxX(5, 5, 7, 7);
 -- t
-SELECT tpcbox(0, 0, 2, 2) &lt;&lt;| tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;| tpcboxX(5, 5, 7, 7);
 -- t
 -- Neither box carries a z dimension or a time span, so those tests are false.
-SELECT tpcbox(0, 0, 2, 2) &lt;&lt;/ tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;/ tpcboxX(5, 5, 7, 7);
 -- f
-SELECT tpcbox(0, 0, 2, 2) &lt;&lt;# tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;# tpcboxX(5, 5, 7, 7);
 -- f
 </programlisting>
 				</listitem>
@@ -526,11 +526,11 @@ SELECT tpcbox(0, 0, 2, 2) &lt;&lt;# tpcbox(5, 5, 7, 7);
 tpcbox {=, &lt;&gt;, &lt;, &lt;=, &gt;, &gt;=} tpcbox → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcbox(0, 0, 2, 2) = tpcbox(0, 0, 2, 2);
+SELECT tpcboxX(0, 0, 2, 2) = tpcboxX(0, 0, 2, 2);
 -- t
-SELECT tpcbox(0, 0, 2, 2) &lt;&gt; tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt;&gt; tpcboxX(5, 5, 7, 7);
 -- t
-SELECT tpcbox(0, 0, 2, 2) &lt; tpcbox(5, 5, 7, 7);
+SELECT tpcboxX(0, 0, 2, 2) &lt; tpcboxX(5, 5, 7, 7);
 -- t
 </programlisting>
 				</listitem>
@@ -890,13 +890,13 @@ minusTpcbox(tpcpoint,tpcbox,border_inc boolean=true) → tpcpoint
 SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz), tpcpoint(pcpoint(1, 2, 2, 2), '2001-01-02'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]),
-  tpcbox_zt(0, 0, 0, 2, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxZT(0, 0, 0, 2, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 2
 -- The box does not intersect the tpcpoint, so nothing is removed.
 SELECT numInstants(minusTpcbox(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz), tpcpoint(pcpoint(1, 2, 2, 2), '2001-01-02'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]),
-  tpcbox_zt(10, 10, 10, 12, 12, 12, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxZT(10, 10, 10, 12, 12, 12, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 3
 </programlisting>
 				</listitem>
@@ -1016,7 +1016,7 @@ SELECT tpcpointSeq(ARRAY[
 SELECT tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]) @&gt;
-  tpcbox_z(1, 1, 1, 2, 2, 2, 1);
+  tpcboxZ(1, 1, 1, 2, 2, 2, 1);
 -- true
 </programlisting>
 				</listitem>
@@ -1038,7 +1038,7 @@ SELECT tpcpointSeq(ARRAY[
 SELECT tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]) &lt;&lt;
-  tpcbox_z(10, 10, 10, 12, 12, 12, 1);
+  tpcboxZ(10, 10, 10, 12, 12, 12, 1);
 -- true
 SELECT tpcpointSeq(ARRAY[
   tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz),
@@ -1069,7 +1069,7 @@ SELECT round(nearestApproachDistance( tpcpoint(pcpoint(1, 1, 1, 1),
 SELECT round(nearestApproachDistance(tpcpointSeq(ARRAY[ tpcpoint(pcpoint(1, 1, 1, 1),
   '2001-01-01'::timestamptz), tpcpoint(pcpoint(1, 2, 2, 2), '2001-01-02'::timestamptz),
   tpcpoint(pcpoint(1, 3, 3, 3), '2001-01-03'::timestamptz)]),
-  tpcbox_z(10, 10, 10, 12, 12, 12, 1))::numeric, 4);
+  tpcboxZ(10, 10, 10, 12, 12, 12, 1))::numeric, 4);
 -- 12.1244
 SELECT round((tpcpoint(pcpoint(1, 1, 1, 1), '2001-01-01'::timestamptz) |=|
   tpcpoint(pcpoint(1, 10, 10, 10), '2001-01-01'::timestamptz))::numeric, 4);
@@ -1621,7 +1621,7 @@ SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[ tpcpatch(pcpatch(pcpoint(1, 1, 1,
   pcpoint(1, 2, 2, 2)), '2001-01-01'::timestamptz),
   tpcpatch(pcpatch(pcpoint(1, 3, 3, 3),
   pcpoint(1, 4, 4, 4)), '2001-01-02'::timestamptz)]),
-  tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxXT(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
 -- The dropped patch stays present on the open interval before its instant,
 -- so the complement keeps two instants.
@@ -1629,7 +1629,7 @@ SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[ tpcpatch(pcpatch(pcpoint(1, 1,
   pcpoint(1, 2, 2, 2)), '2001-01-01'::timestamptz),
   tpcpatch(pcpatch(pcpoint(1, 3, 3, 3),
   pcpoint(1, 4, 4, 4)), '2001-01-02'::timestamptz)]),
-  tpcbox_xt(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxXT(0, 0, 2, 2, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 2
 </programlisting>
 				</listitem>
@@ -1647,7 +1647,7 @@ SELECT numInstants(atTpcboxFine(tpcpatchSeq(ARRAY[ tpcpatch(pcpatch(pcpoint(1, 1
   pcpoint(1, 2, 2, 2)), '2001-01-01'::timestamptz),
   tpcpatch(pcpatch(pcpoint(1, 3, 3, 3),
   pcpoint(1, 4, 4, 4)), '2001-01-02'::timestamptz)]),
-  tpcbox_xt(0, 0, 1, 1, tstzspan '[2001-01-01, 2001-01-03]', 1)));
+  tpcboxXT(0, 0, 1, 1, tstzspan '[2001-01-01, 2001-01-03]', 1)));
 -- 1
 </programlisting>
 				</listitem>

--- a/mobilitydb/datagen/pointcloud/random_tpcpoint.sql
+++ b/mobilitydb/datagen/pointcloud/random_tpcpoint.sql
@@ -220,7 +220,7 @@ DECLARE
   period tstzspan := random_tstzspan(lowtime, hightime, 30);
 BEGIN
   PERFORM ensure_random_pcid();
-  RETURN tpcbox_zt(xmin, ymin, zmin, xmax, ymax, zmax, period, 1, 0);
+  RETURN tpcboxZT(xmin, ymin, zmin, xmax, ymax, zmax, period, 1, 0);
 END;
 $$ LANGUAGE PLPGSQL STRICT;
 

--- a/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
+++ b/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
@@ -77,31 +77,31 @@ CREATE TYPE tpcbox (
  * Constructors
  ******************************************************************************/
 
-CREATE FUNCTION tpcbox(xmin float8, ymin float8, xmax float8, ymax float8,
+CREATE FUNCTION tpcboxX(xmin float8, ymin float8, xmax float8, ymax float8,
     pcid integer DEFAULT 0, srid integer DEFAULT 0)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Tpcbox_constructor_2d'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION tpcbox_z(xmin float8, ymin float8, zmin float8,
+CREATE FUNCTION tpcboxZ(xmin float8, ymin float8, zmin float8,
     xmax float8, ymax float8, zmax float8,
     pcid integer DEFAULT 0, srid integer DEFAULT 0)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Tpcbox_constructor_3d'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION tpcbox_t(period tstzspan, pcid integer DEFAULT 0)
+CREATE FUNCTION tpcboxT(period tstzspan, pcid integer DEFAULT 0)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Tpcbox_constructor_t'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION tpcbox_xt(xmin float8, ymin float8, xmax float8, ymax float8,
+CREATE FUNCTION tpcboxXT(xmin float8, ymin float8, xmax float8, ymax float8,
     period tstzspan, pcid integer DEFAULT 0, srid integer DEFAULT 0)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Tpcbox_constructor_xt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION tpcbox_zt(xmin float8, ymin float8, zmin float8,
+CREATE FUNCTION tpcboxZT(xmin float8, ymin float8, zmin float8,
     xmax float8, ymax float8, zmax float8, period tstzspan,
     pcid integer DEFAULT 0, srid integer DEFAULT 0)
   RETURNS tpcbox

--- a/mobilitydb/src/pointcloud/tpcbox.c
+++ b/mobilitydb/src/pointcloud/tpcbox.c
@@ -127,7 +127,7 @@ PG_FUNCTION_INFO_V1(Tpcbox_constructor_2d);
 /**
  * @ingroup mobilitydb_pointcloud_box_constructor
  * @brief 2D constructor — tpcbox(xmin, ymin, xmax, ymax, pcid, srid)
- * @sqlfn tpcbox()
+ * @sqlfn tpcboxX()
  */
 Datum
 Tpcbox_constructor_2d(PG_FUNCTION_ARGS)
@@ -146,8 +146,8 @@ PGDLLEXPORT Datum Tpcbox_constructor_3d(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tpcbox_constructor_3d);
 /**
  * @ingroup mobilitydb_pointcloud_box_constructor
- * @brief 3D constructor — tpcbox_z(xmin, ymin, zmin, xmax, ymax, zmax, pcid, srid)
- * @sqlfn tpcbox_z()
+ * @brief 3D constructor — tpcboxZ(xmin, ymin, zmin, xmax, ymax, zmax, pcid, srid)
+ * @sqlfn tpcboxZ()
  */
 Datum
 Tpcbox_constructor_3d(PG_FUNCTION_ARGS)
@@ -168,8 +168,8 @@ PGDLLEXPORT Datum Tpcbox_constructor_t(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tpcbox_constructor_t);
 /**
  * @ingroup mobilitydb_pointcloud_box_constructor
- * @brief Time-only constructor — tpcbox_t(period, pcid)
- * @sqlfn tpcbox_t()
+ * @brief Time-only constructor — tpcboxT(period, pcid)
+ * @sqlfn tpcboxT()
  */
 Datum
 Tpcbox_constructor_t(PG_FUNCTION_ARGS)
@@ -184,8 +184,8 @@ PGDLLEXPORT Datum Tpcbox_constructor_xt(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tpcbox_constructor_xt);
 /**
  * @ingroup mobilitydb_pointcloud_box_constructor
- * @brief XY+T constructor — tpcbox_xt(xmin, ymin, xmax, ymax, period, pcid, srid)
- * @sqlfn tpcbox_xt()
+ * @brief XY+T constructor — tpcboxXT(xmin, ymin, xmax, ymax, period, pcid, srid)
+ * @sqlfn tpcboxXT()
  */
 Datum
 Tpcbox_constructor_xt(PG_FUNCTION_ARGS)
@@ -205,8 +205,8 @@ PGDLLEXPORT Datum Tpcbox_constructor_zt(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tpcbox_constructor_zt);
 /**
  * @ingroup mobilitydb_pointcloud_box_constructor
- * @brief XYZ+T constructor — tpcbox_zt(xmin, ymin, zmin, xmax, ymax, zmax, period, pcid, srid)
- * @sqlfn tpcbox_zt()
+ * @brief XYZ+T constructor — tpcboxZT(xmin, ymin, zmin, xmax, ymax, zmax, period, pcid, srid)
+ * @sqlfn tpcboxZT()
  */
 Datum
 Tpcbox_constructor_zt(PG_FUNCTION_ARGS)

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -1,116 +1,116 @@
-SELECT tpcbox(0, 0, 10, 10, 1, 0);
-           tpcbox            
+SELECT tpcboxX(0, 0, 10, 10, 1, 0);
+           tpcboxx           
 -----------------------------
  TPCBOX(X((0,0),(10,10)), 1)
 (1 row)
 
-SELECT tpcbox_z(0, 0, 0, 10, 10, 10, 1, 0);
-             tpcbox_z             
+SELECT tpcboxZ(0, 0, 0, 10, 10, 10, 1, 0);
+             tpcboxz              
 ----------------------------------
  TPCBOX(Z((0,0,0),(10,10,10)), 1)
 (1 row)
 
-SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1);
-                                  tpcbox_t                                  
+SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1);
+                                  tpcboxt                                   
 ----------------------------------------------------------------------------
  TPCBOX(T([Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST]), 1)
 (1 row)
 
-SELECT tpcbox_xt(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
-                                          tpcbox_xt                                          
+SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+                                          tpcboxxt                                           
 ---------------------------------------------------------------------------------------------
  TPCBOX(XT(((0,0),(10,10)),[Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST]), 1)
 (1 row)
 
-SELECT tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
-                                            tpcbox_zt                                             
+                                             tpcboxzt                                             
 --------------------------------------------------------------------------------------------------
  TPCBOX(ZT(((0,0,0),(10,10,10)),[Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST]), 1)
 (1 row)
 
-SELECT hasX(tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT hasX(tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
  hasx 
 ------
  t
 (1 row)
 
-SELECT hasZ(tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT hasZ(tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
  hasz 
 ------
  t
 (1 row)
 
-SELECT hasT(tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT hasT(tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
  hast 
 ------
  t
 (1 row)
 
-SELECT hasZ(tpcbox(0, 0, 10, 10, 1, 0));
+SELECT hasZ(tpcboxX(0, 0, 10, 10, 1, 0));
  hasz 
 ------
  f
 (1 row)
 
-SELECT hasT(tpcbox(0, 0, 10, 10, 1, 0));
+SELECT hasT(tpcboxX(0, 0, 10, 10, 1, 0));
  hast 
 ------
  f
 (1 row)
 
-SELECT xmin(tpcbox(0, 0, 10, 10, 1, 0));
+SELECT xmin(tpcboxX(0, 0, 10, 10, 1, 0));
  xmin 
 ------
     0
 (1 row)
 
-SELECT xmax(tpcbox(0, 0, 10, 10, 1, 0));
+SELECT xmax(tpcboxX(0, 0, 10, 10, 1, 0));
  xmax 
 ------
    10
 (1 row)
 
-SELECT ymin(tpcbox(0, 0, 10, 10, 1, 0));
+SELECT ymin(tpcboxX(0, 0, 10, 10, 1, 0));
  ymin 
 ------
     0
 (1 row)
 
-SELECT ymax(tpcbox(0, 0, 10, 10, 1, 0));
+SELECT ymax(tpcboxX(0, 0, 10, 10, 1, 0));
  ymax 
 ------
    10
 (1 row)
 
-SELECT zmin(tpcbox_z(0, 0, 1, 10, 10, 9, 1, 0));
+SELECT zmin(tpcboxZ(0, 0, 1, 10, 10, 9, 1, 0));
  zmin 
 ------
     1
 (1 row)
 
-SELECT zmax(tpcbox_z(0, 0, 1, 10, 10, 9, 1, 0));
+SELECT zmax(tpcboxZ(0, 0, 1, 10, 10, 9, 1, 0));
  zmax 
 ------
     9
 (1 row)
 
-SELECT zmin(tpcbox(0, 0, 10, 10, 1, 0));
+SELECT zmin(tpcboxX(0, 0, 10, 10, 1, 0));
  zmin 
 ------
      
 (1 row)
 
-SELECT pcid(tpcbox(0, 0, 10, 10, 7, 0));
+SELECT pcid(tpcboxX(0, 0, 10, 10, 7, 0));
  pcid 
 ------
     7
 (1 row)
 
-SELECT SRID(tpcbox(0, 0, 10, 10, 1, 4326));
+SELECT SRID(tpcboxX(0, 0, 10, 10, 1, 4326));
  srid 
 ------
  4326
@@ -156,157 +156,157 @@ FROM (SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
            3 |           6
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
           ?column?           
 -----------------------------
  TPCBOX(X((0,0),(10,10)), 1)
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
          ?column?          
 ---------------------------
  TPCBOX(X((3,3),(5,5)), 1)
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(50, 50, 60, 60, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(50, 50, 60, 60, 1, 0);
  ?column? 
 ----------
  
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 0, 0) + tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT tpcbox(0, 0, 5, 5, 0, 0) * tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 8, 8, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 8, 8, 1, 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 20, 20, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 20, 20, 1, 0);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT tpcbox(2, 2, 8, 8, 1, 0)   <@ tpcbox(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(2, 2, 8, 8, 1, 0)   <@ tpcboxX(0, 0, 10, 10, 1, 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(3, 3, 10, 10, 1, 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(50, 50, 60, 60, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(50, 50, 60, 60, 1, 0);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   ~= tpcboxX(0, 0, 5, 5, 1, 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT contains(tpcbox(0, 0, 10, 10, 1, 0), tpcbox(2, 2, 8, 8, 1, 0));
+SELECT contains(tpcboxX(0, 0, 10, 10, 1, 0), tpcboxX(2, 2, 8, 8, 1, 0));
  contains 
 ----------
  t
 (1 row)
 
-SELECT contained(tpcbox(2, 2, 8, 8, 1, 0), tpcbox(0, 0, 10, 10, 1, 0));
+SELECT contained(tpcboxX(2, 2, 8, 8, 1, 0), tpcboxX(0, 0, 10, 10, 1, 0));
  contained 
 -----------
  t
 (1 row)
 
-SELECT overlaps(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(3, 3, 10, 10, 1, 0));
+SELECT overlaps(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(3, 3, 10, 10, 1, 0));
  overlaps 
 ----------
  t
 (1 row)
 
-SELECT same(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(0, 0, 5, 5, 1, 0));
+SELECT same(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(0, 0, 5, 5, 1, 0));
  same 
 ------
  t
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0)  -|- tpcbox(5, 0, 10, 5, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)  -|- tpcboxX(5, 0, 10, 5, 1, 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT adjacent(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(5, 0, 10, 5, 1, 0));
+SELECT adjacent(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(5, 0, 10, 5, 1, 0));
  adjacent 
 ----------
  t
 (1 row)
 
-SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 8, 8, 2, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 8, 8, 2, 0);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(0, 0, 5, 5, 2, 0);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   ~= tpcboxX(0, 0, 5, 5, 2, 0);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
-SELECT tpcbox(0, 0, 5, 5, 0, 0) && tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0, 0) && tpcboxX(3, 3, 10, 10, 1, 0);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT tpcbox(0, 0, 5, 5, 0, 0) @> tpcbox(1, 1, 4, 4, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0, 0) @> tpcboxX(1, 1, 4, 4, 1, 0);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT tpcbox(0, 0, 5, 5, 1, 4326) && tpcbox(3, 3, 10, 10, 1, 3857);
+SELECT tpcboxX(0, 0, 5, 5, 1, 4326) && tpcboxX(3, 3, 10, 10, 1, 3857);
 ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
-SELECT tpcbox(0, 0, 5, 5, 1, 4326) + tpcbox(3, 3, 10, 10, 1, 3857);
+SELECT tpcboxX(0, 0, 5, 5, 1, 4326) + tpcboxX(3, 3, 10, 10, 1, 3857);
 ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
-SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) &&
-  tpcbox_t(tstzspan '[2024-01-02, 2024-01-03]', 1);
+SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) &&
+  tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) +
-  tpcbox_t(tstzspan '[2024-01-02, 2024-01-03]', 1);
+SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) +
+  tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 1);
                                   ?column?                                  
 ----------------------------------------------------------------------------
  TPCBOX(T([Mon Jan 01 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]), 1)
 (1 row)
 
-SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 0)),
-  (tpcbox(3, 3, 10, 10, 1, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 0)),
+  (tpcboxX(3, 3, 10, 10, 1, 0))) t(b);
            extent            
 -----------------------------
  TPCBOX(X((0,0),(10,10)), 1)
 (1 row)
 
-SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 0)),
-  (tpcbox(3, 3, 10, 10, 2, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 0)),
+  (tpcboxX(3, 3, 10, 10, 2, 0))) t(b);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
-SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 0, 0)),
-  (tpcbox(3, 3, 10, 10, 1, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 0, 0)),
+  (tpcboxX(3, 3, 10, 10, 1, 0))) t(b);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 4326)),
-  (tpcbox(3, 3, 10, 10, 1, 3857))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 4326)),
+  (tpcboxX(3, 3, 10, 10, 1, 3857))) t(b);
 ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
-SELECT tpcbox(0, 0, 5, 5, 1, 0) =  tpcbox(0, 0, 5, 5, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) =  tpcboxX(0, 0, 5, 5, 1, 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0) <> tpcbox(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) <> tpcboxX(0, 0, 5, 5, 2, 0);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0) <  tpcbox(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) <  tpcboxX(0, 0, 5, 5, 2, 0);
  ?column? 
 ----------
  t

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox_tbl.test.out
@@ -141,42 +141,42 @@ SET enable_indexscan = off;
 SET
 SET enable_bitmapscan = off;
 SET
-SELECT COUNT(*) AS seq_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  seq_count 
 -----------
          0
 (1 row)
 
-SELECT COUNT(*) AS seq_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  seq_left 
 ----------
        11
 (1 row)
 
-SELECT COUNT(*) AS seq_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  seq_overleft 
 --------------
            16
 (1 row)
 
-SELECT COUNT(*) AS seq_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  seq_above 
 -----------
         46
 (1 row)
 
-SELECT COUNT(*) AS seq_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  seq_front 
 -----------
          0
 (1 row)
 
-SELECT COUNT(*) AS seq_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  seq_before 
 ------------
@@ -189,42 +189,42 @@ SET enable_indexscan = on;
 SET
 SET enable_bitmapscan = on;
 SET
-SELECT COUNT(*) AS quadtree_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  quadtree_count 
 ----------------
               0
 (1 row)
 
-SELECT COUNT(*) AS quadtree_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  quadtree_left 
 ---------------
             11
 (1 row)
 
-SELECT COUNT(*) AS quadtree_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  quadtree_overleft 
 -------------------
                 16
 (1 row)
 
-SELECT COUNT(*) AS quadtree_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  quadtree_above 
 ----------------
              46
 (1 row)
 
-SELECT COUNT(*) AS quadtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  quadtree_front 
 ----------------
               0
 (1 row)
 
-SELECT COUNT(*) AS quadtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  quadtree_before 
 -----------------
@@ -235,42 +235,42 @@ DROP INDEX tbl_tpcbox_quadtree_idx;
 DROP INDEX
 CREATE INDEX tbl_tpcbox_kdtree_idx ON tbl_tpcbox USING spgist(b tpcbox_kdtree_ops);
 CREATE INDEX
-SELECT COUNT(*) AS kdtree_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  kdtree_count 
 --------------
             0
 (1 row)
 
-SELECT COUNT(*) AS kdtree_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  kdtree_left 
 -------------
           11
 (1 row)
 
-SELECT COUNT(*) AS kdtree_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  kdtree_overleft 
 -----------------
               16
 (1 row)
 
-SELECT COUNT(*) AS kdtree_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  kdtree_above 
 --------------
            46
 (1 row)
 
-SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  kdtree_front 
 --------------
             0
 (1 row)
 
-SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
  kdtree_before 
 ---------------
@@ -278,7 +278,7 @@ SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
 (1 row)
 
 WITH test AS (
-  SELECT b |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  SELECT b |=| tpcboxZT(200, 200, 200, 210, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcbox ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
@@ -298,14 +298,14 @@ RESET
 RESET enable_bitmapscan;
 RESET
 CREATE TABLE tbl_tpcbox_pcid AS
-  SELECT 1 AS k, tpcbox_zt(20, 0, 0, 30, 10, 10,
+  SELECT 1 AS k, tpcboxZT(20, 0, 0, 30, 10, 10,
     tstzspan '[2001-01-01, 2001-12-31]', 2, 0) AS b;
 SELECT 1
 CREATE INDEX tbl_tpcbox_pcid_quadtree_idx ON tbl_tpcbox_pcid USING spgist(b);
 CREATE INDEX
 SET enable_seqscan = off;
 SET
-SELECT COUNT(*) FROM tbl_tpcbox_pcid WHERE b >> tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT COUNT(*) FROM tbl_tpcbox_pcid WHERE b >> tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 ERROR:  Operation on TPCBox values with different schemas: 2 vs 1
 RESET enable_seqscan;

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -337,21 +337,21 @@ SELECT atTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::f
  t
 (1 row)
 
-SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NOT NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT minusTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT minusTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
  ?column? 
 ----------
@@ -359,21 +359,21 @@ SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-0
 (1 row)
 
 SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
-  tpcbox_z(0, 0, 0, 2, 2, 2, 1)));
+  tpcboxZ(0, 0, 0, 2, 2, 2, 1)));
  numinstants 
 -------------
            2
 (1 row)
 
 SELECT minusTpcbox(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
-  tpcbox_z(0, 0, 0, 10, 10, 10, 1)) IS NULL;
+  tpcboxZ(0, 0, 0, 10, 10, 10, 1)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcpoint(PC_MakePoint(1, ARRAY[3.0, 3.0, 3.0]::float[]), '2024-01-03'::timestamptz)]),
-  tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1)));
+  tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1)));
  numinstants 
 -------------
            2
@@ -670,5 +670,5 @@ SELECT tpcpoint '2300000063000000000000000000F03F0000000000000040000000000000084
 (1 row)
 
 SELECT tpcpoint '2300000063000000000000000000F03F00000000000000400000000000000840000000@2024-01-01' &&
-  tpcbox_xt(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
+  tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
 ERROR:  No schema registered for pcid 99

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint_tbl.test.out
@@ -134,7 +134,7 @@ WHERE atTime(temp, tstzspan '[2001-01-01, 2002-01-01]') IS NOT NULL;
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tpcpoint WHERE atTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 1, 0)) IS NOT NULL;
  count 
 -------
@@ -142,7 +142,7 @@ SELECT COUNT(*) FROM tbl_tpcpoint WHERE atTpcbox(temp,
 (1 row)
 
 SELECT bool_and(atTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NULL)
 FROM tbl_tpcpoint;
  bool_and 
@@ -151,7 +151,7 @@ FROM tbl_tpcpoint;
 (1 row)
 
 SELECT bool_and(minusTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NOT NULL)
 FROM tbl_tpcpoint;
  bool_and 

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -359,21 +359,21 @@ SELECT atTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.
  t
 (1 row)
 
-SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NOT NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT minusTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT minusTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
  ?column? 
 ----------
@@ -381,21 +381,21 @@ SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::fl
 (1 row)
 
 SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
-  tpcbox(0, 0, 3, 3, 1)));
+  tpcboxX(0, 0, 3, 3, 1)));
  numinstants 
 -------------
            1
 (1 row)
 
 SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
-  tpcbox(0, 0, 3, 3, 1)));
+  tpcboxX(0, 0, 3, 3, 1)));
  numinstants 
 -------------
            2
 (1 row)
 
 SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), PC_MakePoint(1, ARRAY[6.0, 6.0, 6.0]::float[])]), '2024-01-02'::timestamptz)]),
-  tpcbox_t(tstzspan '[2024-01-01, 2024-01-01]', 1)));
+  tpcboxT(tstzspan '[2024-01-01, 2024-01-01]', 1)));
  numinstants 
 -------------
            1
@@ -453,56 +453,56 @@ SELECT numInstants(afterTimestamp(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[
            1
 (1 row)
 
-SELECT numInstants(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 3, 3, 3,
+SELECT numInstants(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 3, 3, 3,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
  numinstants 
 -------------
            1
 (1 row)
 
-SELECT startNumPoints(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 3, 3, 3,
+SELECT startNumPoints(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 3, 3, 3,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
  startnumpoints 
 ----------------
               2
 (1 row)
 
-SELECT startNumPoints(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 1, 1, 1,
+SELECT startNumPoints(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
  startnumpoints 
 ----------------
               1
 (1 row)
 
-SELECT atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(10, 10, 10, 20, 20, 20,
+SELECT atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(10, 10, 10, 20, 20, 20,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 3, 3, 3,
+SELECT minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 3, 3, 3,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT startNumPoints(minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 1, 1, 1,
+SELECT startNumPoints(minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
  startnumpoints 
 ----------------
               1
 (1 row)
 
-SELECT PC_AsText(getValue(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 1, 1, 1,
+SELECT PC_AsText(getValue(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
          pc_astext          
 ----------------------------
  {"pcid":1,"pts":[[1,1,1]]}
 (1 row)
 
-SELECT PC_AsText(getValue(minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox_zt(0, 0, 0, 1, 1, 1,
+SELECT PC_AsText(getValue(minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
          pc_astext          
 ----------------------------
@@ -734,5 +734,5 @@ SELECT tpcpatch '4F000000630000000000000002000000000000000000F03F000000000000F03
 (1 row)
 
 SELECT tpcpatch '4F000000630000000000000002000000000000000000F03F000000000000F03F000000000000F03F0000000000000040000000000000004000000000000000400000000000000000000000000000@2024-01-01' &&
-  tpcbox_xt(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
+  tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
 ERROR:  No schema registered for pcid 99

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch_tbl.test.out
@@ -141,7 +141,7 @@ WHERE atTime(temp, tstzspan '[2001-01-01, 2002-01-01]') IS NOT NULL;
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tpcpatch WHERE atTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 1, 0)) IS NOT NULL;
  count 
 -------
@@ -149,7 +149,7 @@ SELECT COUNT(*) FROM tbl_tpcpatch WHERE atTpcbox(temp,
 (1 row)
 
 SELECT bool_and(atTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NULL)
 FROM tbl_tpcpatch;
  bool_and 
@@ -158,7 +158,7 @@ FROM tbl_tpcpatch;
 (1 row)
 
 SELECT bool_and(minusTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NOT NULL)
 FROM tbl_tpcpatch;
  bool_and 
@@ -168,7 +168,7 @@ FROM tbl_tpcpatch;
 
 SELECT COUNT(*) FROM tbl_tpcpatch
 WHERE atTpcboxFine(temp,
-  tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+  tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
     tstzspan '[2001-01-01, 2002-01-01]', 1, 0)) IS NOT NULL;
  count 
 -------
@@ -176,11 +176,11 @@ WHERE atTpcboxFine(temp,
 (1 row)
 
 SELECT bool_and(numPoints(atTpcboxFine(temp,
-  tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+  tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
     tstzspan '[2001-01-01, 2002-01-01]', 1, 0))) <= numPoints(temp))
 FROM tbl_tpcpatch
 WHERE atTpcboxFine(temp,
-  tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+  tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
     tstzspan '[2001-01-01, 2002-01-01]', 1, 0)) IS NOT NULL;
  bool_and 
 ----------

--- a/mobilitydb/test/pointcloud/expected/436_tpc_topops.test.out
+++ b/mobilitydb/test/pointcloud/expected/436_tpc_topops.test.out
@@ -1,16 +1,16 @@
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) && (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) && (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) && (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) && (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) && (tpcbox_zt(100, 100, 100, 110, 110, 110, tstzspan '[2099-01-01, 2099-12-31]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) && (tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan '[2099-01-01, 2099-12-31]', 1, 0));
  ?column? 
 ----------
  f
@@ -40,13 +40,13 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::t
  f
 (1 row)
 
-SELECT (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) @> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) @> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <@ (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <@ (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
  ?column? 
 ----------
  t
@@ -64,19 +64,19 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::t
  t
 (1 row)
 
-SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
+SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) && (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) && (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcbox_zt(100, 100, 100, 110, 110, 110, tstzspan '[2099-01-01, 2099-12-31]', 1, 0));
+SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan '[2099-01-01, 2099-12-31]', 1, 0));
  ?column? 
 ----------
  f
@@ -88,13 +88,13 @@ SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), 
  t
 (1 row)
 
-SELECT (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) @> (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) @> (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) <@ (tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
+SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) <@ (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
  ?column? 
 ----------
  t

--- a/mobilitydb/test/pointcloud/expected/436_tpc_topops_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/436_tpc_topops_tbl.test.out
@@ -58,7 +58,7 @@ SELECT bool_and(NOT (temp -|- temp)) FROM tbl_tpcpatch;
  f
 (1 row)
 
-SELECT bool_and(tpcbox_zt(-200, -200, -200, 200, 200, 200,
+SELECT bool_and(tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0) @> temp)
 FROM tbl_tpcpoint;
  bool_and 
@@ -66,7 +66,7 @@ FROM tbl_tpcpoint;
  t
 (1 row)
 
-SELECT bool_and(tpcbox_zt(-200, -200, -200, 200, 200, 200,
+SELECT bool_and(tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0) @> temp)
 FROM tbl_tpcpatch;
  bool_and 
@@ -74,14 +74,14 @@ FROM tbl_tpcpatch;
  t
 (1 row)
 
-SELECT bool_and(temp <@ tpcbox_zt(-200, -200, -200, 200, 200, 200,
+SELECT bool_and(temp <@ tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0)) FROM tbl_tpcpoint;
  bool_and 
 ----------
  t
 (1 row)
 
-SELECT bool_and(temp <@ tpcbox_zt(-200, -200, -200, 200, 200, 200,
+SELECT bool_and(temp <@ tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0)) FROM tbl_tpcpatch;
  bool_and 
 ----------

--- a/mobilitydb/test/pointcloud/expected/437_tpc_posops.test.out
+++ b/mobilitydb/test/pointcloud/expected/437_tpc_posops.test.out
@@ -1,88 +1,88 @@
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) << (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) << (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) >> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) >> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-15'::timestamptz)) << (tpcbox_zt(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-15'::timestamptz)) << (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &< (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &< (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &> (tpcbox_zt(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <<| (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <<| (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) |>> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) |>> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &<| (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &<| (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) |&> (tpcbox_zt(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) |&> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <</ (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <</ (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) />> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) />> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &</ (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &</ (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) /&> (tpcbox_zt(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) /&> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <<# (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <<# (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) #>> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) #>> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t

--- a/mobilitydb/test/pointcloud/expected/437_tpc_posops_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/437_tpc_posops_tbl.test.out
@@ -71,7 +71,7 @@ SELECT bool_and(NOT (temp #>> temp)) FROM tbl_tpcpatch;
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tpcpoint
-WHERE temp << tpcbox_zt(-200, -200, -200, 200, 200, 200,
+WHERE temp << tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0);
  count 
 -------
@@ -79,7 +79,7 @@ WHERE temp << tpcbox_zt(-200, -200, -200, 200, 200, 200,
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tpcpoint
-WHERE tpcbox_zt(-200, -200, -200, 200, 200, 200,
+WHERE tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0) >> temp;
  count 
 -------

--- a/mobilitydb/test/pointcloud/expected/438_tpc_distance.test.out
+++ b/mobilitydb/test/pointcloud/expected/438_tpc_distance.test.out
@@ -16,13 +16,13 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[3.0, 4.0, 0.0]::float[]), '2024-01-01'::t
         5
 (1 row)
 
-SELECT (tpcbox_zt(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0)) |=| (tpcbox_zt(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+SELECT (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0)) |=| (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
  ?column? 
 ----------
         0
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::timestamptz)) |=| (tpcbox_zt(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::timestamptz)) |=| (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
  ?column? 
 ----------
         0
@@ -30,14 +30,14 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::t
 
 SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]),
                  '2024-01-01'::timestamptz)) |=|
-       (tpcbox_zt(0, 0, 0, 0, 0, 0,
+       (tpcboxZT(0, 0, 0, 0, 0, 0,
                   tstzspan '[2099-01-01, 2099-01-02]', 1, 0)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::timestamptz)) |=| (tpcbox_zt(0, 0, 0, 0, 0, 0,
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::timestamptz)) |=| (tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2024-01-01, 2024-01-02]', 999, 0)) > 1e10;
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 999
 INSERT INTO pointcloud_formats (pcid, srid, schema)

--- a/mobilitydb/test/pointcloud/expected/438_tpc_distance_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/438_tpc_distance_tbl.test.out
@@ -24,10 +24,10 @@ SET enable_indexscan = off;
 SET
 SET enable_bitmapscan = off;
 SET
-SELECT k, ((temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
+SELECT k, ((temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2001-06-01, 2001-06-30]', 1, 0)) > 0)::text AS finite
 FROM tbl_tpcpoint
-ORDER BY temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
+ORDER BY temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2001-06-01, 2001-06-30]', 1, 0)
 LIMIT 5;
  k  | finite 
@@ -45,10 +45,10 @@ SET enable_indexscan = on;
 SET
 SET enable_bitmapscan = on;
 SET
-SELECT k, ((temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
+SELECT k, ((temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2001-06-01, 2001-06-30]', 1, 0)) > 0)::text AS finite
 FROM tbl_tpcpoint
-ORDER BY temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
+ORDER BY temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2001-06-01, 2001-06-30]', 1, 0)
 LIMIT 5;
  k  | finite 

--- a/mobilitydb/test/pointcloud/expected/439_tpc_gist_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/439_tpc_gist_tbl.test.out
@@ -7,7 +7,7 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  seq_count 
 -----------
@@ -21,7 +21,7 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  idx_count 
 -----------
@@ -45,7 +45,7 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  seq_count 
 -----------
@@ -59,7 +59,7 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  idx_count 
 -----------
@@ -83,7 +83,7 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_contained FROM tbl_tpcpatch
-WHERE temp <@ tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+WHERE temp <@ tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
   tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
  seq_contained 
 ---------------
@@ -97,7 +97,7 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_contained FROM tbl_tpcpatch
-WHERE temp <@ tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+WHERE temp <@ tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
   tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
  idx_contained 
 ---------------
@@ -111,7 +111,7 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_before FROM tbl_tpcpatch
-WHERE temp <<# tpcbox_zt(0, 0, 0, 100, 100, 100,
+WHERE temp <<# tpcboxZT(0, 0, 0, 100, 100, 100,
   tstzspan '[2001-12-15, 2002-01-01]', 1, 0);
  seq_before 
 ------------
@@ -125,7 +125,7 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_before FROM tbl_tpcpatch
-WHERE temp <<# tpcbox_zt(0, 0, 0, 100, 100, 100,
+WHERE temp <<# tpcboxZT(0, 0, 0, 100, 100, 100,
   tstzspan '[2001-12-15, 2002-01-01]', 1, 0);
  idx_before 
 ------------
@@ -139,7 +139,7 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_left FROM tbl_tpcpatch
-WHERE temp << tpcbox_zt(50, -1000, -1000, 1000, 1000, 1000,
+WHERE temp << tpcboxZT(50, -1000, -1000, 1000, 1000, 1000,
   tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
  seq_left 
 ----------
@@ -153,7 +153,7 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_left FROM tbl_tpcpatch
-WHERE temp << tpcbox_zt(50, -1000, -1000, 1000, 1000, 1000,
+WHERE temp << tpcboxZT(50, -1000, -1000, 1000, 1000, 1000,
   tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
  idx_left 
 ----------
@@ -261,7 +261,7 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_fn_box FROM tbl_tpcpoint
-WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
  seq_fn_box 
 ------------
@@ -276,7 +276,7 @@ WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
 (1 row)
 
 SELECT COUNT(*) AS seq_fn_patch FROM tbl_tpcpatch
-WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
  seq_fn_patch 
 --------------
@@ -290,7 +290,7 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_fn_box FROM tbl_tpcpoint
-WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
  idx_fn_box 
 ------------
@@ -305,7 +305,7 @@ WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
 (1 row)
 
 SELECT COUNT(*) AS idx_fn_patch FROM tbl_tpcpatch
-WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
  idx_fn_patch 
 --------------

--- a/mobilitydb/test/pointcloud/expected/440_tpc_spgist_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/440_tpc_spgist_tbl.test.out
@@ -7,7 +7,7 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  seq_count 
 -----------
@@ -21,7 +21,7 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  idx_count 
 -----------
@@ -34,7 +34,7 @@ CREATE INDEX tbl_tpcpoint_kdtree_idx ON tbl_tpcpoint
   USING spgist(temp tpcpoint_kdtree_ops);
 CREATE INDEX
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  kdtree_count 
 --------------
@@ -52,7 +52,7 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  seq_count 
 -----------
@@ -66,7 +66,7 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  idx_count 
 -----------
@@ -79,7 +79,7 @@ CREATE INDEX tbl_tpcpatch_kdtree_idx ON tbl_tpcpatch
   USING spgist(temp tpcpatch_kdtree_ops);
 CREATE INDEX
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
  kdtree_count 
 --------------
@@ -97,7 +97,7 @@ RESET
 CREATE INDEX tbl_tpcpoint_knn_quadtree_idx ON tbl_tpcpoint USING spgist(temp);
 CREATE INDEX
 WITH test AS (
-  SELECT temp |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  SELECT temp |=| tpcboxZT(200, 200, 200, 210, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
@@ -114,7 +114,7 @@ CREATE INDEX tbl_tpcpoint_knn_kdtree_idx ON tbl_tpcpoint
   USING spgist(temp tpcpoint_kdtree_ops);
 CREATE INDEX
 WITH test AS (
-  SELECT temp |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  SELECT temp |=| tpcboxZT(200, 200, 200, 210, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
@@ -130,7 +130,7 @@ DROP INDEX
 CREATE INDEX tbl_tpcpatch_knn_quadtree_idx ON tbl_tpcpatch USING spgist(temp);
 CREATE INDEX
 WITH test AS (
-  SELECT temp |=| tpcbox_xt(200, 200, 210, 210,
+  SELECT temp |=| tpcboxXT(200, 200, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
@@ -141,7 +141,7 @@ CREATE INDEX tbl_tpcpatch_knn_kdtree_idx ON tbl_tpcpatch
   USING spgist(temp tpcpatch_kdtree_ops);
 CREATE INDEX
 WITH test AS (
-  SELECT temp |=| tpcbox_xt(200, 200, 210, 210,
+  SELECT temp |=| tpcboxXT(200, 200, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -34,35 +34,35 @@
 -- Constructors
 -------------------------------------------------------------------------------
 
-SELECT tpcbox(0, 0, 10, 10, 1, 0);
-SELECT tpcbox_z(0, 0, 0, 10, 10, 10, 1, 0);
-SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1);
-SELECT tpcbox_xt(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
-SELECT tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT tpcboxX(0, 0, 10, 10, 1, 0);
+SELECT tpcboxZ(0, 0, 0, 10, 10, 10, 1, 0);
+SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1);
+SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+SELECT tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
 
 -------------------------------------------------------------------------------
 -- Accessors
 -------------------------------------------------------------------------------
 
-SELECT hasX(tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT hasX(tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
-SELECT hasZ(tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT hasZ(tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
-SELECT hasT(tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT hasT(tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
-SELECT hasZ(tpcbox(0, 0, 10, 10, 1, 0));   -- false: no Z
-SELECT hasT(tpcbox(0, 0, 10, 10, 1, 0));   -- false: no T
+SELECT hasZ(tpcboxX(0, 0, 10, 10, 1, 0));   -- false: no Z
+SELECT hasT(tpcboxX(0, 0, 10, 10, 1, 0));   -- false: no T
 
-SELECT xmin(tpcbox(0, 0, 10, 10, 1, 0));
-SELECT xmax(tpcbox(0, 0, 10, 10, 1, 0));
-SELECT ymin(tpcbox(0, 0, 10, 10, 1, 0));
-SELECT ymax(tpcbox(0, 0, 10, 10, 1, 0));
-SELECT zmin(tpcbox_z(0, 0, 1, 10, 10, 9, 1, 0));
-SELECT zmax(tpcbox_z(0, 0, 1, 10, 10, 9, 1, 0));
-SELECT zmin(tpcbox(0, 0, 10, 10, 1, 0));   -- NULL: no Z
-SELECT pcid(tpcbox(0, 0, 10, 10, 7, 0));
-SELECT SRID(tpcbox(0, 0, 10, 10, 1, 4326));
+SELECT xmin(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT xmax(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT ymin(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT ymax(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT zmin(tpcboxZ(0, 0, 1, 10, 10, 9, 1, 0));
+SELECT zmax(tpcboxZ(0, 0, 1, 10, 10, 9, 1, 0));
+SELECT zmin(tpcboxX(0, 0, 10, 10, 1, 0));   -- NULL: no Z
+SELECT pcid(tpcboxX(0, 0, 10, 10, 7, 0));
+SELECT SRID(tpcboxX(0, 0, 10, 10, 1, 4326));
 
 -------------------------------------------------------------------------------
 -- Conversions
@@ -97,33 +97,33 @@ FROM (SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
 -- Set operations
 -------------------------------------------------------------------------------
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0) + tpcbox(3, 3, 10, 10, 1, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(3, 3, 10, 10, 1, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0) * tpcbox(50, 50, 60, 60, 1, 0);  -- NULL (disjoint)
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(50, 50, 60, 60, 1, 0);  -- NULL (disjoint)
 
 -- A box carrying coordinates states the schema they are read in, so a box
 -- naming schema 0 and one naming schema 1 have no common extent to combine
-SELECT tpcbox(0, 0, 5, 5, 0, 0) + tpcbox(3, 3, 10, 10, 1, 0);
-SELECT tpcbox(0, 0, 5, 5, 0, 0) * tpcbox(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
 
 -------------------------------------------------------------------------------
 -- Topological predicates — same pcid
 -------------------------------------------------------------------------------
 
-SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 8, 8, 1, 0);
-SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 20, 20, 1, 0);
-SELECT tpcbox(2, 2, 8, 8, 1, 0)   <@ tpcbox(0, 0, 10, 10, 1, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(3, 3, 10, 10, 1, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(50, 50, 60, 60, 1, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 8, 8, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 20, 20, 1, 0);
+SELECT tpcboxX(2, 2, 8, 8, 1, 0)   <@ tpcboxX(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(50, 50, 60, 60, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   ~= tpcboxX(0, 0, 5, 5, 1, 0);
 
 -- The portable spelling of each operator above answers the same
-SELECT contains(tpcbox(0, 0, 10, 10, 1, 0), tpcbox(2, 2, 8, 8, 1, 0));
-SELECT contained(tpcbox(2, 2, 8, 8, 1, 0), tpcbox(0, 0, 10, 10, 1, 0));
-SELECT overlaps(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(3, 3, 10, 10, 1, 0));
-SELECT same(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(0, 0, 5, 5, 1, 0));
-SELECT tpcbox(0, 0, 5, 5, 1, 0)  -|- tpcbox(5, 0, 10, 5, 1, 0);
-SELECT adjacent(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(5, 0, 10, 5, 1, 0));
+SELECT contains(tpcboxX(0, 0, 10, 10, 1, 0), tpcboxX(2, 2, 8, 8, 1, 0));
+SELECT contained(tpcboxX(2, 2, 8, 8, 1, 0), tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT overlaps(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(3, 3, 10, 10, 1, 0));
+SELECT same(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(0, 0, 5, 5, 1, 0));
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)  -|- tpcboxX(5, 0, 10, 5, 1, 0);
+SELECT adjacent(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(5, 0, 10, 5, 1, 0));
 
 -------------------------------------------------------------------------------
 -- Topological predicates — the schema decides what a coordinate means
@@ -131,25 +131,25 @@ SELECT adjacent(tpcbox(0, 0, 5, 5, 1, 0), tpcbox(5, 0, 10, 5, 1, 0));
 
 -- Two schemas give the same number two meanings, so the boxes are not
 -- comparable and the predicate has no answer to give
-SELECT tpcbox(0, 0, 10, 10, 1, 0) @> tpcbox(2, 2, 8, 8, 2, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   && tpcbox(0, 0, 5, 5, 2, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0)   ~= tpcbox(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 8, 8, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0)   ~= tpcboxX(0, 0, 5, 5, 2, 0);
 
 -- Schema 0 is a schema like any other once a box carries coordinates
-SELECT tpcbox(0, 0, 5, 5, 0, 0) && tpcbox(3, 3, 10, 10, 1, 0);
-SELECT tpcbox(0, 0, 5, 5, 0, 0) @> tpcbox(1, 1, 4, 4, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0, 0) && tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0, 0) @> tpcboxX(1, 1, 4, 4, 1, 0);
 
 -- The SRID is read on the same terms: one schema, two reference systems, so
 -- the same pair of numbers denotes two different places
-SELECT tpcbox(0, 0, 5, 5, 1, 4326) && tpcbox(3, 3, 10, 10, 1, 3857);
-SELECT tpcbox(0, 0, 5, 5, 1, 4326) + tpcbox(3, 3, 10, 10, 1, 3857);
+SELECT tpcboxX(0, 0, 5, 5, 1, 4326) && tpcboxX(3, 3, 10, 10, 1, 3857);
+SELECT tpcboxX(0, 0, 5, 5, 1, 4326) + tpcboxX(3, 3, 10, 10, 1, 3857);
 
 -- A box carrying no coordinates names no schema, so it meets a box of any
 -- schema: this is the shape a time-only query box takes against an index
-SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) &&
-  tpcbox_t(tstzspan '[2024-01-02, 2024-01-03]', 1);
-SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) +
-  tpcbox_t(tstzspan '[2024-01-02, 2024-01-03]', 1);
+SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) &&
+  tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 1);
+SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) +
+  tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 1);
 
 -------------------------------------------------------------------------------
 -- Extent aggregation
@@ -158,21 +158,21 @@ SELECT tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 0) +
 -- The aggregate answers the extent of the boxes it folds, so it is bounded by
 -- the same comparability the operators are: an extent spanning two schemas, or
 -- two reference systems, states a region no schema can read
-SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 0)),
-  (tpcbox(3, 3, 10, 10, 1, 0))) t(b);
-SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 0)),
-  (tpcbox(3, 3, 10, 10, 2, 0))) t(b);
-SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 0, 0)),
-  (tpcbox(3, 3, 10, 10, 1, 0))) t(b);
-SELECT extent(b) FROM (VALUES (tpcbox(0, 0, 5, 5, 1, 4326)),
-  (tpcbox(3, 3, 10, 10, 1, 3857))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 0)),
+  (tpcboxX(3, 3, 10, 10, 1, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 0)),
+  (tpcboxX(3, 3, 10, 10, 2, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 0, 0)),
+  (tpcboxX(3, 3, 10, 10, 1, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 4326)),
+  (tpcboxX(3, 3, 10, 10, 1, 3857))) t(b);
 
 -------------------------------------------------------------------------------
 -- Comparison operators
 -------------------------------------------------------------------------------
 
-SELECT tpcbox(0, 0, 5, 5, 1, 0) =  tpcbox(0, 0, 5, 5, 1, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0) <> tpcbox(0, 0, 5, 5, 2, 0);
-SELECT tpcbox(0, 0, 5, 5, 1, 0) <  tpcbox(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) =  tpcboxX(0, 0, 5, 5, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) <> tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1, 0) <  tpcboxX(0, 0, 5, 5, 2, 0);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
@@ -107,50 +107,50 @@ CREATE INDEX tbl_tpcbox_quadtree_idx ON tbl_tpcbox USING spgist(b);
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
-SELECT COUNT(*) AS seq_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS seq_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS seq_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS seq_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS seq_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS seq_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS seq_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
-SELECT COUNT(*) AS quadtree_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS quadtree_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS quadtree_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS quadtree_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS quadtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS quadtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS quadtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 DROP INDEX tbl_tpcbox_quadtree_idx;
 
 CREATE INDEX tbl_tpcbox_kdtree_idx ON tbl_tpcbox USING spgist(b tpcbox_kdtree_ops);
-SELECT COUNT(*) AS kdtree_count FROM tbl_tpcbox WHERE b @> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS kdtree_left FROM tbl_tpcbox WHERE b << tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS kdtree_overleft FROM tbl_tpcbox WHERE b &< tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS kdtree_above FROM tbl_tpcbox WHERE b |>> tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
-SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcbox_zt(0, 0, 0,
+SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
   10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 WITH test AS (
-  SELECT b |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  SELECT b |=| tpcboxZT(200, 200, 200, 210, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcbox ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
@@ -162,11 +162,11 @@ RESET enable_bitmapscan;
 -- The index key of a box keeps its bounds and drops the schema identifier,
 -- so a box of another schema is answered by the operator on the value.
 CREATE TABLE tbl_tpcbox_pcid AS
-  SELECT 1 AS k, tpcbox_zt(20, 0, 0, 30, 10, 10,
+  SELECT 1 AS k, tpcboxZT(20, 0, 0, 30, 10, 10,
     tstzspan '[2001-01-01, 2001-12-31]', 2, 0) AS b;
 CREATE INDEX tbl_tpcbox_pcid_quadtree_idx ON tbl_tpcbox_pcid USING spgist(b);
 SET enable_seqscan = off;
-SELECT COUNT(*) FROM tbl_tpcbox_pcid WHERE b >> tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT COUNT(*) FROM tbl_tpcbox_pcid WHERE b >> tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
 RESET enable_seqscan;
 DROP TABLE tbl_tpcbox_pcid;

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -188,24 +188,24 @@ SELECT atValue(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
 
 SELECT atTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
   tstzspan '[2024-01-02, 2024-01-03]') IS NOT NULL;
-SELECT atTpcbox(:inst2, tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT atTpcbox(:inst2, tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NOT NULL;
-SELECT minusTpcbox(:inst2, tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT minusTpcbox(:inst2, tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
 
 -- Pcid-mismatch identity: at → NULL, minus → unchanged.
-SELECT atTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT atTpcbox(:inst1, tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
 
 -- Boxes without every dimension: a spatial-only box restricts spatially, a
 -- temporal-only box temporally. Minus of a box covering the whole value is
 -- empty.
 SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
-  tpcbox_z(0, 0, 0, 2, 2, 2, 1)));
+  tpcboxZ(0, 0, 0, 2, 2, 2, 1)));
 SELECT minusTpcbox(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
-  tpcbox_z(0, 0, 0, 10, 10, 10, 1)) IS NULL;
+  tpcboxZ(0, 0, 0, 10, 10, 10, 1)) IS NULL;
 SELECT numInstants(atTpcbox(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
-  tpcbox_t(tstzspan '[2024-01-01, 2024-01-02]', 1)));
+  tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1)));
 
 -- Restriction to the instants before / after a timestamp. The strict flag
 -- is true by default and excludes the instant at the timestamp itself, which
@@ -356,6 +356,6 @@ SELECT splitEachNSpans(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), 2);
 
 SELECT tpcpoint '2300000063000000000000000000F03F00000000000000400000000000000840000000@2024-01-01';
 SELECT tpcpoint '2300000063000000000000000000F03F00000000000000400000000000000840000000@2024-01-01' &&
-  tpcbox_xt(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
+  tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint_tbl.test.sql
@@ -109,18 +109,18 @@ WHERE atTime(temp, tstzspan '[2001-01-01, 2002-01-01]') IS NOT NULL;
 
 -- atTpcbox over the full datagen extent leaves every row populated.
 SELECT COUNT(*) FROM tbl_tpcpoint WHERE atTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 1, 0)) IS NOT NULL;
 
 -- atTpcbox with a pcid mismatch yields NULL (empty) for every row.
 SELECT bool_and(atTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NULL)
 FROM tbl_tpcpoint;
 
 -- minusTpcbox is the complement.
 SELECT bool_and(minusTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NOT NULL)
 FROM tbl_tpcpoint;
 

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -197,21 +197,21 @@ SELECT atValue(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]),
 
 SELECT atTime(tpcpatchSeq(ARRAY[:inst1, :inst2]),
   tstzspan '[2024-01-02, 2024-01-03]') IS NOT NULL;
-SELECT atTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT atTpcbox(:inst1, tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NOT NULL;
-SELECT minusTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT minusTpcbox(:inst1, tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
-SELECT atTpcbox(:inst1, tpcbox_zt(0, 0, 0, 10, 10, 10,
+SELECT atTpcbox(:inst1, tpcboxZT(0, 0, 0, 10, 10, 10,
   tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
 
 -- Boxes without every dimension: a spatial-only box applies the PCBOUNDS
 -- test alone, a temporal-only box the period test alone.
 SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[:inst1, :inst2]),
-  tpcbox(0, 0, 3, 3, 1)));
+  tpcboxX(0, 0, 3, 3, 1)));
 SELECT numInstants(minusTpcbox(tpcpatchSeq(ARRAY[:inst1, :inst2]),
-  tpcbox(0, 0, 3, 3, 1)));
+  tpcboxX(0, 0, 3, 3, 1)));
 SELECT numInstants(atTpcbox(tpcpatchSeq(ARRAY[:inst1, :inst2]),
-  tpcbox_t(tstzspan '[2024-01-01, 2024-01-01]', 1)));
+  tpcboxT(tstzspan '[2024-01-01, 2024-01-01]', 1)));
 
 -- Restriction to the instants before / after a timestamp. The strict flag
 -- is true by default and excludes the instant at the timestamp itself, which
@@ -238,26 +238,26 @@ SELECT numInstants(afterTimestamp(:inst2, timestamptz '2024-01-02', false));
 -- and the at-restriction returns NULL.
 -------------------------------------------------------------------------------
 
-SELECT numInstants(atTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 3, 3, 3,
+SELECT numInstants(atTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 3, 3, 3,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
-SELECT startNumPoints(atTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 3, 3, 3,
+SELECT startNumPoints(atTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 3, 3, 3,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
-SELECT startNumPoints(atTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 1, 1, 1,
+SELECT startNumPoints(atTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
-SELECT atTpcboxFine(:inst1, tpcbox_zt(10, 10, 10, 20, 20, 20,
+SELECT atTpcboxFine(:inst1, tpcboxZT(10, 10, 10, 20, 20, 20,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
 
 -- minus is the complement.
-SELECT minusTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 3, 3, 3,
+SELECT minusTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 3, 3, 3,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
-SELECT startNumPoints(minusTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 1, 1, 1,
+SELECT startNumPoints(minusTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
 
 -- The patch a restriction that drops a point answers is read back point by
 -- point, which is what states that its data area holds the survivors alone.
-SELECT PC_AsText(getValue(atTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 1, 1, 1,
+SELECT PC_AsText(getValue(atTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
-SELECT PC_AsText(getValue(minusTpcboxFine(:inst1, tpcbox_zt(0, 0, 0, 1, 1, 1,
+SELECT PC_AsText(getValue(minusTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 1, 1, 1,
   tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
 
 -------------------------------------------------------------------------------
@@ -371,6 +371,6 @@ SELECT splitEachNSpans(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]), 2);
 
 SELECT tpcpatch '4F000000630000000000000002000000000000000000F03F000000000000F03F000000000000F03F0000000000000040000000000000004000000000000000400000000000000000000000000000@2024-01-01';
 SELECT tpcpatch '4F000000630000000000000002000000000000000000F03F000000000000F03F000000000000F03F0000000000000040000000000000004000000000000000400000000000000000000000000000@2024-01-01' &&
-  tpcbox_xt(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
+  tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch_tbl.test.sql
@@ -116,18 +116,18 @@ WHERE atTime(temp, tstzspan '[2001-01-01, 2002-01-01]') IS NOT NULL;
 
 -- atTpcbox over the full datagen extent leaves every row populated.
 SELECT COUNT(*) FROM tbl_tpcpatch WHERE atTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 1, 0)) IS NOT NULL;
 
 -- atTpcbox with a pcid mismatch yields NULL (empty) for every row.
 SELECT bool_and(atTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NULL)
 FROM tbl_tpcpatch;
 
 -- minusTpcbox is the complement.
 SELECT bool_and(minusTpcbox(temp,
-  tpcbox_zt(-100, -100, 0, 100, 100, 100,
+  tpcboxZT(-100, -100, 0, 100, 100, 100,
     tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NOT NULL)
 FROM tbl_tpcpatch;
 
@@ -142,17 +142,17 @@ FROM tbl_tpcpatch;
 -- points cleanly.
 SELECT COUNT(*) FROM tbl_tpcpatch
 WHERE atTpcboxFine(temp,
-  tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+  tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
     tstzspan '[2001-01-01, 2002-01-01]', 1, 0)) IS NOT NULL;
 
 -- For every row, fine-restrict point counts at most equal the un-restricted
 -- count.
 SELECT bool_and(numPoints(atTpcboxFine(temp,
-  tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+  tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
     tstzspan '[2001-01-01, 2002-01-01]', 1, 0))) <= numPoints(temp))
 FROM tbl_tpcpatch
 WHERE atTpcboxFine(temp,
-  tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+  tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
     tstzspan '[2001-01-01, 2002-01-01]', 1, 0)) IS NOT NULL;
 
 -- atGeometry over a generously-sized polygon keeps every row.

--- a/mobilitydb/test/pointcloud/queries/436_tpc_topops.test.sql
+++ b/mobilitydb/test/pointcloud/queries/436_tpc_topops.test.sql
@@ -32,9 +32,9 @@
 
 \set p1 'tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), ''2024-01-01''::timestamptz)'
 \set p2 'tpcpoint(PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), ''2024-01-05''::timestamptz)'
-\set big_box 'tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan ''[2024-01-01, 2024-01-31]'', 1, 0)'
-\set far_box 'tpcbox_zt(100, 100, 100, 110, 110, 110, tstzspan ''[2099-01-01, 2099-12-31]'', 1, 0)'
-\set bad_box 'tpcbox_zt(0, 0, 0, 10, 10, 10, tstzspan ''[2024-01-01, 2024-01-31]'', 999, 0)'
+\set big_box 'tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan ''[2024-01-01, 2024-01-31]'', 1, 0)'
+\set far_box 'tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan ''[2099-01-01, 2099-12-31]'', 1, 0)'
+\set bad_box 'tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan ''[2024-01-01, 2024-01-31]'', 999, 0)'
 \set span_in 'tstzspan ''[2024-01-01, 2024-01-31]'''
 \set span_far 'tstzspan ''[2099-01-01, 2099-12-31]'''
 

--- a/mobilitydb/test/pointcloud/queries/436_tpc_topops_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/436_tpc_topops_tbl.test.sql
@@ -52,17 +52,17 @@ SELECT bool_and(NOT (temp -|- temp)) FROM tbl_tpcpatch;
 -- All-encompassing query box should contain every row.
 -------------------------------------------------------------------------------
 
-SELECT bool_and(tpcbox_zt(-200, -200, -200, 200, 200, 200,
+SELECT bool_and(tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0) @> temp)
 FROM tbl_tpcpoint;
-SELECT bool_and(tpcbox_zt(-200, -200, -200, 200, 200, 200,
+SELECT bool_and(tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0) @> temp)
 FROM tbl_tpcpatch;
 
 -- Reverse direction: every row is contained in that big box.
-SELECT bool_and(temp <@ tpcbox_zt(-200, -200, -200, 200, 200, 200,
+SELECT bool_and(temp <@ tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0)) FROM tbl_tpcpoint;
-SELECT bool_and(temp <@ tpcbox_zt(-200, -200, -200, 200, 200, 200,
+SELECT bool_and(temp <@ tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0)) FROM tbl_tpcpatch;
 
 -- Time-only: every row's tstzspan is contained in this wide span.

--- a/mobilitydb/test/pointcloud/queries/437_tpc_posops.test.sql
+++ b/mobilitydb/test/pointcloud/queries/437_tpc_posops.test.sql
@@ -32,8 +32,8 @@
 
 \set p_low  'tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), ''2024-01-01''::timestamptz)'
 \set p_high 'tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), ''2024-01-15''::timestamptz)'
-\set box_left  'tpcbox_zt(0, 0, 0, 5, 5, 5,    tstzspan ''[2024-01-01, 2024-01-15]'', 1, 0)'
-\set box_right 'tpcbox_zt(20, 20, 20, 30, 30, 30, tstzspan ''[2025-01-01, 2025-01-15]'', 1, 0)'
+\set box_left  'tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan ''[2024-01-01, 2024-01-15]'', 1, 0)'
+\set box_right 'tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan ''[2025-01-01, 2025-01-15]'', 1, 0)'
 
 -------------------------------------------------------------------------------
 -- X axis: <<, >>, &<, &>

--- a/mobilitydb/test/pointcloud/queries/437_tpc_posops_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/437_tpc_posops_tbl.test.sql
@@ -57,11 +57,11 @@ SELECT bool_and(NOT (temp #>> temp)) FROM tbl_tpcpatch;
 -------------------------------------------------------------------------------
 
 SELECT COUNT(*) FROM tbl_tpcpoint
-WHERE temp << tpcbox_zt(-200, -200, -200, 200, 200, 200,
+WHERE temp << tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0);
 
 SELECT COUNT(*) FROM tbl_tpcpoint
-WHERE tpcbox_zt(-200, -200, -200, 200, 200, 200,
+WHERE tpcboxZT(-200, -200, -200, 200, 200, 200,
   tstzspan '[2001-01-01, 2030-01-01]', 1, 0) >> temp;
 
 -- Reverse: every row is "before" a span that starts well after

--- a/mobilitydb/test/pointcloud/queries/438_tpc_distance.test.sql
+++ b/mobilitydb/test/pointcloud/queries/438_tpc_distance.test.sql
@@ -31,8 +31,8 @@
 
 \set p1 'tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), ''2024-01-01''::timestamptz)'
 \set p2 'tpcpoint(PC_MakePoint(1, ARRAY[3.0, 4.0, 0.0]::float[]), ''2024-01-01''::timestamptz)'
-\set box_at_origin 'tpcbox_zt(0, 0, 0, 0, 0, 0, tstzspan ''[2024-01-01, 2024-01-02]'', 1, 0)'
-\set box_far       'tpcbox_zt(3, 4, 0, 3, 4, 0, tstzspan ''[2024-01-01, 2024-01-02]'', 1, 0)'
+\set box_at_origin 'tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan ''[2024-01-01, 2024-01-02]'', 1, 0)'
+\set box_far       'tpcboxZT(3, 4, 0, 3, 4, 0, tstzspan ''[2024-01-01, 2024-01-02]'', 1, 0)'
 
 -- Self-distance is zero.
 SELECT (:p1) |=| (:p1);
@@ -50,11 +50,11 @@ SELECT (:p1) |=| (:box_at_origin);
 -- Disjoint time spans yield NULL, as the temporal geo nearest approach does.
 SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]),
                  '2024-01-01'::timestamptz)) |=|
-       (tpcbox_zt(0, 0, 0, 0, 0, 0,
+       (tpcboxZT(0, 0, 0, 0, 0, 0,
                   tstzspan '[2099-01-01, 2099-01-02]', 1, 0)) IS NULL;
 
 -- Pcid mismatch is an error: values of two schemas cannot be compared.
-SELECT (:p1) |=| (tpcbox_zt(0, 0, 0, 0, 0, 0,
+SELECT (:p1) |=| (tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2024-01-01, 2024-01-02]', 999, 0)) > 1e10;
 
 -- The same holds between two temporal pointcloud values. A second schema is

--- a/mobilitydb/test/pointcloud/queries/438_tpc_distance_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/438_tpc_distance_tbl.test.sql
@@ -48,20 +48,20 @@ CREATE INDEX tbl_tpcpoint_gist_dist_idx ON tbl_tpcpoint USING gist(temp);
 SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
-SELECT k, ((temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
+SELECT k, ((temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2001-06-01, 2001-06-30]', 1, 0)) > 0)::text AS finite
 FROM tbl_tpcpoint
-ORDER BY temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
+ORDER BY temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2001-06-01, 2001-06-30]', 1, 0)
 LIMIT 5;
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
-SELECT k, ((temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
+SELECT k, ((temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2001-06-01, 2001-06-30]', 1, 0)) > 0)::text AS finite
 FROM tbl_tpcpoint
-ORDER BY temp |=| tpcbox_zt(0, 0, 0, 0, 0, 0,
+ORDER BY temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
   tstzspan '[2001-06-01, 2001-06-30]', 1, 0)
 LIMIT 5;
 

--- a/mobilitydb/test/pointcloud/queries/439_tpc_gist_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/439_tpc_gist_tbl.test.sql
@@ -41,14 +41,14 @@ SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 DROP INDEX tbl_tpcpoint_gist_idx;
@@ -66,14 +66,14 @@ SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 DROP INDEX tbl_tpcpatch_gist_idx;
@@ -93,31 +93,31 @@ CREATE INDEX tbl_tpcpatch_gist_idx ON tbl_tpcpatch USING gist(temp);
 -- <@  : value's bbox contained in the query bbox.
 SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_contained FROM tbl_tpcpatch
-WHERE temp <@ tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+WHERE temp <@ tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
   tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
 SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_contained FROM tbl_tpcpatch
-WHERE temp <@ tpcbox_zt(-1000, -1000, -1000, 1000, 1000, 1000,
+WHERE temp <@ tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
   tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
 
 -- <<# : strictly before (time)
 SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_before FROM tbl_tpcpatch
-WHERE temp <<# tpcbox_zt(0, 0, 0, 100, 100, 100,
+WHERE temp <<# tpcboxZT(0, 0, 0, 100, 100, 100,
   tstzspan '[2001-12-15, 2002-01-01]', 1, 0);
 SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_before FROM tbl_tpcpatch
-WHERE temp <<# tpcbox_zt(0, 0, 0, 100, 100, 100,
+WHERE temp <<# tpcboxZT(0, 0, 0, 100, 100, 100,
   tstzspan '[2001-12-15, 2002-01-01]', 1, 0);
 
 -- << : strictly left (X)
 SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_left FROM tbl_tpcpatch
-WHERE temp << tpcbox_zt(50, -1000, -1000, 1000, 1000, 1000,
+WHERE temp << tpcboxZT(50, -1000, -1000, 1000, 1000, 1000,
   tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
 SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_left FROM tbl_tpcpatch
-WHERE temp << tpcbox_zt(50, -1000, -1000, 1000, 1000, 1000,
+WHERE temp << tpcboxZT(50, -1000, -1000, 1000, 1000, 1000,
   tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
 
 DROP INDEX tbl_tpcpatch_gist_idx;
@@ -173,22 +173,22 @@ CREATE INDEX tbl_tpcpatch_gist_idx ON tbl_tpcpatch USING gist(temp);
 
 SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_fn_box FROM tbl_tpcpoint
-WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
 SELECT COUNT(*) AS seq_fn_span FROM tbl_tpcpoint
 WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
 SELECT COUNT(*) AS seq_fn_patch FROM tbl_tpcpatch
-WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
 
 SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_fn_box FROM tbl_tpcpoint
-WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
 SELECT COUNT(*) AS idx_fn_span FROM tbl_tpcpoint
 WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
 SELECT COUNT(*) AS idx_fn_patch FROM tbl_tpcpatch
-WHERE overlaps(temp, tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
 
 DROP INDEX tbl_tpcpoint_gist_idx;

--- a/mobilitydb/test/pointcloud/queries/440_tpc_spgist_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/440_tpc_spgist_tbl.test.sql
@@ -41,14 +41,14 @@ SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 DROP INDEX tbl_tpcpoint_quadtree_idx;
@@ -61,7 +61,7 @@ CREATE INDEX tbl_tpcpoint_kdtree_idx ON tbl_tpcpoint
   USING spgist(temp tpcpoint_kdtree_ops);
 
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcpoint
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 DROP INDEX tbl_tpcpoint_kdtree_idx;
@@ -76,14 +76,14 @@ SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 DROP INDEX tbl_tpcpatch_quadtree_idx;
@@ -92,7 +92,7 @@ CREATE INDEX tbl_tpcpatch_kdtree_idx ON tbl_tpcpatch
   USING spgist(temp tpcpatch_kdtree_ops);
 
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcpatch
-WHERE temp && tpcbox_zt(0, 0, 0, 50, 50, 50,
+WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
 
 DROP INDEX tbl_tpcpatch_kdtree_idx;
@@ -107,7 +107,7 @@ RESET enable_bitmapscan;
 
 CREATE INDEX tbl_tpcpoint_knn_quadtree_idx ON tbl_tpcpoint USING spgist(temp);
 WITH test AS (
-  SELECT temp |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  SELECT temp |=| tpcboxZT(200, 200, 200, 210, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
@@ -116,7 +116,7 @@ DROP INDEX tbl_tpcpoint_knn_quadtree_idx;
 CREATE INDEX tbl_tpcpoint_knn_kdtree_idx ON tbl_tpcpoint
   USING spgist(temp tpcpoint_kdtree_ops);
 WITH test AS (
-  SELECT temp |=| tpcbox_zt(200, 200, 200, 210, 210, 210,
+  SELECT temp |=| tpcboxZT(200, 200, 200, 210, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
@@ -124,7 +124,7 @@ DROP INDEX tbl_tpcpoint_knn_kdtree_idx;
 
 CREATE INDEX tbl_tpcpatch_knn_quadtree_idx ON tbl_tpcpatch USING spgist(temp);
 WITH test AS (
-  SELECT temp |=| tpcbox_xt(200, 200, 210, 210,
+  SELECT temp |=| tpcboxXT(200, 200, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
@@ -133,7 +133,7 @@ DROP INDEX tbl_tpcpatch_knn_quadtree_idx;
 CREATE INDEX tbl_tpcpatch_knn_kdtree_idx ON tbl_tpcpatch
   USING spgist(temp tpcpatch_kdtree_ops);
 WITH test AS (
-  SELECT temp |=| tpcbox_xt(200, 200, 210, 210,
+  SELECT temp |=| tpcboxXT(200, 200, 210, 210,
   tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
   FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;

--- a/mobilitydb/test/pointcloud/smoketest.sql
+++ b/mobilitydb/test/pointcloud/smoketest.sql
@@ -68,10 +68,10 @@ SELECT numValues(set(ARRAY[
 
 \echo '=== pgpointcloud smoke: TPCBox bounding box ==='
 
-SELECT xmin(tpcbox(10, 20, 30, 40, 1, 0))         AS tpcbox_xmin_expect_10,
-       xmax(tpcbox(10, 20, 30, 40, 1, 0))         AS tpcbox_xmax_expect_30,
-       pcid(tpcbox(10, 20, 30, 40, 7, 0))         AS tpcbox_pcid_expect_7,
-       hasZ(tpcbox_z(1, 2, 3, 4, 5, 6, 1, 0))     AS tpcbox_hasz_expect_true;
+SELECT xmin(tpcboxX(10, 20, 30, 40, 1, 0))         AS tpcbox_xmin_expect_10,
+       xmax(tpcboxX(10, 20, 30, 40, 1, 0))         AS tpcbox_xmax_expect_30,
+       pcid(tpcboxX(10, 20, 30, 40, 7, 0))         AS tpcbox_pcid_expect_7,
+       hasZ(tpcboxZ(1, 2, 3, 4, 5, 6, 1, 0))     AS tpcbox_hasz_expect_true;
 
 SELECT xmin(tpcbox(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]))))
        AS patch_to_tpcbox_xmin_expect_10;
@@ -83,12 +83,12 @@ SELECT xmin(tpcbox(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0])))
 
 \echo '=== pgpointcloud smoke: TPCBox set operations ==='
 
-SELECT xmin(tpcbox(0, 0, 5, 5, 1) + tpcbox(3, 3, 10, 10, 1)) AS union_xmin_0,
-       xmax(tpcbox(0, 0, 5, 5, 1) + tpcbox(3, 3, 10, 10, 1)) AS union_xmax_10,
-       xmin(tpcbox(0, 0, 5, 5, 1) * tpcbox(3, 3, 10, 10, 1)) AS inter_xmin_3;
+SELECT xmin(tpcboxX(0, 0, 5, 5, 1) + tpcboxX(3, 3, 10, 10, 1)) AS union_xmin_0,
+       xmax(tpcboxX(0, 0, 5, 5, 1) + tpcboxX(3, 3, 10, 10, 1)) AS union_xmax_10,
+       xmin(tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1)) AS inter_xmin_3;
 
-SELECT tpcbox(0, 0, 10, 10, 1) @> tpcbox(2, 2, 8, 8, 1)   AS contains_true,
-       tpcbox(0, 0, 5, 5, 1)   && tpcbox(3, 3, 10, 10, 1) AS overlaps_true;
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxX(2, 2, 8, 8, 1)   AS contains_true,
+       tpcboxX(0, 0, 5, 5, 1)   && tpcboxX(3, 3, 10, 10, 1) AS overlaps_true;
 
 \echo '=== pgpointcloud smoke: tpcpoint lifted temporal type ==='
 


### PR DESCRIPTION
The box constructors of every other family spell the dimensions they take
in camelCase, because their arguments are all floats and timestamps and
cannot be told apart by type: stboxX, stboxZ, stboxT, stboxXT, stboxZT.
The temporal pointcloud box has the same constraint and spells the same
five forms with an underscore, and its two-dimensional form under the
bare type name.

The bare name belongs to the conversions, which is what stbox(geometry)
and stbox(box2d) are, so tpcbox(pcpatch) and tpcbox(pcpoint) keep it and
the five constructors take the dimension suffix instead.

tbox is not a counter-example: it overloads one bare name because its
forms differ by argument type, tbox(intspan, tstzspan) against
tbox(floatspan, tstzspan), so it never needs a suffix to disambiguate.

The catalog is the source of truth the bindings read and the SQL is its
projection, so each name moves in both: the @sqlfn on the wrapper and the
CREATE FUNCTION. Removing an underscore is a real rename rather than a
recase, so the expected output moves with the queries that echo it.

The time-only form keeps its pcid. A schema is what a value of that
schema is, the way a geodetic box is a box of geographies, and geodstboxT
carries that distinction on a box holding no coordinates too.

