### PR TITLE
Read a temporal pose chain from its MF-JSON representation

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1442,7 +1442,7 @@
 					<para><link linkend="tposeFromText"><varname>tposeFromText</varname>, <varname>tposeFromEWKT</varname></link>: Entrada desde la representación de texto conocido (WKT) o desde la representación extendida de texto conocido (EWKT)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tposeFromMFJSON"><varname>tposeFromMFJSON</varname></link>: Entrada desde la representación JSON de características móviles (MF-JSON)</para>
+					<para><link linkend="tposeFromMFJSON"><varname>tposeFromMFJSON</varname>, <varname>tposechainFromMFJSON</varname></link>: Entrada desde la representación JSON de características móviles (MF-JSON)</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tposeFromBinary"><varname>tposeFromBinary</varname>, <varname>tposeFromEWKB</varname>, <varname>tposeFromHexEWKB</varname></link>: Entrada desde la representación binaria conocida (WKB), desde la representación extendida binaria conocida (EWKB), o desde la representación hexadecimal extendida binaria conocida (HexEWKB)</para>

--- a/doc/es/temporal_pose_types.xml
+++ b/doc/es/temporal_pose_types.xml
@@ -780,10 +780,15 @@ SELECT asEWKT(tposechainFromHexEWKB(asHexEWKB(tposechain 'SRID=5676;
 
 			<listitem xml:id="tposeFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tposeFromMFJSON</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tposechainFromMFJSON</varname></primary></indexterm>
 				<para>Entrada desde la representación JSON de características móviles (MF-JSON)</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tposeFromMFJSON(bytea) → tpose
+tposeFromMFJSON(text) &#8594; tpose
+tposechainFromMFJSON(text) &#8594; tposechain
 </programlisting>
+				<para>Una cadena de poses se escribe como el arreglo de sus eslabones, de modo que
+					un documento <varname>MovingPoseChain</varname> contiene un arreglo de objetos
+					pose para cada instante</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose 'SRID=3812;Pose(Point(1 2),0.5)@2001-01-01',
   3)));
@@ -791,6 +796,9 @@ SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose 'SRID=3812;Pose(Point(1 2),0.5)@200
 SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose 'SRID=5676;
   Pose(Point Z(1 2 3),1,0,0,0)@2001-01-01', 3)));
 -- SRID=5676;Pose(POINT Z(1 2 3),1,0,0,0)@2001-01-01
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain 'SRID=3812;
+  PoseChain(Pose(Point(1 2),0.5),Pose(Point(3 4),0.25))@2001-01-01', 3)));
+-- SRID=3812;PoseChain(Pose(POINT(1 2),0.5),Pose(POINT(3 4),0.25))@2001-01-01
 </programlisting>
 			</listitem>
 

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1444,7 +1444,7 @@
 						<para><link linkend="tposeFromText"><varname>tposeFromText</varname>, <varname>tposeFromEWKT</varname></link>: Input from the Well-Known Text (WKT) or from the Extended Well-Known Text (EWKT) representation</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tposeFromMFJSON"><varname>tposeFromMFJSON</varname></link>: Input from the Moving Features JSON (MF-JSON) representation</para>
+						<para><link linkend="tposeFromMFJSON"><varname>tposeFromMFJSON</varname>, <varname>tposechainFromMFJSON</varname></link>: Input from the Moving Features JSON (MF-JSON) representation</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="tposeFromBinary"><varname>tposeFromBinary</varname>, <varname>tposeFromEWKB</varname>, <varname>tposeFromHexEWKB</varname></link>: Input from the Well-Known Binary (WKB), from the Extended Well-Known Binary (EWKB), or from the Hexadecimal Extended Well-Known Binary (HexEWKB) representation</para>

--- a/doc/temporal_pose_types.xml
+++ b/doc/temporal_pose_types.xml
@@ -785,10 +785,15 @@ SELECT asEWKT(tposechainFromHexEWKB(asHexEWKB(tposechain 'SRID=5676;
 
 			<listitem xml:id="tposeFromMFJSON">
 				<indexterm significance="normal"><primary><varname>tposeFromMFJSON</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>tposechainFromMFJSON</varname></primary></indexterm>
 				<para>Input from the Moving Features JSON (MF-JSON) representation</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-tposeFromMFJSON(bytea) → tpose
+tposeFromMFJSON(text) &#8594; tpose
+tposechainFromMFJSON(text) &#8594; tposechain
 </programlisting>
+				<para>A pose chain is written as the array of its links, so a
+					<varname>MovingPoseChain</varname> document holds an array of pose objects
+					for every instant</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose 'SRID=3812;Pose(Point(1 2),0.5)@2001-01-01',
   3)));
