### PR TITLE
Read a span index descent through the internal predicates

### DIFF
--- a/meos/src/temporal/span_index.c
+++ b/meos/src/temporal/span_index.c
@@ -53,6 +53,11 @@
 
 /**
  * @brief Leaf consistency for span types
+ * @details An index holds spans of one type -- the column fixes it, and the
+ * query span is built from the operand type the operator class declares -- so
+ * the two spans are comparable by construction. A descent therefore calls the
+ * internal predicates, which assert that contract; the external ones test it,
+ * and testing here would pay for it again at every entry the scan visits
  * @param[in] key Element in the index
  * @param[in] query Value being looked up in the index
  * @param[in] strategy Operator of the operator class being applied
@@ -65,28 +70,28 @@ span_index_leaf_consistent(const Span *key, const Span *query,
   switch (strategy)
   {
     case RTOverlapStrategyNumber:
-      return overlaps_span_span(key, query);
+      return span_overlaps(key, query);
     case RTContainsStrategyNumber:
-      return contains_span_span(key, query);
+      return span_contains(key, query);
     case RTContainedByStrategyNumber:
-      return contains_span_span(query, key);
+      return span_contains(query, key);
     case RTEqualStrategyNumber:
     case RTSameStrategyNumber:
       return span_eq(key, query);
     case RTAdjacentStrategyNumber:
-      return adjacent_span_span(key, query);
+      return span_adjacent(key, query);
     case RTLeftStrategyNumber:
     case RTBeforeStrategyNumber:
-      return left_span_span(key, query);
+      return span_left(key, query);
     case RTOverLeftStrategyNumber:
     case RTOverBeforeStrategyNumber:
-      return overleft_span_span(key, query);
+      return span_overleft(key, query);
     case RTRightStrategyNumber:
     case RTAfterStrategyNumber:
-      return right_span_span(key, query);
+      return span_right(key, query);
     case RTOverRightStrategyNumber:
     case RTOverAfterStrategyNumber:
-      return overright_span_span(key, query);
+      return span_overright(key, query);
     default:
       meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
         "unrecognized span strategy: %d", strategy);
@@ -108,25 +113,25 @@ span_gist_inner_consistent(const Span *key, const Span *query,
   {
     case RTOverlapStrategyNumber:
     case RTContainedByStrategyNumber:
-      return overlaps_span_span(key, query);
+      return span_overlaps(key, query);
     case RTContainsStrategyNumber:
     case RTEqualStrategyNumber:
     case RTSameStrategyNumber:
-      return contains_span_span(key, query);
+      return span_contains(key, query);
     case RTAdjacentStrategyNumber:
-      return adjacent_span_span(key, query) || overlaps_span_span(key, query);
+      return span_adjacent(key, query) || span_overlaps(key, query);
     case RTLeftStrategyNumber:
     case RTBeforeStrategyNumber:
-      return ! overright_span_span(key, query);
+      return ! span_overright(key, query);
     case RTOverLeftStrategyNumber:
     case RTOverBeforeStrategyNumber:
-      return ! right_span_span(key, query);
+      return ! span_right(key, query);
     case RTRightStrategyNumber:
     case RTAfterStrategyNumber:
-      return ! overleft_span_span(key, query);
+      return ! span_overleft(key, query);
     case RTOverRightStrategyNumber:
     case RTOverAfterStrategyNumber:
-      return ! left_span_span(key, query);
+      return ! span_left(key, query);
     default:
       meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
         "unrecognized span strategy: %d", strategy);

--- a/meos/src/temporal/span_spgist.c
+++ b/meos/src/temporal/span_spgist.c
@@ -247,6 +247,12 @@ getQuadrant2D(const Span *centroid, const Span *query)
 
 /**
  * @brief Can any span from nodebox overlap with the query?
+ * @details A node bounds spans of the tree's own type -- the centroid it is
+ * built from fixes it -- and the query span carries the operand type the
+ * operator class declares, so this predicate and the six below it compare
+ * spans that are comparable by construction. They therefore call the internal
+ * predicates, which assert that contract; the external ones test it, and a
+ * descent testing it here would pay for it once per node it visits
  */
 bool
 overlap2D(const SpanNode *nodebox, const Span *query)
@@ -254,7 +260,7 @@ overlap2D(const SpanNode *nodebox, const Span *query)
   Span s;
   span_set(nodebox->left.lower, nodebox->right.upper, nodebox->left.lower_inc,
     nodebox->right.upper_inc, nodebox->left.basetype, nodebox->left.spantype, &s);
