### PR TITLE
Report every instant an aggregation builds, so the splice can free it

### DIFF
--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -420,7 +420,11 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
   int count2, datum_func2 func, int *newcount, void ***tofree, int *nfree)
 {
   TInstant **result = palloc(sizeof(TInstant *) * (count1 + count2));
-  void **tofree1 = palloc(sizeof(TInstant *) * Max(count1, count2));
+  /* Every instant this function builds is reported for freeing, and it builds
+   * at most one per input instant, so the array is sized like the result. The
+   * earlier Max(count1, count2) held only while the instants copied from
+   * state1 went unreported, which is what leaked them */
+  void **tofree1 = palloc(sizeof(TInstant *) * (count1 + count2));
   int i = 0, j = 0, count = 0, nfree1 = 0;
   while (i < count1 && j < count2)
   {
@@ -457,6 +461,8 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
         if (tinstant_eq(inst1, inst2))
         {
           result[count++] = tinstant_copy(inst1);
+          if (tofree)
+            tofree1[nfree1++] = result[count - 1];
         }
         else
         {
@@ -474,6 +480,8 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
     else if (cmp < 0)
     {
       result[count++] = tinstant_copy(inst1);
+      if (tofree)
+        tofree1[nfree1++] = result[count - 1];
       i++;
     }
     else


### PR DESCRIPTION
Report every instant an aggregation builds, so the splice can free it

tinstant_tagg builds the merged array and, beside it, the array of instants the
caller must free once it has copied them into the skiplist. It reported the
instants it built from the new values and stayed silent about the ones it
copied from the accumulated state, so those copies reached the skiplist, were
copied again on insertion, and were never freed.

Witness: meos/test/temporal_test under valgrind reports 24 bytes in 1 block
definitely lost, allocated by tinstant_copy at temporal_aggfuncs.c:476 through
tinstant_tagg -- the branch that takes an instant from state1 because its
timestamp is the earlier one. The suite now reports no leak and exits 0 under
--error-exitcode=1, its 732 lines of output unchanged.

Two branches were silent and both are the same case. One is that earlier-
timestamp copy; the other is the merge branch, which copies an instant when the
two agree at a shared timestamp and equally builds a value nothing else owns.
Each now reports what it built, as the two branches beside them already did.

Why the array had to grow with them: it was sized Max(count1, count2), which
holds only while the instants copied from state1 go unreported -- reporting is
what the size has to cover, and a walk that reports on every step of i and
every step of j reports up to count1 + count2 times. Adding the two lines
without the size would have written past the allocation on the first input
where both operands contribute. It is now sized like the result array beside
it, which is what the function can build at most.

Measured: temporal_test goes 24 bytes to 0. The seven smoke suites pass
valgrind, and the sixteen combine assertions of temporal_agg still read "agrees
with serial", which is what says the aggregation still answers what it did --
the instants being freed after the skiplist has copied them, not before.
