### PR TITLE
Measure a portion's clearance against the tolerance its coordinates fix

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -5871,6 +5871,8 @@ typedef struct
   RelateEdges re;  /**< The same edges, with what reading them selectively
                         needs, so a point is located against a component
                         without walking it whole */
+  double xmin, ymin, xmax, ymax; /**< Extent of the component, read from the
+                        boxes its edges already carry */
 } RelateComp;
 
 /**
@@ -5917,6 +5919,14 @@ relate_area_comps_iter(const LWGEOM *geom, RelateComp **comps, int *ncomp,
   for (int i = 0; i < c->nedges; i++)
     c->edges[i] = (Edge *) meos_array_get(c->arr, i);
   relate_edges_init(&c->re, c->edges, c->nedges, index);
+  c->xmin = c->ymin = DBL_MAX;
+  c->xmax = c->ymax = -DBL_MAX;
+  for (int i = 0; i < c->nedges; i++)
+  {
+    const Edge *e = c->edges[i];
+    c->xmin = fmin(c->xmin, e->xmin); c->xmax = fmax(c->xmax, e->xmax);
+    c->ymin = fmin(c->ymin, e->ymin); c->ymax = fmax(c->ymax, e->ymax);
+  }
   return;
 }
 
@@ -6015,7 +6025,12 @@ relate_clearance(double x, double y, const RelateComp *comps, int ncomp,
         {
           int j = (int) *(int64 *) meos_array_get(candidates, c);
           double d = relate_edge_distance(x, y, comps[i].edges[j]);
-          if (d <= MEOS_GEOM_TOLERANCE)
+          /* An edge the point LIES ON is no clearance from it. What the
+           * distance misses the edge by is a property of the arithmetic --
+           * a few units in the last place of the largest coordinate -- so an
+           * absolute floor leaves a point on its own edge reading as a
+           * feature a rounding step away */
+          if (d <= fmax(comps[i].edges[j]->tol, MEOS_GEOM_TOLERANCE))
             continue;
           if (best < 0 || d < best)
             best = d;
