### PR TITLE
Report the overlay a geometry type is refused for, rather than crashing

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2112,6 +2112,15 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
   LWGEOM *lwresult = lwgeom_intersection_prec(geom1, geom2, -1);
+  /* MEOS: the overlay answers NULL for a geometry it cannot read -- a
+   * polyhedral surface reaches the default arm of #LWGEOM2GEOS, whose lwerror
+   * the MEOS handler reports and RETURNS from -- so the answer is absent
+   * rather than empty and serializing it would read a null pointer */
+  if (! lwresult)
+  {
+    lwgeom_free(geom1); lwgeom_free(geom2);
+    return NULL;
+  }
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(geom1); lwgeom_free(geom2); lwgeom_free(lwresult);
   return result;
@@ -2153,6 +2162,15 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
   LWGEOM *lwresult = lwgeom_difference_prec(geom1, geom2, -1);
+  /* MEOS: the overlay answers NULL for a geometry it cannot read -- a
+   * polyhedral surface reaches the default arm of #LWGEOM2GEOS, whose lwerror
+   * the MEOS handler reports and RETURNS from -- so the answer is absent
+   * rather than empty and serializing it would read a null pointer */
+  if (! lwresult)
+  {
+    lwgeom_free(geom1); lwgeom_free(geom2);
+    return NULL;
+  }
   GSERIALIZED *result = geo_serialize(lwresult);
   lwgeom_free(geom1); lwgeom_free(geom2); lwgeom_free(lwresult);
   return result;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1374,6 +1374,40 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* An overlay of a geometry the GEOS library cannot read answers NOTHING
+   * rather than an empty geometry, and serializing what is absent reads a null
+   * pointer. A polyhedral surface is the type it refuses, and the error the
+   * refusal raises is what a caller reads the absence by. Under the handler
+   * that EXITS these lines are unreachable, so only a binding meets them */
+  const char *ps = "POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))";
+  const char *ovl[] = {
+    "LINESTRING(0 2,4 2)",
+    "POLYGON((1 1,2 1,2 2,1 2,1 1))",
+    "POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))",
+  };
+  for (int i = 0; i < 3; i++)
+  {
+    GSERIALIZED *pa = geom_in(ps, -1);
+    GSERIALIZED *pb = geom_in(ovl[i], -1);
+    assert(pa != NULL); assert(pb != NULL);
+    meos_errno_reset();
+    GSERIALIZED *pd = geom_difference2d(pa, pb);
+    int ed = meos_errno();
+    printf("difference of a polyhedral surface: %s, errno %d\n",
+      pd ? "answered" : "nothing", ed);
+    assert(pd == NULL);
+    assert(ed != 0);
+    if (pd) free(pd);
+    meos_errno_reset();
+    GSERIALIZED *pi = geom_intersection2d(pa, pb);
+    int ei = meos_errno();
+    printf("intersection of a polyhedral surface: %s, errno %d\n",
+      pi ? "answered" : "nothing", ei);
+    if (pi) free(pi);
+    free(pa); free(pb);
+    meos_errno_reset();
+  }
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
`geom_intersection2d` and `geom_difference2d` hand their operands to the GEOS
overlay and serialize what comes back. The overlay answers NOTHING for a
geometry it cannot read: a polyhedral surface reaches the default arm of
`LWGEOM2GEOS`, whose `lwerror` the MEOS handler reports and RETURNS from. The
absent answer is then serialized, and the process dies.

  Program received signal SIGSEGV
  #0  geo_serialize () from libmeos.so
  #1  geom_difference2d () from libmeos.so

The sibling three functions along already answers this. `geom_unary_union`
tests the same overlay's result and returns the absence, its comment naming
the same arm; the two entries here were left without the test.

ONLY A BINDING MEETS IT. PostgreSQL routes an error through `ereport`, which
longjmps out before the return, so the extension never reaches the line. Every
language binding installs `meos_initialize_noexit_error_handler`, where the
raise RETURNS and the caller runs on -- which is why the suite has stayed green
over it.

WITNESS

  geom_difference2d(
    'POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))',
    'LINESTRING(0 2,4 2)')

  before  SIGSEGV
  after   nothing, errno 12

MEASURED

  a polyhedral surface against a       before: SIGSEGV on 4 of the 6, the
  line, a polygon and another          two survivors being the intersections
  polyhedral surface, each             a line takes the native arm for
  differenced and intersected          after: 6 of 6 answered or refused,
                                       every refusal carrying errno 12
  the same six through the arm         unmoved: the intersection of a
  that does NOT reach the overlay      polyhedral surface with a line still
                                       answers, so the guard takes only the
                                       absent result
  a TIN against a TIN                  answers before and after; GEOS reads a
                                       TIN, so the crash is the REFUSED type
                                       and not the areal path
  meos/test/geo_test.c                 exits 0 here, SIGSEGV against a library
                                       without the test

WHY

A function that cannot answer says so; it does not hand its caller a value it
never built. The overlay reports the refusal itself, so the error is already
raised and the only thing missing is for the caller to stop.

The reason it survives is that the two handlers disagree about what a raise
does. Under the one that exits, the lines after a failed call are unreachable
and cannot be wrong. Under the one every binding installs, they run. Code
after an error is therefore not dead code, and a null it never checks is a
crash in every consumer but the one the tests use.

