### PR TITLE
Read the SRID of a temporal point cloud box from its schema

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3208,7 +3208,7 @@
 				<title>Constructores</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpcbox_tpcbox"><varname>tpcbox</varname>, <varname>tpcbox_z</varname>, <varname>tpcbox_t</varname>, <varname>tpcbox_xt</varname>, <varname>tpcbox_zt</varname></link>: Construye un tpcbox a partir de límites X/Y/Z/T explícitos y un pcid</para>
+						<para><link linkend="tpcbox_tpcbox"><varname>tpcbox</varname>, <varname>tpcbox_z</varname>, <varname>tpcbox_t</varname>, <varname>tpcbox_xt</varname>, <varname>tpcbox_zt</varname></link>: Construye un tpcbox a partir de límites X/Y/Z/T explícitos y un pcid, cuyo esquema declara el SRID</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -3236,7 +3236,7 @@
 						<para><link linkend="tpcbox_tmin"><varname>tmin</varname>, <varname>tmax</varname></link>: Devuelve un límite temporal, NULL si la caja no tiene dimensión T</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpcbox_pcid"><varname>pcid</varname>, <varname>SRID</varname></link>: Devuelve el identificador de esquema y el SRID</para>
+						<para><link linkend="tpcbox_pcid"><varname>pcid</varname>, <varname>SRID</varname></link>: Devuelve el identificador de esquema y el SRID que declara dicho esquema</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -259,18 +259,19 @@ SELECT numValues(set(ARRAY[pcpoint(1, 10.0, 20.0, 30.0),
 					<indexterm significance="normal"><primary><varname>tpcbox_t</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcbox_xt</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcbox_zt</varname></primary></indexterm>
-					<para>Construye un tpcbox a partir de límites X/Y/Z/T explícitos y un pcid</para>
+					<para>Construye un tpcbox a partir de límites X/Y/Z/T explícitos y un pcid, cuyo esquema declara el SRID</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tpcboxX(xmin,ymin,xmax,ymax,pcid,srid integer=0) → tpcbox
-tpcboxZ(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid integer=0) → tpcbox
+tpcboxX(xmin,ymin,xmax,ymax,pcid) → tpcbox
+tpcboxZ(xmin,ymin,zmin,xmax,ymax,zmax,pcid) → tpcbox
 tpcboxT(period,pcid) → tpcbox
-tpcboxXT(xmin,ymin,xmax,ymax,period,pcid,srid integer=0) → tpcbox
-tpcboxZT(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid integer=0) → tpcbox
+tpcboxXT(xmin,ymin,xmax,ymax,period,pcid) → tpcbox
+tpcboxZT(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid) → tpcbox
 </programlisting>
+					<para>El SRID no es un parámetro: se lee del esquema nombrado por el pcid, y un pcid que no nombra ningún esquema registrado es un error</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcboxX(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1);
 -- TPCBOX(X((0,0),(10,10)), 1)
-SELECT tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+SELECT tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1);
 -- TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-02]), 1)
 </programlisting>
 				</listitem>
@@ -297,9 +298,8 @@ SELECT tpcbox(pcpoint(1, 10.0, 20.0, 30.0));
 					<para>Convierte un pcpatch a un tpcbox</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tpcbox(pcpatch) → tpcbox
-tpcbox(pcpatch,integer) → tpcbox
 </programlisting>
-					<para>La extensión en X y en Y del resultado es la de los límites PCBOUNDS integrados en el parche, y su extensión en Z, cuando el esquema que nombra el pcid tiene una dimensión Z, es la que indican los puntos del parche. La segunda forma acepta un SRID explícito en lugar de buscarlo en el esquema.</para>
+					<para>La extensión en X y en Y del resultado es la de los límites PCBOUNDS integrados en el parche, y su extensión en Z, cuando el esquema que nombra el pcid tiene una dimensión Z, es la que indican los puntos del parche. El SRID es el que declara el esquema nombrado por el pcid.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(pcpatch(pcpoint(1, 10.0, 20.0, 30.0)));
 -- TPCBOX(Z((10,20,30),(10,20,30)), 1)
@@ -322,7 +322,7 @@ hasZ(tpcbox) → boolean
 hasT(tpcbox) → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1, 0) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1) AS b)
   SELECT hasX(b), hasZ(b) FROM b;
 -- t | f
 </programlisting>
@@ -345,7 +345,7 @@ zmin(tpcbox) → float
 zmax(tpcbox) → float
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1, 0) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1) AS b)
   SELECT xmin(b), xmax(b) FROM b;
 -- 0 | 10
 </programlisting>
@@ -368,15 +368,15 @@ SELECT tmin(tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1));
 				<listitem xml:id="tpcbox_pcid">
 					<indexterm significance="normal"><primary><varname>pcid</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
-					<para>Devuelve el identificador de esquema y el SRID</para>
+					<para>Devuelve el identificador de esquema y el SRID que declara dicho esquema</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 pcid(tpcbox) → integer
 SRID(tpcbox) → integer
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 7, 4326) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1) AS b)
   SELECT pcid(b), SRID(b) FROM b;
--- 7 | 4326
+-- 1 | 4326
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -392,7 +392,7 @@ WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 7, 4326) AS b)
 round(tpcbox,integer=0) → tpcbox
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT round(tpcboxX(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
+SELECT round(tpcboxX(0.123456, 1.234567, 2.345678, 3.456789, 1), 2);
 -- TPCBOX(X((0.12,1.23),(2.35,3.46)), 1)
 </programlisting>
 				</listitem>
@@ -405,7 +405,7 @@ setSRID(tpcbox,integer) → tpcbox
 </programlisting>
 					<para>No reproyecta las coordenadas, para ello, proyecte primero el tpcpoint subyacente y tome la caja delimitadora del resultado</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1, 0), 4326));
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1), 4326));
 -- 4326
 </programlisting>
 				</listitem>
@@ -423,9 +423,9 @@ tpcbox {+, *} tpcbox → tpcbox
 </programlisting>
 					<para>Ambos operandos deben compartir el mismo <varname>pcid</varname>, y la intersección es NULL cuando las dos cajas son disjuntas.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) + tpcboxX(3, 3, 10, 10, 1);
 -- TPCBOX(X((0,0),(10,10)), 1)
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
 -- TPCBOX(X((3,3),(5,5)), 1)
 </programlisting>
 				</listitem>
@@ -448,17 +448,17 @@ SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
 tpcbox {&amp;&amp;, @&gt;, &lt;@, ~=, -|-} tpcbox → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcboxX(0, 0, 10, 10, 1, 0) @&gt; tpcboxX(2, 2, 8, 8, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) @&gt; tpcboxX(2, 2, 8, 8, 1);
 -- t
-SELECT tpcboxX(2, 2, 8, 8, 1, 0) &lt;@ tpcboxX(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(2, 2, 8, 8, 1) &lt;@ tpcboxX(0, 0, 10, 10, 1);
 -- t
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) &amp;&amp; tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(3, 3, 10, 10, 1);
 -- t
 SELECT tpcboxX(0, 0, 2, 2) ~= tpcboxX(0, 0, 2, 2);
 -- t
 SELECT tpcboxX(0, 0, 2, 2) -|- tpcboxX(5, 5, 7, 7);
 -- f
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) &amp;&amp; tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(0, 0, 5, 5, 2);
 -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 </programlisting>
 				</listitem>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3217,7 +3217,7 @@
 				<title>Constructors</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpcbox_tpcbox"><varname>tpcbox</varname>, <varname>tpcbox_z</varname>, <varname>tpcbox_t</varname>, <varname>tpcbox_xt</varname>, <varname>tpcbox_zt</varname></link>: Construct a tpcbox from explicit X/Y/Z/T bounds and a pcid</para>
+						<para><link linkend="tpcbox_tpcbox"><varname>tpcbox</varname>, <varname>tpcbox_z</varname>, <varname>tpcbox_t</varname>, <varname>tpcbox_xt</varname>, <varname>tpcbox_zt</varname></link>: Construct a tpcbox from explicit X/Y/Z/T bounds and a pcid, whose schema states the SRID</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -3245,7 +3245,7 @@
 						<para><link linkend="tpcbox_tmin"><varname>tmin</varname>, <varname>tmax</varname></link>: Return a temporal bound, NULL if the box has no T dimension</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpcbox_pcid"><varname>pcid</varname>, <varname>SRID</varname></link>: Return the schema id and SRID</para>
+						<para><link linkend="tpcbox_pcid"><varname>pcid</varname>, <varname>SRID</varname></link>: Return the schema id and the SRID its schema states</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -260,18 +260,19 @@ SELECT numValues(set(ARRAY[pcpoint(1, 10.0, 20.0, 30.0),
 					<indexterm significance="normal"><primary><varname>tpcbox_t</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcbox_xt</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>tpcbox_zt</varname></primary></indexterm>
-					<para>Construct a tpcbox from explicit X/Y/Z/T bounds and a pcid</para>
+					<para>Construct a tpcbox from explicit X/Y/Z/T bounds and a pcid, whose schema states the SRID</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tpcboxX(xmin,ymin,xmax,ymax,pcid,srid integer=0) → tpcbox
-tpcboxZ(xmin,ymin,zmin,xmax,ymax,zmax,pcid,srid integer=0) → tpcbox
+tpcboxX(xmin,ymin,xmax,ymax,pcid) → tpcbox
+tpcboxZ(xmin,ymin,zmin,xmax,ymax,zmax,pcid) → tpcbox
 tpcboxT(period,pcid) → tpcbox
-tpcboxXT(xmin,ymin,xmax,ymax,period,pcid,srid integer=0) → tpcbox
-tpcboxZT(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid,srid integer=0) → tpcbox
+tpcboxXT(xmin,ymin,xmax,ymax,period,pcid) → tpcbox
+tpcboxZT(xmin,ymin,zmin,xmax,ymax,zmax,period,pcid) → tpcbox
 </programlisting>
+					<para>The SRID is not a parameter: it is read from the schema the pcid names, and a pcid naming no registered schema is an error</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcboxX(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1);
 -- TPCBOX(X((0,0),(10,10)), 1)
-SELECT tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+SELECT tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1);
 -- TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-02]), 1)
 </programlisting>
 				</listitem>
@@ -298,9 +299,8 @@ SELECT tpcbox(pcpoint(1, 10.0, 20.0, 30.0));
 					<para>Convert a pcpatch to a tpcbox</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 tpcbox(pcpatch) → tpcbox
-tpcbox(pcpatch,integer) → tpcbox
 </programlisting>
-					<para>The X and Y extent of the result is the PCBOUNDS the patch embeds, and its Z extent, where the schema the pcid names holds a Z dimension, is the one the points of the patch state. The second form takes an explicit SRID instead of looking it up from the schema.</para>
+					<para>The X and Y extent of the result is the PCBOUNDS the patch embeds, and its Z extent, where the schema the pcid names holds a Z dimension, is the one the points of the patch state. The SRID is the one the schema the pcid names states.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT tpcbox(pcpatch(pcpoint(1, 10.0, 20.0, 30.0)));
 -- TPCBOX(Z((10,20,30),(10,20,30)), 1)
@@ -323,7 +323,7 @@ hasZ(tpcbox) → boolean
 hasT(tpcbox) → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1, 0) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1) AS b)
   SELECT hasX(b), hasZ(b) FROM b;
 -- t | f
 </programlisting>
@@ -346,7 +346,7 @@ zmin(tpcbox) → float
 zmax(tpcbox) → float
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1, 0) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1) AS b)
   SELECT xmin(b), xmax(b) FROM b;
 -- 0 | 10
 </programlisting>
@@ -369,15 +369,15 @@ SELECT tmin(tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1));
 				<listitem xml:id="tpcbox_pcid">
 					<indexterm significance="normal"><primary><varname>pcid</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
-					<para>Return the schema id and SRID</para>
+					<para>Return the schema id and the SRID its schema states</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 pcid(tpcbox) → integer
 SRID(tpcbox) → integer
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 7, 4326) AS b)
+WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 1) AS b)
   SELECT pcid(b), SRID(b) FROM b;
--- 7 | 4326
+-- 1 | 4326
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -393,7 +393,7 @@ WITH b AS (SELECT tpcboxX(0, 0, 10, 10, 7, 4326) AS b)
 round(tpcbox,integer=0) → tpcbox
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT round(tpcboxX(0.123456, 1.234567, 2.345678, 3.456789, 1, 0), 2);
+SELECT round(tpcboxX(0.123456, 1.234567, 2.345678, 3.456789, 1), 2);
 -- TPCBOX(X((0.12,1.23),(2.35,3.46)), 1)
 </programlisting>
 				</listitem>
@@ -406,7 +406,7 @@ setSRID(tpcbox,integer) → tpcbox
 </programlisting>
 					<para>Does not reproject coordinates, for that, project the underlying tpcpoint first and take the bbox of the result</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1, 0), 4326));
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1), 4326));
 -- 4326
 </programlisting>
 				</listitem>
