### PR TITLE
Say that a temporal point cloud box operation raises on a mismatch

### DIFF
--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -435,7 +435,7 @@ SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
 
 		<sect2 xml:id="tpcbox_topo">
 			<title>Operaciones topológicas</title>
-			<para>Todos los operadores topológicos toman dos valores <varname>tpcbox</varname> con <varname>pcid</varname> coincidente. Una discrepancia de pcid siempre devuelve falso (no un error) para que los escaneos de índice se comporten de forma intuitiva.</para>
+			<para>Todos los operadores topológicos toman dos valores <varname>tpcbox</varname> que declaran el mismo esquema y el mismo sistema de referencia. Una discrepancia en cualquiera de los dos genera un error en lugar de responder falso: el <varname>pcid</varname> es lo que da a un número almacenado su significado como coordenada, por lo que dos cajas que nombran esquemas distintos no tienen una extensión común que comparar.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_topo_ops">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
@@ -467,7 +467,7 @@ SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(0, 0, 5, 5, 2);
 
 		<sect2 xml:id="tpcbox_pos">
 			<title>Operaciones de posición</title>
-			<para>Dieciséis predicados de posición alineados por eje, paralelos a los de <varname>stbox</varname>. Cada uno comprueba la relación estricta o de solapamiento a lo largo de un eje. Todos requieren <varname>pcid</varname> coincidente; la discrepancia devuelve falso. Los predicados del eje Z requieren que ambas cajas tengan dimensión Z; los del eje T requieren que ambas tengan dimensión T.</para>
+			<para>Dieciséis predicados de posición alineados por eje, paralelos a los de <varname>stbox</varname>. Cada uno comprueba la relación estricta o de solapamiento a lo largo de un eje. Todos requieren el mismo esquema y el mismo sistema de referencia, y una discrepancia en cualquiera de los dos genera un error. Los predicados del eje Z requieren que ambas cajas tengan dimensión Z; los del eje T requieren que ambas tengan dimensión T.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_pos_ops">
 					<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -437,7 +437,7 @@ SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
 
 		<sect2 xml:id="tpcbox_topo">
 			<title>Topological Operations</title>
-			<para>All topological operators take two <varname>tpcbox</varname> values with matching <varname>pcid</varname>. A pcid mismatch always yields false (not an error) so that index scans behave intuitively.</para>
+			<para>All topological operators take two <varname>tpcbox</varname> values that state the same schema and the same reference system. A mismatch in either raises an error rather than answering false: the <varname>pcid</varname> is what gives a stored number its meaning as a coordinate, so two boxes naming different schemas have no common extent to compare.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_topo_ops">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
@@ -469,7 +469,7 @@ SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(0, 0, 5, 5, 2);
 
 		<sect2 xml:id="tpcbox_pos">
 			<title>Position Operations</title>
-			<para>Sixteen axis-aligned position predicates, parallel to those on <varname>stbox</varname>. Each tests strict-or-overlap relationship along one axis. All require matching <varname>pcid</varname>; mismatch returns false. Z-axis predicates require both boxes to have a Z dimension; T-axis predicates require both to have a T dimension.</para>
+			<para>Sixteen axis-aligned position predicates, parallel to those on <varname>stbox</varname>. Each tests strict-or-overlap relationship along one axis. All require the same schema and the same reference system, and a mismatch in either raises an error. Z-axis predicates require both boxes to have a Z dimension; T-axis predicates require both to have a T dimension.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_pos_ops">
 					<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>


### PR DESCRIPTION
The chapter states both answers. Its overview says two tpcbox values naming
different schemas make "an operation between them raise an error instead of
comparing their geometric or temporal extent", while the topological section
says "a pcid mismatch always yields false (not an error)" and the position
section says "mismatch returns false". The code raises: ensure_same_pcid_tpcbox
reports "Operation on TPCBox values with different schemas" and
ensure_same_srid_tpcbox reports "Operation on TPCBox values with different
SRIDs", and the expected output of 410_tpcbox carries the first of those three
times.

The rationale the topological section offered for the false answer does not
hold either. An index scan is not made intuitive by a predicate that answers
false across schemas: the SP-GiST key drops the pcid, so the spatial filter is
what prunes those rows, and a sequential scan and a GiST scan over the same
mixed column both raise.

Both sections now state the same rule as the overview, and name the reference
system beside the schema, since a mismatch in either is what the operators
refuse.