### PR TITLE
Reclaim the text a jsonpath numeric literal is scanned into

### DIFF
--- a/pgtypes/utils/jsonpath.c
+++ b/pgtypes/utils/jsonpath.c
@@ -268,6 +268,8 @@ jsonPathFromCstring(char *str, int len, struct Node *escontext)
     freeJsonPathParseItem(jsonpath->expr);
     pfree(jsonpath);
     pfree(buf.data);
+    /* MEOS: reclaim the scratch the scan put on the free list (early-return) */
+    json_reset_tofree();
     return NULL;
   }
 
@@ -279,6 +281,10 @@ jsonPathFromCstring(char *str, int len, struct Node *escontext)
 
   freeJsonPathParseItem(jsonpath->expr);
   pfree(jsonpath);
+  /* MEOS: the flattening above copies every string into the result, so the
+   * scratch the scan left on the free list is dead here. jsonb_from_cstring
+   * drains at the same point of its own conversion */
+  json_reset_tofree();
   return result;
 }
 

--- a/pgtypes/utils/jsonpath_gram.c
+++ b/pgtypes/utils/jsonpath_gram.c
@@ -2240,6 +2240,13 @@ makeItemNumeric(JsonPathString *s)
 {
   JsonPathParseItem *v = makeItemType(jpiNumeric);
   v->value.numeric = pg_numeric_in(s->val, -1);
+  /* MEOS: a numeric literal is converted here and the text it was scanned
+   * into is kept by nobody -- unlike a string, a key or a variable, whose
+   * item holds the same buffer and frees it with the parse tree. PostgreSQL
+   * reclaims it by resetting the memory context; here it goes on the
+   * parse-time free list that jsonPathFromCstring drains, the mechanism
+   * jsonb_from_cstring already uses for its own scan scratch */
+  json_add_tofree(s->val);
   return v;
 }
 


### PR DESCRIPTION
Reclaim the text a jsonpath numeric literal is scanned into

The jsonpath scanner builds each token's text in a buffer it allocates, and
the grammar decides who owns it. A string, a key and a variable each become an
item that holds the same buffer and releases it with the parse tree. A numeric
literal does not: makeItemNumeric converts the text with pg_numeric_in and
keeps only the Numeric, so the buffer it converted from is held by nobody.

Witness: meos/test/json_test under valgrind reports 160 bytes in 5 blocks,
every one allocated by resizeString under addstring and reached through
jsonpath_yylex, parsejsonpath and jsonPathFromCstring -- reading a jsonpath
that carries a number is what runs it, and the suite's paths carry five. The
name resizeString appears in one of the suite's leak stacks before and in none
after; the suite now reports 0 bytes definitely, indirectly and possibly lost,
and exits 0 under --error-exitcode=1.

The mechanism is the one the tree already has. json_add_tofree and
json_reset_tofree (pgtypes/utils/jsonb_util.c) are the parse-time free list
MEOS keeps for exactly this: an allocation PostgreSQL would reclaim by
resetting its memory context, which a standalone build has to release by name.
jsonpath_exec.c drains it at six sites and jsonb.c and jsonfuncs.c at three
more; jsonPathFromCstring drained it nowhere, which is the gap. It now drains
after the flattening has copied every string into the result, and on the
early return a failed flattening takes -- the two points jsonb_from_cstring
drains at in its own conversion, the second of which its comment calls the
early-return leak.

Why the registration sits in makeItemNumeric rather than at the scanner: the
scanner cannot know whether the token it just built will be kept, and putting
every buffer on the list would double-free the ones an item owns. The grammar
knows, and makeItemNumeric is the one place where the text is converted and
then not kept.

Measured: json_test goes 160 bytes to 0 with its 59 lines of output unchanged,
and the seven smoke suites pass valgrind, tjsonb_smoketest at 189 results.
