### PR TITLE
State the same predicate once per base type

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1395,7 +1395,7 @@
 						<para><link linkend="pose_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="pose_same"><varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
+						<para><link linkend="pose_same"><varname>same</varname>, <varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1819,7 +1819,7 @@
 						<para><link linkend="npoint_srid"><varname>SRID</varname></link>: Devuelve el identificador de referencia espacial</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="npoint_same"><varname>equals</varname>, <varname>::</varname></link>: Igualdad espacial para puntos de red</para>
+						<para><link linkend="npoint_same"><varname>same</varname>, <varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2100,6 +2100,9 @@
 				<itemizedlist>
 					<listitem>
 						<para><link linkend="cbuffer_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="cbuffer_same"><varname>same</varname>, <varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -362,6 +362,21 @@ SELECT cbuffer 'Cbuffer(Point(1 1), 0.6)' &gt;= cbuffer 'Cbuffer(Point(1 1), 0.5
 -- true
 </programlisting>
 				</listitem>
+
+				<listitem xml:id="cbuffer_same">
+					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
+					<para>¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+same(cbuffer,cbuffer) &#8594; boolean
+cbuffer ~= cbuffer &#8594; boolean
+</programlisting>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT cbuffer 'Cbuffer(Point(1 1), 0.3)' ~= cbuffer 'Cbuffer(Point(1 1.0000001),
+  0.30000001)';
+-- true
+</programlisting>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 	</sect1>

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -330,14 +330,15 @@ SELECT SRID(nsegment 'Nsegment(76, 0.3, 0.5)');
 				</listitem>
 			</itemizedlist>
 
-			<para>Dos valores <varname>npoint</varname> pueden tener diferentes identificadores de ruta pero pueden representar el mismo punto espacial en la intersección de las dos rutas. La función <varname>equals</varname> se utiliza para verificar la igualdad espacial de los puntos de la red.</para>
+			<para>Dos valores <varname>npoint</varname> pueden tener diferentes identificadores de ruta pero pueden representar el mismo punto espacial en la intersección de las dos rutas. La función <varname>same</varname> se utiliza para verificar la similitud espacial de los puntos de la red.</para>
 			<itemizedlist>
 				<listitem xml:id="npoint_same">
-					<indexterm significance="normal"><primary><varname>equals</varname></primary></indexterm>
-					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
-					<para>Igualdad espacial para puntos de red</para>
+					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
+					<para>¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-equals(npoint,npoint)::Boolean
+same(npoint,npoint) &#8594; boolean
+npoint ~= npoint &#8594; boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH inter(geom) AS (
@@ -345,7 +346,7 @@ WITH inter(geom) AS (
   FROM ways t1, ways t2 WHERE t1.gid = 1 AND t2.gid = 2), fractions(f1, f2) AS (
   SELECT ST_LineLocatePoint(t1.the_geom, i.geom), ST_LineLocatePoint(t2.the_geom, i.geom)
   FROM ways t1, ways t2, inter i WHERE t1.gid = 1 AND t2.gid = 2)
-SELECT equals(npoint(1, f1), npoint(2, f2)) FROM fractions;
+SELECT same(npoint(1, f1), npoint(2, f2)) FROM fractions;
 -- true
 </programlisting>
 				</listitem>

--- a/doc/es/temporal_pose_types.xml
+++ b/doc/es/temporal_pose_types.xml
@@ -486,10 +486,14 @@ SELECT pose 'Pose(Point(1 1), 0.6)' &gt;= pose 'Pose(Point(1 1), 0.5)';
 				</listitem>
 
 				<listitem xml:id="pose_same">
+					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-{pose,posechain} ~= {pose,posechain} &#8594; boolean
+same(pose,pose) &#8594; boolean
+same(posechain,posechain) &#8594; boolean
+pose ~= pose &#8594; boolean
+posechain ~= posechain &#8594; boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pose 'Pose(SRID=5676;Point(1 1), 0.3)' ~= pose 'Pose(SRID=5676;

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1395,7 +1395,7 @@
 						<para><link linkend="pose_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="pose_same"><varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
+						<para><link linkend="pose_same"><varname>same</varname>, <varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1822,7 +1822,7 @@
 						<para><link linkend="npoint_srid"><varname>SRID</varname></link>: Return the spatial reference identifier</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="npoint_same"><varname>equals</varname>, <varname>::</varname></link>: Spatial similarity</para>
