### PR TITLE
Overlay two regions on the circles that bound them

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -142,6 +142,10 @@ angle_normalize(double a)
 
 extern LWGEOM *meos_oriented_envelope(const LWGEOM *geom);
 extern LWGEOM *meos_areal_union(const LWGEOM *geom);
+extern LWGEOM *meos_areal_intersection(const LWGEOM *geom1,
+  const LWGEOM *geom2);
+extern LWGEOM *meos_areal_difference(const LWGEOM *geom1,
+  const LWGEOM *geom2);
 extern LWGEOM *meos_linear_union(const LWGEOM *geom);
 extern LWGEOM *meos_centroid(const LWGEOM *geom);
 extern LWGEOM *meos_lift_ordinates(const LWGEOM *geom, const LWGEOM **geoms,

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -48,6 +48,7 @@
 #include "meos.h"
 #include "meos_internal_geo.h"
 #include "geo/geo_funcs.h"
+#include "geo/geo_poly_clip.h"
 #include "geo/postgis_funcs.h"
 #include "geo/tgeo_spatialfuncs.h"
 
@@ -2358,30 +2359,43 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
  *****************************************************************************/
 
 /**
- * @brief Select all non-interior pieces from two boundaries for a union.
- * @details This function does not resolve coincident boundary pieces.
- * Those pieces are returned in @p boundary and are handled by the next
- * overlay stage. The result is therefore:
- *   exterior(A relative to B) + exterior(B relative to A)
- * while pieces lying strictly inside the other geometry are discarded.
+ * @brief Select the pieces of two boundaries that bound the overlay
+ * @details A piece of one boundary bounds the answer when it lies on the side
+ * of the other geometry that the operation keeps, and the operation is the
+ * whole of what tells the three apart:
+ *
+ *     union         exterior(A wrt B) + exterior(B wrt A)
+ *     intersection  interior(A wrt B) + interior(B wrt A)
+ *     difference    exterior(A wrt B) + interior(B wrt A)
+ *
+ * so nothing about the two shapes enters beyond where each piece sits.
+ * A piece lying ON the other boundary is coincident, and only a union
+ * resolves one here. The others are returned in @p boundary, which the caller
+ * reads as a pair this does not answer.
  */
 static void
-buffer_select_union_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
-  const MeosArray *pieces_b, const LWGEOM *geom_a, MeosArray *result,
-  MeosArray *boundary)
+buffer_select_overlay_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
+  const MeosArray *pieces_b, const LWGEOM *geom_a, ClipOper oper,
+  MeosArray *result, MeosArray *boundary)
 {
   assert(pieces_a); assert(geom_b); assert(pieces_b); assert(geom_a);
   assert(result); assert(boundary);
+  /* The side of the other geometry each of the two boundaries contributes */
+  BufferPieceLocation keep_a = (oper == CL_INTERSECTION) ?
+    BUFFER_PIECE_INTERIOR : BUFFER_PIECE_EXTERIOR;
+  BufferPieceLocation keep_b = (oper == CL_UNION) ?
+    BUFFER_PIECE_EXTERIOR : BUFFER_PIECE_INTERIOR;
   /* Pieces belonging to A */
   for (uint32_t i = 0; i < pieces_a->count; i++)
   {
     BufferPiece *piece = (BufferPiece *) meos_array_get(pieces_a, i);
     BufferPieceLocation location = buffer_classify_piece(piece, geom_b);
-    if (location == BUFFER_PIECE_EXTERIOR)
+    if (location == keep_a)
       meos_array_add(result, piece);
     else if (location == BUFFER_PIECE_BOUNDARY)
     {
-      if (! buffer_resolve_coincident_piece(piece, geom_a, geom_b, result))
+      if (oper != CL_UNION ||
+          ! buffer_resolve_coincident_piece(piece, geom_a, geom_b, result))
         meos_array_add(boundary, piece);
     }
   }
@@ -2390,11 +2404,12 @@ buffer_select_union_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
   {
     BufferPiece *piece = (BufferPiece *) meos_array_get(pieces_b, i);
     BufferPieceLocation location = buffer_classify_piece(piece, geom_a);
-    if (location == BUFFER_PIECE_EXTERIOR)
+    if (location == keep_b)
       meos_array_add(result, piece);
     else if (location == BUFFER_PIECE_BOUNDARY)
     {
-      if (! buffer_resolve_coincident_piece(piece, geom_b, geom_a, result))
+      if (oper != CL_UNION ||
+          ! buffer_resolve_coincident_piece(piece, geom_b, geom_a, result))
         meos_array_add(boundary, piece);
     }
   }
@@ -3452,46 +3467,65 @@ buffer_boundaries_cross(const LWGEOM *geom1, const LWGEOM *geom2)
  *****************************************************************************/
 
 /**
- * @brief Union two crossing buffer surfaces while preserving circular arcs.
- * @details This is the first end-to-end overlay path.
- * It is intentionally restricted to the crossing case:
- * - boundaries intersect at one or more discrete nodes;
- * - neither geometry contains the other;
- * - coincident boundary portions are deferred;
- * - the selected exterior pieces form one connected boundary.
+ * @brief Answer a Boolean operation on two areal geometries while preserving
+ * circular arcs
+ * @details One mechanism answers the three operations, and the boundary of the
+ * answer is always built the same way: the two boundaries are cut at the nodes
+ * where they meet, every piece is placed inside or outside the other geometry
+ * by its own midpoint, the operation says which side it keeps
+ * (#buffer_select_overlay_boundary), and the kept pieces are chained back into
+ * rings. An arc is cut into arcs of its own circle throughout, so the answer
+ * carries the circles its operands do rather than the chords a linearization
+ * would put in their place.
+ *
+ * Nothing here asks how the two geometries lie relative to one another. Where
+ * their boundaries stay apart there is nothing to cut and every piece is
+ * wholly inside or wholly outside, which is the containment and the disjoint
+ * case answered by the same selection; and a geometry of several components is
+ * read piece by piece, so one component inside and another outside need no
+ * separate treatment.
+ * @param[in] geom1,geom2 Areal geometries
+ * @param[in] oper Operation, one of @p CL_UNION, @p CL_INTERSECTION and
+ * @p CL_DIFFERENCE
+ * @param[out] touching Set when the two boundaries meet without their
+ * interiors overlapping, which a union answers as two surfaces
+ * @return The overlay, an EMPTY geometry where it covers nothing, or @p NULL
+ * for a pair this does not answer -- boundaries that run along one another,
+ * and a meeting that is not a crossing
  */
 static LWGEOM *
-buffer_union_crossing(const LWGEOM *geom1, const LWGEOM *geom2,
+buffer_areal_overlay(const LWGEOM *geom1, const LWGEOM *geom2, ClipOper oper,
   bool *touching)
 {
   assert(geom1); assert(geom2); assert(touching);
   *touching = false;
-  int relation = buffer_components_relation(geom1, geom2);
-  /* This routine is only for the proper crossing/partial-overlap case */
-  if (relation != 1)
-    return NULL;
+  bool crossing = buffer_boundaries_intersect(geom1, geom2);
 
   /* A point intersection by itself does not imply an overlapping union
    * boundary. In particular, two buffers may merely touch at one point.
    * Such components should remain separate surfaces. */
-  if (! buffer_boundaries_cross(geom1, geom2))
+  if (crossing && ! buffer_boundaries_cross(geom1, geom2))
     return NULL;
 
-  /* Collect the exact intersection nodes */
+  /* Collect the exact intersection nodes. Boundaries that stay apart have
+   * none, and the split below then leaves every piece whole */
   MeosArray *intersections = meos_array_create(sizeof(POINT2D));
-  if (! buffer_collect_boundary_intersections(geom1, geom2, intersections))
+  if (crossing)
   {
-    meos_array_destroy(intersections);
-    return NULL;
-  }
+    if (! buffer_collect_boundary_intersections(geom1, geom2, intersections))
+    {
+      meos_array_destroy(intersections);
+      return NULL;
+    }
 
-  /* A boundary intersection was reported, but there are no discrete
-   * nodes. This indicates a coincident/overlapping-boundary case.
-   * Defer it to the next topology layer. */
-  if (meos_array_count(intersections) == 0)
-  {
-    meos_array_destroy(intersections);
-    return NULL;
+    /* A boundary intersection was reported, but there are no discrete
+     * nodes. This indicates a coincident/overlapping-boundary case.
+     * Defer it to the next topology layer. */
+    if (meos_array_count(intersections) == 0)
+    {
+      meos_array_destroy(intersections);
+      return NULL;
+    }
   }
 
   /* Extract and split both complete boundaries */
@@ -3510,18 +3544,20 @@ buffer_union_crossing(const LWGEOM *geom1, const LWGEOM *geom2,
   buffer_split_pieces(raw_a, intersections, split_a);
   buffer_split_pieces(raw_b, intersections, split_b);
 
-  /* Select the exterior portions of both boundaries */
+  /* Select the portions of both boundaries the operation keeps */
   MeosArray *selected = meos_array_create(sizeof(BufferPiece));
   MeosArray *boundary = meos_array_create(sizeof(BufferPiece));
-  buffer_select_union_boundary(split_a, geom2, split_b, geom1, selected,
-    boundary);
+  buffer_select_overlay_boundary(split_a, geom2, split_b, geom1, oper,
+    selected, boundary);
 
   /* Two boundaries that meet only at isolated points without their interiors
    * overlapping, as two discs touching at one point do, leave every piece of
    * both boundaries on the union boundary. There is nothing to dissolve, and
    * chaining rings that meet at a single node does not produce a surface, so
-   * the pair is left to the caller as two surfaces. */
-  if (meos_array_count(selected) ==
+   * the pair is left to the caller as two surfaces. Boundaries that never meet
+   * keep every piece for a union too, and that is an answer rather than a
+   * refusal, so the question is only asked where they do */
+  if (crossing && meos_array_count(selected) ==
       meos_array_count(split_a) + meos_array_count(split_b))
   {
     *touching = true;
@@ -3541,7 +3577,24 @@ buffer_union_crossing(const LWGEOM *geom1, const LWGEOM *geom2,
     meos_array_destroy(intersections);
     return NULL;
   }
-  /* Reconstruct the complete union boundary:
+  /* An operation keeping no piece of either boundary covers no area. Where
+   * the boundaries stay apart that IS the answer -- two regions that never
+   * meet share nothing, and one inside the other leaves nothing behind. Where
+   * they MEET it is not: two discs touching at a point share that point, and
+   * two surfaces meeting along an edge share the edge. Such an answer is of
+   * lower dimension than the surfaces this assembles, so the pair is left to
+   * the caller rather than answered as the region of no area, which would
+   * drop a point set that is really there */
+  if (meos_array_count(selected) == 0 && crossing)
+  {
+    meos_array_destroy(selected); meos_array_destroy(boundary);
+    meos_array_destroy(split_a); meos_array_destroy(split_b);
+    meos_array_destroy(raw_a); meos_array_destroy(raw_b);
+    meos_array_destroy(intersections);
+    return NULL;
+  }
+
+  /* Reconstruct the complete overlay boundary:
    * selected pieces
    * -> closed rings
    * -> containment hierarchy
@@ -3550,13 +3603,32 @@ buffer_union_crossing(const LWGEOM *geom1, const LWGEOM *geom2,
    * -> CURVEPOLYGON / MULTISURFACE
    */
   int32_t srid = lwgeom_get_srid(geom1);
-  LWGEOM *result = buffer_make_surfaces_from_pieces(selected, srid);
+  LWGEOM *result = meos_array_count(selected) == 0 ?
+    lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0)) :
+    buffer_make_surfaces_from_pieces(selected, srid);
   /* Clean up and return */
   meos_array_destroy(selected); meos_array_destroy(boundary);
   meos_array_destroy(split_a); meos_array_destroy(split_b);
   meos_array_destroy(raw_a); meos_array_destroy(raw_b);
   meos_array_destroy(intersections);
   return result;
+}
+
+/**
+ * @brief Union two crossing buffer surfaces while preserving circular arcs.
+ * @details The caller asks whether the two surfaces MERGE into one, so only
+ * the proper crossing case answers it: a pair whose boundaries stay apart, or
+ * one of which contains the other, is left to the caller to assemble.
+ */
+static LWGEOM *
+buffer_union_crossing(const LWGEOM *geom1, const LWGEOM *geom2,
+  bool *touching)
+{
+  assert(geom1); assert(geom2); assert(touching);
+  *touching = false;
+  if (buffer_components_relation(geom1, geom2) != 1)
+    return NULL;
+  return buffer_areal_overlay(geom1, geom2, CL_UNION, touching);
 }
 
 /*****************************************************************************
@@ -4684,6 +4756,34 @@ buffer_union_components(LWGEOM **buffers, uint32_t count, int32_t srid)
 }
 
 /**
+ * @brief Return whether the overlay reads a geometry as the surfaces it draws
+ * @details The engine walks a boundary that bounds area, so what it reads is a
+ * surface or a collection of surfaces and nothing besides: a member of any
+ * other kind draws something the boundary walk has no place for
+ */
+static bool
+buffer_is_areal_geometry(const LWGEOM *geom)
+{
+  assert(geom);
+  uint8_t type = geom->type;
+  if (type == POLYGONTYPE || type == CURVEPOLYTYPE || type == TRIANGLETYPE)
+    return true;
+  if (type != MULTIPOLYGONTYPE && type != MULTISURFACETYPE &&
+      type != COLLECTIONTYPE)
+    return false;
+  const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
+  if (coll->ngeoms == 0)
+    return false;
+  for (uint32_t i = 0; i < coll->ngeoms; i++)
+  {
+    uint8_t comp = coll->geoms[i]->type;
+    if (comp != POLYGONTYPE && comp != CURVEPOLYTYPE && comp != TRIANGLETYPE)
+      return false;
+  }
+  return true;
+}
+
+/**
  * @brief Return the union of the areal components of a geometry
  * @details The components are dissolved into the surfaces they cover: a pair
  * whose interiors meet becomes one surface, and a pair that only touches stays
@@ -4703,25 +4803,17 @@ meos_areal_union(const LWGEOM *geom)
   if (lwgeom_is_empty(geom))
     return NULL;
 
+  /* A point or a line has no area to dissolve, and a geometry carrying one is
+   * not what this answers */
+  if (! buffer_is_areal_geometry(geom))
+    return NULL;
+
   /* One surface is its own union */
   uint8_t type = geom->type;
   if (type == POLYGONTYPE || type == CURVEPOLYTYPE || type == TRIANGLETYPE)
     return lwgeom_clone_deep(geom);
-  if (type != MULTIPOLYGONTYPE && type != MULTISURFACETYPE &&
-      type != COLLECTIONTYPE)
-    return NULL;
 
   const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
-  if (coll->ngeoms == 0)
-    return NULL;
-  /* A point or a line has no area to dissolve, and a geometry carrying one is
-   * not what this answers */
-  for (uint32_t i = 0; i < coll->ngeoms; i++)
-  {
-    uint8_t comp = coll->geoms[i]->type;
-    if (comp != POLYGONTYPE && comp != CURVEPOLYTYPE && comp != TRIANGLETYPE)
-      return NULL;
-  }
   if (coll->ngeoms == 1)
     return lwgeom_clone_deep(coll->geoms[0]);
 
@@ -4782,6 +4874,89 @@ meos_areal_union(const LWGEOM *geom)
     }
   }
   return result;
+}
+
+/**
+ * @brief Answer a Boolean operation on two areal geometries
+ * @details The operands are read as the surfaces they draw and the answer is
+ * built from their two boundaries, so an operand bounded by circular arcs is
+ * answered on those circles. An operand carrying anything that is not a
+ * surface is not one this reads, and neither is a pair whose boundaries run
+ * along one another rather than crossing
+ * @param[in] geom1,geom2 Geometries
+ * @param[in] oper Operation
+ * @return The overlay, an EMPTY geometry where the operation covers nothing,
+ * or @p NULL for a pair this does not answer -- a caller that has another way
+ * to answer may take it
+ */
+static LWGEOM *
+buffer_areal_operation(const LWGEOM *geom1, const LWGEOM *geom2,
+  ClipOper oper)
+{
+  assert(geom1); assert(geom2);
+  int32_t srid = lwgeom_get_srid(geom1);
+  /* What an empty operand answers is the set identity of the operation:
+   * nothing meets an empty region, and an empty region takes nothing from a
+   * subject while leaving nothing of one */
+  bool empty1 = lwgeom_is_empty(geom1);
+  bool empty2 = lwgeom_is_empty(geom2);
+  if (empty1 || empty2)
+  {
+    if (oper == CL_DIFFERENCE && ! empty1)
+      return lwgeom_clone_deep(geom1);
+    return lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0));
+  }
+  if (! buffer_is_areal_geometry(geom1) || ! buffer_is_areal_geometry(geom2))
+    return NULL;
+
+  bool touching;
+  LWGEOM *result = buffer_areal_overlay(geom1, geom2, oper, &touching);
+  if (! result)
+    return NULL;
+
+  /* The boundary is welded out of pieces, so a surface comes back as a curve
+   * polygon even where every piece of it is a segment. A pair of operands
+   * carrying no arc is answered with polygons: the conversion reads the pieces
+   * of a ring that carries no arc into one point array and loses nothing */
+  if (! lwgeom_has_arc(result))
+  {
+    LWGEOM *straight = lwgeom_stroke(result, 0);
+    if (straight)
+    {
+      lwgeom_free(result);
+      result = straight;
+    }
+  }
+  return result;
+}
+
+/**
+ * @brief Return the intersection of two areal geometries
+ * @details See #buffer_areal_operation()
+ * @param[in] geom1,geom2 Geometries
+ * @return The region both cover, an EMPTY geometry where they cover none in
+ * common, or @p NULL for a pair this does not answer
+ */
+LWGEOM *
+meos_areal_intersection(const LWGEOM *geom1, const LWGEOM *geom2)
+{
+  assert(geom1); assert(geom2);
+  return buffer_areal_operation(geom1, geom2, CL_INTERSECTION);
+}
+
+/**
+ * @brief Return the difference of two areal geometries
+ * @details See #buffer_areal_operation()
+ * @param[in] geom1,geom2 Geometries
+ * @return The region the first covers and the second does not, an EMPTY
+ * geometry where the second covers all of the first, or @p NULL for a pair
+ * this does not answer
+ */
+LWGEOM *
+meos_areal_difference(const LWGEOM *geom1, const LWGEOM *geom2)
+{
+  assert(geom1); assert(geom2);
+  return buffer_areal_operation(geom1, geom2, CL_DIFFERENCE);
 }
 
 /*****************************************************************************

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2136,6 +2136,24 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   if (geo_clip_subject(gs2) && geo_meos_supported(gs1))
     return geo_clip_linear_geom(gs2, gs1, true);
 
+  /* An areal pair the native overlay reads is answered on the circles its
+   * operands carry, where the route below reads an arc as the chain of chords
+   * a linearization puts in its place. It declines a pair whose boundaries run
+   * along one another rather than crossing, and the route below answers that
+   * one */
+  if (geo_is_planar_areal(gs1) && geo_is_planar_areal(gs2))
+  {
+    LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
+    LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
+    LWGEOM *lwresult = meos_areal_intersection(geom1, geom2);
+    GSERIALIZED *result = lwresult ? geo_serialize(lwresult) : NULL;
+    if (lwresult)
+      lwgeom_free(lwresult);
+    lwgeom_free(geom1); lwgeom_free(geom2);
+    if (result)
+      return result;
+  }
+
 #if GEOS
   /* Other types fall through to GEOS */
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
@@ -2202,6 +2220,24 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
      * answer one point set two ways depending on how it is spelled */
     if (geo_every_part_bounds_area(gs1))
       return geo_copy(gs1);
