### PR TITLE
Report the S2CELL family in the installed meos.pc

### DIFF
--- a/meos/CMakeLists.txt
+++ b/meos/CMakeLists.txt
@@ -609,7 +609,7 @@ if(MEOS)
   # add_definitions() pairs in the top-level CMakeLists, so that the installed
   # library describes its own feature set.
   set(_meos_pc_cflags -DMEOS=1)
-  foreach(_family CBUFFER H3 JSON NPOINT POINTCLOUD POSE QUADBIN RASTER RGEO)
+  foreach(_family CBUFFER H3 JSON NPOINT POINTCLOUD POSE QUADBIN RASTER RGEO S2CELL)
     if(${_family})
       list(APPEND _meos_pc_cflags -D${_family}=1)
     else()


### PR DESCRIPTION
The `Cflags` of the installed `meos.pc` carry the resolved value of every
optional family, so a consumer that asks pkg-config compiles the same branch of
the public headers the library was built from. The list they are emitted from
mirrors the `add_definitions()` pairs of the top-level CMakeLists, and now names
the same ten families those pairs define: S2CELL joins CBUFFER, H3, JSON,
NPOINT, POINTCLOUD, POSE, QUADBIN, RASTER and RGEO.

Against a prefix installed from this tree with `-DALL=ON`,
`pkg-config --cflags meos` reports `-DS2CELL=1`, and the set of family names it
carries is equal to the set the top-level CMakeLists defines. Configured with
`-DALL=OFF` the same field reports `-DS2CELL=0`, the value a consumer needs in
order to read the negative branch deliberately rather than by omission. The
MEOS target builds clean with no warnings.

