### PR TITLE
State an operation by its operator and its function once

### DIFF
--- a/doc/es/portable_sql.xml
+++ b/doc/es/portable_sql.xml
@@ -31,6 +31,8 @@
 				<row><entry>Topología</entry><entry>&amp;&amp;</entry><entry><indexterm significance="normal"><primary><varname>overlaps</varname></primary></indexterm>overlaps(a, b)</entry></row>
 				<row><entry></entry><entry>@&gt;</entry><entry><indexterm significance="normal"><primary><varname>contains</varname></primary></indexterm>contains(a, b)</entry></row>
 				<row><entry></entry><entry>&lt;@</entry><entry><indexterm significance="normal"><primary><varname>contained</varname></primary></indexterm>contained(a, b)</entry></row>
+				<row><entry></entry><entry>#@&gt;</entry><entry>contains(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;@#</entry><entry>contained(a, b)</entry></row>
 				<row><entry></entry><entry>-|-</entry><entry><indexterm significance="normal"><primary><varname>adjacent</varname></primary></indexterm>adjacent(a, b)</entry></row>
 				<row><entry>Posición temporal</entry><entry>&lt;&lt;#</entry><entry><indexterm significance="normal"><primary><varname>before</varname></primary></indexterm>before(a, b)</entry></row>
 				<row><entry></entry><entry>#&gt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>after</varname></primary></indexterm>after(a, b)</entry></row>
@@ -56,6 +58,8 @@
 				<row><entry></entry><entry>#&gt;=</entry><entry><indexterm significance="normal"><primary><varname>tGe</varname></primary></indexterm>tGe(a, b)</entry></row>
 				<row><entry>Distancia</entry><entry>&lt;-&gt;</entry><entry><indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>tDistance(a, b)</entry></row>
 				<row><entry></entry><entry>|=|</entry><entry><indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>nearestApproachDistance(a, b)</entry></row>
+				<row><entry>Distancia (base / set / span / span set)</entry><entry>&lt;-&gt;</entry><entry>distance / setDistance (a, b)</entry></row>
+				<row><entry>Distancia de rejilla (índice de celda)</entry><entry>&lt;-&gt;</entry><entry><indexterm significance="normal"><primary><varname>th3GridDistance</varname></primary></indexterm>th3GridDistance(a, b)</entry></row>
 				<row><entry>Igual</entry><entry>~=</entry><entry><indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>same(a, b)</entry></row>
 				<row><entry>Comparación tradicional</entry><entry>=</entry><entry><indexterm significance="normal"><primary><varname>eq</varname></primary></indexterm>eq(a, b)</entry></row>
 				<row><entry></entry><entry>&lt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>ne</varname></primary></indexterm>ne(a, b)</entry></row>
@@ -86,6 +90,18 @@
 				<row><entry>Intersección (set / span / span set)</entry><entry>*</entry><entry>setIntersection / spanIntersection / spansetIntersection (a, b)</entry></row>
 				<row><entry>Diferencia (set / span / span set)</entry><entry>-</entry><entry>setMinus / spanMinus / spansetMinus (a, b)</entry></row>
 				<row><entry>Concatenación (set / temporal)</entry><entry>||</entry><entry>setConcat / tConcat (a, b)</entry></row>
+				<row><entry>Acceso a campo / elemento JSON</entry><entry>-&gt;</entry><entry>jsonbsetObjectField / tjsonbObjectField / jsonbsetArrayElement / tjsonbArrayElement (a, b)</entry></row>
+				<row><entry></entry><entry>-&gt;&gt;</entry><entry>jsonbsetObjectFieldText / tjsonbObjectFieldText / jsonbsetArrayElementText / tjsonbArrayElementText (a, b)</entry></row>
+				<row><entry>Existencia de clave JSON</entry><entry>?</entry><entry>jsonbsetExists / tjsonbExists (a, b)</entry></row>
+				<row><entry></entry><entry>?&amp;</entry><entry>jsonbsetExistsAll / tjsonbExistsAll (a, b)</entry></row>
+				<row><entry></entry><entry>?|</entry><entry>jsonbsetExistsAny / tjsonbExistsAny (a, b)</entry></row>
+				<row><entry>Ruta JSON</entry><entry>@?</entry><entry>jsonbsetPathExists / tjsonbPathExists (a, b)</entry></row>
+				<row><entry></entry><entry>@@</entry><entry>jsonbsetPathMatch / tjsonbPathMatch (a, b)</entry></row>
+				<row><entry></entry><entry>#-</entry><entry>jsonbsetDeletePath / tjsonbDeletePath (a, b)</entry></row>
+				<row><entry>Identificador de ruta (punto de red)</entry><entry>@=</entry><entry><indexterm significance="normal"><primary><varname>same_rid</varname></primary></indexterm>same_rid(a, b)</entry></row>
+				<row><entry></entry><entry>@?</entry><entry><indexterm significance="normal"><primary><varname>contains_rid</varname></primary></indexterm>contains_rid(a, b)</entry></row>
+				<row><entry></entry><entry>?@</entry><entry><indexterm significance="normal"><primary><varname>contained_rid</varname></primary></indexterm>contained_rid(a, b)</entry></row>
+				<row><entry></entry><entry>@@</entry><entry><indexterm significance="normal"><primary><varname>overlaps_rid</varname></primary></indexterm>overlaps_rid(a, b)</entry></row>
 			</tbody>
 		</tgroup>
 	</informaltable>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -1381,10 +1381,10 @@
 				<title>Operaciones de distancia</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="pose_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Devuelve la distancia</para>
