### PR TITLE
Give every smoke suite an input its functions accept

### DIFF
--- a/meos/src/geo/tgeo_tile.c
+++ b/meos/src/geo/tgeo_tile.c
@@ -692,7 +692,8 @@ stbox_space_time_tiles(const STBox *bounds, double xsize, double ysize,
         (! ensure_not_empty(sorigin) || ! ensure_point_type(sorigin))) ||
       (MEOS_FLAGS_GET_Z(bounds->flags) &&
         (! ensure_not_negative_datum(Float8GetDatum(zsize), T_FLOAT8) ||
-         ! ensure_same_spatial_dimensionality_stbox_geo(bounds, sorigin))) ||
+         (sorigin &&
+           ! ensure_same_spatial_dimensionality_stbox_geo(bounds, sorigin)))) ||
       (duration &&
         (! ensure_has_T(T_STBOX, bounds->flags) ||
          ! ensure_positive_duration(duration))))

--- a/pgtypes/utils/jsonfuncs.c
+++ b/pgtypes/utils/jsonfuncs.c
@@ -813,10 +813,15 @@ pg_jsonb_array_element_text(const Jsonb *jb, int idx)
   }
 
   JsonbValue *v = getIthJsonbValueFromContainer(&((Jsonb *) jb)->root, idx);
-  if (v != NULL && v->type != jbvNull)
-    return JsonbValueAsText(v);
-
-  return NULL;
+  if (! v)
+    return NULL;
+  /* The container answers a value of its own, as the element accessor above
+   * says by freeing it, and JsonbValueAsText copies out of that value and
+   * keeps none of it -- so the value is this function's to release whichever
+   * branch it takes */
+  text *result = (v->type != jbvNull) ? JsonbValueAsText(v) : NULL;
+  pfree(v); /* MEOS */
+  return result;
 }
 
 /*****************************************************************************/

