### PR TITLE
Measure an empty geometry rather than reporting it as an error

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -872,6 +872,8 @@ geo_is_unitary(const GSERIALIZED *gs)
  *  Uses Euclidean 3D/2D length depending on input dimensions.
  * @param[in] gs Geometry
  * @return On error return @p DBL_MAX
+ * @note An empty geometry draws no line, so its length is 0. The question has
+ * an answer, and #lwgeom_length gives it
  * @note PostGIS function: @p LWGEOM_length_linestring(PG_FUNCTION_ARGS)
  */
 double
@@ -879,7 +881,7 @@ geom_length(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(gs, DBL_MAX);
-  if (gserialized_is_empty(gs) || ! ensure_not_geodetic_geo(gs))
+  if (! ensure_not_geodetic_geo(gs))
     return DBL_MAX;
 
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
@@ -898,6 +900,8 @@ geom_length(const GSERIALIZED *gs)
  * Uses Euclidian 2D computation even if input is 3D
  * @param[in] gs Geometry
  * @return On error return @p DBL_MAX
+ * @note An empty geometry bounds no area, so its perimeter is 0. The question
+ * has an answer, and #lwgeom_perimeter_2d gives it
  * @note PostGIS function: @p LWGEOM_perimeter2d_poly(PG_FUNCTION_ARGS)
  */
 double
@@ -905,7 +909,7 @@ geom_perimeter(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(gs, DBL_MAX);
-  if (gserialized_is_empty(gs) || ! ensure_not_geodetic_geo(gs))
+  if (! ensure_not_geodetic_geo(gs))
     return DBL_MAX;
 
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -609,6 +609,42 @@ int main(void)
   free(tri); free(env);
   meos_errno_reset();
 
+  /* An EMPTY geometry draws no line and bounds no area, so it measures 0.
+   * That is an ANSWER: nothing is raised, and a caller reading the error
+   * return would have no error to read it by */
+  const char *emptywkt[] = {
+    "LINESTRING EMPTY",
+    "POLYGON EMPTY",
+    "GEOMETRYCOLLECTION EMPTY",
+  };
+  for (int i = 0; i < 3; i++)
+  {
+    GSERIALIZED *e = geom_in(emptywkt[i], -1);
+    assert(e != NULL);
+    meos_errno_reset();
+    double elen = geom_length(e);
+    double eper = geom_perimeter(e);
+    printf("%s: length %g, perimeter %g, errno %d\n", emptywkt[i], elen, eper,
+      meos_errno());
+    assert(elen == 0.0);
+    assert(eper == 0.0);
+    assert(meos_errno() == 0);
+    free(e);
+    meos_errno_reset();
+  }
+  /* The measures a NON-empty geometry carries are what says the removed guard
+   * took the empty case alone */
+  GSERIALIZED *meas = geom_in("POLYGON((0 0,3 0,3 4,0 4,0 0))", -1);
+  assert(meas != NULL);
+  meos_errno_reset();
+  printf("the 3 by 4 rectangle: length %g, perimeter %g\n", geom_length(meas),
+    geom_perimeter(meas));
+  assert(geom_length(meas) == 0.0);
+  assert(geom_perimeter(meas) == 14.0);
+  assert(meos_errno() == 0);
+  free(meas);
+  meos_errno_reset();
+
   /* A relationship of a curved geometry is read on the arc itself. The
    * polygon below is a circle of centre (49.092934300 -78.568502344) and
    * radius 17.469913928; the segment's ends lie 1.646e-3 and 5.64 INSIDE it,


### PR DESCRIPTION
`geom_length` and `geom_perimeter` return `DBL_MAX` for an EMPTY geometry, the
value each documents as its error return, and they raise nothing on the way.
A caller therefore cannot tell the two apart: `meos_errno()` reads 0, and the
`1.8e308` goes on into whatever arithmetic asked for the measure.

The empty case sits inside the same condition as the geodetic one:

  if (gserialized_is_empty(gs) || ! ensure_not_geodetic_geo(gs))
    return DBL_MAX;

`ensure_not_geodetic_geo` raises before answering false, so the second half of
that condition reaches the caller with an errno to read it by. The first half
has none, because an empty geometry is not an error: it draws no line and
bounds no area, so it measures 0. Removing it leaves the measure to
`lwgeom_length` and `lwgeom_perimeter_2d`, which already answer 0 for every
empty spelling -- an empty collection sums over no members, and an empty ring
walks no vertices.

WITNESS

  LINESTRING EMPTY           length 1.79769e+308  errno 0
  GEOMETRYCOLLECTION EMPTY   length 1.79769e+308  errno 0

before, against a length of 0 after, errno still 0. PostGIS answers 0 for
`ST_Length('LINESTRING EMPTY')`, and the entry's own note names
`LWGEOM_length_linestring` as the function it implements.

MEASURED

  LINESTRING EMPTY, POLYGON EMPTY   length 0 and perimeter 0 for all three,
  and GEOMETRYCOLLECTION EMPTY      errno 0; DBL_MAX for all three before
  a 3 by 4 rectangle                length 0, perimeter 14, unmoved, which
                                    is what says the removed clause took the
                                    empty case alone
  callers of the two entries        3, none of which can reach the removed
  across meos and mobilitydb        clause: stbox_perimeter measures
                                    stbox_geo of a box already guarded to
                                    have an X dimension, and the other two
                                    read a geometry column
  the two entries under             0 files, against 3 for the control
  mobilitydb/                       geom_in, so no SQL surface moves
  meos/test/geo_test.c              passes here, aborts against master at
                                    the first empty assertion
  full meos/test suite              the 55 invocations the CI step compiles
                                    and runs, clean

WHY

An error return says the question could not be answered. "How long is a
geometry that draws nothing" is answerable, and the answer is 0 -- the same 0
the entries already give for a point, which draws nothing either and is
measured rather than refused. The empty geometry was the one shape whose
measure was reported as a failure to measure.

That the two cases shared a condition is what hid it. A guard raising an error
and a guard taking a shortcut look alike from inside the function and differ
entirely from outside it, where one arrives with an errno and the other
without. Splitting them is what makes the documented contract -- DBL_MAX means
an error occurred -- true again.

