### PR TITLE
Say what every rigid geometry function does in its brief

### DIFF
--- a/meos/include/rgeo/trgeo_boxops.h
+++ b/meos/include/rgeo/trgeo_boxops.h
@@ -44,12 +44,12 @@
 
 /*****************************************************************************/
 
-/* Functions computing the bounding box at the creation of the temporal rigid 
+/* Functions computing the bounding box at the creation of the temporal rigid
  * geometry */
 
 extern void trgeoinst_set_stbox(const GSERIALIZED *geom, const TInstant *inst,
   STBox *box);
-extern void trgeoinstarr_static_stbox(const GSERIALIZED *geom, 
+extern void trgeoinstarr_static_stbox(const GSERIALIZED *geom,
   TInstant **instants, int count, STBox *box);
 extern void trgeoinstarr_rotating_stbox(const GSERIALIZED *geom,
   TInstant **instants, int count, STBox *box);

--- a/meos/include/rgeo/trgeo_distance.h
+++ b/meos/include/rgeo/trgeo_distance.h
@@ -89,7 +89,7 @@ typedef struct {
 /* Closest features pair */
 
 typedef struct {
-  double dist;;
+  double dist;
   TimestampTz t;
 } tdist_elem;
 

--- a/meos/include/rgeo/trgeo_vclip.h
+++ b/meos/include/rgeo/trgeo_vclip.h
@@ -61,10 +61,49 @@
 
 /* V-clip functions */
 
+/*****************************************************************************
+ * Inline helpers shared by the v-clip walk and the temporal distance
+ *****************************************************************************/
+
+/**
+ * @brief Return the sum of two vertex numbers modulo the vertex count
+ */
+static inline uint32_t
+uint_mod_add(uint32_t i, uint32_t j, uint32_t n)
+{
+  return (i + j) % n;
+}
+
+/**
+ * @brief Return the difference of two vertex numbers modulo the vertex count
+ * @pre j < n, so that adding @p n keeps the difference positive
+ */
+static inline uint32_t
+uint_mod_sub(uint32_t i, uint32_t j, uint32_t n)
+{
+  return (i + n - j) % n;
+}
+
+/**
+ * @brief Return the relative position of a point on a segment
+ * @details
+ * s < 0      -> p before point vs
+ * s = 0      -> p = vs
+ * 0 < s < 1  -> p = vs * (1 - s)  + ve * s
+ * s = 1      -> p = ve
+ * 1 < s      -> p after point ve
+ */
+static inline double
+compute_s(POINT4D p, POINT4D vs, POINT4D ve)
+{
+  return ((p.x - vs.x) * (ve.x - vs.x) + (p.y - vs.y) * (ve.y - vs.y)) /
+    ((ve.x - vs.x) * (ve.x - vs.x) + (ve.y - vs.y) * (ve.y - vs.y));
+}
+
 extern int v_clip_tpoly_point(const LWPOLY *poly, const LWPOINT *point,
   const Pose *pose, uint32_t *poly_feature, double *dist);
 extern int v_clip_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
-  const Pose *pose1, const Pose *pose2, uint32_t *poly1_feature, 
+  const Pose *pose1, const Pose *pose2, uint32_t *poly1_feature,
   uint32_t *poly2_feature, double *dist);
 
 extern void apply_pose_point4d(POINT4D *p, const Pose *pose);

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -515,7 +515,7 @@ trgeometry_end_value(const Temporal *temp)
 /**
  * @ingroup meos_rgeo_accessor
  * @brief Return in the last argument a copy of the n-th value of a temporal
- * value 
+ * value
  * @param[in] temp Temporal rigid geometry
  * @param[in] n Number (1-based)
  * @param[out] result Resulting timestamp
@@ -767,7 +767,7 @@ trgeometry_sequence_n(const Temporal *temp, int n)
   else /* temp->subtype == TSEQUENCESET */
   {
     const TSequenceSet *ss = (const TSequenceSet *) temp;
-    res_pose = (n >= 1 && n <= ss->count) ? TSEQUENCESET_SEQ_N(ss, n - 1) : 
+    res_pose = (n >= 1 && n <= ss->count) ? TSEQUENCESET_SEQ_N(ss, n - 1) :
       NULL;
   }
   if (! res_pose)
@@ -791,7 +791,7 @@ TSequence **
 trgeometry_sequences(const Temporal *temp, int *count)
 {
   /* The out parameter is defined even when a later check fails */
-  VALIDATE_NOT_NULL(count, NULL); 
+  VALIDATE_NOT_NULL(count, NULL);
   *count = 0;
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -909,7 +909,7 @@ TSequence **
 trgeometry_segments(const Temporal *temp, int *count)
 {
   /* The out parameter is defined even when a later check fails */
-  VALIDATE_NOT_NULL(count, NULL); 
+  VALIDATE_NOT_NULL(count, NULL);
   *count = 0;
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -1331,7 +1331,7 @@ trgeometry_restrict_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc
 
   Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_restrict_timestamptz(tpose, t, atfunc);
-  pfree(tpose); 
+  pfree(tpose);
   if (! res)
     return NULL;
   Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
@@ -1546,7 +1546,7 @@ trgeometry_before_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
 
   Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_before_timestamptz(tpose, t, atfunc);
-  pfree(tpose); 
+  pfree(tpose);
   if (! res)
     return NULL;
   Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
@@ -1572,7 +1572,7 @@ trgeometry_after_timestamptz(const Temporal *temp, TimestampTz t, bool atfunc)
 
   Temporal *tpose = trgeometry_to_tpose(temp);
   Temporal *res = temporal_after_timestamptz(tpose, t, atfunc);
-  pfree(tpose); 
+  pfree(tpose);
   if (! res)
     return NULL;
   Temporal *result = geometry_tpose_to_trgeometry(trgeo_geom_p(temp), res);
@@ -1650,7 +1650,7 @@ trgeometry_append_tsequence(Temporal *temp, const TSequence *seq,
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL); VALIDATE_TRGEOMETRY(seq, NULL);
-  if ((temp->subtype != TINSTANT && 
+  if ((temp->subtype != TINSTANT &&
       ! ensure_same_interp(temp, (Temporal *) seq)) ||
       ! ensure_spatial_validity(temp, (Temporal *) seq) ||
       ! ensure_temporal_isof_subtype((Temporal *) seq, TSEQUENCE))

--- a/meos/src/rgeo/trgeo_boxops.c
+++ b/meos/src/rgeo/trgeo_boxops.c
@@ -364,7 +364,7 @@ STBox *
 trgeometry_split_n_stboxes(const Temporal *temp, int box_count, int *count)
 {
   /* The out parameter is defined even when a later check fails */
-  VALIDATE_NOT_NULL(count, NULL); 
+  VALIDATE_NOT_NULL(count, NULL);
   *count = 0;
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);
@@ -517,7 +517,7 @@ trgeometry_split_each_n_stboxes(const Temporal *temp, int elems_per_box,
   int *count)
 {
   /* The out parameter is defined even when a later check fails */
-  VALIDATE_NOT_NULL(count, NULL); 
+  VALIDATE_NOT_NULL(count, NULL);
   *count = 0;
   /* Ensure the validity of the arguments */
   VALIDATE_TRGEOMETRY(temp, NULL);

--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -54,7 +54,6 @@
 #include <meos_internal.h>
 #include "temporal/meos_catalog.h"
 #include "temporal/temporal.h"
-#include "temporal/temporal.h"
 #include "temporal/lifting.h"
 #include "temporal/temporal_aggfuncs.h"
 #include "temporal/tsequence.h"
@@ -72,7 +71,8 @@
  *****************************************************************************/
 
 /**
- * @brief
+ * @brief Return a closest-feature pair for two geometries under their poses at
+ * an instant
  */
 static cfp_elem
 cfp_make(LWGEOM *geom_1, LWGEOM *geom_2, Pose *pose_1, Pose *pose_2,
@@ -93,7 +93,8 @@ cfp_make(LWGEOM *geom_1, LWGEOM *geom_2, Pose *pose_1, Pose *pose_2,
 }
 
 /**
- * @brief
+ * @brief Return a closest-feature pair whose two features are the first of each
+ * geometry
  */
 static inline cfp_elem
 cfp_make_zero(LWGEOM *geom_1, LWGEOM *geom_2, Pose *pose_1, Pose *pose_2,
@@ -103,7 +104,7 @@ cfp_make_zero(LWGEOM *geom_1, LWGEOM *geom_2, Pose *pose_1, Pose *pose_2,
 }
 
 /**
- * @brief
+ * @brief Initialize an array of closest-feature pairs with a starting capacity
  */
 static void
 init_cfp_array(cfp_array *cfpa, size_t n)
@@ -114,7 +115,7 @@ init_cfp_array(cfp_array *cfpa, size_t n)
 }
 
 /**
- * @brief
+ * @brief Free an array of closest-feature pairs and the poses it owns
  */
 static void
 free_cfp_array(cfp_array *cfpa)
@@ -130,7 +131,7 @@ free_cfp_array(cfp_array *cfpa)
 }
 
 /**
- * @brief
+ * @brief Append a closest-feature pair to its array, growing the array as needed
  */
 static void
 append_cfp_elem(cfp_array *cfpa, cfp_elem cfp)
@@ -156,7 +157,7 @@ append_cfp_elem(cfp_array *cfpa, cfp_elem cfp)
 }
 
 /**
- * @brief
+ * @brief Return a distance point, that is a distance and the time it holds at
  */
 static tdist_elem
 tdist_make(double dist, TimestampTz t)
@@ -168,7 +169,7 @@ tdist_make(double dist, TimestampTz t)
 }
 
 /**
- * @brief
+ * @brief Initialize an array of distance points with a starting capacity
  */
 static void
 init_tdist_array(tdist_array *tda, size_t n)
@@ -179,7 +180,7 @@ init_tdist_array(tdist_array *tda, size_t n)
 }
 
 /**
- * @brief
+ * @brief Free the distance points held by an array
  */
 static inline void
 free_tdist_array(tdist_array *tda)
@@ -188,7 +189,7 @@ free_tdist_array(tdist_array *tda)
 }
 
 /**
- * @brief
+ * @brief Append a distance point to its array, growing the array as needed
  */
 static void
 append_tdist_elem(tdist_array *tda, tdist_elem td)
@@ -252,92 +253,13 @@ tdist_array_sort(tdist_array *tda)
  * V-clip
  *****************************************************************************/
 
-/**
- * @brief
- */
-static inline uint32_t
-uint_mod_add(uint32_t i, uint32_t j, uint32_t n)
-{
-  return (i + j) % n;
-}
-
-/**
- * @brief
- * @pre j < n
- */
-// Handle negative values correctly
-static inline uint32_t
-uint_mod_sub(uint32_t i, uint32_t j, uint32_t n)
-{
-  assert(j < n);
-  return (i + n - j) % n;
-}
-
-/**
- * @brief Computes the relative position of point on segment v(vs, ve)
- * @details
- * s < 0      -> p before point vs
- * s = 0      -> p = vs
- * 0 < s < 1  -> p = vs * (1 - s)  + ve * s
- * s = 1      -> p = ve
- * 1 < s      -> p after point ve
- */
-static inline double
-compute_s(POINT4D p, POINT4D vs, POINT4D ve)
-{
-  return ((p.x - vs.x) * (ve.x - vs.x) + (p.y - vs.y) * (ve.y - vs.y)) /
-    ((ve.x - vs.x) * (ve.x - vs.x) + (ve.y - vs.y) * (ve.y - vs.y));
-}
-
-/**
- * @brief Computes the signed length of the cross product of the vectors
- * (vs, p) and (vs, ve)
- * @details The sign of this value determines the relative position between
- * p and the line l going through segment (vs, ve) (oriented towards ve).
- * angle > 0: p is on the right of l
- * angle = 0: P is on l
- * angle < 0: P is on the left of l
- */
-static inline double
-compute_angle(POINT4D p, POINT4D vs, POINT4D ve)
-{
-  return (p.x - vs.x) * (ve.y - vs.y) - (p.y - vs.y) * (ve.x - vs.x);
-}
-
-/**
- * @brief Computes the distance between point p and segment v(vs, ve)
- * @note This assumes that the projection of p on the line l going through 
- * (vs, ve) is between vs and ve. (0 <= compute_s(p, vs, ve) <= 1)
- */
-static inline double
-compute_dist2(POINT4D p, POINT4D vs, POINT4D ve)
-{
-  double s = compute_s(p, vs, ve);
-  return (p.x - vs.x - (ve.x - vs.x) * s) * (p.x - vs.x - (ve.x - vs.x) * s) + 
-    (p.y - vs.y - (ve.y - vs.y) * s) * (p.y - vs.y - (ve.y - vs.y) * s);
-}
-
-// /**
- // * @brief Tests if a polygon is defined in counter-clockwise order (ccw)
- // * @return Returns True if it is the case
- // * @note The polygon must be convex
- // */
-// static bool
-// poly_is_ccw(const LWPOLY *poly)
-// {
-  // POINT4D v1, v2, v3;
-  // getPoint4d_p(poly->rings[0], 0, &v1);
-  // getPoint4d_p(poly->rings[0], 1, &v2);
-  // getPoint4d_p(poly->rings[0], 2, &v3);
-  // return compute_angle(v1, v2, v3) < 0;
-// }
-
 /*****************************************************************************
  * Temporal distance
  *****************************************************************************/
 
 /**
- * @brief
+ * @brief Return the temporal distance between a temporal rigid geometry instant
+ * and a geometry
  */
 TInstant *
 dist2d_trgeoinst_geo(const TInstant *inst, const GSERIALIZED *gs)
@@ -352,7 +274,7 @@ dist2d_trgeoinst_geo(const TInstant *inst, const GSERIALIZED *gs)
 }
 
 /**
- * @brief
+ * @brief Interpolate the position and the rotation of a pose segment at a ratio
  */
 static void
 pose_interpolate_2d(Pose *pose1, Pose *pose2, double ratio, double *x,
@@ -435,7 +357,8 @@ rel_posesegm_interpolate(Pose *pose1_s, Pose *pose1_e, Pose *pose2_s,
 }
 
 /**
- * @brief
+ * @brief Return, at a ratio of a segment, the function whose root is a transition
+ * of the closest feature between a fixed point and a rotating polygon edge
  */
 static double
 f_tpoint_poly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
@@ -477,7 +400,8 @@ transition_ratio(double t, double prev_result)
 }
 
 /**
- * @brief
+ * @brief Return the ratio at which the closest feature between a fixed point and a
+ * rotating polygon transitions across an end of an edge
  */
 static double
 solve_s_tpoly_point(LWPOLY *poly, LWPOINT *point, Pose *poly_pose_s,
@@ -557,7 +481,8 @@ solve_s_tpoly_point(LWPOLY *poly, LWPOINT *point, Pose *poly_pose_s,
 }
 
 /**
- * @brief
+ * @brief Return the sentinel reporting no transition, the crossing of an edge line
+ * contributing none for a point target
  */
 static double
 solve_angle_0_tpoly_point(LWPOLY *poly UNUSED,
@@ -573,9 +498,6 @@ solve_angle_0_tpoly_point(LWPOLY *poly UNUSED,
 /* Forward declaration: defined with the sequence-set distance helpers below */
 static int trgeoseq_segment_index(const TSequence *seq, TimestampTz t);
 
-/**
- * @brief
- */
 /**
  * @brief Append the time at which a translating polygon reaches a point it
  * meets, where that time carries no point of its own
@@ -820,7 +742,8 @@ edge_vertex_tpoly_point(LWPOLY *poly, Pose *pose_start, Pose *pose_end,
 }
 
 /**
- * @brief
+ * @brief Return the temporal distance between a temporal rigid geometry sequence
+ * and a point
  */
 TSequence *
 dist2d_trgeoseq_point(const TSequence *seq, const GSERIALIZED *gs,
@@ -961,7 +884,8 @@ dist2d_trgeoseq_point(const TSequence *seq, const GSERIALIZED *gs,
 }
 
 /**
- * @brief
+ * @brief Return, at a ratio of a segment, the function whose root is a transition
+ * of the closest feature between a fixed polygon and a rotating one
  */
 static double
 f_tpoly_poly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
@@ -985,7 +909,8 @@ f_tpoly_poly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
 }
 
 /**
- * @brief
+ * @brief Return the ratio at which the closest feature between a fixed polygon and
+ * a rotating one transitions across an end of an edge of the rotating one
  */
 static double
 solve_s_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s, Pose *poly_pose_e,
@@ -1060,7 +985,8 @@ solve_s_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s, Pose *poly_pose_e,
 }
 
 /**
- * @brief
+ * @brief Return, at a ratio of a segment, the function whose root is a transition
+ * of the closest feature between a rotating polygon and a fixed one
  */
 static double
 f_poly_tpoly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
@@ -1082,7 +1008,8 @@ f_poly_tpoly(POINT4D p, POINT4D q, POINT4D r, Pose *poly_pose_s,
 }
 
 /**
- * @brief
+ * @brief Return the ratio at which the closest feature between a rotating polygon
+ * and a fixed one transitions across an end of an edge of the fixed one
  */
 static double
 solve_s_poly_tpoly(LWPOLY *poly1, LWPOLY *poly2, Pose *poly_pose_s,
@@ -1242,7 +1169,8 @@ vertex_vertex_tpoly_poly(LWPOLY *poly1, Pose *pose_start, Pose *pose_end,
 }
 
 /**
- * @brief
+ * @brief Return, at a ratio of a segment, the function whose root is the ratio at
+ * which two edges of the polygons become parallel
  */
 static double
 f_parallel_edges_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s, Pose *poly_pose_e,
@@ -1270,7 +1198,8 @@ f_parallel_edges_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s, Pose *poly_pose_e,
 }
 
 /**
- * @brief
+ * @brief Return the ratio at which an edge of each polygon becomes parallel to the
+ * other
  */
 static double
 solve_parallel_edges_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s,
@@ -1328,14 +1257,15 @@ solve_parallel_edges_tpoly_poly(LWPOLY *poly1, Pose *poly_pose_s,
 }
 
 /**
- * @brief
+ * @brief Return the sentinel reporting no transition, the crossing of an edge line
+ * contributing none between two polygons
  */
 static inline double
-solve_angle_0_poly_tpoly(LWPOLY *poly1 UNUSED, 
-  LWPOLY *poly2 UNUSED, 
+solve_angle_0_poly_tpoly(LWPOLY *poly1 UNUSED,
+  LWPOLY *poly2 UNUSED,
   Pose *poly_pose_s UNUSED,
-  Pose *poly_pose_e UNUSED, 
-  uint32_t poly1_v UNUSED, 
+  Pose *poly_pose_e UNUSED,
+  uint32_t poly1_v UNUSED,
   uint32_t poly2_v UNUSED,
   double ratio UNUSED)
 {
@@ -1675,7 +1605,7 @@ edge_vertex_tpoly_poly(LWPOLY *poly1, Pose *pose_start, Pose *pose_end,
 }
 
 /**
- * @brief
+ * @brief Append the distance the v-clip oracle answers for a closest-feature pair
  */
 static void
 compute_dist_tpoly_poly(cfp_elem *cfp, tdist_array *tda)
@@ -1869,7 +1799,8 @@ trgeoseq_segment_index(const TSequence *seq, TimestampTz t)
 }
 
 /**
- * @brief
+ * @brief Return the temporal distance between a temporal rigid geometry sequence
+ * and a polygon
  */
 TSequence *
 dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs,
@@ -1961,7 +1892,7 @@ dist2d_trgeoseq_poly(const TSequence *seq, const GSERIALIZED *gs,
 
     if (loop > MEOS_MAX_ITERS)
     {
-      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, 
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
         "Temporal distance: Cycle detected, current features: (%d, %d)",
         cfp.cf_1, cfp.cf_2);
       return NULL;
@@ -2227,7 +2158,8 @@ dist2d_trgeoseq_line(const TSequence *seq, const GSERIALIZED *gs,
 }
 
 /**
- * @brief
+ * @brief Return the temporal distance between a temporal rigid geometry sequence
+ * and a geometry
  */
 TSequence *
 dist2d_trgeoseq_geo(const TSequence *seq, const GSERIALIZED *gs,
@@ -2264,7 +2196,8 @@ dist2d_trgeoseq_geo(const TSequence *seq, const GSERIALIZED *gs,
 }
 
 /**
- * @brief
+ * @brief Return the temporal distance between a temporal rigid geometry sequence
+ * set and a geometry
  */
 TSequenceSet *
 dist2d_trgeoseqset_geo(const TSequenceSet *ss, const GSERIALIZED *gs,
@@ -2722,7 +2655,7 @@ nai_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
       /* The closest point may be at an exclusive bound. */
       Datum value;
       temporal_value_at_timestamptz(temp, min->t, false, &value);
-      result = trgeometryinst_make(trgeo_geom_p(temp), DatumGetPoseP(value), 
+      result = trgeometryinst_make(trgeo_geom_p(temp), DatumGetPoseP(value),
         min->t);
       pfree(dist); pfree(DatumGetPointer(value));
     }
@@ -2936,7 +2869,7 @@ shortestline_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
     return NULL;
-  
+
   Temporal *dist = tdistance_trgeometry_geo(temp, gs);
   if (dist == NULL)
     return NULL;

--- a/meos/src/rgeo/trgeo_inst.c
+++ b/meos/src/rgeo/trgeo_inst.c
@@ -89,7 +89,7 @@ trgeoinst_set_pose(TInstant *inst)
 }
 
 /**
- * @brief Return a new temporal pose instant obtained by removing the 
+ * @brief Return a new temporal pose instant obtained by removing the
  * reference geometry of a temporal rigid geometry instant
  */
 TInstant *

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -56,7 +56,7 @@
  * @param[in,out] temp_srid SRID of the temporal rigid geometry
  * @param[in] geom Reference geometry
  */
-TInstant * 
+TInstant *
 trgeoinst_parse(const char **str, MeosType temptype, bool end,
   int *temp_srid, const GSERIALIZED *geom)
 {
@@ -176,7 +176,7 @@ trgeoseq_cont_parse(const char **str, MeosType temptype, interpType interp,
   else
   {
     meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
-      "Could not parse %s value: Missing closing bracket/parenthesis", 
+      "Could not parse %s value: Missing closing bracket/parenthesis",
       type_str);
     goto error;
   }

--- a/meos/src/rgeo/trgeo_seq.c
+++ b/meos/src/rgeo/trgeo_seq.c
@@ -94,7 +94,7 @@ trgeoseq_set_pose(TSequence *seq)
 }
 
 /**
- * @brief Return a new temporal pose sequence obtained by removing the 
+ * @brief Return a new temporal pose sequence obtained by removing the
  * reference geometry of a temporal rigid geometry
  */
 TSequence *

--- a/meos/src/rgeo/trgeo_seqset.c
+++ b/meos/src/rgeo/trgeo_seqset.c
@@ -62,7 +62,7 @@ const GSERIALIZED *
 trgeoseqset_geom_p(const TSequenceSet *ss)
 {
   assert(ss); assert(ss->temptype == T_TRGEOMETRY);
-  assert(ensure_has_geom(ss->flags)); 
+  assert(ensure_has_geom(ss->flags));
   return (GSERIALIZED *) (
     /* start of data */
     ((char *) ss) + DOUBLE_PAD(sizeof(TSequenceSet)) +
@@ -73,7 +73,7 @@ trgeoseqset_geom_p(const TSequenceSet *ss)
 }
 
 /**
- * @brief Return a new temporal pose sequence obtained by removing the 
+ * @brief Return a new temporal pose sequence obtained by removing the
  * reference geometry of a temporal rigid geometry
  */
 TSequenceSet *

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -1057,7 +1057,7 @@ trgeometry_frechet_path(const Temporal *temp1, const Temporal *temp2,
   int *count)
 {
   /* The out parameter is defined even when a later check fails */
-  VALIDATE_NOT_NULL(count, NULL); 
+  VALIDATE_NOT_NULL(count, NULL);
   *count = 0;
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))
@@ -1082,7 +1082,7 @@ trgeometry_dyntimewarp_path(const Temporal *temp1, const Temporal *temp2,
   int *count)
 {
   /* The out parameter is defined even when a later check fails */
-  VALIDATE_NOT_NULL(count, NULL); 
+  VALIDATE_NOT_NULL(count, NULL);
   *count = 0;
   /* Ensure the validity of the arguments */
   if (! ensure_valid_trgeo_trgeo(temp1, temp2))

--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -140,49 +140,12 @@ ea_spatialrel_trgeo_poses_geo(const Temporal *temp, const GSERIALIZED *gs,
 
 /*****************************************************************************/
 
-// /**
- // * @brief Generic spatial relationship for the traversed area of a temporal
- // * rigid geometry and a geometry
- // * @param[in] temp Temporal rigid geometry
- // * @param[in] gs Geometry
- // * @param[in] param Parameter
- // * @param[in] func PostGIS function to be called
- // * @param[in] numparam Number of parameters of the functions
- // * @param[in] invert True if the arguments should be inverted
- // * @return On error return -1
- // */
-// static int
-// spatialrel_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
-  // Datum param, varfunc func, int numparam, bool invert)
-// {
-  // /* Ensure the validity of the arguments */
-  // if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
-    // return -1;
-
-  // assert(numparam == 2 || numparam == 3);
-  // Datum dgeo = PointerGetDatum(gs);
-  // Datum dtrav = PointerGetDatum(trgeometry_traversed_area(temp, UNARY_UNION_NO));
-  // Datum result;
-  // if (numparam == 2)
-  // {
-    // datum_func2 func2 = (datum_func2) func;
-    // result = invert ? func2(dgeo, dtrav) : func2(dtrav, dtrav);
-  // }
-  // else /* numparam == 3 */
-  // {
-    // datum_func3 func3 = (datum_func3) func;
-    // result = invert ? func3(dgeo, dtrav, param) : func3(dtrav, dgeo, param);
-  // }
-  // pfree(DatumGetPointer(dtrav));
-  // return result ? 1 : 0;
-// }
-
 /*****************************************************************************
  * Ever/always contains
  *****************************************************************************/
 
 /**
- * @brief Return 1 if a geometry ever contains a temporal rigid geometry, 0 if 
+ * @brief Return 1 if a geometry ever contains a temporal rigid geometry, 0 if
  * not, and -1 on error or if the geometry is empty
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
@@ -212,7 +175,7 @@ ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * 0 if not, and -1 on error or if the geometry is empty
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
- * @note The function tests whether the placements are contained in the 
+ * @note The function tests whether the placements are contained in the
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
@@ -230,7 +193,7 @@ econtains_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
  * 0 if not, and -1 on error or if the geometry is empty
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
- * @note The function tests whether the placements are contained in the 
+ * @note The function tests whether the placements are contained in the
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
@@ -316,7 +279,7 @@ ea_covers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
  * 0 if not, and -1 on error or if the geometry is empty
  * @param[in] gs Geometry
  * @param[in] temp Temporal geometry
- * @note The function tests whether the placements are covered in the 
+ * @note The function tests whether the placements are covered in the
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
@@ -334,7 +297,7 @@ ecovers_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
  * 0 if not, and -1 on error or if the geometry is empty
  * @param[in] gs Geometry
  * @param[in] temp Temporal geometry
- * @note The function tests whether the placements are covered in the 
+ * @note The function tests whether the placements are covered in the
  * geometry
  * https://postgis.net/docs/ST_Relate.html
  * https://postgis.net/docs/ST_Contains.html
@@ -444,7 +407,7 @@ ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 }
 /**
  * @ingroup meos_rgeo_rel_ever
- * @brief Return 1 if a temporal rigid geometry and a geometry are ever 
+ * @brief Return 1 if a temporal rigid geometry and a geometry are ever
  * disjoint, 0 if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
@@ -458,7 +421,7 @@ edisjoint_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 
 /**
  * @ingroup meos_rgeo_rel_ever
- * @brief Return 1 if a temporal rigid geometry and a geometry are always 
+ * @brief Return 1 if a temporal rigid geometry and a geometry are always
  * disjoint,0 if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
@@ -633,7 +596,7 @@ aintersects_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 
 /**
  * @ingroup meos_rgeo_rel_ever
- * @brief Return 1 if a temporal rigid geometry and a geometry ever touch, 0 
+ * @brief Return 1 if a temporal rigid geometry and a geometry ever touch, 0
  * if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
@@ -647,7 +610,7 @@ etouches_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 
 /**
  * @ingroup meos_rgeo_rel_ever
- * @brief Return 1 if a temporal rigid geometry and a geometry always touch, 
+ * @brief Return 1 if a temporal rigid geometry and a geometry always touch,
  * 0 if not, and -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
@@ -730,7 +693,7 @@ edwithin_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs, double dist
 
 /**
  * @ingroup meos_rgeo_rel_ever
- * @brief Return 1 if a geometry and a temporal rigid geometry are always 
+ * @brief Return 1 if a geometry and a temporal rigid geometry are always
  * within a distance, 0 if not, -1 on error or if the geometry is empty
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
@@ -825,8 +788,8 @@ ea_dwithin_trgeoseq_trgeoseq_discstep(const TSequence *seq1,
  */
 int
 tdwithin_trgeosegm_trgeosegm(Datum sv1 UNUSED, Datum ev1 UNUSED,
-  Datum sv2 UNUSED, Datum ev2 UNUSED, TimestampTz lower UNUSED, 
-  TimestampTz upper UNUSED, double dist UNUSED, TimestampTz *t1 UNUSED, 
+  Datum sv2 UNUSED, Datum ev2 UNUSED, TimestampTz lower UNUSED,
+  TimestampTz upper UNUSED, double dist UNUSED, TimestampTz *t1 UNUSED,
   TimestampTz *t2 UNUSED)
 {
   meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
@@ -878,7 +841,7 @@ ea_dwithin_trgeoseq_trgeoseq_cont(const TSequence *seq1, const TSequence *seq2,
     /* Both segments are constant */
     if (datum_point_eq(sv1, ev1) && datum_point_eq(sv2, ev2))
     {
-      bool res = DatumGetBool(datum_geom_dwithin2d(sv1, sv2, 
+      bool res = DatumGetBool(datum_geom_dwithin2d(sv1, sv2,
         Float8GetDatum(dist)));
       if ((ever && res) || (! ever && ! res))
         return ret_loop;
@@ -1031,7 +994,7 @@ edwithin_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2, dou
 
 /**
  * @ingroup meos_rgeo_rel_ever
- * @brief Return 1 if two temporal rigid geometries are always within a 
+ * @brief Return 1 if two temporal rigid geometries are always within a
  * distance, 0 if not, -1 on error or if the temporal rigid geometries do not
  * intersect on time
  * @param[in] temp1,temp2 Temporal rigid geometries

--- a/meos/src/rgeo/trgeo_utils.c
+++ b/meos/src/rgeo/trgeo_utils.c
@@ -54,7 +54,7 @@
 /*****************************************************************************/
 
 /**
- * @brief 
+ * @brief Ensure that two polygons have the same rings with the same vertex counts
  */
 static void
 ensure_same_rings_lwpoly(const LWPOLY *poly1, const LWPOLY *poly2)
@@ -67,7 +67,7 @@ ensure_same_rings_lwpoly(const LWPOLY *poly1, const LWPOLY *poly2)
 }
 
 /**
- * @brief 
+ * @brief Ensure that two polyhedral surfaces have the same component geometries
  */
 static void
 ensure_same_geoms_lwpsurface(const LWPSURFACE *psurface1,
@@ -81,7 +81,7 @@ ensure_same_geoms_lwpsurface(const LWPSURFACE *psurface1,
 }
 
 /**
- * @brief 
+ * @brief Return true if two geometries have the same points in the same order
  */
 static bool
 same_lwgeom(const LWGEOM *geom1, const LWGEOM *geom2)
@@ -97,12 +97,12 @@ same_lwgeom(const LWGEOM *geom1, const LWGEOM *geom2)
   {
     if (FLAGS_GET_Z(geom1->flags))
     {
-      result = fabs(p1.x - p2.x) < MEOS_EPSILON && 
+      result = fabs(p1.x - p2.x) < MEOS_EPSILON &&
         fabs(p1.y - p2.y) < MEOS_EPSILON && fabs(p1.z - p2.z) < MEOS_EPSILON;
     }
     else
     {
-      result = fabs(p1.x - p2.x) < MEOS_EPSILON && 
+      result = fabs(p1.x - p2.x) < MEOS_EPSILON &&
         fabs(p1.y - p2.y) < MEOS_EPSILON;
     }
   }
@@ -123,7 +123,7 @@ ensure_same_geom(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
   if (gserialized_get_type(gs1) != gserialized_get_type(gs2))
   {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, 
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Operation on different reference geometries");
     return false;
   }
@@ -137,7 +137,7 @@ ensure_same_geom(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
   if (! same_lwgeom(geom1, geom2))
   {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, 
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Operation on different reference geometries");
     return false;
   }
@@ -152,7 +152,8 @@ ensure_same_geom(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 /*****************************************************************************/
 
 /**
- * @brief
+ * @brief Return the radius of a geometry, that is the greatest distance from the
+ * origin to one of its points
  */
 double
 geom_radius(const GSERIALIZED *gs)

--- a/meos/src/rgeo/trgeo_vclip.c
+++ b/meos/src/rgeo/trgeo_vclip.c
@@ -63,27 +63,7 @@
  *****************************************************************************/
 
 /**
- * @brief 
- */
-static inline uint32_t
-uint_mod_add(uint32_t i, uint32_t j, uint32_t n)
-{
-  return (i + j) % n;
-}
-
-/**
- * @brief 
- */
-// Handle negative values correctly
-// Requirement: j < n
-static inline uint32_t
-uint_mod_sub(uint32_t i, uint32_t j, uint32_t n)
-{
-  return (i + n - j) % n;
-}
-
-/**
- * @brief 
+ * @brief Apply a pose to a point, that is rotate it and then translate it
  */
 void
 apply_pose_point4d(POINT4D *p, const Pose *pose)
@@ -97,22 +77,7 @@ apply_pose_point4d(POINT4D *p, const Pose *pose)
 }
 
 /**
- * @brief Computes the relative position of point on segment v(vs, ve)
- * s < 0      -> p before point vs
- * s = 0      -> p = vs
- * 0 < s < 1  -> p = vs * (1 - s)  + ve * s
- * s = 1      -> p = ve
- * 1 < s      -> p after point ve
- */
-static inline double
-compute_s(POINT4D p, POINT4D vs, POINT4D ve)
-{
-  return ((p.x - vs.x) * (ve.x - vs.x) + (p.y - vs.y) * (ve.y - vs.y)) /
-    ((ve.x - vs.x) * (ve.x - vs.x) + (ve.y - vs.y) * (ve.y - vs.y));
-}
-
-/**
- * @brief Computes the signed length of the cross product of the vectors
+ * @brief Return the signed length of the cross product of the vectors
  * (vs, p) and (vs, ve)
  * @details The sign of this value determines the relative position between p
  * and the line l going though segment (vs, ve) (oriented towards ve)
@@ -127,7 +92,7 @@ compute_angle(POINT4D p, POINT4D vs, POINT4D ve)
 }
 
 /**
- * @brief Computes the distance between point p and segment v(vs, ve)
+ * @brief Return the distance between a point and a segment
  *
  * Note: this assumes that the projection of p
  * on the line l going through (vs, ve) is
@@ -142,7 +107,8 @@ compute_dist2(POINT4D p, POINT4D vs, POINT4D ve)
 }
 
 /**
- * @brief Computes the distance between point p and segment v(vs, ve)
+ * @brief Return the distance between a point and a segment, admitting a
+ * projection that falls outside it
  */
 static inline double
 compute_dist2_safe(POINT4D p, POINT4D vs, POINT4D ve)
@@ -153,14 +119,13 @@ compute_dist2_safe(POINT4D p, POINT4D vs, POINT4D ve)
   else if (s >= 1)
     return (p.x - ve.x) * (p.x - ve.x) + (p.y - ve.y) * (p.y - ve.y);
   else
-    return 
-      (p.x - vs.x - (ve.x - vs.x) * s) * (p.x - vs.x - (ve.x - vs.x) * s) + 
+    return
+      (p.x - vs.x - (ve.x - vs.x) * s) * (p.x - vs.x - (ve.x - vs.x) * s) +
       (p.y - vs.y - (ve.y - vs.y) * s) * (p.y - vs.y - (ve.y - vs.y) * s);
 }
 
 /**
- * @brief Tests if a polygon is defined in counter-clockwise order (ccw)
- * @return Returns True if it is the case
+ * @brief Return true if a polygon is defined in counter-clockwise order
  * @note The polygon must be convex
  */
 static bool
@@ -174,7 +139,8 @@ poly_is_ccw(const LWPOLY *poly)
 }
 
 /**
- * @brief 
+ * @brief Return the vertex of a polygon closest to a point, walking to a
+ * neighbouring vertex while one stands closer
  */
 static int
 vertex_vertex_tpoly_point(const LWPOLY *poly, POINT4D point,
@@ -220,7 +186,8 @@ vertex_vertex_tpoly_point(const LWPOLY *poly, POINT4D point,
 }
 
 /**
- * @brief 
+ * @brief Return the edge of a polygon closest to a point, walking to a
+ * neighbouring feature while one stands closer
  */
 static int
 edge_vertex_tpoly_point(const LWPOLY *poly, POINT4D point,
@@ -298,7 +265,8 @@ edge_vertex_tpoly_point(const LWPOLY *poly, POINT4D point,
 }
 
 /**
- * @brief 
+ * @brief Return the closest feature of a polygon under a pose to a point, and the
+ * distance between them
  */
 int
 v_clip_tpoly_point(const LWPOLY *poly, const LWPOINT *point,
@@ -364,7 +332,8 @@ v_clip_tpoly_point(const LWPOLY *poly, const LWPOINT *point,
 }
 
 /**
- * @brief 
+ * @brief Return the closest vertices of two polygons, walking to a neighbouring
+ * vertex of either while one stands closer
  */
 static int
 vertex_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
@@ -440,7 +409,8 @@ vertex_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
 }
 
 /**
- * @brief 
+ * @brief Return the closest edge and vertex of two polygons, walking to a
+ * neighbouring feature of either while one stands closer
  */
 static int
 edge_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
@@ -547,7 +517,8 @@ edge_vertex_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
 }
 
 /**
- * @brief 
+ * @brief Return the closest edges of two polygons, walking to a neighbouring
+ * feature of either while one stands closer
  */
 static int
 edge_edge_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
@@ -579,9 +550,9 @@ edge_edge_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
   }
 
   /* Check if the edges intersect */
-  if (compute_angle(v1_start, v2_start, v2_end) * 
-        compute_angle(v1_end, v2_start, v2_end) < 0 && 
-      compute_angle(v2_start, v1_start, v1_end) * 
+  if (compute_angle(v1_start, v2_start, v2_end) *
+        compute_angle(v1_end, v2_start, v2_end) < 0 &&
+      compute_angle(v2_start, v1_start, v1_end) *
         compute_angle(v2_end, v1_start, v1_end) < 0)
     return MEOS_INTERSECT;
 
@@ -605,7 +576,8 @@ edge_edge_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
 }
 
 /**
- * @brief 
+ * @brief Return the closest features of two polygons under their poses, and the
+ * distance between them
  */
 int
 v_clip_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
@@ -661,7 +633,7 @@ v_clip_tpoly_tpoly(const LWPOLY *poly1, const LWPOLY *poly2,
       getPoint4d_p(poly2->rings[0], i2, &v2);
       if (pose2)
         apply_pose_point4d(&v2, pose2);
-      *dist = sqrt((v1.x - v2.x) * (v1.x - v2.x) + 
+      *dist = sqrt((v1.x - v2.x) * (v1.x - v2.x) +
         (v1.y - v2.y) * (v1.y - v2.y));
     }
     else if (*poly1_feature % 2 == 0) /* vertex <-> edge */


### PR DESCRIPTION
Every function and helper of the rigid geometry family carries a brief
naming the quantity it returns, in the phrasing the sibling families use:
the closest-feature and distance point arrays holding a walk's state, the
modular vertex arithmetic, the pose interpolation, the functions whose roots
are the closest-feature transitions of a rotating polygon against a point,
against a fixed polygon and against another rotating one, the parallel-edge
solver, the v-clip walks over vertex, edge and polygon pairs, the ring and
point comparisons admitting two reference geometries, and the temporal
distance of an instant, a sequence and a sequence set against a geometry.
Each doxygen block sits above the function it documents and holds a single
brief, and the two distance helpers state one sentence each, one of them
naming the projection that falls outside the segment. The counter-clockwise
test and the traversed-area relationship each live in one place: the test in
the v-clip file, the relationship in the lifted walk over the placements
that SQL reaches as traversedArea. Each helper the walk and the temporal
distance share holds one definition, the vertex arithmetic modulo the vertex
count and the relative position of a point on a segment standing static
inline in the v-clip header both files read, and the cross product and the
point to segment distance standing in the walk that calls them. The family
reads uniformly elsewhere: the temporal header include appears once, the
distance element declares its field with one semicolon, and no line ends in
a space.

