### PR TITLE
Make the temporal box extent aggregate answer what its operator answers

### DIFF
--- a/meos/include/temporal/tbox.h
+++ b/meos/include/temporal/tbox.h
@@ -54,6 +54,10 @@
 
 extern bool ensure_same_dimensionality_tbox(const TBox *box1, const TBox *box2);
 
+/* Validity of a pair of temporal boxes */
+
+extern bool ensure_valid_tbox_tbox(const TBox *box1, const TBox *box2);
+
 /* Conversion */
 
 extern TBox *set_tbox(const Set *s);

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -1602,7 +1602,7 @@ tbox_tbox_flags(const TBox *box1, const TBox *box2, bool *hasx, bool *hast)
  * this one
  * @param[in] box1,box2 Temporal boxes
  */
-static bool
+bool
 ensure_valid_tbox_tbox(const TBox *box1, const TBox *box2)
 {
   /* Ensure the validity of the arguments */

--- a/mobilitydb/src/temporal/tbox.c
+++ b/mobilitydb/src/temporal/tbox.c
@@ -1080,6 +1080,10 @@ Tbox_extent_transfn(PG_FUNCTION_ARGS)
   }
 
   /* Both boxes are not null */
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tbox_tbox(box1, box2) ||
+      ! ensure_same_dimensionality_tbox(box1, box2))
+    PG_RETURN_NULL();
   memcpy(result, box1, sizeof(TBox));
   tbox_expand(box2, result);
   PG_RETURN_TBOX_P(result);
@@ -1103,7 +1107,10 @@ Tbox_extent_combinefn(PG_FUNCTION_ARGS)
   if (!box1 && box2)
     PG_RETURN_TBOX_P(box2);
   /* Both boxes are not null */
-  ensure_same_dimensionality_tbox(box1, box2);
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_tbox_tbox(box1, box2) ||
+      ! ensure_same_dimensionality_tbox(box1, box2))
+    PG_RETURN_NULL();
   TBox *result = tbox_copy(box1);
   tbox_expand(box2, result);
   PG_RETURN_TBOX_P(result);

--- a/mobilitydb/test/temporal/expected/021_tbox.test.out
+++ b/mobilitydb/test/temporal/expected/021_tbox.test.out
@@ -1341,6 +1341,45 @@ SELECT extent(box) FROM test;
  TBOXFLOAT XT([1, 3],[Mon Jan 01 00:00:00 2001 PST, Wed Jan 03 00:00:00 2001 PST])
 (1 row)
 
