### PR TITLE
Report the MF-JSON sequence a reader refuses instead of constructing from it

### DIFF
--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -1207,6 +1207,10 @@ tsequence_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
   int count = 0;
   TInstant **instants = tinstarr_from_mfjson(mfjson, spatial, srid, temptype,
     &count);
+  /* The instants are what the sequence is made of, so a document the array
+   * reader refuses leaves nothing to construct */
+  if (! instants)
+    return NULL;
 
   /* Get lower bound flag, default to true if not specified */
   bool lower_inc = true;
@@ -1278,6 +1282,14 @@ tsequenceset_from_mfjson(json_object *mfjson, bool spatial, int32_t srid,
     seqvalue = json_object_array_get_idx(seqs, i);
     sequences[i] = tsequence_from_mfjson(seqvalue, spatial, srid, temptype,
       interp);
+    /* A sequence set is every one of its sequences, so a member the sequence
+     * reader refuses leaves nothing to construct: release the ones already
+     * read and report the refusal the member reader states */
+    if (! sequences[i])
+    {
+      pfree_array((void **) sequences, i);
+      return NULL;
+    }
   }
   return tsequenceset_make_free(sequences, nseqs, NORMALIZE);
 }

--- a/mobilitydb/test/geo/expected/053_tpoint_inout.test.out
+++ b/mobilitydb/test/geo/expected/053_tpoint_inout.test.out
@@ -124,6 +124,12 @@ SELECT asEWKT(tgeompointFromMFJSON(asMFJSON(tgeompoint 'Interp=Step;{[Point(1 2)
  Interp=Step;{[POINT(1 2)@Mon Jan 01 00:00:00 2001 PST, POINT(3 4)@Tue Jan 02 00:00:00 2001 PST], [POINT(1 2)@Wed Jan 03 00:00:00 2001 PST, POINT(3 4)@Thu Jan 04 00:00:00 2001 PST]}
 (1 row)
 
+SELECT tgeompointFromMFJSON('{"type":"MovingPoint","sequences":[{"coordinates":[],"datetimes":[],"lower_inc":true,"upper_inc":true}],"interpolation":"Linear"}');
+ERROR:  Invalid value of 'coordinates' array in MFJSON string
+SELECT tgeompointFromMFJSON('{"type":"MovingPoint","sequences":[{"coordinates":[[1,1]],"datetimes":["2001-01-01T00:00:00+00"],"lower_inc":true,"upper_inc":true},{"coordinates":[],"datetimes":[],"lower_inc":true,"upper_inc":true}],"interpolation":"Linear"}');
+ERROR:  Invalid value of 'coordinates' array in MFJSON string
+SELECT tgeompointFromMFJSON('{"type":"MovingPoint","coordinates":[],"datetimes":[],"lower_inc":true,"upper_inc":true}');
+ERROR:  Unable to find 'interpolation' in MFJSON string
 SELECT asEWKT(tgeompointFromMFJSON(asMFJSON(tgeompoint 'SRID=4326;Point(1 2 3)@2001-01-01',1,0,2)));
                          asewkt                         
 --------------------------------------------------------

--- a/mobilitydb/test/geo/queries/053_tpoint_inout.test.sql
+++ b/mobilitydb/test/geo/queries/053_tpoint_inout.test.sql
@@ -59,6 +59,12 @@ SELECT asEWKT(tgeompointFromMFJSON(asMFJSON(tgeompoint '{[Point(1 2)@2001-01-01,
 SELECT asEWKT(tgeompointFromMFJSON(asMFJSON(tgeompoint 'Interp=Step;[Point(1 2)@2001-01-01, Point(3 4)@2001-01-02]')));
 SELECT asEWKT(tgeompointFromMFJSON(asMFJSON(tgeompoint 'Interp=Step;{[Point(1 2)@2001-01-01, Point(3 4)@2001-01-02],[Point(1 2)@2001-01-03, Point(3 4)@2001-01-04]}')));
 
+-- A member the sequence reader refuses is reported, whether it is the only
+-- member or one of several
+SELECT tgeompointFromMFJSON('{"type":"MovingPoint","sequences":[{"coordinates":[],"datetimes":[],"lower_inc":true,"upper_inc":true}],"interpolation":"Linear"}');
+SELECT tgeompointFromMFJSON('{"type":"MovingPoint","sequences":[{"coordinates":[[1,1]],"datetimes":["2001-01-01T00:00:00+00"],"lower_inc":true,"upper_inc":true},{"coordinates":[],"datetimes":[],"lower_inc":true,"upper_inc":true}],"interpolation":"Linear"}');
+SELECT tgeompointFromMFJSON('{"type":"MovingPoint","coordinates":[],"datetimes":[],"lower_inc":true,"upper_inc":true}');
+
 -- Additional attributes
 SELECT asEWKT(tgeompointFromMFJSON(asMFJSON(tgeompoint 'SRID=4326;Point(1 2 3)@2001-01-01',1,0,2)));
 SELECT asEWKT(tgeompointFromMFJSON(asMFJSON(tgeompoint 'SRID=4326;{Point(1 2 3)@2001-01-01, Point(4 5 6)@2001-01-02}',1,0,2)));


### PR DESCRIPTION
tsequence_from_mfjson returns the refusal tinstarr_from_mfjson states, and
tsequenceset_from_mfjson returns the refusal a member states, releasing the
sequences already read. Both constructors below them take the array as given:
tsequence_make_free dereferences the pointer it is handed and
tsequenceset_make_free reaches ensure_valid_tseqarr, which reads every member,
so a document one level refuses reaches them as a value they read through.

A sequences array holding one member the reader refuses now answers with that
member's own message, both where it is the only member and where it follows a
member that reads.

