### PR TITLE
Fail a smoke suite that is handed an input MEOS refuses

### DIFF
--- a/meos/test/run_smoketests.sh
+++ b/meos/test/run_smoketests.sh
@@ -91,8 +91,25 @@ for suite in "${SUITES[@]}"; do
     fail=1
   else
     lines=$(wc -l < "$bin.out")
-    warns=$(wc -l < "$bin.err")
-    echo "[ok]    $suite — $lines results, $warns validation warns"
+    # A validation warning is a `[meos warn]` line, which the generated suite's
+    # own error handler writes when MEOS REFUSES an input. Count that, not the
+    # whole of stderr: PROJ writes its own notices there
+    # (proj_normalize_for_visualization, from the reprojection entries), so a
+    # line count reports a suite as carrying warnings it does not have.
+    warns=$(grep -c '\[meos warn\]' "$bin.err" || true)
+    notices=$(grep -vc '\[meos warn\]' "$bin.err" || true)
+    if [ "$warns" -ne 0 ]; then
+      # A refused input means the call returned at its guard and the function
+      # body never ran, so the suite reports coverage it does not have and
+      # anything wrong below that guard is unreachable. Every entry is to be
+      # called with a value it ACCEPTS.
+      echo "[FAIL]  $suite — $lines results, $warns validation warning(s):"
+      grep '\[meos warn\]' "$bin.err" | sort | uniq -c | sed 's/^/          /'
+      echo "          give each entry an input it accepts, then re-run"
+      fail=1
+    else
+      echo "[ok]    $suite — $lines results, 0 validation warns, $notices library notice(s)"
+    fi
   fi
 done
 


### PR DESCRIPTION
Fail a smoke suite that is handed an input MEOS refuses

WHY THIS IS THE RIGHT ANSWER, at the level of the model. The smoke suites exist
to call every public entry once with an input that entry ACCEPTS, so that
valgrind sees the function's own work. When MEOS refuses the input, the call
returns at the guard and the body never runs: the suite reports coverage it does
not have, and anything wrong below that guard is unreachable. That is what
carried a leak in pg_jsonb_array_element_text and a SIGSEGV in stbox_time_tiles
until the inputs were corrected. A refused input is therefore a defect in the
suite, and a defect belongs in the exit code, not in a number nobody reads.

The count is now of `[meos warn]` lines rather than of stderr lines. Those two
are different populations: PROJ writes its own notices to the same stream --
`proj_normalize_for_visualization: Cannot retrieve source or target CRS` from
the reprojection entries -- so the old figure reported suites as carrying
warnings they did not have. They are still shown, as "library notice(s)", where
they cannot be mistaken for a refusal.

WITNESS, both directions, run against a libmeos built from this tree into a
private prefix.

At the current state the seven suites read

  [ok]    trgeometry_test        — 140 results, 0 validation warns, 0 library notice(s)
  [ok]    tpose_smoketest        — 218 results, 0 validation warns, 2 library notice(s)
  [ok]    tcbuffer_smoketest     — 192 results, 0 validation warns, 1 library notice(s)
  [ok]    tnpoint_smoketest      — 129 results, 0 validation warns, 0 library notice(s)
  [ok]    tgeometry_smoketest    — 455 results, 0 validation warns, 4 library notice(s)
  [ok]    tjsonb_smoketest       — 189 results, 0 validation warns, 0 library notice(s)
  [ok]    temporal_agg_smoketest —  23 results, 0 validation warns, 0 library notice(s)

and the script exits 0. The 7 notices are PROJ's, and the old line count reported
them as validation warnings.

The NEGATIVE control is what makes this a guard rather than a message. Routing
one entry back to an input it refuses -- geom_azimuth to the polygon, azimuth
being defined between two points -- the same run answers

  [FAIL]  tgeometry_smoketest — 455 results, 1 validation warning(s):
                1 [meos warn] Only point geometries accepted
          give each entry an input it accepts, then re-run

with exit 1, the other six suites unaffected. Reverting the routing returns all
seven to [ok] and exit 0.

MEASURED, and what did NOT move. The valgrind arm is untouched: leak mode, the
suppression file and the --error-exitcode are as they were, and "All smoke
suites passed valgrind" reads the same on both sides. The generated suites are
not regenerated differently -- the injection above was reverted and the tree
carries no change outside this script. No timing leg: the added work is one grep
per suite over a file the script already wrote.

The counts this holds at zero were reached across five merged changes and are
worth nothing without something keeping them there: 71 SKIP comments and 62
refused inputs, both now 0, with nothing until this failing on their return.

