### PR TITLE
Name in the contributor notes what the tree actually carries

### DIFF
--- a/doc/contributing/bbox_validation_design_notes.md
+++ b/doc/contributing/bbox_validation_design_notes.md
@@ -159,7 +159,14 @@ to the function that owns the behaviour; nothing generic reads a box's fields.
 | `temporal_bbox_cmp` | their B-tree order |
 | `temporal_bbox_size` | the box size for a temporal type |
 | `bbox_expand` | merge the first box into the second |
-| `ensure_valid_bbox_bbox` | are two boxes comparable (§2) |
+| `ensure_valid_bbox_bbox` | are two boxes comparable (§2) — **proposed, not yet in the tree** |
+
+Seven of those eight exist. `ensure_valid_bbox_bbox` does not: the tree validates
+comparability through the per-type entries — `ensure_valid_stbox_stbox`,
+`ensure_valid_tbox_tbox`, `ensure_valid_span_span` and their siblings — and every
+caller names the one its operand type needs. The dispatcher below is what this note
+PROPOSES so that generic code has one entry to call (§3.2); it is written out to fix
+the shape, not to describe code that ships.
 
 `ensure_bbox_temporal_compatible` and `ensure_same_index_bboxtype` are `ensure_*`
 members of the same family, so a validating dispatcher is the family's own shape

--- a/doc/contributing/th3index_design_notes.md
+++ b/doc/contributing/th3index_design_notes.md
@@ -36,7 +36,7 @@ Five hazards reliably bite workloads using H3 cells. Each is a property of the H
 
 - **Pentagon cells**. The H3 grid has 12 pentagonal (instead of hexagonal) cells per resolution &#x2014; the Eisenstein duals of the icosahedron's 12 vertices. `h3GridRing` may fail near these pentagons; `h3GridPathCells` fails if the path crosses one. The error is loud (libh3 raises an explicit failure), but workloads that expect ring / path operations to always succeed need a guard.
 
-  **Mitigation**: defensive code should wrap pentagon-sensitive calls and check `h3_is_pentagon_cell` on inputs and key outputs. For trajectories that pass near a pentagon, fall back to `gridDisk` (which is pentagon-safe) or compute path segments in pieces around the pentagon.
+  **Mitigation**: defensive code should wrap pentagon-sensitive calls and check `h3_is_pentagon` on inputs and key outputs. For trajectories that pass near a pentagon, fall back to `gridDisk` (which is pentagon-safe) or compute path segments in pieces around the pentagon.
 
 - **Compaction / decompaction round-trip**. `h3CompactCells` produces the most compact mixed-resolution representation of a set of cells; `h3UncompactCells` expands it back. The round-trip is lossless in spatial extent, but **cell ordering is not preserved** &#x2014; libh3 does not guarantee a sorted output. Queries that consume the output as if its order were stable will return different results before and after compaction even when the underlying spatial set is identical.
 
@@ -50,11 +50,11 @@ Five hazards reliably bite workloads using H3 cells. Each is a property of the H
 
 The on-disk representation of `th3index` is byte-identical to `tbigint` (each instant carries one 64-bit H3 cell ID plus a timestamp). Consequences for storage planning:
 
-- **WKT** via `th3_in` and `th3_out`. Cells render as canonical hex strings (e.g. `'8928308280fffff'`), which is also the form accepted on input. Round-trip is bit-stable.
+- **WKT** via `th3index_in`. Cells render as canonical hex strings (e.g. `'8928308280fffff'`), which is also the form accepted on input. Round-trip is bit-stable. The written form comes from the generic `temporal_out`: `T_TH3INDEX` is one of the types that reach it (`type_out.c`) rather than one carrying a renderer of its own, as `tint`, `tfloat`, `tbool` and `ttext` do.
 
 - **WKB / EWKB / HexWKB** via the standard PostGIS endian-flag-then-payload pattern. Stable across PostgreSQL major versions.
 
