### PR TITLE
Test in the timestamptz-set restrictions what their delegate asserts

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -120,6 +120,8 @@ jobs:
           ./error_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o merge_test merge_test.c -L/usr/local/lib -lmeos
           ./merge_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o restrict_tstzset_validity_test restrict_tstzset_validity_test.c -L/usr/local/lib -lmeos
+          ./restrict_tstzset_validity_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o geo_test geo_test.c -L/usr/local/lib -lmeos
           ./geo_test
           # Every program under meos/test is a check of the installed library, and

--- a/meos/src/temporal/temporal_restrict_meos.c
+++ b/meos/src/temporal/temporal_restrict_meos.c
@@ -499,6 +499,7 @@ Temporal *
 temporal_at_tstzset(const Temporal *temp, const Set *s)
 {
   /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSET(s, NULL);
   return temporal_restrict_tstzset(temp, s, REST_AT);
 }
 
@@ -514,6 +515,7 @@ Temporal *
 temporal_minus_tstzset(const Temporal *temp, const Set *s)
 {
   /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(temp, NULL); VALIDATE_TSTZSET(s, NULL);
   return temporal_restrict_tstzset(temp, s, REST_MINUS);
 }
 

--- a/meos/test/restrict_tstzset_validity_test.c
+++ b/meos/test/restrict_tstzset_validity_test.c
@@ -1,0 +1,150 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests how the timestamptz-set restrictions of the MEOS
+ * API report an invalid argument under the noexit error handler.
+ *
+ * A public MEOS function tests the conditions its internal form asserts, so a
+ * binding calling it with a null pointer or a set of the wrong type receives an
+ * error it can raise in its host language. An assertion cannot carry that
+ * contract: it is compiled out under NDEBUG, which leaves the release build a
+ * binding links against with no check at all, and the internal
+ * #temporal_restrict_tstzset the restrictions delegate to states its
+ * preconditions that way.
+ *
+ * The program verifies that #temporal_at_tstzset and #temporal_minus_tstzset
+ * report a null temporal value, a null set, and a set that is not a timestamptz
+ * set, by returning NULL and setting #meos_errno — and that a valid restriction
+ * still answers with no error left behind. Their siblings over a timestamptz
+ * span already carry the contract and are asserted beside them, so the program
+ * states the family's behaviour rather than two functions of it.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o restrict_tstzset_validity_test restrict_tstzset_validity_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <assert.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+
+/* Main program */
+int main(void)
+{
+  /* Initialize MEOS and install the error handler that reports through
+   * meos_errno instead of exiting */
+  meos_initialize();
+  meos_initialize_timezone("UTC");
+  meos_initialize_noexit_error_handler();
+
+  Temporal *temp = tint_in("[1@2001-01-01, 2@2001-01-03]");
+  Set *tstzset = tstzset_in("{2001-01-01, 2001-01-02}");
+  Set *intset = intset_in("{1, 2}");
+  Span *tstzspan = tstzspan_in("[2001-01-01, 2001-01-02]");
+  assert(temp); assert(tstzset); assert(intset); assert(tstzspan);
+
+  /* A null temporal value is reported rather than dereferenced */
+  meos_errno_reset();
+  Temporal *res = temporal_at_tstzset(NULL, tstzset);
+  printf("temporal_at_tstzset(NULL, {2001-01-01, 2001-01-02}): NULL, errno %d\n",
+    meos_errno());
+  assert(res == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG);
+
+  meos_errno_reset();
+  res = temporal_minus_tstzset(NULL, tstzset);
+  assert(res == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG);
+
+  /* A null set is reported alike */
+  meos_errno_reset();
+  res = temporal_at_tstzset(temp, NULL);
+  printf("temporal_at_tstzset([1@2001-01-01, 2@2001-01-03], NULL): NULL, "
+    "errno %d\n", meos_errno());
+  assert(res == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG);
+
+  meos_errno_reset();
+  res = temporal_minus_tstzset(temp, NULL);
+  assert(res == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG);
+
+  /* A set that is not a timestamptz set is reported as a type error: the
+   * restriction reads the set's elements as timestamps, so accepting an
+   * integer set would read one type's bytes as another's */
+  meos_errno_reset();
+  res = temporal_at_tstzset(temp, intset);
+  printf("temporal_at_tstzset([1@2001-01-01, 2@2001-01-03], {1, 2}): NULL, "
+    "errno %d\n", meos_errno());
+  assert(res == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_TYPE);
+
+  meos_errno_reset();
+  res = temporal_minus_tstzset(temp, intset);
+  assert(res == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG_TYPE);
+
+  /* The siblings over a timestamptz span answer the same way */
+  meos_errno_reset();
+  res = temporal_at_tstzspan(NULL, tstzspan);
+  assert(res == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG);
+
+  meos_errno_reset();
+  res = temporal_minus_tstzspan(temp, NULL);
+  assert(res == NULL);
+  assert(meos_errno() == MEOS_ERR_INVALID_ARG);
+
+  /* A valid restriction still answers, and the guards leave no error behind */
+  meos_errno_reset();
+  res = temporal_at_tstzset(temp, tstzset);
+  assert(res != NULL);
+  assert(meos_errno() == 0);
+  char *out = tint_out(res);
+  printf("temporal_at_tstzset([1@2001-01-01, 2@2001-01-03], "
+    "{2001-01-01, 2001-01-02}): %s\n", out);
+  free(out); free(res);
+
+  meos_errno_reset();
+  res = temporal_minus_tstzset(temp, tstzset);
+  assert(res != NULL);
+  assert(meos_errno() == 0);
+  free(res);
+
+  free(temp); free(tstzset); free(intset); free(tstzspan);
+
+  /* Finalize MEOS */
+  meos_finalize();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
A public MEOS function tests the conditions its internal form asserts, so a
binding calling it with bad input receives an error it can raise in its host
language rather than a crash. temporal_at_tstzset and temporal_minus_tstzset
carry the marker comment for that guard with no guard beneath it, and the
temporal_restrict_tstzset they delegate to states its preconditions as
assert(temp); assert(s), which NDEBUG compiles out of the release build a
binding links against.

THE WITNESS. Against libmeos built from this tree with the guards removed, a
program calling temporal_at_tstzset(NULL, s) dies:

  Segmentation fault (core dumped)     exit 139

With them it answers, and reports rather than dereferences:

  temporal_at_tstzset(NULL, {2001-01-01, 2001-01-02}): NULL, errno 10
  temporal_at_tstzset([1@2001-01-01, 2@2001-01-03], NULL): NULL, errno 10
  temporal_at_tstzset([1@2001-01-01, 2@2001-01-03], {1, 2}): NULL, errno 11
  temporal_at_tstzset([1@2001-01-01, 2@2001-01-03],
    {2001-01-01, 2001-01-02}): {1@2001-01-01 00:00:00+00, 1@2001-01-02 00:00:00+00}

WHY THESE TWO CONDITIONS AND NOT A PAIR VALIDATOR. The guard is the one its
timestamptz-span sibling already carries, VALIDATE_NOT_NULL over the temporal
value and the typed macro over the container, and it states exactly what the
delegate asserts. ensure_valid_temporal_set is the validator for the OTHER
axis: it requires the temporal value's base type to equal the set's, which
holds for atValues restricting a tint by an intset and fails for every
temporal type restricted by a set of timestamps. The type check is what keeps
a set of another element type from being read as timestamps.

MEASURED. The two functions are the only ones in meos/src whose validity
marker is followed immediately by the return: 2415 markers, 2 of them. A
release build of libmeos and the new meos/test program answer as quoted above,
exit 0 with the guards and 139 without, so the program discriminates the change
rather than agreeing with the tree either way. The SQL surface does not move:
both PG wrappers are STRICT, so a null never reached the C function through
them, and the macros expand to the same assert in the extension build.

