### PR TITLE
Drop the empty declaration in front of the text typedef

### DIFF
--- a/pgtypes/pg_text.h
+++ b/pgtypes/pg_text.h
@@ -38,7 +38,6 @@
 
 #include "pg_basetypes.h"
 
-typedef struct varlena;
 typedef struct varlena text;
 
 typedef unsigned int Oid;


### PR DESCRIPTION
Drop the empty declaration in front of the text typedef

WHY THIS IS THE RIGHT ANSWER, at the level of the model. The text header opens
with two lines where one does the work: an empty `typedef struct varlena;` in
front of `typedef struct varlena text;`. A typedef with no declarator names no
type -- it is a declaration that declares nothing -- so the first line is not a
weaker form of the second, it is inert. What forward-declares the tag AND names
it is the second line, which stays. The header therefore says exactly what it
said, with one line fewer, and the compiler stops objecting to a construct the
language gives no meaning to.

It is the lone outlier of its family: ONE occurrence across pgtypes and
meos/include against SEVEN real varlena typedefs, and the nearest sibling,
pg_json.h, spells the same thing as two bare typedefs with no empty line in
front of them.

WITNESS, as a translation unit a reader can paste. Against master, a file whose
whole content is

  #include <stdbool.h>
  #include <pg_text.h>
  struct varlena *probe_tag(void) { return (struct varlena *) 0; }
  text *probe_text(void) { return (text *) 0; }
  int main(void) { return probe_tag() == (struct varlena *) probe_text() ? 0 : 1; }

compiled with `gcc -Wall -Wextra` reports

  pg_text.h:41:16: warning: useless storage class specifier in empty declaration

and nothing else. After the deletion the same file compiles, links and RUNS
clean -- 0 diagnostics, exit 0 -- so BOTH the tag and the typedef still resolve
and still denote the same type. That is the whole behavioural question the line
could have been answering, and it answers it the same way without the line.

Every consumer that includes this public header sees that warning, which is why
the tjsonb smoke suite is the one suite whose C file cannot compile
warning-free.

MEASURED, and what did NOT move. pg_regress 336/336. The two-build comparison
is the strongest possible result here and it is worth stating precisely: built
at the base and at HEAD, the two libmeos are BYTE-IDENTICAL, so there is no
answer for any instrument to move -- an empty declaration emits no code. The
Windows job's toolchain builds it clean as well. No timing leg: nothing is
emitted, so nothing is executed.

NOT TOUCHED, because the measurement says it is the convention rather than a
defect of this file: the header does not compile standalone, `bool` being
undeclared at its prototypes. NINE of the pg_*.h headers use `bool` and NOT ONE
includes stdbool.h, so every one of them expects a caller that has already
provided it. Making this header self-contained alone would make it the outlier
in the other direction; making the family self-contained is a change to a
published header set, a different problem, and the owner's call.