+						<para><link linkend="npoint_same"><varname>same</varname>, <varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2106,6 +2106,9 @@
 				<itemizedlist>
 					<listitem>
 						<para><link linkend="cbuffer_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
+					</listitem>
+					<listitem>
+						<para><link linkend="cbuffer_same"><varname>same</varname>, <varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -362,6 +362,21 @@ SELECT cbuffer 'Cbuffer(Point(1 1), 0.6)' &gt;= cbuffer 'Cbuffer(Point(1 1), 0.5
 -- true
 </programlisting>
 				</listitem>
+
+				<listitem xml:id="cbuffer_same">
+					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
+					<para>Are the two values approximately equal with respect to an epsilon value?</para>
+					<programlisting role="syntax" xml:space="preserve" format="linespecific">
+same(cbuffer,cbuffer) &#8594; boolean
+cbuffer ~= cbuffer &#8594; boolean
+</programlisting>
+					<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT cbuffer 'Cbuffer(Point(1 1), 0.3)' ~= cbuffer 'Cbuffer(Point(1 1.0000001),
+  0.30000001)';
+-- true
+</programlisting>
+				</listitem>
 			</itemizedlist>
 		</sect2>
 	</sect1>

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -331,11 +331,12 @@ SELECT SRID(nsegment 'Nsegment(76, 0.3, 0.5)');
 			<para>Two <varname>npoint</varname> values may be have different route identifiers but may represent the same spatial point at the intersection of the two routes. Function <varname>same</varname> is used for testing spatial simalarity of network points.</para>
 			<itemizedlist>
 				<listitem xml:id="npoint_same">
-					<indexterm significance="normal"><primary><varname>equals</varname></primary></indexterm>
-					<indexterm significance="normal"><primary><varname>::</varname></primary></indexterm>
-					<para>Spatial similarity</para>
+					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
+					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
+					<para>Are the two values approximately equal with respect to an epsilon value?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-equals(npoint,npoint)::Boolean
+same(npoint,npoint) &#8594; boolean
+npoint ~= npoint &#8594; boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH inter(geom) AS (
@@ -343,7 +344,7 @@ WITH inter(geom) AS (
   FROM ways t1, ways t2 WHERE t1.gid = 1 AND t2.gid = 2), fractions(f1, f2) AS (
   SELECT ST_LineLocatePoint(t1.the_geom, i.geom), ST_LineLocatePoint(t2.the_geom, i.geom)
   FROM ways t1, ways t2, inter i WHERE t1.gid = 1 AND t2.gid = 2)
-SELECT equals(npoint(1, f1), npoint(2, f2)) FROM fractions;
+SELECT same(npoint(1, f1), npoint(2, f2)) FROM fractions;
 -- true
 </programlisting>
 				</listitem>

--- a/doc/temporal_pose_types.xml
+++ b/doc/temporal_pose_types.xml
@@ -485,10 +485,14 @@ SELECT pose 'Pose(Point(1 1), 0.6)' &gt;= pose 'Pose(Point(1 1), 0.5)';
 				</listitem>
 
 				<listitem xml:id="pose_same">
+					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Are the two values approximately equal with respect to an epsilon value?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
-{pose,posechain} ~= {pose,posechain} &#8594; boolean
+same(pose,pose) &#8594; boolean
+same(posechain,posechain) &#8594; boolean
+pose ~= pose &#8594; boolean
+posechain ~= posechain &#8594; boolean
 </programlisting>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pose 'Pose(SRID=5676;Point(1 1), 0.3)' ~= pose 'Pose(SRID=5676;

--- a/meos/include/geo/tgeo_spatialfuncs.h
+++ b/meos/include/geo/tgeo_spatialfuncs.h
@@ -66,8 +66,6 @@ extern bool datum_point_eq(Datum point1, Datum point2);
 extern bool datum_point_same(Datum point1, Datum point2);
 extern Datum datum2_point_eq(Datum point1, Datum point2);
 extern Datum datum2_point_ne(Datum point1, Datum point2);
