### PR TITLE
Give the GeoPose and elevation entries a value they accept

### DIFF
--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -912,6 +912,16 @@ TPOSE_CONFIG = dict(
         # regardless of the source/target SRID. The default int32_t -> 0
         # target SRID is SRID_UNKNOWN, which ensure_srid_known() rejects.
         "pose_transform_pipeline": {1: "pipeline1", 2: "4326"},
+        # The GeoPose writers need a geodetic value, and the two elevation
+        # restrictions a value carrying Z and a floatspan to cut it with.
+        "pose_as_geopose":                 {0: "pose_geod1"},
+        "tpose_as_geopose":                {0: "tpose_geod1"},
+        "tpose_as_geopose_stream":         {0: "tpose_geod1"},
+        "tpose_as_geopose_stream_header":  {0: "tpose_geod1"},
+        "tpose_as_geopose_stream_element": {0: "tpose_geod1",
+                                            1: "tpose_geod_inst1"},
+        "tpose_at_elevation":    {0: "tpose_z1", 1: "floatspan1"},
+        "tpose_minus_elevation": {0: "tpose_z1", 1: "floatspan1"},
         # posearr_round takes a canned array of poses plus its count; the
         # return is a `Pose **` array of fresh per-element copies with no
         # `int *` count arg and no `Set *` arg for emit_call's generic
@@ -978,6 +988,14 @@ TPOSE_CONFIG = dict(
   /* Reprojection reads the source SRID off the value, so the transform input
    * carries one explicitly. */
   Pose *pose_srid1 = pose_in("SRID=4326;Pose(Point(1 2), 0.5)");
+  /* GeoPose is defined against a geodetic frame, so the writers take a GEODETIC
+   * pose; pose1 is planar and draws "GeoPose JSON requires a geodetic pose, got
+   * a planar one". The value is the one 103_pose_geopose.test.sql uses. */
+  Pose *pose_geod1 =
+    pose_in("SRID=4326;Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)");
+  /* An elevation is a range of Z, so the span these two restrict by is a
+   * FLOATSPAN, not the tstzspan every other Span * argument here takes. */
+  Span *floatspan1 = floatspan_in("[1, 2]");
   Pose *pose_out_param = NULL;
   /* The pose chain family, the second family this header publishes. The WKT
    * values are those of mobilitydb/test/posechain/queries/550_posechain and
@@ -1107,6 +1125,16 @@ TPOSE_CONFIG = dict(
     "SRID=4326;PoseChain(GeodPose(Point Z(-122.3 47.7 11), 1, 0, 0, 0),"
     " Pose(Point Z(0 3 0), 1, 0, 0, 0))@2001-01-02");
   const Temporal *tposechainarr1[] = { tposechain_geod1, tposechain_geod2 };
+  /* The geodetic twin of tpose1, for the four GeoPose writers, with its start
+   * instant for the per-instant stream entry. */
+  Temporal *tpose_geod1 = tpose_in(
+    "SRID=4326;[Geodpose(Point(8 47 1500), 0.707107, 0, 0, 0.707107)@2001-01-02,"
+    " Geodpose(Point(9 48 1600), 0.707107, 0, 0, 0.707107)@2001-01-03]");
+  TInstant *tpose_geod_inst1 = (TInstant *) temporal_start_instant(tpose_geod1);
+  /* A tpose carrying Z, for the two elevation restrictions. The pose climbs
+   * from 0 to 4 so floatspan1 cuts it rather than missing it entirely. */
+  Temporal *tpose_z1 = tpose_in(
+    "[Pose(Point(0 0 0),1,0,0,0)@2001-01-02, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]");
   int n_out = 0;
 """,
     cleanup="""\
@@ -1123,6 +1151,11 @@ TPOSE_CONFIG = dict(
   }
 
   if (tpose_inst1) free(tpose_inst1);
+  if (tpose_geod_inst1) free(tpose_geod_inst1);
+  if (tpose_geod1) free(tpose_geod1);
+  if (tpose_z1) free(tpose_z1);
+  if (floatspan1) free(floatspan1);
+  if (pose_geod1) free(pose_geod1);
   if (tpose1) free(tpose1);
   if (tpoint1) free(tpoint1);
   if (tfloat1) free(tfloat1);


### PR DESCRIPTION
Give the GeoPose and elevation entries a value they accept

Seven entries of the tpose smoke suite are called with an input their own guard
refuses, so each reports NULL and a validation warning rather than answering.

The five GeoPose writers -- pose_as_geopose, tpose_as_geopose and the three
stream forms -- are defined against a geodetic frame and say so: "GeoPose JSON
requires a geodetic pose, got a planar one". They were reached with pose1 and
tpose1, which are planar. They now take a geodetic pose and a geodetic tpose,
spelled as 103_pose_geopose.test.sql spells one, with the sequence's start
instant for the per-instant stream element.

The two elevation restrictions ask for a range of Z, so their Span * is a
FLOATSPAN and their value must carry Z -- neither of which the defaults give
them: every other Span * in this config is a tstzspan, and tpose1 is 2D, which
draws "The tpose must have Z dimension". They now take the climbing 3D pose and
the floatspan of 105_tpose_spatialfuncs.test.sql, whose span cuts the value
rather than missing it.

Measured on the tpose suite: validation warnings 19 -> 12, and the twelve left
are the pose chain ones that #2518 answers -- the two changes touch disjoint
entries and compose to 0. All seven print a document or a restricted value
instead of NULL. The emitted answer count does not move, which is the point:
these calls were always made, and were always refused. run_smoketests.sh passes
all seven suites and every one stays valgrind-clean.
