### PR TITLE
Sample a PostGIS raster through the vendored raster core

### DIFF
--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -34,7 +34,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
 </programlisting>
-				<para>Evalúa el píxel de la <varname>band</varname> en cada instante de <varname>traj</varname> usando muestreo bilineal-vecino más próximo (<varname>ST_Value</varname> con <varname>resample=false</varname>). Devuelve un <varname>tfloat</varname> de conjunto de instantes cuyos valores se redondean a cuatro decimales. Devuelve <varname>NULL</varname> cuando ningún instante se interseca con el ráster.</para>
+				<para>Evalúa la banda <varname>band</varname> en cada instante de <varname>traj</varname> con muestreo del vecino más próximo, es decir, el valor del píxel en el que cae la posición. Devuelve un <varname>tfloat</varname> de conjunto de instantes que contiene los instantes que caen en un píxel con datos, y <varname>NULL</varname> cuando ningún instante se interseca con el ráster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
 WITH rast AS (

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -34,7 +34,7 @@ CREATE EXTENSION mobilitydb CASCADE;
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
 </programlisting>
-				<para>Evaluates pixel <varname>band</varname> at every instant of <varname>traj</varname> using bilinear-nearest sampling (<varname>ST_Value</varname> with <varname>resample=false</varname>). Returns an instant-set <varname>tfloat</varname> whose values are rounded to four decimal places. Returns <varname>NULL</varname> when no instant intersects the raster.</para>
+				<para>Evaluates band <varname>band</varname> at every instant of <varname>traj</varname> with nearest-neighbour sampling, that is, the value of the pixel the position falls in. Returns an instant-set <varname>tfloat</varname> holding the instants that fall on a pixel carrying data, and <varname>NULL</varname> when no instant intersects the raster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
 WITH rast AS (

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -145,30 +145,24 @@ extern bool raquet_gt(const Raquet *rq1, const Raquet *rq2);
 
 /* Sampling functions */
 
-/**
- * @brief Callback returning the raster pixel value at a point: return true
- * and set @p value, or return false when the point lies outside the raster
- * or on a nodata pixel
- */
-typedef bool (*raster_sample_fn)(void *ctx, const GSERIALIZED *point,
-  double *value);
+/* Sampling of a PostGIS raster: reads the band the position falls in with
+ * nearest-neighbour resampling, and derives the bounding-box pre-filter from
+ * the raster extent */
 
-extern Temporal *raster_value(const Temporal *traj, const STBox *box,
-  raster_sample_fn sample, void *ctx);
-
-extern Temporal *raster_at_value(const Temporal *traj, const STBox *box,
-  raster_sample_fn sample, void *ctx, const Span *vspan);
-extern Temporal *raster_minus_value(const Temporal *traj, const STBox *box,
-  raster_sample_fn sample, void *ctx, const Span *vspan);
-extern int eraster_value(const Temporal *traj, const STBox *box,
-  raster_sample_fn sample, void *ctx, const Span *vspan);
-extern int araster_value(const Temporal *traj, const STBox *box,
-  raster_sample_fn sample, void *ctx, const Span *vspan);
+extern Temporal *raster_value(const Temporal *traj, const Raster *rast,
+  int band);
+extern Temporal *raster_at_value(const Temporal *traj, const Raster *rast,
+  int band, const Span *vspan);
+extern Temporal *raster_minus_value(const Temporal *traj, const Raster *rast,
+  int band, const Span *vspan);
+extern int eraster_value(const Temporal *traj, const Raster *rast, int band,
+  const Span *vspan);
+extern int araster_value(const Temporal *traj, const Raster *rast, int band,
+  const Span *vspan);
 
 /* GDAL-backed sampling of a raster file: opens the file, derives the
- * bounding-box pre-filter from its geotransform, and thinly wraps
- * raster_value/raster_at_value/raster_minus_value/eraster_value/
- * araster_value with a GDALRasterIO-backed sample callback */
+ * bounding-box pre-filter from its geotransform, and reads the band through
+ * GDALRasterIO */
 
 extern Temporal *raster_value_gdal(const Temporal *traj, const char *path,
   int band);

--- a/meos/include/raster/raster_quadbin.h
+++ b/meos/include/raster/raster_quadbin.h
@@ -37,6 +37,7 @@
 
 /* MEOS */
 #include <meos.h>
+#include <meos_geo.h>
 #include <meos_raster.h>
 
 /*****************************************************************************/
@@ -48,6 +49,25 @@ extern void raster_quadbin_bounds(uint64 cell, double *xmin, double *ymin,
   double *xmax, double *ymax);
 
 extern uint32_t raster_quadbin_zoom(uint64 cell);
+
+/**
+ * @brief Callback returning the raster pixel value at a point: return true
+ * and set @p value, or return false when the point lies outside the raster
+ * or on a nodata pixel
+ */
+typedef bool (*raster_sample_fn)(void *ctx, const GSERIALIZED *point,
+  double *value);
+
+extern Temporal *raster_value_sampler(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx);
+extern Temporal *raster_at_value_sampler(const Temporal *traj,
+  const STBox *box, raster_sample_fn sample, void *ctx, const Span *vspan);
+extern Temporal *raster_minus_value_sampler(const Temporal *traj,
+  const STBox *box, raster_sample_fn sample, void *ctx, const Span *vspan);
+extern int eraster_value_sampler(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan);
+extern int araster_value_sampler(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx, const Span *vspan);
 
 /*****************************************************************************/
 

--- a/meos/src/raster/raquet_gdal.c
+++ b/meos/src/raster/raquet_gdal.c
@@ -560,7 +560,7 @@ raster_value_gdal(const Temporal *traj, const char *path, int band)
   if (! raster_value_gdal_open(path, band, &ds, &ctx, &box))
     return NULL;
   meos_gdal_enter();
-  Temporal *result = raster_value(traj, &box, &raster_value_gdal_sample,
+  Temporal *result = raster_value_sampler(traj, &box, &raster_value_gdal_sample,
     &ctx);
   meos_gdal_leave();
   raquet_gdal_release(ds, NULL, NULL);
@@ -590,7 +590,7 @@ raster_at_value_gdal(const Temporal *traj, const char *path, int band,
   if (! raster_value_gdal_open(path, band, &ds, &ctx, &box))
     return NULL;
   meos_gdal_enter();
-  Temporal *result = raster_at_value(traj, &box, &raster_value_gdal_sample,
+  Temporal *result = raster_at_value_sampler(traj, &box, &raster_value_gdal_sample,
     &ctx, vspan);
   meos_gdal_leave();
   raquet_gdal_release(ds, NULL, NULL);
@@ -620,7 +620,7 @@ raster_minus_value_gdal(const Temporal *traj, const char *path, int band,
   if (! raster_value_gdal_open(path, band, &ds, &ctx, &box))
     return NULL;
   meos_gdal_enter();
-  Temporal *result = raster_minus_value(traj, &box,
+  Temporal *result = raster_minus_value_sampler(traj, &box,
     &raster_value_gdal_sample, &ctx, vspan);
   meos_gdal_leave();
   raquet_gdal_release(ds, NULL, NULL);
@@ -652,7 +652,7 @@ eraster_value_gdal(const Temporal *traj, const char *path, int band,
   if (! raster_value_gdal_open(path, band, &ds, &ctx, &box))
     return -1;
   meos_gdal_enter();
-  int result = eraster_value(traj, &box, &raster_value_gdal_sample, &ctx,
+  int result = eraster_value_sampler(traj, &box, &raster_value_gdal_sample, &ctx,
     vspan);
   meos_gdal_leave();
   raquet_gdal_release(ds, NULL, NULL);
@@ -684,7 +684,7 @@ araster_value_gdal(const Temporal *traj, const char *path, int band,
   if (! raster_value_gdal_open(path, band, &ds, &ctx, &box))
     return -1;
   meos_gdal_enter();
-  int result = araster_value(traj, &box, &raster_value_gdal_sample, &ctx,
+  int result = araster_value_sampler(traj, &box, &raster_value_gdal_sample, &ctx,
     vspan);
   meos_gdal_leave();
   raquet_gdal_release(ds, NULL, NULL);

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -417,13 +417,12 @@ raster_tile_value_quadbin(const Temporal *traj, const uint8_t *pixels,
 }
 
 /**
- * @ingroup meos_raster
  * @brief Return the values of a raster sampled at the instants of a
  * trajectory
  * @details The pixel access is delegated to the @p sample callback so that
- * the one algorithm serves any raster engine: the MobilityDB extension
- * samples through PostGIS raster's @p ST_Value, a program using the MEOS
- * library samples through GDAL or any other reader.
+ * the one algorithm serves any raster engine: a PostGIS raster is read
+ * through the vendored raster core, a raster file through GDAL, a Raquet
+ * tile from its own pixel array.
  * @param[in] traj Trajectory (temporal geometry point)
  * @param[in] box Bounding box of the raster used as a pre-filter, may be
  * @p NULL
@@ -431,11 +430,10 @@ raster_tile_value_quadbin(const Temporal *traj, const uint8_t *pixels,
  * @param[in] ctx Opaque context passed through to the callback
  * @return A temporal float, or @p NULL when no instant of @p traj falls
  * inside the raster or survives nodata filtering
- * @csqlfn #Raster_value()
  */
 Temporal *
-raster_value(const Temporal *traj, const STBox *box, raster_sample_fn sample,
-  void *ctx)
+raster_value_sampler(const Temporal *traj, const STBox *box,
+  raster_sample_fn sample, void *ctx)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL((void *) sample, NULL);
@@ -482,21 +480,21 @@ raster_value(const Temporal *traj, const STBox *box, raster_sample_fn sample,
 }
 
 /*****************************************************************************
- * raster_at_value / raster_minus_value / eraster_value / araster_value
+ * raster_at_value_sampler / raster_minus_value_sampler /
+ * eraster_value_sampler / araster_value_sampler
  *****************************************************************************/
 
 /**
- * @ingroup meos_raster
  * @brief Return a trajectory restricted to the instants where the sampled
  * raster pixel value falls inside a float span
- * @details Equivalent to, with @p v = #raster_value(traj, box, sample, ctx):
+ * @details Equivalent to, with
+ * @p v = #raster_value_sampler(traj, box, sample, ctx):
  * @code
  * atTime(traj, getTime(atSpan(v, vspan)))
  * @endcode
- * composed here in C (on top of #tnumber_restrict_span, #temporal_time and
- * #temporal_restrict_tstzspanset) so that any MEOS caller supplying a
- * @p sample callback gets the restriction, not just the PostGIS raster PG
- * binding.
+ * composed here in C on top of #tnumber_restrict_span, #temporal_time and
+ * #temporal_restrict_tstzspanset, so that every caller supplying a @p sample
+ * callback gets the restriction.
  * @param[in] traj Trajectory (temporal geometry point)
  * @param[in] box Bounding box of the raster used as a pre-filter, may be
  * @p NULL
@@ -505,17 +503,16 @@ raster_value(const Temporal *traj, const STBox *box, raster_sample_fn sample,
  * @param[in] vspan Float value range (inclusive bounds)
  * @return A trajectory restricted to the qualifying instants, or @p NULL
  * when none qualify
- * @csqlfn #Raster_at_value()
  */
 Temporal *
-raster_at_value(const Temporal *traj, const STBox *box,
+raster_at_value_sampler(const Temporal *traj, const STBox *box,
   raster_sample_fn sample, void *ctx, const Span *vspan)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL((void *) sample, NULL);
   VALIDATE_NOT_NULL(vspan, NULL);
 
-  Temporal *v = raster_value(traj, box, sample, ctx);
+  Temporal *v = raster_value_sampler(traj, box, sample, ctx);
   if (! v)
     return NULL;
   Temporal *v1 = tnumber_restrict_span(v, vspan, REST_AT);
@@ -530,10 +527,10 @@ raster_at_value(const Temporal *traj, const STBox *box,
 }
 
 /**
- * @ingroup meos_raster
  * @brief Return a trajectory restricted to the instants where the sampled
  * raster pixel value falls outside a float span
- * @details Equivalent to, with @p v = #raster_value(traj, box, sample, ctx):
+ * @details Equivalent to, with
+ * @p v = #raster_value_sampler(traj, box, sample, ctx):
  * @code
  * atTime(traj, getTime(minusSpan(v, vspan)))
  * @endcode
@@ -545,17 +542,16 @@ raster_at_value(const Temporal *traj, const STBox *box,
  * @param[in] vspan Float value range to exclude
  * @return A trajectory restricted to the qualifying instants, or @p NULL
  * when none qualify
- * @csqlfn #Raster_minus_value()
  */
 Temporal *
-raster_minus_value(const Temporal *traj, const STBox *box,
+raster_minus_value_sampler(const Temporal *traj, const STBox *box,
   raster_sample_fn sample, void *ctx, const Span *vspan)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL((void *) sample, NULL);
   VALIDATE_NOT_NULL(vspan, NULL);
 
-  Temporal *v = raster_value(traj, box, sample, ctx);
+  Temporal *v = raster_value_sampler(traj, box, sample, ctx);
   if (! v)
     return NULL;
   Temporal *v1 = tnumber_restrict_span(v, vspan, REST_MINUS);
@@ -570,7 +566,6 @@ raster_minus_value(const Temporal *traj, const STBox *box,
 }
 
 /**
- * @ingroup meos_raster
  * @brief Return true if a trajectory ever samples a raster pixel value
  * inside a float span
  * @param[in] traj Trajectory (temporal geometry point)
@@ -581,17 +576,16 @@ raster_minus_value(const Temporal *traj, const STBox *box,
  * @param[in] vspan Float value range
  * @return 1 if the trajectory ever samples a value inside @p vspan, 0 if
  * not, and -1 on error
- * @csqlfn #Eraster_value()
  */
 int
-eraster_value(const Temporal *traj, const STBox *box,
+eraster_value_sampler(const Temporal *traj, const STBox *box,
   raster_sample_fn sample, void *ctx, const Span *vspan)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(traj, -1); VALIDATE_NOT_NULL((void *) sample, -1);
   VALIDATE_NOT_NULL(vspan, -1);
 
-  Temporal *v = raster_value(traj, box, sample, ctx);
+  Temporal *v = raster_value_sampler(traj, box, sample, ctx);
   if (! v)
     return 0;
   Temporal *v1 = tnumber_restrict_span(v, vspan, REST_AT);
@@ -603,7 +597,6 @@ eraster_value(const Temporal *traj, const STBox *box,
 }
 
 /**
- * @ingroup meos_raster
  * @brief Return true if every in-raster-extent instant of a trajectory
  * samples a pixel value inside a float span
  * @param[in] traj Trajectory (temporal geometry point)
@@ -614,17 +607,16 @@ eraster_value(const Temporal *traj, const STBox *box,
  * @param[in] vspan Float value range
  * @return 1 if every sampled value falls inside @p vspan, 0 if not, and -1
  * on error
- * @csqlfn #Araster_value()
  */
 int
-araster_value(const Temporal *traj, const STBox *box,
+araster_value_sampler(const Temporal *traj, const STBox *box,
   raster_sample_fn sample, void *ctx, const Span *vspan)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(traj, -1); VALIDATE_NOT_NULL((void *) sample, -1);
   VALIDATE_NOT_NULL(vspan, -1);
 
-  Temporal *v = raster_value(traj, box, sample, ctx);
+  Temporal *v = raster_value_sampler(traj, box, sample, ctx);
   if (! v)
     return 0;
   Temporal *v1 = tnumber_restrict_span(v, vspan, REST_MINUS);

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -57,8 +57,11 @@
 #include <string.h>
 /* MEOS */
 #include <meos.h>
+#include <meos_geo.h>
 #include <meos_internal.h>
 #include <meos_raster.h>
+#include "geo/geo_funcs.h"
+#include "raster/raster_quadbin.h"
 #include "temporal/temporal.h"
 
 /*****************************************************************************
@@ -258,6 +261,269 @@ raster_num_bands(const Raster *rast)
   }
   int result = (int) rt_raster_get_num_bands(raster);
   rt_raster_destroy(raster);
+  return result;
+}
+
+/*****************************************************************************
+ * Sampling functions
+ *
+ * The trajectory-sampling algorithm itself lives in #raster_value() and its
+ * restriction and predicate companions; what follows is the pixel reader that
+ * answers them for a PostGIS raster, so that the operators are computed by
+ * MEOS for every binding rather than by PostgreSQL for one of them.
+ *****************************************************************************/
+
+/**
+ * @brief State a raster sampling call keeps for the length of a trajectory:
+ * the deserialized raster, the band the values are read from, and the inverse
+ * geotransform, computed once and handed to every point conversion
+ */
+typedef struct
+{
+  rt_raster raster;   /**< Raster carrying its bands */
+  rt_band band;       /**< Band the pixel values are read from */
+  double igt[6];      /**< Inverse geotransform of the raster */
+} RasterSampleState;
+
+/**
+ * @brief Raster sampling callback reading one pixel of a PostGIS raster
+ * through the vendored raster core
+ * @details The point is converted to raster coordinates with the inverse
+ * geotransform and read with nearest-neighbour resampling. A point outside
+ * the pixel grid and a nodata pixel alike answer that there is no value,
+ * which is the contract of ::raster_sample_fn
+ */
+static bool
+raster_value_sample(void *ctxp, const GSERIALIZED *point, double *value)
+{
+  RasterSampleState *state = (RasterSampleState *) ctxp;
+  /* The point is read, not kept: its GBOX is degenerate, so its lower corner
+   * is the point itself */
+  GBOX gbox;
+  gserialized_get_gbox_p((GSERIALIZED *) point, &gbox);
+  double xr, yr;
+  if (rt_raster_geopoint_to_rasterpoint(state->raster, gbox.xmin, gbox.ymin,
+      &xr, &yr, state->igt) != ES_NONE)
+    return false;
+  int isnodata;
+  if (rt_band_get_pixel_resample(state->band, xr, yr, RT_NEAREST, value,
+      &isnodata) != ES_NONE)
+    return false;
+  return ! isnodata;
+}
+
+/**
+ * @brief Build the sampling state and the extent pre-filter shared by every
+ * raster sampling function
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] rast Raster
+ * @param[in] band Band number (1-based)
+ * @param[out] state Sampling state; on success its raster is owned by the
+ * caller, which releases it with #raster_destroy()
+ * @param[out] box Bounding box of the raster extent
+ * @return true on success; on failure sets a MEOS error and returns false
+ */
+static bool
+raster_sample_state_make(const Temporal *traj, const Raster *rast, int band,
+  RasterSampleState *state, STBox *box)
+{
+  /* The bands are needed, so the raster is fully deserialized. It keeps
+   * pointers into `rast` without owning them, and the caller destroys it
+   * before `rast` is handed back to its own caller */
+  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not deserialize raster");
+    return false;
+  }
+  /* A raster and a trajectory in different reference systems state their
+   * positions in different units, which the sampling cannot reconcile */
+  if (! ensure_same_srid(tspatial_srid(traj), rt_raster_get_srid(raster)))
+  {
+    raster_destroy(raster);
+    return false;
+  }
+  int numbands = (int) rt_raster_get_num_bands(raster);
+  if (band < 1 || band > numbands)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Raster has no band %d, it has %d", band, numbands);
+    return false;
+  }
+  /* Fetch the band using the 0-based internal index */
+  rt_band rtband = rt_raster_get_band(raster, (uint32_t) (band - 1));
+  if (! rtband ||
+      rt_raster_get_inverse_geotransform_matrix(raster, NULL,
+        state->igt) != ES_NONE)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not read band %d of the raster", band);
+    return false;
+  }
+  state->raster = raster;
+  state->band = rtband;
+
+  /* Bounding box of the raster extent, which bears the rotation of the
+   * geotransform */
+  rt_envelope env;
+  if (rt_raster_get_envelope(raster, &env) != ES_NONE)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not compute the extent of the raster");
+    return false;
+  }
+  memset(box, 0, sizeof(STBox));
+  box->xmin = env.MinX; box->xmax = env.MaxX;
+  box->ymin = env.MinY; box->ymax = env.MaxY;
+  return true;
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return the values of a raster band sampled at the instants of a
+ * trajectory
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] rast Raster
+ * @param[in] band Band number (1-based)
+ * @return A temporal float, or @p NULL when no instant of @p traj falls
+ * inside the raster or survives nodata filtering
+ * @csqlfn #Raster_value()
+ */
+Temporal *
+raster_value(const Temporal *traj, const Raster *rast, int band)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL(rast, NULL);
+
+  RasterSampleState state;
+  STBox box;
+  if (! raster_sample_state_make(traj, rast, band, &state, &box))
+    return NULL;
+  Temporal *result = raster_value_sampler(traj, &box, &raster_value_sample,
+    &state);
+  raster_destroy(state.raster);
+  return result;
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return the instants of a trajectory where the sampled raster pixel
+ * value falls inside a float span
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] rast Raster
+ * @param[in] band Band number (1-based)
+ * @param[in] vspan Float value range (inclusive bounds)
+ * @return A trajectory restricted to the qualifying instants, or @p NULL
+ * when none qualify
+ * @csqlfn #Raster_at_value()
+ */
+Temporal *
+raster_at_value(const Temporal *traj, const Raster *rast, int band,
+  const Span *vspan)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL(rast, NULL);
+  VALIDATE_NOT_NULL(vspan, NULL);
+
+  RasterSampleState state;
+  STBox box;
+  if (! raster_sample_state_make(traj, rast, band, &state, &box))
+    return NULL;
+  Temporal *result = raster_at_value_sampler(traj, &box, &raster_value_sample,
+    &state, vspan);
+  raster_destroy(state.raster);
+  return result;
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return the instants of a trajectory where the sampled raster pixel
+ * value falls outside a float span
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] rast Raster
+ * @param[in] band Band number (1-based)
+ * @param[in] vspan Float value range to exclude
+ * @return A trajectory restricted to the qualifying instants, or @p NULL
+ * when none qualify
+ * @csqlfn #Raster_minus_value()
+ */
+Temporal *
+raster_minus_value(const Temporal *traj, const Raster *rast, int band,
+  const Span *vspan)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(traj, NULL); VALIDATE_NOT_NULL(rast, NULL);
+  VALIDATE_NOT_NULL(vspan, NULL);
+
+  RasterSampleState state;
+  STBox box;
+  if (! raster_sample_state_make(traj, rast, band, &state, &box))
+    return NULL;
+  Temporal *result = raster_minus_value_sampler(traj, &box,
+    &raster_value_sample, &state, vspan);
+  raster_destroy(state.raster);
+  return result;
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return true if a trajectory ever samples a raster pixel value inside
+ * a float span
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] rast Raster
+ * @param[in] band Band number (1-based)
+ * @param[in] vspan Float value range (inclusive bounds)
+ * @return On error, return -1
+ * @csqlfn #Eraster_value()
+ */
+int
+eraster_value(const Temporal *traj, const Raster *rast, int band,
+  const Span *vspan)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(traj, -1); VALIDATE_NOT_NULL(rast, -1);
+  VALIDATE_NOT_NULL(vspan, -1);
+
+  RasterSampleState state;
+  STBox box;
+  if (! raster_sample_state_make(traj, rast, band, &state, &box))
+    return -1;
+  int result = eraster_value_sampler(traj, &box, &raster_value_sample, &state,
+    vspan);
+  raster_destroy(state.raster);
+  return result;
+}
+
+/**
+ * @ingroup meos_raster
+ * @brief Return true if every instant of a trajectory that falls inside a
+ * raster samples a pixel value inside a float span
+ * @param[in] traj Trajectory (temporal geometry point)
+ * @param[in] rast Raster
+ * @param[in] band Band number (1-based)
+ * @param[in] vspan Float value range (inclusive bounds)
+ * @return On error, return -1
+ * @csqlfn #Araster_value()
+ */
+int
+araster_value(const Temporal *traj, const Raster *rast, int band,
+  const Span *vspan)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(traj, -1); VALIDATE_NOT_NULL(rast, -1);
+  VALIDATE_NOT_NULL(vspan, -1);
+
+  RasterSampleState state;
+  STBox box;
+  if (! raster_sample_state_make(traj, rast, band, &state, &box))
+    return -1;
+  int result = araster_value_sampler(traj, &box, &raster_value_sample, &state,
+    vspan);
+  raster_destroy(state.raster);
   return result;
 }
 

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -74,6 +74,14 @@ static const char *raster_two_bands =
   "0a0000000000000000000000000000000000000000000000000000000000000000000000"
   "0000000000";
 
+/* The 3x3 raster of the rasterValue cases: a 32BF band of 1 degree pixels
+ * holding 10, nodata, 30 / 40, 50, 60 / 70, 80, 90, with -9999 declared as
+ * its nodata value */
+static const char *raster_values =
+  "0100000100000000000000f03f000000000000f0bf0000000000000000000000000000"
+  "084000000000000000000000000000000000e6100000030003004a003c1cc600002041"
+  "003c1cc60000f04100002042000048420000704200008c420000a0420000b442";
+
 /* Main program */
 int main(void)
 {
@@ -267,6 +275,78 @@ int main(void)
   }
   free(zero_quadbin);
   free(traj);
+
+  /* The sampling of a PostGIS raster is answered by MEOS, so a program using
+   * the library reads the values a PostgreSQL session reads. The trajectory
+   * below visits pixel(1,1) = 10, the nodata pixel(1,2), a position outside
+   * the raster, and pixel(3,1) = 70, so the two positions carrying data are
+   * the two the sampling answers */
+  Raster *rast_values = raster_from_hexwkb(raster_values);
+  assert(rast_values != NULL);
+  Temporal *traj_values = tgeompoint_in("SRID=4326;[POINT(0.5 2.5)@2001-01-01,"
+    " POINT(1.5 2.5)@2001-01-02, POINT(5.5 5.5)@2001-01-03,"
+    " POINT(0.5 0.5)@2001-01-04]");
+  assert(traj_values != NULL);
+  meos_errno_reset();
+  Temporal *values = raster_value(traj_values, rast_values, 1);
+  assert(values != NULL);
+  assert(meos_errno() == 0);
+  char *values_str = tfloat_out(values, 0);
+  printf("raster_value(traj, raster, 1): %s\n", values_str);
+  assert(temporal_num_instants(values) == 2);
+  assert(tfloat_start_value(values) == 10.0);
+  assert(tfloat_end_value(values) == 70.0);
+  free(values_str); free(values);
+
+  /* The restrictions and the predicates read the same values: only the
+   * position sampling 70 falls inside [40, 90] */
+  Span *vspan = floatspan_in("[40, 90]");
+  assert(vspan != NULL);
+  Temporal *at = raster_at_value(traj_values, rast_values, 1, vspan);
+  assert(at != NULL && temporal_num_instants(at) == 1);
+  Temporal *minus = raster_minus_value(traj_values, rast_values, 1,
+    vspan);
+  assert(minus != NULL && temporal_num_instants(minus) == 1);
+  int ever = eraster_value(traj_values, rast_values, 1, vspan);
+  int always = araster_value(traj_values, rast_values, 1, vspan);
+  printf("eraster_value: %d, araster_value: %d\n", ever,
+    always);
+  assert(ever == 1 && always == 0);
+  assert(meos_errno() == 0);
+  free(at); free(minus);
+
+  /* A band the raster does not have is refused, in either direction */
+  const int bad_bands[] = {0, -1, 2};
+  for (size_t i = 0; i < sizeof(bad_bands) / sizeof(bad_bands[0]); i++)
+  {
+    meos_errno_reset();
+    Temporal *none = raster_value(traj_values, rast_values,
+      bad_bands[i]);
+    printf("raster_value(band %d): %s, errno %d\n", bad_bands[i],
+      none ? "non-NULL" : "NULL", meos_errno());
+    assert(none == NULL);
+    assert(meos_errno() != 0);
+  }
+
+  /* A raster and a trajectory in different reference systems state their
+   * positions in different units, which is an error and not an empty answer */
+  Temporal *traj_3857 = tgeompoint_in("SRID=3857;{POINT(0.5 2.5)@2001-01-01}");
+  assert(traj_3857 != NULL);
+  meos_errno_reset();
+  assert(raster_value(traj_3857, rast_values, 1) == NULL);
+  assert(meos_errno() != 0);
+
+  /* A null argument is rejected rather than dereferenced */
+  meos_errno_reset();
+  assert(raster_value(NULL, rast_values, 1) == NULL);
+  assert(raster_value(traj_values, NULL, 1) == NULL);
+  assert(raster_at_value(traj_values, rast_values, 1, NULL) == NULL);
+  assert(raster_minus_value(traj_values, rast_values, 1, NULL) == NULL);
+  assert(eraster_value(traj_values, rast_values, 1, NULL) == -1);
+  assert(araster_value(traj_values, rast_values, 1, NULL) == -1);
+  assert(meos_errno() != 0);
+
+  free(vspan); free(traj_3857); free(traj_values); free(rast_values);
 
   meos_finalize();
   printf("raster_test: all assertions passed\n");

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -29,48 +29,24 @@
 
 /**
  * @file
- * @brief C implementation of raster_value() — PostGIS raster band sampling
- * along tgeompoint trajectories.
+ * @brief PostgreSQL functions of the raster sampling operators.
  *
- * The function iterates over the instants of the trajectory in C, filters
- * out-of-range positions with a bounding-box pre-check derived from the
- * raster's convex hull, calls PostGIS ST_Value() for each in-range instant,
- * and assembles the surviving (value, timestamp) pairs directly into a
- * heap-allocated TSequence (DISCRETE interpolation), bypassing the SQL
- * string_agg / to_char / text→tfloat pipeline.
- *
- * PostGIS raster internals (rt_api.h) are not exported from
- * postgis_raster-3.so.  The implementation therefore calls the published SQL
- * surface (ST_ConvexHull, ST_Value) via PostgreSQL's OidFunctionCall
- * mechanism, resolving OIDs once per session through regprocedurein.
+ * The wrappers pass their arguments to MEOS, which samples a PostGIS raster
+ * through the vendored raster core: a `raster` column is detoasted into the
+ * serialized form the MEOS functions take, so the operators answer the same
+ * values to every binding of the library and not to PostgreSQL alone.
  */
 
-/* C */
-#include <math.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <fmgr.h>
-/*
- * utils/builtins.h pulls in fmgrprotos.h, which declares `json_object` as a
- * PostgreSQL callable function.  meos_internal.h then includes json-c/json.h
- * which tries to typedef the same name as a struct — a C-level conflict.
- * Forward-declare only the symbols we need to avoid the full builtins.h include.
- */
-
-extern Datum regprocedurein(PG_FUNCTION_ARGS);
-
-/* PostgreSQL */
 #include <utils/array.h>
-/* PostGIS */
-#include <liblwgeom.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
 #include <meos_raster.h>
-#include <pgtypes.h>
+#include <pgtypes.h>          /* text_to_cstring, cstring_to_text */
 #include "temporal/span.h"    /* PG_GETARG_SPAN_P */
-#include "temporal/tinstant.h"
-#include "temporal/tsequence.h"
 #include "temporal/type_util.h" /* bstring2bytea */
 #include "geo/stbox.h"        /* PG_RETURN_STBOX_P */
 #include "raster/raquet.h"    /* Raquet, PG_GETARG_RAQUET_P, raquet_pixtype_size */
@@ -80,120 +56,14 @@ extern Datum regprocedurein(PG_FUNCTION_ARGS);
 #include "pg_temporal/type_util.h" /* raquetarr_extract */
 #include "pg_raster/temporal_raster.h"
 
-/*****************************************************************************
- * OID cache helpers
- *****************************************************************************/
-
-/**
- * @brief Return the OID of a function identified by its SQL signature string.
- *
- * Uses regprocedurein so that type names are resolved in the current search
- * path without hard-coding any numeric OIDs.
- */
-static Oid
-lookup_func_oid(const char *signature)
-{
-  return DatumGetObjectId(DirectFunctionCall1(regprocedurein,
-    CStringGetDatum(signature)));
-}
-
-/** Cached OID for ST_ConvexHull(raster) → geometry */
-static Oid st_convexhull_raster_oid = InvalidOid;
-
-/** Cached OID for ST_Value(raster, integer, geometry, boolean) → float8 */
-static Oid st_value_oid = InvalidOid;
-
-static void
-init_oids(void)
-{
-  if (st_convexhull_raster_oid == InvalidOid)
-    st_convexhull_raster_oid = lookup_func_oid("st_convexhull(raster)");
-  if (st_value_oid == InvalidOid)
-    st_value_oid =
-      lookup_func_oid("st_value(raster,integer,geometry,boolean,text)");
-}
-
-/*****************************************************************************
- * raster_value
- *****************************************************************************/
-
-/**
- * @brief Raster sampling callback backed by PostGIS raster's ST_Value: the
- * context is a prepared FunctionCallInfo whose raster/band/nodata/resample
- * arguments are constant, only the point argument varies per call
- */
-static bool
-raster_st_value_sample(void *ctx, const GSERIALIZED *point, double *value)
-{
-  FunctionCallInfo fcinfo_val = (FunctionCallInfo) ctx;
-  fcinfo_val->args[2].value = PointerGetDatum(point);
-  fcinfo_val->args[2].isnull = false;
-  fcinfo_val->isnull = false;   /* reset before every call */
-  Datum pixval = FunctionCallInvoke(fcinfo_val);
-  if (fcinfo_val->isnull)
-    return false;   /* nodata pixel, or point outside the raster or the band */
-  *value = DatumGetFloat8(pixval);
-  return true;
-}
-
-/**
- * @brief Build the convex-hull STBox pre-filter and the reusable ST_Value
- * FunctionCallInfo shared by every raster sampling/restriction/predicate
- * wrapper
- * @details Arg 2 (the point) of @p fcinfo_val is left uninitialized: it is
- * set on every call by #raster_st_value_sample. The FmgrInfo backing
- * @p fcinfo_val is palloc'd so that its lifetime matches the calling
- * wrapper's memory context, same as the LOCAL_FCINFO buffer itself.
- */
-static void
-raster_value_setup(Datum rast_datum, int32 band, STBox *box,
-  FunctionCallInfo fcinfo_val)
-{
-  /* OID resolution (once per session) */
-  init_oids();
-
-  /* Raster convex hull — the bounding-box pre-filter of the MEOS kernel */
-  Datum hull_datum =
-    OidFunctionCall1(st_convexhull_raster_oid, rast_datum);
-  GSERIALIZED *hull_gs = (GSERIALIZED *) DatumGetPointer(hull_datum);
-  GBOX hull_box;
-  gserialized_get_gbox_p(hull_gs, &hull_box);
-  pfree(hull_gs);
-  memset(box, 0, sizeof(STBox));
-  box->xmin = hull_box.xmin;
-  box->xmax = hull_box.xmax;
-  box->ymin = hull_box.ymin;
-  box->ymax = hull_box.ymax;
-
-  /* Prepare a reusable FunctionCallInfo for ST_Value (handles NULL returns) */
-  FmgrInfo *flinfo = palloc0(sizeof(FmgrInfo));
-  fmgr_info(st_value_oid, flinfo);
-  InitFunctionCallInfoData(*fcinfo_val, flinfo, 5, DEFAULT_COLLATION_OID,
-    NULL, NULL);
-  /* Arg 0 (raster) and Arg 1 (band) are constant for every instant */
-  fcinfo_val->args[0].value = rast_datum;
-  fcinfo_val->args[0].isnull = false;
-  fcinfo_val->args[1].value = Int32GetDatum(band);
-  fcinfo_val->args[1].isnull = false;
-  /* Arg 3 (exclude_nodata) = true — ST_Value reports a nodata pixel as NULL,
-   * which #raster_st_value_sample turns into "no value here", as the
-   * #raster_sample_fn contract requires. With false the sentinel comes back as
-   * an ordinary number and is sampled as though it were data */
-  fcinfo_val->args[3].value  = BoolGetDatum(true);
-  fcinfo_val->args[3].isnull = false;
-  /* Arg 4 (resample) = 'nearest' — PostGIS 3.6+ added this parameter */
-  fcinfo_val->args[4].value = PointerGetDatum(cstring_to_text("nearest"));
-  fcinfo_val->args[4].isnull = false;
-}
-
 PGDLLEXPORT Datum Raster_value(PG_FUNCTION_ARGS);
 PG_FUNCTION_INFO_V1(Raster_value);
 /**
  * @ingroup mobilitydb_raster
  * @brief Return the values of a raster band sampled at the instants of a
  * trajectory
- * @param[in] rast Raster
  * @param[in] traj Trajectory
+ * @param[in] rast Raster
  * @param[in] band Band number (1-based, default 1)
  * @sqlfn rasterValue()
  */
@@ -201,17 +71,13 @@ Datum
 Raster_value(PG_FUNCTION_ARGS)
 {
   Temporal *traj = PG_GETARG_TEMPORAL_P(0);
-  Datum rast_datum = PG_GETARG_DATUM(1);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(PG_GETARG_DATUM(1));
   int32 band = PG_ARGISNULL(2) ? 1 : PG_GETARG_INT32(2);
 
-  STBox box;
-  LOCAL_FCINFO(fcinfo_val, 5);
-  raster_value_setup(rast_datum, band, &box, fcinfo_val);
-
-  Temporal *result = raster_value(traj, &box, &raster_st_value_sample,
-    fcinfo_val);
+  Temporal *result = raster_value(traj, rast, band);
 
   PG_FREE_IF_COPY(traj, 0);
+  PG_FREE_IF_COPY(rast, 1);
   if (result == NULL)
     PG_RETURN_NULL();
   PG_RETURN_POINTER(result);
@@ -237,18 +103,14 @@ Datum
 Raster_at_value(PG_FUNCTION_ARGS)
 {
   Temporal *traj = PG_GETARG_TEMPORAL_P(0);
-  Datum rast_datum = PG_GETARG_DATUM(1);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(PG_GETARG_DATUM(1));
   Span *vspan = PG_GETARG_SPAN_P(2);
   int32 band = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
 
-  STBox box;
-  LOCAL_FCINFO(fcinfo_val, 5);
-  raster_value_setup(rast_datum, band, &box, fcinfo_val);
-
-  Temporal *result = raster_at_value(traj, &box, &raster_st_value_sample,
-    fcinfo_val, vspan);
+  Temporal *result = raster_at_value(traj, rast, band, vspan);
 
   PG_FREE_IF_COPY(traj, 0);
+  PG_FREE_IF_COPY(rast, 1);
   if (result == NULL)
     PG_RETURN_NULL();
   PG_RETURN_POINTER(result);
@@ -270,18 +132,14 @@ Datum
 Raster_minus_value(PG_FUNCTION_ARGS)
 {
   Temporal *traj = PG_GETARG_TEMPORAL_P(0);
-  Datum rast_datum = PG_GETARG_DATUM(1);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(PG_GETARG_DATUM(1));
   Span *vspan = PG_GETARG_SPAN_P(2);
   int32 band = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
 
-  STBox box;
-  LOCAL_FCINFO(fcinfo_val, 5);
-  raster_value_setup(rast_datum, band, &box, fcinfo_val);
-
-  Temporal *result = raster_minus_value(traj, &box, &raster_st_value_sample,
-    fcinfo_val, vspan);
+  Temporal *result = raster_minus_value(traj, rast, band, vspan);
 
   PG_FREE_IF_COPY(traj, 0);
+  PG_FREE_IF_COPY(rast, 1);
   if (result == NULL)
     PG_RETURN_NULL();
   PG_RETURN_POINTER(result);
@@ -293,8 +151,8 @@ PG_FUNCTION_INFO_V1(Eraster_value);
  * @ingroup mobilitydb_raster
  * @brief Return true if a trajectory ever samples a raster pixel value
  * inside a float range
- * @param[in] rast Raster
  * @param[in] traj Trajectory (SRID matching the raster)
+ * @param[in] rast Raster
  * @param[in] vspan Float value range
  * @param[in] band Band number (1-based, default 1)
  * @sqlfn eRasterValue()
@@ -303,18 +161,14 @@ Datum
 Eraster_value(PG_FUNCTION_ARGS)
 {
   Temporal *traj = PG_GETARG_TEMPORAL_P(0);
-  Datum rast_datum = PG_GETARG_DATUM(1);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(PG_GETARG_DATUM(1));
   Span *vspan = PG_GETARG_SPAN_P(2);
   int32 band = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
 
-  STBox box;
-  LOCAL_FCINFO(fcinfo_val, 5);
-  raster_value_setup(rast_datum, band, &box, fcinfo_val);
-
-  int result = eraster_value(traj, &box, &raster_st_value_sample,
-    fcinfo_val, vspan);
+  int result = eraster_value(traj, rast, band, vspan);
 
   PG_FREE_IF_COPY(traj, 0);
+  PG_FREE_IF_COPY(rast, 1);
   if (result < 0)
     PG_RETURN_NULL();
   PG_RETURN_BOOL(result);
@@ -326,8 +180,8 @@ PG_FUNCTION_INFO_V1(Araster_value);
  * @ingroup mobilitydb_raster
  * @brief Return true if every in-raster-extent instant of a trajectory
  * samples a pixel value inside a float range
- * @param[in] rast Raster
  * @param[in] traj Trajectory (SRID matching the raster)
+ * @param[in] rast Raster
  * @param[in] vspan Float value range
  * @param[in] band Band number (1-based, default 1)
  * @sqlfn aRasterValue()
@@ -336,18 +190,14 @@ Datum
 Araster_value(PG_FUNCTION_ARGS)
 {
   Temporal *traj = PG_GETARG_TEMPORAL_P(0);
-  Datum rast_datum = PG_GETARG_DATUM(1);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(PG_GETARG_DATUM(1));
   Span *vspan = PG_GETARG_SPAN_P(2);
   int32 band = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
 
-  STBox box;
-  LOCAL_FCINFO(fcinfo_val, 5);
-  raster_value_setup(rast_datum, band, &box, fcinfo_val);
-
-  int result = araster_value(traj, &box, &raster_st_value_sample,
-    fcinfo_val, vspan);
+  int result = araster_value(traj, rast, band, vspan);
 
   PG_FREE_IF_COPY(traj, 0);
+  PG_FREE_IF_COPY(rast, 1);
   if (result < 0)
     PG_RETURN_NULL();
   PG_RETURN_BOOL(result);

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -102,6 +102,33 @@ FROM rast;
 (1 row)
 
 WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}', r, 2)
+FROM rast;
+ERROR:  Raster has no band 2, it has 1
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}', r, 0)
+FROM rast;
+ERROR:  Raster has no band 0, it has 1
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01}', r)
+FROM rast;
+ERROR:  Operation on mixed SRID
+WITH rast AS (
   SELECT ST_SetValues(
     ST_AddBand(
       ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -133,6 +133,35 @@ WITH rast AS (
 SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}', r)::text AS result
 FROM rast;
 
+-- A band the raster does not have is an error, in either direction.
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}', r, 2)
+FROM rast;
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}', r, 0)
+FROM rast;
+
+-- A raster and a trajectory in different reference systems state their
+-- positions in different units, which is an error and not an empty answer.
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01}', r)
+FROM rast;
+
 -------------------------------------------------------------------------------
 -- atRasterValue / minusRasterValue / eRasterValue / aRasterValue
 -------------------------------------------------------------------------------

--- a/tools/scripts/liblwgeom_geos_baseline.txt
+++ b/tools/scripts/liblwgeom_geos_baseline.txt
@@ -8,6 +8,9 @@ meos/src/geo/postgis_funcs.c	lwgeom_difference_prec
 meos/src/geo/postgis_funcs.c	lwgeom_intersection_prec
 meos/src/geo/postgis_funcs.c	lwgeom_unaryunion_prec
 meos/src/raster/raster_rtcore.c	rt_raster_destroy
+meos/src/raster/raster_rtcore.c	rt_raster_geopoint_to_rasterpoint
 meos/src/raster/raster_rtcore.c	rt_raster_get_band
+meos/src/raster/raster_rtcore.c	rt_raster_get_envelope
+meos/src/raster/raster_rtcore.c	rt_raster_get_inverse_geotransform_matrix
 meos/src/raster/raster_rtcore.c	rt_raster_get_num_bands
-meos/src/temporal/temporal_modif.c	lwgeom_linemerge_directed
+meos/src/raster/raster_rtcore.c	rt_raster_get_srid


### PR DESCRIPTION
The raster sampling operators read their pixels with rt_core: raster_value
and its restriction and predicate companions take the raster itself,
deserialize it, convert each position of the trajectory with the inverse
geotransform, and read the band with nearest-neighbour resampling, which is
the value ST_Value(rast, band, point, true, 'nearest') answers. The
PostgreSQL functions hand their detoasted argument to them and do nothing
else, so a raster is sampled by MEOS and the operators are available to every
binding of the library.

Those five names are the C twins of the SQL functions rasterValue,
atRasterValue, minusRasterValue, eRasterValue and aRasterValue. The
sampler-parameterised kernels they share with the GDAL entry points carry the
suffix of the argument that tells them apart and are declared in the family's
own header, a callback and an opaque context being what no binding calls.

A raster and a trajectory in different spatial reference systems state their
positions in different units, which the sampling refuses, and a band the
raster does not carry is refused in either direction. Both are decided once
per call, before the first position is read.

Witness, from a program holding only the library, which reads what a
PostgreSQL session reads: the 3x3 band of the regression suite holds 10,
nodata and 30 in its first row and 70, 80 and 90 in its third, and
meos/test/raster_test.c reads it from its HexWKB with no PostgreSQL
involved:

  raster_value(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
    POINT(1.5 2.5)@2001-01-02, POINT(5.5 5.5)@2001-01-03,
    POINT(0.5 0.5)@2001-01-04]', rast, 1)
  = {10@2001-01-01 00:00:00+00, 70@2001-01-04 00:00:00+00}

the nodata pixel and the position outside the extent carrying no value. Band
2 of that one-band raster answers "Raster has no band 2, it has 1", and a
trajectory in SRID 3857 against the 4326 raster answers "Operation on mixed
SRID".

The numbers: 500_raster.test.sql holds 19 rasterValue cases, 5 atRasterValue
and minusRasterValue cases and 9 eRasterValue and aRasterValue cases, whose
expected values stand as they are, and it grows by the 27 lines of the three
cases above; 500_raster_tbl keeps its 100-row fixture. meos/test/raster_test.c
covers the sampling, the two restrictions and the two predicates, and runs
under valgrind with 0 errors and 0 bytes lost.

The rule: sampling is an operation on a raster value, so it belongs where the
library keeps its operations, and reading a band is what the vendored raster
core is for. PostgreSQL carries the value in and the answer out.

