### PR TITLE
Release both geometries when the reference check refuses

### DIFF
--- a/meos/src/rgeo/trgeo_utils.c
+++ b/meos/src/rgeo/trgeo_utils.c
@@ -139,6 +139,8 @@ ensure_same_geom(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   {
     meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
       "Operation on different reference geometries");
+    lwgeom_free(geom1);
+    lwgeom_free(geom2);
     return false;
   }
 


### PR DESCRIPTION
Release both geometries when the reference check refuses

ensure_same_geom deserializes the two reference geometries to compare them,
and releases both once they agree. Where they do not, it reports the
disagreement and returns without releasing either, so the refusal costs what
the agreement does not.

Witness: meos/test/trgeo_test under valgrind reports two records of 136 bytes
each, 32 direct and 104 indirect, allocated by lwgeom_from_gserialized inside
ensure_same_geom and reached through temporal_insert by way of
temporal_geom_combinable -- inserting into a temporal rigid geometry whose
reference body differs is what runs it. The name appears in two of the suite's
leak stacks before and in none after, against a control that reads those same
two, and the suite falls from 88 bytes definitely lost to 24, the remainder
belonging to stbox_geo and answered separately.

Why here and not at the top of the function: the two deserializations are this
function's own scratch, wanted only for same_lwgeom, and the agreeing path
already says so by freeing them before it answers true. The refusing path is
the same function with the same scratch and one different answer, so it frees
the same two things. The earlier returns need nothing -- they are taken before
either deserialization.

Measured: trgeo_test drops 272 bytes across the two records, exits 0 under
--error-exitcode=1 for everything this change owns, and the seven smoke suites
pass valgrind with trgeometry_test at 139 results.