+  }
+
+  /* An areal pair the native overlay reads is answered on the circles its
+   * operands carry, where the route below reads an arc as the chain of chords
+   * a linearization puts in its place. It declines a pair whose boundaries run
+   * along one another rather than crossing, and the route below answers that
+   * one */
+  if (geo_is_planar_areal(gs1) && geo_is_planar_areal(gs2))
+  {
+    LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
+    LWGEOM *geom2 = lwgeom_from_gserialized(gs2);
+    LWGEOM *lwresult = meos_areal_difference(geom1, geom2);
+    GSERIALIZED *result = lwresult ? geo_serialize(lwresult) : NULL;
+    if (lwresult)
+      lwgeom_free(lwresult);
+    lwgeom_free(geom1); lwgeom_free(geom2);
+    if (result)
+      return result;
   }
 
 #if GEOS

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1560,6 +1560,138 @@ int main(void)
   free(fw); free(fd); free(flat); free(along);
   meos_errno_reset();
 
+  /* An areal pair is overlaid on the circles its operands carry. The two
+   * discs of radius 2 about (2,2) and (4,2) cross where both circles pass,
+   * at x = 3 and y = 2 +- sqrt(3), and the answer names those points and
+   * keeps the two arcs between them -- where reaching the GEOS overlay
+   * strokes both circles first and answers the chords */
+  const char *d1w = "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))";
+  const char *d2w = "CURVEPOLYGON(CIRCULARSTRING(2 2,4 4,6 2,4 0,2 2))";
+  const char *inw = "CURVEPOLYGON(CIRCULARSTRING(1 2,2 3,3 2,2 1,1 2))";
+  const char *awayw = "POLYGON((100 100,101 100,101 101,100 101,100 100))";
+  const char *ov_exp[] = {
+    /* the lens the two discs share */
+    "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(3 3.732051,2.267949 3,2 2),"
+      "CIRCULARSTRING(2 2,2.267949 1,3 0.267949),"
+      "CIRCULARSTRING(3 0.267949,3.732051 1,4 2),"
+      "CIRCULARSTRING(4 2,3.732051 3,3 3.732051)))",
+    /* the first disc with that lens taken out of it */
+    "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 2,1 0.267949,3 0.267949),"
+      "CIRCULARSTRING(3 0.267949,2.267949 1,2 2),"
+      "CIRCULARSTRING(2 2,2.267949 3,3 3.732051),"
+      "CIRCULARSTRING(3 3.732051,1 3.732051,0 2)))",
+    /* a disc inside a disc: the intersection is the inner one ... */
+    "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(1 2,2 1,3 2),"
+      "CIRCULARSTRING(3 2,2 3,1 2)))",
+    /* ... and the difference is the outer one carrying it as a HOLE */
+    "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 2,2 0,4 2),"
+      "CIRCULARSTRING(4 2,2 4,0 2)),"
+      "COMPOUNDCURVE(CIRCULARSTRING(1 2,2 3,3 2),"
+      "CIRCULARSTRING(3 2,2 1,1 2)))",
+    /* a disc inside a disc, the other way round: nothing is left */
+    "POLYGON EMPTY",
+    /* and two regions that never meet share no area */
+    "POLYGON EMPTY",
+  };
+  const char *ov_a[] = { d1w, d1w, d1w, d1w, inw, d1w };
+  const char *ov_b[] = { d2w, d2w, inw, inw, d1w, awayw };
+  const int ov_op[] =  { 0,   1,   0,   1,   1,   0 };
+  for (int i = 0; i < 6; i++)
+  {
+    GSERIALIZED *oa = geom_in(ov_a[i], -1);
+    GSERIALIZED *ob = geom_in(ov_b[i], -1);
+    assert(oa != NULL); assert(ob != NULL);
+    meos_errno_reset();
+    GSERIALIZED *ores = ov_op[i] ? geom_difference2d(oa, ob) :
+      geom_intersection2d(oa, ob);
+    assert(ores != NULL);
+    char *ow = geo_as_text(ores, 6);
+    printf("areal overlay %d: %.60s\n", i, ow);
+    assert(strcmp(ow, ov_exp[i]) == 0);
+    free(ow); free(ores); free(oa); free(ob);
+    meos_errno_reset();
+  }
+  /* THE REGION OF NO AREA IS SPELLED ONE WAY, whichever operand is empty and
+   * whatever type it carries. That is the rule #clip_empty_areal states for
+   * the polygonal arm -- what an empty result is drawn as follows from the
+   * OPERATION, never from which trivial case reached it -- and an empty
+   * CURVEPOLYGON operand is the one route by which the other spelling still
+   * came back */
+  const char *em_a[] = { "CURVEPOLYGON EMPTY", "POLYGON EMPTY",
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))", "POLYGON EMPTY" };
+  const char *em_b[] = { "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))",
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))",
+    "MULTISURFACE EMPTY", "CURVEPOLYGON EMPTY" };
+  const int em_op[] = { 0, 0, 0, 1 };
+  for (int i = 0; i < 4; i++)
+  {
+    GSERIALIZED *ea = geom_in(em_a[i], -1);
+    GSERIALIZED *eb = geom_in(em_b[i], -1);
+    assert(ea != NULL); assert(eb != NULL);
+    meos_errno_reset();
+    GSERIALIZED *er = em_op[i] ? geom_difference2d(ea, eb) :
+      geom_intersection2d(ea, eb);
+    assert(er != NULL);
+    char *ew = geo_as_text(er, 6);
+    printf("an empty areal operand answers: %s\n", ew);
+    assert(strcmp(ew, "POLYGON EMPTY") == 0);
+    free(ew); free(er); free(ea); free(eb);
+    meos_errno_reset();
+  }
+  /* WHAT THE OVERLAY KEEPS ANSWERING BECAUSE THIS ARM DECLINES IT. Two discs
+   * touching at one point share that point, and a point is of lower dimension
+   * than the surfaces the arm assembles. Answering the region of no area there
+   * would drop a point set that is really there, so the pair goes on to the
+   * route that draws it */
+  GSERIALIZED *tg1 = geom_in("CURVEPOLYGON(CIRCULARSTRING(0 0,1 1,2 0,1 -1,"
+    "0 0))", -1);
+  GSERIALIZED *tg2 = geom_in("CURVEPOLYGON(CIRCULARSTRING(2 0,3 1,4 0,3 -1,"
+    "2 0))", -1);
+  assert(tg1 != NULL); assert(tg2 != NULL);
+  meos_errno_reset();
+  GSERIALIZED *tgi = geom_intersection2d(tg1, tg2);
+  assert(tgi != NULL);
+  char *tgw = geo_as_text(tgi, 6);
+  printf("two discs touching at one point share: %s\n", tgw);
+  assert(strcmp(tgw, "POINT(2 0)") == 0);
+  free(tgw); free(tgi);
+  /* The DIFFERENCE of the same pair takes a point set of no area from a
+   * region, so it is the region -- and it keeps its arcs */
+  meos_errno_reset();
+  GSERIALIZED *tgd = geom_difference2d(tg1, tg2);
+  assert(tgd != NULL);
+  char *tgdw = geo_as_text(tgd, 6);
+  printf("the first of them less the second: %.44s\n", tgdw);
+  assert(strstr(tgdw, "CIRCULARSTRING") != NULL);
+  free(tgdw); free(tgd); free(tg1); free(tg2);
+  meos_errno_reset();
+  /* ONE REGION, TWO SPELLINGS, AND THEY MUST AGREE. A pair of POLYGONs is
+   * overlaid by the Clipper2 arm; the same region spelled TRIANGLE reaches
+   * the native one. Neither carries an arc, so the two answer the same
+   * polygon and the areas are exact */
+  const char *sp_tri = "TRIANGLE((0 0,4 0,2 4,0 0))";
+  const char *sp_pol = "POLYGON((0 0,4 0,2 4,0 0))";
+  const char *sp_cl  = "POLYGON((1 1,5 1,5 5,1 5,1 1))";
+  for (int op = 0; op < 2; op++)
+  {
+    GSERIALIZED *ta = geom_in(sp_tri, -1);
+    GSERIALIZED *pa2 = geom_in(sp_pol, -1);
+    GSERIALIZED *cb2 = geom_in(sp_cl, -1);
+    assert(ta != NULL); assert(pa2 != NULL); assert(cb2 != NULL);
+    meos_errno_reset();
+    GSERIALIZED *rn = op ? geom_difference2d(ta, cb2) :
+      geom_intersection2d(ta, cb2);
+    GSERIALIZED *rc = op ? geom_difference2d(pa2, cb2) :
+      geom_intersection2d(pa2, cb2);
+    assert(rn != NULL); assert(rc != NULL);
+    double an = geom_area(rn), ac = geom_area(rc);
+    printf("triangle and polygon spellings of one region, %s: %.12f %.12f\n",
+      op ? "minus" : "meet", an, ac);
+    assert(fabs(an - ac) < 1e-12);
+    free(rn); free(rc); free(ta); free(pa2); free(cb2);
+    meos_errno_reset();
+  }
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
Part of the campaign that removes GEOS from MEOS without losing what it answers.

