### PR TITLE
Clip a geometry that is itself a curve without stroking it into chords

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -396,6 +396,31 @@ linesegm_intersect(double ax, double ay, double rx, double ry,
  *****************************************************************************/
 
 /**
+ * @brief Return how far an angular span turns, in the sense it is traversed
+ * @details The span runs from @p theta0 to @p theta1, counterclockwise when
+ * @p ccw is true and clockwise otherwise
+ */
+static inline double
+arc_span_sweep(double theta0, double theta1, bool ccw)
+{
+  return ccw ?
+    angle_normalize(theta1 - theta0) :
+    angle_normalize(theta0 - theta1);
+}
+
+/**
+ * @brief Return how far an angle stands from the start of an angular span, in
+ * the sense the span is traversed
+ */
+static inline double
+arc_span_offset(double theta0, bool ccw, double phi)
+{
+  return ccw ?
+    angle_normalize(phi - theta0) :
+    angle_normalize(theta0 - phi);
+}
+
+/**
  * @brief Return true if an angle lies within an angular span
  * @details The span is traversed from @p theta0 to @p theta1, counterclockwise
  * when @p ccw is true and clockwise otherwise. Every arc question either
@@ -405,12 +430,8 @@ linesegm_intersect(double ax, double ay, double rx, double ry,
 static inline bool
 arc_span_contains(double theta0, double theta1, bool ccw, double phi)
 {
-  double sweep = ccw ?
-    angle_normalize(theta1 - theta0) :
-    angle_normalize(theta0 - theta1);
-  double off = ccw ?
-    angle_normalize(phi - theta0) :
-    angle_normalize(theta0 - phi);
+  double sweep = arc_span_sweep(theta0, theta1, ccw);
+  double off = arc_span_offset(theta0, ccw, phi);
   return off <= sweep + MEOS_GEOM_TOLERANCE;
 }
 
@@ -538,7 +559,46 @@ arcsegm_intersect(double ax, double ay, double rx, double ry, const Edge *e,
 }
 
 /**
- * @brief Return true if two circular arc edges intersect
+ * @brief Return where along an arc a point of it stands, as a fraction of the
+ * arc's span
+ * @details An arc is walked by its ANGLE, so the parameter of a point is how
+ * far its direction from the centre has turned from the arc's start, over how
+ * far the arc turns in all. The turn is read in the arc's own sense, so a
+ * clockwise arc grows its parameter clockwise
+ */
+static inline double
+arc_point_parameter(const Edge *e, double x, double y)
+{
+  double phi = atan2(y - e->cy, x - e->cx);
+  double sweep = arc_span_sweep(e->theta0, e->theta1, e->ccw);
+  if (sweep < MEOS_GEOM_TOLERANCE)
+    return 0.0;
+  double off = arc_span_offset(e->theta0, e->ccw, phi);
+  double t = off / sweep;
+  /* A point the arithmetic puts just OUTSIDE the span belongs to whichever end
+   * it stands nearer, and one a rounding step BEFORE the start has turned
+   * nearly the whole circle rather than none of it */
+  if (t > 1.0 && (2 * M_PI - off) < (off - sweep))
+    return 0.0;
+  return (t < 0.0) ? 0.0 : ((t > 1.0) ? 1.0 : t);
+}
+
+/**
+ * @brief Return the point standing at a fraction along an arc's span
+ */
+static inline void
+arc_parameter_point(const Edge *e, double t, double *x, double *y)
+{
+  double sweep = arc_span_sweep(e->theta0, e->theta1, e->ccw);
+  double phi = e->ccw ? e->theta0 + t * sweep : e->theta0 - t * sweep;
+  *x = e->cx + e->radius * cos(phi);
+  *y = e->cy + e->radius * sin(phi);
+  return;
+}
+
+/**
+ * @brief Return the points at which two circular arc edges meet, and whether
+ * they are arcs of ONE circle
  * @details The supporting circles of two arcs meet on their radical line at
  * `a = (d^2 + r1^2 - r2^2) / (2 d)` from the first centre, at a half-chord
  * `h = sqrt(r1^2 - a^2)` off the centre line, giving at most two candidate
@@ -547,27 +607,33 @@ arcsegm_intersect(double ax, double ay, double rx, double ry, const Edge *e,
  * arcs of equal radius lie on the same circle: they meet iff their angular
  * spans share an endpoint.
  */
-static inline bool
-arcarc_intersect(const Edge *e1, const Edge *e2)
+static inline int
+arcarc_intersect_points(const Edge *e1, const Edge *e2, double ix[2],
+  double iy[2], bool *same_circle)
 {
   double dx = e2->cx - e1->cx, dy = e2->cy - e1->cy;
   double d = hypot(dx, dy);
   double r1 = e1->radius, r2 = e2->radius;
+  if (same_circle)
+    *same_circle = false;
 
   /* Concentric supporting circles */
   if (d < MEOS_GEOM_TOLERANCE)
   {
     if (fabs(r1 - r2) > MEOS_GEOM_TOLERANCE)
-      return false;
-    /* Same circle: the arcs meet iff their spans share an endpoint angle */
-    return arc_contains_angle(e2, e1->theta0) ||
-      arc_contains_angle(e2, e1->theta1) ||
-      arc_contains_angle(e1, e2->theta0) ||
-      arc_contains_angle(e1, e2->theta1);
+      return 0;
+    /* Same circle: the arcs run along one another wherever their spans do,
+     * which is a shared stretch rather than a pair of points */
+    if (same_circle)
+      *same_circle = arc_contains_angle(e2, e1->theta0) ||
+        arc_contains_angle(e2, e1->theta1) ||
+        arc_contains_angle(e1, e2->theta0) ||
+        arc_contains_angle(e1, e2->theta1);
+    return 0;
   }
   /* Circles too far apart or one strictly inside the other */
   if (d > r1 + r2 + MEOS_GEOM_TOLERANCE || d < fabs(r1 - r2) - MEOS_GEOM_TOLERANCE)
-    return false;
+    return 0;
 
   double a = (d * d + r1 * r1 - r2 * r2) / (2 * d);
   double h2 = r1 * r1 - a * a;
@@ -577,19 +643,36 @@ arcarc_intersect(const Edge *e1, const Edge *e2)
   double ux = dx / d, uy = dy / d;         /* Unit vector from c1 to c2 */
   double mx = e1->cx + a * ux, my = e1->cy + a * uy; /* Foot on the centre line */
 
-  /* Candidate points m +/- h * perp(u), tested against both arcs' spans */
+  /* Candidate points m +/- h * perp(u), kept when both spans hold them */
+  int n = 0;
   for (int k = 0; k < 2; k++)
   {
     double px = mx + (k ? h : -h) * (-uy);
     double py = my + (k ? h : -h) * ux;
     if (arc_contains_angle(e1, atan2(py - e1->cy, px - e1->cx)) &&
         arc_contains_angle(e2, atan2(py - e2->cy, px - e2->cx)))
-      return true;
+    {
+      ix[n] = px; iy[n] = py; n++;
+    }
     /* A tangency has a single candidate point */
     if (h < MEOS_GEOM_TOLERANCE)
       break;
   }
-  return false;
+  return n;
+}
+
+/**
+ * @brief Return true if two circular arc edges intersect
+ * @details The points they meet at answer it, together with the case of two
+ * arcs of ONE circle, which share a stretch rather than a point
+ */
+static inline bool
+arcarc_intersect(const Edge *e1, const Edge *e2)
+{
+  double ix[2], iy[2];
+  bool same_circle;
+  int n = arcarc_intersect_points(e1, e2, ix, iy, &same_circle);
+  return (n > 0 || same_circle);
 }
 
 /*****************************************************************************

--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -260,6 +260,7 @@ extern TSequenceSet *tgeoseqset_restrict_stbox(const TSequenceSet *ss, const STB
 
 extern void *geo_edge_ctx_make(const GSERIALIZED *gs);
 extern bool geo_is_planar_linear(const GSERIALIZED *gs);
+extern bool geo_clip_subject(const GSERIALIZED *gs);
 extern bool geo_is_point_set(const GSERIALIZED *gs);
 extern bool geo_meos_supported(const GSERIALIZED *gs);
 extern GSERIALIZED *geo_points_covered(const GSERIALIZED *pts,

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2098,9 +2098,9 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
   /* The part of a line inside the other geometry, read from the segment
    * kernels, which answer an arc of that geometry exactly */
-  if (geo_is_planar_linear(gs1) && geo_meos_supported(gs2))
+  if (geo_clip_subject(gs1) && geo_meos_supported(gs2))
     return geo_clip_linear_geom(gs1, gs2, true);
-  if (geo_is_planar_linear(gs2) && geo_meos_supported(gs1))
+  if (geo_clip_subject(gs2) && geo_meos_supported(gs1))
     return geo_clip_linear_geom(gs2, gs1, true);
 
 #if GEOS
@@ -2141,7 +2141,7 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   /* Difference takes the FIRST operand apart, so only its own kind decides */
   if (geo_is_point_set(gs1))
     return geo_points_covered(gs1, gs2, false);
-  if (geo_is_planar_linear(gs1) && geo_meos_supported(gs2))
+  if (geo_clip_subject(gs1) && geo_meos_supported(gs2))
     return geo_clip_linear_geom(gs1, gs2, false);
 
 #if GEOS

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -962,6 +962,25 @@ geo_meos_supported(const GSERIALIZED *gs)
 }
 
 /**
+ * @brief Return true if the clip walks a geometry as its subject
+ * @details The walk solves each edge of the subject against the other
+ * geometry, and it has a kernel for a straight edge and one for an arc, so
+ * every planar geometry whose edges are curves of those two kinds is one it
+ * takes. An areal subject is left to the overlay, which answers a surface
+ * rather than the curves bounding it
+ */
+bool
+geo_clip_subject(const GSERIALIZED *gs)
+{
+  assert(gs);
+  if (FLAGS_GET_Z(gs->gflags) || FLAGS_GET_GEODETIC(gs->gflags))
+    return false;
+  uint32_t t = gserialized_get_type(gs);
+  return (t == LINETYPE || t == MULTILINETYPE || t == CIRCSTRINGTYPE ||
+    t == COMPOUNDTYPE || t == MULTICURVETYPE);
+}
+
+/**
  * @brief Return true if a geometry draws points and nothing else
  */
 bool
