### PR TITLE
Stop an aggregation at the step that reports it has no answer

### DIFF
--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -737,7 +737,7 @@ skiplist_splice(SkipList *list, void **keys, void **values, int count,
   }
 
   /* Free memory */
-  if (spliced_count != 0)
+  if (spliced_count != 0 && tofree)
   {
     pfree_array((void **) tofree, nfree);
     /* The merge answers the new values in one array and reports the values to

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -628,6 +628,13 @@ tsequence_tagg_iter(const TSequence *seq1, const TSequence *seq2,
         for (int j = 0; j < i; j++)
           pfree(instants[j]);
         pfree(instants);
+        /* The synchronized copies and the piece computed before the
+         * intersection are this function's too, and a negative answer tells
+         * the caller that it wrote nothing, so nothing else will free them */
+        pfree(syncseq1);
+        pfree(syncseq2);
+        for (int j = 0; j < nseqs; j++)
+          pfree(sequences[j]);
         return -1;
       }
     }
@@ -699,6 +706,22 @@ tsequence_tagg(TSequence **sequences1, int count1, TSequence **sequences2,
   {
     int countstep = tsequence_tagg_iter(seq1, seq2, func, crossings,
       &sequences[k]);
+    if (countstep < 0)
+    {
+      /* The step raised and wrote nothing. Folding a negative answer into the
+       * count walks k backwards and hands the normalization a length that is
+       * not the number of sequences there are, so the aggregation stops here
+       * and answers that it has none. The step freed what it held; the
+       * sequences already placed are this function's, and sequences[k] is the
+       * one tofree names, so it is released once */
+      for (int n = 0; n < k; n++)
+        pfree(sequences[n]);
+      if (tofree)
+        pfree(tofree);
+      pfree(sequences);
+      *newcount = 0;
+      return NULL;
+    }
     k += countstep - 1;
 
     /* Need to get all info from seq1 and seq2 since we might free one of them

--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -50,6 +50,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <meos.h>
+#include <meos_internal.h>
 #include <meos_geo.h>
 #include <meos_h3.h>
 #include <meos_pose.h>
@@ -295,6 +296,34 @@ int main(void)
   printf("set_round(floatset): answered %s\n", ftext);
   assert(strcmp(ftext, "{1.23, 2.35}") == 0);
   free(ftext); free(frounded); free(fset);
+  meos_errno_reset();
+
+  /* An aggregation whose values disagree at a timestamp they share reports the
+   * disagreement, and under the noexit handler that report RETURNS. The step
+   * that raises answers a negative count; folding it into the running length
+   * walked that length backwards and handed the normalization a number that is
+   * not how many sequences there are, so the process ended inside
+   * tseqarr_normalize instead of at the caller's check */
+  meos_errno_reset();
+  Temporal *magg1 = tint_in("{[1@2001-01-01, 3@2001-01-03]}");
+  Temporal *magg2 = tint_in("{[7@2001-01-01, 9@2001-01-03]}");
+  assert(magg1 != NULL && magg2 != NULL && meos_errno() == 0);
+  SkipList *mst1 = temporal_merge_transfn(NULL, magg1);
+  SkipList *mst2 = temporal_merge_transfn(NULL, magg2);
+  assert(mst1 != NULL && mst2 != NULL && meos_errno() == 0);
+  SkipList *mcomb = temporal_merge_combinefn(mst1, mst2);
+  printf("merge combine of values disagreeing at a shared timestamp: "
+    "declined, errno %d\n", meos_errno());
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_VALUE);
+  /* The combine answers a state either way, and which of the two it keeps is
+   * what says whose storage is still the caller's */
+  if (mst1 != mcomb)
+    skiplist_free(mst1);
+  if (mst2 != mcomb)
+    skiplist_free(mst2);
+  if (mcomb)
+    skiplist_free(mcomb);
+  free(magg1); free(magg2);
   meos_errno_reset();
 
   free(tpt1); free(tpt2);


### PR DESCRIPTION
Stop an aggregation at the step that reports it has no answer

Aggregating two temporal values that disagree at a timestamp they share is an
error, and tsequence_tagg_iter raises it and answers -1. Its caller folded that
answer into the running length -- k += countstep - 1 -- so a refusal moved the
length two places BACKWARDS, and what reached tseqarr_normalize was not the
number of sequences there are.

Witness: under meos_initialize_noexit_error_handler, the handler every language
binding installs because a binding must return an exception to its host rather
than terminate it, merging tint '{[1@2001-01-01, 3@2001-01-03]}' with
tint '{[7@2001-01-01, 9@2001-01-03]}' reports "The temporal values have
different value at their common timestamp" and then ends the process:
tseqarr_normalize: Assertion `count > 0' failed, signal 6. The same two values
now leave errno at MEOS_ERR_INVALID_ARG_VALUE and the call returns. The default
handler ends the process AT the report, which is why only a binding, or a test
holding that handler, could reach the assertion at all, and why no SQL case can
witness it, PostgreSQL raising out of the callsite instead.

This is the class #2185 named when it let a liblwgeom error reach the caller:
a site that reports and returns its own failure value needs the CALLER
hardened too, "because returning NULL otherwise just moves the dereference one
frame up". That PR hardened four such call chains; this is a fifth, in the
aggregation path, where the failure value is a count rather than a pointer and
so is read arithmetically instead of dereferenced.

Why the caller is where this belongs: -1 is not a count, and the step already
says so by answering a negative number rather than writing anything into the
array it was given. The length is the caller's to maintain, so the caller is
the only place that can decline to advance it; the step cannot know whether it
is the first of many. The aggregation therefore stops and answers that it has
none, rather than handing on a length it has no basis for. The step also now
releases the two synchronized copies and the piece it built before the
intersection, which a negative answer tells nobody else to free.

Measured: the case joins meos/test/error_test.c, whose subject is exactly that
handler, and the file's valgrind total is unchanged by it -- 38 bytes in 1
block in both arms, a pre-existing missing free of geo_as_ewkt's result at line
206 that is another defect and gets its own PR. The seven smoke suites pass
valgrind, at 139, 152, 192, 129, 453, 189 and 19 results. No pg_regress answer
moves, no SQL path reaching the branch. check_meos_error_returns.py reads 10
pre-existing sites and no new violations, the cleanup being expressed so the
site keeps the shape its baseline entry names.
