### PR TITLE
Free the points a pose segment locates through

### DIFF
--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -445,14 +445,25 @@ posesegm_locate(const Pose *start, const Pose *end, const Pose *value)
     result1 = pointsegm_locate(PointerGetDatum(gs1), PointerGetDatum(gs2),
       PointerGetDatum(gs), NULL);
     if (result1 < 0.0)
+    {
+      pfree(gs1); pfree(gs2); pfree(gs);
       return -1.0;
+    }
   }
   else
   {
     /* If constant segment and the point of the value is different */
     if (! geopoint_eq(gs1, gs))
+    {
+      pfree(gs1); pfree(gs2); pfree(gs);
       return -1.0;
+    }
   }
+  /* The three points have answered the positional question and nothing below
+   * reads them: what follows is the rotation, which the poses carry
+   * themselves. They are this function's own serializations, so they are
+   * released here rather than at each of the returns that follow */
+  pfree(gs1); pfree(gs2); pfree(gs);
   if (MEOS_FLAGS_GET_Z(start->flags))
   {
     /* Invert the SLERP applied in posesegm_interpolate. For


### PR DESCRIPTION
Free the points a pose segment locates through

posesegm_locate answers where a pose sits on the segment between two others,
and it asks that question of geometry: it serializes all three poses to points
and compares those. The three serializations are its own, and it returned
through twelve exits without releasing any of them.

Witness: meos/test/trgeo_test under valgrind reports three records of 128 bytes
in 4 blocks each, allocated by gserialized_from_lwgeom under pose_to_point and
reached through tsegment_restrict_value, tsegment_intersection_value and
datumsegm_locate -- restricting a temporal pose to a value is what runs it. The
name posesegm_locate appears in three of the suite's leak stacks before and in
none after, against a control that reads those same three.

Why here rather than at each exit: the points answer the positional question in
the first block and nothing below reads them -- what follows is the rotation,
which the poses carry themselves, as quaternion components or as a yaw. So the
release belongs at the end of that block, plus the two exits inside it, and the
ten later returns need nothing. Freeing at all twelve would state the lifetime
in twelve places when it ends in one.

Measured: the three records are gone, the suite keeping the three that remain,
which sit at trgeo_test.c:292 and :479, carry test frames rather than library
ones and belong to the test rather than to this function. valgrind's own
summary reads 88 bytes definitely lost in 3 blocks, down from six records. The
seven smoke suites pass valgrind, tpose at 152 results and trgeometry at 139,
so the surface that reads this kernel answers as before.
