### PR TITLE
Reach the combine functions the suite never runs

### DIFF
--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -738,7 +738,14 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
 
   /* Free memory */
   if (spliced_count != 0)
+  {
     pfree_array((void **) tofree, nfree);
+    /* The merge answers the new values in one array and reports the values to
+     * free in another. The sequence path answers the same array for both, so
+     * the array of new values is a second allocation only when they differ */
+    if (values != (void **) tofree)
+      pfree(values);
+  }
   return;
 }
 

--- a/meos/test/.gitignore
+++ b/meos/test/.gitignore
@@ -7,6 +7,7 @@
 /tnpoint_smoketest.c
 /tgeometry_smoketest.c
 /tjsonb_smoketest.c
+/temporal_agg_smoketest.c
 
 # Table fixtures exported from the pg_regress archives by
 # tools/gen_test_csv.py. mobilitydb/test/<family>/data/load_*.sql.xz is the one

--- a/meos/test/smoke/temporal_agg.json
+++ b/meos/test/smoke/temporal_agg.json
@@ -1,0 +1,91 @@
+{
+  "type_label": "temporal agg",
+  "header": "meos.h",
+  "out": "temporal_agg_smoketest.c",
+  "only": [
+    "_(transfn|combinefn|finalfn)$"
+  ],
+  "extra_includes": "#include <meos_internal.h>",
+  "arg_map": {
+    "Temporal *": "tint1",
+    "Set *": "tstzset1",
+    "Span *": "tstzspan1",
+    "SpanSet *": "tstzspanset1",
+    "TBox *": "tbox1",
+    "Interval *": "interv1",
+    "TimestampTz": "tstz1",
+    "DateADT": "date1",
+    "text *": "txt1",
+    "int": "1",
+    "int32": "1",
+    "int64": "1",
+    "double": "1.0"
+  },
+  "name_arg_map": {
+    "^tint_": {
+      "Temporal *": "tint1"
+    },
+    "^tbigint_": {
+      "Temporal *": "tbigint1"
+    },
+    "^tfloat_": {
+      "Temporal *": "tfloat1"
+    },
+    "^tbool_": {
+      "Temporal *": "tbool1"
+    },
+    "^ttext_": {
+      "Temporal *": "ttext1"
+    },
+    "^tnumber_": {
+      "Temporal *": "tfloat1"
+    }
+  },
+  "common_inputs": [
+    "  Temporal *tint1 = tint_in(\"{[1@2001-01-01, 3@2001-01-03],[4@2001-01-04, 6@2001-01-06]}\");",
+    "  Temporal *tbigint1 = tbigint_in(\"{[1@2001-01-01, 3@2001-01-03],[4@2001-01-04, 6@2001-01-06]}\");",
+    "  Temporal *tfloat1 = tfloat_in(\"{[1@2001-01-01, 3@2001-01-03],[4@2001-01-04, 6@2001-01-06]}\");",
+    "  Temporal *tbool1 = tbool_in(\"{[t@2001-01-01, t@2001-01-03],[f@2001-01-04, f@2001-01-06]}\");",
+    "  Temporal *ttext1 = ttext_in(\"{[A@2001-01-01, B@2001-01-03],[C@2001-01-04, D@2001-01-06]}\");",
+    "  Set *tstzset1 = tstzset_in(\"{2001-01-01, 2001-01-03}\");",
+    "  Span *tstzspan1 = tstzspan_in(\"[2001-01-01, 2001-01-03]\");",
+    "  SpanSet *tstzspanset1 = tstzspanset_in(\"{[2001-01-01, 2001-01-03]}\");",
+    "  TBox *tbox1 = tbox_in(\"TBOXFLOAT XT([1,2],[2001-01-01,2001-01-03])\");",
+    "  Interval *interv1 = interval_in(\"1 day\", -1);",
+    "  TimestampTz tstz1 = timestamptz_in(\"2001-01-01\", -1);",
+    "  DateADT date1 = date_in(\"2001-01-01\");",
+    "  text *txt1 = cstring_to_text(\"AAA\");",
+    "  Temporal *tint2 = tint_in(\"{[7@2001-01-10, 9@2001-01-13],[2@2001-01-14, 5@2001-01-16]}\");",
+    "  Temporal *tbigint2 = tbigint_in(\"{[7@2001-01-10, 9@2001-01-13],[2@2001-01-14, 5@2001-01-16]}\");",
+    "  Temporal *tfloat2 = tfloat_in(\"{[7.5@2001-01-10, 9.5@2001-01-13],[2.5@2001-01-14, 5.5@2001-01-16]}\");",
+    "  Temporal *tbool2 = tbool_in(\"{[f@2001-01-10, f@2001-01-13],[t@2001-01-14, t@2001-01-16]}\");",
+    "  Temporal *ttext2 = ttext_in(\"{[X@2001-01-10, Y@2001-01-13],[Z@2001-01-14, W@2001-01-16]}\");",
+    "  Set *tstzset2 = tstzset_in(\"{2001-01-10, 2001-01-13}\");",
+    "  Span *tstzspan2 = tstzspan_in(\"[2001-01-10, 2001-01-13]\");",
+    "  SpanSet *tstzspanset2 = tstzspanset_in(\"{[2001-01-10, 2001-01-13]}\");",
+    "  TBox *tbox2 = tbox_in(\"TBOXFLOAT XT([3,4],[2001-01-10,2001-01-13])\");",
+    "  TimestampTz tstz2 = timestamptz_in(\"2001-01-10\", -1);"
+  ],
+  "cleanup": [
+    "  free(tint1);",
+    "  free(tbigint1);",
+    "  free(tfloat1);",
+    "  free(tbool1);",
+    "  free(ttext1);",
+    "  free(tstzset1);",
+    "  free(tstzspan1);",
+    "  free(tstzspanset1);",
+    "  free(tbox1);",
+    "  free(interv1);",
+    "  free(txt1);",
+    "  free(tint2);",
+    "  free(tbigint2);",
+    "  free(tfloat2);",
+    "  free(tbool2);",
+    "  free(ttext2);",
+    "  free(tstzset2);",
+    "  free(tstzspan2);",
+    "  free(tstzspanset2);",
+    "  free(tbox2);"
+  ]
+}

