### PR TITLE
Measure the area a planar geometry encloses

### DIFF
--- a/meos/include/meos_geo.h
+++ b/meos/include/meos_geo.h
@@ -373,6 +373,7 @@ extern GSERIALIZED *geog_centroid(const GSERIALIZED *gs, bool use_spheroid);
 extern double geog_length(const GSERIALIZED *gs, bool use_spheroid);
 extern double geog_perimeter(const GSERIALIZED *gs, bool use_spheroid);
 extern bool geom_azimuth(const GSERIALIZED *gs1, const GSERIALIZED *gs2, double *result);
+extern double geom_area(const GSERIALIZED *gs);
 extern double geom_length(const GSERIALIZED *gs);
 extern double geom_perimeter(const GSERIALIZED *gs);
 extern int line_numpoints(const GSERIALIZED *gs);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -863,6 +863,35 @@ geo_is_unitary(const GSERIALIZED *gs)
 
 /**
  * @ingroup meos_geo_base_accessor
+ * @brief Return the area of a geometry
+ * @details Defined by
+ *   - area(point) = 0
+ *   - area(line) = 0
+ *   - area(polygon) = the area it encloses, its holes taken out
+ *
+ * Uses Euclidean 2D computation even if input is 3D.
+ * @param[in] gs Geometry
+ * @return On error return @p DBL_MAX
+ * @note An empty geometry encloses nothing, so its area is 0. The question has
+ * an answer, and #lwgeom_area gives it
+ * @note PostGIS function: @p ST_Area(PG_FUNCTION_ARGS)
+ */
+double
+geom_area(const GSERIALIZED *gs)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(gs, DBL_MAX);
+  if (! ensure_not_geodetic_geo(gs))
+    return DBL_MAX;
+
+  LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+  double area = lwgeom_area(lwgeom);
+  lwgeom_free(lwgeom);
+  return area;
+}
+
+/**
+ * @ingroup meos_geo_base_accessor
  * @brief Return the length of a geometry
  * @details Defined by
  *   - length(point) = 0

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -48,6 +48,7 @@
  */
 
 #include <assert.h>
+#include <float.h>
 #include <math.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -625,10 +626,12 @@ int main(void)
     meos_errno_reset();
     double elen = geom_length(e);
     double eper = geom_perimeter(e);
-    printf("%s: length %g, perimeter %g, errno %d\n", emptywkt[i], elen, eper,
-      meos_errno());
+    double ear = geom_area(e);
+    printf("%s: length %g, perimeter %g, area %g, errno %d\n", emptywkt[i],
+      elen, eper, ear, meos_errno());
     assert(elen == 0.0);
     assert(eper == 0.0);
+    assert(ear == 0.0);
     assert(meos_errno() == 0);
     free(e);
     meos_errno_reset();
@@ -638,12 +641,44 @@ int main(void)
   GSERIALIZED *meas = geom_in("POLYGON((0 0,3 0,3 4,0 4,0 0))", -1);
   assert(meas != NULL);
   meos_errno_reset();
-  printf("the 3 by 4 rectangle: length %g, perimeter %g\n", geom_length(meas),
-    geom_perimeter(meas));
+  printf("the 3 by 4 rectangle: length %g, perimeter %g, area %g\n",
+    geom_length(meas), geom_perimeter(meas), geom_area(meas));
   assert(geom_length(meas) == 0.0);
   assert(geom_perimeter(meas) == 14.0);
+  assert(geom_area(meas) == 12.0);
   assert(meos_errno() == 0);
   free(meas);
