### PR TITLE
Borrow the point a raster tile reads rather than copying it

### DIFF
--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -366,7 +366,10 @@ raster_tile_value_quadbin(const Temporal *traj, const uint8_t *pixels,
   for (int i = 0; i < count; i++)
   {
     /* Extract lon/lat from point geometry via GBOX (xmin==xmax for points) */
-    GSERIALIZED *pt_gs = (GSERIALIZED *) DatumGetPointer(tinstant_value(insts[i]));
+    /* The point is read, never kept, and the instant that holds it outlives
+     * this call, so it is borrowed rather than copied */
+    const GSERIALIZED *pt_gs =
+      (const GSERIALIZED *) DatumGetPointer(tinstant_value_p(insts[i]));
     GBOX pt_box;
     gserialized_get_gbox_p(pt_gs, &pt_box);
     double lon = pt_box.xmin;
@@ -445,8 +448,9 @@ raster_value(const Temporal *traj, const STBox *box, raster_sample_fn sample,
 
   for (int i = 0; i < count; i++)
   {
-    GSERIALIZED *pt_gs =
-      (GSERIALIZED *) DatumGetPointer(tinstant_value(insts[i]));
+    /* Borrowed, as above: the sampling reads the point and keeps nothing */
+    const GSERIALIZED *pt_gs =
+      (const GSERIALIZED *) DatumGetPointer(tinstant_value_p(insts[i]));
 
     /* Bounding-box pre-filter: for a point the GBOX is degenerate */
     if (box)
@@ -677,7 +681,10 @@ trajectory_quadbins(const Temporal *traj, uint32_t zoom, int *count)
 
   for (int i = 0; i < ninsts; i++)
   {
-    GSERIALIZED *pt_gs = (GSERIALIZED *) DatumGetPointer(tinstant_value(insts[i]));
+    /* The point is read, never kept, and the instant that holds it outlives
+     * this call, so it is borrowed rather than copied */
+    const GSERIALIZED *pt_gs =
+      (const GSERIALIZED *) DatumGetPointer(tinstant_value_p(insts[i]));
     GBOX pt_box;
     gserialized_get_gbox_p(pt_gs, &pt_box);
     double lon = pt_box.xmin;


### PR DESCRIPTION
Borrow the point a raster tile reads rather than copying it

Three loops in the raster quadbin code read a trajectory instant's point to
take its bounding box, and each asked for it with tinstant_value, which COPIES
the value into an allocation the caller owns. None of the three keeps the
point, and none freed the copy, so every instant of every trajectory left one
serialized geometry behind.

Witness: meos/test/raster_test under valgrind reports 416 bytes across three
records -- 320 in 10 blocks, 64 in 2 and 32 in 1 -- every one allocated by
datum_copy under tinstant_value and reached through raster_tile_value_quadbin
and trajectory_quadbins. Those two names appear in three of the suite's leak
stacks before and in none after, against a control that reads those same three,
and the suite now exits 0 under --error-exitcode=1 with its 165 lines of output
unchanged.

Why the accessor rather than a free: a copy that is read and dropped is an
allocation the code never needed. tinstant_value_p answers the same value
without one, and the pointer stays good for the whole call, the instants coming
from temporal_insts_p over the caller's own argument. That is the rule the
kernel already follows -- allocate nothing where an accessor can fill or lend
-- so pairing tinstant_value with a pfree would have kept the malloc and added
the bookkeeping instead of removing both.

The third site is not in the witness. Two of the three run in raster_test; the
sampling loop of the tile-array form does not, and it carries the same
statement. It is the same defect in the same file, so it is fixed here rather
than left for the next sweep to find.

Measured: raster_test goes 416 bytes to 0, and the file now holds three
tinstant_value_p and no tinstant_value. The seven smoke suites pass valgrind.
