### PR TITLE
Declare the tbigint values count as its definition does

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -1472,7 +1472,7 @@ extern bool tint_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool 
 extern bool tint_value_n(const Temporal *temp, int n, int *result);
 extern bool tbigint_value_n(const Temporal *temp, int64 n, int64 *result);
 extern int *tint_values(const Temporal *temp, int *count);
-extern int64 *tbigint_values(const Temporal *temp, int32 *count);
+extern int64 *tbigint_values(const Temporal *temp, int *count);
 extern double tnumber_avg_value(const Temporal *temp);
 extern double tnumber_integral(const Temporal *temp);
 extern double tnumber_twavg(const Temporal *temp);


### PR DESCRIPTION
`tbigint_values` is declared `int64 *tbigint_values(const Temporal *temp,
int32 *count)` in `meos/include/meos.h:1475` while it is defined
`tbigint_values(const Temporal *temp, int *count)` in
`meos/src/temporal/temporal_meos.c:485`. The header holds 59 `int *count`
declarations and this one `int32 *count`; the two spellings are one type on the
targets MEOS builds for, so nothing has ever failed to compile.

WITNESS. A catalog generated from these headers reads the out-count by its
declared form to know that a function ANSWERS AN ARRAY. For `tbool_values` it
records

    "arrayReturn": {"lengthFrom": {"kind": "param", "name": "count"},
                    "element": {"c": "bool", "canonical": "bool"}}

and for `tbigint_values`, whose C signature differs only in that spelling, it
records `{"outParams": ["count"]}` and no `arrayReturn` at all. A binding
generated from it answers `bool[] TboolValues(IntPtr temp)` beside
`IntPtr TbigintValues(IntPtr temp, IntPtr count)` — the array unreachable, its
length handed to the caller as a raw pointer to fill.

MEASURED. 185 functions in the catalog carry an `arrayReturn`; `tbigint_values`
is the one function that returns a pointer beside a by-pointer `count` and
carries none. With the declaration corrected it joins them, and no other
function's shape moves. strict-ci on this commit: both targets built clean with
every family on, pg_regress local-pass against the merge-base baseline, the
meos/test set compiled and run; the Windows UCRT64 build and the generated
smoke suites are green on the same sha. `getValues(tbigint …)` is exercised at
`mobilitydb/test/temporal/queries/022_temporal.test.sql:1085` and its expected
output does not move.

WHY. A declaration and its definition are one function, and where they disagree
about how a parameter's type is spelled, the one that compiles the body is the
one that is right — every caller passes an `int *` either way. `int` is what the
definition writes, what the other 59 declarations in the header write, and what
the sibling `tbool_`, `tfloat_` and `ttext_values` write. The answers do not
move: the parameter keeps the same width and the same meaning.