--- a/mobilitydb/test/geo/expected/051_stbox.test.out
+++ b/mobilitydb/test/geo/expected/051_stbox.test.out
@@ -2106,3 +2106,41 @@ SELECT round(distance, 6) FROM test;
 
 DROP INDEX tbl_stbox3d_kdtree_idx;
 DROP INDEX
+SELECT stbox_extent_combinefn(stbox 'SRID=4326;STBOX X((0,0),(1,1))',
+  stbox 'SRID=4326;STBOX X((5,5),(6,6))');
+     stbox_extent_combinefn     
+--------------------------------
+ SRID=4326;STBOX X((0,0),(6,6))
+(1 row)
+
+SELECT stbox_extent_combinefn(stbox 'STBOX T([2001-01-01,2001-01-02])',
+  stbox 'STBOX T([2001-01-03,2001-01-04])');
+                        stbox_extent_combinefn                         
+-----------------------------------------------------------------------
+ STBOX T([Mon Jan 01 00:00:00 2001 PST, Thu Jan 04 00:00:00 2001 PST])
+(1 row)
+
+SELECT stbox_extent_combinefn(stbox 'SRID=4326;STBOX X((0,0),(1,1))',
+  stbox 'SRID=3857;STBOX X((5,5),(6,6))');
+ERROR:  Operation on mixed SRID
+SELECT stbox_extent_combinefn(stbox 'STBOX X((0,0),(1,1))',
+  stbox 'STBOX XT(((5,5),(6,6)),[2001-01-01,2001-01-02])');
+ERROR:  The arguments must be of the same dimensionality
+SELECT stbox_extent_combinefn(NULL::stbox, stbox 'STBOX X((5,5),(6,6))');
+ stbox_extent_combinefn 
+------------------------
+ STBOX X((5,5),(6,6))
+(1 row)
+
+SELECT stbox_extent_combinefn(stbox 'STBOX X((0,0),(1,1))', NULL::stbox);
+ stbox_extent_combinefn 
+------------------------
+ STBOX X((0,0),(1,1))
+(1 row)
+
+SELECT stbox_extent_combinefn(NULL::stbox, NULL::stbox);
+ stbox_extent_combinefn 
+------------------------
+ 
+(1 row)
+