@@ -425,9 +425,9 @@ tpcbox {+, *} tpcbox → tpcbox
 </programlisting>
 					<para>Both operands must share the same <varname>pcid</varname>, and the intersection is NULL when the two boxes are disjoint.</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) + tpcboxX(3, 3, 10, 10, 1);
 -- TPCBOX(X((0,0),(10,10)), 1)
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
 -- TPCBOX(X((3,3),(5,5)), 1)
 </programlisting>
 				</listitem>
@@ -450,17 +450,17 @@ SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
 tpcbox {&amp;&amp;, @&gt;, &lt;@, ~=, -|-} tpcbox → boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT tpcboxX(0, 0, 10, 10, 1, 0) @&gt; tpcboxX(2, 2, 8, 8, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) @&gt; tpcboxX(2, 2, 8, 8, 1);
 -- t
-SELECT tpcboxX(2, 2, 8, 8, 1, 0) &lt;@ tpcboxX(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(2, 2, 8, 8, 1) &lt;@ tpcboxX(0, 0, 10, 10, 1);
 -- t
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) &amp;&amp; tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(3, 3, 10, 10, 1);
 -- t
 SELECT tpcboxX(0, 0, 2, 2) ~= tpcboxX(0, 0, 2, 2);
 -- t
 SELECT tpcboxX(0, 0, 2, 2) -|- tpcboxX(5, 5, 7, 7);
 -- f
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) &amp;&amp; tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(0, 0, 5, 5, 2);
 -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 </programlisting>
 				</listitem>

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -239,7 +239,36 @@ tpcbox_parse(const char **str)
   bool hasx = MEOS_FLAGS_GET_X(box->flags);
   bool hasz = MEOS_FLAGS_GET_Z(box->flags);
   bool hast = MEOS_FLAGS_GET_T(box->flags);
-  TPCBox *result = tpcbox_make(hasx, hasz, hast, geodetic, box->srid, pcid,
+
+  /* Reconcile the two levels a TPCBox states its reference system at: the
+   * `SRID=` prefix the value carries and the schema its pcid names. This is
+   * the one site where both are genuinely written, so it is the one site that
+   * owes the reconciliation. A level reading `SRID_UNKNOWN` states nothing, so
+   * either level alone carries the answer and the schema is preferred where it
+   * speaks; two levels stating different systems is a value contradicting
+   * itself, which is an error rather than a choice between them. Where no
+   * schema resolves — a pcid of 0, or a MEOS program with no catalog behind
+   * it — the prefix is the only level there is, so reading a value never
+   * requires a catalog to be reachable */
+  srid = box->srid;
+  if (pcid != 0)
+  {
+    int32_t schema_srid = meos_pc_schema_srid(pcid);
+    if (schema_srid != SRID_INVALID && schema_srid != SRID_UNKNOWN)
+    {
+      if (srid != SRID_UNKNOWN && srid != schema_srid)
+      {
+        pfree(box);
+        meos_error(ERROR, MEOS_ERR_TEXT_INPUT,
+          "Could not parse %s value: The value states SRID %d and the schema "
+          "of pcid %u states SRID %d", type_str, srid, pcid, schema_srid);
+        return NULL;
+      }
+      srid = schema_srid;
+    }
+  }
+
+  TPCBox *result = tpcbox_make(hasx, hasz, hast, geodetic, srid, pcid,
     box->xmin, box->xmax, box->ymin, box->ymax, box->zmin, box->zmax,
     hast ? &box->period : NULL);
   pfree(box);
@@ -804,9 +833,9 @@ tpcbox_expand(const TPCBox *box1, TPCBox *box2)
   }
   if (MEOS_FLAGS_GET_T(box2->flags) && MEOS_FLAGS_GET_T(box1->flags))
     span_expand(&box1->period, &box2->period);
-  /* Propagate pcid / srid from the enriching box if box2's was unset */
-  if (box2->pcid == 0) box2->pcid = box1->pcid;
-  if (box2->srid == 0) box2->srid = box1->srid;
+  /* The schema and its SRID are not extent: a combine grows what the boxes
+   * measure and leaves what they are measured in alone, the comparability
+   * gate having already established the two agree */
 }
 
 /**
@@ -914,8 +943,8 @@ inter_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2, TPCBox *result)
     return false;  /* no shared dimensions → no intersection */
 
   memset(result, 0, sizeof(TPCBox));
-  result->srid = (box1->srid != 0) ? box1->srid : box2->srid;
-  result->pcid = (box1->pcid != 0) ? box1->pcid : box2->pcid;
+  result->srid = box1->srid;
+  result->pcid = box1->pcid;
   MEOS_FLAGS_SET_X(result->flags, hasx);
   MEOS_FLAGS_SET_Z(result->flags, hasz);
   MEOS_FLAGS_SET_T(result->flags, hast);

--- a/mobilitydb/datagen/pointcloud/random_tpcpoint.sql
+++ b/mobilitydb/datagen/pointcloud/random_tpcpoint.sql
@@ -220,7 +220,7 @@ DECLARE
   period tstzspan := random_tstzspan(lowtime, hightime, 30);
 BEGIN
   PERFORM ensure_random_pcid();
-  RETURN tpcboxZT(xmin, ymin, zmin, xmax, ymax, zmax, period, 1, 0);
+  RETURN tpcboxZT(xmin, ymin, zmin, xmax, ymax, zmax, period, 1);
 END;
 $$ LANGUAGE PLPGSQL STRICT;
 

--- a/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
+++ b/mobilitydb/sql/pointcloud/410_tpcbox.in.sql
@@ -78,14 +78,14 @@ CREATE TYPE tpcbox (
  ******************************************************************************/
 
 CREATE FUNCTION tpcboxX(xmin float8, ymin float8, xmax float8, ymax float8,
-    pcid integer DEFAULT 0, srid integer DEFAULT 0)
+    pcid integer DEFAULT 0)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Tpcbox_constructor_2d'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION tpcboxZ(xmin float8, ymin float8, zmin float8,
     xmax float8, ymax float8, zmax float8,
-    pcid integer DEFAULT 0, srid integer DEFAULT 0)
+    pcid integer DEFAULT 0)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Tpcbox_constructor_3d'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -96,14 +96,14 @@ CREATE FUNCTION tpcboxT(period tstzspan, pcid integer DEFAULT 0)
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION tpcboxXT(xmin float8, ymin float8, xmax float8, ymax float8,
-    period tstzspan, pcid integer DEFAULT 0, srid integer DEFAULT 0)
+    period tstzspan, pcid integer DEFAULT 0)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Tpcbox_constructor_xt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE FUNCTION tpcboxZT(xmin float8, ymin float8, zmin float8,
     xmax float8, ymax float8, zmax float8, period tstzspan,
-    pcid integer DEFAULT 0, srid integer DEFAULT 0)
+    pcid integer DEFAULT 0)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Tpcbox_constructor_zt'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
@@ -116,12 +116,6 @@ CREATE FUNCTION tpcboxZT(xmin float8, ymin float8, zmin float8,
 CREATE FUNCTION tpcbox(pcpatch)
   RETURNS tpcbox
   AS 'MODULE_PATHNAME', 'Pcpatch_to_tpcbox'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-
--- Explicit SRID override — takes no catalog detour.
-CREATE FUNCTION tpcbox(pcpatch, srid integer)
-  RETURNS tpcbox
-  AS 'MODULE_PATHNAME', 'Pcpatch_to_tpcbox_srid'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 -- pcpoint → TPCBox: degenerate single-point bbox with spatial bounds =

--- a/mobilitydb/src/pointcloud/tpcbox.c
+++ b/mobilitydb/src/pointcloud/tpcbox.c
@@ -122,6 +122,29 @@ Tpcbox_send(PG_FUNCTION_ARGS)
  * Constructors
  *****************************************************************************/
 
+/**
+ * @brief Return the SRID stated by the schema a pcid names, 0 when it names none
+ * @details The schema is what holds the SRID, so a box reads it from there
+ *   rather than being told: pgpointcloud registers one SRID per pcid and
+ *   derives every value's SRID from it. A pcid of 0 is pgpointcloud's
+ *   "unknown" value and names no schema to read
+ * @note A pcid naming no registered schema is an error rather than a box with
+ *   an assumed SRID, which is how PC_MakePoint answers the same input.
+ *   @p mobilitydb_pc_schema states a miss by returning NULL, so the test is
+ *   what keeps a hand-written pcid from reaching a null dereference
+ */
+static int32_t
+tpcbox_srid_of_pcid(int32 pcid)
+{
+  if (pcid == 0)
+    return 0;
+  PCSCHEMA *schema = mobilitydb_pc_schema((uint32_t) pcid);
+  if (schema == NULL)
+    ereport(ERROR, (errcode(ERRCODE_INVALID_PARAMETER_VALUE),
+      errmsg("No pointcloud schema is registered for pcid %d", pcid)));
+  return (int32_t) schema->srid;
+}
+
 PGDLLEXPORT Datum Tpcbox_constructor_2d(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Tpcbox_constructor_2d);
 /**
@@ -137,7 +160,7 @@ Tpcbox_constructor_2d(PG_FUNCTION_ARGS)
   double xmax = PG_GETARG_FLOAT8(2);
   double ymax = PG_GETARG_FLOAT8(3);
   int32 pcid = PG_GETARG_INT32(4);
-  int32_t srid = PG_GETARG_INT32(5);
+  int32_t srid = tpcbox_srid_of_pcid(pcid);
   PG_RETURN_TPCBOX_P(tpcbox_make(true, false, false, false,
     srid, (uint32_t) pcid, xmin, xmax, ymin, ymax, 0.0, 0.0, NULL));
 }
@@ -159,7 +182,7 @@ Tpcbox_constructor_3d(PG_FUNCTION_ARGS)
   double ymax = PG_GETARG_FLOAT8(4);
   double zmax = PG_GETARG_FLOAT8(5);
   int32 pcid = PG_GETARG_INT32(6);
-  int32_t srid = PG_GETARG_INT32(7);
+  int32_t srid = tpcbox_srid_of_pcid(pcid);
   PG_RETURN_TPCBOX_P(tpcbox_make(true, true, false, false,
     srid, (uint32_t) pcid, xmin, xmax, ymin, ymax, zmin, zmax, NULL));
 }
@@ -196,7 +219,7 @@ Tpcbox_constructor_xt(PG_FUNCTION_ARGS)
   double ymax = PG_GETARG_FLOAT8(3);
   Span *period = PG_GETARG_SPAN_P(4);
   int32 pcid = PG_GETARG_INT32(5);
-  int32_t srid = PG_GETARG_INT32(6);
+  int32_t srid = tpcbox_srid_of_pcid(pcid);
   PG_RETURN_TPCBOX_P(tpcbox_make(true, false, true, false,
     srid, (uint32_t) pcid, xmin, xmax, ymin, ymax, 0.0, 0.0, period));
 }
@@ -219,7 +242,7 @@ Tpcbox_constructor_zt(PG_FUNCTION_ARGS)
   double zmax = PG_GETARG_FLOAT8(5);
   Span *period = PG_GETARG_SPAN_P(6);
   int32 pcid = PG_GETARG_INT32(7);
-  int32_t srid = PG_GETARG_INT32(8);
+  int32_t srid = tpcbox_srid_of_pcid(pcid);
   PG_RETURN_TPCBOX_P(tpcbox_make(true, true, true, false,
     srid, (uint32_t) pcid, xmin, xmax, ymin, ymax, zmin, zmax, period));
 }
@@ -240,27 +263,7 @@ Datum
 Pcpatch_to_tpcbox(PG_FUNCTION_ARGS)
 {
   Pcpatch *pa = PG_GETARG_PCPATCH_P(0);
-  PCSCHEMA *schema = mobilitydb_pc_schema(pa->pcid);
-  TPCBox *result = pcpatch_to_tpcbox(pa, (int32_t) schema->srid);
-  PG_FREE_IF_COPY(pa, 0);
-  PG_RETURN_TPCBOX_P(result);
-}
-
-PGDLLEXPORT Datum Pcpatch_to_tpcbox_srid(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Pcpatch_to_tpcbox_srid);
-/**
- * @ingroup mobilitydb_pointcloud_box_constructor
- * @brief Return a TPCBox built from a pcpatch with an explicit SRID override
- * @details Skips the schema lookup. Useful when pointcloud_formats.srid = 0
- *   and the caller knows the real SRID from a PostGIS context.
- * @sqlfn tpcbox()
- */
-Datum
-Pcpatch_to_tpcbox_srid(PG_FUNCTION_ARGS)
-{
-  Pcpatch *pa = PG_GETARG_PCPATCH_P(0);
-  int32_t srid = PG_GETARG_INT32(1);
-  TPCBox *result = pcpatch_to_tpcbox(pa, srid);
+  TPCBox *result = pcpatch_to_tpcbox(pa, tpcbox_srid_of_pcid((int32) pa->pcid));
   PG_FREE_IF_COPY(pa, 0);
   PG_RETURN_TPCBOX_P(result);
 }

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -1,10 +1,16 @@
-SELECT tpcboxX(0, 0, 10, 10, 1, 0);
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 2, srid, schema FROM pointcloud_formats WHERE pcid = 1;
+INSERT 0 1
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 5, 4326, schema FROM pointcloud_formats WHERE pcid = 1;
+INSERT 0 1
+SELECT tpcboxX(0, 0, 10, 10, 1);
            tpcboxx           
 -----------------------------
  TPCBOX(X((0,0),(10,10)), 1)
 (1 row)
 
-SELECT tpcboxZ(0, 0, 0, 10, 10, 10, 1, 0);
+SELECT tpcboxZ(0, 0, 0, 10, 10, 10, 1);
              tpcboxz              
 ----------------------------------
  TPCBOX(Z((0,0,0),(10,10,10)), 1)
@@ -16,106 +22,114 @@ SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1);
  TPCBOX(T([Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST]), 1)
 (1 row)
 
-SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1);
                                           tpcboxxt                                           
 ---------------------------------------------------------------------------------------------
  TPCBOX(XT(((0,0),(10,10)),[Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST]), 1)
 (1 row)
 
 SELECT tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+  tstzspan '[2024-01-01, 2024-01-02]', 1);
                                              tpcboxzt                                             
 --------------------------------------------------------------------------------------------------
  TPCBOX(ZT(((0,0,0),(10,10,10)),[Mon Jan 01 00:00:00 2024 PST, Tue Jan 02 00:00:00 2024 PST]), 1)
 (1 row)
 
 SELECT hasX(tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+  tstzspan '[2024-01-01, 2024-01-02]', 1));
  hasx 
 ------
  t
 (1 row)
 
 SELECT hasZ(tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+  tstzspan '[2024-01-01, 2024-01-02]', 1));
  hasz 
 ------
  t
 (1 row)
 
 SELECT hasT(tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+  tstzspan '[2024-01-01, 2024-01-02]', 1));
  hast 
 ------
  t
 (1 row)
 
-SELECT hasZ(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT hasZ(tpcboxX(0, 0, 10, 10, 1));
  hasz 
 ------
  f
 (1 row)
 
-SELECT hasT(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT hasT(tpcboxX(0, 0, 10, 10, 1));
  hast 
 ------
  f
 (1 row)
 
-SELECT xmin(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT xmin(tpcboxX(0, 0, 10, 10, 1));
  xmin 
 ------
     0
 (1 row)
 
-SELECT xmax(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT xmax(tpcboxX(0, 0, 10, 10, 1));
  xmax 
 ------
    10
 (1 row)
 
-SELECT ymin(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT ymin(tpcboxX(0, 0, 10, 10, 1));
  ymin 
 ------
     0
 (1 row)
 
-SELECT ymax(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT ymax(tpcboxX(0, 0, 10, 10, 1));
  ymax 
 ------
    10
 (1 row)
 
-SELECT zmin(tpcboxZ(0, 0, 1, 10, 10, 9, 1, 0));
+SELECT zmin(tpcboxZ(0, 0, 1, 10, 10, 9, 1));
  zmin 
 ------
     1
 (1 row)
 
-SELECT zmax(tpcboxZ(0, 0, 1, 10, 10, 9, 1, 0));
+SELECT zmax(tpcboxZ(0, 0, 1, 10, 10, 9, 1));
  zmax 
 ------
     9
 (1 row)
 
-SELECT zmin(tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT zmin(tpcboxX(0, 0, 10, 10, 1));
  zmin 
 ------
      
 (1 row)
 
-SELECT pcid(tpcboxX(0, 0, 10, 10, 7, 0));
+SELECT pcid(tpcboxX(0, 0, 10, 10, 2));
  pcid 
 ------
-    7
+    2
 (1 row)
 
-SELECT SRID(tpcboxX(0, 0, 10, 10, 1, 4326));
+SELECT SRID(tpcboxX(0, 0, 10, 10, 1));
+ srid 
+------
+    0
+(1 row)
+
+SELECT SRID(tpcboxX(0, 0, 10, 10, 5));
  srid 
 ------
  4326
 (1 row)
 
+SELECT tpcboxX(0, 0, 10, 10, 7);
+ERROR:  No pointcloud schema is registered for pcid 7
 SELECT xmin(b), xmax(b), ymin(b), ymax(b)
 FROM (SELECT tpcbox(pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
   pcpoint(1, 4.0, 5.0, 6.0))) AS b) t;
@@ -156,113 +170,115 @@ FROM (SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
            3 |           6
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) + tpcboxX(3, 3, 10, 10, 1);
           ?column?           
 -----------------------------
  TPCBOX(X((0,0),(10,10)), 1)
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
          ?column?          
 ---------------------------
  TPCBOX(X((3,3),(5,5)), 1)
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(50, 50, 60, 60, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(50, 50, 60, 60, 1);
  ?column? 
 ----------
  
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 0, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0) + tpcboxX(3, 3, 10, 10, 1);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT tpcboxX(0, 0, 5, 5, 0, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0) * tpcboxX(3, 3, 10, 10, 1);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 8, 8, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxX(2, 2, 8, 8, 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 20, 20, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxX(2, 2, 20, 20, 1);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT tpcboxX(2, 2, 8, 8, 1, 0)   <@ tpcboxX(0, 0, 10, 10, 1, 0);
+SELECT tpcboxX(2, 2, 8, 8, 1)   <@ tpcboxX(0, 0, 10, 10, 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1)   && tpcboxX(3, 3, 10, 10, 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(50, 50, 60, 60, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1)   && tpcboxX(50, 50, 60, 60, 1);
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   ~= tpcboxX(0, 0, 5, 5, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1)   ~= tpcboxX(0, 0, 5, 5, 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT contains(tpcboxX(0, 0, 10, 10, 1, 0), tpcboxX(2, 2, 8, 8, 1, 0));
+SELECT contains(tpcboxX(0, 0, 10, 10, 1), tpcboxX(2, 2, 8, 8, 1));
  contains 
 ----------
  t
 (1 row)
 
-SELECT contained(tpcboxX(2, 2, 8, 8, 1, 0), tpcboxX(0, 0, 10, 10, 1, 0));
+SELECT contained(tpcboxX(2, 2, 8, 8, 1), tpcboxX(0, 0, 10, 10, 1));
  contained 
 -----------
  t
 (1 row)
 
-SELECT overlaps(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(3, 3, 10, 10, 1, 0));
+SELECT overlaps(tpcboxX(0, 0, 5, 5, 1), tpcboxX(3, 3, 10, 10, 1));
  overlaps 
 ----------
  t
 (1 row)
 
-SELECT same(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(0, 0, 5, 5, 1, 0));
+SELECT same(tpcboxX(0, 0, 5, 5, 1), tpcboxX(0, 0, 5, 5, 1));
  same 
 ------
  t
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)  -|- tpcboxX(5, 0, 10, 5, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1)  -|- tpcboxX(5, 0, 10, 5, 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT adjacent(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(5, 0, 10, 5, 1, 0));
+SELECT adjacent(tpcboxX(0, 0, 5, 5, 1), tpcboxX(5, 0, 10, 5, 1));
  adjacent 
 ----------
  t
 (1 row)
 
-SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 8, 8, 2, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxX(2, 2, 8, 8, 2);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1)   && tpcboxX(0, 0, 5, 5, 2);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   ~= tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1)   ~= tpcboxX(0, 0, 5, 5, 2);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
-SELECT tpcboxX(0, 0, 5, 5, 0, 0) && tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0) && tpcboxX(3, 3, 10, 10, 1);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT tpcboxX(0, 0, 5, 5, 0, 0) @> tpcboxX(1, 1, 4, 4, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0) @> tpcboxX(1, 1, 4, 4, 1);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT tpcboxX(0, 0, 5, 5, 1, 4326) && tpcboxX(3, 3, 10, 10, 1, 3857);
+SELECT tpcbox 'SRID=4326;TPCBOX(X((0,0),(5,5)), 1)' &&
+  tpcbox 'SRID=3857;TPCBOX(X((3,3),(10,10)), 1)';
 ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
-SELECT tpcboxX(0, 0, 5, 5, 1, 4326) + tpcboxX(3, 3, 10, 10, 1, 3857);
+SELECT tpcbox 'SRID=4326;TPCBOX(X((0,0),(5,5)), 1)' +
+  tpcbox 'SRID=3857;TPCBOX(X((3,3),(10,10)), 1)';
 ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
 SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) &&
   tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 1);
@@ -275,40 +291,70 @@ SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) +
   tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 1);
                                   ?column?                                  
 ----------------------------------------------------------------------------
- TPCBOX(T([Mon Jan 01 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]), 1)
+ TPCBOX(T([Mon Jan 01 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]), 0)
 (1 row)
 
-SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 0)),
-  (tpcboxX(3, 3, 10, 10, 1, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1)),
+  (tpcboxX(3, 3, 10, 10, 1))) t(b);
            extent            
 -----------------------------
  TPCBOX(X((0,0),(10,10)), 1)
 (1 row)
 
-SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 0)),
-  (tpcboxX(3, 3, 10, 10, 2, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1)),
+  (tpcboxX(3, 3, 10, 10, 2))) t(b);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
-SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 0, 0)),
-  (tpcboxX(3, 3, 10, 10, 1, 0))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 0)),
+  (tpcboxX(3, 3, 10, 10, 1))) t(b);
 ERROR:  Operation on TPCBox values with different schemas: 0 vs 1
-SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 4326)),
-  (tpcboxX(3, 3, 10, 10, 1, 3857))) t(b);
+SELECT extent(b) FROM (VALUES (tpcbox 'SRID=4326;TPCBOX(X((0,0),(5,5)), 1)'),
+  (tpcbox 'SRID=3857;TPCBOX(X((3,3),(10,10)), 1)')) t(b);
 ERROR:  Operation on TPCBox values with different SRIDs: 4326 vs 3857
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) =  tpcboxX(0, 0, 5, 5, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) =  tpcboxX(0, 0, 5, 5, 1);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) <> tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) <> tpcboxX(0, 0, 5, 5, 2);
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) <  tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) <  tpcboxX(0, 0, 5, 5, 2);
  ?column? 
 ----------
  t
 (1 row)
 
+SELECT tpcbox 'TPCBOX(X((0,0),(10,10)), 5)';
+                tpcbox                 
+---------------------------------------
+ SRID=4326;TPCBOX(X((0,0),(10,10)), 5)
+(1 row)
+
+SELECT tpcbox 'SRID=4326;TPCBOX(X((0,0),(10,10)), 5)';
+                tpcbox                 
+---------------------------------------
+ SRID=4326;TPCBOX(X((0,0),(10,10)), 5)
+(1 row)
+
+SELECT tpcbox 'SRID=3857;TPCBOX(X((0,0),(10,10)), 5)';
+ERROR:  Could not parse tpcbox value: The value states SRID 3857 and the schema of pcid 5 states SRID 4326
+LINE 1: SELECT tpcbox 'SRID=3857;TPCBOX(X((0,0),(10,10)), 5)';
+                      ^
+SELECT tpcbox 'SRID=3857;TPCBOX(X((0,0),(10,10)), 7)';
+                tpcbox                 
+---------------------------------------
+ SRID=3857;TPCBOX(X((0,0),(10,10)), 7)
+(1 row)
+
+SELECT tpcbox 'TPCBOX(X((0,0),(10,10)), 7)';
+           tpcbox            
+-----------------------------
+ TPCBOX(X((0,0),(10,10)), 7)
+(1 row)
+
+DELETE FROM pointcloud_formats WHERE pcid IN (2, 5);
+DELETE 2

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox_tbl.test.out
@@ -142,42 +142,42 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  seq_count 
 -----------
          0
 (1 row)
 
 SELECT COUNT(*) AS seq_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  seq_left 
 ----------
        11
 (1 row)
 
 SELECT COUNT(*) AS seq_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  seq_overleft 
 --------------
            16
 (1 row)
 
 SELECT COUNT(*) AS seq_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  seq_above 
 -----------
         46
 (1 row)
 
 SELECT COUNT(*) AS seq_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  seq_front 
 -----------
          0
 (1 row)
 
 SELECT COUNT(*) AS seq_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  seq_before 
 ------------
           0
