### PR TITLE
Guard a function by what it needs, not by who calls it

### DIFF
--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1111,11 +1111,9 @@ spatial_set_stbox(Datum d, MeosType basetype, STBox *result)
       return true;
     }
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return pose_set_stbox(DatumGetPoseP(d), result);
-#endif
-#if POSE
     case T_POSECHAIN:
       return posechain_set_stbox(DatumGetPoseChainP(d), result);
 #endif

--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -414,11 +414,9 @@ spatialarr_set_bbox(const Datum *values, MeosType basetype, int count,
   else if (basetype == T_NPOINT)
     npointarr_set_stbox(values, count, (STBox *) box);
 #endif
-#if POSE || RGEO
+#if POSE
   else if (basetype == T_POSE)
     posearr_set_stbox(values, count, (STBox *) box);
-#endif
-#if POSE
   else if (basetype == T_POSECHAIN)
     posechainarr_set_stbox(values, count, (STBox *) box);
 #endif

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -155,7 +155,6 @@ datum2_point_eq(Datum point1, Datum point2)
   return BoolGetDatum(datum_point_eq(point1, point2));
 }
 
-#if CBUFFER || RGEO
 /**
  * @brief Return true if the points are equal
  */
@@ -182,7 +181,6 @@ datum2_point_nsame(Datum point1, Datum point2)
 {
   return BoolGetDatum(! datum_point_same(point1, point2));
 }
-#endif /* CBUFFER || RGEO */
 
 /**
  * @brief Return the centroid of a geometry
@@ -327,7 +325,7 @@ npoint_flags(void)
 }
 #endif /* NPOINT */ 
 
-#if POSE || RGEO 
+#if POSE 
 /**
  * @brief Get the MEOS flags from a pose
  */
@@ -340,7 +338,7 @@ pose_flags(Pose *pose)
   MEOS_FLAGS_SET_GEODETIC(result, MEOS_FLAGS_GET_GEODETIC(pose->flags));
   return result;
 }
-#endif /* POSE || RGEO */
+#endif /* POSE */
 
 #if POSE
 /**
@@ -488,11 +486,9 @@ spatial_flags(Datum d, MeosType basetype)
     case T_NPOINT:
       return npoint_flags();
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return pose_flags(DatumGetPoseP(d));
-#endif
-#if POSE
     case T_POSECHAIN:
       return posechain_flags(DatumGetPoseChainP(d));
 #endif

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -193,12 +193,10 @@ spatial_set_srid(Datum d, MeosType basetype, int32_t srid)
       cbuffer_set_srid_int(DatumGetCbufferP(d), srid);
       return true;
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       pose_set_srid_int(DatumGetPoseP(d), srid);
       return true;
-#endif
-#if POSE
     case T_POSECHAIN:
       posechain_set_srid_int(DatumGetPoseChainP(d), srid);
       return true;
@@ -605,13 +603,13 @@ point_transf_pj(GSERIALIZED *gs, int32_t srid_to, const LWPROJ *pj)
  * to another SRID
  */
 Datum
-#if CBUFFER || POSE || RGEO
+#if CBUFFER || POSE
   datum_transf_pj(Datum d, MeosType basetype, int32_t srid_to,
     const LWPROJ *pj)
 #else
   datum_transf_pj(Datum d, MeosType basetype, int32_t srid_to UNUSED,
     const LWPROJ *pj)