@@ -796,6 +801,9 @@ SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose 'SRID=3812;Pose(Point(1 2),0.5)@200
 SELECT asEWKT(tposeFromMFJSON(asMFJSON(tpose 'SRID=5676;
   Pose(Point Z(1 2 3),1,0,0,0)@2001-01-01', 3)));
 -- SRID=5676;Pose(POINT Z(1 2 3),1,0,0,0)@2001-01-01
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain 'SRID=3812;
+  PoseChain(Pose(Point(1 2),0.5),Pose(Point(3 4),0.25))@2001-01-01', 3)));
+-- SRID=3812;PoseChain(Pose(POINT(1 2),0.5),Pose(POINT(3 4),0.25))@2001-01-01
 </programlisting>
 			</listitem>
 

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -949,6 +949,79 @@ parse_mfjson_poses(json_object *mfjson, int32_t srid, int *count)
   *count = nposes;
   return values;
 }
+
+/**
+ * @brief Return a pose chain from its GeoJSON representation
+ * @details A chain is written as the array of its links, each of them a pose
+ * object, which is what @p posechain_as_json_sb emits
+ */
+static PoseChain *
+parse_mfjson_posechain(json_object *mfjson, int32_t srid)
+{
+  if (json_object_get_type(mfjson) != json_type_array)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid pose chain in the 'values' array of the MFJSON string");
+    return NULL;
+  }
+  int nposes = (int) json_object_array_length(mfjson);
+  if (nposes < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "A pose chain in the MFJSON string carries no link");
+    return NULL;
+  }
+
+  const Pose **poses = palloc(sizeof(Pose *) * nposes);
+  for (int i = 0; i < nposes; i++)
+    poses[i] = parse_mfjson_pose(json_object_array_get_idx(mfjson, i), srid);
+  PoseChain *result = posechain_make(poses, nposes);
+  for (int i = 0; i < nposes; i++)
+    if (poses[i])
+      pfree((void *) poses[i]);
+  pfree(poses);
+  return result;
+}
+
+/**
+ * @brief Return an array of pose chains from its GeoJSON pose chain values
+ */
+static Datum *
+parse_mfjson_posechains(json_object *mfjson, int32_t srid, int *count)
+{
+  json_object *mfjsonTmp = mfjson;
+  json_object *values_json = NULL;
+  values_json = findMemberByName(mfjsonTmp, "values");
+  if (values_json == NULL)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Unable to find 'values' in MFJSON string");
+    return NULL;
+  }
+  if (json_object_get_type(values_json) != json_type_array)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid 'values' array in MFJSON string");
+    return NULL;
+  }
+
+  int nchains = (int) json_object_array_length(values_json);
+  if (nchains < 1)
+  {
+    meos_error(ERROR, MEOS_ERR_MFJSON_INPUT,
+      "Invalid value of 'values' array in MFJSON string");
+    return NULL;
+  }
+
+  Datum *values = palloc(sizeof(Datum) * nchains);
+  for (int i = 0; i < nchains; ++i)
+  {
+    json_object *chain = json_object_array_get_idx(values_json, i);
+    values[i] = PointerGetDatum(parse_mfjson_posechain(chain, srid));
+  }
+  *count = nchains;
+  return values;
+}
 #endif /* POSE */
 
 /*****************************************************************************/
@@ -1086,6 +1159,8 @@ tinstant_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
 #if POSE
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
+    else if (temptype == T_TPOSECHAIN)
+      values = parse_mfjson_posechains(mfjson, srid, &nvalues);
 #endif /* POSE */
 #if QUADBIN
     /* quadbin, like h3index, is a scalar cell id carried with a bbox: the
@@ -1155,7 +1230,9 @@ tinstarr_from_mfjson(json_object *mfjson, bool isgeo, int32_t srid,
 #if POSE
     else if (temptype == T_TPOSE || temptype == T_TRGEOMETRY)
       values = parse_mfjson_poses(mfjson, srid, &nvalues);
-#endif /* RGEO */
+    else if (temptype == T_TPOSECHAIN)
+      values = parse_mfjson_posechains(mfjson, srid, &nvalues);
+#endif /* POSE */
 #if QUADBIN
     /* quadbin, like h3index, is a scalar cell id carried with a bbox: the
      * 'values' array holds plain cell ids parsed as base values */
