### PR TITLE
Ask a point cloud box pair whether both measure the same kind of coordinate

### DIFF
--- a/doc/es/temporal_pointcloud.xml
+++ b/doc/es/temporal_pointcloud.xml
@@ -437,7 +437,7 @@ SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
 
 		<sect2 xml:id="tpcbox_topo">
 			<title>Operaciones topológicas</title>
-			<para>Todos los operadores topológicos toman dos valores <varname>tpcbox</varname> que declaran el mismo esquema y el mismo sistema de referencia. Una discrepancia en cualquiera de los dos genera un error en lugar de responder falso: el <varname>pcid</varname> es lo que da a un número almacenado su significado como coordenada, por lo que dos cajas que nombran esquemas distintos no tienen una extensión común que comparar.</para>
+			<para>Todos los operadores topológicos toman dos valores <varname>tpcbox</varname> que declaran el mismo esquema, el mismo sistema de referencia y el mismo tipo de coordenada, plana o esférica. Una discrepancia en cualquiera de los dos genera un error en lugar de responder falso: el <varname>pcid</varname> es lo que da a un número almacenado su significado como coordenada, por lo que dos cajas que nombran esquemas distintos no tienen una extensión común que comparar.</para>
 			<para>También toman dos cajas que comparten un eje. Una caja que contiene coordenadas y una caja que contiene un período no coinciden en ningún eje, por lo que un predicado topológico entre ellas no tiene nada que comparar y genera un error a su vez.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_topo_ops">
@@ -465,6 +465,9 @@ SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(0, 0, 5, 5, 2);
 -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 SELECT tpcboxX(0, 0, 10, 10, 1) &amp;&amp; tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
 -- ERROR:  The temporal values must have at least one common dimension
+SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' &amp;&amp;
+  tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)';
+-- ERROR:  Operation on mixed planar and geodetic coordinates
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -472,7 +475,7 @@ SELECT tpcboxX(0, 0, 10, 10, 1) &amp;&amp; tpcboxT(tstzspan '[2024-01-01, 2024-0
 
 		<sect2 xml:id="tpcbox_pos">
 			<title>Operaciones de posición</title>
-			<para>Dieciséis predicados de posición alineados por eje, paralelos a los de <varname>stbox</varname>. Cada uno comprueba la relación estricta o de solapamiento a lo largo de un eje. Los doce que leen coordenadas requieren el mismo esquema y el mismo sistema de referencia, y una discrepancia en cualquiera de los dos genera un error; los cuatro que leen el eje temporal no requieren ninguno de los dos, ya que una marca de tiempo significa lo mismo sea cual sea el esquema en el que se leen las coordenadas. Todo predicado requiere que ambas cajas lleven el eje que él lee, de modo que los del eje Z necesitan una dimensión Z en ambas y los del eje T un período en ambas.</para>
+			<para>Dieciséis predicados de posición alineados por eje, paralelos a los de <varname>stbox</varname>. Cada uno comprueba la relación estricta o de solapamiento a lo largo de un eje. Los doce que leen coordenadas requieren el mismo esquema, el mismo sistema de referencia y el mismo tipo de coordenada, y una discrepancia en cualquiera de los tres genera un error; los cuatro que leen el eje temporal no requieren ninguno de los dos, ya que una marca de tiempo significa lo mismo sea cual sea el esquema en el que se leen las coordenadas. Todo predicado requiere que ambas cajas lleven el eje que él lee, de modo que los del eje Z necesitan una dimensión Z en ambas y los del eje T un período en ambas.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_pos_ops">
 					<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>

--- a/doc/temporal_pointcloud.xml
+++ b/doc/temporal_pointcloud.xml
@@ -439,7 +439,7 @@ SELECT tpcboxX(0, 0, 5, 5, 1) * tpcboxX(3, 3, 10, 10, 1);
 
 		<sect2 xml:id="tpcbox_topo">
 			<title>Topological Operations</title>
-			<para>All topological operators take two <varname>tpcbox</varname> values that state the same schema and the same reference system. A mismatch in either raises an error rather than answering false: the <varname>pcid</varname> is what gives a stored number its meaning as a coordinate, so two boxes naming different schemas have no common extent to compare.</para>
+			<para>All topological operators take two <varname>tpcbox</varname> values that state the same schema, the same reference system, and the same kind of coordinate, planar or spherical. A mismatch in either raises an error rather than answering false: the <varname>pcid</varname> is what gives a stored number its meaning as a coordinate, so two boxes naming different schemas have no common extent to compare.</para>
 			<para>They also take two boxes sharing an axis. A box holding coordinates and a box holding a period meet on no axis at all, so a topological predicate between them has nothing to compare and raises in its turn.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_topo_ops">
@@ -467,6 +467,9 @@ SELECT tpcboxX(0, 0, 5, 5, 1) &amp;&amp; tpcboxX(0, 0, 5, 5, 2);
 -- ERROR:  Operation on TPCBox values with different schemas: 1 vs 2
 SELECT tpcboxX(0, 0, 10, 10, 1) &amp;&amp; tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0);
 -- ERROR:  The temporal values must have at least one common dimension
+SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' &amp;&amp;
+  tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)';
+-- ERROR:  Operation on mixed planar and geodetic coordinates
 </programlisting>
 				</listitem>
 			</itemizedlist>
@@ -474,7 +477,7 @@ SELECT tpcboxX(0, 0, 10, 10, 1) &amp;&amp; tpcboxT(tstzspan '[2024-01-01, 2024-0
 
 		<sect2 xml:id="tpcbox_pos">
 			<title>Position Operations</title>
-			<para>Sixteen axis-aligned position predicates, parallel to those on <varname>stbox</varname>. Each tests a strict-or-overlap relationship along one axis. The twelve that read coordinates require the same schema and the same reference system, and a mismatch in either raises an error; the four that read the time axis require neither, a timestamp meaning the same thing whichever schema the coordinates are read in. Every predicate requires both boxes to carry the axis it reads, so the Z-axis ones need a Z dimension in both and the T-axis ones a time span in both.</para>
+			<para>Sixteen axis-aligned position predicates, parallel to those on <varname>stbox</varname>. Each tests a strict-or-overlap relationship along one axis. The twelve that read coordinates require the same schema, the same reference system and the same kind of coordinate, and a mismatch in any of the three raises an error; the four that read the time axis require neither, a timestamp meaning the same thing whichever schema the coordinates are read in. Every predicate requires both boxes to carry the axis it reads, so the Z-axis ones need a Z dimension in both and the T-axis ones a time span in both.</para>
 			<itemizedlist>
 				<listitem xml:id="tpcbox_pos_ops">
 					<indexterm significance="normal"><primary><varname>&lt;&lt;</varname></primary></indexterm>

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -66,6 +66,7 @@
 #include "temporal/span.h"
 #include "temporal/type_parser.h"
 #include "temporal/type_util.h"
+#include "geo/geo_funcs.h"
 #include "geo/tspatial_parser.h"
 #include "pointcloud/pcpatch.h"
 #include "pointcloud/pgsql_compat.h"
@@ -133,11 +134,13 @@ ensure_valid_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
   /* Ensure the validity of the arguments */
   VALIDATE_TPCBOX(box1, false); VALIDATE_TPCBOX(box2, false);
   /* Both boxes carry coordinates here, so both name the schema those
-   * coordinates are read in. A box carrying none has nothing to interpret,
-   * so it meets a box of any schema */
+   * coordinates are read in, the reference system they are measured in, and
+   * whether they are planar or spherical. A box carrying none has nothing to
+   * interpret, so it meets a box of any schema */
   if (MEOS_FLAGS_GET_X(box1->flags) && MEOS_FLAGS_GET_X(box2->flags) &&
       (! ensure_same_pcid_tpcbox(box1, box2) ||
-       ! ensure_same_srid_tpcbox(box1, box2)))
+       ! ensure_same_srid_tpcbox(box1, box2) ||
+       ! ensure_same_geodetic(box1->flags, box2->flags)))
     return false;
   return true;
 }