@@ -1043,6 +1062,207 @@ geo_is_planar_linear(const GSERIALIZED *gs)
 }
 
 /**
+ * @brief Add to @p out the part of one arc the intervals describe, each piece
+ * carrying the three points a circular string is read from
+ * @details An arc keeps its own circle, so a piece of it is the arc through
+ * its two ends and the point halfway along the stretch, never the chord
+ * between them
+ */
+static void
+arc_pieces(const Edge *arc, const Span *intervarr, int count, bool inside,
+  MeosArray *out, MeosArray *touches)
+{
+  double prev = 0.0;
+  for (int j = 0; j <= count; j++)
+  {
+    double lo = (j < count) ? DatumGetFloat8(intervarr[j].lower) : 1.0;
+    double hi = (j < count) ? DatumGetFloat8(intervarr[j].upper) : 1.0;
+    double s0, s1;
+    if (inside)
+    {
+      if (j == count)
+        break;
+      s0 = lo; s1 = hi;
+    }
+    else
+    {
+      s0 = prev; s1 = lo;
+      prev = hi;
+    }
+    if (s1 - s0 <= MEOS_GEOM_TOLERANCE)
+    {
+      if (inside)
+      {
+        POINT2D touch;
+        arc_parameter_point(arc, s0, &touch.x, &touch.y);
+        meos_array_add(touches, &touch);
+      }
+      continue;
+    }
+    POINT2D piece[3];
+    arc_parameter_point(arc, s0, &piece[0].x, &piece[0].y);
+    arc_parameter_point(arc, (s0 + s1) * 0.5, &piece[1].x, &piece[1].y);
+    arc_parameter_point(arc, s1, &piece[2].x, &piece[2].y);
+    /* An end of the arc is the point the arc is READ from, not the one its
+     * angle recomputes, which lands a rounding step away */
+    if (s0 <= MEOS_GEOM_TOLERANCE)
+    {
+      piece[0].x = arc->x1; piece[0].y = arc->y1;
+    }
+    if (s1 >= 1.0 - MEOS_GEOM_TOLERANCE)
+    {
+      piece[2].x = arc->x2; piece[2].y = arc->y2;
+    }
+    meos_array_add(out, &piece[0]);
+    meos_array_add(out, &piece[1]);
+    meos_array_add(out, &piece[2]);
+  }
+  return;
+}
+
+/**
+ * @brief Order two parameters along an arc
+ */
+static int
+arc_cut_cmp(const void *a, const void *b)
+{
+  double x = *(const double *) a, y = *(const double *) b;
+  return (x < y) ? -1 : ((x > y) ? 1 : 0);
+}
+
+/**
+ * @brief Compute the parameter intervals of one ARC lying inside a geometry
+ * @details The straight kernels solve a segment against each edge and answer
+ * in the SEGMENT's parameter. An arc is walked by its angle instead, so its
+ * crossings are collected as points and read back through
+ * #arc_point_parameter, and the stretches between consecutive crossings are
+ * decided by where their midpoint stands. Two arcs of ONE circle share a
+ * stretch rather than a pair of points, which is the case a crossing count
+ * cannot see and #arcarc_intersect_points reports separately
+ * @param[in] arc The arc being clipped
+ * @param[in] edges,nedges The edges of the geometry to clip against
+ * @param[in] all_edges,nall,rtree,xmax What locating a point against the
+ * geometry needs
+ */
+static void
+intervals_from_arc_subject(const Edge *arc, Edge **edges, int nedges,
+  Edge **all_edges, int nall, const RTree *rtree, double xmax)
+{
+  assert(arc); assert(edges);
+  /* The parameters at which the arc meets anything, its two ends included */
+  double *cuts = palloc(sizeof(double) * (2 * nedges + 2));
+  double *meets = palloc(sizeof(double) * (2 * nedges + 2));
+  int ncuts = 0, nmeets = 0;
+  cuts[ncuts++] = 0.0;
+  cuts[ncuts++] = 1.0;
+
+  for (int i = 0; i < nedges; i++)
+  {
+    const Edge *e = edges[i];
+    double ix[2], iy[2];
+    int n = 0;
+    if (e->etype == EDGE_POLYARC || e->etype == EDGE_LINEARC)
+    {
+      bool same_circle;
+      n = arcarc_intersect_points(arc, e, ix, iy, &same_circle);
+      if (same_circle)
+      {
+        /* The two run along one another, so the other's ends standing in
+         * THIS arc's span are what bound the stretch they share */
+        double ax, ay;
+        for (int k = 0; k < 2; k++)
+        {
+          arc_parameter_point(e, k ? 1.0 : 0.0, &ax, &ay);
+          if (arc_contains_angle(arc, atan2(ay - arc->cy, ax - arc->cx)))
+            cuts[ncuts++] = arc_point_parameter(arc, ax, ay);
+        }
+        continue;
+      }
+    }
+    else if (e->etype == EDGE_POINT)
+    {
+      if (point_on_arc(e->x1, e->y1, arc))
+      {
+        ix[0] = e->x1; iy[0] = e->y1; n = 1;
+      }
+    }
+    else
+    {
+      /* A straight edge meets the arc where the segment does, and the point
+       * it meets at is what carries over to the arc's own parameter */
+      double t[2];
+      int m = arcsegm_intersect(e->x1, e->y1, e->x2 - e->x1, e->y2 - e->y1,
+        arc, t);
+      for (int k = 0; k < m; k++)
+      {
+        if (t[k] < -MEOS_GEOM_TOLERANCE || t[k] > 1.0 + MEOS_GEOM_TOLERANCE)
+          continue;
+        ix[n] = e->x1 + t[k] * (e->x2 - e->x1);
+        iy[n] = e->y1 + t[k] * (e->y2 - e->y1);
+        n++;
+      }
+    }
+    for (int k = 0; k < n; k++)
+    {
+      double t = arc_point_parameter(arc, ix[k], iy[k]);
+      cuts[ncuts++] = t;
+      /* An edge that bounds no area is met at a POINT rather than along a
+       * stretch, and no midpoint between crossings reports it */
+      if (e->etype == EDGE_POINT || e->etype == EDGE_LINESEG ||
+          e->etype == EDGE_LINEARC)
+        meets[nmeets++] = t;
+    }
+  }
+  qsort(cuts, ncuts, sizeof(double), arc_cut_cmp);
+
+  /* A stretch between two consecutive crossings lies wholly inside or wholly
+   * outside, so its midpoint answers for all of it */
+  for (int k = 0; k < ncuts - 1; k++)
+  {
+    double lo = cuts[k], hi = cuts[k + 1];
+    if (hi - lo <= MEOS_GEOM_TOLERANCE)
+      continue;
+    double mx, my;
+    arc_parameter_point(arc, (lo + hi) * 0.5, &mx, &my);
+    bool inside = point_in_polygon_index(mx, my, all_edges, nall, rtree, xmax);
+    if (! inside)
+    {
+      /* A stretch a surface does not hold may still run along a line of it */
+      POINT2D mp = { mx, my };
+      inside = point_inter_points_lines(&mp, edges, nedges);
+    }
+    if (inside)
+    {
+      Span sp;
+      span_set(Float8GetDatum(lo), Float8GetDatum(hi), true, true, T_FLOAT8,
+        T_FLOATSPAN, &sp);
+      meos_array_add(intervals, &sp);
+    }
+  }
+  /* The points the arc merely meets, kept where no stretch already holds one */
+  for (int k = 0; k < nmeets; k++)
+  {
+    bool held = false;
+    for (uint32_t q = 0; q < intervals->count && ! held; q++)
+    {
+      const Span *sp = (const Span *) meos_array_get(intervals, q);
+      double lo = DatumGetFloat8(sp->lower), hi = DatumGetFloat8(sp->upper);
+      held = (meets[k] >= lo - MEOS_GEOM_TOLERANCE &&
+        meets[k] <= hi + MEOS_GEOM_TOLERANCE);
+    }
+    if (! held)
+    {
+      Span sp;
+      span_set(Float8GetDatum(meets[k]), Float8GetDatum(meets[k]), true, true,
+        T_FLOAT8, T_FLOATSPAN, &sp);
+      meos_array_add(intervals, &sp);
+    }
+  }
+  pfree(cuts); pfree(meets);
+  return;
+}
+
+/**
  * @brief Return true if a point lies on the segment two points draw
  */
 static bool
