### PR TITLE
Free the strings an error message is built from

### DIFF
--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -464,6 +464,7 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
           meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
             "The temporal values have different value at their common timestamp %s",
             t1);
+          pfree(t1);
           return NULL;
         }
       }

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -915,6 +915,7 @@ ensure_increasing_timestamps(const TInstant *inst1, const TInstant *inst2,
     char *t2 = pg_timestamptz_out(inst2->t);
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Timestamps for temporal value must be increasing: %s, %s", t1, t2);
+    pfree(t1); pfree(t2);
     return false;
   }
   if (merge && inst1->t == inst2->t &&
@@ -925,6 +926,7 @@ ensure_increasing_timestamps(const TInstant *inst1, const TInstant *inst2,
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "The temporal values have different value at their overlapping instant %s",
       t1);
+    pfree(t1);
     return false;
   }
   return true;

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -251,6 +251,7 @@ ensure_valid_tseqarr(TSequence **sequences, int count)
         char *t2 = pg_timestamptz_out(lower2);
         meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
           "Timestamps for temporal value must be increasing: %s, %s", t1, t2);
+        pfree(t1); pfree(t2);
         return false;
       }
       if (! ensure_spatial_validity((Temporal *) sequences[i - 1],


### PR DESCRIPTION
Free the strings an error message is built from

An error that names a timestamp builds that timestamp's text with
pg_timestamptz_out, which returns an allocation the caller owns. Four sites
free it after the report and six did not, across four error branches. The
report itself is finished with the string the moment meos_error formats it,
and the branch returns immediately after, so nothing else can free it.

Witness: meos/test/merge_test under valgrind reports 69 bytes in 3 blocks
definitely lost, every one allocated by pg_timestamptz_out inside
ensure_increasing_timestamps and reached through tsequence_merge and
temporal_merge_array; merging two temporal values whose timestamps do not
increase is what runs it. The same suite now reports no leak and exits 0
under --error-exitcode=1.

Why this is the caller's to free rather than meos_error's: the entries take a
format and its arguments, so the strings are the caller's own values, built
for one report and unreachable after it. The four sites already doing it --
two in temporal_modif.c and one each in temporal_aggfuncs.c and tinstant.c --
are the idiom this brings the other six to. One of the six is the sibling
branch of a function whose other branch already frees: tinstant_tagg releases
its message string when the values disagree at a common timestamp in the
sequence path and did not in the instant path.

Measured: merge_test goes 69 bytes to 0, with typeof_test read by the same
command in the same run as a control that still answers 14 leak lines, so the
zero is the code rather than the instrument. No other suite moves: json_test
166, raster_test 416, temporal_test 24, trgeo_test 384 and typeof_test 529
bytes are identical before and after, none of them this class. The seven
smoke suites pass valgrind and check_meos_error_returns.py reads 10
pre-existing sites with no new violations.
