### PR TITLE
Tag both argument orders of a kernel that answers them from one body

### DIFF
--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -678,7 +678,7 @@ ea_touches_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] dist Distance
- * @csqlfn #Edwithin_trgeometry_geo()
+ * @csqlfn #Edwithin_trgeometry_geo() #Edwithin_geo_trgeometry()
  */
 int
 edwithin_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
@@ -698,7 +698,7 @@ edwithin_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs, double dist
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] dist Distance
- * @csqlfn #Adwithin_trgeometry_geo()
+ * @csqlfn #Adwithin_trgeometry_geo() #Adwithin_geo_trgeometry()
  */
 int
 adwithin_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)

--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -1533,7 +1533,7 @@ minus_set_timestamptz(const Set *s, TimestampTz t)
  * @param[in] s Set
  * @param[in] i Value
  * @return On error return @p INT_MAX
- * @csqlfn #Distance_set_value()
+ * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 int
 distance_set_int(const Set *s, int i)
@@ -1549,7 +1549,7 @@ distance_set_int(const Set *s, int i)
  * @param[in] s Set
  * @param[in] i Value
  * @return On error return @p INT64_MAX
- * @csqlfn #Distance_set_value()
+ * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 int64
 distance_set_bigint(const Set *s, int64 i)
@@ -1565,7 +1565,7 @@ distance_set_bigint(const Set *s, int64 i)
  * @param[in] s Set
  * @param[in] d Value
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_set_value()
+ * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 double
 distance_set_float(const Set *s, double d)
@@ -1581,7 +1581,7 @@ distance_set_float(const Set *s, double d)
  * @param[in] s Set
  * @param[in] d Value
  * @return On error return @p INT_MAX
- * @csqlfn #Distance_set_value()
+ * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 int
 distance_set_date(const Set *s, DateADT d)
@@ -1598,7 +1598,7 @@ distance_set_date(const Set *s, DateADT d)
  * @param[in] s Set
  * @param[in] t Value
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_set_value()
+ * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 double
 distance_set_timestamptz(const Set *s, TimestampTz t)

--- a/meos/src/temporal/span_ops_meos.c
+++ b/meos/src/temporal/span_ops_meos.c
@@ -1356,7 +1356,7 @@ minus_span_timestamptz(const Span *s, TimestampTz t)
  * @param[in] s Span
  * @param[in] i Value
  * @return On error return @p INT_MAX
- * @csqlfn #Distance_span_value()
+ * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 int
 distance_span_int(const Span *s, int i)
@@ -1372,7 +1372,7 @@ distance_span_int(const Span *s, int i)
  * @param[in] s Span
  * @param[in] i Value
  * @return On error return @p INT64_MAX
- * @csqlfn #Distance_span_value()
+ * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 int64
 distance_span_bigint(const Span *s, int64 i)
@@ -1388,7 +1388,7 @@ distance_span_bigint(const Span *s, int64 i)
  * @param[in] s Span
  * @param[in] d Value
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_span_value()
+ * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 double
 distance_span_float(const Span *s, double d)
@@ -1404,7 +1404,7 @@ distance_span_float(const Span *s, double d)
  * @param[in] s Span
  * @param[in] d Value
  * @return On error return @p INT_MAX
- * @csqlfn #Distance_span_value()
+ * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 int
 distance_span_date(const Span *s, DateADT d)
@@ -1421,7 +1421,7 @@ distance_span_date(const Span *s, DateADT d)
  * @param[in] s Span
  * @param[in] t Value
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_span_value()
+ * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 double
 distance_span_timestamptz(const Span *s, TimestampTz t)

--- a/meos/src/temporal/spanset_ops_meos.c
+++ b/meos/src/temporal/spanset_ops_meos.c
@@ -1275,7 +1275,7 @@ minus_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
  * @param[in] ss Span set
  * @param[in] i Value
  * @return On error return @p INT_MAX
- * @csqlfn #Distance_spanset_value()
+ * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 int
 distance_spanset_int(const SpanSet *ss, int i)
@@ -1291,7 +1291,7 @@ distance_spanset_int(const SpanSet *ss, int i)
  * @param[in] ss Span set
  * @param[in] i Value
  * @return On error return @p INT64_MAX
- * @csqlfn #Distance_spanset_value()
+ * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 int64
 distance_spanset_bigint(const SpanSet *ss, int64 i)
@@ -1307,7 +1307,7 @@ distance_spanset_bigint(const SpanSet *ss, int64 i)
  * @param[in] ss Span set
  * @param[in] d Value
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_spanset_value()
+ * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 double
 distance_spanset_float(const SpanSet *ss, double d)
