### PR TITLE
Say that the minimum spatial distance ignores time

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1099,7 +1099,7 @@
 					<para><link linkend="tgeo_nearestApproachInstant"><varname>nearestApproachInstant</varname></link>: Devuelve el instante del primer punto temporal en el que los dos argumentos están a la distancia más cercana &Z_support; &geography_support;</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tgeo_minDistance"><varname>minDistance</varname></link>: Devuelve la distancia espacial mínima entre dos geometrías temporales sobre la unión de sus extensiones temporales</para>
+					<para><link linkend="tgeo_minDistance"><varname>minDistance</varname></link>: Devuelve la distancia espacial mínima entre dos geometrías temporales, ignorando el tiempo</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tgeo_setset_join"><varname>eDwithinPairs</varname>, <varname>aDwithinPairs</varname>, <varname>tDwithinPairs</varname>, <varname>eIntersectsPairs</varname>, <varname>aIntersectsPairs</varname>, <varname>tIntersectsPairs</varname>, <varname>eDisjointPairs</varname>, <varname>aDisjointPairs</varname>, <varname>tDisjointPairs</varname>, <varname>eTouchesPairs</varname>, <varname>aTouchesPairs</varname>, <varname>tTouchesPairs</varname></link>: Devuelve los pares de índices que cumplen la relación entre dos arreglos de geometrías temporales, generalizando las relaciones espaciales escalares a una unión espacial conjunto-conjunto</para>

--- a/doc/es/temporal_spatial_p2.xml
+++ b/doc/es/temporal_spatial_p2.xml
@@ -255,13 +255,13 @@ SELECT to_timestamp(ST_ClosestPointOfApproach( tgeompoint '[Point(0 0 0)@2001-01
 
 			<listitem xml:id="tgeo_minDistance">
 				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
-				<para>Devuelve la distancia espacial mínima entre dos geometrías temporales sobre la unión de sus extensiones temporales</para>
+				<para>Devuelve la distancia espacial mínima entre dos geometrías temporales, ignorando el tiempo</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 minDistance({tgeo,geo},{tgeo,geo}) → float
 minDistance(tgeo[],tgeo[]) → float
 minDistance(tgeo,tgeo) → float
 </programlisting>
-				<para>La forma escalar devuelve la distancia mínima alcanzada entre los dos argumentos sobre la intersección de sus extensiones temporales, equivalente al valor mínimo de la distancia temporal <varname>&lt;-&gt;</varname>. La forma de arreglo generaliza esto a dos conjuntos de geometrías temporales y devuelve el mínimo sobre todos los pares. La forma de agregado, utilizada con <varname>GROUP BY</varname>, devuelve la distancia mínima alcanzada sobre todos los pares agregados en el grupo.</para>
+				<para>La distancia se mide entre las dos trayectorias descartando el tiempo, igual a <varname>ST_Distance</varname> de la trayectoria de cada argumento. Por lo tanto, dos valores que siguen el mismo camino en momentos distintos están a distancia cero. La cantidad sincronizada en el tiempo, que compara los dos argumentos solo en los instantes que comparten, es <link linkend="tgeo_nearestApproachDistance"><varname>nearestApproachDistance</varname></link>. La forma de arreglo generaliza esto a dos conjuntos de geometrías temporales y devuelve el mínimo sobre todos los pares. La forma de agregado, utilizada con <varname>GROUP BY</varname>, devuelve la distancia mínima alcanzada sobre todos los pares agregados en el grupo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minDistance(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)',
   geometry 'Point(0 1)');

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1099,7 +1099,7 @@
 					<para><link linkend="tgeo_nearestApproachInstant"><varname>nearestApproachInstant</varname></link>: Return the instant of the first temporal point at which the two arguments are at the nearest distance &Z_support; &geography_support;</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tgeo_minDistance"><varname>minDistance</varname></link>: Return the minimum spatial distance between two temporal geometries over the union of their temporal extents</para>
+					<para><link linkend="tgeo_minDistance"><varname>minDistance</varname></link>: Return the minimum spatial distance between two temporal geometries, ignoring time</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tgeo_setset_join"><varname>eDwithinPairs</varname>, <varname>aDwithinPairs</varname>, <varname>tDwithinPairs</varname>, <varname>eIntersectsPairs</varname>, <varname>aIntersectsPairs</varname>, <varname>tIntersectsPairs</varname>, <varname>eDisjointPairs</varname>, <varname>aDisjointPairs</varname>, <varname>tDisjointPairs</varname>, <varname>eTouchesPairs</varname>, <varname>aTouchesPairs</varname>, <varname>tTouchesPairs</varname></link>: Return the qualifying index pairs of two arrays of temporal geometries, generalising the scalar spatial relationships to a set-set spatial join</para>

--- a/doc/temporal_spatial_p2.xml
+++ b/doc/temporal_spatial_p2.xml
@@ -254,13 +254,13 @@ SELECT to_timestamp(ST_ClosestPointOfApproach( tgeompoint '[Point(0 0 0)@2001-01
 
 			<listitem xml:id="tgeo_minDistance">
 				<indexterm significance="normal"><primary><varname>minDistance</varname></primary></indexterm>
-				<para>Return the minimum spatial distance between two temporal geometries over the union of their temporal extents</para>
+				<para>Return the minimum spatial distance between two temporal geometries, ignoring time</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 minDistance({tgeo,geo},{tgeo,geo}) → float
 minDistance(tgeo[],tgeo[]) → float
 minDistance(tgeo,tgeo) → float
 </programlisting>
-				<para>The scalar form returns the minimum distance reached between the two arguments over the intersection of their temporal extents, equivalent to the minimum value of the temporal distance <varname>&lt;-&gt;</varname>. The array form generalises this to two sets of temporal geometries and returns the minimum across all pairs. The aggregate form, used with <varname>GROUP BY</varname>, returns the minimum distance reached over all aggregated pairs in the group.</para>
+				<para>The distance is measured between the two trajectories with time discarded, equal to <varname>ST_Distance</varname> of the trajectory of each argument. Two values that follow the same path at different times are therefore at distance zero. The time-synchronous quantity, which compares the two arguments only at the instants they share, is <link linkend="tgeo_nearestApproachDistance"><varname>nearestApproachDistance</varname></link>. The array form generalises this to two sets of temporal geometries and returns the minimum across all pairs. The aggregate form, used with <varname>GROUP BY</varname>, returns the minimum distance reached over all aggregated pairs in the group.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT minDistance(tgeompoint '[Point(0 0)@2001-01-01, Point(1 1)@2001-01-03)',
   geometry 'Point(0 1)');


### PR DESCRIPTION
minDistance compares the two trajectories with time discarded. Probed against
libmeos, two temporal points that follow the same path a year apart read 0.000000
where nearestApproachDistance reads DBL_MAX, and two paths that cross without
sharing time read 0.000000 likewise.

The temporal geometry chapter describes the opposite twice: the entry says the
distance is taken over the union of the temporal extents, and the explanation
says the scalar form measures over their intersection and is equivalent to the
minimum value of the temporal distance. That second sentence describes
nearestApproachDistance, the time-synchronous quantity.

The entry now states that the distance ignores time, that it equals ST_Distance
of the trajectory of each argument, that two values following one path at
different times are at distance zero, and that nearestApproachDistance is the
time-synchronous quantity, which it links. The wording matches the temporal
circular buffer chapter, which already describes its own minDistance this way.
The reference index carries the same one-liner in both languages.

