### PR TITLE
Read the points a point cloud patch holds

### DIFF
--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -269,6 +269,8 @@ extern Pcpatch *pcpatch_copy(const Pcpatch *pa);
 
 extern uint32_t pcpatch_get_pcid(const Pcpatch *pa);
 extern uint32_t pcpatch_npoints(const Pcpatch *pa);
+extern Pcpoint *pcpatch_point_n(const Pcpatch *pa, int n);
+extern Pcpoint **pcpatch_points(const Pcpatch *pa, int *count);
 extern uint32 pcpatch_hash(const Pcpatch *pa);
 extern uint64 pcpatch_hash_extended(const Pcpatch *pa, uint64 seed);
 

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -440,6 +440,114 @@ uint32_t pcpatch_npoints(const Pcpatch *pa)
 }
 
 /**
+ * @brief Return a serialized copy of a point
+ * @details The bytes past the meaningful prefix are pgpointcloud's struct-tail
+ * padding, which the serialization leaves uninitialized. They are zeroed so
+ * that two pcpoints holding the same point hold the same bytes, as
+ * @c pcpoint_hex_out prints them
+ */
+static Pcpoint *
+pcpoint_serialize(const PCPOINT *pcpt)
+{
+  Pcpoint *result = (Pcpoint *) meos_pc_point_serialize(pcpt);
+  if (! result)
+    return NULL;
+  size_t meaningful = pcpoint_meaningful_size(result);
+  memset(((uint8_t *) result) + meaningful, 0, VARSIZE(result) - meaningful);
+  return result;
+}
+
+/**
+ * @ingroup meos_pointcloud_base_accessor
+ * @brief Return a copy of the n-th point of a pcpatch
+ * @param[in] pa Point cloud patch
+ * @param[in] n Number of the point, one-based: 1 is the first point and the
+ * number of points of the patch the last one. A negative @p n counts from the
+ * end, so that -1 is the last point and minus the number of points the first
+ * @return On error, or when @p n addresses no point of the patch, return
+ * @p NULL
+ * @details The indexing is the one pgPointCloud defines for @c PC_PointN,
+ * which owns the type
+ * @see #pcpatch_points() to obtain every point in a single call
+ */
+Pcpoint *
+pcpatch_point_n(const Pcpatch *pa, int n)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL);
+  const PCSCHEMA *schema = meos_pc_schema(pa->pcid);
+  if (! schema)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "No schema registered for pcid %u", pa->pcid);
+    return NULL;
+  }
+
+  /* Pcpatch is byte-compatible with SERIALIZED_PATCH (see pcpatch.h) */
+  PCPATCH *patch = MEOS_PC_PATCH_DESERIALIZE((const SERIALIZED_PATCH *) pa,
+    schema);
+  if (! patch)
+    return NULL;
+
+  /* pc_patch_pointn applies the one-based and the negative convention, and
+   * answers NULL for an index addressing no point of the patch */
+  PCPOINT *pcpt = pc_patch_pointn(patch, n);
+  Pcpoint *result = NULL;
+  if (pcpt)
+  {
+    result = pcpoint_serialize(pcpt);
+    pc_point_free(pcpt);
+  }
+  pc_patch_free(patch);
+  return result;
+}
+
+/**
+ * @ingroup meos_pointcloud_base_accessor
+ * @brief Return the array of points of a pcpatch
+ * @param[in] pa Point cloud patch
+ * @param[out] count Number of elements of the output array
+ * @return On error return @p NULL
+ * @details Every point carries the schema of the patch it comes from, and the
+ * points are returned in the order the patch stores them, which is the order
+ * #pcpatch_point_n() indexes
+ */
+Pcpoint **
+pcpatch_points(const Pcpatch *pa, int *count)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(pa, NULL); VALIDATE_NOT_NULL(count, NULL);
+  const PCSCHEMA *schema = meos_pc_schema(pa->pcid);
+  if (! schema)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "No schema registered for pcid %u", pa->pcid);
+    return NULL;
+  }
+
+  PCPATCH *patch = MEOS_PC_PATCH_DESERIALIZE((const SERIALIZED_PATCH *) pa,
+    schema);
+  if (! patch)
+    return NULL;
+  PCPOINTLIST *pl = pc_pointlist_from_patch(patch);
+  if (! pl)
+  {
+    pc_patch_free(patch);
+    return NULL;
+  }
+
+  Pcpoint **result = palloc(sizeof(Pcpoint *) * pl->npoints);
+  for (uint32_t i = 0; i < pl->npoints; i++)
+    /* The list owns its points, so each one is serialized into a copy */
+    result[i] = pcpoint_serialize(pc_pointlist_get_point(pl, (int) i));
+  *count = (int) pl->npoints;
+
+  pc_pointlist_free(pl);
+  pc_patch_free(patch);
+  return result;
+}
+
+/**
  * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 32-bit hash of a pcpatch
  * @return On error return @p UINT32_MAX

--- a/meos/test/tpointcloud_test.c
+++ b/meos/test/tpointcloud_test.c
@@ -117,6 +117,60 @@ int main(void)
   assert(meos_errno() != 0);
   meos_errno_reset();
 
+  /* With a schema registered, a patch built from its points answers which
+   * point stands at a given position */
+  PCDimensionSpec dims[3] = {
+    { "X", NULL, 1, "int32_t", 1, 0, true },
+    { "Y", NULL, 2, "int32_t", 1, 0, true },
+    { "Z", NULL, 3, "int32_t", 1, 0, true }
+  };
+  assert(meos_pc_schema_register_dims(2, 4326, "none", dims, 3));
+  double v1[3] = {1, 1, 1}, v2[3] = {2, 2, 2}, v3[3] = {3, 3, 3};
+  Pcpoint *p1 = pcpoint_make(2, v1, 3);
+  Pcpoint *p2 = pcpoint_make(2, v2, 3);
+  Pcpoint *p3 = pcpoint_make(2, v3, 3);
+  assert(p1 != NULL && p2 != NULL && p3 != NULL);
+  const Pcpoint *pts[3] = { p1, p2, p3 };
+  Pcpatch *pa = pcpatch_make(pts, 3);
+  assert(pa != NULL);
+  assert(pcpatch_npoints(pa) == 3);
+
+  /* The position is one-based, and a negative one counts from the end, which
+   * is the indexing pgPointCloud defines for PC_PointN */
+  Pcpoint *first = pcpatch_point_n(pa, 1);
+  Pcpoint *last = pcpatch_point_n(pa, 3);
+  Pcpoint *last_from_end = pcpatch_point_n(pa, -1);
+  Pcpoint *first_from_end = pcpatch_point_n(pa, -3);
+  assert(first != NULL && last != NULL);
+  assert(last_from_end != NULL && first_from_end != NULL);
+  assert(pcpoint_eq(first, p1));
+  assert(pcpoint_eq(last, p3));
+  assert(pcpoint_eq(last_from_end, last));
+  assert(pcpoint_eq(first_from_end, first));
+
+  /* A position addressing no point of the patch is answered with NULL, and
+   * asking for one is not an error */
+  assert(pcpatch_point_n(pa, 0) == NULL);
+  assert(pcpatch_point_n(pa, 4) == NULL);
+  assert(pcpatch_point_n(pa, -4) == NULL);
+  assert(meos_errno() == 0);
+
+  /* The array form holds the same points in the same order */
+  int count;
+  Pcpoint **points = pcpatch_points(pa, &count);
+  assert(points != NULL);
+  assert(count == (int) pcpatch_npoints(pa));
+  for (int i = 0; i < count; i++)
+  {
+    Pcpoint *nth = pcpatch_point_n(pa, i + 1);
+    assert(pcpoint_eq(points[i], nth));
+    free(nth); free(points[i]);
+  }
+  printf("a patch of %d points answers each of them by its position\n", count);
+  free(points);
+  free(first); free(last); free(last_from_end); free(first_from_end);
+  free(p1); free(p2); free(p3); free(pa);
+
   free(tpcpoint); free(tpcpoint_out);
   free(tpcpatch); free(tpcpatch_out);
   free(box);


### PR DESCRIPTION
A pcpatch is a collection of pcpoints, which is what pgPointCloud's own
documentation states of the two types it owns: "we collect a group of PcPoint
into a PcPatch". MEOS states half of that relation. It builds a patch from
points through pcpatch_make and counts them through pcpatch_npoints, and no
entry gives one back, so the points go in and never come out.

pcpatch_point_n reads the point at a position and pcpatch_points reads them
all, mirroring posechain_pose_n and posechain_poses, which state the same
relation for the family that models it completely.

The position is the one pgPointCloud defines for PC_PointN, read from
pc_patch_pointn: one-based, a negative position counting from the end, and a
position addressing no point of the patch answered with NULL rather than an
error. Each point carries the schema of the patch, and is a copy the caller
owns.

The SQL surface is unchanged. The point cloud extension already answers this
question through PC_PointN and PC_Explode, and the gap was in MEOS, which is
what every binding reads.

