### PR TITLE
Name the wrapper of the container each restriction takes

### DIFF
--- a/meos/src/pointcloud/pcset_meos.c
+++ b/meos/src/pointcloud/pcset_meos.c
@@ -309,7 +309,7 @@ union_set_pcpoint(const Set *s, const Pcpoint *pt)
 /**
  * @ingroup meos_pointcloud_set_setops
  * @brief Return the union of a pcpoint and a set
- * @csqlfn #Union_set_value()
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_pcpoint_set(const Pcpoint *pt, const Set *s)
@@ -337,7 +337,7 @@ intersection_set_pcpoint(const Set *s, const Pcpoint *pt)
 /**
  * @ingroup meos_pointcloud_set_setops
  * @brief Return the intersection of a pcpoint and a set
- * @csqlfn #Intersection_set_value()
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_pcpoint_set(const Pcpoint *pt, const Set *s)
@@ -593,7 +593,7 @@ union_set_pcpatch(const Set *s, const Pcpatch *pa)
 /**
  * @ingroup meos_pointcloud_set_setops
  * @brief Return the union of a pcpatch and a set
- * @csqlfn #Union_set_value()
+ * @csqlfn #Union_value_set()
  */
 Set *
 union_pcpatch_set(const Pcpatch *pa, const Set *s)
@@ -621,7 +621,7 @@ intersection_set_pcpatch(const Set *s, const Pcpatch *pa)
 /**
  * @ingroup meos_pointcloud_set_setops
  * @brief Return the intersection of a pcpatch and a set
- * @csqlfn #Intersection_set_value()
+ * @csqlfn #Intersection_value_set()
  */
 Set *
 intersection_pcpatch_set(const Pcpatch *pa, const Set *s)

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -1397,7 +1397,7 @@ trgeometry_restrict_tstzset(const Temporal *temp, const Set *s, bool atfunc)
  * @brief Restrict a temporal rigid geometry to a timestamptz set
  * @param[in] temp Temporal rigid geometry
  * @param[in] s Set
- * @csqlfn #Temporal_at_tstzspanset()
+ * @csqlfn #Temporal_at_tstzset()
  */
 Temporal *
 trgeometry_at_tstzset(const Temporal *temp, const Set *s)
@@ -1411,7 +1411,7 @@ trgeometry_at_tstzset(const Temporal *temp, const Set *s)
  * timestamptz set
  * @param[in] temp Temporal rigid geometry
  * @param[in] s Set
- * @csqlfn #Temporal_minus_tstzspanset()
+ * @csqlfn #Temporal_minus_tstzset()
  */
 Temporal *
 trgeometry_minus_tstzset(const Temporal *temp, const Set *s)

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -1302,7 +1302,7 @@ distance_spanset_span(const SpanSet *ss, const Span *s)
  * @param[in] ss1,ss2 Span sets
  * @return On error return the sentinel of the base type given by
  * #distance_sentinel()
- * @csqlfn #Distance_spanset_span()
+ * @csqlfn #Distance_spanset_spanset()
  */
 Datum
 distance_spanset_spanset(const SpanSet *ss1, const SpanSet *ss2)


### PR DESCRIPTION
A @csqlfn names the PG wrapper a MEOS function corresponds to, and seven of
them name a wrapper over a different container. The wrapper exists and is
reachable and its arity matches, so no check sees it; what a catalog derives
from the tag is the SQL surface of a different overload.

THE WITNESS. Regenerating the MEOS-API catalog against this tree answers, for
trgeometry_at_tstzset — whose C signature is (const Temporal *, const Set *) —
the timestamptz-SPAN-SET overload:

  trgeometry_at_tstzset -> atTime(trgeometry, tstzspanset)

so that key is claimed by two functions at once while
atTime(trgeometry, tstzset), which 150_trgeo.in.sql declares over
Temporal_at_tstzset, is named by none. With the tag corrected it answers

  trgeometry_at_tstzset -> atTime(trgeometry, tstzset)

and the same holds for minusTime, for distance(intspanset, intspanset), and
for setUnion(pcpoint, pcpointset).

WHY. The SQL that binds a wrapper is what says which overload that wrapper
answers, so a tag naming a wrapper over another container states a
correspondence the extension does not have. 150_trgeo.in.sql binds
atTime(trgeometry, tstzset) to Temporal_at_tstzset, 009_spanset_ops.in.sql
binds distance(intspanset, intspanset) to Distance_spanset_spanset, and
400_pcset.in.sql binds setUnion(pcpoint, pcpointset) to Union_value_set with
setUnion(pcpointset, pcpoint) to Union_set_value. Each file already contradicts
itself: the internal trgeometry_restrict_tstzset names Temporal_at_tstzset and
Temporal_minus_tstzset, distance_spanset_span beside it names its own wrapper,
and the minus pair in pcset_meos.c already names the value-first form the geo,
npoint, cbuffer and pose families all name.

MEASURED. Against master 7764de91d9, catalog regeneration moves these seven
functions and no others, and colliding registration keys — one SQL name and
argument list claimed by more than one public function — go 182 to 180. The
change is comment-only, so no runtime answer moves: the receipt reads
both_targets=ok and pg_regress=local-pass, with the cppcheck, warning-clean,
inherited-codegen, csqlfn, license, int64-header and workflow gates clean, and
a MSYS2 UCRT64 build of libmeos green. Every wrapper vacated keeps its other
claimants, six, four, seven, sixteen and sixteen of them.

