### PR TITLE
Say what every remaining function does in its brief

### DIFF
--- a/meos/examples/read_spatial_ref_sys.c
+++ b/meos/examples/read_spatial_ref_sys.c
@@ -68,7 +68,7 @@ typedef struct
 } PjStrs;
 
 /**
- * @brief 
+ * @brief Return the PROJ strings of an SRID, read from the spatial_ref_sys table
  */
 static PjStrs
 GetProjStringsSPI(int32_t srid)

--- a/meos/src/cbuffer/tcbuffer_distance.c
+++ b/meos/src/cbuffer/tcbuffer_distance.c
@@ -1839,7 +1839,8 @@ nad_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
- * @brief
+ * @brief Bounding box of one segment of a temporal circular buffer sequence,
+ * carrying the index of the segment it bounds
  */
 typedef struct
 {
@@ -1851,7 +1852,8 @@ typedef struct
 } TcbufferSegBox;
 
 /**
- * @brief
+ * @brief Compare two segment boxes by their minimum x, the order the sweep reads
+ * them in
  */
 static int
 tcbuffersegbox_cmp_minx(const void *a, const void *b)

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -3225,7 +3225,7 @@ ensure_circle_type(const GSERIALIZED *gs)
 
 /**
  * @brief Return true if a point lies on the boundary of a geometry
- * @brief Uses the exact line/arc engine
+ * @details Uses the exact line/arc engine
  */
 bool
 relate_point_on_boundary(double x, double y, Edge **edges, int nedges)