-extern Datum datum2_point_same(Datum point1, Datum point2);
-extern Datum datum2_point_nsame(Datum point1, Datum point2);
 extern Datum datum2_geom_centroid(Datum geo);
 extern Datum datum2_geog_centroid(Datum geo);
 

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -165,24 +165,6 @@ datum2_point_ne(Datum point1, Datum point2)
 }
 
 /**
- * @brief Return true if the points are equal
- */
-Datum
-datum2_point_same(Datum point1, Datum point2)
-{
-  return BoolGetDatum(datum_point_same(point1, point2));
-}
-
-/**
- * @brief Return true if the points are equal
- */
-Datum
-datum2_point_nsame(Datum point1, Datum point2)
-{
-  return BoolGetDatum(! datum_point_same(point1, point2));
-}
-
-/**
  * @brief Return the centroid of a geometry
  */
 Datum

--- a/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
+++ b/mobilitydb/sql/cbuffer/200_cbuffer.in.sql
@@ -255,13 +255,13 @@ CREATE FUNCTION cbuffer_dwithin(cbuffer, cbuffer, float)
  * Same
  *****************************************************************************/
 
-CREATE FUNCTION cbuffer_same(cbuffer, cbuffer)
+CREATE FUNCTION same(cbuffer, cbuffer)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Cbuffer_same'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR ~= (
-  PROCEDURE = cbuffer_same,
+  PROCEDURE = same,
   LEFTARG = cbuffer, RIGHTARG = cbuffer,
   COMMUTATOR = ~=,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel

--- a/mobilitydb/sql/npoint/306_tnpoint_spatialfuncs.in.sql
+++ b/mobilitydb/sql/npoint/306_tnpoint_spatialfuncs.in.sql
@@ -84,6 +84,13 @@ CREATE FUNCTION same(npoint, npoint)
   SUPPORT span_supportfn
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+CREATE OPERATOR ~= (
+  PROCEDURE = same,
+  LEFTARG = npoint, RIGHTARG = npoint,
+  COMMUTATOR = ~=,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
+);
+
 /*****************************************************************************
  * Length
  *****************************************************************************/