--- a/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
+++ b/mobilitydb/test/pointcloud/expected/410_tpcbox.test.out
@@ -328,6 +328,22 @@ SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) +
  TPCBOX(T([Mon Jan 01 00:00:00 2024 PST, Wed Jan 03 00:00:00 2024 PST]), 0)
 (1 row)
 
+SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' &&
+  tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)';
+ERROR:  Operation on mixed planar and geodetic coordinates
+SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' @>
+  tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)';
+ERROR:  Operation on mixed planar and geodetic coordinates
+SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' <<
+  tpcbox 'GEODTPCBOX(X((5,5),(7,7)), 1)';
+ERROR:  Operation on mixed planar and geodetic coordinates
+SELECT tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)' &&
+  tpcbox 'GEODTPCBOX(X((1,1),(3,3)), 1)';
+ ?column? 
+----------
+ t
+(1 row)
+
 SELECT tpcboxXT(0, 0, 5, 5, tstzspan '[2024-01-01, 2024-01-15]', 1) <<#
   tpcboxXT(0, 0, 5, 5, tstzspan '[2025-01-01, 2025-01-15]', 2);
  ?column? 

--- a/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
+++ b/mobilitydb/test/pointcloud/queries/410_tpcbox.test.sql
@@ -199,6 +199,20 @@ SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) &&
 SELECT tpcboxT(tstzspan '[2024-01-01, 2024-01-02]', 0) +
   tpcboxT(tstzspan '[2024-01-02, 2024-01-03]', 1);
 
+-- Planar and spherical coordinates are two different measurements of the
+-- world, so a box of each has nothing comparable to offer the other even when
+-- both name the same schema and the same reference system
+SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' &&
+  tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)';
+SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' @>
+  tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)';
+SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' <<
+  tpcbox 'GEODTPCBOX(X((5,5),(7,7)), 1)';
+
+-- Two spherical boxes of the same schema are compared as any other pair
+SELECT tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)' &&
+  tpcbox 'GEODTPCBOX(X((1,1),(3,3)), 1)';
+
 -------------------------------------------------------------------------------
 -- Position predicates — each asks about the axis it reads
 -------------------------------------------------------------------------------


### PR DESCRIPTION
A TPCBox frame is its schema, its reference system and whether its coordinates
are planar or spherical, which is what the frame table of
doc/contributing/bbox_validation_design_notes.md states and what section 2.1
requires: a box whose frame extends another's reuses that one's predicates, so
the point cloud box checks SRID and geodetic exactly as the spatiotemporal box
does and then adds the schema. It checked the schema and the SRID and left the
third out.

Witness, two boxes agreeing on schema and reference system and differing only in
the kind of coordinate:

  SELECT tpcbox 'SRID=4326;TPCBOX(X((1,1),(2,2)), 1)' &&
    tpcbox 'GEODTPCBOX(X((1,1),(2,2)), 1)';
  -- t

It now raises `Operation on mixed planar and geodetic coordinates`, which is
what the same pair already raises written as an stbox.

Why the t was wrong: the two boxes hold the same four numbers and mean different
things by them, one a rectangle on a plane and the other a region of a sphere, so
the comparison is metres against yards and has no answer. The predicate reported
an overlap that nothing established.

Reachable from the text surface, which is why the suite can hold it: the
GEODTPCBOX spelling fixes the SRID at 4326, so a planar box written with an
explicit SRID=4326 prefix agrees with it on both fields already compared.
tpcbox_make takes the two independently and is published, so a binding reaches
it without the parser.

Measured. The full pg_regress suite passes on PostgreSQL 18 through the
baseline-diff against master, and 1 of the 320 expected files changes: 15 added
lines in 410_tpcbox, one hunk, nothing removed. libmeos, the extension and the
extension without families build with zero warnings. The added predicate is one
flag-word comparison beside the two the validator already makes.

Both manuals state the third requirement beside the other two, and the suite
carries the refused pair for a topological and a position operator together with
the two spherical boxes that are still compared.