-#endif /* CBUFFER || POSE || RGEO */
+#endif /* CBUFFER || POSE */
 {
   assert(spatial_basetype(basetype));
   switch (basetype)
@@ -645,11 +643,9 @@ Datum
       return PointerGetDatum(cbuffer_transf_pj(DatumGetCbufferP(d), srid_to,
         pj));
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return PointerGetDatum(pose_transf_pj(DatumGetPoseP(d), srid_to, pj));
-#endif
-#if POSE
     case T_POSECHAIN:
       return PointerGetDatum(posechain_transf_pj(DatumGetPoseChainP(d),
         srid_to, pj));

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -733,11 +733,9 @@ meostype_length(MeosType type)
   if (type == T_NPOINT)
     return sizeof(Npoint);
 #endif
-#if POSE || RGEO
+#if POSE
   if (type == T_POSE)
     return -1;
-#endif
-#if POSE
   if (type == T_POSECHAIN)
     return -1;
 #endif

--- a/meos/src/temporal/set_aggfuncs_meos.c
+++ b/meos/src/temporal/set_aggfuncs_meos.c
@@ -100,15 +100,13 @@ set_expand_bbox(Datum value, MeosType basetype, void *box)
     stbox_expand(&box1, (STBox *) box);
   }
 #endif /* NPOINT */
-#if POSE || RGEO
+#if POSE
   else if (basetype == T_POSE)
   {
     STBox box1;
     pose_set_stbox(DatumGetPoseP(value), &box1);
     stbox_expand(&box1, (STBox *) box);
   }
-#endif /* POSE */
-#if POSE
   else if (basetype == T_POSECHAIN)
   {
     STBox box1;

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -1400,11 +1400,9 @@ round_fn(MeosType basetype)
     case T_NPOINT:
       return &datum_npoint_round;
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return &datum_pose_round;
-#endif
-#if POSE
     case T_POSECHAIN:
       return &datum_posechain_round;
 #endif

--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -63,7 +63,7 @@
 #if CBUFFER
   #include <meos_cbuffer.h>
 #endif
-#if POSE || RGEO
+#if POSE
   #include <meos_pose.h>
   #include "pose/pose.h"
 #endif

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -140,7 +140,7 @@ extern LWGEOM *parse_geojson(json_object *geojson, int *hasz);
  * @return On error return @p false
  */
 bool
-#if CBUFFER || NPOINT || POSE || RGEO
+#if CBUFFER || NPOINT || POSE
 basetype_in(const char *str, MeosType type, bool end, Datum *result)
 #else
 basetype_in(const char *str, MeosType type, bool end UNUSED, Datum *result)
@@ -279,7 +279,7 @@ basetype_in(const char *str, MeosType type, bool end UNUSED, Datum *result)
       return true;
     }
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
     {
       Pose *pose = pose_parse(&str, end);
@@ -288,8 +288,6 @@ basetype_in(const char *str, MeosType type, bool end UNUSED, Datum *result)
       *result = PointerGetDatum(pose);
       return true;
     }
-#endif
-#if POSE
     case T_POSECHAIN:
     {
       PoseChain *pc = posechain_parse(&str, end);
@@ -797,7 +795,7 @@ parse_mfjson_npoints(json_object *mfjson, int32_t srid, int *count)
 
 /*****************************************************************************/
 
-#if POSE || RGEO
+#if POSE
 /**
  * @brief Return a pose from its GeoJSON representation
  */Pose *
@@ -1085,7 +1083,7 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
     else if (temptype == T_TNPOINT)
       values = parse_mfjson_npoints(mfjson, srid, &nvalues);
 #endif /* NPOINT */
-#if POSE || RGEO
+#if POSE
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
 #endif /* POSE */
@@ -1154,7 +1152,7 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
     else if (temptype == T_TNPOINT)
       values = parse_mfjson_npoints(mfjson, srid, &nvalues);
 #endif /* NPOINT */
-#if POSE || RGEO
+#if POSE
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
 #endif /* RGEO */
@@ -1941,7 +1939,7 @@ npoint_from_wkb_state(meos_wkb_parse_state *s)
 }
 #endif /* NPOINT */
 
-#if POSE || RGEO
+#if POSE
 /**
  * @brief Return the state flags initialized with a byte flag read from the
  * buffer
@@ -2137,11 +2135,9 @@ base_from_wkb_state(meos_wkb_parse_state *s)
     case T_PCPATCH:
       return PointerGetDatum(pcvarlena_from_wkb_state(s));
 #endif /* POINTCLOUD */
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return PointerGetDatum(pose_from_wkb_state(s));
-#endif /* POSE */
-#if POSE
     case T_POSECHAIN:
       return PointerGetDatum(posechain_from_wkb_state(s));
 #endif /* POSE */
