### PR TITLE
Name the point cloud box in the union that holds every bounding box

### DIFF
--- a/meos/include/meos.h
+++ b/meos/include/meos.h
@@ -207,6 +207,31 @@ typedef struct
 } STBox;
 
 /**
+ * Structure to represent point cloud spatiotemporal boxes
+ *
+ * Every field down to the flags is byte-identical to #STBox, so the shared
+ * spatiotemporal code reads a TPCBox through an @p STBox pointer and projects
+ * it to one by dropping the trailing pcid. The pgpointcloud schema id follows
+ * that common prefix, since boxes of different schemas name different
+ * dimensions and cannot be compared. @p meos_pointcloud.h asserts the shared
+ * offsets field by field.
+ */
+typedef struct
+{
+  Span period;          /**< time span */
+  double xmin;          /**< minimum x value */
+  double ymin;          /**< minimum y value */
+  double zmin;          /**< minimum z value */
+  double xmax;          /**< maximum x value */
+  double ymax;          /**< maximum y value */
+  double zmax;          /**< maximum z value */
+  int32_t srid;         /**< SRID */
+  int16 flags;          /**< flags */
+  char padding[2];      /**< explicit pad, kept zero: send/recv copy the struct */
+  uint32_t pcid;        /**< pgpointcloud schema id */
+} TPCBox;
+
+/**
  * @brief Enumeration that defines the temporal subtypes used in MEOS
  */
 typedef enum

--- a/meos/include/meos_pointcloud.h
+++ b/meos/include/meos_pointcloud.h
@@ -63,36 +63,12 @@ typedef struct Pcpatch Pcpatch;
  * pointer; obtain one via @ref meos_pc_schema. */
 typedef struct PCSCHEMA PCSCHEMA;
 
-/**
- * @brief Bounding box for pgpointcloud temporal types.
- *
- * Mirrors STBox (spatiotemporal box) but carries an additional @p pcid
- * field — pgpointcloud schema id — because TPCBoxes from different
- * schemas cannot meaningfully be compared / unioned (the underlying
- * dimensions are schema-specific). Fixed-size struct; no varlena.
- *
- * Flag bits live in @p MEOS_FLAGS_* (see @p meos_internal.h): @p X
- * (bounds present), @p Z (z-dimension present), @p T (time span
- * present), @p GEODETIC (geographic coords). A TPCBox must have at
- * least one of X or T.
- */
-typedef struct
-{
-  Span period;        /**< time span */
-  double xmin;        /**< minimum x value */
-  double ymin;        /**< minimum y value */
-  double zmin;        /**< minimum z value */
-  double xmax;        /**< maximum x value */
-  double ymax;        /**< maximum y value */
-  double zmax;        /**< maximum z value */
-  int32_t srid;       /**< SRID */
-  int16 flags;        /**< flags */
-  /* Every field above is byte-identical to STBox, so a TPCBox is read
-   * through an @p STBox pointer by the shared spatiotemporal code. The
-   * pgpointcloud schema id follows that common prefix. */
-  char padding[2];    /**< explicit pad, kept zero: send/recv copy the struct */
-  uint32_t pcid;      /**< pgpointcloud schema id */
-} TPCBox;
+/* @p TPCBox is declared in @p meos.h beside the three other bounding boxes
+ * (@p Span, @p TBox, @p STBox), so that every box type is one member of
+ * @p bboxunion. Its flag bits live in @p MEOS_FLAGS_* (see
+ * @p meos_internal.h): @p X (bounds present), @p Z (z-dimension present),
+ * @p T (time span present), @p GEODETIC (geographic coords). A TPCBox must
+ * have at least one of X or T. */
 
 /* A TPCBox begins with a whole STBox: every STBox field sits at the same
  * offset, so the shared spatiotemporal code reads a TPCBox through an

--- a/meos/include/temporal/temporal.h
+++ b/meos/include/temporal/temporal.h
@@ -280,8 +280,7 @@ typedef union bboxunion
   TBox b;      /**< Temporal box */
   STBox g;     /**< Spatiotemporal box */
 #if POINTCLOUD
-  /* TPCBox is 88 bytes (vs STBox 80) — shares Span+xyz prefix layout */
-  char tpc[88];
+  TPCBox c;    /**< Point cloud spatiotemporal box */
 #endif
 } bboxunion;
 


### PR DESCRIPTION
`bboxunion` exists so that any bounding box can be stacked in one automatic
variable and passed to the generic code that does not know which box it holds.
Three of its four members name their type. The fourth spelled the point cloud
box as `char tpc[88]`, a byte count written by hand, because `TPCBox` was the
one bounding box declared outside `meos.h` and so was not in scope where the
union is defined.

The witness is the field nobody has added yet. Give `TPCBox` one more `double`
-- the ordinary way a box type grows -- and the union does not follow it:
`sizeof(TPCBox)` reads 96 while `sizeof(bboxunion)` stays 88, so a TPCBox
written into a bboxunion overruns it by eight bytes. That build is clean. No
warning names the eight bytes, because nothing relates the literal to the
type: `meos_pointcloud.h` asserts the TPCBox layout against STBox field by
field -- ten `static_assert`s covering every shared offset, the flags among
them -- and not one of them reaches the union. The assertion that would have
caught it is the one nobody wrote, and every generic path that stacks a box
and writes a TPCBox into it runs off the end of the object.

The type therefore joins its three siblings. `Span`, `TBox` and `STBox` are
declared consecutively in `meos.h`, and `TPCBox` now follows `STBox` there. It
is declared unconditionally, as those three are: the layout assertions that
stay behind in `meos_pointcloud.h` name it whatever the family flag says, so a
guarded declaration leaves that header unable to compile on its own. The
declaration moves whole, comment included, and `meos_pointcloud.h` keeps both
the assertions -- which still see STBox, since it includes `meos.h` -- and the
family surface that is genuinely its own. A consumer that includes only
`meos_pointcloud.h` still sees the type for the same reason.

The union member is then `TPCBox c`, and the size follows the type. The same
added field now reads `sizeof(TPCBox) = 96`, `sizeof(bboxunion) = 96`, and an
overrun of zero. The member alone stays behind the family guard, so a build
without the point cloud family keeps the union at the width its three remaining
members need.

Why the size and not an assertion is the right answer: a `static_assert` tying
88 to `sizeof(TPCBox)` would also have caught the overrun, and would leave the
union stating a fact about a type it cannot name. The union's job is to be wide
enough for every bounding box, which is a question about the set of box types,
so it is answered by listing them -- and a member that names its type cannot
disagree with it. That is what the other three members already do.

Measured, nothing moves. `sizeof(bboxunion)` is 88 and `_Alignof` is 8, both
before and after, with `Span` 24, `TBox` 56, `STBox` 80 and `TPCBox` 88
unchanged; the alignment is no longer incidental, since a `char` array carries
alignment 1 and left the union's 8 resting on the other three members. No
caller names the member -- the union is written through as a whole, and the
old `tpc` spelling has no readers. `pg_regress` passes in full on PostgreSQL
18, both targets build with every family flag and no warning, the MSYS2 UCRT64
build is clean, and the generated smoke suites run 0 validation warnings.

