### PR TITLE
State what a baselined return-type multiplicity is

### DIFF
--- a/tools/scripts/check_csqlfn.py
+++ b/tools/scripts/check_csqlfn.py
@@ -466,9 +466,15 @@ RETURNS_BASELINE_HEADER = (
     '# return types than their SQL declarations state, as\n'
     '# tools/scripts/check_csqlfn.py --returns reads them. A host resolves an\n'
     '# overload on the arguments, so this is a surface a binding cannot\n'
-    '# express. Grandfathered in, keyed by wrapper. The list only shrinks: a\n'
-    '# new one fails the check. Regenerate with --returns-rebaseline after a\n'
-    '# fix.\n')
+    '# express. Keyed by wrapper. The list only shrinks: a new one fails the\n'
+    '# check. Regenerate with --returns-rebaseline.\n'
+    '#\n'
+    '# Every claimant here that answers a scalar is a PUBLIC typed function,\n'
+    '# and where a generic claims the wrapper too it is internal and answers\n'
+    '# a Datum. The typed functions are the wrapper\'s public link, so dropping\n'
+    '# their tags takes the SQL name out of every generated binding instead of\n'
+    '# resolving the multiplicity. The type the surface answers is the one the\n'
+    '# CREATE FUNCTION declares, and a binding reads it from there.\n')
 
 
 def read_returns_baseline():

--- a/tools/scripts/csqlfn_returns_baseline.txt
+++ b/tools/scripts/csqlfn_returns_baseline.txt
@@ -2,9 +2,15 @@
 # return types than their SQL declarations state, as
 # tools/scripts/check_csqlfn.py --returns reads them. A host resolves an
 # overload on the arguments, so this is a surface a binding cannot
-# express. Grandfathered in, keyed by wrapper. The list only shrinks: a
-# new one fails the check. Regenerate with --returns-rebaseline after a
-# fix.
+# express. Keyed by wrapper. The list only shrinks: a new one fails the
+# check. Regenerate with --returns-rebaseline.
+#
+# Every claimant here that answers a scalar is a PUBLIC typed function,
+# and where a generic claims the wrapper too it is internal and answers
+# a Datum. The typed functions are the wrapper's public link, so dropping
+# their tags takes the SQL name out of every generated binding instead of
+# resolving the multiplicity. The type the surface answers is the one the
+# CREATE FUNCTION declares, and a binding reads it from there.
 Distance_set_set
 NAD_number_tnumber
 NAD_tbox_tbox


### PR DESCRIPTION
The csqlfn_returns baseline names six wrappers and says the list only
shrinks, which reads as six tag removals waiting to be made. Every claimant
of those six that answers a scalar is a public typed function -- the five
set distances under meos_setspan_dist and the three temporal ones under
meos_temporal_dist for each nearest-approach wrapper -- and where a generic
claims the wrapper too it is internal and answers a Datum. The typed
functions are therefore the wrapper's public link, and dropping their tags
takes the SQL name out of every generated binding rather than resolving the
multiplicity.

The baseline header states that, and states where the answer is instead: the
type a surface answers is the one its CREATE FUNCTION declares, which is
what a binding reads.

