### PR TITLE
Take nothing from a region for a clip that covers no area

### DIFF
--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -261,6 +261,8 @@ extern TSequenceSet *tgeoseqset_restrict_stbox(const TSequenceSet *ss, const STB
 extern void *geo_edge_ctx_make(const GSERIALIZED *gs);
 extern bool geo_is_planar_linear(const GSERIALIZED *gs);
 extern bool geo_clip_subject(const GSERIALIZED *gs);
+extern bool geo_is_planar_areal(const GSERIALIZED *gs);
+extern bool geo_every_part_bounds_area(const GSERIALIZED *gs);
 extern bool geo_is_point_set(const GSERIALIZED *gs);
 extern bool geo_meos_supported(const GSERIALIZED *gs);
 extern GSERIALIZED *geo_points_covered(const GSERIALIZED *pts,

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2186,6 +2186,24 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (geo_clip_subject(gs1) && geo_meos_supported(gs2))
     return geo_clip_linear_geom(gs1, gs2, false);
 
+  /* A region loses no area to a clip that covers none. A point set and a curve
+   * are of lower dimension than the plane, so what they take from a region is
+   * of lower dimension too, and the region a difference answers is the subject
+   * unchanged -- which also keeps the arcs of a curved subject, where reaching
+   * the overlay would return them as the chain of chords it reads them by */
+  if (geo_is_planar_areal(gs1) &&
+      (geo_is_point_set(gs2) || geo_clip_subject(gs2)))
+  {
+    /* A part enclosing NO area is not a region but its own boundary, and a
+     * clip of no area takes part of THAT: the line a flat ring lies along
+     * removes the ring entirely. The rule holds of a region, so the guard asks
+     * whether EVERY part of the subject is one -- a total would let a subject
+     * mixing a region with a part of no area keep the part a clip covers, and
+     * answer one point set two ways depending on how it is spelled */
+    if (geo_every_part_bounds_area(gs1))
+      return geo_copy(gs1);
+  }
+
 #if GEOS
   /* Other types fall through to GEOS */
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -981,6 +981,59 @@ geo_clip_subject(const GSERIALIZED *gs)
 }
 
 /**
+ * @brief Return true if a geometry draws AREA and nothing else
+ * @details A type whose every part bounds a region, so the geometry holds no
+ * point and no curve of its own. A collection is excluded whatever it holds:
+ * its members may be of any dimension, and one of them being a line is what
+ * makes a difference against a line remove something
+ */
+bool
+geo_is_planar_areal(const GSERIALIZED *gs)
+{
+  assert(gs);
+  if (FLAGS_GET_Z(gs->gflags) || FLAGS_GET_GEODETIC(gs->gflags))
+    return false;
+  uint32_t t = gserialized_get_type(gs);
+  return (t == POLYGONTYPE || t == MULTIPOLYGONTYPE || t == TRIANGLETYPE ||
+    t == CURVEPOLYTYPE || t == MULTISURFACETYPE || t == TINTYPE ||
+    t == POLYHEDRALSURFACETYPE);
+}
+
+/**
+ * @brief Return true if every part of a geometry bounds a region
+ * @details A ring enclosing no area bounds no region: what it contributes is
+ * the linework it traces, one dimension lower. #geom_extract_edges already
+ * says which of the two every ring of every part is -- a ring of no area
+ * yields LINE edges where one bounding a region yields POLY ones -- so reading
+ * that classification is what keeps this answer and the engine's own from
+ * disagreeing about a part. It also needs no tolerance of its own: the one
+ * that decides a ring lives in the extraction, where it is an area read
+ * against the extent the ring occupies rather than a length
+ */
+bool
+geo_every_part_bounds_area(const GSERIALIZED *gs)
+{
+  assert(gs);
+  LWGEOM *geom = lwgeom_from_gserialized(gs);
+  MeosArray *edges = geom_extract_edges(geom);
+  /* A geometry drawing nothing at all bounds no region either */
+  bool result = edges && meos_array_count(edges) > 0;
+  if (edges)
+  {
+    for (uint32_t i = 0; result && i < edges->count; i++)
+    {
+      const Edge *edge = (const Edge *) meos_array_get(edges, i);
+      if (! edge ||
+          (edge->etype != EDGE_POLYSEG && edge->etype != EDGE_POLYARC))
+        result = false;
+    }
+    meos_array_destroy(edges);
+  }
+  lwgeom_free(geom);
+  return result;
+}
+
+/**
  * @brief Return true if a geometry draws points and nothing else
  */
 bool

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1413,14 +1413,15 @@ int main(void)
    * rather than an empty geometry, and serializing what is absent reads a null
    * pointer. A polyhedral surface is the type it refuses, and the error the
    * refusal raises is what a caller reads the absence by. Under the handler
-   * that EXITS these lines are unreachable, so only a binding meets them */
+   * that EXITS these lines are unreachable, so only a binding meets them.
+   * Each clip here COVERS AREA, which is what carries the pair to the overlay:
+   * a clip of no area is answered from the subject and never reaches it */
   const char *ps = "POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))";
   const char *ovl[] = {
-    "LINESTRING(0 2,4 2)",
     "POLYGON((1 1,2 1,2 2,1 2,1 1))",
     "POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))",
   };
-  for (int i = 0; i < 3; i++)
+  for (int i = 0; i < 2; i++)
   {
     GSERIALIZED *pa = geom_in(ps, -1);
     GSERIALIZED *pb = geom_in(ovl[i], -1);
@@ -1442,6 +1443,122 @@ int main(void)
     free(pa); free(pb);
     meos_errno_reset();
   }
+  /* A region loses no area to a clip that covers none, so the difference is
+   * the subject itself -- kept as the subject was WRITTEN, where the overlay
+   * would return a curve as the chain of chords it reads it by and a triangle
+   * as a polygon. The rule needs the subject to enclose something: a flat ring
+   * is its own boundary, and the line it lies along removes all of it */
+  const char *ar_subj[] = {
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+    "TRIANGLE((0 0,4 0,2 4,0 0))",
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))",
+    /* A surface of one flat face bounds a region as much as a polygon does,
+     * and it is the region the GEOS overlay refuses to read at all, so here
+     * the rule answers where reaching the overlay has nothing to answer */
+    "POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))",
+  };
+  const char *ar_clip[] = {
+    "POINT(2 2)",
+    "LINESTRING(0 2,4 2)",
+    "CIRCULARSTRING(0 2,2 4,4 2)",
+  };
+  for (int i = 0; i < 4; i++)
+  {
+    GSERIALIZED *as = geom_in(ar_subj[i], -1);
+    assert(as != NULL);
+    char *aw = geo_as_text(as, 6);
+    for (int j = 0; j < 3; j++)
+    {
+      GSERIALIZED *ac = geom_in(ar_clip[j], -1);
+      assert(ac != NULL);
+      meos_errno_reset();
+      GSERIALIZED *ad = geom_difference2d(as, ac);
+      assert(ad != NULL);
+      char *dw = geo_as_text(ad, 6);
+      printf("%.28s minus %.24s: %s\n", ar_subj[i], ar_clip[j],
+        strcmp(dw, aw) == 0 ? "the subject" : dw);
+      assert(strcmp(dw, aw) == 0);
+      free(dw); free(ad); free(ac);
+      meos_errno_reset();
+    }
+    free(aw); free(as);
+  }
+  /* THE RULE IS ABOUT EVERY PART, NOT ABOUT A TOTAL. A subject mixing a
+   * region with a ring that encloses no area is not a region throughout: the
+   * ring traces the segment (3 0)-(5 0), so a clip covering that segment takes
+   * it, and only the square is left. Reading a total area instead would answer
+   * the subject unchanged and keep a segment the clip covers -- and would
+   * answer one point set two ways, since the same members spelled as a
+   * collection stay outside the guard and lose the segment */
+  const char *pt_subj[] = {
+    "MULTIPOLYGON(((0 0,1 0,1 1,0 1,0 0)),((3 0,5 0,5 0,3 0,3 0)))",
+    "GEOMETRYCOLLECTION(POLYGON((0 0,1 0,1 1,0 1,0 0)),"
+      "POLYGON((3 0,5 0,5 0,3 0,3 0)))",
+  };
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *ps1 = geom_in(pt_subj[i], -1);
+    GSERIALIZED *ps2 = geom_in("LINESTRING(3 0,5 0)", -1);
+    assert(ps1 != NULL); assert(ps2 != NULL);
+    meos_errno_reset();
+    GSERIALIZED *pr = geom_difference2d(ps1, ps2);
+    assert(pr != NULL);
+    double pa_area = geom_area(pr);
+    char *pw = geo_as_text(pr, 6);
+    printf("a subject carrying a part of no area, minus that part: %s\n", pw);
+    /* The square alone: the part of no area is gone, and both spellings of
+     * the same point set answer it the same way */
+    assert(strstr(pw, "3 0") == NULL);
+    assert(strstr(pw, "5 0") == NULL);
+    assert(fabs(pa_area - 1.0) < 1e-12);
+    free(pw); free(pr); free(ps1); free(ps2);
+    meos_errno_reset();
+  }
+  /* A hole enclosing no area removes nothing from the surface it sits in, so
+   * the subject IS a region and the rule holds of it: the answer is the
+   * subject, of the subject's own area */
+  GSERIALIZED *dh = geom_in("POLYGON((0 0,10 0,10 10,0 10,0 0),"
+    "(3 5,7 5,7 5,3 5,3 5))", -1);
+  GSERIALIZED *dl = geom_in("LINESTRING(3 5,7 5)", -1);
+  assert(dh != NULL); assert(dl != NULL);
+  meos_errno_reset();
+  GSERIALIZED *dr = geom_difference2d(dh, dl);
+  assert(dr != NULL);
+  printf("a shell carrying a hole of no area, minus that hole's line: "
+    "area %.6f\n", geom_area(dr));
+  assert(fabs(geom_area(dr) - 100.0) < 1e-12);
+  free(dr); free(dh); free(dl);
+  meos_errno_reset();
+
+  /* Only the DIFFERENCE of such a pair is answered from the subject. The
+   * intersection of the same surface with the same line keeps its own arm,
+   * which reads the line as the subject it clips and answers it, so the two
+   * overlays part company on this pair and each says so here */
+  GSERIALIZED *ps_s = geom_in("POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))", -1);
+  GSERIALIZED *ps_l = geom_in("LINESTRING(0 2,4 2)", -1);
+  assert(ps_s != NULL); assert(ps_l != NULL);
+  meos_errno_reset();
+  GSERIALIZED *ps_i = geom_intersection2d(ps_s, ps_l);
+  int ps_e = meos_errno();
+  printf("intersection of a polyhedral surface and a line: %s, errno %d\n",
+    ps_i ? "answered" : "nothing", ps_e);
+  assert(ps_i != NULL);
+  assert(ps_e == 0);
+  free(ps_i); free(ps_s); free(ps_l);
+  meos_errno_reset();
+  /* A subject enclosing nothing is NOT one of them: the line it lies along
+   * takes all of it, and the answer is the region of no area */
+  GSERIALIZED *flat = geom_in("POLYGON((0 0,2 0,4 0,0 0))", -1);
+  GSERIALIZED *along = geom_in("LINESTRING(0 0,4 0)", -1);
+  assert(flat != NULL); assert(along != NULL);
+  meos_errno_reset();
+  GSERIALIZED *fd = geom_difference2d(flat, along);
+  assert(fd != NULL);
+  char *fw = geo_as_text(fd, 6);
+  printf("a flat ring minus the line it lies along: %s\n", fw);
+  assert(strstr(fw, "EMPTY") != NULL);
+  free(fw); free(fd); free(flat); free(along);
+  meos_errno_reset();
 
   /* Finalize MEOS */
   meos_finalize();