@@ -190,42 +190,42 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS quadtree_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  quadtree_count 
 ----------------
               0
 (1 row)
 
 SELECT COUNT(*) AS quadtree_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  quadtree_left 
 ---------------
             11
 (1 row)
 
 SELECT COUNT(*) AS quadtree_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  quadtree_overleft 
 -------------------
                 16
 (1 row)
 
 SELECT COUNT(*) AS quadtree_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  quadtree_above 
 ----------------
              46
 (1 row)
 
 SELECT COUNT(*) AS quadtree_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  quadtree_front 
 ----------------
               0
 (1 row)
 
 SELECT COUNT(*) AS quadtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  quadtree_before 
 -----------------
                0
@@ -236,42 +236,42 @@ DROP INDEX
 CREATE INDEX tbl_tpcbox_kdtree_idx ON tbl_tpcbox USING spgist(b tpcbox_kdtree_ops);
 CREATE INDEX
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  kdtree_count 
 --------------
             0
 (1 row)
 
 SELECT COUNT(*) AS kdtree_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  kdtree_left 
 -------------
           11
 (1 row)
 
 SELECT COUNT(*) AS kdtree_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  kdtree_overleft 
 -----------------
               16
 (1 row)
 
 SELECT COUNT(*) AS kdtree_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  kdtree_above 
 --------------
            46
 (1 row)
 
 SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  kdtree_front 
 --------------
             0
 (1 row)
 
 SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
  kdtree_before 
 ---------------
              0
@@ -279,7 +279,7 @@ SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
 
 WITH test AS (
   SELECT b |=| tpcboxZT(200, 200, 200, 210, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcbox ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
    round    
@@ -297,18 +297,23 @@ RESET enable_indexscan;
 RESET
 RESET enable_bitmapscan;
 RESET
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 2, srid, schema FROM pointcloud_formats WHERE pcid = 1;
+INSERT 0 1
 CREATE TABLE tbl_tpcbox_pcid AS
   SELECT 1 AS k, tpcboxZT(20, 0, 0, 30, 10, 10,
-    tstzspan '[2001-01-01, 2001-12-31]', 2, 0) AS b;
+    tstzspan '[2001-01-01, 2001-12-31]', 2) AS b;
 SELECT 1
 CREATE INDEX tbl_tpcbox_pcid_quadtree_idx ON tbl_tpcbox_pcid USING spgist(b);
 CREATE INDEX
 SET enable_seqscan = off;
 SET
 SELECT COUNT(*) FROM tbl_tpcbox_pcid WHERE b >> tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-01-01, 2001-12-31]', 1);
 ERROR:  Operation on TPCBox values with different schemas: 2 vs 1
 RESET enable_seqscan;
 RESET
 DROP TABLE tbl_tpcbox_pcid;
 DROP TABLE
+DELETE FROM pointcloud_formats WHERE pcid = 2;
+DELETE 1

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint.test.out
@@ -338,21 +338,21 @@ SELECT atTime(tpcpointSeq(ARRAY[tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::f
 (1 row)
 
 SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NOT NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NOT NULL;
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT minusTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[]), '2024-01-02'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
+SELECT atTpcbox(tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz), tpcbox
+  'TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-31]), 999)') IS NULL;
  ?column? 
 ----------
  t
@@ -670,5 +670,5 @@ SELECT tpcpoint '2300000063000000000000000000F03F0000000000000040000000000000084
 (1 row)
 
 SELECT tpcpoint '2300000063000000000000000000F03F00000000000000400000000000000840000000@2024-01-01' &&
-  tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
+  tpcbox 'TPCBOX(XT(((0,0),(10,10)),[2024-01-01, 2024-01-31]), 99)';
 ERROR:  No schema registered for pcid 99

--- a/mobilitydb/test/pointcloud/expected/420_tpcpoint_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/420_tpcpoint_tbl.test.out
@@ -135,15 +135,16 @@ WHERE atTime(temp, tstzspan '[2001-01-01, 2002-01-01]') IS NOT NULL;
 
 SELECT COUNT(*) FROM tbl_tpcpoint WHERE atTpcbox(temp,
   tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 1, 0)) IS NOT NULL;
+    tstzspan '[2001-01-01, 2001-12-31]', 1)) IS NOT NULL;
  count 
 -------
    100
 (1 row)
 
 SELECT bool_and(atTpcbox(temp,
-  tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NULL)
+  tpcbox
+    'TPCBOX(ZT(((-100,-100,0),(100,100,100)),[2001-01-01, 2001-12-31]), 999)')
+  IS NULL)
 FROM tbl_tpcpoint;
  bool_and 
 ----------
@@ -151,8 +152,9 @@ FROM tbl_tpcpoint;
 (1 row)
 
 SELECT bool_and(minusTpcbox(temp,
-  tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NOT NULL)
+  tpcbox
+    'TPCBOX(ZT(((-100,-100,0),(100,100,100)),[2001-01-01, 2001-12-31]), 999)')
+  IS NOT NULL)
 FROM tbl_tpcpoint;
  bool_and 
 ----------

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch.test.out
@@ -360,21 +360,21 @@ SELECT atTime(tpcpatchSeq(ARRAY[tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.
 (1 row)
 
 SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NOT NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NOT NULL;
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT minusTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
+SELECT atTpcbox(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcbox
+  'TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-31]), 999)') IS NULL;
  ?column? 
 ----------
  t
@@ -454,56 +454,56 @@ SELECT numInstants(afterTimestamp(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[
 (1 row)
 
 SELECT numInstants(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 3, 3, 3,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
+  tstzspan '[2024-01-01, 2024-01-31]', 1)));
  numinstants 
 -------------
            1
 (1 row)
 
 SELECT startNumPoints(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 3, 3, 3,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
+  tstzspan '[2024-01-01, 2024-01-31]', 1)));
  startnumpoints 
 ----------------
               2
 (1 row)
 
 SELECT startNumPoints(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 1, 1, 1,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
+  tstzspan '[2024-01-01, 2024-01-31]', 1)));
  startnumpoints 
 ----------------
               1
 (1 row)
 
 SELECT atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(10, 10, 10, 20, 20, 20,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 3, 3, 3,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
 SELECT startNumPoints(minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 1, 1, 1,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
+  tstzspan '[2024-01-01, 2024-01-31]', 1)));
  startnumpoints 
 ----------------
               1
 (1 row)
 
 SELECT PC_AsText(getValue(atTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 1, 1, 1,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
+  tstzspan '[2024-01-01, 2024-01-31]', 1))));
          pc_astext          
 ----------------------------
  {"pcid":1,"pts":[[1,1,1]]}
 (1 row)
 
 SELECT PC_AsText(getValue(minusTpcboxFine(tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz), tpcboxZT(0, 0, 0, 1, 1, 1,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
+  tstzspan '[2024-01-01, 2024-01-31]', 1))));
          pc_astext          
 ----------------------------
  {"pcid":1,"pts":[[2,2,2]]}
@@ -734,5 +734,5 @@ SELECT tpcpatch '4F000000630000000000000002000000000000000000F03F000000000000F03
 (1 row)
 
 SELECT tpcpatch '4F000000630000000000000002000000000000000000F03F000000000000F03F000000000000F03F0000000000000040000000000000004000000000000000400000000000000000000000000000@2024-01-01' &&
-  tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
+  tpcbox 'TPCBOX(XT(((0,0),(10,10)),[2024-01-01, 2024-01-31]), 99)';
 ERROR:  No schema registered for pcid 99

--- a/mobilitydb/test/pointcloud/expected/430_tpcpatch_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/430_tpcpatch_tbl.test.out
@@ -142,15 +142,16 @@ WHERE atTime(temp, tstzspan '[2001-01-01, 2002-01-01]') IS NOT NULL;
 
 SELECT COUNT(*) FROM tbl_tpcpatch WHERE atTpcbox(temp,
   tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 1, 0)) IS NOT NULL;
+    tstzspan '[2001-01-01, 2001-12-31]', 1)) IS NOT NULL;
  count 
 -------
    100
 (1 row)
 
 SELECT bool_and(atTpcbox(temp,
-  tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NULL)
+  tpcbox
+    'TPCBOX(ZT(((-100,-100,0),(100,100,100)),[2001-01-01, 2001-12-31]), 999)')
+  IS NULL)
 FROM tbl_tpcpatch;
  bool_and 
 ----------
@@ -158,8 +159,9 @@ FROM tbl_tpcpatch;
 (1 row)
 
 SELECT bool_and(minusTpcbox(temp,
-  tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NOT NULL)
+  tpcbox
+    'TPCBOX(ZT(((-100,-100,0),(100,100,100)),[2001-01-01, 2001-12-31]), 999)')
+  IS NOT NULL)
 FROM tbl_tpcpatch;
  bool_and 
 ----------
@@ -169,7 +171,7 @@ FROM tbl_tpcpatch;
 SELECT COUNT(*) FROM tbl_tpcpatch
 WHERE atTpcboxFine(temp,
   tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-    tstzspan '[2001-01-01, 2002-01-01]', 1, 0)) IS NOT NULL;
+    tstzspan '[2001-01-01, 2002-01-01]', 1)) IS NOT NULL;
  count 
 -------
    100
@@ -177,11 +179,11 @@ WHERE atTpcboxFine(temp,
 
 SELECT bool_and(numPoints(atTpcboxFine(temp,
   tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-    tstzspan '[2001-01-01, 2002-01-01]', 1, 0))) <= numPoints(temp))
+    tstzspan '[2001-01-01, 2002-01-01]', 1))) <= numPoints(temp))
 FROM tbl_tpcpatch
 WHERE atTpcboxFine(temp,
   tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-    tstzspan '[2001-01-01, 2002-01-01]', 1, 0)) IS NOT NULL;
+    tstzspan '[2001-01-01, 2002-01-01]', 1)) IS NOT NULL;
  bool_and 
 ----------
  t

--- a/mobilitydb/test/pointcloud/expected/436_tpc_topops.test.out
+++ b/mobilitydb/test/pointcloud/expected/436_tpc_topops.test.out
@@ -1,16 +1,16 @@
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) && (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) && (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) && (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1)) && (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) && (tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan '[2099-01-01, 2099-12-31]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) && (tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan '[2099-01-01, 2099-12-31]', 1));
  ?column? 
 ----------
  f
@@ -40,13 +40,13 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::t
  f
 (1 row)
 
-SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) @> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1)) @> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <@ (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <@ (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1));
  ?column? 
 ----------
  t
@@ -64,19 +64,19 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::t
  t
 (1 row)
 
-SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
+SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) && (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1)) && (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan '[2099-01-01, 2099-12-31]', 1, 0));
+SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) && (tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan '[2099-01-01, 2099-12-31]', 1));
  ?column? 
 ----------
  f
@@ -88,13 +88,13 @@ SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), 
  t
 (1 row)
 
-SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) @> (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1)) @> (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) <@ (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1, 0));
+SELECT (tpcpatch(PC_Patch(ARRAY[PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), PC_MakePoint(1, ARRAY[2.0, 2.0, 2.0]::float[])]), '2024-01-01'::timestamptz)) <@ (tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1));
  ?column? 
 ----------
  t

--- a/mobilitydb/test/pointcloud/expected/436_tpc_topops_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/436_tpc_topops_tbl.test.out
@@ -59,7 +59,7 @@ SELECT bool_and(NOT (temp -|- temp)) FROM tbl_tpcpatch;
 (1 row)
 
 SELECT bool_and(tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0) @> temp)
+  tstzspan '[2001-01-01, 2030-01-01]', 1) @> temp)
 FROM tbl_tpcpoint;
  bool_and 
 ----------
@@ -67,7 +67,7 @@ FROM tbl_tpcpoint;
 (1 row)
 
 SELECT bool_and(tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0) @> temp)
+  tstzspan '[2001-01-01, 2030-01-01]', 1) @> temp)
 FROM tbl_tpcpatch;
  bool_and 
 ----------
@@ -75,14 +75,14 @@ FROM tbl_tpcpatch;
 (1 row)
 
 SELECT bool_and(temp <@ tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0)) FROM tbl_tpcpoint;
+  tstzspan '[2001-01-01, 2030-01-01]', 1)) FROM tbl_tpcpoint;
  bool_and 
 ----------
  t
 (1 row)
 
 SELECT bool_and(temp <@ tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0)) FROM tbl_tpcpatch;
+  tstzspan '[2001-01-01, 2030-01-01]', 1)) FROM tbl_tpcpatch;
  bool_and 
 ----------
  t

--- a/mobilitydb/test/pointcloud/expected/437_tpc_posops.test.out
+++ b/mobilitydb/test/pointcloud/expected/437_tpc_posops.test.out
@@ -1,88 +1,88 @@
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) << (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) << (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) >> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1)) >> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-15'::timestamptz)) << (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), '2024-01-15'::timestamptz)) << (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1));
  ?column? 
 ----------
  f
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &< (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &< (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <<| (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <<| (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) |>> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1)) |>> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &<| (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &<| (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) |&> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) |&> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <</ (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <</ (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) />> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1)) />> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &</ (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) &</ (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) /&> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) /&> (tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan '[2024-01-01, 2024-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <<# (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz)) <<# (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1));
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1, 0)) #>> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
+SELECT (tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan '[2025-01-01, 2025-01-15]', 1)) #>> (tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), '2024-01-01'::timestamptz));
  ?column? 
 ----------
  t

