### PR TITLE
Ask a point cloud box pair for the axis they share

### DIFF
--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -438,6 +438,7 @@ SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
 		<sect2 xml:id="tpcbox_topo">
 			<title>Operaciones topológicas</title>
 			<para>Todos los operadores topológicos toman dos valores <varname>tpcbox</varname> que declaran el mismo esquema y el mismo sistema de referencia. Una discrepancia en cualquiera de los dos genera un error en lugar de responder falso: el <varname>pcid</varname> es lo que da a un número almacenado su significado como coordenada, por lo que dos cajas que nombran esquemas distintos no tienen una extensión común que comparar.</para>
+			<para>También toman dos cajas que comparten un eje. Una caja que contiene coordenadas y una caja que contiene un período no coinciden en ningún eje, por lo que un predicado topológico entre ellas no tiene nada que comparar y genera un error a su vez.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_topo_ops">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
@@ -462,6 +463,8 @@ SELECT tpcboxX(0, 0, 2, 2) -|- tpcboxX(5, 5, 7, 7);
 -- f
 SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(0, 0, 5, 5, 2);
 -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
+SELECT tpcboxX(0, 0, 10, 10, 1) &amp;&amp; tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+-- ERROR:  The temporal values must have at least one common dimension
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -440,6 +440,7 @@ SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
 		<sect2 xml:id="tpcbox_topo">
 			<title>Topological Operations</title>
 			<para>All topological operators take two <varname>tpcbox</varname> values that state the same schema and the same reference system. A mismatch in either raises an error rather than answering false: the <varname>pcid</varname> is what gives a stored number its meaning as a coordinate, so two boxes naming different schemas have no common extent to compare.</para>
+			<para>They also take two boxes sharing an axis. A box holding coordinates and a box holding a period meet on no axis at all, so a topological predicate between them has nothing to compare and raises in its turn.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_topo_ops">
 					<indexterm significance="normal"><primary><varname>&amp;&amp;</varname></primary></indexterm>
@@ -464,6 +465,8 @@ SELECT tpcboxX(0, 0, 2, 2) -|- tpcboxX(5, 5, 7, 7);
 -- f
 SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(0, 0, 5, 5, 2);
 -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
+SELECT tpcboxX(0, 0, 10, 10, 1) &amp;&amp; tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+-- ERROR:  The temporal values must have at least one common dimension
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -1033,7 +1033,8 @@ bool
 contains_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2))
+  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
+      ! ensure_common_dimension(box1->flags, box2->flags))
     return false;
   return tpcbox_contains(box1, box2);
 }
@@ -1059,7 +1060,8 @@ bool
 contained_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2))
+  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
+      ! ensure_common_dimension(box1->flags, box2->flags))
     return false;
   return tpcbox_contained(box1, box2);
 }
@@ -1085,7 +1087,8 @@ bool
 overlaps_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2))
+  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
+      ! ensure_common_dimension(box1->flags, box2->flags))
     return false;
   return tpcbox_overlaps(box1, box2);
 }
@@ -1113,7 +1116,8 @@ bool
 same_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2))
+  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
+      ! ensure_common_dimension(box1->flags, box2->flags))
     return false;
   return tpcbox_same(box1, box2);
 }
@@ -1139,7 +1143,8 @@ bool
 adjacent_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2))
+  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
+      ! ensure_common_dimension(box1->flags, box2->flags))
     return false;
   return tpcbox_adjacent(box1, box2);
 }

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -264,6 +264,40 @@ SELECT adjacent(tpcboxX(0, 0, 5, 5, 1), tpcboxX(5, 0, 10, 5, 1));
  t
 (1 row)
 