+						<para><link linkend="pose_distance_op"><varname>&lt;-&gt;</varname></link>: Devuelve la distancia</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="pose_nearestApproachDistance"><varname>nearestApproachDistance</varname>, <varname>|=|</varname></link>: Devuelve la distancia de aproximación más cercana</para>
+						<para><link linkend="pose_nearestApproachDistance"><varname>|=|</varname></link>: Devuelve la distancia de aproximación más cercana</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1395,7 +1395,7 @@
 						<para><link linkend="pose_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="pose_same"><varname>same</varname>, <varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
+						<para><link linkend="pose_same"><varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1819,7 +1819,7 @@
 						<para><link linkend="npoint_srid"><varname>SRID</varname></link>: Devuelve el identificador de referencia espacial</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="npoint_same"><varname>same</varname>, <varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
+						<para><link linkend="npoint_same"><varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2088,10 +2088,10 @@
 				<title>Operaciones de distancia</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="cbuffer_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Devuelve la distancia</para>
+						<para><link linkend="cbuffer_distance_op"><varname>&lt;-&gt;</varname></link>: Devuelve la distancia</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="cbuffer_nearestApproachDistance"><varname>nearestApproachDistance</varname>, <varname>|=|</varname></link>: Devuelve la distancia de aproximación más cercana</para>
+						<para><link linkend="cbuffer_nearestApproachDistance"><varname>|=|</varname></link>: Devuelve la distancia de aproximación más cercana</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2102,7 +2102,7 @@
 						<para><link linkend="cbuffer_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="cbuffer_same"><varname>same</varname>, <varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
+						<para><link linkend="cbuffer_same"><varname>~=</varname></link>: ¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2474,10 +2474,10 @@
 			<title>Operaciones de distancia</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="trgeometry_tdistance"><varname>&lt;-&gt;</varname>, <varname>tDistance</varname></link>: Devuelve la distancia temporal entre dos geometrías rígidas temporales</para>
+					<para><link linkend="trgeometry_tdistance"><varname>&lt;-&gt;</varname></link>: Devuelve la distancia temporal entre dos geometrías rígidas temporales</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="trgeometry_nad"><varname>|=|</varname>, <varname>nearestApproachDistance</varname></link>: Devuelve la distancia más pequeña entre dos geometrías rígidas temporales sobre su dominio temporal compartido</para>
+					<para><link linkend="trgeometry_nad"><varname>|=|</varname></link>: Devuelve la distancia más pequeña entre dos geometrías rígidas temporales sobre su dominio temporal compartido</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="trgeometry_nai"><varname>nearestApproachInstant</varname></link>: Devuelve el instante en el que los dos argumentos están a su menor distancia mutua</para>
@@ -2989,10 +2989,10 @@
 					<para><link linkend="tcell_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Comparaciones tradicionales</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tcell_ever_always"><varname>eEq</varname>, <varname>aEq</varname>, <varname>eNe</varname>, <varname>aNe</varname>, <varname>?=</varname>, <varname>?&lt;&gt;</varname>, <varname>%=</varname>, <varname>%&lt;&gt;</varname></link>: Comparaciones siempre y alguna vez</para>
+					<para><link linkend="tcell_ever_always"><varname>?=</varname>, <varname>?&lt;&gt;</varname>, <varname>%=</varname>, <varname>%&lt;&gt;</varname></link>: Comparaciones siempre y alguna vez</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tcell_tcomp"><varname>tEq</varname>, <varname>tNe</varname>, <varname>#=</varname>, <varname>#&lt;&gt;</varname></link>: Comparaciones temporales</para>
+					<para><link linkend="tcell_tcomp"><varname>#=</varname>, <varname>#&lt;&gt;</varname></link>: Comparaciones temporales</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3077,7 +3077,7 @@
 					<para><link linkend="tcell_h3_is_valid_vertex"><varname>isValidVertex</varname></link>: Devolver un booleano temporal que indica en cada instante si el valor es un vértice H3 válido</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tcell_h3_grid_distance"><varname>th3GridDistance</varname>, <varname>&lt;-&gt;</varname></link>: Devolver la distancia temporal en saltos de cuadrícula (número de pasos de una sola celda) entre dos celdas temporales</para>