--- a/mobilitydb/test/geo/queries/051_stbox.test.sql
+++ b/mobilitydb/test/geo/queries/051_stbox.test.sql
@@ -633,3 +633,29 @@ SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_stbox3d_kdtree_idx;
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- The combine function answers what the aggregate answers
+--
+-- A COMBINEFUNC is reached only by a parallel plan, and which rows a worker
+-- receives is not controllable, so a parallel query cannot state a
+-- deterministic expected output. The function is therefore called directly,
+-- which is what makes these the first cases to reach it at all.
+-------------------------------------------------------------------------------
+
+SELECT stbox_extent_combinefn(stbox 'SRID=4326;STBOX X((0,0),(1,1))',
+  stbox 'SRID=4326;STBOX X((5,5),(6,6))');
+SELECT stbox_extent_combinefn(stbox 'STBOX T([2001-01-01,2001-01-02])',
+  stbox 'STBOX T([2001-01-03,2001-01-04])');
+-- Two reference systems have no common extent, so the combine refuses
+SELECT stbox_extent_combinefn(stbox 'SRID=4326;STBOX X((0,0),(1,1))',
+  stbox 'SRID=3857;STBOX X((5,5),(6,6))');
+-- And boxes holding different dimensions are the second refusal
+SELECT stbox_extent_combinefn(stbox 'STBOX X((0,0),(1,1))',
+  stbox 'STBOX XT(((5,5),(6,6)),[2001-01-01,2001-01-02])');
+-- A null state on either side leaves the other untouched
+SELECT stbox_extent_combinefn(NULL::stbox, stbox 'STBOX X((5,5),(6,6))');
+SELECT stbox_extent_combinefn(stbox 'STBOX X((0,0),(1,1))', NULL::stbox);
+SELECT stbox_extent_combinefn(NULL::stbox, NULL::stbox);
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/pointcloud/expected/441_tpc_aggfuncs_tbl.test.out
+++ b/mobilitydb/test/pointcloud/expected/441_tpc_aggfuncs_tbl.test.out
@@ -120,3 +120,29 @@ SELECT numInstants(tdensity(seq))  > 0 FROM tbl_tpcpatch_seq;
  t
 (1 row)
 
+SELECT tpcbox_extent_transfn(tpcboxX(0, 0, 5, 5, 1), tpcboxX(3, 3, 10, 10, 1));
+    tpcbox_extent_transfn    
+-----------------------------
+ TPCBOX(X((0,0),(10,10)), 1)
+(1 row)
+
+SELECT tpcbox_extent_transfn(tpcboxX(0, 0, 5, 5, 1), tpcboxX(3, 3, 10, 10, 0));
+ERROR:  Operation on TPCBox values with different schemas: 1 vs 0
+SELECT tpcbox_extent_transfn(NULL::tpcbox, tpcboxX(3, 3, 10, 10, 1));
+    tpcbox_extent_transfn    
+-----------------------------
+ TPCBOX(X((3,3),(10,10)), 1)
+(1 row)
+
+SELECT tpcbox_extent_transfn(tpcboxX(0, 0, 5, 5, 1), NULL::tpcbox);
+   tpcbox_extent_transfn   
+---------------------------
+ TPCBOX(X((0,0),(5,5)), 1)
+(1 row)
+
+SELECT tpcbox_extent_transfn(NULL::tpcbox, NULL::tpcbox);
+ tpcbox_extent_transfn 
+-----------------------
+ 
+(1 row)
+

--- a/mobilitydb/test/pointcloud/queries/441_tpc_aggfuncs_tbl.test.sql
+++ b/mobilitydb/test/pointcloud/queries/441_tpc_aggfuncs_tbl.test.sql
@@ -93,3 +93,24 @@ SELECT numInstants(tdensity(inst)) > 0 FROM tbl_tpcpatch_inst;
 SELECT numInstants(tdensity(seq))  > 0 FROM tbl_tpcpatch_seq;
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- The combine function answers what the aggregate answers
+--
+-- A COMBINEFUNC is reached only by a parallel plan, and which rows a worker
+-- receives is not controllable, so a parallel query cannot state a
+-- deterministic expected output. The function is therefore called directly,
+-- which is what makes these the first cases to reach it at all.
+-------------------------------------------------------------------------------
+
+-- extent(tpcbox) names its transition function as its own combine, so the one
+-- function answers in both roles
+SELECT tpcbox_extent_transfn(tpcboxX(0, 0, 5, 5, 1), tpcboxX(3, 3, 10, 10, 1));
+-- The schema states what a coordinate means, so two of them are a refusal
+SELECT tpcbox_extent_transfn(tpcboxX(0, 0, 5, 5, 1), tpcboxX(3, 3, 10, 10, 0));
+-- A null state on either side leaves the other untouched
+SELECT tpcbox_extent_transfn(NULL::tpcbox, tpcboxX(3, 3, 10, 10, 1));
+SELECT tpcbox_extent_transfn(tpcboxX(0, 0, 5, 5, 1), NULL::tpcbox);
+SELECT tpcbox_extent_transfn(NULL::tpcbox, NULL::tpcbox);
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/temporal/expected/015_span_aggfuncs.test.out
+++ b/mobilitydb/test/temporal/expected/015_span_aggfuncs.test.out
@@ -420,3 +420,53 @@ SELECT numSpans(spansetUnion(t)) FROM tbl_tstzspanset;
       479
 (1 row)
 
