### PR TITLE
Answer whether a geometry is simple without reaching the GEOS library

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2960,31 +2960,17 @@ geom_is_simple(const GSERIALIZED *gs)
 
   LWGEOM *geom = lwgeom_from_gserialized(gs);
   bool result;
-  if (meos_is_simple(geom, &result))
-  {
-    lwgeom_free(geom);
+  bool covered = meos_is_simple(geom, &result);
+  lwgeom_free(geom);
+  if (covered)
     return result;
-  }
 
-#if GEOS
-  /* A geometry carrying a circular arc meets itself along an arc, which the
-   * segment intersection the answer above rests on does not read */
-  int simple = lwgeom_is_simple(geom);
-  lwgeom_free(geom);
-  if (simple < 0)
-  {
-    meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
-      "Whether the geometry is simple could not be determined");
-    return false;
-  }
-  return simple != 0;
-#else /* ! GEOS */
-  lwgeom_free(geom);
+  /* #meos_is_simple answers every type #geom_meos_supported admits, and a
+   * geodetic geometry is refused above, so a geometry reaching here carries a
+   * type the engine does not read at all */
   meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
-    "Whether a geometry carrying a circular arc is simple is answered by the "
-    "GEOS library, which this build excludes: configure with -DGEOS=ON");
+    "Unsupported geometry type");
   return false;
-#endif /* GEOS */
 }
 
 /*****************************************************************************/

--- a/tools/scripts/liblwgeom_geos_baseline.txt
+++ b/tools/scripts/liblwgeom_geos_baseline.txt
@@ -6,7 +6,6 @@
 # a call over. The library answers 125 entry points in all.
 meos/src/geo/postgis_funcs.c	lwgeom_difference_prec
 meos/src/geo/postgis_funcs.c	lwgeom_intersection_prec
-meos/src/geo/postgis_funcs.c	lwgeom_is_simple
 meos/src/geo/postgis_funcs.c	lwgeom_unaryunion_prec
 meos/src/raster/raster_rtcore.c	rt_raster_destroy
 meos/src/raster/raster_rtcore.c	rt_raster_get_band


### PR DESCRIPTION
Answer whether a geometry is simple without reaching the GEOS library

`meos_is_simple` answers every type `geom_meos_supported` admits, and
`geom_is_simple` refuses a geodetic geometry before consulting it, so the arm
that hands an uncovered geometry to `lwgeom_is_simple` receives none. What
remains of it is the report that a geometry carries a type the engine does not
read, which is the message every other entry gives for that case.

`lwgeom_is_simple` leaves the baseline of liblwgeom entry points that reach
GEOS through a call MEOS makes, which stands at seven.

WITNESS

  SELECT ST_IsSimple('CIRCULARSTRING(0 0,2 2,4 0,2 -2,0 0)');   t

answered by the engine itself in a build configured `-DGEOS=OFF`, where the
removed arm reports `MEOS_ERR_FEATURE_NOT_SUPPORTED` and returns false.

MEASURED

  one geometry of each of the 15    15 answered, 0 declined, in a build with
  types geom_meos_supported         GEOS compiled out, which is what says the
  admits, run with -DGEOS=OFF       removed arm is unreachable: such a build
                                    declines exactly what reaches it
  the same 15, the 11 arc cases,    identical answers before and after,
  and the 42-record GEOS isSimple   68 records in all
  corpus
  callers of lwgeom_is_simple       1 before, 0 after, the one being the arm
  across meos/src and meos/include  removed here
  check_liblwgeom_geos.py           clean at 7 baselined entry points of 125
  full meos/test suite              the 54 invocations the CI step compiles
                                    and runs, clean

The one differing record of the isSimple corpus is `POLYGON((0 0,10 10,0 0))`,
a ring of three points the reader declines, and it differs identically before
and after.

WHY

An arm is reachable when some input takes it. This one is guarded by
`meos_is_simple` answering false, which it does only for a type its switch
does not name; the switch names all fifteen types the supported predicate
admits, and the geodetic case never reaches the switch. So the guard is false
for every geometry the engine accepts, and the arm is dead rather than rare.

A build without GEOS is what turns that reading into a measurement: the arm it
compiles in place of the GEOS call raises rather than answering, so any input
still reaching it appears as a decline. None does.

What the caller receives for a geometry the engine genuinely cannot read is
unchanged in kind: an error naming the unsupported type, rather than an error
naming a library the build excludes.