+					<para><link linkend="tcell_h3_grid_distance"><varname>&lt;-&gt;</varname></link>: Devolver la distancia temporal en saltos de cuadrícula (número de pasos de una sola celda) entre dos celdas temporales</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tcell_h3_cell_to_local_ij"><varname>th3CellToLocalIj</varname>, <varname>th3LocalIjToCell</varname></link>: Convertir entre una celda temporal y un par de coordenadas locales (I, J) temporales relativas a una celda temporal de origen</para>
@@ -3410,7 +3410,7 @@
 				<title>Operaciones de distancia</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpcpoint_nearestApproachDistance"><varname>|=|</varname>, <varname>nearestApproachDistance</varname></link>: Devuelve la distancia más cercana</para>
+						<para><link linkend="tpcpoint_nearestApproachDistance"><varname>|=|</varname></link>: Devuelve la distancia más cercana</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpoint_nearestApproachInstant"><varname>nearestApproachInstant</varname></link>: Devuelve el instante del tpcpoint en el que los dos argumentos están a la distancia más cercana</para>
@@ -3419,7 +3419,7 @@
 						<para><link linkend="tpcpoint_shortestLine"><varname>shortestLine</varname></link>: Devuelve la línea que une el punto de acercamiento más cercano entre los dos argumentos</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpcpoint_tDistance"><varname>tDistance</varname>, <varname>&lt;-&gt;</varname></link>: Devuelve la distancia temporal</para>
+						<para><link linkend="tpcpoint_tDistance"><varname>&lt;-&gt;</varname></link>: Devuelve la distancia temporal</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -3580,7 +3580,7 @@
 				<title>Operaciones de distancia</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpcpatch_nearestApproachDistance"><varname>|=|</varname>, <varname>nearestApproachDistance</varname></link>: Devuelve la distancia más cercana</para>
+						<para><link linkend="tpcpatch_nearestApproachDistance"><varname>|=|</varname></link>: Devuelve la distancia más cercana</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -995,10 +995,6 @@ SELECT ts2cell '47c3c@2001-01-01' = ts2cell '47c3c@2001-01-01';
 		</listitem>
 
 		<listitem xml:id="tcell_ever_always">
-			<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
-			<indexterm significance="normal"><primary><varname>aEq</varname></primary></indexterm>
-			<indexterm significance="normal"><primary><varname>eNe</varname></primary></indexterm>
-			<indexterm significance="normal"><primary><varname>aNe</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
@@ -1021,8 +1017,6 @@ SELECT ts2cell '47c3c@2001-01-01' ?= s2cell '47c3c';
 		</listitem>
 
 		<listitem xml:id="tcell_tcomp">
-			<indexterm significance="normal"><primary><varname>tEq</varname></primary></indexterm>
-			<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>#=</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>#&lt;&gt;</varname></primary></indexterm>
 			<para>Comparaciones temporales</para>
@@ -1406,7 +1400,6 @@ SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
 </programlisting>
 			</listitem>
 			<listitem xml:id="tcell_h3_grid_distance">