@@ -1317,6 +1394,7 @@ ensure_temptype_mfjson(const char *typestr)
 #endif /* POINTCLOUD */
 #if POSE
       && strcmp(typestr, "MovingPose") != 0
+      && strcmp(typestr, "MovingPoseChain") != 0
 #endif /* POSE */
 #if QUADBIN
       && strcmp(typestr, "MovingQuadbin") != 0
@@ -1432,6 +1510,8 @@ temporal_from_mfjson(const char *mfjson, MeosType temptype)
 #if POSE
   else if (strcmp(typestr, "MovingPose") == 0)
     jtemptype = T_TPOSE;
+  else if (strcmp(typestr, "MovingPoseChain") == 0)
+    jtemptype = T_TPOSECHAIN;
 #endif /* POSE */
 #if QUADBIN
   else if (strcmp(typestr, "MovingQuadbin") == 0)

--- a/mobilitydb/test/posechain/expected/552_tposechain.test.out
+++ b/mobilitydb/test/posechain/expected/552_tposechain.test.out
@@ -22,6 +22,46 @@ SELECT asEWKT(tposechain '{[PoseChain(Pose(Point(0 0), 0))@2001-01-01, PoseChain
  {[PoseChain(Pose(POINT(0 0),0))@Mon Jan 01 00:00:00 2001 PST, PoseChain(Pose(POINT(1 1),0))@Tue Jan 02 00:00:00 2001 PST], [PoseChain(Pose(POINT(2 2),0))@Wed Jan 03 00:00:00 2001 PST]}
 (1 row)
 
+SELECT asMFJSON(tposechain 'PoseChain(Pose(Point(1 2), 0.5), Pose(Point(3 4), 0.25))@2001-01-01');
+                                                                                          asmfjson                                                                                           
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {"type":"MovingPoseChain","values":[[{"position":{"lat":2,"lon":1},"yaw":0.5},{"position":{"lat":4,"lon":3},"yaw":0.25}]],"datetimes":["2001-01-01T00:00:00-08:00"],"interpolation":"None"}
+(1 row)
+
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain 'PoseChain(Pose(Point(1 2), 0.5), Pose(Point(3 4), 0.25))@2001-01-01', 3)));
+                                       asewkt                                       
+------------------------------------------------------------------------------------
+ PoseChain(Pose(POINT(1 2),0.5),Pose(POINT(3 4),0.25))@Mon Jan 01 00:00:00 2001 PST
+(1 row)
+
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain '[PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))@2001-01-01, PoseChain(Pose(Point(1 1), 0.5), Pose(Point(2 1), 0.5))@2001-01-02]', 3)));
+                                                                               asewkt                                                                               
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ [PoseChain(Pose(POINT(0 0),0),Pose(POINT(1 0),0))@Mon Jan 01 00:00:00 2001 PST, PoseChain(Pose(POINT(1 1),0.5),Pose(POINT(2 1),0.5))@Tue Jan 02 00:00:00 2001 PST]
+(1 row)
+
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain '{[PoseChain(Pose(Point(0 0), 0))@2001-01-01, PoseChain(Pose(Point(1 1), 0))@2001-01-02], [PoseChain(Pose(Point(2 2), 0))@2001-01-03]}', 3)));
+                                                                                          asewkt                                                                                          
+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+ {[PoseChain(Pose(POINT(0 0),0))@Mon Jan 01 00:00:00 2001 PST, PoseChain(Pose(POINT(1 1),0))@Tue Jan 02 00:00:00 2001 PST], [PoseChain(Pose(POINT(2 2),0))@Wed Jan 03 00:00:00 2001 PST]}
+(1 row)
+
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain 'SRID=4326;PoseChain(Pose(Point(1 2), 0.5), Pose(Point(2 3), 0.25))@2001-01-01', 3)));
+                                            asewkt                                            
+----------------------------------------------------------------------------------------------
+ SRID=4326;PoseChain(Pose(POINT(1 2),0.5),Pose(POINT(2 3),0.25))@Mon Jan 01 00:00:00 2001 PST
+(1 row)
+
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain 'PoseChain(Pose(Point Z(1 2 3), 1, 0, 0, 0), Pose(Point Z(1 0 0), 1, 0, 0, 0))@2001-01-01', 3)));
+                                               asewkt                                                
+-----------------------------------------------------------------------------------------------------
+ PoseChain(Pose(POINT Z (1 2 3),1,0,0,0),Pose(POINT Z (1 0 0),1,0,0,0))@Mon Jan 01 00:00:00 2001 PST
+(1 row)
+
+SELECT tposechainFromMFJSON('{"type":"MovingPose","values":[{"position":{"lat":2,"lon":1},"yaw":0.5}],"datetimes":["2001-01-01T00:00:00+00"],"interpolation":"None"}');
+ERROR:  Invalid 'type' value in MFJSON string, expected: tposechain, received: tpose
+SELECT tposechainFromMFJSON('{"type":"MovingPoseChain","values":[[]],"datetimes":["2001-01-01T00:00:00+00"],"interpolation":"None"}');
+ERROR:  A pose chain in the MFJSON string carries no link
 SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2001-01-01, PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))@2001-01-02]';
 ERROR:  Operation on pose chains of 1 and 2 links
 LINE 1: SELECT tposechain '[PoseChain(Pose(Point(0 0), 0))@2001-01-0...