--- a/mobilitydb/test/pointcloud/expected/437_tpc_posops_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/437_tpc_posops_tbl.test.out
@@ -72,7 +72,7 @@ SELECT bool_and(NOT (temp #>> temp)) FROM tbl_tpcpatch;
 
 SELECT COUNT(*) FROM tbl_tpcpoint
 WHERE temp << tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2030-01-01]', 1);
  count 
 -------
      0
@@ -80,7 +80,7 @@ WHERE temp << tpcboxZT(-200, -200, -200, 200, 200, 200,
 
 SELECT COUNT(*) FROM tbl_tpcpoint
 WHERE tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0) >> temp;
+  tstzspan '[2001-01-01, 2030-01-01]', 1) >> temp;
  count 
 -------
      0

--- a/mobilitydb/test/pointcloud/expected/438_tpc_distance.test.out
+++ b/mobilitydb/test/pointcloud/expected/438_tpc_distance.test.out
@@ -16,13 +16,13 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[3.0, 4.0, 0.0]::float[]), '2024-01-01'::t
         5
 (1 row)
 
-SELECT (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0)) |=| (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+SELECT (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1)) |=| (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1));
  ?column? 
 ----------
         0
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::timestamptz)) |=| (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::timestamptz)) |=| (tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan '[2024-01-01, 2024-01-02]', 1));
  ?column? 
 ----------
         0
@@ -31,14 +31,14 @@ SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::t
 SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]),
                  '2024-01-01'::timestamptz)) |=|
        (tpcboxZT(0, 0, 0, 0, 0, 0,
-                  tstzspan '[2099-01-01, 2099-01-02]', 1, 0)) IS NULL;
+                  tstzspan '[2099-01-01, 2099-01-02]', 1)) IS NULL;
  ?column? 
 ----------
  t
 (1 row)
 
-SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::timestamptz)) |=| (tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2024-01-01, 2024-01-02]', 999, 0)) > 1e10;
+SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), '2024-01-01'::timestamptz)) |=| (tpcbox
+  'TPCBOX(ZT(((0,0,0),(0,0,0)),[2024-01-01, 2024-01-02]), 999)') > 1e10;
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 999
 INSERT INTO pointcloud_formats (pcid, srid, schema)
 SELECT 2, srid, schema FROM pointcloud_formats WHERE pcid = 1;

--- a/mobilitydb/test/pointcloud/expected/438_tpc_distance_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/438_tpc_distance_tbl.test.out
@@ -25,10 +25,10 @@ SET
 SET enable_bitmapscan = off;
 SET
 SELECT k, ((temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2001-06-01, 2001-06-30]', 1, 0)) > 0)::text AS finite
+  tstzspan '[2001-06-01, 2001-06-30]', 1)) > 0)::text AS finite
 FROM tbl_tpcpoint
 ORDER BY temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2001-06-01, 2001-06-30]', 1, 0)
+  tstzspan '[2001-06-01, 2001-06-30]', 1)
 LIMIT 5;
  k  | finite 
 ----+--------
@@ -46,10 +46,10 @@ SET
 SET enable_bitmapscan = on;
 SET
 SELECT k, ((temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2001-06-01, 2001-06-30]', 1, 0)) > 0)::text AS finite
+  tstzspan '[2001-06-01, 2001-06-30]', 1)) > 0)::text AS finite
 FROM tbl_tpcpoint
 ORDER BY temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2001-06-01, 2001-06-30]', 1, 0)
+  tstzspan '[2001-06-01, 2001-06-30]', 1)
 LIMIT 5;
  k  | finite 
 ----+--------

--- a/mobilitydb/test/pointcloud/expected/439_tpc_gist_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/439_tpc_gist_tbl.test.out
@@ -8,7 +8,7 @@ SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  seq_count 
 -----------
         26
@@ -22,7 +22,7 @@ SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  idx_count 
 -----------
         26
@@ -46,7 +46,7 @@ SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  seq_count 
 -----------
         45
@@ -60,7 +60,7 @@ SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  idx_count 
 -----------
         45
@@ -84,7 +84,7 @@ SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_contained FROM tbl_tpcpatch
 WHERE temp <@ tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-  tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2002-01-01]', 1);
  seq_contained 
 ---------------
            100
@@ -98,7 +98,7 @@ SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_contained FROM tbl_tpcpatch
 WHERE temp <@ tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-  tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2002-01-01]', 1);
  idx_contained 
 ---------------
            100
@@ -112,7 +112,7 @@ SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_before FROM tbl_tpcpatch
 WHERE temp <<# tpcboxZT(0, 0, 0, 100, 100, 100,
-  tstzspan '[2001-12-15, 2002-01-01]', 1, 0);
+  tstzspan '[2001-12-15, 2002-01-01]', 1);
  seq_before 
 ------------
          95
@@ -126,7 +126,7 @@ SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_before FROM tbl_tpcpatch
 WHERE temp <<# tpcboxZT(0, 0, 0, 100, 100, 100,
-  tstzspan '[2001-12-15, 2002-01-01]', 1, 0);
+  tstzspan '[2001-12-15, 2002-01-01]', 1);
  idx_before 
 ------------
          95
@@ -140,7 +140,7 @@ SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_left FROM tbl_tpcpatch
 WHERE temp << tpcboxZT(50, -1000, -1000, 1000, 1000, 1000,
-  tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2002-01-01]', 1);
  seq_left 
 ----------
         9
@@ -154,7 +154,7 @@ SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_left FROM tbl_tpcpatch
 WHERE temp << tpcboxZT(50, -1000, -1000, 1000, 1000, 1000,
-  tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2002-01-01]', 1);
  idx_left 
 ----------
         9
@@ -262,7 +262,7 @@ SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_fn_box FROM tbl_tpcpoint
 WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+  tstzspan '[2001-06-01, 2001-12-31]', 1));
  seq_fn_box 
 ------------
          26
@@ -277,7 +277,7 @@ WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
 
 SELECT COUNT(*) AS seq_fn_patch FROM tbl_tpcpatch
 WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+  tstzspan '[2001-06-01, 2001-12-31]', 1));
  seq_fn_patch 
 --------------
            45
@@ -291,7 +291,7 @@ SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_fn_box FROM tbl_tpcpoint
 WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+  tstzspan '[2001-06-01, 2001-12-31]', 1));
  idx_fn_box 
 ------------
          26
@@ -306,7 +306,7 @@ WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
 
 SELECT COUNT(*) AS idx_fn_patch FROM tbl_tpcpatch
 WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+  tstzspan '[2001-06-01, 2001-12-31]', 1));
  idx_fn_patch 
 --------------
            45

--- a/mobilitydb/test/pointcloud/expected/440_tpc_spgist_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/440_tpc_spgist_tbl.test.out
@@ -8,7 +8,7 @@ SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  seq_count 
 -----------
         26
@@ -22,7 +22,7 @@ SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  idx_count 
 -----------
         26
@@ -35,7 +35,7 @@ CREATE INDEX tbl_tpcpoint_kdtree_idx ON tbl_tpcpoint
 CREATE INDEX
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  kdtree_count 
 --------------
            26
@@ -53,7 +53,7 @@ SET enable_bitmapscan = off;
 SET
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  seq_count 
 -----------
         45
@@ -67,7 +67,7 @@ SET enable_bitmapscan = on;
 SET
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  idx_count 
 -----------
         45
@@ -80,7 +80,7 @@ CREATE INDEX tbl_tpcpatch_kdtree_idx ON tbl_tpcpatch
 CREATE INDEX
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
  kdtree_count 
 --------------
            45
@@ -98,7 +98,7 @@ CREATE INDEX tbl_tpcpoint_knn_quadtree_idx ON tbl_tpcpoint USING spgist(temp);
 CREATE INDEX
 WITH test AS (
   SELECT temp |=| tpcboxZT(200, 200, 200, 210, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
    round    
@@ -115,7 +115,7 @@ CREATE INDEX tbl_tpcpoint_knn_kdtree_idx ON tbl_tpcpoint
 CREATE INDEX
 WITH test AS (
   SELECT temp |=| tpcboxZT(200, 200, 200, 210, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
    round    
@@ -131,7 +131,7 @@ CREATE INDEX tbl_tpcpatch_knn_quadtree_idx ON tbl_tpcpatch USING spgist(temp);
 CREATE INDEX
 WITH test AS (
   SELECT temp |=| tpcboxXT(200, 200, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 ERROR:  Operation on mixed 2D/3D dimensions
@@ -142,7 +142,7 @@ CREATE INDEX tbl_tpcpatch_knn_kdtree_idx ON tbl_tpcpatch
 CREATE INDEX
 WITH test AS (
   SELECT temp |=| tpcboxXT(200, 200, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 ERROR:  Operation on mixed 2D/3D dimensions

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -30,39 +30,55 @@
 -- Value-level tests for tpcbox (constructors, accessors, set operations,
 -- topological predicates, comparison operators).
 
+-- A box reads its reference system off the schema its pcid names, so every
+-- pcid constructed with below names one. Schema 2 states the same reference
+-- system as schema 1, which is what leaves the schemas themselves as the only
+-- thing two such boxes disagree about; schema 5 states a different one.
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 2, srid, schema FROM pointcloud_formats WHERE pcid = 1;
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 5, 4326, schema FROM pointcloud_formats WHERE pcid = 1;
+
 -------------------------------------------------------------------------------
 -- Constructors
 -------------------------------------------------------------------------------
 
-SELECT tpcboxX(0, 0, 10, 10, 1, 0);
-SELECT tpcboxZ(0, 0, 0, 10, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1);
+SELECT tpcboxZ(0, 0, 0, 10, 10, 10, 1);
 SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 1);
-SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-02]', 1);
 SELECT tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-02]', 1, 0);
+  tstzspan '[2024-01-01, 2024-01-02]', 1);
 
 -------------------------------------------------------------------------------
 -- Accessors
 -------------------------------------------------------------------------------
 
 SELECT hasX(tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+  tstzspan '[2024-01-01, 2024-01-02]', 1));
 SELECT hasZ(tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
+  tstzspan '[2024-01-01, 2024-01-02]', 1));
 SELECT hasT(tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-02]', 1, 0));
-SELECT hasZ(tpcboxX(0, 0, 10, 10, 1, 0));   -- false: no Z
-SELECT hasT(tpcboxX(0, 0, 10, 10, 1, 0));   -- false: no T
+  tstzspan '[2024-01-01, 2024-01-02]', 1));
+SELECT hasZ(tpcboxX(0, 0, 10, 10, 1));   -- false: no Z
+SELECT hasT(tpcboxX(0, 0, 10, 10, 1));   -- false: no T
 
-SELECT xmin(tpcboxX(0, 0, 10, 10, 1, 0));
-SELECT xmax(tpcboxX(0, 0, 10, 10, 1, 0));
-SELECT ymin(tpcboxX(0, 0, 10, 10, 1, 0));
-SELECT ymax(tpcboxX(0, 0, 10, 10, 1, 0));
-SELECT zmin(tpcboxZ(0, 0, 1, 10, 10, 9, 1, 0));
-SELECT zmax(tpcboxZ(0, 0, 1, 10, 10, 9, 1, 0));
-SELECT zmin(tpcboxX(0, 0, 10, 10, 1, 0));   -- NULL: no Z
-SELECT pcid(tpcboxX(0, 0, 10, 10, 7, 0));
-SELECT SRID(tpcboxX(0, 0, 10, 10, 1, 4326));
+SELECT xmin(tpcboxX(0, 0, 10, 10, 1));
+SELECT xmax(tpcboxX(0, 0, 10, 10, 1));
+SELECT ymin(tpcboxX(0, 0, 10, 10, 1));
+SELECT ymax(tpcboxX(0, 0, 10, 10, 1));
+SELECT zmin(tpcboxZ(0, 0, 1, 10, 10, 9, 1));
+SELECT zmax(tpcboxZ(0, 0, 1, 10, 10, 9, 1));
+SELECT zmin(tpcboxX(0, 0, 10, 10, 1));   -- NULL: no Z
+SELECT pcid(tpcboxX(0, 0, 10, 10, 2));
+SELECT SRID(tpcboxX(0, 0, 10, 10, 1));
+-- The SRID is the one the schema states, so it is not the caller's to supply
+SELECT SRID(tpcboxX(0, 0, 10, 10, 5));
+
+-- A pcid naming no registered schema states no reference system to read, so
+-- the box is refused rather than built with an assumed one, which is how
+-- PC_MakePoint answers the same input
+SELECT tpcboxX(0, 0, 10, 10, 7);
 
 -------------------------------------------------------------------------------
 -- Conversions