-				<indexterm significance="normal"><primary><varname>th3GridDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Devolver la distancia temporal en saltos de cuadrícula (número de pasos de una sola celda) entre dos celdas temporales</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_circular_buffers.xml
+++ b/doc/es/temporal_circular_buffers.xml
@@ -293,7 +293,6 @@ SELECT asEWKT(transformPipeline(transformPipeline(cbuffer, pipeline, 4326), pipe
 
 			<itemizedlist>
 				<listitem xml:id="cbuffer_distance_op">
-					<indexterm significance="normal"><primary><varname>distance</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Devuelve la distancia</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -312,7 +311,6 @@ SELECT round(cbuffer 'Cbuffer(Point(0 0),3)' &lt;-&gt; cbuffer 'Cbuffer(Point(3 
 </programlisting>
 				</listitem>
 				<listitem xml:id="cbuffer_nearestApproachDistance">
-					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 					<para>Devuelve la distancia de aproximación más cercana</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -364,7 +362,6 @@ SELECT cbuffer 'Cbuffer(Point(1 1), 0.6)' &gt;= cbuffer 'Cbuffer(Point(1 1), 0.5
 				</listitem>
 
 				<listitem xml:id="cbuffer_same">
-					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_network_points.xml
+++ b/doc/es/temporal_network_points.xml
@@ -333,7 +333,6 @@ SELECT SRID(nsegment 'Nsegment(76, 0.3, 0.5)');
 			<para>Dos valores <varname>npoint</varname> pueden tener diferentes identificadores de ruta pero pueden representar el mismo punto espacial en la intersección de las dos rutas. La función <varname>same</varname> se utiliza para verificar la similitud espacial de los puntos de la red.</para>
 			<itemizedlist>
 				<listitem xml:id="npoint_same">
-					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -1064,7 +1064,6 @@ SELECT tpcpointSeq(ARRAY[
 				<itemizedlist>
 					<listitem xml:id="tpcpoint_nearestApproachDistance">
 						<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
-						<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 						<para>Devuelve la distancia más cercana</para>
 						<programlisting role="syntax" xml:space="preserve" format="linespecific">
 nearestApproachDistance(tpcpoint,{tpcbox,tpcpoint}) → float
@@ -1116,7 +1115,6 @@ SELECT ST_AsText(shortestLine(tpcpointSeq(ARRAY[
 					</listitem>
 
 					<listitem xml:id="tpcpoint_tDistance">
-						<indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>
 						<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 						<para>Devuelve la distancia temporal</para>
 						<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -1841,7 +1839,6 @@ SELECT tpcpatchSeq(ARRAY[
 				<itemizedlist>
 					<listitem xml:id="tpcpatch_nearestApproachDistance">
 						<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
-						<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 						<para>Devuelve la distancia más cercana</para>
 						<programlisting role="syntax" xml:space="preserve" format="linespecific">
 nearestApproachDistance(tpcpatch,{tpcbox,tpcpatch}) → float

--- a/doc/es/temporal_pose_types.xml
+++ b/doc/es/temporal_pose_types.xml
@@ -410,7 +410,6 @@ SELECT asEWKT(transformPipeline(transformPipeline(pose, pipeline, 4326), pipelin
 
 			<itemizedlist>
 				<listitem xml:id="pose_distance_op">
-					<indexterm significance="normal"><primary><varname>distance</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Devuelve la distancia</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -432,7 +431,6 @@ SELECT round(geometry 'Point empty' &lt;-&gt; pose 'Pose(Point(4 0),0)', 6);
 </programlisting>
 				</listitem>
 				<listitem xml:id="pose_nearestApproachDistance">
-					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 					<para>Devuelve la distancia de aproximación más cercana</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -486,7 +484,6 @@ SELECT pose 'Pose(Point(1 1), 0.6)' &gt;= pose 'Pose(Point(1 1), 0.5)';
 				</listitem>
 
 				<listitem xml:id="pose_same">
-					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>¿Son los dos valores aproximadamente iguales con respecto a un valor épsilon?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/es/temporal_rigid_geometries.xml
+++ b/doc/es/temporal_rigid_geometries.xml
@@ -675,7 +675,6 @@ SELECT getTime(minusElevation(trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0
 		<itemizedlist>
 			<listitem xml:id="trgeometry_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>
 				<para>Devuelve la distancia temporal entre dos geometrías rígidas temporales</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {geometry,trgeometry} &lt;-&gt; {geometry,trgeometry} → tfloat
@@ -697,7 +696,6 @@ SELECT asText(tDistance( trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 
 			<listitem xml:id="trgeometry_nad">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 				<para>Devuelve la distancia más pequeña entre dos geometrías rígidas temporales sobre su dominio temporal compartido</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {geometry,trgeometry,stbox} |=| {geometry,trgeometry,stbox} → float

--- a/doc/portable_sql.xml
+++ b/doc/portable_sql.xml
@@ -31,6 +31,8 @@
 				<row><entry>Topology</entry><entry>&amp;&amp;</entry><entry><indexterm significance="normal"><primary><varname>overlaps</varname></primary></indexterm>overlaps(a, b)</entry></row>
 				<row><entry></entry><entry>@&gt;</entry><entry><indexterm significance="normal"><primary><varname>contains</varname></primary></indexterm>contains(a, b)</entry></row>
 				<row><entry></entry><entry>&lt;@</entry><entry><indexterm significance="normal"><primary><varname>contained</varname></primary></indexterm>contained(a, b)</entry></row>
+				<row><entry></entry><entry>#@&gt;</entry><entry>contains(a, b)</entry></row>
+				<row><entry></entry><entry>&lt;@#</entry><entry>contained(a, b)</entry></row>
 				<row><entry></entry><entry>-|-</entry><entry><indexterm significance="normal"><primary><varname>adjacent</varname></primary></indexterm>adjacent(a, b)</entry></row>
 				<row><entry>Time position</entry><entry>&lt;&lt;#</entry><entry><indexterm significance="normal"><primary><varname>before</varname></primary></indexterm>before(a, b)</entry></row>
 				<row><entry></entry><entry>#&gt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>after</varname></primary></indexterm>after(a, b)</entry></row>
@@ -56,6 +58,8 @@
 				<row><entry></entry><entry>#&gt;=</entry><entry><indexterm significance="normal"><primary><varname>tGe</varname></primary></indexterm>tGe(a, b)</entry></row>
 				<row><entry>Distance</entry><entry>&lt;-&gt;</entry><entry><indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>tDistance(a, b)</entry></row>
 				<row><entry></entry><entry>|=|</entry><entry><indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>nearestApproachDistance(a, b)</entry></row>
+				<row><entry>Distance (base / set / span / span set)</entry><entry>&lt;-&gt;</entry><entry>distance / setDistance (a, b)</entry></row>
+				<row><entry>Grid distance (cell index)</entry><entry>&lt;-&gt;</entry><entry><indexterm significance="normal"><primary><varname>th3GridDistance</varname></primary></indexterm>th3GridDistance(a, b)</entry></row>
 				<row><entry>Same</entry><entry>~=</entry><entry><indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>same(a, b)</entry></row>
 				<row><entry>Traditional comparison</entry><entry>=</entry><entry><indexterm significance="normal"><primary><varname>eq</varname></primary></indexterm>eq(a, b)</entry></row>
 				<row><entry></entry><entry>&lt;&gt;</entry><entry><indexterm significance="normal"><primary><varname>ne</varname></primary></indexterm>ne(a, b)</entry></row>
@@ -86,6 +90,18 @@
 				<row><entry>Intersection (set / span / span set)</entry><entry>*</entry><entry>setIntersection / spanIntersection / spansetIntersection (a, b)</entry></row>
 				<row><entry>Difference (set / span / span set)</entry><entry>-</entry><entry>setMinus / spanMinus / spansetMinus (a, b)</entry></row>
 				<row><entry>Concatenation (set / temporal)</entry><entry>||</entry><entry>setConcat / tConcat (a, b)</entry></row>
+				<row><entry>JSON field / element access</entry><entry>-&gt;</entry><entry>jsonbsetObjectField / tjsonbObjectField / jsonbsetArrayElement / tjsonbArrayElement (a, b)</entry></row>
+				<row><entry></entry><entry>-&gt;&gt;</entry><entry>jsonbsetObjectFieldText / tjsonbObjectFieldText / jsonbsetArrayElementText / tjsonbArrayElementText (a, b)</entry></row>
+				<row><entry>JSON key existence</entry><entry>?</entry><entry>jsonbsetExists / tjsonbExists (a, b)</entry></row>
+				<row><entry></entry><entry>?&amp;</entry><entry>jsonbsetExistsAll / tjsonbExistsAll (a, b)</entry></row>
+				<row><entry></entry><entry>?|</entry><entry>jsonbsetExistsAny / tjsonbExistsAny (a, b)</entry></row>
+				<row><entry>JSON path</entry><entry>@?</entry><entry>jsonbsetPathExists / tjsonbPathExists (a, b)</entry></row>
+				<row><entry></entry><entry>@@</entry><entry>jsonbsetPathMatch / tjsonbPathMatch (a, b)</entry></row>
+				<row><entry></entry><entry>#-</entry><entry>jsonbsetDeletePath / tjsonbDeletePath (a, b)</entry></row>
+				<row><entry>Route identifier (network point)</entry><entry>@=</entry><entry><indexterm significance="normal"><primary><varname>same_rid</varname></primary></indexterm>same_rid(a, b)</entry></row>
+				<row><entry></entry><entry>@?</entry><entry><indexterm significance="normal"><primary><varname>contains_rid</varname></primary></indexterm>contains_rid(a, b)</entry></row>
+				<row><entry></entry><entry>?@</entry><entry><indexterm significance="normal"><primary><varname>contained_rid</varname></primary></indexterm>contained_rid(a, b)</entry></row>
+				<row><entry></entry><entry>@@</entry><entry><indexterm significance="normal"><primary><varname>overlaps_rid</varname></primary></indexterm>overlaps_rid(a, b)</entry></row>
 			</tbody>
 		</tgroup>
 	</informaltable>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -1381,10 +1381,10 @@
 				<title>Distance Operations</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="pose_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Return the distance</para>
+						<para><link linkend="pose_distance_op"><varname>&lt;-&gt;</varname></link>: Return the distance</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="pose_nearestApproachDistance"><varname>nearestApproachDistance</varname>, <varname>|=|</varname></link>: Return the nearest approach distance</para>
+						<para><link linkend="pose_nearestApproachDistance"><varname>|=|</varname></link>: Return the nearest approach distance</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1395,7 +1395,7 @@
 						<para><link linkend="pose_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="pose_same"><varname>same</varname>, <varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
+						<para><link linkend="pose_same"><varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -1822,7 +1822,7 @@
 						<para><link linkend="npoint_srid"><varname>SRID</varname></link>: Return the spatial reference identifier</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="npoint_same"><varname>same</varname>, <varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
+						<para><link linkend="npoint_same"><varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2094,10 +2094,10 @@
 				<title>Distance Operations</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="cbuffer_distance_op"><varname>distance</varname>, <varname>&lt;-&gt;</varname></link>: Return the distance</para>
+						<para><link linkend="cbuffer_distance_op"><varname>&lt;-&gt;</varname></link>: Return the distance</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="cbuffer_nearestApproachDistance"><varname>nearestApproachDistance</varname>, <varname>|=|</varname></link>: Return the nearest approach distance</para>
+						<para><link linkend="cbuffer_nearestApproachDistance"><varname>|=|</varname></link>: Return the nearest approach distance</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2108,7 +2108,7 @@
 						<para><link linkend="cbuffer_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="cbuffer_same"><varname>same</varname>, <varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
+						<para><link linkend="cbuffer_same"><varname>~=</varname></link>: Are the two values approximately equal with respect to an epsilon value?</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -2483,10 +2483,10 @@
 			<title>Distance Operations</title>
 			<itemizedlist>
 				<listitem>
-					<para><link linkend="trgeometry_tdistance"><varname>&lt;-&gt;</varname>, <varname>tDistance</varname></link>: Return the temporal distance between two temporal rigid geometries</para>
+					<para><link linkend="trgeometry_tdistance"><varname>&lt;-&gt;</varname></link>: Return the temporal distance between two temporal rigid geometries</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="trgeometry_nad"><varname>|=|</varname>, <varname>nearestApproachDistance</varname></link>: Return the smallest distance between two temporal rigid geometries over their shared time domain</para>
+					<para><link linkend="trgeometry_nad"><varname>|=|</varname></link>: Return the smallest distance between two temporal rigid geometries over their shared time domain</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="trgeometry_nai"><varname>nearestApproachInstant</varname></link>: Return the instant at which the two arguments are at their smallest mutual distance</para>
@@ -2998,10 +2998,10 @@
 					<para><link linkend="tcell_comp"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&gt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname></link>: Traditional comparisons</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tcell_ever_always"><varname>eEq</varname>, <varname>aEq</varname>, <varname>eNe</varname>, <varname>aNe</varname>, <varname>?=</varname>, <varname>?&lt;&gt;</varname>, <varname>%=</varname>, <varname>%&lt;&gt;</varname></link>: Ever and always comparisons</para>
+					<para><link linkend="tcell_ever_always"><varname>?=</varname>, <varname>?&lt;&gt;</varname>, <varname>%=</varname>, <varname>%&lt;&gt;</varname></link>: Ever and always comparisons</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tcell_tcomp"><varname>tEq</varname>, <varname>tNe</varname>, <varname>#=</varname>, <varname>#&lt;&gt;</varname></link>: Temporal comparisons</para>
+					<para><link linkend="tcell_tcomp"><varname>#=</varname>, <varname>#&lt;&gt;</varname></link>: Temporal comparisons</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
@@ -3086,7 +3086,7 @@
 					<para><link linkend="tcell_h3_is_valid_vertex"><varname>isValidVertex</varname></link>: Return a temporal boolean stating at each instant whether the value is a valid H3 vertex</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="tcell_h3_grid_distance"><varname>th3GridDistance</varname>, <varname>&lt;-&gt;</varname></link>: Return the temporal grid-hop distance (number of single-cell steps) between two temporal cells</para>
+					<para><link linkend="tcell_h3_grid_distance"><varname>&lt;-&gt;</varname></link>: Return the temporal grid-hop distance (number of single-cell steps) between two temporal cells</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="tcell_h3_cell_to_local_ij"><varname>th3CellToLocalIj</varname>, <varname>th3LocalIjToCell</varname></link>: Convert between a temporal cell and a temporal local (I, J) coordinate pair relative to an origin temporal cell</para>
@@ -3419,7 +3419,7 @@
 				<title>Distance Operations</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpcpoint_nearestApproachDistance"><varname>|=|</varname>, <varname>nearestApproachDistance</varname></link>: Return the smallest distance ever</para>
+						<para><link linkend="tpcpoint_nearestApproachDistance"><varname>|=|</varname></link>: Return the smallest distance ever</para>
 					</listitem>
 					<listitem>
 						<para><link linkend="tpcpoint_nearestApproachInstant"><varname>nearestApproachInstant</varname></link>: Return the instant of the tpcpoint at which the two arguments are at the nearest distance</para>
@@ -3428,7 +3428,7 @@
 						<para><link linkend="tpcpoint_shortestLine"><varname>shortestLine</varname></link>: Return the line connecting the nearest approach point between the two arguments</para>
 					</listitem>
 					<listitem>
-						<para><link linkend="tpcpoint_tDistance"><varname>tDistance</varname>, <varname>&lt;-&gt;</varname></link>: Return the temporal distance</para>
+						<para><link linkend="tpcpoint_tDistance"><varname>&lt;-&gt;</varname></link>: Return the temporal distance</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>
@@ -3589,7 +3589,7 @@
 				<title>Distance Operations</title>
 				<itemizedlist>
 					<listitem>
-						<para><link linkend="tpcpatch_nearestApproachDistance"><varname>|=|</varname>, <varname>nearestApproachDistance</varname></link>: Return the smallest distance ever</para>
+						<para><link linkend="tpcpatch_nearestApproachDistance"><varname>|=|</varname></link>: Return the smallest distance ever</para>
 					</listitem>
 				</itemizedlist>
 			</sect3>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -998,10 +998,6 @@ SELECT ts2cell '47c3c@2001-01-01' = ts2cell '47c3c@2001-01-01';
 		</listitem>
 
 		<listitem xml:id="tcell_ever_always">
-			<indexterm significance="normal"><primary><varname>eEq</varname></primary></indexterm>
-			<indexterm significance="normal"><primary><varname>aEq</varname></primary></indexterm>
-			<indexterm significance="normal"><primary><varname>eNe</varname></primary></indexterm>
-			<indexterm significance="normal"><primary><varname>aNe</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>?=</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>?&lt;&gt;</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>%=</varname></primary></indexterm>
@@ -1024,8 +1020,6 @@ SELECT ts2cell '47c3c@2001-01-01' ?= s2cell '47c3c';
 		</listitem>
 
 		<listitem xml:id="tcell_tcomp">
-			<indexterm significance="normal"><primary><varname>tEq</varname></primary></indexterm>
-			<indexterm significance="normal"><primary><varname>tNe</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>#=</varname></primary></indexterm>
 			<indexterm significance="normal"><primary><varname>#&lt;&gt;</varname></primary></indexterm>
 			<para>Temporal comparisons</para>
@@ -1409,7 +1403,6 @@ SELECT isValidVertex(th3CellToVertex(th3index '871fa44a8ffffff@2001-01-01', 0));
 </programlisting>
 			</listitem>
 			<listitem xml:id="tcell_h3_grid_distance">
-				<indexterm significance="normal"><primary><varname>th3GridDistance</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 				<para>Return the temporal grid-hop distance (number of single-cell steps) between two temporal cells</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/temporal_circular_buffers.xml
+++ b/doc/temporal_circular_buffers.xml
@@ -293,7 +293,6 @@ SELECT asEWKT(transformPipeline(transformPipeline(cbuffer, pipeline, 4326), pipe
 
 			<itemizedlist>
 				<listitem xml:id="cbuffer_distance_op">
-					<indexterm significance="normal"><primary><varname>distance</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Return the distance</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -312,7 +311,6 @@ SELECT round(cbuffer 'Cbuffer(Point(0 0),3)' &lt;-&gt; cbuffer 'Cbuffer(Point(3 
 </programlisting>
 				</listitem>
 				<listitem xml:id="cbuffer_nearestApproachDistance">
-					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 					<para>Return the nearest approach distance</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -364,7 +362,6 @@ SELECT cbuffer 'Cbuffer(Point(1 1), 0.6)' &gt;= cbuffer 'Cbuffer(Point(1 1), 0.5
 				</listitem>
 
 				<listitem xml:id="cbuffer_same">
-					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Are the two values approximately equal with respect to an epsilon value?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/temporal_network_points.xml
+++ b/doc/temporal_network_points.xml
@@ -331,7 +331,6 @@ SELECT SRID(nsegment 'Nsegment(76, 0.3, 0.5)');
 			<para>Two <varname>npoint</varname> values may be have different route identifiers but may represent the same spatial point at the intersection of the two routes. Function <varname>same</varname> is used for testing spatial simalarity of network points.</para>
 			<itemizedlist>
 				<listitem xml:id="npoint_same">
-					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Are the two values approximately equal with respect to an epsilon value?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -1064,7 +1064,6 @@ SELECT tpcpointSeq(ARRAY[
 				<itemizedlist>
 					<listitem xml:id="tpcpoint_nearestApproachDistance">
 						<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
-						<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 						<para>Return the smallest distance ever</para>
 						<programlisting role="syntax" xml:space="preserve" format="linespecific">
 nearestApproachDistance(tpcpoint,{tpcbox,tpcpoint}) → float
@@ -1116,7 +1115,6 @@ SELECT ST_AsText(shortestLine(tpcpointSeq(ARRAY[
 					</listitem>
 
 					<listitem xml:id="tpcpoint_tDistance">
-						<indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>
 						<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 						<para>Return the temporal distance</para>
 						<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -1840,7 +1838,6 @@ SELECT tpcpatchSeq(ARRAY[
 				<itemizedlist>
 					<listitem xml:id="tpcpatch_nearestApproachDistance">
 						<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
-						<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 						<para>Return the smallest distance ever</para>
 						<programlisting role="syntax" xml:space="preserve" format="linespecific">
 nearestApproachDistance(tpcpatch,{tpcbox,tpcpatch}) → float

--- a/doc/temporal_pose_types.xml
+++ b/doc/temporal_pose_types.xml
@@ -409,7 +409,6 @@ SELECT asEWKT(transformPipeline(transformPipeline(pose, pipeline, 4326), pipelin
 
 			<itemizedlist>
 				<listitem xml:id="pose_distance_op">
-					<indexterm significance="normal"><primary><varname>distance</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
 					<para>Return the distance</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -431,7 +430,6 @@ SELECT round(geometry 'Point empty' &lt;-&gt; pose 'Pose(Point(4 0),0)', 6);
 </programlisting>
 				</listitem>
 				<listitem xml:id="pose_nearestApproachDistance">
-					<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
 					<para>Return the nearest approach distance</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">
@@ -485,7 +483,6 @@ SELECT pose 'Pose(Point(1 1), 0.6)' &gt;= pose 'Pose(Point(1 1), 0.5)';
 				</listitem>
 
 				<listitem xml:id="pose_same">
-					<indexterm significance="normal"><primary><varname>same</varname></primary></indexterm>
 					<indexterm significance="normal"><primary><varname>~=</varname></primary></indexterm>
 					<para>Are the two values approximately equal with respect to an epsilon value?</para>
 					<programlisting role="syntax" xml:space="preserve" format="linespecific">

--- a/doc/temporal_rigid_geometries.xml
+++ b/doc/temporal_rigid_geometries.xml
@@ -676,7 +676,6 @@ SELECT getTime(minusElevation(trgeometry 'Polygon Z((0 0 0,1 0 0,1 1 0,0 1 0,0 0
 		<itemizedlist>
 			<listitem xml:id="trgeometry_tdistance">
 				<indexterm significance="normal"><primary><varname>&lt;-&gt;</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>tDistance</varname></primary></indexterm>
 				<para>Return the temporal distance between two temporal rigid geometries</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {geometry,trgeometry} &lt;-&gt; {geometry,trgeometry} → tfloat
@@ -698,7 +697,6 @@ SELECT asText(tDistance( trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));
 
 			<listitem xml:id="trgeometry_nad">
 				<indexterm significance="normal"><primary><varname>|=|</varname></primary></indexterm>
-				<indexterm significance="normal"><primary><varname>nearestApproachDistance</varname></primary></indexterm>
 				<para>Return the smallest distance between two temporal rigid geometries over their shared time domain</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 {geometry,trgeometry,stbox} |=| {geometry,trgeometry,stbox} → float


### PR DESCRIPTION
The manual states an operation that has an operator by that operator alone, and
doc/portable_sql.xml carries the operator-to-function association once, at the
end, for an engine that does not accept a given operator. Six chapters
therefore drop the function indexterm of an entry whose own operator already
backs that function, 19 in each language: the cell index 7, the circular
buffers 3, the point cloud 3, the poses 3, the rigid geometries 2 and the
network points 1. Their signature lines and examples already read in the
operator and are unchanged.

A cast keeps its function name, which is the rule's own exception, and 22
indexterms stay because no operator backs them: cmp, which the btree
comparisons do not name, and the JSON functions whose named form carries a
null_handle or a Tz argument that the operator cannot express and that binds a
different C symbol.

The mapping table states all 67 operators the SQL declares, against 55 of them
before. It gains the JSON field, element, existence and path operators, the
tjsonb time containment pair, the four network point route identifier
operators, and the operand classes of <-> beyond the temporal one, which take
rows of their own as the union and the arithmetic senses of + already do.

doc/reference.xml and its Spanish twin are regenerated, so an appendix row
states the operator its entry states. tools/doc/gen_reference.py --check reads
OK for both languages and tools/doc/check_icon_parity.py compares 759 entries
with the same icons in each.