-  return overlaps_span_span(&s, query);
+  return span_overlaps(&s, query);
 }
 
 /**
@@ -266,7 +272,7 @@ contain2D(const SpanNode *nodebox, const Span *query)
   Span s;
   span_set(nodebox->left.lower, nodebox->right.upper, nodebox->left.lower_inc,
     nodebox->right.upper_inc, nodebox->left.basetype, nodebox->left.spantype, &s);
-  return contains_span_span(&s, query);
+  return span_contains(&s, query);
 }
 
 /**
@@ -275,7 +281,7 @@ contain2D(const SpanNode *nodebox, const Span *query)
 bool
 left2D(const SpanNode *nodebox, const Span *query)
 {
-  return left_span_span(&nodebox->right, query);
+  return span_left(&nodebox->right, query);
 }
 
 /**
@@ -284,7 +290,7 @@ left2D(const SpanNode *nodebox, const Span *query)
 bool
 overLeft2D(const SpanNode *nodebox, const Span *query)
 {
-  return overleft_span_span(&nodebox->right, query);
+  return span_overleft(&nodebox->right, query);
 }
 
 /**
@@ -293,7 +299,7 @@ overLeft2D(const SpanNode *nodebox, const Span *query)
 bool
 right2D(const SpanNode *nodebox, const Span *query)
 {
-  return right_span_span(&nodebox->left, query);
+  return span_right(&nodebox->left, query);
 }
 
 /**
@@ -302,7 +308,7 @@ right2D(const SpanNode *nodebox, const Span *query)
 bool
 overRight2D(const SpanNode *nodebox, const Span *query)
 {
-  return overright_span_span(&nodebox->left, query);
+  return span_overright(&nodebox->left, query);
 }
 
 /**
@@ -311,8 +317,8 @@ overRight2D(const SpanNode *nodebox, const Span *query)
 bool
 adjacent2D(const SpanNode *nodebox, const Span *query)
 {
-  return adjacent_span_span(&nodebox->left, query) ||
-    adjacent_span_span(&nodebox->right, query);
+  return span_adjacent(&nodebox->left, query) ||
+    span_adjacent(&nodebox->right, query);
 }
 
 /**

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -185,12 +185,15 @@ bbox_expand_tpcbox(const void *box1, void *box2)
 /**
  * @brief Return `true` if the first span contains the second one, `false`
  * otherwise
+ * @details An R-tree stores homogeneous boxes -- same span type by
+ * construction -- so the validation of #contains_span_span is unnecessary here
+ * and the internal predicate, which asserts that contract, is called instead
  * @param[in] box1,box2 Spans
  */
 static inline bool
 bbox_contains_span(const void *box1, const void *box2)
 {
-  return contains_span_span((Span *) box1, (Span *) box2);
+  return span_contains((const Span *) box1, (const Span *) box2);
 }
 
 /**
@@ -259,7 +262,7 @@ bbox_overlaps_span(const void *box1, const void *box2)
 static bool
 bbox_adjacent_span(const void *box1, const void *box2)
 {
-  return adjacent_span_span((const Span *) box1, (const Span *) box2);
+  return span_adjacent((const Span *) box1, (const Span *) box2);
 }
 
 static bool
@@ -415,10 +418,10 @@ bbox_position_span(const void *box1, const void *box2, IndexSearchOp op)
   const Span *s2 = (const Span *) box2;
   switch (op)
   {
-    case INDEX_LEFT:      return left_span_span(s1, s2);
-    case INDEX_OVERLEFT:  return overleft_span_span(s1, s2);
-    case INDEX_RIGHT:     return right_span_span(s1, s2);
-    case INDEX_OVERRIGHT: return overright_span_span(s1, s2);
+    case INDEX_LEFT:      return span_left(s1, s2);
+    case INDEX_OVERLEFT:  return span_overleft(s1, s2);
+    case INDEX_RIGHT:     return span_right(s1, s2);
+    case INDEX_OVERRIGHT: return span_overright(s1, s2);
     default:              return false;
   }
 }

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -141,6 +141,14 @@ span_inner_consistent(const void *nodebox, const void *query, IndexSearchOp op)
   }
 }
 
+/**
+ * @brief Return true if a leaf entry satisfies the search operation
+ * @details A tree stores homogeneous spans -- same span type by construction,
+ * which #ensure_valid_sptree_box establishes at the entry point -- so the
+ * internal predicates, which assert that contract, are what the descent calls
+ * @param[in] key,query Spans
+ * @param[in] op Search operation
+ */
 static bool
 span_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
 {
@@ -148,15 +156,15 @@ span_leaf_consistent(const void *key, const void *query, IndexSearchOp op)
   const Span *q = (const Span *) query;
   switch (op)
   {
-    case INDEX_CONTAINS:      return contains_span_span(k, q);
-    case INDEX_CONTAINED_BY:  return contains_span_span(q, k);
-    case INDEX_SAME:          return contains_span_span(k, q) && contains_span_span(q, k);
-    case INDEX_ADJACENT:      return adjacent_span_span(k, q);
-    case INDEX_OVERLAPS:      return overlaps_span_span(k, q);
-    case INDEX_LEFT:          return left_span_span(k, q);
-    case INDEX_OVERLEFT:      return overleft_span_span(k, q);
-    case INDEX_RIGHT:         return right_span_span(k, q);
-    case INDEX_OVERRIGHT:     return overright_span_span(k, q);
+    case INDEX_CONTAINS:      return span_contains(k, q);
+    case INDEX_CONTAINED_BY:  return span_contains(q, k);
+    case INDEX_SAME:          return span_contains(k, q) && span_contains(q, k);
+    case INDEX_ADJACENT:      return span_adjacent(k, q);
+    case INDEX_OVERLAPS:      return span_overlaps(k, q);
+    case INDEX_LEFT:          return span_left(k, q);
+    case INDEX_OVERLEFT:      return span_overleft(k, q);
+    case INDEX_RIGHT:         return span_right(k, q);
+    case INDEX_OVERRIGHT:     return span_overright(k, q);
     default:
       /* A span has one dimension, which the value operations order */
       return false;


### PR DESCRIPTION
An index establishes the validity of its operands once, where the scan key
becomes a box, and every comparison the descent then makes may assume it. The
span index instead reached its answers through the external predicates, each of
which tests that validity again, so a scan paid for `ensure_valid_span_span` at
every entry and every node it visited.

The witness is a plain lookup. `SELECT * FROM tbl_intspan WHERE i && intspan
'[1, 5]'` descends the GiST tree calling `span_gist_inner_consistent` per inner
page and `span_index_leaf_consistent` per leaf entry, and each of those called
`overlaps_span_span`, whose body is `if (! ensure_valid_span_span(s1, s2))
return false; return span_overlaps(s1, s2);`. The answer is the same either way
-- what the entry pays for is two `VALIDATE_NOT_NULL` expansions and an
`ensure_same_span_type` in front of the two `datum_cmp` calls that are the whole
of the work.

The operands are comparable by construction, which is why the test can be
dropped rather than merely moved. A column fixes the span type, and the query
span is built from the operand type the operator class declares -- every branch
of `span_gist_get_span` derives it from the scan key's own subtype -- so it
cannot produce a span of another type than the key. That is exactly the contract
`span_overlaps` and its siblings assert, and asserting a contract the caller
guarantees is what an internal predicate is for; testing it is what the external
one is for, and the external one is called at the entry point.

Measured, nothing else moves. A two-arm run over 16 span literals crossed with
themselves against all 14 GiST strategies -- 3584 answers, `errno` recorded after
every call -- is identical between this commit and its base, with 1118 true leaf
answers and 1564 true inner answers so the corpus reaches both switches. The
kernel corpus of 3141 answers moves one line, `time_of_day()`, which reports the
wall clock and cannot repeat across two runs. `pg_regress` passes in full on
PostgreSQL 18, both targets build with every family flag and no warning, and the
MSYS2 UCRT64 build is clean. The change is not on a measured hot path in this
suite, so no timing is claimed for it.

The three consistency functions therefore call the internal twins.
`span_index_leaf_consistent` and `span_gist_inner_consistent` serve the
PostgreSQL GiST and SP-GiST opclasses for both spans and span sets, and
`span_leaf_consistent` serves the in-memory SP-tree, where
`ensure_valid_sptree_box` establishes the same contract at the entry point. The
R-tree callbacks follow the reasoning `bbox_overlaps_span` already carries in
that file.

The equality case of the leaf switch was already reading `span_eq`, the internal
twin, beside eight neighbours that were not.

Why the internal twin is the right answer rather than a cheaper one: a MEOS
predicate exists in two halves on purpose. The external half owns the question
"are these two operands comparable at all", answers it to a caller who may have
built them from anywhere, and reports through `meos_error` because that caller
has no other channel. The internal half owns the relation itself and states its
precondition as an assertion, because its callers are the ones that already know.
An index is the clearest case of a caller that knows: it holds a homogeneous
structure, and it establishes that homogeneity once at the entry point precisely
so the descent need not ask again. Calling the external half from inside the
descent asks a question whose answer the structure already fixed, and it asks it
once per page rather than once per scan. The change does not weaken a check; it
puts the check where the knowledge is, which is the same division of labour
`span_overlaps` and `overlaps_span_span` were written to express.