-- **MFJSON** via `asMFJSON(th3index)` and `th3indexFromMFJSON(text)`. The cell payload renders as the int64 cell identifier in the `values` array, the same representation carried by `tbigint`; consumers that need the canonical hex form apply `h3_cell_to_string`.
+- **MFJSON** via `asMFJSON(th3index)` and `th3indexFromMFJSON(text)`. The cell payload renders as the int64 cell identifier in the `values` array, the same representation carried by `tbigint`; consumers that need the canonical hex form apply `h3index_out`.
 
 - **pg_dump** uses WKT in plain mode and WKB under `--binary-upgrade`; both round-trip cleanly.
 

--- a/doc/contributing/tpointcloud_schema_design_notes.md
+++ b/doc/contributing/tpointcloud_schema_design_notes.md
@@ -65,7 +65,7 @@ CREATE TABLE pointcloud_dimensions (
 
 **`UNIQUE (pcid, name)`** is what makes `pc_schema_check_xyzm` unambiguous: the X, Y, Z and M dimensions are found by name, so two dimensions sharing one name would leave the choice to array order.
 
-The domains are libpc's own. The interpretation names are the ten of `pc_schema.c:21-22`. `unknown`, the eleventh, sits **outside** the domain: it is what the parser answers for a value it does not recognise, not a storage a schema states. The compression names are those of `pc_compression_string` (`pc_schema.c:84-93`).
+The domains are libpc's own. The interpretation names are the ten of `pc_schema.c:21-22`. `unknown`, the eleventh, sits **outside** the domain: it is what the parser answers for a value it does not recognise, not a storage a schema states. The compression names are those of `pc_compression_name` (`pc_schema.c:84-93`).
 
 ## The example of the manual, stated in SQL
 


### PR DESCRIPTION
Name in the contributor notes what the tree actually carries

Three of the thirteen notes under doc/contributing name symbols the tree does
not have, so a reader following them looks for a function that is not there.

Witness: `th3_in` and `th3_out` for the temporal H3 index, where the entry is
`th3index_in` and there is no type-specific renderer at all — `T_TH3INDEX`
reaches the generic `temporal_out` through `type_out.c`, unlike `tint`,
`tfloat`, `tbool` and `ttext`, which do declare one. Also `h3_is_pentagon_cell`
for `h3_is_pentagon`, `h3_cell_to_string` for `h3index_out`, and
`pc_compression_string` for `pc_compression_name`, whose citation of
`pc_schema.c:84-93` is otherwise right: the names sit there, under a function
declared on line 81.

The bounding box note states something different and is corrected differently.
Its section 3.1 dispatch table lists eight dispatchers and seven of them exist;
`ensure_valid_bbox_bbox` does not, the tree validating comparability through
the per-type `ensure_valid_stbox_stbox`, `ensure_valid_tbox_tbox` and
`ensure_valid_span_span`. It was given a table row and a full C body beside an
argument that "a validating dispatcher is the family's own shape rather than a
new idea", which is a proposal rather than a description, and nothing said so.
The row and the body now say so, because the design the note argues for is
worth keeping as a proposal and is not worth reading as an entry to call.

Why the notes rather than the code: each name is one a reader would call, and
the tree is the authority for what exists. Where the note and the tree disagree
about a name, the note is what moves — none of these is a rename the code owes.

Measured: all thirteen notes were checked, every backticked identifier and
every cited path against a 35 MB corpus of the tracked sources. Ten resolve
completely and are untouched. After this the three read 5 of 5, 19 of 19, and
20 of 21, the twenty-first being the row now labelled as proposed. Two classes
of apparent miss are not defects and are left alone: the `foo`/`tfoo`
placeholders of new_temporal_type.md, which stand for the type a reader is
adding, and the PostgreSQL paths and symbols of gist_sortsupport_design_notes.md,
which are correctly absent from this repository.