@@ -4054,7 +4054,7 @@ relate_point_area(const LWGEOM *point_geom, const LWGEOM *area_geom,
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Set the DE-9IM matrix of a linear geometry and a point
  */
 static void
 relate_linear_point(const LWGEOM *line_geom, const LWGEOM *point_geom,
@@ -4132,7 +4132,7 @@ relate_linear_edges_overlap(const Edge *a, const Edge *b, double *t0,
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Set the DE-9IM matrix of an areal geometry and a point
  */
 static void
 relate_area_point(const LWGEOM *area_geom, const LWGEOM *point_geom,
@@ -5174,7 +5174,7 @@ relate_linear_area(const LWGEOM *line_geom, const LWGEOM *area_geom,
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Set the DE-9IM matrix of an areal geometry and a linear one
  */
 static void
 relate_area_linear(const LWGEOM *area_geom, const LWGEOM *line_geom,

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1850,7 +1850,7 @@ stbox_stbox_flags(const STBox *box1, const STBox *box2, bool *hasx,
 /**
  * @brief Verify the conditions and set the ouput variables with the values of
  * the flags of the boxes
- * @brief Mixing 2D/3D is enabled to compute, for example, 2.5D operations
+ * @details Mixing 2D/3D is enabled to compute, for example, 2.5D operations
  * @param[in] box1,box2 Input boxes
  * @param[out] hasx,hasz,hast,geodetic Boolean variables
  */

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -3078,7 +3078,8 @@ stbox_spatial_distance(const STBox *box1, const STBox *box2)
  *****************************************************************************/
 
 /**
- * @brief
+ * @brief Bounding box of one segment of a temporal point sequence, carrying the
+ * index of the segment it bounds
  */
 typedef struct
 {
@@ -3090,7 +3091,8 @@ typedef struct
 } SegBox;
 
 /**
- * @brief
+ * @brief Compare two segment boxes by their minimum x, the order the sweep reads
+ * them in
  */
 static int
 segbox_cmp_minx(const void *a, const void *b)
@@ -3101,7 +3103,8 @@ segbox_cmp_minx(const void *a, const void *b)
 }
 
 /**
- * @brief
+ * @brief Return the minimum distance between two temporal point sequences, giving
+ * up once a threshold is reached
  */
 static double
 mindist_tpointseq_tpointseq_threshold(const TSequence *seq1,
@@ -3319,7 +3322,7 @@ typedef struct
 } TgeoarrPair;
 
 /**
- * @brief
+ * @brief Compare two candidate pairs by the distance between their bounding boxes
  */
 static int
 tgeoarr_pair_cmp(const void *a, const void *b)

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -90,7 +90,7 @@
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Serialized point cloud patch, laid out as the upstream library writes it
  */
 typedef struct
 {

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -95,7 +95,7 @@
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Serialized point cloud point, laid out as the upstream library writes it
  */
 typedef struct
 {

--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -60,7 +60,7 @@
  *****************************************************************************/
 
 /**
- * @brief
+ * @brief Point cloud schema held in the cache, keyed by the pcid it belongs to
  */
 typedef struct schema_entry {
   uint32_t pcid;

--- a/meos/src/quadbin/tquadbin.c
+++ b/meos/src/quadbin/tquadbin.c
@@ -390,7 +390,8 @@ tquadbin_value_at_timestamptz(const Temporal *temp, TimestampTz t,
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return a value unchanged, the value function of the casts between
+ * tbigint and tquadbin, which share the same representation
  */
 static Datum
 datum_quadbin_identity(Datum d)
@@ -448,7 +449,7 @@ tquadbin_to_tbigint(const Temporal *temp)
  *****************************************************************************/
 
 /**
- * @brief 
+ * @brief Return true if two quadbin cells are equal
  */
 Datum
 datum2_quadbin_eq(Datum d1, Datum d2, MeosType type)
@@ -458,7 +459,7 @@ datum2_quadbin_eq(Datum d1, Datum d2, MeosType type)
 }
 
 /**
- * @brief 
+ * @brief Return true if two quadbin cells are different
  */
 Datum
 datum2_quadbin_ne(Datum d1, Datum d2, MeosType type)

--- a/meos/src/quadbin/tquadbin_ops.c
+++ b/meos/src/quadbin/tquadbin_ops.c
@@ -70,7 +70,7 @@
  *****************************************************************************/
 
 /**
- * @brief
+ * @brief Return the resolution of a quadbin cell
  */
 static Datum
 datum_quadbin_get_resolution(Datum d)
@@ -79,7 +79,7 @@ datum_quadbin_get_resolution(Datum d)
 }
 
 /**
- * @brief
+ * @brief Return true if a value is a valid quadbin cell
  */
 static Datum
 datum_quadbin_is_valid_cell(Datum d)
@@ -88,7 +88,7 @@ datum_quadbin_is_valid_cell(Datum d)
 }
 
 /**
- * @brief
+ * @brief Return the parent of a quadbin cell at a given resolution
  */
 static Datum
 datum_quadbin_cell_to_parent(Datum cell_d, Datum res_d)
@@ -99,7 +99,7 @@ datum_quadbin_cell_to_parent(Datum cell_d, Datum res_d)
 }
 
 /**
- * @brief
+ * @brief Return the center point of a quadbin cell
  */
 static Datum
 datum_quadbin_cell_to_point(Datum d)
@@ -114,7 +114,7 @@ datum_quadbin_cell_to_point(Datum d)
 }
 
 /**
- * @brief
+ * @brief Return the boundary of a quadbin cell as a geometry
  */
 static Datum
 datum_quadbin_cell_to_boundary(Datum d)
@@ -138,7 +138,7 @@ datum_quadbin_cell_to_boundary(Datum d)
 }
 
 /**
- * @brief
+ * @brief Return the quadkey of a quadbin cell
  */
 static Datum
 datum_quadbin_cell_to_quadkey(Datum d)
@@ -150,7 +150,7 @@ datum_quadbin_cell_to_quadkey(Datum d)
 }
 
 /**
- * @brief
+ * @brief Return the area in square meters of a quadbin cell
  */
 static Datum
 datum_quadbin_cell_area(Datum d)

--- a/mobilitydb/src/geo/tgeo_tile.c
+++ b/mobilitydb/src/geo/tgeo_tile.c
@@ -191,7 +191,7 @@ Stbox_space_time_tiles_common(FunctionCallInfo fcinfo, bool spacetiles,
 PGDLLEXPORT Datum Stbox_space_tiles(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Stbox_space_tiles);
 /**
- * @brief @ingroup mobilitydb_geo_tile
+ * @ingroup mobilitydb_geo_tile
  * @brief Return the spatial grid of a spatiotemporal box
  * @sqlfn spaceTiles()
  */
@@ -204,7 +204,7 @@ Stbox_space_tiles(PG_FUNCTION_ARGS)
 PGDLLEXPORT Datum Stbox_time_tiles(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Stbox_time_tiles);
 /**
- * @brief @ingroup mobilitydb_geo_tile
+ * @ingroup mobilitydb_geo_tile
  * @brief Return the temporal grid of a spatiotemporal box
  * @sqlfn timeTiles()
  */
@@ -217,7 +217,7 @@ Stbox_time_tiles(PG_FUNCTION_ARGS)
 PGDLLEXPORT Datum Stbox_space_time_tiles(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Stbox_space_time_tiles);
 /**
- * @brief @ingroup mobilitydb_geo_tile
+ * @ingroup mobilitydb_geo_tile
  * @brief Return the spatiotemporal grid of a spatiotemporal box
  * @sqlfn spaceTimeTiles()
  */
@@ -296,7 +296,7 @@ Stbox_get_space_tile(PG_FUNCTION_ARGS)
 PGDLLEXPORT Datum Stbox_get_time_tile(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Stbox_get_time_tile);
 /**
- * @brief @ingroup mobilitydb_geo_tile
+ * @ingroup mobilitydb_geo_tile
  * @brief Return a tile in the temporal grid of a spatiotemporal box
  * @sqlfn getStboxTimeTile()
  */

--- a/mobilitydb/src/geo/tspatial_analyze.c
+++ b/mobilitydb/src/geo/tspatial_analyze.c
@@ -194,7 +194,7 @@ nd_box_merge(const ND_BOX *source, ND_BOX *target)
 
 /**
  * @brief What stats cells overlap with this ND_BOX?
- * @brief Put the lowest cell addresses in ND_IBOX->min and the highest in
+ * @details Put the lowest cell addresses in ND_IBOX->min and the highest in
  * ND_IBOX->max
  */
 int

--- a/mobilitydb/src/pose/tpose_compops.c
+++ b/mobilitydb/src/pose/tpose_compops.c
@@ -319,7 +319,6 @@ PG_FUNCTION_INFO_V1(Teq_pose_tpose);
  * @ingroup mobilitydb_pose_comp_temp
  * @brief Return a temporal Boolean that states whether a pose is equal to a
  * temporal pose
- * @brief Return true if a temporal pose is ever equal to a pose
  * @sqlfn tEq()
  * @sqlop @p #=
  */

--- a/mobilitydb/src/posechain/tposechain_compops.c
+++ b/mobilitydb/src/posechain/tposechain_compops.c
@@ -320,7 +320,6 @@ PG_FUNCTION_INFO_V1(Teq_posechain_tposechain);
  * @ingroup mobilitydb_posechain_comp_temp
  * @brief Return a temporal Boolean that states whether a posechain is equal to a
  * temporal posechain
- * @brief Return true if a temporal posechain is ever equal to a posechain
  * @sqlfn tEq()
  * @sqlop @p #=
  */

--- a/mobilitydb/src/temporal/ttext_funcs.c
+++ b/mobilitydb/src/temporal/ttext_funcs.c
@@ -1,5 +1,5 @@
 /*****************************************************************************
- * @brief
+ *
  * This MobilityDB code is provided under The PostgreSQL License.
  * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
  * contributors


### PR DESCRIPTION
Every function, structure and Datum wrapper across the tree carries a brief
naming the quantity it returns, in the phrasing the sibling families use:
the quadbin wrappers over the cell primitives, the cell comparisons and the
identity the tbigint casts lift, the segment boxes and their sweep ordering
that the temporal point and circular buffer distances share, the threshold
form of the minimum distance between two point sequences, the candidate pair
ordering, the three DE-9IM relationships a linear or areal geometry holds
with a point and with a linear one, the point cloud schema cache entry and
the two serialized layouts the upstream library defines, and the reader of
the PROJ strings of an SRID.

Each doxygen block states one brief, so the sentence an author writes below
it reaches the rendered page. The exactness of the line and arc engine, the
mixed dimensions a box comparison admits and the cell addresses a statistics
box fills in stand as details, and the two temporal equality wrappers state
the quantity they answer rather than the ever-equality of a neighbouring
family.

The four spatial and temporal grid functions of a spatiotemporal box join
the tile group their siblings belong to, their group tag standing on the
line doxygen reads it from rather than inside the brief above it. The
temporal text licence header states the shape its siblings state, opening on
a bare continuation line.