--- a/mobilitydb/test/posechain/queries/552_tposechain.test.sql
+++ b/mobilitydb/test/posechain/queries/552_tposechain.test.sql
@@ -39,6 +39,21 @@ SELECT asEWKT(tposechain '{PoseChain(Pose(Point(0 0), 0))@2001-01-01, PoseChain(
 SELECT asEWKT(tposechain '[PoseChain(Pose(Point(0 0), 0))@2001-01-01, PoseChain(Pose(Point(1 1), 0))@2001-01-02]');
 SELECT asEWKT(tposechain '{[PoseChain(Pose(Point(0 0), 0))@2001-01-01, PoseChain(Pose(Point(1 1), 0))@2001-01-02], [PoseChain(Pose(Point(2 2), 0))@2001-01-03]}');
 
+-- A chain is written as the array of its links, and reads back as itself
+SELECT asMFJSON(tposechain 'PoseChain(Pose(Point(1 2), 0.5), Pose(Point(3 4), 0.25))@2001-01-01');
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain 'PoseChain(Pose(Point(1 2), 0.5), Pose(Point(3 4), 0.25))@2001-01-01', 3)));
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain '[PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))@2001-01-01, PoseChain(Pose(Point(1 1), 0.5), Pose(Point(2 1), 0.5))@2001-01-02]', 3)));
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain '{[PoseChain(Pose(Point(0 0), 0))@2001-01-01, PoseChain(Pose(Point(1 1), 0))@2001-01-02], [PoseChain(Pose(Point(2 2), 0))@2001-01-03]}', 3)));
+-- The frame travels in the document's own crs member, which asMFJSON writes
+-- whenever the value carries an SRID
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain 'SRID=4326;PoseChain(Pose(Point(1 2), 0.5), Pose(Point(2 3), 0.25))@2001-01-01', 3)));
+-- A three-dimensional chain states each link as a quaternion
+SELECT asEWKT(tposechainFromMFJSON(asMFJSON(tposechain 'PoseChain(Pose(Point Z(1 2 3), 1, 0, 0, 0), Pose(Point Z(1 0 0), 1, 0, 0, 0))@2001-01-01', 3)));
+-- A document naming another type is refused
+SELECT tposechainFromMFJSON('{"type":"MovingPose","values":[{"position":{"lat":2,"lon":1},"yaw":0.5}],"datetimes":["2001-01-01T00:00:00+00"],"interpolation":"None"}');
+-- A chain carrying no link is refused
+SELECT tposechainFromMFJSON('{"type":"MovingPoseChain","values":[[]],"datetimes":["2001-01-01T00:00:00+00"],"interpolation":"None"}');
+
 -------------------------------------------------------------------------------
 -- Errors
 -- Every value of a temporal pose chain holds the same number of links: a chain


### PR DESCRIPTION
The MF-JSON reader answers a MovingPoseChain document: the accept list admits
the type name the writer emits, the type dispatch maps it to tposechain, and
both the instant and the sequence value dispatches build the chain values.
A chain is written as the array of its links, so parse_mfjson_posechain reads
each link with the pose reader and hands the array to posechain_make, which
carries the frame of the outer link over the whole chain.

The frame travels in the document's own crs member, which asMFJSON writes
whenever the value carries an SRID, so a chain reads back with the SRID it was
written with.

tposechainFromMFJSON is declared in mobilitydb/sql/posechain and answers a
document whose type names another temporal type with the mismatch error, and a
chain holding no link with its own message.

The manual states the chain reader beside the pose one in both languages, as
the text and the binary input entries state their chain forms, and the entry
names the type each function takes.