### PR DESCRIPTION
Take nothing from a region for a clip that covers no area

`geom_difference2d` dispatches on its SUBJECT alone, and the only subject it
answers natively is a point set or a curve. An AREAL subject therefore reaches
the GEOS overlay against every clip, a point and a line included -- and neither
of those covers any area, so neither can take any from a region.

What the overlay answers back is the same region drawn differently: it inserts
a vertex wherever the clip crossed the boundary, rewrites a `TRIANGLE` as a
`POLYGON`, and reads a `CURVEPOLYGON` as the chain of chords it linearizes the
arcs into. The last of those is not a redrawing but a loss.

The subject itself is the answer, so it is what this returns.

THE SUBJECT MUST ENCLOSE SOMETHING, and that is the whole of the condition. A
ring of no area is not a region but its own boundary, and a clip of no area
takes part of THAT: the line a flat ring lies along removes the ring entirely.
A subject enclosing nothing is left to the overlay.

`geo_is_planar_areal` names the types whose every part bounds a region. A
collection is not among them whatever it holds: its members may be of any
dimension, and one of them being a line is exactly what makes a difference
against a line remove something.

WITNESS

  SELECT ST_AsText(ST_Difference(
    'CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))',
    'LINESTRING(0 2,4 2)'));

  before  POLYGON((0.002409 2.098135,0.009631 2.196034,...))
          65 vertices, the circle replaced by chords
  after   CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))