+SELECT tpcboxX(0, 0, 10, 10, 1) && tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+ERROR:  The temporal values must have at least one common dimension
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+ERROR:  The temporal values must have at least one common dimension
+SELECT tpcboxX(0, 0, 10, 10, 1) <@ tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+ERROR:  The temporal values must have at least one common dimension
+SELECT tpcboxX(0, 0, 10, 10, 1) -|- tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+ERROR:  The temporal values must have at least one common dimension
+SELECT tpcboxX(0, 0, 10, 10, 1) ~= tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+ERROR:  The temporal values must have at least one common dimension
+SELECT overlaps(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+ERROR:  The temporal values must have at least one common dimension
+SELECT contains(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+ERROR:  The temporal values must have at least one common dimension
+SELECT contained(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+ERROR:  The temporal values must have at least one common dimension
+SELECT adjacent(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+ERROR:  The temporal values must have at least one common dimension
+SELECT same(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+ERROR:  The temporal values must have at least one common dimension
+SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1) &&
+  tpcboxX(2, 2, 8, 8, 1);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1) &&
+  tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 0);
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxX(2, 2, 8, 8, 2);
 ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 SELECT tpcboxX(0, 0, 5, 5, 1)   && tpcboxX(0, 0, 5, 5, 2);

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -142,6 +142,33 @@ SELECT tpcboxX(0, 0, 5, 5, 1)  -|- tpcboxX(5, 0, 10, 5, 1);
 SELECT adjacent(tpcboxX(0, 0, 5, 5, 1), tpcboxX(5, 0, 10, 5, 1));
 
 -------------------------------------------------------------------------------
+-- Topological predicates — the boxes must share a dimension to be compared
+-------------------------------------------------------------------------------
+
+-- A box holding coordinates and a box holding a period have no axis in
+-- common, so there is nothing for a topological predicate to compare and it
+-- has no answer to give. The box naming no schema is comparable with any
+-- schema, which leaves the shared dimension the only question left to fail on
+SELECT tpcboxX(0, 0, 10, 10, 1) && tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) <@ tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) -|- tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+SELECT tpcboxX(0, 0, 10, 10, 1) ~= tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
+
+-- The portable spelling of each of them refuses the same pair
+SELECT overlaps(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+SELECT contains(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+SELECT contained(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+SELECT adjacent(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+SELECT same(tpcboxX(0, 0, 10, 10, 1), tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0));
+
+-- A box carrying both axes shares one with each of them, so it is compared
+SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1) &&
+  tpcboxX(2, 2, 8, 8, 1);
+SELECT tpcboxXT(0, 0, 10, 10, tstzspan '[2024-01-01, 2024-01-31]', 1) &&
+  tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 0);
+
+-------------------------------------------------------------------------------
 -- Topological predicates — the schema decides what a coordinate means
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
A box holding coordinates and a box holding a period meet on no axis, so a
topological predicate between them has nothing to compare. The five topological
entries of the point cloud box compose the two questions their siblings compose,
in the order doc/contributing/bbox_validation_design_notes.md section 4.1 fixes:
the schema and reference system each box states, then the axis the pair shares.
The second is the primitive every bounding box family already reads, so a point
cloud box adds nothing to it.

Witness, on master, a pair whose boxes share no axis and are answered anyway:

  SELECT tpcboxX(0, 0, 10, 10, 1) @> tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
  -- t
  SELECT tpcboxX(0, 0, 10, 10, 1) && tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
  -- t

Both now raise `The temporal values must have at least one common dimension`,
which is what the same pair already raises written as a tbox and as an stbox.

Why that t is wrong rather than merely undefined: stbox_stbox_flags takes the
conjunction of the two flag words, so an X-only box against a T-only box yields
hasx and hast both false, every guarded comparison is skipped, and contains
falls out of the bottom of its own body as true. The value reports containment
that nothing established. A predicate over an empty set of shared axes has no
answer to give, which is why the two sibling families reject the pair instead of
returning one, and the point cloud box is the only one of the four that did not
ask.

Measured. The full pg_regress suite passes on PostgreSQL 18 through the
baseline-diff against master, and 1 of the 320 expected files changes: the 32
added lines of 410_tpcbox, one hunk, nothing removed. The 22 *topops* expected
files are all unchanged, so no family that routes a temporal value through its
bounding box moves. libmeos, the extension and the extension without families
all build with zero warnings; the meos test suite runs clean over 55 invocations
and threaded_test 8 5000 is clean under ThreadSanitizer. The added check is two
flag-word reads on a path that already reads the same word, so it carries no
measurable cost.

Both manuals state the second requirement beside the first, and the value-level
suite carries the pair each of the five operators refuses together with the pairs
a box carrying both axes still answers.