+  meos_errno_reset();
+
+  /* The area a geometry of each dimension carries: a point and a line enclose
+   * nothing, a ring encloses what it bounds less its holes, and a geodetic
+   * geometry is measured by #geog_area rather than by this one */
+  GSERIALIZED *apt = geom_in("POINT(1 1)", -1);
+  GSERIALIZED *aln = geom_in("LINESTRING(0 0,3 4)", -1);
+  GSERIALIZED *ahole = geom_in(
+    "POLYGON((0 0,10 0,10 10,0 10,0 0),(2 2,4 2,4 4,2 4,2 2))", -1);
+  GSERIALIZED *amulti = geom_in(
+    "MULTIPOLYGON(((0 0,2 0,2 2,0 2,0 0)),((5 5,8 5,8 9,5 9,5 5)))", -1);
+  assert(apt && aln && ahole && amulti);
+  meos_errno_reset();
+  printf("area: point %g, line %g, holed square %g, multipolygon %g\n",
+    geom_area(apt), geom_area(aln), geom_area(ahole), geom_area(amulti));
+  assert(geom_area(apt) == 0.0);
+  assert(geom_area(aln) == 0.0);
+  assert(geom_area(ahole) == 96.0);
+  assert(geom_area(amulti) == 16.0);
+  assert(meos_errno() == 0);
+  free(apt); free(aln); free(ahole); free(amulti);
+  meos_errno_reset();
+  /* A geodetic geometry is refused, as it is by the other planar measures */
+  GSERIALIZED *ageog = geog_in("SRID=4326;POLYGON((0 0,1 0,1 1,0 1,0 0))", -1);
+  assert(ageog != NULL);
+  meos_errno_reset();
+  double gar = geom_area(ageog);
+  printf("area of a geography: %g, errno %d\n", gar, meos_errno());
+  assert(gar == DBL_MAX);
+  assert(meos_errno() != 0);
+  free(ageog);
   meos_errno_reset();
 
   /* A relationship of a curved geometry is read on the arc itself. The


### PR DESCRIPTION
MEOS answers the area of a GEOGRAPHY and not of a geometry. `geog_area` is
published, `geom_length` and `geom_perimeter` are published, and area is the
one measure of the three carrying only its geodetic half. The kernel is
already vendored -- `lwgeom_area` -- so what is missing is the entry that
reaches it.

Nothing else reaches it either. MEOS is what every binding is generated from,
so a measure absent from the library is absent from PyMEOS, JMEOS, GoMEOS,
MEOS.NET and the rest; a consumer wanting the area of a polygon has to leave
MEOS for PostGIS.

`geom_area` mirrors `geom_length` and `geom_perimeter` exactly, differing only
in the kernel it calls. It refuses a geodetic geometry as they do, that being
`geog_area`'s question, and it measures an EMPTY geometry as 0 rather than
refusing it -- the rule the two of them already carry and the one `geog_area`
states for itself in its own comment.

WITNESS

  nm -D --defined-only libmeos.so | grep -w geom_area

  before  0 symbols, against 1 each for geog_area, geom_length and
          geom_perimeter
  after   1

and the same test file compiled against a library without the entry fails at
`error: implicit declaration of function 'geom_area'` under the
`-Werror=implicit-function-declaration` the CI build carries, exit 1, against
exit 0 here.

MEASURED

  a point and a line                 0 and 0, neither enclosing anything
  a 3 by 4 rectangle                 12
  a 10 by 10 square holding a 2 by   96, the hole taken out rather than
  2 hole                             counted
  a multipolygon of a 2 by 2 and a   16, the members summed
  3 by 4 rectangle
  LINESTRING EMPTY, POLYGON EMPTY    0 for each, errno 0, so an empty
  and GEOMETRYCOLLECTION EMPTY       geometry is measured rather than refused
  a geodetic polygon                 DBL_MAX and a non-zero errno, the answer
                                     being geog_area's to give
  meos/test/geo_test.c               passes

WHY

Which measures a library publishes is part of its surface, and a surface with
a geodetic area and no planar one states that a plane has no area. The three
measures answer the same kind of question about the same kind of value, so
either all three carry both halves or the missing one is a gap rather than a
choice.

The entry adds no algorithm. `lwgeom_area` computes the answer today and is
reached by nothing, so what ships here is the surface, and the surface is
what a binding can be generated from.

