### PR TITLE
Drop the inner ring a closed curve contracts through

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -4406,6 +4406,33 @@ buffer_ring_resolved(LWGEOM *raw, const LWGEOM *input, double radius,
 }
 
 /**
+ * @brief Return whether a contracted ring has passed through itself
+ * @details Contracting a ring by more than it encloses carries the contraction
+ * through itself, and it comes back out inverted at the distance it overshot
+ * by. That curve is nearer the input than the buffer distance, so it bounds
+ * nothing and the hole it would stand for is gone rather than uncovered. The
+ * point the ring holds is what says which of the two it is: an interior point
+ * of a true hole lies further from the input than the distance, and an
+ * interior point of the inverted curve lies nearer.
+ * @param[in] ring Contracted ring
+ * @param[in] edges Edges of the geometry being buffered
+ * @param[in] radius Buffer distance
+ * @param[in] srid Spatial reference identifier
+ */
+static bool
+buffer_ring_inverted(LWCOMPOUND *ring, const MeosArray *edges, double radius,
+  int32_t srid)
+{
+  double hx, hy;
+  if (! ring || ! edges)
+    return false;
+  if (! buffer_ring_representative_point(ring, srid, &hx, &hy))
+    return false;
+  return buffer_point_edges_distance(hx, hy, edges) <
+    radius - MEOS_GEOM_TOLERANCE;
+}
+
+/**
  * @brief Buffer a curve, which is a circular string or a compound curve
  * @details The boundary walks the offset of the curve on its left, caps the
  * far end, walks the offset of the reversed curve, which is its right, and
@@ -4441,6 +4468,9 @@ meos_buffer_curve(const LWGEOM *geom, double radius, JoinStyle join_style,
       mitre_limit, true, srid, outer, NULL, NULL);
     bool has_hole = ok && buffer_offset_edges(edges, radius, ! outward,
       join_style, mitre_limit, true, srid, inner, NULL, NULL);
+    /* A closed curve contracts into itself the same way a closed line does */
+    if (has_hole && buffer_ring_inverted(inner, edges, radius, srid))
+      has_hole = false;
     meos_array_destroy(edges);
     if (! ok)
     {
@@ -4906,11 +4936,8 @@ meos_buffer_line_offset(const LWLINE *line, double radius,
     bool inverted = false;
     if (inner)
     {
-      double hx, hy;
       MeosArray *ledges = geom_extract_edges((const LWGEOM *) line);
-      if (ledges && buffer_ring_representative_point(inner, srid, &hx, &hy) &&
-          buffer_point_edges_distance(hx, hy, ledges) <
-            radius - MEOS_GEOM_TOLERANCE)
+      if (buffer_ring_inverted(inner, ledges, radius, srid))
       {
         lwgeom_free(lwcompound_as_lwgeom(inner));
         inner = NULL;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -357,6 +357,39 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* Contracting a closed ring by more than it encloses carries the contraction
+   * through itself, and it re-emerges inverted at the distance it overshot by.
+   * That curve lies NEARER the input than the buffer distance, so it bounds
+   * nothing and the hole it stands for is gone rather than uncovered; kept, it
+   * punches a hole out of the answer and the buffer stops containing the very
+   * geometry it is taken of. The closed LINESTRING branch tests for it; the
+   * closed CURVE branch is the same shape and asked nothing, so a compound
+   * curve buffered past its inradius answered a surface missing its middle.
+   * The witness is a closed curve about 10 by 2, so its inradius is near 1,
+   * buffered on both sides of that. A buffer contains its own input at EVERY
+   * radius, which needs no oracle to check */
+  const char *closed_curve =
+    "CompoundCurve((0 0,10 0),CircularString(10 0,5 2,0 0))";
+  const double closed_radius[] = {0.5, 3.0};
+  char closed_patt[10] = "T*****FF*";
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *g = geom_in(closed_curve, -1);
+    assert(g != NULL);
+    meos_errno_reset();
+    GSERIALIZED *b = geom_buffer(g, closed_radius[i], "");
+    printf("geom_buffer(a closed curve, %s its inradius): answered %d, "
+      "errno %d\n", i ? "past" : "within", b != NULL, meos_errno());
+    assert(b != NULL);
+    assert(meos_errno() == 0);
+    bool covers = geom_relate_pattern(b, g, closed_patt);
+    printf("  it covers the geometry it is taken of: %d\n", covers);
+    assert(covers == true);
+    assert(meos_errno() == 0);
+    free(b); free(g);
+    meos_errno_reset();
+  }
+
   /* The junction between two offsets is settled from the cross product of the
    * directions the two edges meeting there run in, and that product is a sine
    * only where both directions are of unit length. An arc answers a sine and


### PR DESCRIPTION
Drop the inner ring a closed curve contracts through

Buffering a closed ring contracts it inward as well as expanding it outward.
Contracted by more than the ring encloses, the inner offset passes through
itself and re-emerges inverted at the distance it overshot by. That curve lies
NEARER the input than the buffer distance, so it bounds nothing, and kept as a
ring it punches a hole out of the answer.

The closed LINESTRING branch tests for it. The closed CURVE branch is the same
shape and asks nothing, so `buffer_ring_inverted` reads the question once and
both branches ask it: a ring whose representative point stands closer to the
input than the radius is dropped rather than kept as a hole.

WITNESS

  SELECT ST_Covers(
    ST_Buffer('CompoundCurve((0 0,10 0),CircularString(10 0,5 2,0 0))', 3.0),
    'CompoundCurve((0 0,10 0),CircularString(10 0,5 2,0 0))');

The curve is about 10 by 2, so its inradius is near 1 and a radius of 3 passes
well beyond it.

  before  f   the buffer does not contain the geometry it is taken of
  after   t

At 0.5, within the inradius, both answer `t`. A buffer contains its own input
at EVERY radius, whatever the shape, so the before answer is refuted without
appeal to any reference implementation.

MEASURED

  meos/test/geo_test.c          the case above passes here and aborts against
                                the base library
  GEOS buffer corpus            34 records, 31 agree with the reference extent
                                / 1 differs / 2 declined, on the base library
                                and on this one alike
  283 polygons x radii 1/5/50   849 buffers, 482 cover their input / 0 do not
                                / 367 declined, on the base library and on
                                this one alike. The corpus carries no closed
                                curve buffered past its inradius, so it
                                measures that nothing ELSE moves rather than
                                the fix itself
  full meos/test suite          the 54 invocations the CI step compiles and
                                runs, clean

The one differing record of the GEOS corpus and the two declines are the same
records before and after, and belong to the arc-boundary class rather than to
this one. They are a separate defect and carry their own witness.

WHY

The inner offset of a closed ring is the locus of points at the buffer distance
INSIDE it, which exists only while the ring encloses at least that much: the
erosion of a region by a disc of radius r is empty once r passes the inradius.
Beyond that the offset construction still returns a curve, but the curve it
returns is the self-intersection re-emerging on the other side, and every point
of it lies nearer the input than r.

A ring bounds a hole in the buffer only if it stands at least the buffer
distance from the input, since the buffer is by definition every point within
that distance. So the test is the definition: measure the ring against the
input and drop it where it falls short. Nothing here depends on how far past
the inradius the radius reaches, which is why one comparison answers every
radius rather than a threshold per shape.
