### PR TITLE
Answer cell equality with the primitive the dispatchers are given

### DIFF
--- a/meos/include/h3/th3index.h
+++ b/meos/include/h3/th3index.h
@@ -76,16 +76,4 @@ extern bool ensure_valid_th3index_h3index(const Temporal *temp, H3Index cell);
 extern bool ensure_valid_th3index_tgeogpoint(const Temporal *temp1,
   const Temporal *temp2);
 
-/*****************************************************************************
- * Low-level Datum-returning accessors (used by th3index_compops.c)
- *****************************************************************************/
-
-/**
- * @brief Compare two H3 cell Datums for equality; used as the per-instant
- * comparison function by the ever/always dispatchers. Delegates to
- * `datum2_eq` since h3 cell equality is bit equality at the int64 level.
- */
-extern Datum datum2_h3index_eq(Datum d1, Datum d2, MeosType type);
-extern Datum datum2_h3index_ne(Datum d1, Datum d2, MeosType type);
-
 #endif /* __TH3INDEX_H__ */

--- a/meos/include/quadbin/tquadbin.h
+++ b/meos/include/quadbin/tquadbin.h
@@ -80,17 +80,4 @@ extern bool ensure_valid_tquadbin_quadbin(const Temporal *temp, Quadbin cell);
 extern bool ensure_valid_tquadbin_tgeompoint(const Temporal *temp1,
   const Temporal *temp2);
 
-/*****************************************************************************
- * Low-level Datum-returning comparison primitives (used by tquadbin
- * comparison-operator wrappers)
- *****************************************************************************/
-
-/**
- * @brief Compare two quadbin cell Datums for equality; used as the
- * per-instant comparison function by the ever/always dispatchers.
- * Delegates to bit equality at the int64 level.
- */
-extern Datum datum2_quadbin_eq(Datum d1, Datum d2, MeosType type);
-extern Datum datum2_quadbin_ne(Datum d1, Datum d2, MeosType type);
-
 #endif /* __TQUADBIN_H__ */

--- a/meos/include/s2cell/ts2cell.h
+++ b/meos/include/s2cell/ts2cell.h
@@ -76,17 +76,4 @@ extern bool ensure_valid_ts2cell_s2cell(const Temporal *temp, S2CellId cell);
 extern bool ensure_valid_ts2cell_tgeogpoint(const Temporal *temp1,
   const Temporal *temp2);
 
-/*****************************************************************************
- * Low-level Datum-returning comparison primitives, used by the ts2cell
- * comparison-operator wrappers
- *****************************************************************************/
-
-/**
- * @brief Compare two S2 cell Datums for equality, the per-instant comparison
- * the ever/always dispatchers apply. Delegates to bit equality at the int64
- * level.
- */
-extern Datum datum2_s2cell_eq(Datum d1, Datum d2, MeosType type);
-extern Datum datum2_s2cell_ne(Datum d1, Datum d2, MeosType type);
-
 #endif /* __TS2CELL_H__ */

--- a/meos/src/h3/th3index.c
+++ b/meos/src/h3/th3index.c
@@ -124,35 +124,6 @@ ensure_valid_th3index_tgeogpoint(const Temporal *temp1, const Temporal *temp2)
 }
 
 /*****************************************************************************
- * Comparison-primitive wrappers used by th3index_compops.c
- *
- * Equality / inequality for h3 cells is bit equality at the int64
- * level — the `datum2_eq` / `datum2_ne` used by the generic tbigint
- * machinery already covers that. We only need thin type-correct
- * symbols so the compops dispatcher can pass them through.
- *****************************************************************************/
-
-/**
- * @brief Return true if two H3 cells are equal
- */
-Datum
-datum2_h3index_eq(Datum d1, Datum d2, MeosType type)
-{
-  (void) type;
-  return BoolGetDatum(DatumGetH3Index(d1) == DatumGetH3Index(d2));
-}
-
-/**
- * @brief Return true if two H3 cells are different
- */
-Datum
-datum2_h3index_ne(Datum d1, Datum d2, MeosType type)
-{
-  (void) type;
-  return BoolGetDatum(DatumGetH3Index(d1) != DatumGetH3Index(d2));
-}
-
-/*****************************************************************************
  * Input / output
  *
  * th3index's on-disk representation is identical to tbigint's — the

--- a/meos/src/quadbin/tquadbin.c
+++ b/meos/src/quadbin/tquadbin.c
@@ -439,33 +439,4 @@ tquadbin_to_tbigint(const Temporal *temp)
   return tfunc_temporal(temp, &lfinfo);
 }
 
-/*****************************************************************************
- * Comparison-primitive wrappers
- *
- * Equality / inequality for quadbin cells is bit equality at the int64
- * level — the `datum2_eq` / `datum2_ne` used by the generic tbigint
- * machinery already covers that. We only need thin type-correct
- * symbols so the compops dispatcher can pass them through.
- *****************************************************************************/
-
-/**
- * @brief Return true if two quadbin cells are equal
- */
-Datum
-datum2_quadbin_eq(Datum d1, Datum d2, MeosType type)
-{
-  (void) type;
-  return BoolGetDatum(DatumGetQuadbin(d1) == DatumGetQuadbin(d2));
-}
-
-/**
- * @brief Return true if two quadbin cells are different
- */
-Datum
-datum2_quadbin_ne(Datum d1, Datum d2, MeosType type)
-{
-  (void) type;
-  return BoolGetDatum(DatumGetQuadbin(d1) != DatumGetQuadbin(d2));
-}
-
 /*****************************************************************************/

--- a/meos/src/s2cell/ts2cell.c
+++ b/meos/src/s2cell/ts2cell.c
@@ -429,33 +429,4 @@ ts2cell_to_tbigint(const Temporal *temp)
   return tfunc_temporal(temp, &lfinfo);
 }
 
-/*****************************************************************************
- * Comparison-primitive wrappers
- *
- * Equality and inequality for S2 cells are bit equality at the int64 level,
- * which the `datum2_eq` / `datum2_ne` the generic tbigint machinery uses
- * already covers. These are the thin type-correct symbols the compops
- * dispatcher passes through.
- *****************************************************************************/
-
-/**
- * @brief Return true if two S2 cell Datums are equal
- */
-Datum
-datum2_s2cell_eq(Datum d1, Datum d2, MeosType type)
-{
-  (void) type;
-  return BoolGetDatum(DatumGetS2Cell(d1) == DatumGetS2Cell(d2));
-}
-
-/**
- * @brief Return true if two S2 cell Datums are different
- */
-Datum
-datum2_s2cell_ne(Datum d1, Datum d2, MeosType type)
-{
-  (void) type;
-  return BoolGetDatum(DatumGetS2Cell(d1) != DatumGetS2Cell(d2));
-}
-
 /*****************************************************************************/


### PR DESCRIPTION
The h3, quadbin and s2 cell families each reach ever, always and temporal
equality through an eacomp_ or tcomp_ entry taking a
Datum (*)(Datum, Datum, MeosType) comparison, and all 54 call sites of the
three compops files pass the generic datum2_eq or datum2_ne, which a cell
shares with a big integer because a cell identifier is its int64 bit pattern.

datum2_h3index_eq, datum2_h3index_ne, datum2_quadbin_eq, datum2_quadbin_ne,
datum2_s2cell_eq and datum2_s2cell_ne leave the three family headers. Each
restated that bit comparison behind a DatumGetH3Index, DatumGetQuadbin or
DatumGetS2Cell cast and answered for nobody, while the section declaring it
named the compops file as its caller.

