### PR TITLE
Read a bounding box frame only where the operation reads that axis

### DIFF
--- a/doc/contributing/bbox_validation_design_notes.md
+++ b/doc/contributing/bbox_validation_design_notes.md
@@ -340,18 +340,41 @@ if (! ensure_valid_stbox_stbox(box1, box2) ||
   return false;
 ```
 
-### 4.1 Layer 1 is called first, always
+### 4.1 Layer 1 is asked about the axes the operation reads
 
-Where an operation composes the checks inline, the layer-1 call is first in the
-chain; where an operation-class helper exists, it calls layer 1 as its first
-statement.
+An operation validates the frame of every axis it reads, and of no other. Which
+axes those are is what decides whether the layer-1 question arises at all.
 
-This is a rule rather than a preference, for two reasons. Comparability is the
-more fundamental failure — mixing metres with feet is wrong regardless of which
-dimensions happen to be present, so it is what the caller needs to be told. And
-fixing the order makes the diagnostic deterministic: a pair of boxes failing both
-checks reports the same error wherever it enters, rather than whichever failure
-the local author happened to test first.
+Read the frame column of the table in §1 and every entry governs coordinates: a
+span type says what the value extent measures, an SRID and the geodetic bit say
+where the coordinates are, a `pcid` says which schema they are read in. **No box
+type carries a frame field for the time axis.** A timestamp means the same thing
+in every reference system and under every schema, so an operation that compares
+only periods has no frame to disagree about, and asking would refuse a pair it can
+answer.
+
+That gives one rule per operation class:
+
+```
+topological   reads every shared axis  -> the coordinate frame, when both carry X
+position on X/Y/Z  reads coordinates   -> the coordinate frame
+position on T      reads periods       -> nothing to ask
+```
+
+The validators of §2 already carry the same principle one level down: each gates
+its frame predicates on `MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags)`,
+so a box holding no coordinates states no reference system and is comparable with
+any. A topological operation therefore calls the validator unconditionally and
+lets it decide, while a `before` / `after` / `overbefore` / `overafter` does not
+call it at all. `Span` is not an exception: its one axis is the axis every
+operation on it reads, so its validator is always called.
+
+**Where layer 1 is asked, it is asked first.** Comparability is the more
+fundamental failure — mixing metres with feet is wrong regardless of which
+dimensions happen to be present, so it is what the caller needs to be told — and
+fixing the order makes the diagnostic deterministic: a pair failing both checks
+reports the same error wherever it enters, rather than whichever failure the local
+author happened to test first.
 
 ---
 
@@ -488,7 +511,9 @@ Wiring is `new_temporal_type.md` §3.4. The validation contract is this:
    box type must appear in (§2.2); `new_temporal_type.md` §3.4 lists the rest.
 6. **Add nothing to layer 2** (§4). If a dimension primitive seems to be missing,
    check whether the constraint is really frame.
-7. **Call layer 1 first in every operation** (§4.1).
+7. **Ask layer 1 about the axes the operation reads, and ask it first** (§4.1).
+   An operation over periods alone asks nothing: no box type carries a frame
+   field for the time axis.
 8. **Compare frame fields strictly** (§5.2). Absorb belongs to parsers and
    constructors, and there the mismatch branch is mandatory (§5.1).
 9. **Never fill an unset frame field during an expand or merge** (§5.2).

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -472,7 +472,7 @@ SELECT tpcboxX(0, 0, 10, 10, 1) &amp;&amp; tpcboxT(tstzspan '[2024-01-01, 2024-0
 
 		<sect2 xml:id="tpcbox_pos">
 			<title>Operaciones de posición</title>
-			<para>Dieciséis predicados de posición alineados por eje, paralelos a los de <varname>stbox</varname>. Cada uno comprueba la relación estricta o de solapamiento a lo largo de un eje. Todos requieren el mismo esquema y el mismo sistema de referencia, y una discrepancia en cualquiera de los dos genera un error. Los predicados del eje Z requieren que ambas cajas tengan dimensión Z; los del eje T requieren que ambas tengan dimensión T.</para>
+			<para>Dieciséis predicados de posición alineados por eje, paralelos a los de <varname>stbox</varname>. Cada uno comprueba la relación estricta o de solapamiento a lo largo de un eje. Los doce que leen coordenadas requieren el mismo esquema y el mismo sistema de referencia, y una discrepancia en cualquiera de los dos genera un error; los cuatro que leen el eje temporal no requieren ninguno de los dos, ya que una marca de tiempo significa lo mismo sea cual sea el esquema en el que se leen las coordenadas. Todo predicado requiere que ambas cajas lleven el eje que él lee, de modo que los del eje Z necesitan una dimensión Z en ambas y los del eje T un período en ambas.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_pos_ops">
 					<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>
@@ -504,11 +504,16 @@ SELECT tpcboxX(0, 0, 2, 2) &lt;&lt; tpcboxX(5, 5, 7, 7);
 -- t
 SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;| tpcboxX(5, 5, 7, 7);
 -- t
--- Neither box carries a z dimension or a time span, so those tests are false.
+-- Neither box carries a z dimension or a time span, so neither of the next two
+-- has an axis to compare along. The last pair states two schemas, which the
+-- time axis does not read.
 SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;/ tpcboxX(5, 5, 7, 7);
--- f
+-- ERROR:  The tpcbox must have Z dimension
 SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;# tpcboxX(5, 5, 7, 7);
--- f
+-- ERROR:  The tpcbox must have T dimension
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) &lt;&lt;#
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 2);
+-- t
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -474,7 +474,7 @@ SELECT tpcboxX(0, 0, 10, 10, 1) &amp;&amp; tpcboxT(tstzspan '[2024-01-01, 2024-0
 
 		<sect2 xml:id="tpcbox_pos">
 			<title>Position Operations</title>
-			<para>Sixteen axis-aligned position predicates, parallel to those on <varname>stbox</varname>. Each tests strict-or-overlap relationship along one axis. All require the same schema and the same reference system, and a mismatch in either raises an error. Z-axis predicates require both boxes to have a Z dimension; T-axis predicates require both to have a T dimension.</para>
+			<para>Sixteen axis-aligned position predicates, parallel to those on <varname>stbox</varname>. Each tests a strict-or-overlap relationship along one axis. The twelve that read coordinates require the same schema and the same reference system, and a mismatch in either raises an error; the four that read the time axis require neither, a timestamp meaning the same thing whichever schema the coordinates are read in. Every predicate requires both boxes to carry the axis it reads, so the Z-axis ones need a Z dimension in both and the T-axis ones a time span in both.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_pos_ops">
 					<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>
@@ -506,11 +506,16 @@ SELECT tpcboxX(0, 0, 2, 2) &lt;&lt; tpcboxX(5, 5, 7, 7);
 -- t
 SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;| tpcboxX(5, 5, 7, 7);
 -- t
--- Neither box carries a z dimension or a time span, so those tests are false.
+-- Neither box carries a z dimension or a time span, so neither of the next two
+-- has an axis to compare along. The last pair states two schemas, which the
+-- time axis does not read.
 SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;/ tpcboxX(5, 5, 7, 7);
--- f
+-- ERROR:  The tpcbox must have Z dimension
 SELECT tpcboxX(0, 0, 2, 2) &lt;&lt;# tpcboxX(5, 5, 7, 7);
--- f
+-- ERROR:  The tpcbox must have T dimension
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) &lt;&lt;#
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 2);
+-- t
 </programlisting>
 				</listitem>
 			</itemizedlist>

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -1657,8 +1657,8 @@ bool
 before_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
-      ! ensure_has_T(T_TPCBOX, box1->flags) ||
+  VALIDATE_TPCBOX(box1, false); VALIDATE_TPCBOX(box2, false);
+  if (! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
   return tpcbox_before(box1, box2);
@@ -1687,8 +1687,8 @@ bool
 overbefore_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
-      ! ensure_has_T(T_TPCBOX, box1->flags) ||
+  VALIDATE_TPCBOX(box1, false); VALIDATE_TPCBOX(box2, false);
+  if (! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
   return tpcbox_overbefore(box1, box2);
@@ -1717,8 +1717,8 @@ bool
 after_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
-      ! ensure_has_T(T_TPCBOX, box1->flags) ||
+  VALIDATE_TPCBOX(box1, false); VALIDATE_TPCBOX(box2, false);
+  if (! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
   return tpcbox_after(box1, box2);
@@ -1747,8 +1747,8 @@ bool
 overafter_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpcbox_tpcbox(box1, box2) ||
-      ! ensure_has_T(T_TPCBOX, box1->flags) ||
+  VALIDATE_TPCBOX(box1, false); VALIDATE_TPCBOX(box2, false);
+  if (! ensure_has_T(T_TPCBOX, box1->flags) ||
       ! ensure_has_T(T_TPCBOX, box2->flags))
     return false;
   return tpcbox_overafter(box1, box2);

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -328,6 +328,44 @@ SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) +
  TPCBOX(T([Mon Jan 01 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]), 0)
 (1 row)
 
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) <<#
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) &<#
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 1) #>>
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 1) #&>
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 2);
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) <<
+  tpcboxXT(10, 10, 20, 20, tstzspan '[2025-01-01, 2025-01-15]', 2);
+ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) <<|
+  tpcboxXT(10, 10, 20, 20, tstzspan '[2025-01-01, 2025-01-15]', 2);
+ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
+SELECT tpcboxX(0, 0, 2, 2, 1) <</ tpcboxX(5, 5, 7, 7, 1);
+ERROR:  The tpcbox must have Z dimension
+SELECT tpcboxX(0, 0, 2, 2, 1) <<# tpcboxX(5, 5, 7, 7, 1);
+ERROR:  The tpcbox must have T dimension
 SELECT extent(b) FROM (VALUES (tpcboxX(0, 0, 5, 5, 1)),
   (tpcboxX(3, 3, 10, 10, 1))) t(b);
            extent            

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -200,6 +200,34 @@ SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) +
   tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 1);
 
 -------------------------------------------------------------------------------
+-- Position predicates — each asks about the axis it reads
+-------------------------------------------------------------------------------
+
+-- The time axis carries no schema and no reference system: a timestamp means
+-- the same thing whatever schema the coordinates are read in, so the four
+-- time-axis predicates compare two boxes of different schemas
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) <<#
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 2);
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) &<#
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 2);
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 1) #>>
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 2);
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 1) #&>
+  tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 2);
+
+-- The twelve that read coordinates still refuse the same pair, the schema being
+-- what gives a coordinate its meaning
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) <<
+  tpcboxXT(10, 10, 20, 20, tstzspan '[2025-01-01, 2025-01-15]', 2);
+SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) <<|
+  tpcboxXT(10, 10, 20, 20, tstzspan '[2025-01-01, 2025-01-15]', 2);
+
+-- Every predicate needs both boxes to carry the axis it reads, which two boxes
+-- of coordinates alone do not for the Z and the time axis
+SELECT tpcboxX(0, 0, 2, 2, 1) <</ tpcboxX(5, 5, 7, 7, 1);
+SELECT tpcboxX(0, 0, 2, 2, 1) <<# tpcboxX(5, 5, 7, 7, 1);
+
+-------------------------------------------------------------------------------
 -- Extent aggregation
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
A frame field says what an extent means, and every frame field the four
bounding box types carry governs coordinates: a span type says what the value
extent measures, an SRID and the geodetic bit say where the coordinates are, a
pcid says which schema they are read in. None of them governs the time axis. A
timestamp means the same thing in every reference system and under every
schema, so an operation that compares only periods has no frame to disagree
about.

Witness, a pair of point cloud boxes stating two schemas, compared along time:

  SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) <<#
    tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 2);
  -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2

It answers t, as the same question already does written as a tbox and as an
stbox, and as tgeompoint <<# tgeompoint already does across two SRIDs. The four
time-axis predicates of the point cloud box take VALIDATE_TPCBOX and the two
ensure_has_T their siblings take, and stop calling the frame validator. The
twelve that read coordinates keep it.

Why the refusal was the wrong answer rather than a strict one: the box pair is
not being asked anything about coordinates, so there is no metre against a yard
to catch. Refusing sends the caller to period(b1) << period(b2), which computes
the same comparison from the same fields with the frame check dropped, so the
strictness buys nothing and costs the direct form. The three sibling families
already answer it, which is what makes this the deviation rather than the rule.

Section 4.1 of doc/contributing/bbox_validation_design_notes.md stated the rule
as layer 1 first, always, which is what the four entries were following. It now
states which axes an operation reads as the thing that decides whether the
question arises at all, keeps the ordering rule for when it does, and notes that
the validators already carry the same principle one level down by gating their
frame predicates on both operands holding X. The closing checklist follows.

Both manuals said all sixteen position predicates require the same schema and
reference system, which is now true of twelve; the paragraph says which twelve
and why the other four differ. Its example asserted that <</ and <<# answer f
for two boxes carrying neither a Z dimension nor a period, where both raise, so
the example states the two errors it actually produces and gains the cross-schema
time comparison.

Measured. The full pg_regress suite passes on PostgreSQL 18 through the
baseline-diff against master, and 1 of the 320 expected files changes: 34 added
lines in 410_tpcbox, one hunk, nothing removed. libmeos, the extension and the
extension without families build with zero warnings. The four entries lose a call
and gain nothing, so no path grows work.

