### PR TITLE
Place a boundary two geometries share rather than declining the pair

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -2269,22 +2269,31 @@ buffer_classify_coincident_piece(const BufferPiece *piece, const LWGEOM *owner,
  */
 static bool
 buffer_resolve_coincident_piece(BufferPiece *piece, const LWGEOM *owner,
-  const LWGEOM *other, MeosArray *result)
+  const LWGEOM *other, ClipOper oper, MeosArray *result)
 {
   assert(piece); assert(owner); assert(other); assert(result);
   int classification = buffer_classify_coincident_piece(piece, owner, other);
-  /* The coincident boundary is external to the union */
-  if (classification == 1)
-  {
-    buffer_pieces_add_unique(result, piece);
-    return true;
-  }
-  /* The coincident boundary is internal to the union */
-  if (classification == 0)
-    return true;
-
   /* Unknown / degenerate topology */
-  return false;
+  if (classification < 0)
+    return false;
+
+  /* Which side each interior lies on is the whole of what the operation needs,
+   * and the two answers it can give divide the three operations in one place:
+   *
+   *   THE SAME SIDE -- the two overlap along here, so a union and an
+   *   intersection are both bounded by the piece, while a difference has
+   *   nothing to bound: where both are present, the first less the second
+   *   covers nothing.
+   *
+   *   OPPOSITE SIDES -- the interiors meet along the piece without overlapping,
+   *   so a difference is bounded by it, the first geometry lying on its own
+   *   side; a union reads it as interior, and an intersection as bounding a
+   *   region that is not there.
+   */
+  bool same_side = (classification == 1);
+  if (same_side == (oper != CL_DIFFERENCE))
+    buffer_pieces_add_unique(result, piece);
+  return true;
 }
 
 /**
@@ -2369,8 +2378,9 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
  *     difference    exterior(A wrt B) + interior(B wrt A)
  *
  * so nothing about the two shapes enters beyond where each piece sits.
- * A piece lying ON the other boundary is coincident, and only a union
- * resolves one here. The others are returned in @p boundary, which the caller
+ * A piece lying ON the other boundary is coincident, and
+ * #buffer_resolve_coincident_piece places it from the side each interior
+ * occupies. One it cannot place is returned in @p boundary, which the caller
  * reads as a pair this does not answer.
  */
 static void
@@ -2394,8 +2404,8 @@ buffer_select_overlay_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
       meos_array_add(result, piece);
     else if (location == BUFFER_PIECE_BOUNDARY)
     {
-      if (oper != CL_UNION ||
-          ! buffer_resolve_coincident_piece(piece, geom_a, geom_b, result))
+      if (! buffer_resolve_coincident_piece(piece, geom_a, geom_b, oper,
+            result))
         meos_array_add(boundary, piece);
     }
   }
@@ -2408,8 +2418,8 @@ buffer_select_overlay_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
       meos_array_add(result, piece);
     else if (location == BUFFER_PIECE_BOUNDARY)
     {
-      if (oper != CL_UNION ||
-          ! buffer_resolve_coincident_piece(piece, geom_b, geom_a, result))
+      if (! buffer_resolve_coincident_piece(piece, geom_b, geom_a, oper,
+            result))
         meos_array_add(boundary, piece);
     }
   }
