### PR TITLE
Let a temporal point cloud box state only a reference system its schema does not

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3250,7 +3250,7 @@
 						<para><link linkend="tpcbox_round"><varname>round</varname></link>: Devuelve un tpcbox con las coordenadas redondeadas al número de dígitos decimales indicado</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpcbox_setSRID"><varname>setSRID</varname></link>: Devuelve un tpcbox con el SRID sobreescrito</para>
+						<para><link linkend="tpcbox_setSRID"><varname>setSRID</varname></link>: Devuelve un tpcbox que declara un sistema de referencia que su esquema no declara</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -399,14 +399,16 @@ SELECT round(tpcboxX(0.123456, 1.234567, 2.345678, 3.456789, 1), 2);
 
 				<listitem xml:id="tpcbox_setSRID">
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
-					<para>Devuelve un tpcbox con el SRID sobreescrito</para>
+					<para>Devuelve un tpcbox que declara un sistema de referencia que su esquema no declara</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 setSRID(tpcbox,integer) → tpcbox
 </programlisting>
-					<para>No reproyecta las coordenadas, para ello, proyecte primero el tpcpoint subyacente y tome la caja delimitadora del resultado</para>
+					<para>El esquema nombrado por el pcid es el que contiene el sistema de referencia, por lo que cuando ese esquema declara uno la caja se rechaza: un pcid de 0 no nombra ningún esquema, y un esquema puede no declarar ninguno. No reproyecta las coordenadas, para ello, proyecte primero el tpcpoint subyacente y tome la caja delimitadora del resultado</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1), 4326));
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10), 4326));
 -- 4326
+SELECT setSRID(tpcboxX(0, 0, 10, 10, 1), 3857);
+-- ERROR: The SRID of a TPCBox is the one its schema states: pcid 1 states SRID 4326
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3259,7 +3259,7 @@
 						<para><link linkend="tpcbox_round"><varname>round</varname></link>: Return a tpcbox with coordinates rounded to a given number of decimal digits</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpcbox_setSRID"><varname>setSRID</varname></link>: Return a tpcbox with the SRID overwritten</para>
+						<para><link linkend="tpcbox_setSRID"><varname>setSRID</varname></link>: Return a tpcbox stating a reference system its schema does not state</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -400,14 +400,16 @@ SELECT round(tpcboxX(0.123456, 1.234567, 2.345678, 3.456789, 1), 2);
 
 				<listitem xml:id="tpcbox_setSRID">
 					<indexterm significance="normal"><primary><varname>setSRID</varname></primary></indexterm>
-					<para>Return a tpcbox with the SRID overwritten</para>
+					<para>Return a tpcbox stating a reference system its schema does not state</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
 setSRID(tpcbox,integer) → tpcbox
 </programlisting>
-					<para>Does not reproject coordinates, for that, project the underlying tpcpoint first and take the bbox of the result</para>
+					<para>The schema a pcid names is what holds the reference system, so where that schema states one the box is refused: a pcid of 0 names no schema, and a schema may state none. Does not reproject coordinates, for that, project the underlying tpcpoint first and take the bbox of the result</para>
 					<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1), 4326));
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10), 4326));
 -- 4326
+SELECT setSRID(tpcboxX(0, 0, 10, 10, 1), 3857);
+-- ERROR: The SRID of a TPCBox is the one its schema states: pcid 1 states SRID 4326
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -459,7 +459,6 @@ extern bool overafter_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2);
 
 /* Validity helpers */
 
-extern bool ensure_same_pcid_tpcbox(const TPCBox *box1, const TPCBox *box2);
 
 /*****************************************************************************
  * Temporal pgpointcloud types (tpcpoint / tpcpatch) — value surface

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -80,11 +80,13 @@
 
 /**
  * @brief Ensure two TPCBoxes share the same schema (pcid).
- * @note pcid 0 is treated as "unknown" — sets/unions involving it propagate
- * the non-zero pcid from the other operand. Rejecting 0-vs-non-0 would
- * block natural workflows like @c tpcbox() aggregation from raw literals.
+ * @note The schemas are compared as they are stated: a pcid of 0 names no
+ * schema, and a box carrying coordinates under it is not comparable with a box
+ * carrying them under a schema that does. The X guard in
+ * #ensure_valid_tpcbox_tpcbox is what lets a box holding no coordinates meet a
+ * box of any schema.
  */
-bool
+static bool
 ensure_same_pcid_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
@@ -100,7 +102,8 @@ ensure_same_pcid_tpcbox(const TPCBox *box1, const TPCBox *box2)
 
 /**
  * @brief Ensure two TPCBoxes share the same SRID.
- * @note SRID 0 is treated as "unknown" — same relaxation as pcid.
+ * @note The reference systems are compared as they are stated, which is the
+ * same strict equality #ensure_same_srid applies to the spatiotemporal box.
  */
 static bool
 ensure_same_srid_tpcbox(const TPCBox *box1, const TPCBox *box2)
