### PR TITLE
Say [out] of a parameter the function writes through

### DIFF
--- a/.github/workflows/check-code.yml
+++ b/.github/workflows/check-code.yml
@@ -44,6 +44,15 @@ jobs:
       - name: Reject an empty or repeated @brief
         run: python3 tools/scripts/check_doxygen_briefs.py
 
+  param_direction_check:
+    name: Every @param[in] names a parameter only read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Reject an @param[in] the function writes through
+        run: python3 tools/scripts/check_param_direction.py
+
   license_check:
     runs-on: ubuntu-latest
     steps:

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -4396,7 +4396,7 @@ geo_from_ewkb(const uint8_t *wkb, size_t wkb_size, int32_t srid)
  * geometry/geography
  * @param[in] gs Geometry/geography
  * @param[in] endian Endianness
- * @param[in] size Size of result
+ * @param[out] size Size of result
  * @note PostGIS function: @p WKBFromLWGEOM(PG_FUNCTION_ARGS)
  */
 uint8_t *

--- a/meos/src/geo/tspatial_parser.c
+++ b/meos/src/geo/tspatial_parser.c
@@ -89,7 +89,7 @@ srid_parse(const char **str, int *srid)
  * @details Shared by the STBox and TPCBox text parsers. Does NOT enforce
  * end-of-input, so a caller may parse a trailing suffix (e.g. the TPCBox
  * `PCID`) after the box body.
- * @param[in] str Input string
+ * @param[in,out] str Input string, advanced past what is read
  * @param[in] geodetic True for a geodetic box
  * @param[in] srid SRID of the box
  * @param[in] type_str Type name used in error messages
@@ -591,7 +591,7 @@ error:
 
 /**
  * @brief Parse a spatiotemporal value from the input buffer
- * @param[in] str Input string
+ * @param[in,out] str Input string, advanced past what is read
   * @param[in] temptype Temporal type
 */
 Temporal *

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -252,7 +252,7 @@ error:
 
 /**
  * @brief Parse the reference geometry of a temporal rigid geometry
- * @param[in] str Input string
+ * @param[in,out] str Input string, advanced past what is read
  * @param[in,out] temp_srid SRID of the temporal rigid geometry
  */
 GSERIALIZED *
@@ -299,7 +299,7 @@ trgeo_parse_geom(const char **str, int32_t temp_srid)
 
 /**
  * @brief Parse a temporal rigid geometry from the buffer.
- * @param[in] str Input string
+ * @param[in,out] str Input string, advanced past what is read
  * @param[in] temptype Temporal type
  */
 Temporal *

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -1013,7 +1013,7 @@ tsequenceset_sequences_p(const TSequenceSet *ss)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return the array of segments of a temporal sequence set
  * @param[in] ss Temporal sequence set
- * @param[in] count Number of values in the output array
+ * @param[out] count Number of values in the output array
  * @csqlfn #Temporal_segments()
  */
 TSequence **
@@ -1241,7 +1241,7 @@ tsequenceset_timestamptz_n(const TSequenceSet *ss, int n, TimestampTz *result)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return the array of distinct timestamps of a temporal sequence set
  * @param[in] ss Temporal sequence set
- * @param[in] count Number of elements in the output array
+ * @param[out] count Number of elements in the output array
  * @csqlfn #Temporal_timestamps()
  */
 TimestampTz *

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -878,7 +878,7 @@ error:
 
 /**
  * @brief Parse a temporal value from the buffer (dispatch function)
- * @param[in] str Input string
+ * @param[in,out] str Input string, advanced past what is read
  * @param[in] temptype Temporal type
  * @return On error return @p NULL
  */

