### PR TITLE
Stop offering a geodetic box that holds no coordinates

### DIFF
--- a/doc/box_types.xml
+++ b/doc/box_types.xml
@@ -176,7 +176,6 @@ SELECT tbox(tstzspan '[2001-01-01,2001-01-02)');
 				<indexterm significance="normal"><primary><varname>stboxXT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stboxZT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>geodstboxZ</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>geodstboxT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>geodstboxZT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Constructor for <varname>stbox</varname></para>
@@ -188,7 +187,6 @@ stboxXT(float,float,float,float,{timestamptz,tstzspan},srid integer=0) → stbox
 stboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},
   srid integer=0) → stbox
 geodstboxZ(float,float,float,float,float,float,srid integer=4326) → stbox
-geodstboxT({timestamptz,tstzspan}) → stbox
 geodstboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},
   srid integer=4326) → stbox
 stbox(geo) → stbox
@@ -209,8 +207,6 @@ SELECT stboxXT(1.0,2.0, 1.0,2.0, tstzspan '[2001-01-03,2001-01-03]');
 SELECT stboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-03]');
 -- Only value dimension with X, Y, and Z geodetic coordinates
 SELECT geodstboxZ(1.0,2.0,3.0,1.0,2.0,3.0);
--- Only time dimension for geodetic box
-SELECT geodstboxT(tstzspan '[2001-01-03,2001-01-03]');
 -- Both value (with X, Y, and Z geodetic coordinates) and time dimensions
 SELECT geodstboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-04]');
 -- Geometry and time dimension

--- a/doc/es/box_types.xml
+++ b/doc/es/box_types.xml
@@ -176,7 +176,6 @@ SELECT tbox(tstzspan '[2001-01-01,2001-01-02)');
 				<indexterm significance="normal"><primary><varname>stboxXT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stboxZT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>geodstboxZ</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>geodstboxT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>geodstboxZT</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
 				<para>Constructor para <varname>stbox</varname></para>
@@ -188,7 +187,6 @@ stboxXT(float,float,float,float,{timestamptz,tstzspan},srid integer=0) → stbox
 stboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},
   srid integer=0) → stbox
 geodstboxZ(float,float,float,float,float,float,srid integer=4326) → stbox
-geodstboxT({timestamptz,tstzspan}) → stbox
 geodstboxZT(float,float,float,float,float,float,{timestamptz,tstzspan},
   srid integer=4326) → stbox
 stbox(geo) → stbox
@@ -209,8 +207,6 @@ SELECT stboxXT(1.0,2.0, 1.0,2.0, tstzspan '[2001-01-03,2001-01-03]');
 SELECT stboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-03]');
 -- Only value dimension with X, Y, and Z geodetic coordinates
 SELECT geodstboxZ(1.0,2.0,3.0,1.0,2.0,3.0);
--- Only time dimension for geodetic box
-SELECT geodstboxT(tstzspan '[2001-01-03,2001-01-03]');
 -- Both value (with X, Y, and Z geodetic coordinates) and time dimensions
 SELECT geodstboxZT(1.0,2.0,3.0, 1.0,2.0,3.0, tstzspan '[2001-01-03,2001-01-04]');
 -- Geometry and time dimension

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -440,7 +440,7 @@
 					<para><link linkend="tbox"><varname>tbox</varname></link>: Constructor para <varname>tbox</varname></para>
 				</listitem>
 				<listitem>
-					<para><link linkend="stbox"><varname>stboxX</varname>, <varname>stboxZ</varname>, <varname>stboxT</varname>, <varname>stboxXT</varname>, <varname>stboxZT</varname>, <varname>geodstboxZ</varname>, <varname>geodstboxT</varname>, <varname>geodstboxZT</varname>, <varname>stbox</varname></link>: Constructor para <varname>stbox</varname></para>
+					<para><link linkend="stbox"><varname>stboxX</varname>, <varname>stboxZ</varname>, <varname>stboxT</varname>, <varname>stboxXT</varname>, <varname>stboxZT</varname>, <varname>geodstboxZ</varname>, <varname>geodstboxZT</varname>, <varname>stbox</varname></link>: Constructor para <varname>stbox</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -440,7 +440,7 @@
 					<para><link linkend="tbox"><varname>tbox</varname></link>: Constructor for <varname>tbox</varname></para>
 				</listitem>
 				<listitem>