@@ -1324,7 +1324,7 @@ distance_spanset_float(const SpanSet *ss, double d)
  * @param[in] ss Span set
  * @param[in] d Value
  * @return On error return @p INT_MAX
- * @csqlfn #Distance_spanset_value()
+ * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 int
 distance_spanset_date(const SpanSet *ss, DateADT d)
@@ -1340,7 +1340,7 @@ distance_spanset_date(const SpanSet *ss, DateADT d)
  * @param[in] ss Span set
  * @param[in] t Value
  * @return On error return @p DBL_MAX
- * @csqlfn #Distance_spanset_value()
+ * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 double
 distance_spanset_timestamptz(const SpanSet *ss, TimestampTz t)

--- a/meos/src/temporal/tnumber_distance_meos.c
+++ b/meos/src/temporal/tnumber_distance_meos.c
@@ -59,7 +59,7 @@
  * @param[in] temp Temporal value
  * @param[in] i Value
  * @return On error return @p NULL
- * @csqlfn #Tdistance_tnumber_number()
+ * @csqlfn #Tdistance_tnumber_number() #Tdistance_number_tnumber()
  */
 Temporal *
 tdistance_tint_int(const Temporal *temp, int i)
@@ -75,7 +75,7 @@ tdistance_tint_int(const Temporal *temp, int i)
  * @param[in] temp Temporal value
  * @param[in] d Value
  * @return On error return @p NULL
- * @csqlfn #Tdistance_tnumber_number()
+ * @csqlfn #Tdistance_tnumber_number() #Tdistance_number_tnumber()
  */
 Temporal *
 tdistance_tfloat_float(const Temporal *temp, double d)


### PR DESCRIPTION
Six MEOS functions serve a SQL surface MobilityDB declares in both argument
orders, and each @csqlfn tag names only one of the two wrappers. The catalog
gives a function the SQL signatures of the wrappers its tag names and drops
the rest, so the commuted direction reaches no catalog entry and every
generated binding is blind to a function the extension ships.

The witness is a signature the extension answers and the catalog does not
carry. `mobilitydb/sql/temporal/036_tnumber_distance.in.sql:45` declares
`tDistance(integer, tint)` and binds it to `Tdistance_number_tnumber`, whose
body hands `tdistance_tnumber_number` the same operands the same way round
as `Tdistance_tnumber_number` does. Naming only the second wrapper leaves
`tdistance_tint_int` holding the single signature `tDistance(tint, integer)`;
naming both gives it `tDistance(integer, tint)` as well. The same holds for
`setDistance(integer, intset)`, `distance(integer, intspan)`,
`distance(integer, intspanset)` and their four sibling base types, and for
`aDwithin(geometry, trgeometry, float)` and `eDwithin(geometry, trgeometry,
float)`.

tdistance_tint_int and tdistance_tfloat_float name
#Tdistance_number_tnumber() beside #Tdistance_tnumber_number(); the
distance_set_*, distance_span_* and distance_spanset_* families name their
#Distance_value_*() twin; and adwithin_trgeometry_geo and
edwithin_trgeometry_geo name #Adwithin_geo_trgeometry() and
#Edwithin_geo_trgeometry(). This is what the spatial families already state
in a single tag: #Tdistance_tgeo_geo() #Tdistance_geo_tgeo(),
#Tdistance_tcbuffer_cbuffer() #Tdistance_cbuffer_tcbuffer().

Measured by deriving the catalog twice, once over the base tree and once over
this one: 10967 signatures become 10986, 19 added and 0 removed, and every
added row is a commuted direction of a signature already present. No existing
attribution moves. check_csqlfn.py --complete reads 0 commuted and 0
mistagged; --targets reads 0 tags naming a wrapper the tree does not define
and 8 unreachable, all of them inside the standing baseline;
check_sqlfn_names.py reads clean. The diff is 19 @csqlfn comment lines and 0
non-comment lines, so no compiled answer can move, and libmeos builds under
MSYS2 UCRT64 as the meos-windows job does.

Why the new answer is the right one is a question about the model rather
than the code, and the tag's own meaning settles it. A @csqlfn tag states the SQL surface a MEOS function serves, and a
function's surface is the set of signatures the SQL binds to it -- not the
subset written with the temporal operand first. Distance and dwithin are
symmetric relations, so an operation written either way round is one
operation, and MobilityDB says so by binding both orders to one wrapper pair
over one kernel and by declaring the operators COMMUTATOR of each other.
Because both orders are that single function's surface, a tag naming one of
them is incomplete rather than a choice, which is why every spatial family
already names both and why the numeric, set, span, spanset and rigid-geometry
families are the outliers being brought into line. Naming the second wrapper
changes no answer the extension gives; it stops the catalog, and therefore
every generated binding, from hiding half of what the extension already
answers.

