### PR TITLE
Free the text a jsonb path element is read from

### DIFF
--- a/pgtypes/utils/jsonfuncs.c
+++ b/pgtypes/utils/jsonfuncs.c
@@ -3311,8 +3311,14 @@ setPathArray(JsonbIterator **it, Datum *path_elems, bool *path_nulls,
     {
       meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
         "path element at position %d is not an integer: \"%s\"", level + 1, c);
+      pfree(path_str); /* MEOS */
       return;
     }
+    /* MEOS: the text of the path element has answered the index and is named
+     * by nothing outside this block. PostgreSQL reclaims it by resetting the
+     * memory context this runs in; MEOS maps palloc onto malloc, so the
+     * release is explicit */
+    pfree(path_str);
   }
   else
     idx = nelems;


### PR DESCRIPTION
Free the text a jsonb path element is read from

setPathArray reads the index of a path element by turning its text into a C
string and parsing that. The string is its own, named by nothing outside the
block that makes it, and it reached both of that block's exits without being
released.

Witness: meos/test/json_test under valgrind reports three records of 2 bytes,
each allocated by pg_text_to_cstring under setPathArray and reached through
jsonb_insert and jsonb_set -- setting or inserting at an array position is what
runs it. The name setPathArray appears in three of the suite's leak stacks
before and in none after, against a control that reads those same three, and
the suite's total falls from 166 bytes to 160.

Why the release is explicit here: PostgreSQL reclaims this by resetting the
memory context the call runs in, and this code is vendored from it unchanged.
MEOS maps palloc onto malloc and has no context to reset, so an allocation
lives until something frees it by name. That is a property of the port rather
than a defect of the original, and it is why the two exits of the block need
what PostgreSQL never had to write.

Measured: json_test goes 166 bytes to 160, and the 160 that remain are one
record, the jsonpath scanner's own buffer, which is NOT this class and is left
alone deliberately: resizeString grows it and jsonpath_yylex assigns it to
yylval->str at eleven sites, so the parse result may name it and a pfree there
would free live memory rather than a leak. The seven smoke suites pass
valgrind.