@@ -2782,11 +2778,9 @@ type_from_wkb(const uint8_t *wkb, size_t size, MeosType type)
   if (type == T_NPOINT)
     return PointerGetDatum(npoint_from_wkb_state(&s));
 #endif /* NPOINT */
-#if POSE || RGEO
+#if POSE
   if (type == T_POSE)
     return PointerGetDatum(pose_from_wkb_state(&s));
-#endif /* POSE */
-#if POSE
   if (type == T_POSECHAIN)
     return PointerGetDatum(posechain_from_wkb_state(&s));
 #endif /* POSE */

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -191,11 +191,9 @@ basetype_out(Datum value, MeosType type, int maxdd)
     case T_PCPATCH:
       return pcpatch_hex_out((const Pcpatch *) DatumGetPointer(value), maxdd);
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return pose_out(DatumGetPoseP(value), maxdd);
-#endif
-#if POSE
     case T_POSECHAIN:
       return posechain_out(DatumGetPoseChainP(value), maxdd);
 #endif
@@ -428,7 +426,7 @@ tpcpatch_as_mfjson_sb(stringbuffer_t *sb, const TInstant *inst, int precision)
 }
 #endif /* POINTCLOUD */
 
-#if POSE || RGEO
+#if POSE
 /**
  * @brief Write into the buffer a pose in the MF-JSON representation
  */
@@ -1433,7 +1431,7 @@ pcpatch_to_wkb_size(const Pcpatch *pa, uint8_t variant)
 }
 #endif /* POINTCLOUD */
 
-#if POSE || RGEO
+#if POSE
 /**
  * @brief Return the size in bytes of a pose in the Well-Known Binary (WKB)
  * representation
@@ -1552,11 +1550,9 @@ base_to_wkb_size(Datum value, MeosType basetype, uint8_t variant)
       return pcpatch_to_wkb_size((const Pcpatch *) DatumGetPointer(value),
         variant);
 #endif /* POINTCLOUD */
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return pose_to_wkb_size(DatumGetPoseP(value), variant, true);
-#endif /* POSE || RGEO */
-#if POSE
     case T_POSECHAIN:
       return posechain_to_wkb_size(DatumGetPoseChainP(value), variant, true);
 #endif /* POSE */
@@ -1839,11 +1835,9 @@ datum_to_wkb_size(Datum value, MeosType type, uint8_t variant)
   if (type == T_NPOINT)
     return npoint_to_wkb_size(DatumGetNpointP(value), variant, false);
 #endif /* NPOINT */
-#if POSE || RGEO
+#if POSE
   if (type == T_POSE)
     return pose_to_wkb_size(DatumGetPoseP(value), variant, false);
-#endif /* POSE || RGEO */
-#if POSE
   if (type == T_POSECHAIN)
     return posechain_to_wkb_size(DatumGetPoseChainP(value), variant, false);
 #endif /* POSE */
@@ -2239,7 +2233,7 @@ npoint_to_wkb_buf(const Npoint *np, uint8_t *buf, uint8_t variant,
 }
 #endif /* NPOINT */
 
-#if POSE || RGEO
+#if POSE
 /**
  * @brief Write into the buffer the flag of a pose in the Well-Known Binary
  * (WKB) representation
@@ -2502,12 +2496,10 @@ base_to_wkb_buf(Datum value, MeosType basetype, uint8_t *buf,
         buf, variant);
       break;
 #endif /* POINTCLOUD */
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       buf = pose_to_wkb_buf(DatumGetPoseP(value), buf, variant, true);
       break;
-#endif /* POSE || RGEO */
-#if POSE
     case T_POSECHAIN:
       buf = posechain_to_wkb_buf(DatumGetPoseChainP(value), buf, variant,
         true);