## What reaches GEOS today, and why the answer is wrong rather than merely absent

An areal pair reaches the GEOS overlay whenever it is not two plain polygons, and `LWGEOM2GEOS` (`postgis/liblwgeom/lwgeom_geos.c:469`) opens by asking `lwgeom_type_arc` and calling `lwgeom_stroke(lwgeom, 32)` on anything that says yes. So a curve polygon is overlaid as the chain of chords a 32-per-quadrant linearization puts in its circles' place. GEOS has no vocabulary for the question either — `GEOSGeomTypes` holds eight members and `CurvePolygon` and `MultiSurface` are neither of them — so what comes back is a converter's limit wearing the clothes of a result.

## The change

The arc-preserving areal overlay is already in the tree. `meos/src/geo/geo_buffer.c` cuts two boundaries at the exact nodes where they meet, places every piece inside or outside the other geometry by its own midpoint, keeps the pieces on one side, and chains them back into rings, holes and surfaces — an arc cut into arcs of its own circle throughout. It is reachable only as the UNION a buffer of several components needs.

The operation is the whole of what tells the three apart:

```
union         exterior(A wrt B) + exterior(B wrt A)
intersection  interior(A wrt B) + interior(B wrt A)
difference    exterior(A wrt B) + interior(B wrt A)
```

