### PR TITLE
Answer an empty overlay with the empty geometry it covers

### DIFF
--- a/meos/src/geo/clip_clipper2.cpp
+++ b/meos/src/geo/clip_clipper2.cpp
@@ -259,8 +259,11 @@ polytree_to_lwgeom(const PolyTree64 &tree, int32_t srid)
   for (const auto &top : tree)
     emit_polygons(*top, srid, polys);
 
+  /* An overlay covering no area is an EMPTY polygon, which is an answer: the
+   * arms that clip a line or a point set answer the empty geometry of their
+   * own kind, and so does the GEOS overlay this one stands in front of */
   if (polys.empty())
-    return nullptr;
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0));
   if (polys.size() == 1)
     return polys[0];
 
@@ -360,7 +363,15 @@ clipper2_clip_poly_poly(const GSERIALIZED *subj_g, const GSERIALIZED *clip_g,
 
   LWGEOM *out_lw = polytree_to_lwgeom(polytree, srid);
   if (out_lw == nullptr)
+  {
+    /* The tree answers a geometry for every outcome, the empty overlay
+     * included, so nothing reaches here. It raises rather than returning
+     * nothing, a null carrying no error being indistinguishable to a caller
+     * from an answer */
+    meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
+      "clipper2_clip_poly_poly: the clip tree yielded no geometry");
     return nullptr;
+  }
   GSERIALIZED *result = geo_serialize(out_lw);
   lwgeom_free(out_lw);
   return result;

--- a/meos/src/geo/geo_poly_clip.c
+++ b/meos/src/geo/geo_poly_clip.c
@@ -50,6 +50,7 @@
 #include <meos_geo.h>        /* for geo_copy */
 #include <meos_internal.h>
 #include "geo/clip_clipper2.h"
+#include "geo/geo_funcs.h"   /* for geo_serialize */
 
 /*****************************************************************************/
 
