### PR TITLE
Free in the tests the values MEOS hands them

### DIFF
--- a/meos/test/error_test.c
+++ b/meos/test/error_test.c
@@ -203,7 +203,9 @@ int main(void)
   GSERIALIZED *webmerc = geo_transform(wgs84, 3857);
   assert(webmerc != NULL);
   assert(meos_errno() == 0);
-  printf("geo_transform(4326 -> 3857): %s\n", geo_as_ewkt(webmerc, 2));
+  char *webmerc_ewkt = geo_as_ewkt(webmerc, 2);
+  printf("geo_transform(4326 -> 3857): %s\n", webmerc_ewkt);
+  free(webmerc_ewkt);
 
   /* An ordered comparison admits only a temporal type whose base type carries
    * an order. A geometry has a B-tree order so that it can be indexed, which is

--- a/meos/test/typeof_test.c
+++ b/meos/test/typeof_test.c
@@ -40,6 +40,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <meos.h>
 #include <meos_catalog.h>
 
@@ -69,19 +70,48 @@ int main(void)
   meos_initialize();
   meos_initialize_timezone("UTC");
 
-  /* Self-describing serializations: the concrete type is recovered */
-  check("tint", temporal_as_hexwkb(tint_in("1@2001-01-01"), 0, &sz), T_TINT);
-  check("tfloat", temporal_as_hexwkb(tfloat_in("1.5@2001-01-01"), 0, &sz),
-    T_TFLOAT);
-  check("intspan", span_as_hexwkb(intspan_in("[1, 3]"), 0, &sz), T_INTSPAN);
-  check("floatspan", span_as_hexwkb(floatspan_in("[1.0, 3.0]"), 0, &sz),
-    T_FLOATSPAN);
-  check("tstzspan",
-    span_as_hexwkb(tstzspan_in("[2001-01-01, 2001-01-02]"), 0, &sz),
-    T_TSTZSPAN);
-  check("intset", set_as_hexwkb(intset_in("{1, 2, 3}"), 0, &sz), T_INTSET);
-  check("intspanset", spanset_as_hexwkb(intspanset_in("{[1,2],[4,5]}"), 0, &sz),
-    T_INTSPANSET);
+  /* Self-describing serializations: the concrete type is recovered. The value
+   * and the text it serializes to are both allocations of this program, so
+   * each is held in a variable long enough to be freed: a value handed
+   * straight to the serializer, or a serialization handed straight to the
+   * check, is one nothing can free */
+  void *val;
+  char *hex;
+
+  val = tint_in("1@2001-01-01");
+  hex = temporal_as_hexwkb(val, 0, &sz);
+  check("tint", hex, T_TINT);
+  free(hex); free(val);
+
+  val = tfloat_in("1.5@2001-01-01");
+  hex = temporal_as_hexwkb(val, 0, &sz);
+  check("tfloat", hex, T_TFLOAT);
+  free(hex); free(val);
+
+  val = intspan_in("[1, 3]");
+  hex = span_as_hexwkb(val, 0, &sz);
+  check("intspan", hex, T_INTSPAN);
+  free(hex); free(val);
+
+  val = floatspan_in("[1.0, 3.0]");
+  hex = span_as_hexwkb(val, 0, &sz);
+  check("floatspan", hex, T_FLOATSPAN);
+  free(hex); free(val);
+
+  val = tstzspan_in("[2001-01-01, 2001-01-02]");
+  hex = span_as_hexwkb(val, 0, &sz);
+  check("tstzspan", hex, T_TSTZSPAN);
+  free(hex); free(val);
+
+  val = intset_in("{1, 2, 3}");
+  hex = set_as_hexwkb(val, 0, &sz);
+  check("intset", hex, T_INTSET);
+  free(hex); free(val);
+
+  val = intspanset_in("{[1,2],[4,5]}");
+  hex = spanset_as_hexwkb(val, 0, &sz);
+  check("intspanset", hex, T_INTSPANSET);
+  free(hex); free(val);
 
   /* Malformed input yields T_UNKNOWN without raising */
   check("null", NULL, T_UNKNOWN);


### PR DESCRIPTION
Free in the tests the values MEOS hands them

Two suites ask MEOS to build a value and then read it straight into a printf or
a helper, so nothing names the allocation and nothing can free it. Under
PostgreSQL a context reset would reclaim it; meos/test links the standalone
library, where an allocation lives until it is freed by name, and these suites
are the instrument the leak checking uses, so a leak of their own is noise in
front of the surface they measure.

Witness: error_test reports 38 bytes in 1 block, the text of geo_as_ewkt handed
to printf at line 206. typeof_test reports 529 bytes across 14 records, two per
case: the value each case builds and the hexwkb text it serializes to, both
passed inline to check(). Under --error-exitcode=1 the two suites now exit 0
and report no leak, error_test printing its 23 lines and typeof_test its 12,
ALL PASS unchanged.

Why the fix is a variable rather than a helper: an allocation needs a name
before anything can free it, and the shape is the same in both -- hold the value
in a variable
long enough to free it. typeof_test gains two locals reused across its seven
cases rather than fourteen names, which keeps the case list as readable as it
was; error_test gains one. stdlib.h joins typeof_test's includes, free() having
had no declaration there.

Measured: 38 bytes to 0 and 529 bytes to 0, each read by valgrind with the
suppression file the smoke runner uses. Neither suite's output moves, which is
what says the frees are frees and not a change of behaviour.