@@ -873,10 +876,12 @@ tpcbox_round(const TPCBox *box, int maxdd)
 
 /**
  * @ingroup meos_pointcloud_box_transf
- * @brief Return a tpcbox with the SRID overwritten.
- * @details Does not transform coordinates; just stamps the new SRID on the
- * result.  For coordinate reprojection, project the underlying tpcpoint first,
- * then take its bbox.
+ * @brief Return a tpcbox stating a reference system its schema does not state
+ * @details The schema a pcid names is what holds the reference system, so
+ * where that schema states one it is not the caller's to set and the box is
+ * refused. A pcid of 0 names no schema and a schema may state none, and there
+ * the box itself is the only level there is. Coordinates are not transformed
+ * either way; to reproject, project the underlying tpcpoint and take its box.
  * @csqlfn #Tpcbox_set_srid()
  */
 TPCBox *
@@ -884,6 +889,17 @@ tpcbox_set_srid(const TPCBox *box, int32_t srid)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_TPCBOX(box, NULL);
+  if (box->pcid != 0)
+  {
+    int32_t schema_srid = meos_pc_schema_srid(box->pcid);
+    if (schema_srid != SRID_INVALID && schema_srid != SRID_UNKNOWN)
+    {
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "The SRID of a TPCBox is the one its schema states: pcid %u states "
+        "SRID %d", box->pcid, schema_srid);
+      return NULL;
+    }
+  }
   TPCBox *result = tpcbox_copy(box);
   result->srid = srid;
   return result;

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -356,5 +356,23 @@ SELECT tpcbox 'TPCBOX(X((0,0),(10,10)), 7)';
  TPCBOX(X((0,0),(10,10)), 7)
 (1 row)
 
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10), 4326));
+ srid 
+------
+ 4326
+(1 row)
+
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1), 4326));
+ srid 
+------
+ 4326
+(1 row)
+
+SELECT setSRID(tpcboxX(0, 0, 10, 10, 5), 3857);
+ERROR:  The SRID of a TPCBox is the one its schema states: pcid 5 states SRID 4326
+SELECT setSRID(tpcboxX(0, 0, 10, 10, 5), 4326);
+ERROR:  The SRID of a TPCBox is the one its schema states: pcid 5 states SRID 4326
+SELECT setSRID(tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 5), 3857);
+ERROR:  The SRID of a TPCBox is the one its schema states: pcid 5 states SRID 4326
 DELETE FROM pointcloud_formats WHERE pcid IN (2, 5);
 DELETE 2

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -217,6 +217,23 @@ SELECT tpcbox 'SRID=3857;TPCBOX(X((0,0),(10,10)), 7)';
 SELECT tpcbox 'TPCBOX(X((0,0),(10,10)), 7)';
 
 -------------------------------------------------------------------------------
+-- setSRID states a reference system the schema does not state
+-------------------------------------------------------------------------------
+
+-- A box naming no schema has no other level, so it takes what it is given
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10), 4326));
+-- The schema pcid 1 names states none either, which leaves the box the only
+-- level there is
+SELECT SRID(setSRID(tpcboxX(0, 0, 10, 10, 1), 4326));
+-- The schema pcid 5 names states one, so the SRID is not the caller's to set,
+-- and agreeing with it is not a licence to set it either
+SELECT setSRID(tpcboxX(0, 0, 10, 10, 5), 3857);
+SELECT setSRID(tpcboxX(0, 0, 10, 10, 5), 4326);
+-- A box carrying no coordinates states no reference system, and pcid 5 still
+-- speaks for it
+SELECT setSRID(tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 5), 3857);
+
+-------------------------------------------------------------------------------
 
 DELETE FROM pointcloud_formats WHERE pcid IN (2, 5);
 

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox_tbl.test.sql
@@ -95,7 +95,8 @@ SELECT COUNT(*) FROM tbl_tpcbox t1, tbl_tpcbox t2 WHERE t1.b <= t2.b;
 
 -- round(b, 0) is idempotent: applying it twice gives the same value.
 SELECT bool_and(round(round(b, 0), 0) ~= round(b, 0)) FROM tbl_tpcbox;
--- setSRID stamps the new SRID without touching pcid.
+-- setSRID stamps the new SRID without touching pcid. The schema pcid 1 names
+-- states no reference system, which is what leaves the box free to state one.
 SELECT bool_and(SRID(setSRID(b, 4326)) = 4326 AND pcid(setSRID(b, 4326)) = pcid(b))
 FROM tbl_tpcbox;
 


### PR DESCRIPTION
The SRID a TPCBox carries is the one its schema states, which is what the
constructors, the written form and the extent aggregate all now hold to.
setSRID stood outside that: it wrote its argument into the box unconditionally,
so a box could state one reference system while the schema its pcid names
stated another. It is the last way to write that contradiction.

The schema is the authority where it speaks, so setSRID refuses there, naming
the SRID the schema states. Agreeing with the schema is not a licence to set it
either: the value is derived, so setting it is not an operation the type has,
whatever the argument. Where no schema speaks the box is the only level there
is and setSRID applies as before, which covers a pcid of 0, a pcid no schema is
registered for, and a schema whose own SRID reads unknown. That is the same
authority the written form was given, minus the branch a round trip owes and
this one does not.

ensure_same_pcid_tpcbox becomes static, as its twin ensure_same_srid_tpcbox
already is. It carries no @ingroup, so no binding projects it, and nothing
outside the file that defines it calls it; the header declaration was the only
reference. Both validators also stated rules the code does not follow — one
promised that a pcid of 0 propagates the other operand's schema, which the
combine paths no longer do, and the other promised an SRID of 0 is exempt,
which was never what it compared.