### PR TITLE
Leave nothing behind for a region that lies inside another

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -3710,15 +3710,24 @@ buffer_areal_overlay(const LWGEOM *geom1, const LWGEOM *geom2, ClipOper oper,
     meos_array_destroy(intersections);
     return NULL;
   }
-  /* An operation keeping no piece of either boundary covers no area. Where
-   * the boundaries stay apart that IS the answer -- two regions that never
-   * meet share nothing, and one inside the other leaves nothing behind. Where
-   * they MEET it is not: two discs touching at a point share that point, and
-   * two surfaces meeting along an edge share the edge. Such an answer is of
-   * lower dimension than the surfaces this assembles, so the pair is left to
-   * the caller rather than answered as the region of no area, which would
-   * drop a point set that is really there */
-  if (meos_array_count(selected) == 0 && crossing)
+  /* An operation keeping no piece of either boundary covers no area, and what
+   * that means differs between the two operations.
+   *
+   * A DIFFERENCE keeping nothing says the FIRST geometry is wholly inside the
+   * second: no piece of its boundary lies outside, and no piece of the other's
+   * lies within. A region inside another leaves nothing behind, and it leaves
+   * nothing behind whether or not the two boundaries touch on the way -- what
+   * they share is of no area, and a difference of regions does not answer one.
+   * So the region of no area IS the answer here.
+   *
+   * An INTERSECTION keeping nothing does NOT say that. Where the boundaries
+   * stay apart the two share nothing and the region of no area is right; but
+   * where they MEET, the two share exactly what they meet along -- two discs
+   * touching at a point share that point, two surfaces meeting along an edge
+   * share the edge. That answer is of lower dimension than the surfaces this
+   * assembles, so the pair is left to the caller rather than answered as
+   * covering nothing, which would drop a point set that is really there */
+  if (meos_array_count(selected) == 0 && crossing && oper != CL_DIFFERENCE)
   {
     meos_array_destroy(selected); meos_array_destroy(boundary);
     meos_array_destroy(split_a); meos_array_destroy(split_b);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1724,6 +1724,48 @@ int main(void)
   free(pzw); free(pz); free(pz_a); free(pz_b);
   meos_errno_reset();
 
+  /* A REGION WHOLLY INSIDE ANOTHER LEAVES NOTHING BEHIND, and it leaves
+   * nothing behind whether or not the two boundaries touch on the way: what
+   * they share along the touch is of no area, and a difference of regions does
+   * not answer one. The pairs below all touch -- a disc inscribed in a square
+   * meets it at four points, and a geometry against itself shares the whole of
+   * its boundary -- so each is a difference that keeps no piece of either
+   * boundary and covers nothing */
+  const char *ins_a[] = {
+    "TRIANGLE((0 0,4 0,2 4,0 0))",
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))",
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))",
+    /* A multisurface is a region the route below declines to read at all, so
+     * these two are answered where nothing answered them */
+    "MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2)),"
+      "((3 3,4 3,4 4,3 4,3 3)))",
+    "MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2)),"
+      "((3 3,4 3,4 4,3 4,3 3)))",
+  };
+  const char *ins_b[] = {
+    "TRIANGLE((0 0,4 0,2 4,0 0))",
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))",
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+    "MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2)),"
+      "((3 3,4 3,4 4,3 4,3 3)))",
+  };
+  for (int i = 0; i < 5; i++)
+  {
+    GSERIALIZED *ia = geom_in(ins_a[i], -1);
+    GSERIALIZED *ib = geom_in(ins_b[i], -1);
+    assert(ia != NULL); assert(ib != NULL);
+    meos_errno_reset();
+    GSERIALIZED *ir = geom_difference2d(ia, ib);
+    assert(ir != NULL);
+    assert(meos_errno() == 0);
+    char *iw = geo_as_text(ir, 6);
+    printf("a region inside another leaves: %s\n", iw);
+    assert(strcmp(iw, "POLYGON EMPTY") == 0);
+    free(iw); free(ir); free(ia); free(ib);
+    meos_errno_reset();
+  }
+
   /* ONE REGION, TWO SPELLINGS, AND THEY MUST AGREE. A pair of POLYGONs is
    * overlaid by the Clipper2 arm; the same region spelled TRIANGLE reaches
    * the native one. Neither carries an arc, so the two answer the same


### PR DESCRIPTION
Part of the campaign that removes GEOS from MEOS without losing what it answers.

## Two operations read an empty selection differently

The areal overlay treats a selection that keeps no piece of either boundary as an answer it cannot draw, and hands the pair on. That reading is right for an intersection and wrong for a difference.

A **difference** keeping nothing says the first geometry lies wholly inside the second: no piece of its boundary is outside, and no piece of the other's is within. A region inside another leaves nothing behind — and it leaves nothing behind whether or not the two boundaries touch on the way, because what they share along a touch is of no area and a difference of regions does not answer one. So the region of no area is the answer, and the pair needs no other route.

An **intersection** keeping nothing does not say that. Where the boundaries stay apart the two share nothing; but where they meet, the two share exactly what they meet along — two discs touching at a point share that point, two surfaces meeting along an edge share the edge. That answer is of lower dimension than the surfaces this assembles, so it stays with the route that draws it.

## Witness

```sql
SELECT ST_AsText(ST_Difference(
  'MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2)),
                ((3 3,4 3,4 4,3 4,3 3)))',
  'POLYGON((0 0,4 0,4 4,0 4,0 0))'));
```

A disc inscribed in the square, beside a small square inside it: the whole of the first geometry lies in the second, and they touch at four points.

```
before  the overlay reads the type and refuses it, so nothing answers
after   POLYGON EMPTY
```

## Measured

| measurement | result |
|---|---|
| 225 ordered type pairs, one geometry of each of the 15 types `geom_meos_supported` admits, with GEOS compiled out | difference reaches GEOS **55 → 49**; intersection unmoved at 39 |
| the 9 residual pairs involving neither TIN, POLYHEDRALSURFACE nor COLLECTION, asked per operation | **all nine are differences** — 0 intersections decline. 6 of them answer here, and the 3 that remain are the ones whose answer is not empty, which is a different mechanism |
| what the existing route answers for those 6 | 4 answer `POLYGON EMPTY`, so those reach the same answer by a shorter road; 2 — both `MULTISURFACE` subjects — it **declines** with errno 12, so those are answered where nothing answered them |
| 13 pairs sharing a boundary, 3000 random star-shaped polygon pairs in two spellings, and 216 buffers | unmoved: 13 answered and 0 declined; 6000 comparisons, 0 declined and 0 apart by more than 1e-6, worst 7.201e-08; and the buffer dump is identical, a difference never reaching the union arm |
| `meos/test/geo_test.c` | 5 witnesses, which abort against a library without this change and pass with it |

## Why

The two operations read an empty selection differently because they ask different questions of it. A difference asks what is left of the first geometry, and nothing kept means nothing is left. An intersection asks what the two have in common, and nothing kept means only that they have no **area** in common — which is not the same as having nothing in common, and is why that half stays where it is until there is something to draw it with.