--- a/mobilitydb/sql/pose/100_pose.in.sql
+++ b/mobilitydb/sql/pose/100_pose.in.sql
@@ -312,13 +312,13 @@ CREATE FUNCTION transformPipeline(pose, text, srid integer DEFAULT 0,
  * Same
  *****************************************************************************/
 
-CREATE FUNCTION pose_same(pose, pose)
+CREATE FUNCTION same(pose, pose)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Pose_same'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR ~= (
-  PROCEDURE = pose_same,
+  PROCEDURE = same,
   LEFTARG = pose, RIGHTARG = pose,
   COMMUTATOR = ~=,
   RESTRICT = tspatial_sel, JOIN = tspatial_joinsel

--- a/mobilitydb/sql/posechain/550_posechain.in.sql
+++ b/mobilitydb/sql/posechain/550_posechain.in.sql
@@ -256,15 +256,16 @@ CREATE FUNCTION transformPipeline(posechain, text, srid integer DEFAULT 0,
  * Same
  *****************************************************************************/
 
-CREATE FUNCTION posechain_same(posechain, posechain)
+CREATE FUNCTION same(posechain, posechain)
   RETURNS boolean
   AS 'MODULE_PATHNAME', 'Posechain_same'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
 CREATE OPERATOR ~= (
+  PROCEDURE = same,
   LEFTARG = posechain, RIGHTARG = posechain,
-  PROCEDURE = posechain_same,
-  COMMUTATOR = ~=
+  COMMUTATOR = ~=,
+  RESTRICT = tspatial_sel, JOIN = tspatial_joinsel
 );
 
 /*****************************************************************************

--- a/mobilitydb/src/npoint/npoint.c
+++ b/mobilitydb/src/npoint/npoint.c
@@ -809,6 +809,7 @@ PG_FUNCTION_INFO_V1(Npoint_same);
  * @ingroup mobilitydb_npoint_comp
  * @brief Return true if two network points are spatially equal
  * @sqlfn same()
+ * @sqlop @p ~=
  */
 Datum
 Npoint_same(PG_FUNCTION_ARGS)

--- a/mobilitydb/src/pose/posechain.c
+++ b/mobilitydb/src/pose/posechain.c
@@ -655,7 +655,7 @@ PG_FUNCTION_INFO_V1(Posechain_same);
  * @ingroup mobilitydb_posechain_base_comp
  * @brief Return true if two pose chains are equal up to the tolerance of the
  * comparison of floating-point values
- * @sqlfn posechain_same()
+ * @sqlfn same()
  * @sqlop @p ~=
  */
 Datum

--- a/mobilitydb/test/cbuffer/expected/200_cbuffer.test.out
+++ b/mobilitydb/test/cbuffer/expected/200_cbuffer.test.out
@@ -288,6 +288,18 @@ SELECT cbuffer 'Cbuffer(Point(1 1),0.500001)' ~= cbuffer 'Cbuffer(Point(1 1),0.5
  f
 (1 row)
 
+SELECT same(cbuffer 'Cbuffer(Point(1.000001 1),0.5)', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ same 
+------
+ t
+(1 row)
+
+SELECT same(cbuffer 'Cbuffer(Point(1.00001 1),0.5)', cbuffer 'Cbuffer(Point(1 1),0.5)');
+ same 
+------
+ f
+(1 row)
+
 SELECT cbuffer 'Cbuffer(Point(1 1),0.5)' = cbuffer 'Cbuffer(Point(1 1),0.5)';
  ?column? 
 ----------

--- a/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
+++ b/mobilitydb/test/cbuffer/queries/200_cbuffer.test.sql
@@ -137,6 +137,8 @@ SELECT cbuffer 'Cbuffer(Point(1 1),0.5000001)' ~= cbuffer 'Cbuffer(Point(1 1),0.
 SELECT cbuffer 'Cbuffer(Point(1.00001 1),0.5)' ~= cbuffer 'Cbuffer(Point(1 1),0.5)';
 SELECT cbuffer 'Cbuffer(Point(1 1.00001),0.5)' ~= cbuffer 'Cbuffer(Point(1 1),0.5)';
 SELECT cbuffer 'Cbuffer(Point(1 1),0.500001)' ~= cbuffer 'Cbuffer(Point(1 1),0.5)';
+SELECT same(cbuffer 'Cbuffer(Point(1.000001 1),0.5)', cbuffer 'Cbuffer(Point(1 1),0.5)');
+SELECT same(cbuffer 'Cbuffer(Point(1.00001 1),0.5)', cbuffer 'Cbuffer(Point(1 1),0.5)');
 
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/npoint/expected/306_tnpoint_spatialfuncs.test.out
+++ b/mobilitydb/test/npoint/expected/306_tnpoint_spatialfuncs.test.out
@@ -410,6 +410,18 @@ SELECT same(npoint 'Npoint(1, 1)', npoint 'Npoint(2, 1)');
  f
 (1 row)
 
+SELECT npoint(1, 0.5) ~= npoint(1, 0.50000001);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT npoint 'Npoint(1, 1)' ~= npoint 'Npoint(2, 1)';
+ ?column? 
+----------
+ f
+(1 row)
+
 SELECT round(length(tnpoint '[Npoint(1, 0.2)@2001-01-01, Npoint(1, 0.4)@2001-01-02, Npoint(1, 0.5)@2001-01-03]'), 6);
   round   
 ----------

--- a/mobilitydb/test/npoint/queries/306_tnpoint_spatialfuncs.test.sql
+++ b/mobilitydb/test/npoint/queries/306_tnpoint_spatialfuncs.test.sql
@@ -126,6 +126,8 @@ FROM temp;
 
 SELECT same(npoint(1, 0.5), npoint(1, 0.50000001));
 SELECT same(npoint 'Npoint(1, 1)', npoint 'Npoint(2, 1)');
+SELECT npoint(1, 0.5) ~= npoint(1, 0.50000001);
+SELECT npoint 'Npoint(1, 1)' ~= npoint 'Npoint(2, 1)';
 -- TODO
 -- SELECT equals(npoint(1, 0.7744007411523213), npoint(2, 0.6952992297355585));
 

--- a/mobilitydb/test/pose/expected/100_pose.test.out
+++ b/mobilitydb/test/pose/expected/100_pose.test.out
@@ -298,6 +298,18 @@ SELECT pose 'Pose(Point(1 1),0.500001)' ~= pose 'Pose(Point(1 1),0.5)';
  f
 (1 row)
 
+SELECT same(pose 'Pose(Point(1.000001 1),0.5)', pose 'Pose(Point(1 1),0.5)');
+ same 
+------
+ t
+(1 row)
+
+SELECT same(pose 'Pose(Point(1.00001 1),0.5)', pose 'Pose(Point(1 1),0.5)');
+ same 
+------
+ f
+(1 row)
+
 SELECT pose 'Pose(Point(1 1),0.5)' = pose 'Pose(Point(1 1),0.5)';
  ?column? 
 ----------

--- a/mobilitydb/test/pose/queries/100_pose.test.sql
+++ b/mobilitydb/test/pose/queries/100_pose.test.sql
@@ -169,6 +169,8 @@ SELECT pose 'Pose(Point(1 1),0.5000001)' ~= pose 'Pose(Point(1 1),0.5)';
 SELECT pose 'Pose(Point(1.00001 1),0.5)' ~= pose 'Pose(Point(1 1),0.5)';
 SELECT pose 'Pose(Point(1 1.00001),0.5)' ~= pose 'Pose(Point(1 1),0.5)';
 SELECT pose 'Pose(Point(1 1),0.500001)' ~= pose 'Pose(Point(1 1),0.5)';
+SELECT same(pose 'Pose(Point(1.000001 1),0.5)', pose 'Pose(Point(1 1),0.5)');
+SELECT same(pose 'Pose(Point(1.00001 1),0.5)', pose 'Pose(Point(1 1),0.5)');
 
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/posechain/expected/550_posechain.test.out
+++ b/mobilitydb/test/posechain/expected/550_posechain.test.out
@@ -213,6 +213,18 @@ SELECT posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))' ~= posech
  t
 (1 row)
 
+SELECT same(posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))', posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))');
+ same 
+------
+ t
+(1 row)
+
+SELECT same(posechain 'PoseChain(Pose(Point(0 0), 0))', posechain 'PoseChain(Pose(Point(0.0000001 0), 0))');
+ same 
+------
+ t
+(1 row)
+
 SELECT posechain 'PoseChain(Pose(Point(0 0), 0))' <> posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
  ?column? 
 ----------