@@ -2513,11 +2523,87 @@ buffer_append_piece_to_curve(LWCOMPOUND *curve, int32_t srid,
  * @details If reverse is returned true, the piece must be reversed before it
  * is appended to the boundary.
  */
+/**
+ * @brief Return the direction a piece leaves one of its ends in
+ * @details The tangent of a segment is the segment; the tangent of an arc is
+ * the sine and cosine at the angle of the end it leaves, turned the way the
+ * arc sweeps. Reading it AT AN END rather than at the midpoint is what tells
+ * two pieces apart where they meet: their midpoints say nothing about the node
+ * they share. See #buffer_piece_side_points(), which reads the same tangent
+ * at the middle to find the sides of a piece
+ * @param[in] piece Boundary piece
+ * @param[in] at_start Read the direction it leaves its START in, rather than
+ * the direction it arrives at its END from
+ * @param[out] dx,dy Unit direction
+ */
+static bool
+buffer_piece_end_direction(const BufferPiece *piece, bool at_start,
+  double *dx, double *dy)
+{
+  assert(piece); assert(dx); assert(dy);
+  double tx, ty;
+  if (piece->type == BUFFER_SEGMENT)
+  {
+    tx = piece->x2 - piece->x1;
+    ty = piece->y2 - piece->y1;
+  }
+  else if (piece->type == BUFFER_ARC)
+  {
+    double sweep = buffer_arc_sweep(piece);
+    if (sweep <= MEOS_GEOM_TOLERANCE)
+      return false;
+    double theta = at_start ? piece->theta1 :
+      (piece->ccw ? piece->theta1 + sweep : piece->theta1 - sweep);
+    if (piece->ccw)
+    {
+      tx = -sin(theta);
+      ty =  cos(theta);
+    }
+    else
+    {
+      tx =  sin(theta);
+      ty = -cos(theta);
+    }
+  }
+  else
+    return false;
+  double length = hypot(tx, ty);
+  if (length <= MEOS_GEOM_TOLERANCE)
+    return false;
+  /* Leaving the END means travelling back along the piece */
+  double sign = at_start ? 1.0 : -1.0;
+  *dx = sign * tx / length;
+  *dy = sign * ty / length;
+  return true;
+}
+
+/**
+ * @brief Return the piece a boundary continues into at a node, and whether it
+ * is traversed in reverse
+ * @details WHERE MORE THAN TWO PIECE-ENDS MEET AT ONE NODE the boundary pinches
+ * -- two regions of the answer touch there at a single point -- and which piece
+ * the walk takes decides whether it closes the two rings that are really there
+ * or ONE ring that visits the node twice. The ring is chosen by turning as
+ * sharply as the node allows, clockwise from the direction the walk arrives in,
+ * which is the traversal that keeps each face of the boundary to itself.
+ * A node where exactly two ends meet has one candidate and the rule does not
+ * arise
+ * @param[in] pieces Boundary pieces
+ * @param[in] used Which of them the walk has taken
+ * @param[in] point The node the walk stands on
+ * @param[in] from_dx,from_dy The direction the walk arrived in, zero for the
+ * first piece of a ring, which has no direction to turn from
+ * @param[out] reverse Set when the piece is traversed from its end
+ */
 static int
 buffer_find_connected_piece(const MeosArray *pieces, const bool *used,
-  POINT2D point, bool *reverse)
+  POINT2D point, double from_dx, double from_dy, bool *reverse)
 {
   assert(pieces); assert(used); assert(reverse);
+  int best = -1;
+  bool best_reverse = false;
+  double best_turn = 0.0;
+  bool have_direction = (from_dx != 0.0 || from_dy != 0.0);
   for (uint32_t i = 0; i < pieces->count; i++)
   {
     if (used[i])
@@ -2525,20 +2611,55 @@ buffer_find_connected_piece(const MeosArray *pieces, const bool *used,
     const BufferPiece *piece = (BufferPiece *) meos_array_get(pieces, i);
     POINT2D start = buffer_piece_start(piece);
     POINT2D end = buffer_piece_end(piece);
-    /* Prefer the natural orientation */
+    bool rev;
     if (buffer_points_equal(start, point))
+      rev = false;
+    else if (buffer_points_equal(end, point))
+      rev = true;
+    else
+      continue;
+    /* The first piece of a ring, and a node with one candidate, need no turn */
+    if (! have_direction)
     {
-      *reverse = false;
+      *reverse = rev;
       return (int) i;
     }
-    /* Otherwise the piece can be traversed in reverse */
-    if (buffer_points_equal(end, point))
+    double dx, dy;
+    if (! buffer_piece_end_direction(piece, ! rev, &dx, &dy))
     {
-      *reverse = true;
-      return (int) i;
+      /* A direction this cannot read orders nothing, so it is taken only where
+       * nothing else offers itself */
+      if (best < 0)
+      {
+        best = (int) i;
+        best_reverse = rev;
+        best_turn = 10.0;
+      }
+      continue;
+    }
+    /* The turn from the arriving direction to the leaving one, measured
+     * clockwise so that the sharpest right turn scores highest. The walk
+     * arrives travelling along (from_dx,from_dy) and leaves along (dx,dy) */
+    double cross = from_dx * dy - from_dy * dx;
+    double dot = from_dx * dx + from_dy * dy;
+    double turn = -atan2(cross, dot);
+    /* Read the turn as a full circle so that the FIRST piece round from the
+     * direction the walk came back along is the smallest, which is the one
+     * that keeps the walk on the face it is tracing rather than crossing to
+     * the other side of the node */
+    if (turn <= 0.0)
+      turn += 2.0 * M_PI;
+    if (best < 0 || turn < best_turn)
+    {
+      best = (int) i;
+      best_reverse = rev;
+      best_turn = turn;
     }
   }
-  return -1;
+  if (best < 0)
+    return -1;
+  *reverse = best_reverse;
+  return best;
 }
 
 /**
@@ -2566,10 +2687,17 @@ buffer_chain_ring_with_pieces(const MeosArray *pieces, bool *used,
   used[start_index] = true;
   POINT2D start = buffer_piece_start(&oriented);
   POINT2D current = buffer_piece_end(&oriented);
+  /* The direction the walk arrives in, which is what decides its turn at a
+   * node several pieces share. It is read from the piece just taken, in the
+   * orientation it was taken in */
+  double from_dx = 0.0, from_dy = 0.0;
+  if (! buffer_piece_end_direction(&oriented, false, &from_dx, &from_dy))
+    from_dx = from_dy = 0.0;
   while (! buffer_points_equal(current, start))
   {
     bool reverse = false;
-    int index = buffer_find_connected_piece(pieces, used, current, &reverse);
+    int index = buffer_find_connected_piece(pieces, used, current, -from_dx,
+      -from_dy, &reverse);
     if (index < 0)
     {
       lwgeom_free(lwcompound_as_lwgeom(curve));
@@ -2590,6 +2718,8 @@ buffer_chain_ring_with_pieces(const MeosArray *pieces, bool *used,
     meos_array_add(ordered, &oriented);
     used[(uint32_t) index] = true;
     current = buffer_piece_end(&oriented);
+    if (! buffer_piece_end_direction(&oriented, false, &from_dx, &from_dy))
+      from_dx = from_dy = 0.0;
   }
   return curve;
 }
@@ -3489,8 +3619,11 @@ buffer_boundaries_cross(const LWGEOM *geom1, const LWGEOM *geom2)
  * @p CL_DIFFERENCE
  * @param[out] touching Set when the two boundaries meet without their
  * interiors overlapping, which a union answers as two surfaces
+ * A stretch the two boundaries SHARE is bounded by the nodes at its ends, so
+ * it splits into a piece of its own and is placed like any other -- by the
+ * side each interior occupies rather than by a midpoint that lies on both.
  * @return The overlay, an EMPTY geometry where it covers nothing, or @p NULL
- * for a pair this does not answer -- boundaries that run along one another,
+ * for a pair this does not answer -- a shared piece whose sides do not resolve,
  * and a meeting that is not a crossing
  */
 static LWGEOM *

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1665,6 +1665,65 @@ int main(void)
   assert(strstr(tgdw, "CIRCULARSTRING") != NULL);
   free(tgdw); free(tgd); free(tg1); free(tg2);
   meos_errno_reset();
+  /* A BOUNDARY THE TWO SHARE IS PLACED, NOT DECLINED. Every piece of the
+   * stretch they share lies on both boundaries, so which side each interior
+   * occupies is what decides it: on the SAME side the two overlap and a union
+   * and an intersection are bounded by it, on OPPOSITE sides they merely meet
+   * and a difference is. A disc against itself shares the whole of its
+   * boundary, and keeps its own circle rather than the chords the route below
+   * would put there */
+  const char *cw_a[] = {
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))",
+    "POLYGON((0 0,2 0,2 2,0 2,0 0))",
+    "POLYGON((0 0,2 0,2 2,0 2,0 0))",
+  };
+  const char *cw_b[] = {
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))",
+    "POLYGON((2 0,4 0,4 2,2 2,2 0))",
+    "POLYGON((2 0,4 0,4 2,2 2,2 0))",
+  };
+  const int cw_op[] = { 0, 0, 1 };
+  const char *cw_exp[] = {
+    /* the disc, on its own circle */
+    "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 2,2 0,4 2),"
+      "CIRCULARSTRING(4 2,2 4,0 2)))",
+    /* two squares meeting along an edge share no area ... */
+    "POLYGON EMPTY",
+    /* ... and neither takes any from the other */
+    "POLYGON((2 2,2 0,0 0,0 2,2 2))",
+  };
+  for (int i = 0; i < 3; i++)
+  {
+    GSERIALIZED *ca = geom_in(cw_a[i], -1);
+    GSERIALIZED *cb = geom_in(cw_b[i], -1);
+    assert(ca != NULL); assert(cb != NULL);
+    meos_errno_reset();
+    GSERIALIZED *cr = cw_op[i] ? geom_difference2d(ca, cb) :
+      geom_intersection2d(ca, cb);
+    assert(cr != NULL);
+    char *cwt = geo_as_text(cr, 6);
+    printf("a shared boundary %d: %.58s\n", i, cwt);
+    assert(strcmp(cwt, cw_exp[i]) == 0);
+    free(cwt); free(cr); free(ca); free(cb);
+    meos_errno_reset();
+  }
+  /* WHERE THE ANSWER LEAVES TWO REGIONS TOUCHING AT ONE POINT, four piece-ends
+   * meet on that node and the walk takes the nearest piece round rather than
+   * the first it finds: the two regions close as two rings, where the first it
+   * finds closes one ring that visits the node twice and is not simple */
+  GSERIALIZED *pz_a = geom_in("POLYGON((0 0,4 0,4 4,0 4,0 0))", -1);
+  GSERIALIZED *pz_b = geom_in("TRIANGLE((0 0,4 0,2 4,0 0))", -1);
+  assert(pz_a != NULL); assert(pz_b != NULL);
+  meos_errno_reset();
+  GSERIALIZED *pz = geom_difference2d(pz_a, pz_b);
+  assert(pz != NULL);
+  char *pzw = geo_as_text(pz, 6);
+  printf("two regions touching at a point: %.46s\n", pzw);
+  assert(strncmp(pzw, "MULTIPOLYGON", 12) == 0);
+  assert(fabs(geom_area(pz) - 8.0) < 1e-12);
+  free(pzw); free(pz); free(pz_a); free(pz_b);
+  meos_errno_reset();
+
   /* ONE REGION, TWO SPELLINGS, AND THEY MUST AGREE. A pair of POLYGONs is
    * overlaid by the Clipper2 arm; the same region spelled TRIANGLE reaches
    * the native one. Neither carries an arc, so the two answer the same


### PR DESCRIPTION
Part of the campaign that removes GEOS from MEOS without losing what it answers.

## What a shared boundary is, and why a midpoint cannot place it

Where two boundaries run along one another instead of crossing, the stretch they share splits into a piece of its own — and every piece of it lies on **both** boundaries. The overlay places a piece by testing its midpoint against the other geometry, and that test says nothing here: the midpoint is on both geometries whichever operation is asked. A piece placed that way is one the overlay cannot answer, and the pair falls through to GEOS.

What does decide it is the side each interior occupies, which `buffer_classify_coincident_piece` already computes for the union. That one answer divides the three operations in a single line:

| | the **same** side — the two overlap along here | **opposite** sides — the interiors meet along it |
|---|---|---|
| union | keep: it bounds the union | drop: it lies inside |
| intersection | keep: it bounds the common region | drop: there is no common region here |
| difference | drop: where both are present, the first less the second covers nothing | keep: the first lies on its own side |

So the resolver keeps a piece when `same_side == (oper != CL_DIFFERENCE)`, and the selection stops deferring. The union arm is unchanged by construction.

## A shared boundary pinches the rings, and the walk needs a rule for it

Where the answer leaves two regions touching at a single point, four piece-ends meet on one node. A walk that takes the first piece it finds there closes **one** ring that visits the node twice — the right area drawn as a ring that is not simple.

The walk turns as the node allows: of the pieces leaving it, it takes the **first one round** from the direction it came back along, which is the traversal that keeps each face of the boundary to itself. `buffer_piece_end_direction` reads that direction at an end of a piece, where `buffer_piece_side_points` reads the same tangent at the middle.

## Witness

```sql
SELECT ST_AsText(ST_Intersection(
  'CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))',
  'CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))'));
```

A disc meeting itself shares the whole of its boundary.

```
before  POLYGON((0.002409088 2.098135349,0.009630547 2.196034281,…))
        65 vertices, the circle it is bounded by replaced by chords
after   CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 2,2 0,4 2),
          CIRCULARSTRING(4 2,2 4,0 2)))
```

## Measured

| measurement | result |
|---|---|
| 225 ordered type pairs, one geometry of each of the 15 types `geom_meos_supported` admits, with GEOS compiled out | intersection reaches GEOS **52 → 39**, difference **61 → 55** |
| 13 pairs sharing a boundary — meeting along an edge, overlapping across one, one inside another, and a geometry against itself | 13 answered, 0 declined, each carrying the area and the shape the existing route answers, and the disc keeping its arcs |
| a square less a triangle they share an edge with, whose answer is two regions touching at a point | `MULTIPOLYGON` of the two triangles, area 8.0 — taking the first piece at that node instead draws one ring through it twice |
| 216 buffers, 18 shapes × 12 radii, against master | **one** cell moves: a `MULTIPOINT` at r=1.5 whose three discs leave a gap answers 2 compound rings where master answers 1. The area is `20.073984350495` either way and the point in the gap reads uncovered on both, so the gap is real and a shell carrying it as a **hole** is what says so without a ring that visits its own node |
| 3000 random star-shaped polygon pairs, one region in two spellings, 6000 comparisons | 0 declined, 0 apart by more than 1e-6 of the larger operand, worst 7.201e-08 — the control's own `CLIP_SCALE = 1e7` snapping, unmoved |
| `meos/test/geo_test.c` | 4 witnesses, which abort against a library without this change and pass with it |

## Why

Which side of a shared piece each interior lies on is the whole of what any of the three operations needs of it, so one classification answers all three and the operation enters only in the last line. Nothing about arcs enters either: the piece is placed by its sides, and a piece that is an arc keeps being one — which is why a disc meeting itself comes back as its own circle rather than as the chords a linearization puts there.

The pinch is the same sentence about rings. A node is a place where the boundary continues, and where several pieces offer themselves the continuation is the nearest one round; any other choice crosses to a face the walk is not tracing and closes it into the one it is.