so `buffer_select_union_boundary` becomes `buffer_select_overlay_boundary` reading which side each boundary contributes, `buffer_union_crossing` becomes `buffer_areal_overlay` over that, and `meos_areal_intersection` / `meos_areal_difference` join `meos_areal_union` as its entries.

Nothing in it asks how the two geometries lie, which is why it is one mechanism rather than four: where the boundaries stay apart there is nothing to cut and every piece is wholly inside or wholly outside, so containment and disjointness fall out of the same selection — a disc inside a disc answers the inner one for an intersection, and the outer one carrying it as a **hole** for a difference, with no case written for either.

## Witness

```sql
SELECT ST_AsText(ST_Intersection(
  'CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))',
  'CURVEPOLYGON(CIRCULARSTRING(2 2,4 4,6 2,4 0,2 2))'));
```

Two discs of radius 2 about (2,2) and (4,2) cross at `x = 3`, `y = 2 ± √3`.

```
before  POLYGON((3.028205 3.715457,3.11114 3.662939,3.191399 3.606415,...))
        89 vertices, both circles replaced by chords, and not one of them the
        crossing node
after   CURVEPOLYGON(COMPOUNDCURVE(
          CIRCULARSTRING(3 3.732051,2.267949 3,2 2),
          CIRCULARSTRING(2 2,2.267949 1,3 0.267949),
          CIRCULARSTRING(3 0.267949,3.732051 1,4 2),
          CIRCULARSTRING(4 2,3.732051 3,3 3.732051)))
```

