### PR TITLE
State in stbox_expand the precondition its callers already establish

### DIFF
--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -120,7 +120,17 @@ void
 stbox_expand(const STBox *box1, STBox *box2)
 {
   assert(box1); assert(box2);
-  
+  /* The reference system is not extent: a combine grows what the boxes measure
+   * and leaves what they are measured in alone, so establishing that the two
+   * state the same one belongs to the caller. #inter_stbox_stbox asserts the
+   * same of its own pair. A box carrying no coordinates states no reference
+   * system, so the pair carrying them is what is tested, and the field is read
+   * directly because the validating accessor reports an absent X itself */
+  assert(! (MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags)) ||
+    (box1->srid == box2->srid &&
+     MEOS_FLAGS_GET_GEODETIC(box1->flags) ==
+     MEOS_FLAGS_GET_GEODETIC(box2->flags)));
+
   if (MEOS_FLAGS_GET_X(box2->flags))
   {
     box2->xmin = Min(box1->xmin, box2->xmin);


### PR DESCRIPTION
The reference system is not extent: a combine grows what two boxes measure
and leaves what they are measured in alone, so a caller that reaches this
function has established that the two boxes state the same one.
inter_stbox_stbox asserts exactly that of its own pair, and the extent
aggregate reaches it through ensure_valid_stbox_stbox on both of its paths.
stbox_expand states nothing, so a caller that skips the test produces a box
labelled with one reference system and measured across two, silently.

The test is on the pair that carries coordinates, because a box carrying none
states no reference system and legitimately expands into a box that does — a
time-only query box is that shape. The fields are read directly rather than
through stbox_srid, whose own answer for a box without X is an error.

The temporal box has this already, one level down: span_expand asserts that
the two spans share a type, which is what states that they measure the same
quantity.