@@ -97,33 +113,33 @@ FROM (SELECT pcpatch(pcpoint(1, 1.0, 2.0, 3.0),
 -- Set operations
 -------------------------------------------------------------------------------
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) * tpcboxX(50, 50, 60, 60, 1, 0);  -- NULL (disjoint)
+SELECT tpcboxX(0, 0, 5, 5, 1) + tpcboxX(3, 3, 10, 10, 1);
+SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
+SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(50, 50, 60, 60, 1);  -- NULL (disjoint)
 
 -- A box carrying coordinates states the schema they are read in, so a box
 -- naming schema 0 and one naming schema 1 have no common extent to combine
-SELECT tpcboxX(0, 0, 5, 5, 0, 0) + tpcboxX(3, 3, 10, 10, 1, 0);
-SELECT tpcboxX(0, 0, 5, 5, 0, 0) * tpcboxX(3, 3, 10, 10, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0) + tpcboxX(3, 3, 10, 10, 1);
+SELECT tpcboxX(0, 0, 5, 5, 0) * tpcboxX(3, 3, 10, 10, 1);
 
 -------------------------------------------------------------------------------
 -- Topological predicates — same pcid
 -------------------------------------------------------------------------------
 
-SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 8, 8, 1, 0);
-SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 20, 20, 1, 0);
-SELECT tpcboxX(2, 2, 8, 8, 1, 0)   <@ tpcboxX(0, 0, 10, 10, 1, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(3, 3, 10, 10, 1, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(50, 50, 60, 60, 1, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   ~= tpcboxX(0, 0, 5, 5, 1, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxX(2, 2, 8, 8, 1);
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxX(2, 2, 20, 20, 1);
+SELECT tpcboxX(2, 2, 8, 8, 1)   <@ tpcboxX(0, 0, 10, 10, 1);
+SELECT tpcboxX(0, 0, 5, 5, 1)   && tpcboxX(3, 3, 10, 10, 1);
+SELECT tpcboxX(0, 0, 5, 5, 1)   && tpcboxX(50, 50, 60, 60, 1);
+SELECT tpcboxX(0, 0, 5, 5, 1)   ~= tpcboxX(0, 0, 5, 5, 1);
 
 -- The portable spelling of each operator above answers the same
-SELECT contains(tpcboxX(0, 0, 10, 10, 1, 0), tpcboxX(2, 2, 8, 8, 1, 0));
-SELECT contained(tpcboxX(2, 2, 8, 8, 1, 0), tpcboxX(0, 0, 10, 10, 1, 0));
-SELECT overlaps(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(3, 3, 10, 10, 1, 0));
-SELECT same(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(0, 0, 5, 5, 1, 0));
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)  -|- tpcboxX(5, 0, 10, 5, 1, 0);
-SELECT adjacent(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(5, 0, 10, 5, 1, 0));
+SELECT contains(tpcboxX(0, 0, 10, 10, 1), tpcboxX(2, 2, 8, 8, 1));
+SELECT contained(tpcboxX(2, 2, 8, 8, 1), tpcboxX(0, 0, 10, 10, 1));
+SELECT overlaps(tpcboxX(0, 0, 5, 5, 1), tpcboxX(3, 3, 10, 10, 1));
+SELECT same(tpcboxX(0, 0, 5, 5, 1), tpcboxX(0, 0, 5, 5, 1));
+SELECT tpcboxX(0, 0, 5, 5, 1)  -|- tpcboxX(5, 0, 10, 5, 1);
+SELECT adjacent(tpcboxX(0, 0, 5, 5, 1), tpcboxX(5, 0, 10, 5, 1));
 
 -------------------------------------------------------------------------------
 -- Topological predicates — the schema decides what a coordinate means
@@ -131,18 +147,23 @@ SELECT adjacent(tpcboxX(0, 0, 5, 5, 1, 0), tpcboxX(5, 0, 10, 5, 1, 0));
 
 -- Two schemas give the same number two meanings, so the boxes are not
 -- comparable and the predicate has no answer to give
-SELECT tpcboxX(0, 0, 10, 10, 1, 0) @> tpcboxX(2, 2, 8, 8, 2, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   && tpcboxX(0, 0, 5, 5, 2, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0)   ~= tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxX(2, 2, 8, 8, 2);
+SELECT tpcboxX(0, 0, 5, 5, 1)   && tpcboxX(0, 0, 5, 5, 2);
+SELECT tpcboxX(0, 0, 5, 5, 1)   ~= tpcboxX(0, 0, 5, 5, 2);
 
 -- Schema 0 is a schema like any other once a box carries coordinates
-SELECT tpcboxX(0, 0, 5, 5, 0, 0) && tpcboxX(3, 3, 10, 10, 1, 0);
-SELECT tpcboxX(0, 0, 5, 5, 0, 0) @> tpcboxX(1, 1, 4, 4, 1, 0);
+SELECT tpcboxX(0, 0, 5, 5, 0) && tpcboxX(3, 3, 10, 10, 1);
+SELECT tpcboxX(0, 0, 5, 5, 0) @> tpcboxX(1, 1, 4, 4, 1);
 
--- The SRID is read on the same terms: one schema, two reference systems, so
--- the same pair of numbers denotes two different places
-SELECT tpcboxX(0, 0, 5, 5, 1, 4326) && tpcboxX(3, 3, 10, 10, 1, 3857);
-SELECT tpcboxX(0, 0, 5, 5, 1, 4326) + tpcboxX(3, 3, 10, 10, 1, 3857);
+-- The SRID is read on the same terms. A constructor can no longer state one
+-- apart from the schema, so the disagreeing pair is written: the schema pcid 1
+-- names states no reference system, which leaves the `SRID=` prefix the only
+-- level that speaks, and two values whose prefixes differ denote two different
+-- places
+SELECT tpcbox 'SRID=4326;TPCBOX(X((0,0),(5,5)), 1)' &&
+  tpcbox 'SRID=3857;TPCBOX(X((3,3),(10,10)), 1)';
+SELECT tpcbox 'SRID=4326;TPCBOX(X((0,0),(5,5)), 1)' +
+  tpcbox 'SRID=3857;TPCBOX(X((3,3),(10,10)), 1)';
 
 -- A box carrying no coordinates names no schema, so it meets a box of any
 -- schema: this is the shape a time-only query box takes against an index
@@ -158,21 +179,45 @@ SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) +
 -- The aggregate answers the extent of the boxes it folds, so it is bounded by
 -- the same comparability the operators are: an extent spanning two schemas, or
 -- two reference systems, states a region no schema can read
-SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 0)),
-  (tpcboxX(3, 3, 10, 10, 1, 0))) t(b);
-SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 0)),
-  (tpcboxX(3, 3, 10, 10, 2, 0))) t(b);
-SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 0, 0)),
-  (tpcboxX(3, 3, 10, 10, 1, 0))) t(b);
-SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1, 4326)),
-  (tpcboxX(3, 3, 10, 10, 1, 3857))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1)),
+  (tpcboxX(3, 3, 10, 10, 1))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1)),
+  (tpcboxX(3, 3, 10, 10, 2))) t(b);
+SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 0)),
+  (tpcboxX(3, 3, 10, 10, 1))) t(b);
+SELECT extent(b) FROM (VALUES (tpcbox 'SRID=4326;TPCBOX(X((0,0),(5,5)), 1)'),
+  (tpcbox 'SRID=3857;TPCBOX(X((3,3),(10,10)), 1)')) t(b);
 
 -------------------------------------------------------------------------------
 -- Comparison operators
 -------------------------------------------------------------------------------
 
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) =  tpcboxX(0, 0, 5, 5, 1, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) <> tpcboxX(0, 0, 5, 5, 2, 0);
-SELECT tpcboxX(0, 0, 5, 5, 1, 0) <  tpcboxX(0, 0, 5, 5, 2, 0);
+SELECT tpcboxX(0, 0, 5, 5, 1) =  tpcboxX(0, 0, 5, 5, 1);
+SELECT tpcboxX(0, 0, 5, 5, 1) <> tpcboxX(0, 0, 5, 5, 2);
+SELECT tpcboxX(0, 0, 5, 5, 1) <  tpcboxX(0, 0, 5, 5, 2);
+
+-------------------------------------------------------------------------------
+-- Input — the two levels that state the reference system
+--
+-- The written form is the one place a value states its reference system twice,
+-- as an `SRID=` prefix and as the schema its pcid names, so it is the one place
+-- the two are reconciled. A level reading SRID_UNKNOWN states nothing.
+-------------------------------------------------------------------------------
+
+-- The schema is the level that holds the SRID, so a value stating none takes
+-- the schema's, and the constructor has no other level to read
+SELECT tpcbox 'TPCBOX(X((0,0),(10,10)), 5)';
+-- Both levels stating the same system is one statement written twice
+SELECT tpcbox 'SRID=4326;TPCBOX(X((0,0),(10,10)), 5)';
+-- Two levels stating different systems is a value contradicting itself
+SELECT tpcbox 'SRID=3857;TPCBOX(X((0,0),(10,10)), 5)';
+-- Where no schema resolves the prefix is the only level there is, which is
+-- what lets a value be read where its schema is not registered
+SELECT tpcbox 'SRID=3857;TPCBOX(X((0,0),(10,10)), 7)';
+SELECT tpcbox 'TPCBOX(X((0,0),(10,10)), 7)';
+
+-------------------------------------------------------------------------------
+
+DELETE FROM pointcloud_formats WHERE pcid IN (2, 5);
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
@@ -108,50 +108,50 @@ SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS seq_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS seq_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS seq_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS seq_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS seq_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS quadtree_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS quadtree_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS quadtree_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS quadtree_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS quadtree_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS quadtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 DROP INDEX tbl_tpcbox_quadtree_idx;
 
 CREATE INDEX tbl_tpcbox_kdtree_idx ON tbl_tpcbox USING spgist(b tpcbox_kdtree_ops);
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcbox WHERE b @> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS kdtree_left FROM tbl_tpcbox WHERE b << tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS kdtree_overleft FROM tbl_tpcbox WHERE b &< tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS kdtree_above FROM tbl_tpcbox WHERE b |>> tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS kdtree_front FROM tbl_tpcbox WHERE b <</ tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 SELECT COUNT(*) AS kdtree_before FROM tbl_tpcbox WHERE b <<# tpcboxZT(0, 0, 0,
-  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  10, 10, 10, tstzspan '[2001-01-01, 2001-12-31]', 1);
 WITH test AS (
   SELECT b |=| tpcboxZT(200, 200, 200, 210, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcbox ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tpcbox_kdtree_idx;
@@ -161,14 +161,17 @@ RESET enable_bitmapscan;
 
 -- The index key of a box keeps its bounds and drops the schema identifier,
 -- so a box of another schema is answered by the operator on the value.
+INSERT INTO pointcloud_formats (pcid, srid, schema)
+SELECT 2, srid, schema FROM pointcloud_formats WHERE pcid = 1;
 CREATE TABLE tbl_tpcbox_pcid AS
   SELECT 1 AS k, tpcboxZT(20, 0, 0, 30, 10, 10,
-    tstzspan '[2001-01-01, 2001-12-31]', 2, 0) AS b;
+    tstzspan '[2001-01-01, 2001-12-31]', 2) AS b;
 CREATE INDEX tbl_tpcbox_pcid_quadtree_idx ON tbl_tpcbox_pcid USING spgist(b);
 SET enable_seqscan = off;
 SELECT COUNT(*) FROM tbl_tpcbox_pcid WHERE b >> tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2001-01-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-01-01, 2001-12-31]', 1);
 RESET enable_seqscan;
 DROP TABLE tbl_tpcbox_pcid;