MEASURED

  225 ordered type pairs, one          difference reaches GEOS 116 -> 67, a
  geometry of each of the 15 types     fall of 49 = the 7 areal types the
  geom_meos_supported admits, with     guard admits x the 7 point and curve
  GEOS compiled out                    clips; intersection unmoved at 60
  4 areal subjects x 5 point and       20 of 20 answer the subject as
  curve clips                          written, where the overlay answers 19
                                       of 20 as the same region redrawn and
                                       1 -- a curve polygon -- as LESS than
                                       the subject, the stroking losing part
                                       of what it encloses
  a collection of a point and a line   answers the point, so the line IS
  minus that line                      taken and a collection stays outside
                                       the guard
  a polygon minus a collection         answers the polygon with a hole, so a
  holding a polygon                    clip that is not lower-dimensional
                                       stays outside it too
  a polygon carrying Z                 unmoved, as for the arms beside this
  a flat ring minus the line it        the region of no area, matching the
  lies along, and minus a point        overlay on all three of its cases
  on it
  a polyhedral surface of one flat     answers the subject for all three,
  face minus a point, a line and an    where the overlay reads the TYPE and
  arc                                  refuses it, so the rule answers a
                                       region GEOS declines outright
  meos/test/geo_test.c                 passes here, aborts against master at
                                       the first subject assertion

WHY

Dimension decides it. A point set and a curve are of lower dimension than the
plane, so the part of a region they can cover has no area, and what a
difference answers is the region less a set of no area -- the region. Nothing
about the shapes enters beyond their dimension, which is why the test is a
type predicate and not a geometry one.

The exception is the subject of no area, and it is the same sentence read the
other way: such a subject IS a set of no area, so a clip of no area is of its
own dimension and can take all of it. The rule holds for a region; the guard
therefore asks whether the subject is one.

A polyhedral surface is one of the types the guard admits, and `lwgeom_area`
sums a collection's members, so a surface whose faces enclose area answers the
subject where it previously reached the overlay and read the refusal. The
polyhedral-surface case of the refusal witness therefore keeps the clips that
COVER AREA -- a polygon and another surface -- which are the pairs that still
reach GEOS, and the lower-dimensional clip moves to the witness above, three
rows where there was one. The refusal itself is unmoved for every pair that
reaches it, and the observation that pair also carried -- that the
INTERSECTION of the same surface and line answers, where the other two clips
are refused -- is asserted beside the difference rows it now parts company
with.