@@ -6035,7 +6050,12 @@ relate_clearance(double x, double y, const RelateComp *comps, int ncomp,
     for (int j = 0; j < comps[i].nedges; j++)
     {
       double d = relate_edge_distance(x, y, comps[i].edges[j]);
-      if (d <= MEOS_GEOM_TOLERANCE)
+      /* An edge the point LIES ON is no clearance from it. What the
+       * distance misses the edge by is a property of the arithmetic --
+       * a few units in the last place of the largest coordinate -- so an
+       * absolute floor leaves a point on its own edge reading as a
+       * feature a rounding step away */
+      if (d <= fmax(comps[i].edges[j]->tol, MEOS_GEOM_TOLERANCE))
         continue;
       if (result < 0 || d < result)
         result = d;
@@ -6081,6 +6101,24 @@ relate_portion_inside_union(const Edge *e, double t, const RelateComp *comps,
 {
   double x, y;
   relate_area_edge_point(e, t, &x, &y);
+  /* A portion is interior to the union only where components MEET: the point
+   * lies on the boundary of the component it belongs to, so some OTHER
+   * component has to cover a neighbourhood of it, and that component's extent
+   * must then contain it. Reading the extents settles every portion no second
+   * component reaches, which is most of them on real multi-part data, and
+   * costs one comparison per component against two point locations */
+  {
+    int reaching = 0;
+    for (int i = 0; i < ncomp && reaching < 2; i++)
+    {
+      double pad = comps[i].re.tol;
+      if (x >= comps[i].xmin - pad && x <= comps[i].xmax + pad &&
+          y >= comps[i].ymin - pad && y <= comps[i].ymax + pad)
+        reaching++;
+    }
+    if (reaching < 2)
+      return false;
+  }
   /* The portion's own edge sets the scale the search starts at: the feature
    * nearest a point of a boundary is normally the next one along it */
   double delta = relate_clearance(x, y, comps, ncomp,

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1126,6 +1126,39 @@ int main(void)
   free(h3s); free(qbs); free(s2s);
   meos_errno_reset();
 
+  /* A second surface lying clear of the first takes nothing away from what
+   * the first covers, so a point interior to one member is interior to the
+   * union of both. A single component answers without reading the union at
+   * all, which makes its answer the reference the two-member spelling is held
+   * to. Both members carry arcs at projected coordinates, where the point the
+   * engine places on an edge misses it by the rounding unit of those
+   * coordinates rather than by nothing */
+  meos_errno_reset();
+  GSERIALIZED *ubm = geom_in("CURVEPOLYGON(CIRCULARSTRING("
+    "448320.7 6180616.3,448330.1 6180626.9,448340.3 6180616.7,"
+    "448330.9 6180606.1,448320.7 6180616.3))", -1);
+  GSERIALIZED *ubu = geom_in("MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING("
+    "448320.7 6180616.3,448330.1 6180626.9,448340.3 6180616.7,"
+    "448330.9 6180606.1,448320.7 6180616.3)),CURVEPOLYGON(CIRCULARSTRING("
+    "448400.3 6180616.1,448410.7 6180626.3,448420.9 6180616.9,"
+    "448410.1 6180606.7,448400.3 6180616.1)))", -1);
+  GSERIALIZED *ubp = geom_in("POINT(448330.5 6180616.5)", -1);
+  assert(ubm != NULL); assert(ubu != NULL); assert(ubp != NULL);
+  char *ubmm = geom_relate(ubm, ubp);
+  char *ubum = geom_relate(ubu, ubp);
+  assert(ubmm != NULL); assert(ubum != NULL);
+  assert(meos_errno() == 0);
+  printf("a point interior to one surface, alone and in the union: %s %s\n",
+    ubmm, ubum);
+  assert(strcmp(ubmm, "0F2FF1FF2") == 0);
+  assert(strcmp(ubum, ubmm) == 0);
+  /* and the predicates the matrix answers say the same */
+  assert(geom_covers(ubu, ubp));
+  assert(geom_intersects(ubu, ubp));
+  assert(meos_errno() == 0);
+  free(ubmm); free(ubum); free(ubm); free(ubu); free(ubp);
+  meos_errno_reset();
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
Measure a portion's clearance against the tolerance its coordinates fix

The boundary of a union is read by splitting each component's boundary at its
intersections with the others and dropping every portion the union covers on
both sides. Which side a portion lies on is decided by offsetting two probes
by half the clearance to the nearest other feature.

`relate_clearance` skips an edge the point lies on by comparing against
`MEOS_GEOM_TOLERANCE`. What a computed point misses its own edge by is a
property of the arithmetic rather than of the geometry -- a few units in the
last place of the largest coordinate -- so the edge the probe stands on
survives that test at projected magnitudes and answers as the nearest feature
a rounding step away. Both probes then land back on the boundary they came
from, the portion reads as covered on both sides, and boundary the union
really carries is dropped. The comparison is against
`fmax(edge->tol, MEOS_GEOM_TOLERANCE)`, the quantity `edge_set_tolerance`
already records on every edge, which is the reading `point_on_arc` and
`point_on_segment` take for the same question.

A portion is interior to the union only where components meet: the point lies
on the boundary of the component it belongs to, so another component has to
cover a neighbourhood of it, and that component's extent has to contain it.
Components carry that extent, read from the boxes their edges already hold,
and a portion no second extent reaches is settled without locating a point at
all.

WITNESS

  SELECT ST_Relate(
    'MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(
       448320.7 6180616.3,448330.1 6180626.9,448340.3 6180616.7,
       448330.9 6180606.1,448320.7 6180616.3)),
      CURVEPOLYGON(CIRCULARSTRING(
       448400.3 6180616.1,448410.7 6180626.3,448420.9 6180616.9,
       448410.1 6180606.7,448400.3 6180616.1)))',
    'POINT(448330.5 6180616.5)');

  before  FF2FF10F2   the point stands in the exterior of the union
  after   0F2FF1FF2   in its interior

The first surface ALONE answers `0F2FF1FF2` on both, a single component being
answered without reading the union. A second surface lying 60 metres clear
takes nothing away from what the first covers, so the two answers have to
agree, and no reference implementation is needed to see that they do not.

The same defect on real data reads as a buffer that fails to contain the
geometry it was built from: over the 283 projected protected-area polygons of
natural_areas.csv at radii 1, 5 and 50, 87 of 849 buffers answer that they do
not cover their own input.

MEASURED

  283 polygons x radii 1/5/50   849 buffers, 395 cover / 87 DO NOT / 367
                                declined at 5742d5cba9, and 482 / 0 / 367
                                here. 482 = 395 + 87, and the declines do not
                                move, so every wrong answer is answered and
                                none is traded for a decline.
  meos/test/relate_corpus.txt        78 records, 0 matrices move
  meos/test/relate_corpus_types.txt  52 records, 0 matrices move
  GEOS buffer corpus, 34 records     31 agree / 1 differ / 2 declined,
                                     output identical (md5 6038421fd0fc78f9)
  geo_test                           passes, and aborts at the new case
                                     against 5742d5cba9
  two components sharing an edge     the shared edge stays interior to the
                                     union; all five probes agree with the one
                                     polygon covering the same point set
  interleaved A/B, 5 rounds,      10 real polygons  0.431
  arms equal in all nine family   20 further real polygons (disjoint sample)
  flags and build type            0.273
                                  a corpus not reaching the code 0.984

Each half alone is insufficient, which is what puts them in one change: the
extent test cannot settle a portion two components both reach, and leaves 49
of the 87; the clearance alone answers all 87 and pays for probes that cannot
change an answer, at 1.191.

WHY

A point on a component's boundary is not in the interior of that component,
so a portion of it belongs to the union's boundary unless some other component
covers a neighbourhood of the point. Reading the extents answers exactly that
question, and reaching a second extent is a necessary condition for it, so a
portion no second extent reaches needs no probe.

Where a probe is needed, it carries information only if it lands off the
boundary it is offsetting from. An offset drawn from a distance the arithmetic
cannot resolve does not, and the engine reads two such probes as evidence that
both sides lie inside. The tolerance an edge carries is the distance below
which a point counts as lying on it, so measuring the clearance against it is
what makes the offset a real one at every scale.