+DELETE FROM pointcloud_formats WHERE pcid = 2;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint.test.sql
@@ -189,13 +189,15 @@ SELECT atValue(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
 SELECT atTime(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]),
   tstzspan '[2024-01-02, 2024-01-03]') IS NOT NULL;
 SELECT atTpcbox(:inst2, tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NOT NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NOT NULL;
 SELECT minusTpcbox(:inst2, tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NULL;
 
--- Pcid-mismatch identity: at → NULL, minus → unchanged.
-SELECT atTpcbox(:inst1, tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
+-- Pcid-mismatch identity: at → NULL, minus → unchanged. The box is written
+-- rather than constructed because the constructor reads the reference system
+-- off the schema its pcid names, and 999 names none.
+SELECT atTpcbox(:inst1, tpcbox
+  'TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-31]), 999)') IS NULL;
 
 -- Boxes without every dimension: a spatial-only box restricts spatially, a
 -- temporal-only box temporally. Minus of a box covering the whole value is
@@ -356,6 +358,6 @@ SELECT splitEachNSpans(tpcpointSeq(ARRAY[:inst1, :inst2, :inst3]), 2);
 
 SELECT tpcpoint '2300000063000000000000000000F03F00000000000000400000000000000840000000@2024-01-01';
 SELECT tpcpoint '2300000063000000000000000000F03F00000000000000400000000000000840000000@2024-01-01' &&
-  tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
+  tpcbox 'TPCBOX(XT(((0,0),(10,10)),[2024-01-01, 2024-01-31]), 99)';
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/420_tpcpoint_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/420_tpcpoint_tbl.test.sql
@@ -110,18 +110,20 @@ WHERE atTime(temp, tstzspan '[2001-01-01, 2002-01-01]') IS NOT NULL;
 -- atTpcbox over the full datagen extent leaves every row populated.
 SELECT COUNT(*) FROM tbl_tpcpoint WHERE atTpcbox(temp,
   tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 1, 0)) IS NOT NULL;
+    tstzspan '[2001-01-01, 2001-12-31]', 1)) IS NOT NULL;
 
 -- atTpcbox with a pcid mismatch yields NULL (empty) for every row.
 SELECT bool_and(atTpcbox(temp,
-  tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NULL)
+  tpcbox
+    'TPCBOX(ZT(((-100,-100,0),(100,100,100)),[2001-01-01, 2001-12-31]), 999)')
+  IS NULL)
 FROM tbl_tpcpoint;
 
 -- minusTpcbox is the complement.
 SELECT bool_and(minusTpcbox(temp,
-  tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NOT NULL)
+  tpcbox
+    'TPCBOX(ZT(((-100,-100,0),(100,100,100)),[2001-01-01, 2001-12-31]), 999)')
+  IS NOT NULL)
 FROM tbl_tpcpoint;
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch.test.sql
@@ -198,11 +198,13 @@ SELECT atValue(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3, :inst4]),
 SELECT atTime(tpcpatchSeq(ARRAY[:inst1, :inst2]),
   tstzspan '[2024-01-02, 2024-01-03]') IS NOT NULL;
 SELECT atTpcbox(:inst1, tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NOT NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NOT NULL;
 SELECT minusTpcbox(:inst1, tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
-SELECT atTpcbox(:inst1, tpcboxZT(0, 0, 0, 10, 10, 10,
-  tstzspan '[2024-01-01, 2024-01-31]', 999, 0)) IS NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NULL;
+-- The box is written rather than constructed because the constructor reads the
+-- reference system off the schema its pcid names, and 999 names none.
+SELECT atTpcbox(:inst1, tpcbox
+  'TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-31]), 999)') IS NULL;
 
 -- Boxes without every dimension: a spatial-only box applies the PCBOUNDS
 -- test alone, a temporal-only box the period test alone.
@@ -239,26 +241,26 @@ SELECT numInstants(afterTimestamp(:inst2, timestamptz '2024-01-02', false));
 -------------------------------------------------------------------------------
 
 SELECT numInstants(atTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 3, 3, 3,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
+  tstzspan '[2024-01-01, 2024-01-31]', 1)));
 SELECT startNumPoints(atTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 3, 3, 3,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
+  tstzspan '[2024-01-01, 2024-01-31]', 1)));
 SELECT startNumPoints(atTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 1, 1, 1,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
+  tstzspan '[2024-01-01, 2024-01-31]', 1)));
 SELECT atTpcboxFine(:inst1, tpcboxZT(10, 10, 10, 20, 20, 20,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NULL;
 
 -- minus is the complement.
 SELECT minusTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 3, 3, 3,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)) IS NULL;
+  tstzspan '[2024-01-01, 2024-01-31]', 1)) IS NULL;
 SELECT startNumPoints(minusTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 1, 1, 1,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0)));
+  tstzspan '[2024-01-01, 2024-01-31]', 1)));
 
 -- The patch a restriction that drops a point answers is read back point by
 -- point, which is what states that its data area holds the survivors alone.
 SELECT PC_AsText(getValue(atTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 1, 1, 1,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
+  tstzspan '[2024-01-01, 2024-01-31]', 1))));
 SELECT PC_AsText(getValue(minusTpcboxFine(:inst1, tpcboxZT(0, 0, 0, 1, 1, 1,
-  tstzspan '[2024-01-01, 2024-01-31]', 1, 0))));
+  tstzspan '[2024-01-01, 2024-01-31]', 1))));
 
 -------------------------------------------------------------------------------
 -- Per-point restrictions by geometry — atGeometry / minusGeometry.
@@ -371,6 +373,6 @@ SELECT splitEachNSpans(tpcpatchSeq(ARRAY[:inst1, :inst2, :inst3]), 2);
 
 SELECT tpcpatch '4F000000630000000000000002000000000000000000F03F000000000000F03F000000000000F03F0000000000000040000000000000004000000000000000400000000000000000000000000000@2024-01-01';
 SELECT tpcpatch '4F000000630000000000000002000000000000000000F03F000000000000F03F000000000000F03F0000000000000040000000000000004000000000000000400000000000000000000000000000@2024-01-01' &&
-  tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 99, 0);
+  tpcbox 'TPCBOX(XT(((0,0),(10,10)),[2024-01-01, 2024-01-31]), 99)';
 
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/queries/430_tpcpatch_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/430_tpcpatch_tbl.test.sql
@@ -117,18 +117,20 @@ WHERE atTime(temp, tstzspan '[2001-01-01, 2002-01-01]') IS NOT NULL;
 -- atTpcbox over the full datagen extent leaves every row populated.
 SELECT COUNT(*) FROM tbl_tpcpatch WHERE atTpcbox(temp,
   tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 1, 0)) IS NOT NULL;
+    tstzspan '[2001-01-01, 2001-12-31]', 1)) IS NOT NULL;
 
 -- atTpcbox with a pcid mismatch yields NULL (empty) for every row.
 SELECT bool_and(atTpcbox(temp,
-  tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NULL)
+  tpcbox
+    'TPCBOX(ZT(((-100,-100,0),(100,100,100)),[2001-01-01, 2001-12-31]), 999)')
+  IS NULL)
 FROM tbl_tpcpatch;
 
 -- minusTpcbox is the complement.
 SELECT bool_and(minusTpcbox(temp,
-  tpcboxZT(-100, -100, 0, 100, 100, 100,
-    tstzspan '[2001-01-01, 2001-12-31]', 999, 0)) IS NOT NULL)
+  tpcbox
+    'TPCBOX(ZT(((-100,-100,0),(100,100,100)),[2001-01-01, 2001-12-31]), 999)')
+  IS NOT NULL)
 FROM tbl_tpcpatch;
 
 -------------------------------------------------------------------------------
@@ -143,17 +145,17 @@ FROM tbl_tpcpatch;
 SELECT COUNT(*) FROM tbl_tpcpatch
 WHERE atTpcboxFine(temp,
   tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-    tstzspan '[2001-01-01, 2002-01-01]', 1, 0)) IS NOT NULL;
+    tstzspan '[2001-01-01, 2002-01-01]', 1)) IS NOT NULL;
 
 -- For every row, fine-restrict point counts at most equal the un-restricted
 -- count.
 SELECT bool_and(numPoints(atTpcboxFine(temp,
   tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-    tstzspan '[2001-01-01, 2002-01-01]', 1, 0))) <= numPoints(temp))
+    tstzspan '[2001-01-01, 2002-01-01]', 1))) <= numPoints(temp))
 FROM tbl_tpcpatch
 WHERE atTpcboxFine(temp,
   tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-    tstzspan '[2001-01-01, 2002-01-01]', 1, 0)) IS NOT NULL;
+    tstzspan '[2001-01-01, 2002-01-01]', 1)) IS NOT NULL;
 
 -- atGeometry over a generously-sized polygon keeps every row.
 SELECT COUNT(*) FROM tbl_tpcpatch

--- a/mobilitydb/test/pointcloud/queries/436_tpc_topops.test.sql
+++ b/mobilitydb/test/pointcloud/queries/436_tpc_topops.test.sql
@@ -32,9 +32,11 @@
 
 \set p1 'tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), ''2024-01-01''::timestamptz)'
 \set p2 'tpcpoint(PC_MakePoint(1, ARRAY[5.0, 5.0, 5.0]::float[]), ''2024-01-05''::timestamptz)'
-\set big_box 'tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan ''[2024-01-01, 2024-01-31]'', 1, 0)'
-\set far_box 'tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan ''[2099-01-01, 2099-12-31]'', 1, 0)'
-\set bad_box 'tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan ''[2024-01-01, 2024-01-31]'', 999, 0)'
+\set big_box 'tpcboxZT(0, 0, 0, 10, 10, 10, tstzspan ''[2024-01-01, 2024-01-31]'', 1)'
+\set far_box 'tpcboxZT(100, 100, 100, 110, 110, 110, tstzspan ''[2099-01-01, 2099-12-31]'', 1)'
+-- The box of a schema that is not registered is written rather than built: a
+-- constructor reads the reference system off the schema its pcid names.
+\set bad_box 'tpcbox ''TPCBOX(ZT(((0,0,0),(10,10,10)),[2024-01-01, 2024-01-31]), 999)'''
 \set span_in 'tstzspan ''[2024-01-01, 2024-01-31]'''
 \set span_far 'tstzspan ''[2099-01-01, 2099-12-31]'''
 

--- a/mobilitydb/test/pointcloud/queries/436_tpc_topops_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/436_tpc_topops_tbl.test.sql
@@ -53,17 +53,17 @@ SELECT bool_and(NOT (temp -|- temp)) FROM tbl_tpcpatch;
 -------------------------------------------------------------------------------
 
 SELECT bool_and(tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0) @> temp)
+  tstzspan '[2001-01-01, 2030-01-01]', 1) @> temp)
 FROM tbl_tpcpoint;
 SELECT bool_and(tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0) @> temp)
+  tstzspan '[2001-01-01, 2030-01-01]', 1) @> temp)
 FROM tbl_tpcpatch;
 
 -- Reverse direction: every row is contained in that big box.
 SELECT bool_and(temp <@ tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0)) FROM tbl_tpcpoint;
+  tstzspan '[2001-01-01, 2030-01-01]', 1)) FROM tbl_tpcpoint;
 SELECT bool_and(temp <@ tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0)) FROM tbl_tpcpatch;
+  tstzspan '[2001-01-01, 2030-01-01]', 1)) FROM tbl_tpcpatch;
 
 -- Time-only: every row's tstzspan is contained in this wide span.
 SELECT bool_and(temp <@ tstzspan '[2001-01-01, 2030-01-01]') FROM tbl_tpcpoint;

--- a/mobilitydb/test/pointcloud/queries/437_tpc_posops.test.sql
+++ b/mobilitydb/test/pointcloud/queries/437_tpc_posops.test.sql
@@ -32,8 +32,8 @@
 
 \set p_low  'tpcpoint(PC_MakePoint(1, ARRAY[1.0, 1.0, 1.0]::float[]), ''2024-01-01''::timestamptz)'
 \set p_high 'tpcpoint(PC_MakePoint(1, ARRAY[10.0, 10.0, 10.0]::float[]), ''2024-01-15''::timestamptz)'
-\set box_left  'tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan ''[2024-01-01, 2024-01-15]'', 1, 0)'
-\set box_right 'tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan ''[2025-01-01, 2025-01-15]'', 1, 0)'
+\set box_left  'tpcboxZT(0, 0, 0, 5, 5, 5,    tstzspan ''[2024-01-01, 2024-01-15]'', 1)'
+\set box_right 'tpcboxZT(20, 20, 20, 30, 30, 30, tstzspan ''[2025-01-01, 2025-01-15]'', 1)'
 
 -------------------------------------------------------------------------------
 -- X axis: <<, >>, &<, &>

--- a/mobilitydb/test/pointcloud/queries/437_tpc_posops_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/437_tpc_posops_tbl.test.sql
@@ -58,11 +58,11 @@ SELECT bool_and(NOT (temp #>> temp)) FROM tbl_tpcpatch;
 
 SELECT COUNT(*) FROM tbl_tpcpoint
 WHERE temp << tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2030-01-01]', 1);
 
 SELECT COUNT(*) FROM tbl_tpcpoint
 WHERE tpcboxZT(-200, -200, -200, 200, 200, 200,
-  tstzspan '[2001-01-01, 2030-01-01]', 1, 0) >> temp;
+  tstzspan '[2001-01-01, 2030-01-01]', 1) >> temp;
 
 -- Reverse: every row is "before" a span that starts well after
 -- the data extent.

--- a/mobilitydb/test/pointcloud/queries/438_tpc_distance.test.sql
+++ b/mobilitydb/test/pointcloud/queries/438_tpc_distance.test.sql
@@ -31,8 +31,8 @@
 
 \set p1 'tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]), ''2024-01-01''::timestamptz)'
 \set p2 'tpcpoint(PC_MakePoint(1, ARRAY[3.0, 4.0, 0.0]::float[]), ''2024-01-01''::timestamptz)'