+SELECT span_extent_combinefn(intspan '[1,3)', intspan '[5,7)');
+ span_extent_combinefn 
+-----------------------
+ [1, 7)
+(1 row)
+
+SELECT span_extent_combinefn(bigintspan '[1,3)', bigintspan '[5,7)');
+ span_extent_combinefn 
+-----------------------
+ [1, 7)
+(1 row)
+
+SELECT span_extent_combinefn(floatspan '[1.5,3.5)', floatspan '[5.5,7.5)');
+ span_extent_combinefn 
+-----------------------
+ [1.5, 7.5)
+(1 row)
+
+SELECT span_extent_combinefn(datespan '[2001-01-01,2001-01-03)',
+  datespan '[2001-01-05,2001-01-07)');
+  span_extent_combinefn   
+--------------------------
+ [01-01-2001, 01-07-2001)
+(1 row)
+
+SELECT span_extent_combinefn(tstzspan '[2001-01-01,2001-01-03)',
+  tstzspan '[2001-01-05,2001-01-07)');
+                    span_extent_combinefn                     
+--------------------------------------------------------------
+ [Mon Jan 01 00:00:00 2001 PST, Sun Jan 07 00:00:00 2001 PST)
+(1 row)
+
+SELECT span_extent_combinefn(NULL::intspan, intspan '[5,7)');
+ span_extent_combinefn 
+-----------------------
+ [5, 7)
+(1 row)
+
+SELECT span_extent_combinefn(intspan '[1,3)', NULL::intspan);
+ span_extent_combinefn 
+-----------------------
+ [1, 3)
+(1 row)
+
+SELECT span_extent_combinefn(NULL::intspan, NULL::intspan);
+ span_extent_combinefn 
+-----------------------
+ 
+(1 row)
+

--- a/mobilitydb/test/temporal/expected/040_temporal_aggfuncs.test.out
+++ b/mobilitydb/test/temporal/expected/040_temporal_aggfuncs.test.out
@@ -1066,3 +1066,55 @@ SELECT numInstants(appendSequence(seq ORDER BY seq)) FROM temp2;
        36168
 (1 row)
 