--- a/tools/scripts/check_param_direction.py
+++ b/tools/scripts/check_param_direction.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+#
+# This MobilityDB code is provided under The PostgreSQL License.
+# Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+# contributors
+#
+# MobilityDB includes portions of PostGIS version 3 source code released
+# under the GNU General Public License (GPLv2 or later).
+# Copyright (c) 2001-2025, PostGIS contributors
+#
+# Permission to use, copy, modify, and distribute this software and its
+# documentation for any purpose, without fee, and without a written
+# agreement is hereby granted, provided that the above copyright notice and
+# this paragraph and the following two paragraphs appear in all copies.
+#
+# IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+# DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+# LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+# EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+# OF SUCH DAMAGE.
+#
+# UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+# INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+# AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+# AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+# PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+#
+
+"""Check that no @param[in] names a parameter the function writes through.
+
+Why
+---
+The doxygen direction is not decoration: MEOS-API reads `@param[out]`
+as the single source of truth for which parameters a binding FOLDS —
+allocates the storage for, passes, and reads the value back out of. A
+parameter the function writes through while its doxygen says `[in]`
+therefore reaches every generated binding as an argument the caller
+must supply and can never read.
+
+`geo_as_ewkb(gs, endian, size_t *size)` is the shape and the cost. It
+writes `*size = data_size` and answers a `uint8_t *` buffer of exactly
+that many bytes, so the size is the ONLY way to know how much of the
+answer is data. Its doxygen said `@param[in] size`, and its own
+sibling `set_as_wkb` says `@param[out] size_out` — so twelve bindings
+projected the one function they could not read the buffer of.
+
+Nothing else sees this. The compiler does not read comments, doxygen
+renders whatever direction it is given, and the catalog's own
+cross-check runs the OTHER way: it drops an `@param[out]` that the
+signature contradicts (a by-value or `const` parameter) and reports it,
+which says nothing about an `[out]` that is missing.
+
+What this checks, and what it does not
+--------------------------------------
+The predicate is a DIRECT write in the function's own body: the
+parameter appears as `*name =` (or `*name +=`, `*name++`, ...) with
+comments stripped, since an assignment inside a comment is not an
+assignment. That makes every finding provable from the one function a
+reader is looking at.
+
+A parameter the function mutates only by handing it to a helper —
+`p_whitespace(str)` advancing a parser's cursor — is outside the
+predicate and is not reported. Widening to it needs the call graph,
+and a check whose findings a reader cannot confirm locally is a check
+people learn to override.
+
+A parameter a function both reads and writes is `@param[in,out]`,
+which the repository already uses; only a bare `[in]` is a finding.
+
+Scope
+-----
+The roots below hold the first-party sources. The vendored trees
+(postgis, pgtypes, clipper2, h3-pg, pointcloud-pg) are top-level
+siblings of these roots rather than subdirectories, so naming what is
+scanned leaves them out without an exclusion list.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+
+SCANNED_ROOTS = ("meos/src", "mobilitydb/src")
+SUFFIXES = (".c",)
+
+#: A doxygen block, the parameter list it labels, and the body's opening brace.
+#: The block and the definition can be separated by preprocessor guards and
+#: blank lines, the shape a `#if MEOS` twin of a symbol uses.
+DEFINITION = re.compile(
+    r"/\*\*(?P<doc>.*?)\*/[^\S\n]*\n"
+    r"(?:[^\S\n]*(?:\#[^\n]*|//[^\n]*)?[^\S\n]*\n)*"
+    r"(?:[A-Za-z_][\w\s\*]*?\n)?"
+    r"(?P<name>[a-z][a-z0-9_]*)\s*\((?P<params>[^;{]*?)\)\s*\{",
+    re.S)
+
+#: One `@param[in]` entry, whose names may be comma-separated.
+PARAM_IN = re.compile(r"@param\[in\]\s+(?P<names>\w+(?:\s*,\s*\w+)*)")
+
+COMMENT = re.compile(r"/\*.*?\*/|//[^\n]*", re.S)
+
+
+def body_of(text: str, brace: int) -> str:
+    """The function body starting at its opening brace, comments stripped.
+
+    The end is found by COUNTING braces: a regex cannot tell which `}`
+    closes which `{`, so it runs past the function and reads the next
+    one's writes as this one's.
+    """
+    depth = 0
+    for index in range(brace, len(text)):
+        if text[index] == "{":
+            depth += 1
+        elif text[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return COMMENT.sub(" ", text[brace:index])
+    return COMMENT.sub(" ", text[brace:])
+
+
+def writes_through(body: str, name: str) -> bool:
+    """Whether the body assigns through `*name`."""
+    return bool(re.search(
+        rf"(?<![\w>])\*\s*{re.escape(name)}\s*(=[^=]|\+\+|--|\+=|-=|\*=|/=)",
+        body))
+
+
+def findings(path: Path):
+    """Return the (line, function, parameter) triples this file answers for."""
+    text = path.read_text(encoding="utf-8", errors="replace")
+    result = []
+    for match in DEFINITION.finditer(text):
+        names = [n for entry in PARAM_IN.finditer(match.group("doc"))
+                 for n in re.split(r"\s*,\s*", entry.group("names"))]
+        if not names:
+            continue
+        params = match.group("params")
+        brace = text.index("{", match.end() - 1)
+        body = body_of(text, brace)
+        for name in names:
+            # A name the parameter list does not carry as a pointer cannot be
+            # written through, whatever the body says about a local of that name.
+            if not re.search(rf"\*\s*{re.escape(name)}\b", params):
+                continue
+            if writes_through(body, name):
+                line = text.count("\n", 0, match.start("doc")) + 1
+                result.append((line, match.group("name"), name))
+    return result
+
+
+def main() -> int:
+    failures = 0
+    scanned = 0
+    for root in SCANNED_ROOTS:
+        for path in sorted((REPO_ROOT / root).rglob("*")):
+            if path.suffix not in SUFFIXES or not path.is_file():
+                continue
+            scanned += 1
+            for line, function, name in findings(path):
+                print(f"{path.relative_to(REPO_ROOT).as_posix()}:{line}: "
+                      f"{function} writes through {name}, "
+                      f"which its doxygen calls @param[in]")
+                failures += 1
+
+    if not scanned:
+        print("ERROR: check_param_direction scanned no files; the roots are wrong.",
+              file=sys.stderr)
+        return 1
+    if failures:
+        print(f"\nERROR: {failures} finding(s) over {scanned} files.", file=sys.stderr)
+        print("A parameter the function writes through is @param[out], or "
+              "@param[in,out] where it is read as well.", file=sys.stderr)
+        return 1
+    print(f"OK: every @param[in] names a parameter the function only reads, "
+          f"over {scanned} files.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
MEOS-API reads `@param[out]` as the single source of truth for which parameters
a binding folds — allocates the storage for, passes, and reads the value back
out of — so a direction is a contract rather than decoration. Eight parameters
that their own function writes through carry `@param[in]` at eb5ddc576618, and
each reaches every generated binding as an argument the caller must supply and
can never read.

THE WITNESS is what the module that decides answers. `parser/outparam.
extract_outparams` over `meos/`, at eb5ddc576618 and here:

    geo_as_ewkb              outParams = None        ->  ['size']
    tsequenceset_segments    outParams = None        ->  ['count']
    tsequenceset_timestamps  outParams = None        ->  ['count']
    set_as_wkb               outParams = ['size_out'] -> ['size_out']

`geo_as_ewkb(gs, endian, size_t *size)` writes `*size = data_size` and answers
a `uint8_t *` holding exactly that many bytes, so the size is the only route to
how much of the answer is data, and a binding that must supply it has none.
`set_as_wkb` is the sibling over the same quantity, and it is the row that does
not move. The two `tsequenceset` walks name the count they write, their own
text already calling it "the output array". The five parsers take
`const char **str`, read through it and advance it past what they consume,
which is `@param[in,out]` — the spelling `tspatial_parser.c` carries for the
SRID it treats the same way.

MEASURED by that instrument: 721 functions carry an `@param[out]` here against
718 at eb5ddc576618, over 872 (function, parameter) pairs against 869. The
three gained are the three rows above; the difference in the other direction
holds NOTHING, so no existing out-parameter leaves. The five `[in,out]` parsers
add no pair, the extractor reading `[out]` alone, which is why the count moves
by three rather than eight. Each of the five compiled sources holds the same
bytes as eb5ddc576618 once comments come out, so no translation unit differs.
`check_param_direction.py` reads `OK: every @param[in] names a parameter the
function only reads, over 333 files`, and answers `geo_as_ewkb writes through
size, which its doxygen calls @param[in]` for a tree where that one tag reads
`[in]`.

WHY the direction belongs to the value, at the level of the model: a
parameter's direction states which side of the call owns the value it carries,
which is what a binding needs in order to decide whether to expose the
parameter or supply the storage itself. A pointer the callee writes through
carries an answer OUT, whoever allocated it, so `[in]` there describes the
pointer's own direction rather than the value's — the one thing the annotation
exists to say. Where the callee reads and writes, the value crosses both ways,
and the repository spells that `[in,out]`.

`tools/scripts/check_param_direction.py` holds the class closed, run by
check-code.yml beside the brief check. Its predicate is a DIRECT write in the
function's own body — `*name =` with comments out, an assignment inside a
comment being none — so every finding is provable from the one function a
reader is looking at. A parameter the function mutates only through a helper
falls outside the predicate and the docstring says so: widening to it needs the
call graph, and a finding a reader cannot confirm locally is one people learn
to override.

Nothing else sees this class. The compiler does not read comments, doxygen
renders whatever direction it is given, and the catalog's own cross-check runs
the other way — it drops an `@param[out]` the signature contradicts, which says
nothing about an `[out]` that is absent.