--- a/mobilitydb/test/posechain/queries/550_posechain.test.sql
+++ b/mobilitydb/test/posechain/queries/550_posechain.test.sql
@@ -138,6 +138,8 @@ SELECT asEWKT(round(transform(posechain 'SRID=4326;PoseChain(GeodPose(Point(0 0 
 SELECT posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))' = posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
 SELECT posechain 'PoseChain(Pose(Point(0 0), 0))' < posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
 SELECT posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))' ~= posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
+SELECT same(posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))', posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))');
+SELECT same(posechain 'PoseChain(Pose(Point(0 0), 0))', posechain 'PoseChain(Pose(Point(0.0000001 0), 0))');
 SELECT posechain 'PoseChain(Pose(Point(0 0), 0))' <> posechain 'PoseChain(Pose(Point(0 0), 0), Pose(Point(1 0), 0))';
 SELECT cmp(posechain 'PoseChain(Pose(Point(0 0), 0))', posechain 'PoseChain(Pose(Point(1 0), 0))');
 


### PR DESCRIPTION
Every base value type that answers spatial sameness answers it under the bare
name its own @sqlfn tag states — same(cbuffer,cbuffer), same(pose,pose),
same(posechain,posechain) beside the same(npoint,npoint) already declared — and
publishes it as the ~= operator, which npoint now carries with the selectivity
estimators its 105 sibling operators declare. The posechain operator carries
those estimators too, as its cbuffer and pose siblings do, and Npoint_same
names the operator it backs.

The manual states the function beside the operator in every chapter that
carries the predicate: the circular buffer chapter gains the entry, the network
point entry names same and ~= where it named a function the SQL does not
declare, and the pose entry states both forms.

datum2_point_same and datum2_point_nsame leave the tgeo_spatialfuncs surface.
A datum2_point_* adapter exists to be passed by address to a lifting entry, as
datum2_point_eq and datum2_point_ne are for the ever and always relationships
of two temporal rigid geometries; no family publishes an ever or always
sameness over temporal values, so those two answer for nobody.