@@ -3173,11 +3165,9 @@ datum_to_wkb_buf(Datum value, MeosType type, uint8_t *buf, uint8_t variant)
     buf = npoint_to_wkb_buf(DatumGetNpointP(value), buf, variant,
       false);
 #endif /* NPOINT */
-#if POSE || RGEO
+#if POSE
   else if (type == T_POSE)
     buf = pose_to_wkb_buf(DatumGetPoseP(value), buf, variant, false);
-#endif /* POSE || RGEO */
-#if POSE
   else if (type == T_POSECHAIN)
     buf = posechain_to_wkb_buf(DatumGetPoseChainP(value), buf, variant, false);
 #endif /* POSE */

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -187,11 +187,9 @@ datum_cmp(Datum l, Datum r, MeosType type)
       return pcpatch_cmp((const Pcpatch *) DatumGetPointer(l),
         (const Pcpatch *) DatumGetPointer(r));
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return pose_cmp(DatumGetPoseP(l), DatumGetPoseP(r));
-#endif
-#if POSE
     case T_POSECHAIN:
       return posechain_cmp(DatumGetPoseChainP(l), DatumGetPoseChainP(r));
 #endif
@@ -322,11 +320,9 @@ datum_eq(Datum l, Datum r, MeosType type)
       return pcpatch_eq((const Pcpatch *) DatumGetPointer(l),
         (const Pcpatch *) DatumGetPointer(r));
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return pose_eq(DatumGetPoseP(l), DatumGetPoseP(r));
-#endif
-#if POSE
     case T_POSECHAIN:
       return posechain_eq(DatumGetPoseChainP(l), DatumGetPoseChainP(r));
 #endif
@@ -599,11 +595,9 @@ datum_hash(Datum d, MeosType type)
     case T_PCPATCH:
       return pcpatch_hash((const Pcpatch *) DatumGetPointer(d));
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return pose_hash(DatumGetPoseP(d));
-#endif
-#if POSE
     case T_POSECHAIN:
       return posechain_hash(DatumGetPoseChainP(d));
 #endif
@@ -672,11 +666,9 @@ datum_hash_extended(Datum d, MeosType type, uint64 seed)
     case T_PCPATCH:
       return pcpatch_hash_extended((const Pcpatch *) DatumGetPointer(d), seed);
 #endif
-#if POSE || RGEO
+#if POSE
     case T_POSE:
       return pose_hash_extended(DatumGetPoseP(d), seed);
-#endif
-#if POSE
     case T_POSECHAIN:
       return posechain_hash_extended(DatumGetPoseChainP(d), seed);
 #endif

--- a/mobilitydb/pg_include/pg_temporal/type_util.h
+++ b/mobilitydb/pg_include/pg_temporal/type_util.h
@@ -95,7 +95,7 @@ extern Cbuffer **cbufferarr_extract(ArrayType *array, int *count);
 extern ArrayType *cbufferarr_to_array(Cbuffer **cbarr, int count,
   bool free_all);
 #endif
-#if POSE || RGEO
+#if POSE
 extern Pose **posearr_extract(ArrayType *array, int *count);
 extern ArrayType *posearr_to_array(Pose **posearr, int count, bool free_all);
 #endif


### PR DESCRIPTION
RGEO is a dependent option on POSE, so every build carrying rigid geometries
carries poses and a guard naming both states one condition twice. POSE alone
answers it, in the thirty guards that name the pair and in the two that reach
it through a longer list, and twenty of those stand beside a POSE block and
read as one. A guard still names RGEO where rigid geometries are what it
carries.

The four datum2_point_eq, datum2_point_ne, datum2_point_same and
datum2_point_nsame of meos/src/geo/tgeo_spatialfuncs.c sit together under no
guard, which is what geo/tgeo_spatialfuncs.h declares for each of them. The
geo sources compile in every build and the four are external, so a build
defines the symbols its headers state whichever families it carries.