--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -2102,8 +2102,65 @@ TJSONB_CONFIG = dict(
         # jsonpath_in needs a jsonpath string, not the jsonb document string
         "jsonpath_in": {0: "jp_str"},
         # jsonb_to_numeric needs a scalar-numeric jsonb document; the default
-        # jb1 is a JSON object, which JsonbExtractScalar() rejects.
+        # jb1 is a JSON object, which JsonbExtractScalar() rejects. Every other
+        # cast out of jsonb wants a scalar of its own kind for the same reason,
+        # and drew "cannot cast jsonb object to type <t>" without one.
         "jsonb_to_numeric": {0: "jb_num1"},
+        "jsonb_to_float4":  {0: "jb_num1"},
+        "jsonb_to_float8":  {0: "jb_num1"},
+        "jsonb_to_int16":   {0: "jb_num1"},
+        "jsonb_to_int32":   {0: "jb_num1"},
+        "jsonb_to_int64":   {0: "jb_num1"},
+        "jsonb_to_bool":    {0: "jb_bool1"},
+        # The ARRAY operations need a jsonb ARRAY: an object has no length, no
+        # element n and no index to delete ("cannot get array length of a
+        # non-array", "cannot delete from object using integer index").
+        "jsonb_array_element":       {0: "jb_arr1"},
+        "jsonb_array_element_text":  {0: "jb_arr1"},
+        "jsonb_array_elements":      {0: "jb_arr1"},
+        "jsonb_array_elements_text": {0: "jb_arr1"},
+        "jsonb_array_length":        {0: "jb_arr1"},
+        "jsonb_delete_index":        {0: "jb_arr1"},
+        # Their temporal and set twins want the same thing one level up: a
+        # temporal value and a set whose VALUES are arrays.
+        "tjsonb_array_length":    {0: "tjsonb_arr1"},
+        "tjsonb_delete_index":    {0: "tjsonb_arr1"},
+        "tjsonb_array_element":   {0: "tjsonb_arr1"},
+        "tjson_array_element":    {0: "ttext_arr1"},
+        "jsonbset_array_length":  {0: "jsonbset_arr1"},
+        "jsonbset_delete_index":  {0: "jsonbset_arr1"},
+        "jsonbset_array_element": {0: "jsonbset_arr1"},
+        # These reach for a key, so their set holds the objects that have one.
+        "jsonbset_object_field":  {0: "jsonbset_obj1"},
+        # jsonbset_delete removes a KEY, so its set holds objects, not the
+        # scalars of jsonbset1 ("cannot delete from scalar").
+        "jsonbset_delete":        {0: "jsonbset_obj1"},
+        # The text-backed json_* entries parse their first argument AS JSON, and
+        # the default txt1 is the bare key "a" -- "invalid input syntax for type
+        # json". The document ones take json_doc1, whose "a" key txt1 then names;
+        # the array ones take a JSON array.
+        "jsonb_from_text":         {0: "json_doc1"},
+        "json_object_field":       {0: "json_doc1"},
+        "json_object_field_text":  {0: "json_doc1"},
+        "json_object_keys":        {0: "json_doc1"},
+        "json_typeof":             {0: "json_doc1"},
+        "json_strip_nulls":        {0: "json_doc1"},
+        "json_array_element":      {0: "json_arr1"},
+        "json_array_element_text": {0: "json_arr1"},
+        "json_array_elements":     {0: "json_arr1"},
+        "json_array_elements_text": {0: "json_arr1"},
+        "json_array_length":       {0: "json_arr1"},
+        # These four take a char * and the default is the bare jsonb document
+        # string, which is not what any of them parses.
+        "tjsonb_in":                  {0: "tjs_seq_str"},
+        "tjsonbinst_in":              {0: "tjs_inst_str"},
+        "tjsonb_from_mfjson":         {0: "tjs_mfjson_str"},
+        "null_handle_type_from_string": {0: "null_handle_str1"},
+        # jsonbset_in parses a SET literal, not a bare jsonb document.
+        "jsonbset_in":                {0: "jsonbset_str1"},
+        # The base-and-time constructors take the TIME set, not a jsonb one.
+        "tjsonbseq_from_base_tstzset": {1: "tstzset1"},
+        "tjsonbseqset_from_base_tstzspanset": {1: "tstzspanset1"},
         # the sequence/sequence-set parsers need temporal WKT, not a bare
         # jsonb document (temporal_parse() would reject it and the callers
         # assert on the subtype of the resulting non-sequence/NULL).
@@ -2113,7 +2170,9 @@ TJSONB_CONFIG = dict(
         # text-backed temporal JSON (T_TTEXT), not on a tjsonb (T_TJSONB).
         "tjson_strip_nulls": {0: "ttext1"},
         "tjson_array_element": {0: "ttext1"},
-        "tjson_array_length": {0: "ttext1"},
+        # ... and this one reads that text AS AN ARRAY, so its ttext carries
+        # arrays rather than the bare strings of ttext1.
+        "tjson_array_length": {0: "ttext_arr1"},
         "tjson_object_field": {0: "ttext1"},
         "tjson_extract_path": {0: "ttext1", 1: "path1", 2: "2"},
         # Input-array double-pointers, paired with a trailing count arg.
@@ -2128,7 +2187,11 @@ TJSONB_CONFIG = dict(
         "jsonb_extract_path_text": {0: "jb_obj1", 1: "path1", 2: "2"},
         "jsonb_delete_array":     {0: "jb_obj1", 1: "keys1", 2: "1"},
         "jsonb_delete_path":      {0: "jb_obj1", 1: "path1", 2: "2"},
-        "jsonb_insert":           {0: "jb_obj1", 1: "path1", 2: "2", 3: "jb1"},
+        # An INSERT refuses a path that already holds a value ("cannot replace
+        # existing key"), so unlike its set/extract/delete siblings it needs a
+        # path whose last element is absent from jb_obj1.
+        "jsonb_insert":           {0: "jb_obj1", 1: "path_new1", 2: "2",
+                                    3: "jb1"},
         "jsonb_set":              {0: "jb_obj1", 1: "path1", 2: "2", 3: "jb1"},
         "jsonb_set_lax":          {0: "jb_obj1", 1: "path1", 2: "2", 3: "jb1",
                                     5: "null_handle_text1"},
@@ -2172,14 +2235,30 @@ TJSONB_CONFIG = dict(
   /* A scalar-numeric jsonb document, for jsonb_to_numeric (a JSON object like
    * jb1 has no scalar to extract). */
   Jsonb *jb_num1 = jsonb_in("123.45");
+  /* The other two scalar kinds the casts out of jsonb ask for, and the ARRAY
+   * the length / element / delete-by-index entries ask for. */
+  Jsonb *jb_bool1 = jsonb_in("true");
+  Jsonb *jb_arr1 = jsonb_in("[1, 2, 3]");
   char *jp_str = "$.a";
   JsonPath *jp1 = jsonpath_in(jp_str);
   char *tjs_seq_str = "[{\\"a\\": 1}@2001-01-02, {\\"a\\": 2}@2001-01-03]";
   char *tjs_seqset_str = "{[{\\"a\\": 1}@2001-01-02], [{\\"a\\": 2}@2001-01-03]}";
+  char *tjs_inst_str = "{\\"a\\": 1}@2001-01-02";
+  /* temporal_as_mfjson() on the array-valued tjsonb built below. */
+  char *tjs_mfjson_str =
+    "{\\"type\\":\\"MovingJsonb\\",\\"values\\":[[1, 2, 3],[4, 5, 6]],"
+    "\\"datetimes\\":[\\"2001-01-02T00:00:00+00:00\\","
+    "\\"2001-01-03T00:00:00+00:00\\"],\\"lower_inc\\":true,"
+    "\\"upper_inc\\":true,\\"interpolation\\":\\"Step\\"}";
+  /* A null-value-treatment keyword, the only thing this parser reads. */
+  char *null_handle_str1 = "use_json_null";
   text *txt1 = text_in("a");
   text *txtarr1[] = { txt1 };
   Numeric num1 = NULL;
   Set *jsonbset1 = jsonbset_in("{1, 2, 3}");
+  /* The time set the base-and-time sequence constructor takes. */
+  Set *tstzset1 = tstzset_in("{2001-01-02, 2001-01-03}");
+  text *json_arr1 = text_in("[1, 2, 3]");
   /* Input arrays for the json_make / *_extract_path / *_delete_array /
    * *_exists_array / *_set / *_insert family below. */
   text *key_a1 = text_in("a");
@@ -2189,6 +2268,10 @@ TJSONB_CONFIG = dict(
   text *keys1[] = { key_a1 };
   text *values1[] = { val_11 };
   text *path1[] = { key_a1, key_b1 };
+  /* A path whose last element is ABSENT from jb_obj1, for the insert. */
+  text *key_c1 = text_in("c");
+  text *path_new1[] = { key_a1, key_c1 };
+  char *jsonbset_str1 = "{1, 2, 3}";
   text *json_doc1 = text_in("{\\"a\\": {\\"b\\": 1}}");
   Jsonb *jb_obj1 = jsonb_in("{\\"a\\": {\\"b\\": 1}}");
   /* A null-value-treatment keyword for jsonb_set_lax / jsonbset_set. */
@@ -2203,9 +2286,21 @@ TJSONB_CONFIG = dict(
   const Jsonb *jbarr1[] = { jb_a1 };
   const Jsonb *jbarr2[] = { jb_a1, jb_b1 };
   Set *jsonbset_obj1 = jsonbset_make(jbarr2, 2);
+  /* A jsonbset of ARRAYS, for the two entries that ask a set for a length or
+   * an index rather than for a key. */
+  Jsonb *jb_arr_a1 = jsonb_in("[1, 2]");
+  Jsonb *jb_arr_b1 = jsonb_in("[3, 4]");
+  const Jsonb *jbarr3[] = { jb_arr_a1, jb_arr_b1 };
+  Set *jsonbset_arr1 = jsonbset_make(jbarr3, 2);
   int n_out = 0;
   Temporal *tjsonb1 = tjsonb_in(
     "[{\\"a\\": 1}@2001-01-02, {\\"a\\": 2}@2001-01-03]");
+  /* The array-valued twins of tjsonb1 and ttext1, for the two entries that
+   * read a temporal value's arrays. */
+  Temporal *tjsonb_arr1 = tjsonb_in(
+    "[[1, 2, 3]@2001-01-02, [4, 5, 6]@2001-01-03]");
+  Temporal *ttext_arr1 = ttext_in(
+    "[\\"[1, 2, 3]\\"@2001-01-02, \\"[4, 5, 6]\\"@2001-01-03]");
   /* borrowed accessor: points into tjsonb1, no allocation and nothing to free */
   const TInstant *tjsonb_inst1 = temporal_start_inst(tjsonb1);
   TSequence    *tjsonb_tseq1    = (TSequence *) tjsonb1;
@@ -2272,10 +2367,19 @@ TJSONB_CONFIG = dict(
   }
 
   if (tjsonb1) free(tjsonb1);
+  if (tjsonb_arr1) free(tjsonb_arr1);
+  if (ttext_arr1) free(ttext_arr1);
   free(ttext1);
   free(jp1);
   free(jb1);
   free(jb_num1);
+  free(jb_bool1);
+  free(jb_arr1);
+  free(json_arr1);
+  free(tstzset1);
+  free(jsonbset_arr1);
+  free(jb_arr_a1);
+  free(jb_arr_b1);
   free(txt1);
   free(jsonbset1);
   free(jsonbset_obj1);
@@ -2285,6 +2389,7 @@ TJSONB_CONFIG = dict(
   free(json_doc1);
   free(key_a1);
   free(key_b1);
+  free(key_c1);
   free(val_11);
   free(null_handle_text1);
   free(tstzspanset1);
@@ -2375,8 +2480,14 @@ def write_test(name, cfg):
     # strip /* */ and // comments before counting (matching the compiler's view).
     code_only = re.sub(r"/\*.*?\*/", "", full_text, flags=re.S)
     code_only = re.sub(r"//[^\n]*", "", code_only)
-    declared = re.findall(r"^\s*[A-Za-z_]\w*[ \t]+\**[ \t]*([A-Za-z_]\w*)[ \t]*=",
-                          cfg["common_inputs"], re.M)
+    # The scanner has to see the SAME declarations the compiler does, or an
+    # unused input keeps its warning: a leading qualifier (`const Jsonb *x`)
+    # and an array declarator (`text *x[] = {...}`) are both ordinary here, and
+    # a pattern reading only `Type *name =` matches neither.
+    declared = re.findall(
+        r"^\s*(?:(?:const|static|unsigned|signed|struct)[ \t]+)*"
+        r"[A-Za-z_]\w*[ \t]+\**[ \t]*([A-Za-z_]\w*)(?:[ \t]*\[[^\]]*\])?[ \t]*=",
+        cfg["common_inputs"], re.M)
     unused = [v for v in dict.fromkeys(declared)
               if len(re.findall(r"\b" + re.escape(v) + r"\b", code_only)) == 1]
     void_block = "".join(f"  (void) {v};\n" for v in unused)

--- a/tools/codegen/gen_smoketest/gen_smoketest.py
+++ b/tools/codegen/gen_smoketest/gen_smoketest.py
@@ -700,7 +700,23 @@ TRGEO_CONFIG = dict(
         "Datum":               "geom1_datum",
     },
     override_args={
-        "geo_tpose_to_trgeometry":          {1: "tpose1"},
+        # The lifting constructor takes a TPOSE, not the default trgeometry.
+        # (The key read `geo_tpose_to_trgeometry`, a name the header no longer
+        # carries, so the override named nothing and the entry drew "The
+        # temporal value must be of type tpose".)
+        "geometry_tpose_to_trgeometry":     {1: "tpose1"},
+        # The four distance entries pair a trgeometry with a temporal POINT.
+        "tdistance_trgeometry_tpoint":      {1: "tpoint1"},
+        "nad_trgeometry_tpoint":            {1: "tpoint1"},
+        "nai_trgeometry_tpoint":            {1: "tpoint1"},
+        "shortestline_trgeometry_tpoint":   {1: "tpoint1"},
+        # The merge refuses two values that disagree where they overlap, so its
+        # second operand is the LATER sequence rather than the canned one.
+        "trgeometry_merge":                 {1: "(Temporal *) trgeo_tseq2"},
+        # An elevation is a range of Z, so the span is a FLOATSPAN and the value
+        # must carry Z -- neither of which the defaults give them.
+        "trgeometry_at_elevation":          {0: "trgeo_z1", 1: "floatspan1"},
+        "trgeometry_minus_elevation":       {0: "trgeo_z1", 1: "floatspan1"},
         # The body-point trajectory follows one POINT of the rigid body; the
         # default polygon geom1 is rejected ("Only point geometries accepted").
         "trgeometry_body_point_trajectory": {1: "geom_point1"},
@@ -721,6 +737,10 @@ TRGEO_CONFIG = dict(
         # is a poseset; the default tstzset1 is refused ("The set must be of
         # type poseset").
         "trgeometry_restrict_values":       {1: "poseset1"},
+        # ... and so are the two entries that spell the same restriction as a
+        # pair, which the line above did not reach.
+        "trgeometry_at_values":             {1: "poseset1"},
+        "trgeometry_minus_values":          {1: "poseset1"},
         "trgeometry_append_tsequence":      {1: "trgeo_tseq2", 2: "false"},
         # char * string constructors and interpolation projections. The WKT is
         # hand-written in the parser format; the MFJSON is pasted verbatim from
@@ -788,6 +808,13 @@ TRGEO_CONFIG = dict(
     (Temporal *) trgeo_inst3, trgeo_inst4, LINEAR, 0.0, NULL, false);
   Temporal *tpoint1 = trgeometry_to_tgeompoint(trgeo_seq1);
   Temporal *tpose1 = trgeometry_to_tpose(trgeo_seq1);
+  /* A rigid geometry carrying Z and the elevation span that cuts it, spelled
+   * as 153_trgeo_spatialfuncs.test.sql spells them. The body climbs from 0 to
+   * 4 so the span crosses it rather than missing it entirely. */
+  Temporal *trgeo_z1 = trgeometry_in(
+    "Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0));"
+    "[Pose(Point(0 0 0),1,0,0,0)@2001-01-01, Pose(Point(0 0 4),1,0,0,0)@2001-01-05]");
+  Span *floatspan1 = floatspan_in("[1, 2]");
   /* Canned input arrays for the array-input constructors: two same-geometry
    * instants in increasing time, and the canned trgeometry sequence. The
    * constructors copy their elements, so these stay owned by the blocks that
@@ -817,6 +844,8 @@ TRGEO_CONFIG = dict(
   if (trgeo_seq1) free(trgeo_seq1);
   if (tpoint1) free(tpoint1);
   if (tpose1) free(tpose1);
+  if (trgeo_z1) free(trgeo_z1);
+  if (floatspan1) free(floatspan1);
   free(stbox1);
   free(poseset1);
   free(pose1);
@@ -1619,6 +1648,26 @@ TGEOMETRY_CONFIG = dict(
         "tpoint_as_mvtgeom":      {2: "4096", 3: "256"},
         "stbox_get_space_tile":   {0: "geom_point1", 4: "geom_point1"},
         "stbox_space_tiles":      {4: "geom_point1"},
+        # ... and their SPACE-TIME twins, which take the same point operands one
+        # argument further along and were left without them.
+        "stbox_get_space_time_tile": {0: "geom_point1", 6: "geom_point1"},
+        # A space-time tiling of a ZT box needs a 3D origin: the box and the
+        # origin must agree in dimension.
+        "stbox_space_time_tiles": {0: "stbox_zt1", 5: "geom_pointz1"},
+        # geom_dwithin is the dimension-aware entry of its trio, so 2D operands
+        # leave its z unknown and liblwgeom says so; the 3D point is what its
+        # own geom_dwithin3d sibling is already given.
+        "geom_dwithin":           {0: "geom_pointz1", 1: "geom_pointz1"},
+        # A time tiling needs the T dimension, so it takes the ZT box its
+        # siblings above already use.
+        "stbox_time_tiles":       {0: "stbox_zt1"},
+        # Azimuth and bearing are defined between two POINTS, and between two
+        # DISTINCT ones -- the default polygon draws "Only point geometries
+        # accepted".
+        "geom_azimuth":           {0: "geom_point1", 1: "geom_point2"},
+        "bearing_point_point":    {0: "geom_point1", 1: "geom_point2"},
+        # The measure a trajectory is annotated with is a temporal FLOAT.
+        "tpoint_tfloat_to_geomeas": {1: "tfloat1"},
         # A tgeometry carrying point values is what converts to a tgeompoint.
         "tgeometry_to_tgeompoint": {0: "tgeo_point1"},
         # The reverse conversion takes a STEP temporal point: a tgeometry can
@@ -1797,6 +1846,9 @@ TGEOMETRY_CONFIG = dict(
   Interval *interv1 = interval_in("1 day", -1);
   GSERIALIZED *geom1 = geom_in("SRID=5676;Polygon((0 0,1 0,1 1,0 1,0 0))", -1);
   GSERIALIZED *geom_point1 = geom_in("SRID=5676;Point(1 1)", -1);
+  /* A second, DISTINCT point: azimuth and bearing are undefined between a
+   * point and itself. */
+  GSERIALIZED *geom_point2 = geom_in("SRID=5676;Point(3 4)", -1);
   GSERIALIZED *geom_pointz1 = geom_in("SRID=5676;Point(1 1 1)", -1);
   GSERIALIZED *geom_line1 = geom_in("SRID=5676;Linestring(0 0, 2 2, 4 0)", -1);
   /* An M-dimensional geometry whose measures are epoch seconds, for the
@@ -1917,6 +1969,8 @@ TGEOMETRY_CONFIG = dict(
     "[SRID=5676;Point(0 0)@2001-01-02, SRID=5676;Point(1 1)@2001-01-03]");
   Temporal *tpoint_z1 = tgeompoint_in(
     "[SRID=5676;Point(0 0 0)@2001-01-02, SRID=5676;Point(1 1 1)@2001-01-03]");
+  /* The measure a trajectory is annotated with, over the same span. */
+  Temporal *tfloat1 = tfloat_in("[1@2001-01-02, 2@2001-01-03]");
   /* A tgeometry carrying point values, and the STEP temporal point it
    * converts to and from. A tgeometry is never linearly interpolated, so the
    * point-valued literal parses as STEP. */
@@ -2017,6 +2071,7 @@ TGEOMETRY_CONFIG = dict(
   if (tgeo1) free(tgeo1);
   if (tpoint1) free(tpoint1);
   if (tpoint_z1) free(tpoint_z1);
+  if (tfloat1) free(tfloat1);
   if (tgeo_point1) free(tgeo_point1);
   if (tpoint_step1) free(tpoint_step1);
   if (tgeo_geod1) free(tgeo_geod1);
@@ -2041,6 +2096,7 @@ TGEOMETRY_CONFIG = dict(
   free(geom_lonlat1);
   free(geog1);
   free(geom_point1);
+  free(geom_point2);
   free(geom_pointz1);
   free(geom_line1);
   free(geom_meas1);


### PR DESCRIPTION
Every public entry of the seven MEOS smoke suites is now called with an input it
ACCEPTS. That was not the case: 62 entries were reached with a value their own
guard refuses, so the call returned at the guard and the function body never
ran. The suite reported coverage it did not have, and two real defects sat below
those guards where nothing could reach them.

MEOS validation warnings across the seven suites: **62 -> 0**.

## The two defects running the entries uncovered

**A leak.** `pg_jsonb_array_element_text` reads a value out of
`getIthJsonbValueFromContainer`, which answers a palloc'd value of its own, and
returns `JsonbValueAsText(v)` without releasing it. Its own twin two functions
above, `pg_jsonb_array_element`, frees exactly that value after converting it,
and `jsonb_util.c:1326` frees the sibling helper's with a comment saying why;
`JsonbValueAsText` copies in all five of its branches and keeps nothing. Under
PostgreSQL the memory-context reset hides it; MEOS maps `palloc` to `malloc`.
Witness: with the new inputs and the library unchanged, `run_smoketests.sh`
FAILS on tjsonb with 160 bytes definitely lost in 5 loss records, three naming
that call reached directly, through the set and through the temporal value.

**A crash.** `stbox_time_tiles` SEGFAULTs on any box carrying Z. It calls
`stbox_space_time_tiles` with `sorigin = NULL` -- a time tiling has no space
origin -- and that function's validation chain guards the first use of the
origin with `sorigin &&` but not the second, so
`ensure_same_spatial_dimensionality_stbox_geo` dereferences NULL. The comment
two lines above names the assumption that broke: *"Since we pass by default
Point(0 0 0) as origin independently of the input STBox"*. Reachable from SQL as
`Stbox_time_tiles()`. Witness: `stbox_time_tiles` on
`SRID=5676;STBOX ZT(((0,0,0),(10,10,10)),[2001-01-01, 2001-01-02])` with a one
day interval dies with SIGSEGV, and answers `OK n=2` -- the two daily tiles --
after. Control: the same probe's X-only box reports "The stbox must have T
dimension" and NULL on both sides.

Both are committed WITH the input change that exposes them, because the inputs
alone leave the valgrind gate red and the suite crashing.

## What each suite was being handed

| suite | was | now |
|---|---|---|
| tjsonb | 45 | 0 |
| trgeometry | 10 | 0 |
| tgeometry | 7 | 0 |
| tpose, tcbuffer, tnpoint, temporal_agg | 0 | 0 |

One jsonb object and one bare text `"a"` were fed to a surface that also asks
for arrays, scalars, JSON documents, temporal literals and a time set --
`json_array_length` was being asked the length of `"a"`, `jsonb_to_int32` was
casting an object. Four trgeometry distance entries were handed a trgeometry
where a temporal point belongs, and one of them returns a `double`, so the
refusal reached the caller as `1.79769e+308` rather than as an error. One
override was keyed on `geo_tpose_to_trgeometry`, a name the header no longer
carries (0 occurrences against 1 for the live `geometry_tpose_to_trgeometry`),
so it named nothing and never routed.

Every canned value is taken rather than invented: the WKT from the family's own
`mobilitydb/test/**/queries`, the hexWKB / GeoPose / MFJSON documents from the
writers that emit them, each run against the canned value.

## Measured

- MEOS validation warnings 62 -> 0 over all seven suites. What the harness still
  prints as "N validation warns" is `wc -l` on stderr; the 7 lines left are
  PROJ's own `proj_normalize_for_visualization` notices, not MEOS.
- pg_regress **336/336** on both sides.
- Every suite valgrind-clean: 0 bytes definitely, indirectly and possibly lost,
  0 errors, exit 0 under `--error-exitcode=1`.
- Two-build comparison over 41 instruments, base against HEAD: **1 answer line
  moves and it is `time_of_day()`**, a wall clock that differs between any two
  runs; 2 further lines masked as nondeterministic by running one arm twice. No
  behavioural answer moves, which is expected -- a canned test input reaches no
  shipped code path, and the added NULL test only replaces a dereference of NULL.
- Every C file the generator writes compiles with no warnings. The unused-input
  scanner is widened in the tjsonb commit because it matched only `Type *name =`
  and so could not see a `const` operand or an array declarator.

## Commits

1. the tjsonb inputs and the `pg_jsonb_array_element_text` leak
2. the `stbox_time_tiles` SIGSEGV, alone, so it reads and reverts on its own
3. the trgeometry and tgeometry inputs, which is what reaches that crash
