### PR TITLE
Intersect two pose chain segments with the kernel that intersects them

### DIFF
--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -2747,6 +2747,10 @@ tsegment_intersection(Datum start1, Datum end1, Datum start2, Datum end2,
   else if (temptype_basetype(temptype) == T_POSE)
     result = tposesegm_intersection(start1, end1, start2, end2, lower,
       upper, t1, t2);
+  /* A pose chain is a base type of its own, so it reaches its own kernel */
+  else if (temptype_basetype(temptype) == T_POSECHAIN)
+    result = tposechainsegm_intersection(start1, end1, start2, end2, lower,
+      upper, t1, t2);
 #endif
   else
   {


### PR DESCRIPTION
tsegment_intersection reaches a kernel per base type, and the pose arm asks
whether the base type is a pose, which a temporal rigid geometry answers and a
temporal pose chain does not. A chain fell to the branch that reports an
unknown type, and that branch returns without writing the two timestamps it is
given, so the ever and always comparisons over two temporal chains read them
uninitialised: valgrind names the read in posesegm_interpolate under
posechainsegm_interpolate, and a rotation of -183.5 degrees reaches
ensure_valid_rotation from the same values.

The chain is a base type of its own and posechainsegm_intersection is the
kernel that answers for it, link by link, so the arm names it.

