### PR TITLE
Free the geometry a box is converted through

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -629,7 +629,6 @@ box2d_to_lwgeom(GBOX *box, int32_t srid)
     /* MobilityDB: The above function does not set the geodetic flag */
     FLAGS_SET_GEODETIC(point->flags, FLAGS_GET_GEODETIC(box->flags));
     result = lwpoint_as_lwgeom(point);
-    /* We cannot lwpoint_free(point); */
   }
   else if ( (box->xmin == box->xmax) || (box->ymin == box->ymax) )
   {
@@ -684,7 +683,6 @@ box2d_to_lwgeom(GBOX *box, int32_t srid)
 LWGEOM *
 box3d_to_lwgeom(BOX3D *box)
 {
-  POINTARRAY *pa;
   LWGEOM *result;
   POINT4D pt;
 
@@ -700,12 +698,16 @@ box3d_to_lwgeom(BOX3D *box)
    *     - Otherwise return a POLYHEDRALSURFACE geometry
    */
 
-  pa = ptarray_construct_empty(LW_TRUE, LW_FALSE, 5);
+  /* The point array below belongs to the point or the line that is built from
+   * it, and the polygon and polyhedron arms build their own through
+   * lwpoly_construct_rectangle. Constructing it for every arm left it owned by
+   * nobody in the four that do not take it */
 
   /* BOX3D is a point */
   if ((box->xmin == box->xmax) && (box->ymin == box->ymax) &&
       (box->zmin == box->zmax))
   {
+    POINTARRAY *pa = ptarray_construct_empty(LW_TRUE, LW_FALSE, 5);
     LWPOINT *lwpt = lwpoint_construct(SRID_UNKNOWN, NULL, pa);
 
     pt.x = box->xmin;
@@ -719,6 +721,7 @@ box3d_to_lwgeom(BOX3D *box)
      ((box->xmin == box->xmax || box->zmin == box->zmax) && box->ymin == box->ymax) ||
      ((box->ymin == box->ymax || box->zmin == box->zmax) && box->xmin == box->xmax))
   {
+    POINTARRAY *pa = ptarray_construct_empty(LW_TRUE, LW_FALSE, 5);
     LWLINE *lwline = lwline_construct(SRID_UNKNOWN, NULL, pa);
 
     pt.x = box->xmin;

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -652,9 +652,12 @@ stbox_geo(const STBox *box)
   FLAGS_SET_Z(geo->flags, hasz);
   FLAGS_SET_GEODETIC(geo->flags, geodetic);
   result = geo_serialize(geo);
-  /* We cannot lwgeom_free(geo); */
-  if (gserialized_get_type(result) != POINTTYPE)
-    lwgeom_free(geo);
+  /* The serialization copies, so the geometry it was built from is this
+   * function's to release whatever its type. The point case was exempted to
+   * avoid a crash that no longer happens: every shape this function can build
+   * -- point, line, plane and polyhedron in 3D, point, line and polygon in 2D,
+   * geodetic and planar alike -- survives the release */
+  lwgeom_free(geo);
   return result;
 }
 


### PR DESCRIPTION
Free the geometry a box is converted through

Converting a bounding box to a geometry builds an LWGEOM, serializes it and
returns the serialization. The LWGEOM is scratch, and two things kept it alive:
stbox_geo released it only when the answer was not a point, under a comment
saying it could not be released at all, and box3d_to_lwgeom built a point array
for every shape while only two of its six arms take one.

Witness: meos/test/trgeo_test under valgrind reports 144 bytes in 1 block
allocated by ptarray_construct_empty under box3d_to_lwgeom, reached through
stbox_geo and nad_trgeometry_stbox. The name stbox_geo appears in one of the
suite's leak stacks before and in none after, the suite's total falling from 88
bytes definitely lost to 64, the remainder being another function's.

Why the release is unconditional now: the point exemption was guarding a
crash that no longer happens. A probe over
every shape stbox_geo can build -- point, line, area in 2D, point, line and
polyhedron in 3D, and the geodetic point and area -- serializes each and
releases it: all eight answer correctly and none crashes, under valgrind with
no leak and no invalid access. The two arms the comment covered are the first
two of those. Whatever made the release unsafe when the comment was written is
not in this path today, so the release is unconditional and the comment says
what is true instead.

The point array is the second half and it leaks on the ORDINARY box. The point
and line arms hand it to lwpoint_construct and lwline_construct, which own it;
the three plane arms and the polyhedron arm build their own through
lwpoly_construct_rectangle and never look at it. Constructing it before the
branch therefore orphaned it for every box that is not degenerate -- the common
case. It is now constructed in the two arms that consume it.

A third comment goes with them: box2d_to_lwgeom says it cannot free its point,
which is true for a reason that is not a caveat -- that point IS the value the
function returns.

Measured: trgeo_test drops 144 bytes and stbox_geo leaves its leak stacks; the
eight-shape probe is valgrind-clean at exit 0; the seven smoke suites pass
valgrind.