## Measured

| measurement | result |
|---|---|
| 200 pairs of crossing discs, both operations, 400 answers, none declined either way | vertices in the answers **42401 → 4299**; worst distance from a vertex to the nearer of the two circles that bound the answer **1.026e-03 → 2.220e-15**. The oracle needs no reference implementation: every boundary point of `A op B`, for discs, lies on one of the two circles |
| 3000 random star-shaped polygon pairs, both operations, 6000 comparisons — one region in two spellings, the `POLYGON` pair reaching the Clipper2 arm and the `CURVEPOLYGON` pair the native one | 0 declined; 0 apart by more than 1e-6 of the larger operand; worst 7.201e-08, which is the control's own `CLIP_SCALE = 1e7` snapping and cannot be beaten |
| 225 ordered type pairs, one geometry of each of the 15 types `geom_meos_supported` admits, with GEOS compiled out | intersection reaches GEOS **60 → 52**, difference **67 → 61**. The pairs that remain among the types the overlay reads are the coincident boundaries it defers. NULL with an errno that is not 13 — an answer absent for no stated reason — **3 → 0** |
| 216 buffers, 18 shapes × 12 radii, dumped from both builds | **identical**, 215 answered and 1 declined in each: the union arm does not move |
| two discs touching at one point | `POINT(2 0)` on both sides — the arm declines, so the route that draws a lower-dimensional answer keeps it |
| an empty operand, an SRID pair, a Z pair, a geodetic pair, a mixed-SRID pair | the empty answers move from `CURVEPOLYGON EMPTY` to `POLYGON EMPTY` where the empty operand is a curve polygon (see below); the SRID is carried as before; the Z and geodetic pairs are untouched because the guard refuses them; a mixed SRID errors with the same errno |
| 18 overlay calls across the SQL fixtures | 0 carry a curved or triangular operand, so the SQL suite is blind to this change and cannot be read as covering it — `meos/test/geo_test.c` is what covers it, with 6 overlay witnesses, the tangent pair, the empty operands and the two spellings of one region |

## What it leaves to the existing route

Two boundaries that **run along** one another rather than crossing: only a union resolves a coincident piece, and the other two return the pair unanswered, so it reaches the existing route unchanged.

An answer of **lower dimension** than the surfaces this assembles: two discs touching at one point share that point, and answering the region of no area there drops a point set that is really there. A selection that keeps nothing while the boundaries meet is therefore left to the route below, which draws it. A selection that keeps nothing while they stay apart is a different sentence and is answered — two regions that never meet share nothing, and one inside the other leaves nothing behind.

## One answer moves besides the arcs

`clip_empty_areal` states that what an empty overlay is drawn as follows from the operation and never from which trivial case reached it, and `POLYGON EMPTY` is the spelling it keeps for all of them; PostGIS instead clones whichever operand happens to be empty. An empty `CURVEPOLYGON` operand is the one route by which `CURVEPOLYGON EMPTY` still comes back, and it answers as its siblings do.