@@ -1070,11 +1290,12 @@ point_on_segment_pts(const POINT2D *p, const POINT2D *a, const POINT2D *b)
  */
 static GSERIALIZED *
 linear_pieces_geo(const MeosArray *pieces, const MeosArray *touches,
-  int32_t srid, bool hasz)
+  const MeosArray *arcs, int32_t srid, bool hasz)
 {
   int npieces = (int) pieces->count / 2;
   int ntouch = touches ? (int) touches->count : 0;
-  if (npieces == 0 && ntouch == 0)
+  int narcs = arcs ? (int) arcs->count / 3 : 0;
+  if (npieces == 0 && ntouch == 0 && narcs == 0)
     return geo_serialize(lwline_as_lwgeom(lwline_construct_empty(srid, hasz,
       false)));
 
@@ -1143,13 +1364,41 @@ linear_pieces_geo(const MeosArray *pieces, const MeosArray *touches,
       pts[npts++] = lwpoint_as_lwgeom(lwpoint_make2d(srid, t->x, t->y));
   }
 
+  /* Each arc piece keeps the circle it came from, so it is written as the
+   * circular string through its two ends and the point between them */
+  LWGEOM **acs = narcs ? palloc(sizeof(LWGEOM *) * narcs) : NULL;
+  for (int i = 0; i < narcs; i++)
+  {
+    POINTARRAY *apa = ptarray_construct_empty(0, 0, 3);
+    for (int k = 0; k < 3; k++)
+    {
+      const POINT2D *q = (const POINT2D *) meos_array_get((MeosArray *) arcs,
+        3 * i + k);
+      POINT4D p4 = { q->x, q->y, 0.0, 0.0 };
+      ptarray_append_point(apa, &p4, LW_TRUE);
+    }
+    acs[i] = lwcircstring_as_lwgeom(lwcircstring_construct(srid, NULL, apa));
+  }
+
   GSERIALIZED *result;
-  int ntotal = nlines + npts;
+  int ntotal = nlines + npts + narcs;
   if (lines && ntotal == 1 && nlines == 1)
   {
     result = geo_serialize(lines[0]);
     lwgeom_free(lines[0]);
     pfree(lines);
+    if (pts)
+      pfree(pts);
+    if (acs)
+      pfree(acs);
+  }
+  else if (acs && ntotal == 1 && narcs == 1)
+  {
+    result = geo_serialize(acs[0]);
+    lwgeom_free(acs[0]);
+    pfree(acs);
+    if (lines)
+      pfree(lines);
     if (pts)
       pfree(pts);
   }
@@ -1160,23 +1409,40 @@ linear_pieces_geo(const MeosArray *pieces, const MeosArray *touches,
     pfree(pts);
     if (lines)
       pfree(lines);
+    if (acs)
+      pfree(acs);
   }
   else
   {
-    /* One kind draws a multi-geometry of it, both draw a collection */
-    uint32_t type = npts == 0 ? MULTILINETYPE :
-      (nlines == 0 ? MULTIPOINTTYPE : COLLECTIONTYPE);
+    /* One kind draws a multi-geometry of it, several draw a collection. A
+     * curve among them is a multi-curve, which admits a straight member */
+    uint32_t type;
+    if (npts == 0 && narcs == 0)
+      type = MULTILINETYPE;
+    else if (nlines == 0 && narcs == 0)
+      type = MULTIPOINTTYPE;
+    else if (npts == 0)
+      type = MULTICURVETYPE;
+    else
+      type = COLLECTIONTYPE;
     LWGEOM **all = palloc(sizeof(LWGEOM *) * ntotal);
+    int at = 0;
     if (lines)
     {
       for (int i = 0; i < nlines; i++)
-        all[i] = lines[i];
+        all[at++] = lines[i];
       pfree(lines);
+    }
+    if (acs)
+    {
+      for (int i = 0; i < narcs; i++)
+        all[at++] = acs[i];
+      pfree(acs);
     }
     if (pts)
     {
       for (int i = 0; i < npts; i++)
-        all[nlines + i] = pts[i];
+        all[at++] = pts[i];
       pfree(pts);
     }
     LWGEOM *out = lwcollection_as_lwgeom(lwcollection_construct(type, srid,
@@ -1264,12 +1530,70 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
   int32_t srid = gserialized_get_srid(line);
   MeosArray *pieces = meos_array_create(sizeof(POINT2D));
   MeosArray *touches = meos_array_create(sizeof(POINT2D));
+  /* Arc pieces are kept apart, each three points of its own circle */
+  MeosArray *arcs = meos_array_create(sizeof(POINT2D));
   /* The kernels accumulate into the thread-local arrays the temporal walker
    * gives them: the polygon one sorts its crossings through `events` */
   events = meos_array_create(sizeof(double));
   intervals = meos_array_create(sizeof(Span));
 
   /* The components a linear geometry draws, one point array each */
+  /* A subject carrying arcs is walked through its EDGES, each solved by the
+   * kernel its own shape asks for */
+  if (! geo_is_planar_linear(line))
+  {
+    MeosArray *sarr = geom_extract_edges(lw);
+    int sn = (int) sarr->count;
+    for (int i = 0; i < sn; i++)
+    {
+      Edge *se = (Edge *) meos_array_get(sarr, i);
+      intervals->count = 0;
+      if (se->etype == EDGE_POLYARC || se->etype == EDGE_LINEARC)
+      {
+        intervals_from_arc_subject(se, ctx->edge_ptrs, ctx->nedges,
+          ctx->edge_ptrs, ctx->nedges, ctx->rtree, ctx->box.xmax);
+        /* The stretches arrive in order and the points the arc merely MEETS
+         * after them, so the array is sorted only where no such point falls
+         * before a stretch. #arc_pieces takes a difference by walking the
+         * GAPS between consecutive intervals, and an unsorted array gives it
+         * gaps that overlap */
+        const Span *aiv = intervals->elems;
+        int acnt = (int) intervals->count;
+        Span *anm = NULL;
+        if (acnt > 1)
+        {
+          anm = spanarr_normalize(intervals->elems, acnt, ORDER, &acnt);
+          aiv = anm;
+        }
+        arc_pieces(se, aiv, acnt, inside, arcs, touches);
+        if (anm)
+          pfree(anm);
+      }
+      else
+      {
+        POINT2D pa = { se->x1, se->y1 }, pb = { se->x2, se->y2 };
+        intervals_from_points(&pa, &pb, ctx->edge_ptrs, ctx->nedges);
+        intervals_from_lines(&pa, &pb, ctx->edge_ptrs, ctx->nedges);
+        intervals_from_arcs(&pa, &pb, ctx->edge_ptrs, ctx->nedges);
+        intervals_from_polygons(&pa, &pb, ctx->edge_ptrs, ctx->nedges,
+          ctx->edge_ptrs, ctx->nedges, ctx->rtree, ctx->srid, ctx->box.xmax);
+        const Span *iv = intervals->elems;
+        int cnt = (int) intervals->count;
+        Span *nm = NULL;
+        if (cnt > 1)
+        {
+          nm = spanarr_normalize(intervals->elems, cnt, ORDER, &cnt);
+          iv = nm;
+        }
+        segment_pieces(&pa, &pb, iv, cnt, inside, pieces, touches);
+        if (nm)
+          pfree(nm);
+      }
+    }
+    meos_array_destroy(sarr);
+    goto assemble;
+  }
+
   uint32_t ncomp = 1;
   const LWLINE **lines = NULL;
   LWLINE *single = NULL;
@@ -1335,10 +1659,13 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
     }
   }
 
-  GSERIALIZED *result = linear_pieces_geo(pieces, touches, srid,
+assemble:
+  ;
+  GSERIALIZED *result = linear_pieces_geo(pieces, touches, arcs, srid,
     FLAGS_GET_Z(line->gflags));
   meos_array_destroy(pieces);
   meos_array_destroy(touches);
+  meos_array_destroy(arcs);
   meos_array_destroy(intervals); intervals = NULL;
   meos_array_destroy(events); events = NULL;
   lwgeom_free(lw);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -48,6 +48,7 @@
  */
 
 #include <assert.h>
+#include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -1261,6 +1262,79 @@ int main(void)
     assert(cd != NULL);
     assert(meos_errno() == 0);
     free(cd); free(ca); free(cb);
+    meos_errno_reset();
+  }
+
+  /* A geometry that is ITSELF a curve keeps its arcs through the clip, so the
+   * pieces come back as arcs rather than as the chords a stroke would draw.
+   * The circle is again the one of radius 2 about (2 2), and the clip cuts it
+   * at y = 3, so the two pieces reach 2 -/+ sqrt(3) exactly. The second row
+   * meets the clip at a single point, which no stretch of the arc reports */
+  const char *arc_a[] = {
+    "CIRCULARSTRING(0 2,2 4,4 2)",
+    "CIRCULARSTRING(0 2,2 4,4 2)",
+    "CIRCULARSTRING(0 2,2 4,4 2)",
+    "CIRCULARSTRING(0 2,2 4,4 2)",
+  };
+  const char *arc_b[] = {
+    "POLYGON((0 0,4 0,4 3,0 3,0 0))",
+    "LINESTRING(2 0,2 5)",
+    /* The quarter of the SAME circle running from (0 2) to (2 4), which the
+     * subject runs ALONG rather than crosses */
+    "CIRCULARSTRING(0 2.0000000000000004,"
+      "0.58578643762690508 3.4142135623730949,2 4)",
+    /* A clip the arc MEETS at a point BEFORE the stretch it runs inside, so
+     * the two kinds of answer arrive in the opposite of their order along
+     * the arc. The difference reads the gaps between them and a wrong order
+     * makes those gaps overlap */
+    "GEOMETRYCOLLECTION(LINESTRING(0.1 0,0.1 5),"
+      "POLYGON((3 -1,5 -1,5 5,3 5,3 -1)))",
+  };
+  const char *arc_inter[] = {
+    "MULTICURVE(CIRCULARSTRING(0 2,0.068148 2.517638,0.267949 3),"
+      "CIRCULARSTRING(3.732051 3,3.931852 2.517638,4 2))",
+    "POINT(2 4)",
+    "CIRCULARSTRING(0 2,0.585786 3.414214,2 4)",
+    "GEOMETRYCOLLECTION(CIRCULARSTRING(3 3.732051,3.732051 3,4 2),"
+      "POINT(0.1 2.6245))",
+  };
+  const char *arc_diff[] = {
+    "CIRCULARSTRING(0.267949 3,2 4,3.732051 3)",
+    "MULTICURVE(CIRCULARSTRING(0 2,0.585786 3.414214,2 4),"
+      "CIRCULARSTRING(2 4,3.414214 3.414214,4 2))",
+    "CIRCULARSTRING(2 4,3.414214 3.414214,4 2)",
+    "MULTICURVE(CIRCULARSTRING(0 2,0.025158 2.316228,0.1 2.6245),"
+      "CIRCULARSTRING(0.1 2.6245,1.28644 3.868377,3 3.732051))",
+  };
+  for (int i = 0; i < 4; i++)
+  {
+    GSERIALIZED *aa = geom_in(arc_a[i], -1);
+    GSERIALIZED *ab = geom_in(arc_b[i], -1);
+    assert(aa != NULL); assert(ab != NULL);
+    meos_errno_reset();
+    GSERIALIZED *ai = geom_intersection2d(aa, ab);
+    assert(ai != NULL);
+    assert(meos_errno() == 0);
+    char *aw = geo_as_text(ai, 6);
+    printf("arc intersection: %s\n", aw);
+    assert(strcmp(aw, arc_inter[i]) == 0);
+    free(aw);
+    meos_errno_reset();
+    GSERIALIZED *ad = geom_difference2d(aa, ab);
+    assert(ad != NULL);
+    assert(meos_errno() == 0);
+    aw = geo_as_text(ad, 6);
+    printf("arc difference: %s\n", aw);
+    assert(strcmp(aw, arc_diff[i]) == 0);
+    free(aw);
+    /* The clip PARTITIONS its subject, so the two pieces give back the length
+     * the whole curve draws. That holds of the arcs themselves rather than of
+     * a drawing of them, which is what the exact answer buys */
+    double whole = geom_length(aa);
+    double part = geom_length(ai) + geom_length(ad);
+    printf("arc length: %.9f against %.9f\n", part, whole);
+    assert(fabs(part - whole) < 1e-9);
+    free(ai); free(ad); free(aa); free(ab);
     meos_errno_reset();
   }
 


### PR DESCRIPTION
`geo_clip_linear_geom` walks a geometry through the segment kernels, which
solve a STRAIGHT segment against another geometry. A subject that is itself a
curve -- a circular string, a compound curve, a multi-curve -- has no straight
segment to walk, so it reached the GEOS library instead, which reads an arc by
replacing it with a chain of chords. The answer then carries the stroking as
error, and a build without GEOS has no answer at all.

`intervals_from_arc_subject` solves the arc the way the kernels solve a
segment, in the arc's own parameter. An arc is walked by its ANGLE, so its
crossings are collected as points and read back through `arc_point_parameter`,
and the stretch between two consecutive crossings lies wholly inside or wholly
outside, which its midpoint answers for. `arc_pieces` reads a stretch back as
the three points a circular string is written from, so a piece of an arc is an
arc of the same circle rather than the chord across it.

Three cases a crossing count cannot see are answered separately: two arcs of
ONE circle run along one another rather than meeting at points, which
`arcarc_intersect_points` now reports; an edge bounding no area is met at a
point that no midpoint between crossings reports; and a piece reaching an end
of the arc carries the coordinates that end is read from, not the ones its
angle recomputes.

The intervals are normalised before the pieces are read off them, as the
straight subject already normalises its own. The stretches arrive in order and
the points the arc merely MEETS after them, so a point falling before a stretch
leaves the array unsorted -- and a difference, which is read as the gaps
between consecutive intervals, then draws gaps that overlap.

`arc_span_sweep` and `arc_span_offset` name the two quantities every arc
question is asked in terms of, so the expression for each is written once
rather than in each function that needs it. `arc_span_contains` reads them and
is unchanged in what it answers.

WITNESS

  SELECT ST_Intersection(
    'CIRCULARSTRING(0 2,2 4,4 2)',
    'POLYGON((0 0,4 0,4 3,0 3,0 0))');

The arc is the upper half of the circle of radius 2 about (2 2), and the clip
cuts it at y = 3, where (x-2)^2 = 3 and x = 2 -/+ sqrt(3).

  before  MULTILINESTRING((0 2,0.002409 2.098135,...,0.268565 3),(...))
          65 vertices, the crossing 6.2e-04 from the circle
  after   MULTICURVE(CIRCULARSTRING(0 2,0.068148 2.517638,0.267949 3),
                     CIRCULARSTRING(3.732051 3,3.931852 2.517638,4 2))

0.267949 and 3.732051 are 2 -/+ sqrt(3) to the six digits printed. A build
configured `-DGEOS=OFF` answers neither before, raising errno 13.

MEASURED -- CORRECTNESS

  30 REAL projected multipolygons of      30 curved subjects, 0 declined, and
  the natural-area corpus, buffered so    the partition identity below holds
  their boundary carries arcs, each       on 30 of 30 here against 0 of 30
  clipped by a half-plane through it;     before; worst relative residual
  coordinates ~5e5/6e6, 2398213 metres    1.4e-13 here, 2.7e-05 before
  of curve in all
  107 synthetic pairs: 10 curve           0 declined, and the branch's own
  subjects x 10 clips -- circular         GEOS=ON and GEOS=OFF builds answer
  strings, compound curves, multi-        byte-identically over all 214
  curves against polygons, a holed        operations, same md5
  polygon, a multipolygon, a curve
  polygon, a line and a point -- plus
  two arcs of one circle, four clips
  meeting an arc AT AN END, and the
  two orders of a meeting point and
  a stretch
  the same 107 pairs on master,           190 of 214 declined; the 24
  GEOS compiled out                       answered are the point and line
                                          clips, and all 24 agree with this
  the closed form 2*pi/3 and 4*pi/3       2.094395102393 and 4.188790204786,
  for the witness above                   12 significant digits; master reads
                                          2.094794389539, 4.0e-04 out
  answers still drawn as a curve          127 of 200 here, 0 of 200 before,
                                          over the first 100 pairs
  vertices in those 100 intersections     380 here, 4537 before
  relate_corpus, _types, areal_pairs,     1693 pairs, 0 answers differing,
  adversarial_pairs, pairs_self,          0 declined
  pairs_tiny, bigcoord
  meos/test/geo_test.c                    passes here, aborts against master
                                          at the first arc assertion
  check_liblwgeom_geos.py                 clean at 7 baselined entry points

That last corpus row is what the shared header change owes: the relate engine
reads the same angular-span primitives, and large and tiny coordinates are
where a tolerance moves an answer if it is going to.

The ordering case earns its place by having failed. A clip meeting the arc at
a point BEFORE the stretch it runs inside gave a difference of 9.84 against a
subject of 6.28 -- longer than the whole curve -- and the hundred pairs above
never produce one, every clip there yielding stretches or a point but not both
out of order.

THE ORACLE NEEDS NO REFERENCE ANSWER. The clip PARTITIONS its subject, so
`length(intersection) + length(difference)` must equal `length(subject)`. That
holds of the curves themselves rather than of a drawing of them, which is why
the stroked answer cannot satisfy it: the chords returned are shorter than the
arcs given. On the real corpus that shortfall is 65 metres in 2398 kilometres.

MEASURED -- COST, interleaved A/B, both arms Release with GEOS ON

  100 synthetic curve pairs, 7 rounds     0.160
  30 real buffered boundaries, 5 rounds   0.804

The two regimes differ and both are reported. On small curves the native answer
costs a sixth of routing to GEOS, which is mostly GEOS's stroke-then-overlay
overhead. On the real boundaries -- thousands of vertices each -- the walk is
what dominates on both sides and the native arm is about a fifth faster. It is
not slower anywhere measured, and it returns an eleventh of the vertices, which
every downstream consumer pays for again.

WHY

A segment meets a geometry along sub-intervals of itself, and the kernels
already answer those exactly, arcs of the OTHER geometry included. What was
missing is only the parameter to answer in: a segment is walked by distance
along it and an arc by angle about its centre, so the same solve reads back
through a different map. Once the crossings are expressed as parameters of the
arc, everything after them -- sorting, deciding a stretch by its midpoint,
taking the complement for a difference -- is the walk the straight subject
already takes, unchanged.

That is what makes the answer exact rather than merely finer. The arc enters
the solution as its own equation and leaves as its own equation; no segment
count sits between them deciding the error. A stroke has to choose how many
chords to draw, and every choice is wrong by something.