+WITH test(box) AS (
+  SELECT tbox 'TBOXINT XT([1,2],[2001-01-01,2001-01-02])' UNION ALL
+  SELECT tbox 'TBOXFLOAT XT([3,4],[2001-01-03,2001-01-04])' )
+SELECT extent(box) FROM test;
+ERROR:  Operation on mixed span types: intspan and floatspan
+SELECT tbox_extent_transfn(tbox 'TBOXINT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+ERROR:  Operation on mixed span types: intspan and floatspan
+SELECT tbox_extent_combinefn(tbox 'TBOXINT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+ERROR:  Operation on mixed span types: intspan and floatspan
+SELECT tbox_extent_transfn(tbox 'TBOXFLOAT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+ tbox_extent_transfn 
+---------------------
+ TBOXFLOAT X([1, 4])
+(1 row)
+
+SELECT tbox_extent_combinefn(tbox 'TBOXFLOAT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+ tbox_extent_combinefn 
+-----------------------
+ TBOXFLOAT X([1, 4])
+(1 row)
+
+SELECT tbox_extent_combinefn(NULL, tbox 'TBOXFLOAT X([3,4])');
+ tbox_extent_combinefn 
+-----------------------
+ TBOXFLOAT X([3, 4])
+(1 row)
+
+SELECT tbox_extent_combinefn(tbox 'TBOXFLOAT X([1,2])', NULL);
+ tbox_extent_combinefn 
+-----------------------
+ TBOXFLOAT X([1, 2])
+(1 row)
+
+SELECT tbox_extent_transfn(tbox 'TBOXFLOAT X([1,2])',
+  tbox 'TBOXFLOAT XT([3,4],[2001-01-03,2001-01-04])');
+ERROR:  The boxes must be of the same dimensionality
+SELECT tbox_extent_combinefn(tbox 'TBOXFLOAT X([1,2])',
+  tbox 'TBOXFLOAT XT([3,4],[2001-01-03,2001-01-04])');
+ERROR:  The boxes must be of the same dimensionality
 SELECT cmp(tbox 'TBOXFLOAT XT([1.0,1.0],[2001-01-02,2001-01-02])', tbox 'TBOXFLOAT XT([1.0,2.0],[2001-01-02, 2001-01-02])');
  cmp 
 -----

--- a/mobilitydb/test/temporal/queries/021_tbox.test.sql
+++ b/mobilitydb/test/temporal/queries/021_tbox.test.sql
@@ -420,6 +420,31 @@ WITH test(box) AS (
   SELECT NULL::tbox UNION ALL SELECT tbox 'TBOXFLOAT XT([1,3],[2001-01-01,2001-01-03])' )
 SELECT extent(box) FROM test;
 
+-- The span type states what a box measures, so an extent spanning two of them
+-- states a quantity nothing reads, exactly as the + operator on the same pair
+-- already answers
+WITH test(box) AS (
+  SELECT tbox 'TBOXINT XT([1,2],[2001-01-01,2001-01-02])' UNION ALL
+  SELECT tbox 'TBOXFLOAT XT([3,4],[2001-01-03,2001-01-04])' )
+SELECT extent(box) FROM test;
+
+-- Both machinery functions of the aggregate answer on the same terms as the
+-- operator. The combine is reached by a parallel plan alone, so it is called
+-- directly here
+SELECT tbox_extent_transfn(tbox 'TBOXINT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+SELECT tbox_extent_combinefn(tbox 'TBOXINT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+SELECT tbox_extent_transfn(tbox 'TBOXFLOAT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+SELECT tbox_extent_combinefn(tbox 'TBOXFLOAT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+-- A box carrying no value span states no span type, so it is comparable with
+-- any box, and a null side leaves the other untouched
+SELECT tbox_extent_combinefn(NULL, tbox 'TBOXFLOAT X([3,4])');
+SELECT tbox_extent_combinefn(tbox 'TBOXFLOAT X([1,2])', NULL);
+-- Which dimensions a box holds is the second question, asked after the first
+SELECT tbox_extent_transfn(tbox 'TBOXFLOAT X([1,2])',
+  tbox 'TBOXFLOAT XT([3,4],[2001-01-03,2001-01-04])');
+SELECT tbox_extent_combinefn(tbox 'TBOXFLOAT X([1,2])',
+  tbox 'TBOXFLOAT XT([3,4],[2001-01-03,2001-01-04])');
+
 -------------------------------------------------------------------------------
 -- Comparison functions
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The span type states what a temporal box measures, so two boxes measuring
different quantities have no common extent. The operator says so:
tbox 'TBOXINT X([1,2])' + tbox 'TBOXFLOAT X([3,4])' answers "Operation on
mixed span types: intspan and floatspan". The aggregate over the same pair
answers TBOXINT X([1, 0]) — a span whose upper bound sits below its lower one,
the int span machinery reading a float span's bytes. Both machinery functions
of the aggregate now read the comparability validator the operators read, so
the three answers agree.

ensure_valid_tbox_tbox becomes visible to the PostgreSQL layer, as
ensure_valid_stbox_stbox already is for the spatiotemporal box, whose extent
aggregate reads it on both of its paths. The dimensionality test the combine
already carried is now read rather than discarded, which is the second layer:
comparability first, then which dimensions the operation needs.

extent(tbox) is declared PARALLEL = safe, and its combine is reached by a
parallel plan alone, so the tests call both machinery functions directly
rather than depending on a worker being available.