+SELECT temporal_extent_combinefn(tstzspan '[2001-01-01,2001-01-03)',
+  tstzspan '[2001-01-05,2001-01-07)');
+                  temporal_extent_combinefn                   
+--------------------------------------------------------------
+ [Mon Jan 01 00:00:00 2001 PST, Sun Jan 07 00:00:00 2001 PST)
+(1 row)
+
+SELECT temporal_extent_combinefn(NULL::tstzspan, tstzspan '[2001-01-05,2001-01-07)');
+                  temporal_extent_combinefn                   
+--------------------------------------------------------------
+ [Fri Jan 05 00:00:00 2001 PST, Sun Jan 07 00:00:00 2001 PST)
+(1 row)
+
+SELECT temporal_extent_combinefn(tstzspan '[2001-01-01,2001-01-03)', NULL::tstzspan);
+                  temporal_extent_combinefn                   
+--------------------------------------------------------------
+ [Mon Jan 01 00:00:00 2001 PST, Wed Jan 03 00:00:00 2001 PST)
+(1 row)
+
+SELECT temporal_extent_combinefn(NULL::tstzspan, NULL::tstzspan);
+ temporal_extent_combinefn 
+---------------------------
+ 
+(1 row)
+
+SELECT tnumber_extent_combinefn(tbox 'TBOXINT XT([1,2],[2001-01-01,2001-01-02])',
+  tbox 'TBOXINT XT([3,4],[2001-01-03,2001-01-04])');
+                            tnumber_extent_combinefn                             
+---------------------------------------------------------------------------------
+ TBOXINT XT([1, 5),[Mon Jan 01 00:00:00 2001 PST, Thu Jan 04 00:00:00 2001 PST])
+(1 row)
+
+SELECT tnumber_extent_combinefn(tbox 'TBOXINT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+ERROR:  Operation on mixed span types: intspan and floatspan
+SELECT tnumber_extent_combinefn(NULL::tbox, tbox 'TBOXINT X([3,4])');
+ tnumber_extent_combinefn 
+--------------------------
+ TBOXINT X([3, 5))
+(1 row)
+
+SELECT tnumber_extent_combinefn(tbox 'TBOXINT X([1,2])', NULL::tbox);
+ tnumber_extent_combinefn 
+--------------------------
+ TBOXINT X([1, 3))
+(1 row)
+
+SELECT tnumber_extent_combinefn(NULL::tbox, NULL::tbox);
+ tnumber_extent_combinefn 
+--------------------------
+ 
+(1 row)
+

--- a/mobilitydb/test/temporal/queries/015_span_aggfuncs.test.sql
+++ b/mobilitydb/test/temporal/queries/015_span_aggfuncs.test.sql
@@ -168,3 +168,26 @@ SELECT numSpans(spanUnion(t)) FROM tbl_tstzspan;
 SELECT numSpans(spansetUnion(t)) FROM tbl_tstzspanset;
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- The combine function answers what the aggregate answers
+--
+-- A COMBINEFUNC is reached only by a parallel plan, and which rows a worker
+-- receives is not controllable, so a parallel query cannot state a
+-- deterministic expected output. The function is therefore called directly,
+-- which is what makes these the first cases to reach it at all.
+-------------------------------------------------------------------------------
+
+SELECT span_extent_combinefn(intspan '[1,3)', intspan '[5,7)');
+SELECT span_extent_combinefn(bigintspan '[1,3)', bigintspan '[5,7)');
+SELECT span_extent_combinefn(floatspan '[1.5,3.5)', floatspan '[5.5,7.5)');
+SELECT span_extent_combinefn(datespan '[2001-01-01,2001-01-03)',
+  datespan '[2001-01-05,2001-01-07)');
+SELECT span_extent_combinefn(tstzspan '[2001-01-01,2001-01-03)',
+  tstzspan '[2001-01-05,2001-01-07)');
+-- A null state on either side leaves the other untouched
+SELECT span_extent_combinefn(NULL::intspan, intspan '[5,7)');
+SELECT span_extent_combinefn(intspan '[1,3)', NULL::intspan);
+SELECT span_extent_combinefn(NULL::intspan, NULL::intspan);
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/temporal/queries/040_temporal_aggfuncs.test.sql
+++ b/mobilitydb/test/temporal/queries/040_temporal_aggfuncs.test.sql
@@ -640,3 +640,29 @@ temp2(seq) AS (
 SELECT numInstants(appendSequence(seq ORDER BY seq)) FROM temp2;
 
 -------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- The combine function answers what the aggregate answers
+--
+-- A COMBINEFUNC is reached only by a parallel plan, and which rows a worker
+-- receives is not controllable, so a parallel query cannot state a
+-- deterministic expected output. The function is therefore called directly,
+-- which is what makes these the first cases to reach it at all.
+-------------------------------------------------------------------------------
+
+SELECT temporal_extent_combinefn(tstzspan '[2001-01-01,2001-01-03)',
+  tstzspan '[2001-01-05,2001-01-07)');
+SELECT temporal_extent_combinefn(NULL::tstzspan, tstzspan '[2001-01-05,2001-01-07)');
+SELECT temporal_extent_combinefn(tstzspan '[2001-01-01,2001-01-03)', NULL::tstzspan);
+SELECT temporal_extent_combinefn(NULL::tstzspan, NULL::tstzspan);
+
+-- The temporal number extent measures a box, whose span type states what the
+-- value dimension holds, so two different ones are a refusal
+SELECT tnumber_extent_combinefn(tbox 'TBOXINT XT([1,2],[2001-01-01,2001-01-02])',
+  tbox 'TBOXINT XT([3,4],[2001-01-03,2001-01-04])');
+SELECT tnumber_extent_combinefn(tbox 'TBOXINT X([1,2])', tbox 'TBOXFLOAT X([3,4])');
+SELECT tnumber_extent_combinefn(NULL::tbox, tbox 'TBOXINT X([3,4])');
+SELECT tnumber_extent_combinefn(tbox 'TBOXINT X([1,2])', NULL::tbox);
+SELECT tnumber_extent_combinefn(NULL::tbox, NULL::tbox);
+
+-------------------------------------------------------------------------------

--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -141,19 +141,11 @@ def parse_args(arg_block: str):
     return out
 
 
-# Global skip patterns that apply to every config. Aggregate transfns /
-# combinefns own their first argument (state) — they pfree it internally
-# and return a new state. The smoke-test pattern (call function, then
-# free the result) leaves the original input dangling and reuses it on
-# the next call, producing use-after-free errors under valgrind. These
-# functions need PG's aggregate framework (or a manual state-handoff
-# pattern) to exercise correctly; the smoke test is the wrong harness.
-GLOBAL_SKIP = {
-    # transfn and finalfn are emitted by emit_aggregate; a combinefn merges two
-    # independent transition states, which the single-input harness cannot seed.
-    "re:_combinefn$":
-        "aggregate combine step needs two independent transition states",
-}
+# Global skip patterns that apply to every config. Aggregates are no longer
+# among them: an aggregate entry owns the state it is handed and answers the
+# state to use next, so emit_aggregate() carries the value through the chain
+# rather than freeing an argument the callee has already taken.
+GLOBAL_SKIP = {}
 
 
 # By-value scalar RETURN types: a fixed, whole-repo set (not a per-config
@@ -174,14 +166,23 @@ BY_VALUE_SCALAR_TYPES = {
 # State types a MEOS aggregate threads through its transition/final functions.
 AGG_STATE_TYPES = ("SkipList *", "Set *", "Span *", "SpanSet *", "TBox *", "STBox *")
 
+# How to read back what a finalizer answers, so a combine can be compared
+# against the serial accumulation of the same values. A return type absent
+# here still gets its combine called and freed, just without the assertion.
+AGG_RESULT_PRINTERS = {
+    "Temporal *": "temporal_out(%s, 6)",
+}
 
-def emit_aggregate(fname, ret, args, eff_arg_map, sig_by_name):
+
+def emit_aggregate(fname, ret, args, eff_arg_map, sig_by_name,
+                   declared_inputs=()):
     """Emit the multi-call sequence for an aggregate transition/final function,
     or return None when this is not a handleable aggregate (leaving it to the
     normal skip machinery).
 
     A `State *X_transfn(State *st, value...)` folds a value into a transition
-    state; a `Result *X_finalfn(State *st)` turns that state into the aggregate.
+    state; a `Result *X_finalfn(State *st)` turns that state into the aggregate;
+    a `State *X_combinefn(State *st1, State *st2)` merges two of them.
     The generic one-call harness cannot express the handoff, so the whole
     sequence is emitted: seed a NULL state, accumulate a canned value (twice for
     a transfn, to exercise the grow/merge path), then free the state (transfn)
@@ -195,6 +196,16 @@ def emit_aggregate(fname, ret, args, eff_arg_map, sig_by_name):
             if v is None:
                 return None
             out.append(v)
+        return out
+
+    def sibling(vals):
+        """The same argument list drawn from the sibling inputs, so the second
+        state of a combine holds a different value from the first. An input
+        with no declared sibling is reused unchanged."""
+        out = []
+        for v in vals:
+            alt = v[:-1] + "2" if v.endswith("1") else None
+            out.append(alt if alt and alt in declared_inputs else v)
         return out
 
     def free_state(state_ty, var):
@@ -215,6 +226,72 @@ def emit_aggregate(fname, ret, args, eff_arg_map, sig_by_name):
                 f"    st = {fname}(st{tail});\n"
                 f"    st = {fname}(st{tail});\n"
                 f"    if (st) {free_state(state_ty, 'st')}; }}\n")
+    if fname.endswith("_combinefn") and sig_by_name:
+        transfn = fname[:-len("_combinefn")] + "_transfn"
+        tsig = sig_by_name.get(transfn)
+        if not tsig:
+            return None
+        _tret, targs = tsig
+        if not targs or targs[0][0].strip() != state_ty:
+            return None
+        vals = canned(targs[1:])
+        if vals is None:
+            return None
+        tail = (", " + ", ".join(vals)) if vals else ""
+        vals2 = sibling(vals)
+        tail2 = (", " + ", ".join(vals2)) if vals2 else ""
+        # Two states are seeded independently, which is what a combine merges
+        # and what the single-input harness could not express. The combine
+        # copies the values of the state it absorbs and returns the other one,
+        # and which of the two it returns depends on which was empty, so the
+        # returned pointer is what says whose storage is still the caller's.
+        # Two declarators, because a `*` in the type text binds to the first
+        # one alone and the second would come out as a non-pointer.
+        #
+        # The answer a combine produces must be the answer the same two values
+        # produce accumulated serially: that identity is why the aggregate is
+        # allowed a combine at all, so where the finalizer is known the block
+        # asserts it and a combine drifting from its transition fails instead
+        # of merely not leaking. The finalizer is the family's own where it
+        # declares one, else the generic entry the SQL aggregates name --
+        # derived from the header rather than listed here.
+        base = fname[: -len("_combinefn")]
+        finalfn = None
+        if f"{base}_finalfn" in sig_by_name:
+            finalfn = f"{base}_finalfn"
+        elif state_ty == "SkipList *" and "temporal_tagg_finalfn" in sig_by_name:
+            finalfn = "temporal_tagg_finalfn"
+        fret = sig_by_name[finalfn][0].strip() if finalfn else None
+        if finalfn and fret in AGG_RESULT_PRINTERS:
+            printer = AGG_RESULT_PRINTERS[fret]
+            # The finalizer consumes the state it is given, so neither the
+            # combined nor the serial skiplist is freed after it runs.
+            return (f"  {{ {state_ty}st1 = NULL; {state_ty}st2 = NULL; {state_ty}ser = NULL;\n"
+                    f"    st1 = {transfn}(st1{tail});\n"
+                    f"    st2 = {transfn}(st2{tail2});\n"
+                    f"    ser = {transfn}(ser{tail});\n"
+                    f"    ser = {transfn}(ser{tail2});\n"
+                    f"    {state_ty}m = {fname}(st1, st2);\n"
+                    f"    if (st1 && st1 != m) {free_state(state_ty, 'st1')};\n"
+                    f"    if (st2 && st2 != m) {free_state(state_ty, 'st2')};\n"
+                    f"    {fret}rc = m ? {finalfn}(m) : NULL;\n"
+                    f"    {fret}rs = ser ? {finalfn}(ser) : NULL;\n"
+                    f"    char *sc = rc ? {printer % 'rc'} : NULL;\n"
+                    f"    char *ss = rs ? {printer % 'rs'} : NULL;\n"
+                    f'    printf("{fname}: %s\\n", (sc && ss) ?\n'
+                    f'      (strcmp(sc, ss) == 0 ? "agrees with serial" :\n'
+                    f'        "DIFFERS FROM SERIAL") : "no answer");\n'
+                    f"    if (sc) free(sc);\n"
+                    f"    if (ss) free(ss);\n"
+                    f"    if (rc) free(rc);\n"
+                    f"    if (rs) free(rs); }}\n")
+        return (f"  {{ {state_ty}st1 = NULL; {state_ty}st2 = NULL;\n"
+                f"    st1 = {transfn}(st1{tail});\n"
+                f"    st2 = {transfn}(st2{tail2});\n"
+                f"    {state_ty}m = {fname}(st1, st2);\n"
+                f"    if (st1 && st1 != m) {free_state(state_ty, 'st1')};\n"
+                f"    if (st2 && st2 != m) {free_state(state_ty, 'st2')};\n"
+                f"    if (m) {free_state(state_ty, 'm')}; }}\n")
     if fname.endswith("_finalfn") and sig_by_name:
         transfn = fname[:-len("_finalfn")] + "_transfn"
         tsig = sig_by_name.get(transfn)
@@ -237,7 +314,7 @@ def emit_aggregate(fname, ret, args, eff_arg_map, sig_by_name):
 
 def emit_call(fname, ret, args, arg_map, skip_map, override_args,
               no_free=(), value_returns=(), name_arg_map=None, manual=(),
-              sig_by_name=None):
+              sig_by_name=None, declared_inputs=()):
     # Manually-covered: the generic emitter cannot express this call shape, and
     # the config exercises the function by hand in its cleanup block, so emit
     # nothing here. A SKIP line would misread as an untested function; the
@@ -266,7 +343,8 @@ def emit_call(fname, ret, args, arg_map, skip_map, override_args,
                 eff_arg_map.update(tymap)
     # Aggregate transition/final functions need a multi-call state handoff that
     # the single-call harness cannot express; emit the whole sequence here.
-    agg = emit_aggregate(fname, ret, args, eff_arg_map, sig_by_name)
+    agg = emit_aggregate(fname, ret, args, eff_arg_map, sig_by_name,
+                         declared_inputs)
     if agg is not None:
         return agg
     # Global regex-pattern skip (applied after per-config so a config can
@@ -478,6 +556,7 @@ HEADER_TEMPLATE = """\
 #include <stdio.h>
 #include <stdlib.h>
 #include <stdint.h>
+#include <string.h>
 #include <meos.h>
 #include <meos_internal.h>
 #include <meos_geo.h>
@@ -2045,6 +2124,26 @@ def write_test(name, cfg):
     # A finalfn builds its transition state with the paired transfn, looked up
     # by signature from every declaration this suite parses.
     sig_by_name = {fname: (ret, args) for fname, ret, args in decls}
+
+    # A combine merges two INDEPENDENTLY accumulated states, so seeding both
+    # from one value makes every idempotent aggregate (tmax, tmin, tand, tor)
+    # answer the same whether or not the combine reads the second state at
+    # all. Where the config declares a sibling input -- tint2 beside tint1 --
+    # the second state is seeded from it, and the assertion witnesses a
+    # dropped state for those aggregates too.
+    declared_inputs = frozenset(
+        re.findall(r"^\s*(?:const\s+)?\w[\w ]*?\**(\w+)\s*=",
+                   cfg["common_inputs"], re.M))
+
+    # A suite may cover PART of a header: `only` keeps the declarations whose
+    # name matches one of its patterns. The signature index above is built
+    # before the filter, so a final or combine step still resolves its paired
+    # transition function even where the patterns do not name it. A header
+    # carrying one coherent surface needs no `only` and emits everything.
+    only = cfg.get("only", ())
+    if only:
+        pats = [re.compile(p) for p in only]
+        decls = [d for d in decls if any(p.search(d[0]) for p in pats)]
     body = "".join(emit_call(fname, ret, args,
                              cfg["arg_map"], cfg["skip"],
                              cfg["override_args"],
@@ -2052,7 +2151,7 @@ def write_test(name, cfg):
                              cfg.get("value_returns", ()),
                              cfg.get("name_arg_map", {}),
                              cfg.get("manual", ()),
-                             sig_by_name)
+                             sig_by_name, declared_inputs)
                    for fname, ret, args in decls)
     # A common-input variable that a given type's surface never consumes is
     # acknowledged with (void), the same idiom emit_call uses for by-value
@@ -2094,7 +2193,7 @@ def load_sidecar(path):
     in-file CONFIG dicts, with two ergonomic differences for JSON:
       - common_inputs / cleanup are arrays of lines (no C-newline escaping);
       - override_args integer indices arrive as strings and are restored to int.
-    Everything else (header/out/arg_map/skip/value_returns/csv_data/
+    Everything else (header/out/arg_map/skip/only/value_returns/csv_data/
     extra_includes) is passed straight through to write_test()."""
     with open(path) as f:
         raw = json.load(f)


### PR DESCRIPTION
Reach the combine functions the suite never runs

A COMBINEFUNC merges two partial aggregate states, and PostgreSQL calls one
only when it splits an aggregation across workers. Nothing in the suite splits
one, so none of these had ever been executed by a test. The state type decides
how each is reached.

Seven take a state PostgreSQL can spell, so they are called from SQL:
span_extent_combinefn over its five span types, stbox_extent_combinefn,
temporal_extent_combinefn, tnumber_extent_combinefn, and tpcbox_extent_transfn,
which the tpcbox extent aggregate names as its own combine. Each is asked to
fold two states, to refuse the states its validator refuses, and to answer with
the other side when one state is null. A direct call is what lets a refusal
have an expected output at all: mixed SRIDs, differing dimensionality, mixed
span types and differing pcids each now state their error in an expected file.

The sixteen whose state is internal cannot be called from SQL, and reaching
them through a parallel plan would mean setting parallel_setup_cost and
parallel_tuple_cost back to 0 -- the harness sets both to 100 so that plans
stay serial -- and then asserting that the planner split, which depends on the
worker count a machine offers. They are MEOS functions, exported as
X_combinefn(SkipList *, SkipList *), so meos/test reaches them directly. The
generator grows a combine arm that seeds two states independently, merges them,
and compares the answer against the same two values accumulated serially,
which is the identity that entitles an aggregate to a combine at all. The
finalizer it compares through is the family's own where one is declared and
the generic temporal_tagg_finalfn otherwise, derived from the header rather
than listed.

The two states are seeded from different values holding disjoint time. With one
value both states hold the same thing, and tmax, tmin, tand, tor and merge
answer the same whether or not the combine reads the second state at all, so a
combine that dropped it would still pass; disjoint rather than merely
different, because values disagreeing at a shared timestamp make merge an error
rather than a question.

Running it found a leak that is not the combine's, and the rest of this message
is that fix. tinstant_tagg allocates the merged array and the array of values
to free separately and reports only the second, while the sequence path answers
one array for both, so skiplist_splice freed that one and left the other
behind.

Witness: the new suite under valgrind before the fix reports 48 bytes in 2
blocks definitely lost, both allocated at temporal_aggfuncs.c:422 and reached
through timestamptz_tcount_transfn and tstzset_tcount_transfn, and 0 bytes lost
after it. Two accumulations are enough to run it -- the suite's own
timestamptz_tcount_transfn(st, tstz1) twice, the second of which splices and
so reaches tinstant_tagg -- and any tcount whose merged subtype is TINSTANT
pays it once per such splice.

Why the splice is where it belongs, rather than tinstant_tagg: the two callers
disagree about ownership and only the splice sees both pointers. The sequence
path hands back one array as both the result and the values to free, so freeing
what it reports frees everything it allocated; the instant path allocates two
arrays and reports one. Freeing the array of new values when it differs from
the reported one states that rule once, and leaves the sequence path untouched
because there the two pointers are equal and the guard declines.

Measured: the seven smoke suites all pass valgrind, at 139, 152, 192, 129, 453,
189 and 19 results, and pg_regress reports 336 of 336 on PostgreSQL 18 with
none failed and none skipped. No answer moves -- the fix frees an array, not
anything reachable from it. Against a combine altered to return its first state
unmerged, all sixteen assertions read DIFFERS FROM SERIAL, where one shared
value moves only four, which is what says the fixture witnesses a dropped state
and not merely a leak.