-					<para><link linkend="stbox"><varname>stboxX</varname>, <varname>stboxZ</varname>, <varname>stboxT</varname>, <varname>stboxXT</varname>, <varname>stboxZT</varname>, <varname>geodstboxZ</varname>, <varname>geodstboxT</varname>, <varname>geodstboxZT</varname>, <varname>stbox</varname></link>: Constructor for <varname>stbox</varname></para>
+					<para><link linkend="stbox"><varname>stboxX</varname>, <varname>stboxZ</varname>, <varname>stboxT</varname>, <varname>stboxXT</varname>, <varname>stboxZT</varname>, <varname>geodstboxZ</varname>, <varname>geodstboxZT</varname>, <varname>stbox</varname></link>: Constructor for <varname>stbox</varname></para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/mobilitydb/sql/geo/051_stbox.in.sql
+++ b/mobilitydb/sql/geo/051_stbox.in.sql
@@ -140,16 +140,6 @@ CREATE FUNCTION stboxZT(float, float, float, float, float, float,
   AS 'MODULE_PATHNAME', 'Stbox_constructor_zt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-CREATE FUNCTION geodstboxT(timestamptz)
-  RETURNS stbox
-  AS 'MODULE_PATHNAME', 'Geodstbox_constructor_t'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
-CREATE FUNCTION geodstboxT(tstzspan)
-  RETURNS stbox
-  AS 'MODULE_PATHNAME', 'Geodstbox_constructor_t'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
 CREATE FUNCTION geodstboxZ(float, float, float, float, float, float,
     srid integer DEFAULT 4326)
   RETURNS stbox

--- a/mobilitydb/src/geo/stbox.c
+++ b/mobilitydb/src/geo/stbox.c
@@ -366,19 +366,6 @@ Geodstbox_constructor_z(PG_FUNCTION_ARGS)
   return Stbox_constructor(fcinfo, true, true, false, true);
 }
 
-PGDLLEXPORT Datum Geodstbox_constructor_t(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Geodstbox_constructor_t);
-/**
- * @ingroup mobilitydb_geo_box_constructor
- * @brief Return a spatiotemporal box constructed from the arguments
- * @sqlfn geodstboxT()
- */
-inline Datum
-Geodstbox_constructor_t(PG_FUNCTION_ARGS)
-{
-  return Stbox_constructor(fcinfo, false, false, true, true);
-}
-
 PGDLLEXPORT Datum Geodstbox_constructor_zt(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Geodstbox_constructor_zt);
 /**

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -256,18 +256,6 @@ SELECT stboxZT(1,2,3,4,5,6,tstzspan '[2001-01-04,2001-01-08]');
  STBOX ZT(((1,2,3),(4,5,6)),[Thu Jan 04 00:00:00 2001 PST, Mon Jan 08 00:00:00 2001 PST])
 (1 row)
 
-SELECT geodstboxT(timestamptz '2001-01-03');
-                                geodstboxt                                 
----------------------------------------------------------------------------
- GEODSTBOX T([Wed Jan 03 00:00:00 2001 PST, Wed Jan 03 00:00:00 2001 PST])
-(1 row)
-
-SELECT geodstboxT(tstzspan '[2001-01-03,2001-01-06]');
-                                geodstboxt                                 
----------------------------------------------------------------------------
- GEODSTBOX T([Wed Jan 03 00:00:00 2001 PST, Sat Jan 06 00:00:00 2001 PST])
-(1 row)
-
 SELECT geodstboxZ(1,2,3,4,5,6);
                geodstboxz               
 ----------------------------------------

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -105,8 +105,6 @@ SELECT stboxXT(1,2,3,4,tstzspan '[2001-01-03,2001-01-06]');
 SELECT stboxZT(1,2,3,4,5,6,timestamptz '2001-01-04');
 SELECT stboxZT(1,2,3,4,5,6,tstzspan '[2001-01-04,2001-01-08]');
 
-SELECT geodstboxT(timestamptz '2001-01-03');
-SELECT geodstboxT(tstzspan '[2001-01-03,2001-01-06]');
 SELECT geodstboxZ(1,2,3,4,5,6);
 SELECT geodstboxZT(1,2,3,4,5,6,timestamptz '2001-01-04');
 SELECT geodstboxZT(1,2,3,4,5,6,tstzspan '[2001-01-04,2001-01-08]');


### PR DESCRIPTION
The geodetic flag says how to read a box's coordinates: great circle
rather than cartesian, a sphere rather than a plane. A box carrying no
coordinates has nothing to read that way, so geodstboxT states a property
of something it does not contain.

It is also the only way to build such a box. Every other producer of a
time-only STBox leaves the flag clear, tstzspan_set_stbox memsetting the
whole struct, so two time-only boxes differ in the flag only when this
constructor makes them differ.

That difference breaks a law the extent aggregate rests on. A union takes
its result's flag from its first argument, so a geodetic time-only box
plus a planar one answers GEODSTBOX T while the same pair in the other
order answers STBOX T, and equality separates the two answers. An extent
over a column holding both is therefore order-dependent, which a parallel
plan is free to change.

Nothing is lost with it. A geodetic value restricted by a time-only box
takes the same purely temporal path either way: the guard reads the frame
only where both boxes carry coordinates, and a box without them
short-circuits to a restriction on the period alone, so atStbox of a
tgeography by stboxT answers what atStbox by geodstboxT answers.

The guard itself stays as it is. Geodetic is one bit with no value for
"not stated", so a box making no claim is exactly a box with no
coordinates, and reading the flag on one would make a planar time-only
query box refuse a geography index.