@@ -67,13 +68,30 @@ _Static_assert(CL_XOR          == MEOS_CLIP_XOR,
 /*****************************************************************************/
 
 /**
+ * @brief Return the areal region of no area
+ * @details Every outcome of a polygon Boolean covering nothing answers this,
+ * so what an empty result is drawn as follows from the OPERATION and never
+ * from which of the trivial cases reached it. PostGIS instead clones whichever
+ * operand happens to be empty, which answers `MULTIPOLYGON EMPTY` down one
+ * path and `POLYGON EMPTY` down another for one question; the general path it
+ * takes when neither operand is empty answers `POLYGON EMPTY`, and that is the
+ * spelling kept here for all of them.
+ */
+static GSERIALIZED *
+clip_empty_areal(int32_t srid)
+{
+  return geo_serialize(lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0)));
+}
+
+/**
  * @brief Clip the two polygons using the given Boolean operation.
  * @param subj  Subject geometry (POLYGON or MULTIPOLYGON, 2D)
  * @param clip  Clipping geometry (POLYGON or MULTIPOLYGON, 2D)
  * @param oper  Operation selector (#CL_INTERSECTION, #CL_UNION,
  * #CL_DIFFERENCE, #CL_XOR)
- * @return Newly-allocated GSERIALIZED holding the result, or @c NULL on
- * empty result. Caller owns the result.
+ * @return Newly-allocated GSERIALIZED holding the result, which is an EMPTY
+ * geometry where the operation covers nothing, as PostGIS answers. Caller owns
+ * the result.
  *
  * 3D rejection, geography rejection, SRID-mismatch and type-validity
  * checks are performed by the SQL wrapper layer
@@ -82,19 +100,22 @@ _Static_assert(CL_XOR          == MEOS_CLIP_XOR,
 GSERIALIZED *
 clip_poly_poly(const GSERIALIZED *subj, const GSERIALIZED *clip, ClipOper oper)
 {
-  /* Trivial cases: at least one input is empty. */
+  /* Trivial cases: at least one input is empty. What each answers is the set
+   * identity for its operation -- nothing meets an empty region, nothing is
+   * taken from a subject by one, and a union with one is the other side */
+  int32_t srid = gserialized_get_srid(subj);
   bool empty_subj = gserialized_is_empty(subj);
   bool empty_clip = gserialized_is_empty(clip);
   if (empty_subj || empty_clip)
   {
     if (oper == CL_INTERSECTION)
-      return NULL;
+      return clip_empty_areal(srid);
     if (oper == CL_DIFFERENCE)
-      return empty_subj ? NULL : geo_copy(subj);
+      return empty_subj ? clip_empty_areal(srid) : geo_copy(subj);
     /* CL_UNION || CL_XOR */
     if (empty_subj && empty_clip)
-      return NULL;
-    return empty_subj ? geo_copy(clip) : geo_copy(subj);
+      return clip_empty_areal(srid);
+    return geo_copy(empty_subj ? clip : subj);
   }
 
   /* Trivial case: bounding boxes don't overlap. Saves the Clipper2 setup
@@ -107,7 +128,7 @@ clip_poly_poly(const GSERIALIZED *subj, const GSERIALIZED *clip, ClipOper oper)
       gbox_overlaps_2d(&sbbox, &clbox) == LW_FALSE)
   {
     if (oper == CL_INTERSECTION)
-      return NULL;
+      return clip_empty_areal(srid);
     if (oper == CL_DIFFERENCE)
       return geo_copy(subj);
     /* CL_UNION || CL_XOR — disjoint, return whichever side. The wrapper

--- a/mobilitydb/test/geo/expected/078_tpoint_clipping.test.out
+++ b/mobilitydb/test/geo/expected/078_tpoint_clipping.test.out
@@ -104,11 +104,25 @@ SELECT st_astext(intersection(
  MULTIPOLYGON(((3 1,1 1,1 3,3 3,3 1)),((7 1,5 1,5 3,7 3,7 1)))
 (1 row)
 
-SELECT intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
-  geometry 'Polygon((10 10,10 11,11 11,11 10,10 10))') IS NULL;
- ?column? 
-----------
- t
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+  geometry 'Polygon((10 10,10 11,11 11,11 10,10 10))'));
+   st_astext   
+---------------
+ POLYGON EMPTY
+(1 row)
+
+SELECT st_astext(difference(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+  geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))'));
+   st_astext   
+---------------
+ POLYGON EMPTY
+(1 row)
+
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+  geometry 'MultiPolygon EMPTY'));
+   st_astext   
+---------------
+ POLYGON EMPTY
 (1 row)
 
 SELECT st_astext(intersection(

--- a/mobilitydb/test/geo/queries/078_tpoint_clipping.test.sql
+++ b/mobilitydb/test/geo/queries/078_tpoint_clipping.test.sql
@@ -86,11 +86,16 @@ SELECT st_astext(intersection(
   geometry 'Polygon((0 0,0 4,8 4,8 0,0 0))'));
 
 -------------------------------------------------------------------------------
--- Empty result (cover polys.empty() in polytree_to_lwgeom and NULL propagation)
+-- Empty result (cover polys.empty() in polytree_to_lwgeom, and the empty
+-- geometry every path answers for an overlay that covers nothing)
 -------------------------------------------------------------------------------
 
-SELECT intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
-  geometry 'Polygon((10 10,10 11,11 11,11 10,10 10))') IS NULL;
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+  geometry 'Polygon((10 10,10 11,11 11,11 10,10 10))'));
+SELECT st_astext(difference(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+  geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))'));
+SELECT st_astext(intersection(geometry 'Polygon((1 1,1 2,2 2,2 1,1 1))',
+  geometry 'MultiPolygon EMPTY'));
 
 -------------------------------------------------------------------------------
 -- MULTIPOLYGON result (cover polys.size() > 1 LWMPOLY wrapping)


### PR DESCRIPTION
`clip_poly_poly` returns nothing for an overlay that covers no area, and it
does so from four places: an empty operand, bounding boxes that keep apart,
and the clip tree yielding no polygon. Its docstring states that as the
contract, and `clip_ext` turns it into SQL NULL, so `intersection()` on two
polygons that keep apart answers UNKNOWN to a question whose answer is the
region of no area.

Nothing tells the two apart. `meos_errno()` reads 0, exactly as it does for an
answer, so a caller cannot distinguish an empty overlay from a failure. It also
defeats the derivation the native engine is meant to support -- `covers(A,B)`
holds exactly when `B \ A` is empty -- because the test for emptiness is the
value that also means error.

`clip_empty_areal` is the one region of no area, and every one of the four
places answers it. What an empty result is drawn as therefore follows from the
operation and never from which of the trivial cases reached it. The arms
beside this one already behave so: a line clipped to nothing answers
`LINESTRING EMPTY` and a point set answers `POINT EMPTY`.

WITNESS

  SELECT ST_AsText(intersection(
    'Polygon((1 1,1 2,2 2,2 1,1 1))',
    'Polygon((10 10,10 11,11 11,11 10,10 10))'));

  before  (NULL)
  after   POLYGON EMPTY

MEASURED

  10 overlays covering nothing: an       9 of 10 answered NULL with errno 0
  empty operand on each side, spelled    before, 10 of 10 answer a geometry
  POLYGON EMPTY and MULTIPOLYGON         after, every one of them
  EMPTY, two polygons keeping apart,     POLYGON EMPTY
  and each of a polygon and a
  multipolygon against itself
  a polygon against an EMPTY clip,       unmoved, the answer being the
  which covers something               polygon itself
  225 ordered type pairs, one            declines unchanged at 60 for
  geometry of each of the 15 types       intersection and 116 for difference,
  geom_meos_supported admits, with       so no dispatch moves; the nulls
  GEOS compiled out                      carrying no error go 3 to 0
  the four liblwgeom overlay entries     identical to the vendored copy, so
  read from PostGIS master               what is matched here is current
  078_tpoint_clipping                    passes, its expected output taken
                                         from the harness rather than written

The case that test carried asserted the answer `IS NULL`, under a comment
naming the very branch this changes, so it recorded the behaviour rather than
a wanted result. It now reads the answer through `ST_AsText` and covers the
empty operand beside the two that keep apart.

WHERE THIS DIFFERS FROM PostGIS, DELIBERATELY. PostGIS clones whichever
operand is empty, so one question answers two ways: `A ∩ MULTIPOLYGON EMPTY`
is a `MULTIPOLYGON EMPTY` while `A ∩ B` for two polygons keeping apart is a
`POLYGON EMPTY`, and `A \ EMPTY` hands back a `TRIANGLE` where the general
path would answer a `POLYGON`. Its own source marks the three places with
`/* match empty type? */`. The spelling kept here is the one its GENERAL path
produces, which is what a caller meets in every case but the degenerate ones.

WHY

An empty result is a result. The value a function returns to say it could not
answer must not also be a value it returns as an answer, or the caller has no
way to read either -- the same sentence as an empty geometry taking the error
return of a measure.

Which of four short-circuits ran is not a property of the two geometries, so
it cannot be allowed to decide what their overlay is drawn as. One region of
no area, reached from all four, is what makes the answer a function of the
question.