-\set box_at_origin 'tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan ''[2024-01-01, 2024-01-02]'', 1, 0)'
-\set box_far       'tpcboxZT(3, 4, 0, 3, 4, 0, tstzspan ''[2024-01-01, 2024-01-02]'', 1, 0)'
+\set box_at_origin 'tpcboxZT(0, 0, 0, 0, 0, 0, tstzspan ''[2024-01-01, 2024-01-02]'', 1)'
+\set box_far       'tpcboxZT(3, 4, 0, 3, 4, 0, tstzspan ''[2024-01-01, 2024-01-02]'', 1)'
 
 -- Self-distance is zero.
 SELECT (:p1) |=| (:p1);
@@ -51,11 +51,12 @@ SELECT (:p1) |=| (:box_at_origin);
 SELECT (tpcpoint(PC_MakePoint(1, ARRAY[0.0, 0.0, 0.0]::float[]),
                  '2024-01-01'::timestamptz)) |=|
        (tpcboxZT(0, 0, 0, 0, 0, 0,
-                  tstzspan '[2099-01-01, 2099-01-02]', 1, 0)) IS NULL;
+                  tstzspan '[2099-01-01, 2099-01-02]', 1)) IS NULL;
 
--- Pcid mismatch is an error: values of two schemas cannot be compared.
-SELECT (:p1) |=| (tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2024-01-01, 2024-01-02]', 999, 0)) > 1e10;
+-- Pcid mismatch is an error: values of two schemas cannot be compared. The
+-- box is written rather than built, 999 naming no registered schema.
+SELECT (:p1) |=| (tpcbox
+  'TPCBOX(ZT(((0,0,0),(0,0,0)),[2024-01-01, 2024-01-02]), 999)') > 1e10;
 
 -- The same holds between two temporal pointcloud values. A second schema is
 -- registered as a copy of the first one, as the typmod test does.

--- a/mobilitydb/test/pointcloud/queries/438_tpc_distance_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/438_tpc_distance_tbl.test.sql
@@ -49,20 +49,20 @@ SET enable_seqscan = on;
 SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT k, ((temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2001-06-01, 2001-06-30]', 1, 0)) > 0)::text AS finite
+  tstzspan '[2001-06-01, 2001-06-30]', 1)) > 0)::text AS finite
 FROM tbl_tpcpoint
 ORDER BY temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2001-06-01, 2001-06-30]', 1, 0)
+  tstzspan '[2001-06-01, 2001-06-30]', 1)
 LIMIT 5;
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT k, ((temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2001-06-01, 2001-06-30]', 1, 0)) > 0)::text AS finite
+  tstzspan '[2001-06-01, 2001-06-30]', 1)) > 0)::text AS finite
 FROM tbl_tpcpoint
 ORDER BY temp |=| tpcboxZT(0, 0, 0, 0, 0, 0,
-  tstzspan '[2001-06-01, 2001-06-30]', 1, 0)
+  tstzspan '[2001-06-01, 2001-06-30]', 1)
 LIMIT 5;
 
 DROP INDEX tbl_tpcpoint_gist_dist_idx;

--- a/mobilitydb/test/pointcloud/queries/439_tpc_gist_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/439_tpc_gist_tbl.test.sql
@@ -42,14 +42,14 @@ SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 DROP INDEX tbl_tpcpoint_gist_idx;
 RESET enable_seqscan;
@@ -67,14 +67,14 @@ SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 DROP INDEX tbl_tpcpatch_gist_idx;
 RESET enable_seqscan;
@@ -94,31 +94,31 @@ CREATE INDEX tbl_tpcpatch_gist_idx ON tbl_tpcpatch USING gist(temp);
 SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_contained FROM tbl_tpcpatch
 WHERE temp <@ tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-  tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2002-01-01]', 1);
 SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_contained FROM tbl_tpcpatch
 WHERE temp <@ tpcboxZT(-1000, -1000, -1000, 1000, 1000, 1000,
-  tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2002-01-01]', 1);
 
 -- <<# : strictly before (time)
 SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_before FROM tbl_tpcpatch
 WHERE temp <<# tpcboxZT(0, 0, 0, 100, 100, 100,
-  tstzspan '[2001-12-15, 2002-01-01]', 1, 0);
+  tstzspan '[2001-12-15, 2002-01-01]', 1);
 SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_before FROM tbl_tpcpatch
 WHERE temp <<# tpcboxZT(0, 0, 0, 100, 100, 100,
-  tstzspan '[2001-12-15, 2002-01-01]', 1, 0);
+  tstzspan '[2001-12-15, 2002-01-01]', 1);
 
 -- << : strictly left (X)
 SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_left FROM tbl_tpcpatch
 WHERE temp << tpcboxZT(50, -1000, -1000, 1000, 1000, 1000,
-  tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2002-01-01]', 1);
 SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_left FROM tbl_tpcpatch
 WHERE temp << tpcboxZT(50, -1000, -1000, 1000, 1000, 1000,
-  tstzspan '[2001-01-01, 2002-01-01]', 1, 0);
+  tstzspan '[2001-01-01, 2002-01-01]', 1);
 
 DROP INDEX tbl_tpcpatch_gist_idx;
 RESET enable_seqscan;
@@ -174,22 +174,22 @@ CREATE INDEX tbl_tpcpatch_gist_idx ON tbl_tpcpatch USING gist(temp);
 SET enable_seqscan = on;  SET enable_indexscan = off; SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_fn_box FROM tbl_tpcpoint
 WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+  tstzspan '[2001-06-01, 2001-12-31]', 1));
 SELECT COUNT(*) AS seq_fn_span FROM tbl_tpcpoint
 WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
 SELECT COUNT(*) AS seq_fn_patch FROM tbl_tpcpatch
 WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+  tstzspan '[2001-06-01, 2001-12-31]', 1));
 
 SET enable_seqscan = off; SET enable_indexscan = on; SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_fn_box FROM tbl_tpcpoint
 WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+  tstzspan '[2001-06-01, 2001-12-31]', 1));
 SELECT COUNT(*) AS idx_fn_span FROM tbl_tpcpoint
 WHERE overlaps(temp, tstzspan '[2001-06-01, 2001-12-31]');
 SELECT COUNT(*) AS idx_fn_patch FROM tbl_tpcpatch
 WHERE overlaps(temp, tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0));
+  tstzspan '[2001-06-01, 2001-12-31]', 1));
 
 DROP INDEX tbl_tpcpoint_gist_idx;
 DROP INDEX tbl_tpcpatch_gist_idx;

--- a/mobilitydb/test/pointcloud/queries/440_tpc_spgist_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/440_tpc_spgist_tbl.test.sql
@@ -42,14 +42,14 @@ SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 DROP INDEX tbl_tpcpoint_quadtree_idx;
 
@@ -62,7 +62,7 @@ CREATE INDEX tbl_tpcpoint_kdtree_idx ON tbl_tpcpoint
 
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcpoint
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 DROP INDEX tbl_tpcpoint_kdtree_idx;
 
@@ -77,14 +77,14 @@ SET enable_indexscan = off;
 SET enable_bitmapscan = off;
 SELECT COUNT(*) AS seq_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 SET enable_seqscan = off;
 SET enable_indexscan = on;
 SET enable_bitmapscan = on;
 SELECT COUNT(*) AS idx_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 DROP INDEX tbl_tpcpatch_quadtree_idx;
 
@@ -93,7 +93,7 @@ CREATE INDEX tbl_tpcpatch_kdtree_idx ON tbl_tpcpatch
 
 SELECT COUNT(*) AS kdtree_count FROM tbl_tpcpatch
 WHERE temp && tpcboxZT(0, 0, 0, 50, 50, 50,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0);
+  tstzspan '[2001-06-01, 2001-12-31]', 1);
 
 DROP INDEX tbl_tpcpatch_kdtree_idx;
 
@@ -108,7 +108,7 @@ RESET enable_bitmapscan;
 CREATE INDEX tbl_tpcpoint_knn_quadtree_idx ON tbl_tpcpoint USING spgist(temp);
 WITH test AS (
   SELECT temp |=| tpcboxZT(200, 200, 200, 210, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tpcpoint_knn_quadtree_idx;
@@ -117,7 +117,7 @@ CREATE INDEX tbl_tpcpoint_knn_kdtree_idx ON tbl_tpcpoint
   USING spgist(temp tpcpoint_kdtree_ops);
 WITH test AS (
   SELECT temp |=| tpcboxZT(200, 200, 200, 210, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tpcpoint_knn_kdtree_idx;
@@ -125,7 +125,7 @@ DROP INDEX tbl_tpcpoint_knn_kdtree_idx;
 CREATE INDEX tbl_tpcpatch_knn_quadtree_idx ON tbl_tpcpatch USING spgist(temp);
 WITH test AS (
   SELECT temp |=| tpcboxXT(200, 200, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tpcpatch_knn_quadtree_idx;
@@ -134,7 +134,7 @@ CREATE INDEX tbl_tpcpatch_knn_kdtree_idx ON tbl_tpcpatch
   USING spgist(temp tpcpatch_kdtree_ops);
 WITH test AS (
   SELECT temp |=| tpcboxXT(200, 200, 210, 210,
-  tstzspan '[2001-06-01, 2001-12-31]', 1, 0) AS distance
+  tstzspan '[2001-06-01, 2001-12-31]', 1) AS distance
   FROM tbl_tpcpatch ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tpcpatch_knn_kdtree_idx;

--- a/mobilitydb/test/pointcloud/smoketest.sql
+++ b/mobilitydb/test/pointcloud/smoketest.sql
@@ -68,10 +68,10 @@ SELECT numValues(set(ARRAY[
 
 \echo '=== pgpointcloud smoke: TPCBox bounding box ==='
 
-SELECT xmin(tpcboxX(10, 20, 30, 40, 1, 0))         AS tpcbox_xmin_expect_10,
-       xmax(tpcboxX(10, 20, 30, 40, 1, 0))         AS tpcbox_xmax_expect_30,
-       pcid(tpcboxX(10, 20, 30, 40, 7, 0))         AS tpcbox_pcid_expect_7,
-       hasZ(tpcboxZ(1, 2, 3, 4, 5, 6, 1, 0))     AS tpcbox_hasz_expect_true;
+SELECT xmin(tpcboxX(10, 20, 30, 40, 1))         AS tpcbox_xmin_expect_10,
+       xmax(tpcboxX(10, 20, 30, 40, 1))         AS tpcbox_xmax_expect_30,
+       pcid(tpcboxX(10, 20, 30, 40, 1))         AS tpcbox_pcid_expect_1,
+       hasZ(tpcboxZ(1, 2, 3, 4, 5, 6, 1))     AS tpcbox_hasz_expect_true;
 
 SELECT xmin(tpcbox(PC_Patch(PC_MakePoint(1, ARRAY[10.0, 20.0, 30.0]))))
        AS patch_to_tpcbox_xmin_expect_10;


### PR DESCRIPTION
The SRID a TPCBox carries is the one its schema states, so the four
coordinate-carrying constructors resolve it from the pcid instead of taking
it, and the explicit override goes. pgPointCloud is the model: PC_MakePoint
and PC_MakePatch take a pcid alone, no function in that extension takes an
srid, and pointcloud_columns derives the srid by joining the pcid to
pointcloud_formats. tpcboxX, tpcboxZ, tpcboxXT and tpcboxZT lose their srid
parameter, and tpcbox(pcpatch, srid integer) loses its overload.

A pcid naming no registered schema is an error rather than a box with an
assumed SRID, which is how PC_MakePoint answers the same input. Before this
the resolver read the NULL that the schema lookup returns on a miss and took
the backend down; tpcbox(pcpatch) held the same unguarded read and now goes
through the same resolver.

The written form is the one place a value states its reference system twice,
as an SRID= prefix and as the schema its pcid names, so it is the one place
the two are reconciled. A level reading SRID_UNKNOWN states nothing and the
other stands; two levels stating different systems is a value contradicting
itself and an error; and where no schema resolves, the prefix is the only
level there is. That last branch is what lets a value be read where its
schema is not registered, which a MEOS program with no catalog behind it
depends on.

The absorb goes from tpcbox_expand and inter_tpcbox_tpcbox with it. A combine
grows what two boxes measure and leaves what they are measured in alone,
which is what stbox_expand already does.

A test naming a pcid no schema declares now writes its box rather than
constructing it, the constructor reading the catalog and the parser
deliberately not. 410_tpcbox registers the schemas it reads, covers the two
new refusals, and reaches the mixed-SRID guard through the written form,
which is where two boxes of one schema can still disagree about the SRID.

