### PR TITLE
Assert in each bounding box internal what its external validates

### DIFF
--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1884,6 +1884,8 @@ bool
 stbox_contains(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   bool hasx, hasz, hast, geodetic;
   stbox_stbox_flags(box1, box2, &hasx, &hasz, &hast, &geodetic);
   if (hasx && (box2->xmin < box1->xmin || box2->xmax > box1->xmax ||
@@ -1925,6 +1927,8 @@ bool
 stbox_contained(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   return stbox_contains(box2, box1);
 }
 
@@ -1954,6 +1958,8 @@ bool
 stbox_overlaps(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   bool hasx, hasz, hast, geodetic;
   stbox_stbox_flags(box1, box2, &hasx, &hasz, &hast, &geodetic);
   if (hasx && (box1->xmax < box2->xmin || box1->xmin > box2->xmax ||
@@ -1994,6 +2000,8 @@ bool
 stbox_same(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   bool hasx, hasz, hast, geodetic;
   stbox_stbox_flags(box1, box2, &hasx, &hasz, &hast, &geodetic);
   if (hasx && (box1->xmin != box2->xmin || box1->xmax != box2->xmax ||
@@ -2052,6 +2060,8 @@ bool
 stbox_adjacent(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   bool hasx, hasz, hast, geodetic;
   stbox_stbox_flags(box1, box2, &hasx, &hasz, &hast, &geodetic);
   /* Boxes are adjacent if they meet in every common dimension and touch in at
@@ -2135,8 +2145,9 @@ bool
 stbox_left(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
   return (box1->xmax < box2->xmin);
 }
 
@@ -2169,8 +2180,9 @@ bool
 stbox_overleft(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
   return (box1->xmax <= box2->xmax);
 }
 
@@ -2203,8 +2215,9 @@ bool
 stbox_right(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
   return (box1->xmin > box2->xmax);
 }
 
@@ -2237,8 +2250,9 @@ bool
 stbox_overright(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
   return (box1->xmin >= box2->xmin);
 }
 
@@ -2270,8 +2284,9 @@ bool
 stbox_below(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
   return (box1->ymax < box2->ymin);
 }
 
@@ -2303,8 +2318,9 @@ bool
 stbox_overbelow(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
   return (box1->ymax <= box2->ymax);
 }
 
@@ -2336,8 +2352,9 @@ bool
 stbox_above(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
   return (box1->ymin > box2->ymax);
 }
 
@@ -2369,8 +2386,9 @@ bool
 stbox_overabove(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
   return (box1->ymin >= box2->ymin);
 }
 
@@ -2403,8 +2421,9 @@ bool
 stbox_front(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_Z(box1->flags));
-  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_Z(T_STBOX, box1->flags));
+  assert(ensure_has_Z(T_STBOX, box2->flags));
   return (box1->zmax < box2->zmin);
 }
 
@@ -2437,8 +2456,9 @@ bool
 stbox_overfront(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_Z(box1->flags));
-  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_Z(T_STBOX, box1->flags));
+  assert(ensure_has_Z(T_STBOX, box2->flags));
   return (box1->zmax <= box2->zmax);
 }
 
@@ -2471,8 +2491,9 @@ bool
 stbox_back(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_Z(box1->flags));
-  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_Z(T_STBOX, box1->flags));
+  assert(ensure_has_Z(T_STBOX, box2->flags));
   return (box1->zmin > box2->zmax);
 }
 
@@ -2505,8 +2526,9 @@ bool
 stbox_overback(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_Z(box1->flags));
-  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_Z(T_STBOX, box1->flags));
+  assert(ensure_has_Z(T_STBOX, box2->flags));
   return (box1->zmin >= box2->zmin);
 }
 
@@ -2540,8 +2562,8 @@ bool
 stbox_before(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_STBOX, box1->flags));
+  assert(ensure_has_T(T_STBOX, box2->flags));
   return span_left(&box1->period, &box2->period);
 }
 
@@ -2573,8 +2595,8 @@ bool
 stbox_overbefore(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_STBOX, box1->flags));
+  assert(ensure_has_T(T_STBOX, box2->flags));
   return span_overleft(&box1->period, &box2->period);
 }
 
@@ -2606,8 +2628,8 @@ bool
 stbox_after(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_STBOX, box1->flags));
+  assert(ensure_has_T(T_STBOX, box2->flags));
   return span_right(&box1->period, &box2->period);
 }
 
@@ -2639,8 +2661,8 @@ bool
 stbox_overafter(const STBox *box1, const STBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_STBOX, box1->flags));
+  assert(ensure_has_T(T_STBOX, box2->flags));
   return span_overright(&box1->period, &box2->period);
 }
 

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -1024,6 +1024,8 @@ bool
 tpcbox_contains(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   return stbox_contains((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1051,6 +1053,8 @@ bool
 tpcbox_contained(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   return stbox_contained((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1078,6 +1082,8 @@ bool
 tpcbox_overlaps(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   return stbox_overlaps((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1106,6 +1112,8 @@ bool
 tpcbox_same(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   return stbox_same((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1134,6 +1142,8 @@ bool
 tpcbox_adjacent(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   return stbox_adjacent((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1275,8 +1285,9 @@ bool
 tpcbox_left(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_X(T_TPCBOX, box1->flags));
+  assert(ensure_has_X(T_TPCBOX, box2->flags));
   return stbox_left((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1306,8 +1317,9 @@ bool
 tpcbox_overleft(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_X(T_TPCBOX, box1->flags));
+  assert(ensure_has_X(T_TPCBOX, box2->flags));
   return stbox_overleft((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1336,8 +1348,9 @@ bool
 tpcbox_right(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_X(T_TPCBOX, box1->flags));
+  assert(ensure_has_X(T_TPCBOX, box2->flags));
   return stbox_right((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1366,8 +1379,9 @@ bool
 tpcbox_overright(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_X(T_TPCBOX, box1->flags));
+  assert(ensure_has_X(T_TPCBOX, box2->flags));
   return stbox_overright((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1398,8 +1412,9 @@ bool
 tpcbox_below(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_X(T_TPCBOX, box1->flags));
+  assert(ensure_has_X(T_TPCBOX, box2->flags));
   return stbox_below((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1428,8 +1443,9 @@ bool
 tpcbox_overbelow(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_X(T_TPCBOX, box1->flags));
+  assert(ensure_has_X(T_TPCBOX, box2->flags));
   return stbox_overbelow((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1458,8 +1474,9 @@ bool
 tpcbox_above(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_X(T_TPCBOX, box1->flags));
+  assert(ensure_has_X(T_TPCBOX, box2->flags));
   return stbox_above((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1488,8 +1505,9 @@ bool
 tpcbox_overabove(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_X(T_TPCBOX, box1->flags));
+  assert(ensure_has_X(T_TPCBOX, box2->flags));
   return stbox_overabove((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1521,8 +1539,9 @@ bool
 tpcbox_front(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_Z(box1->flags));
-  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_Z(T_TPCBOX, box1->flags));
+  assert(ensure_has_Z(T_TPCBOX, box2->flags));
   return stbox_front((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1552,8 +1571,9 @@ bool
 tpcbox_overfront(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_Z(box1->flags));
-  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_Z(T_TPCBOX, box1->flags));
+  assert(ensure_has_Z(T_TPCBOX, box2->flags));
   return stbox_overfront((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1582,8 +1602,9 @@ bool
 tpcbox_back(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_Z(box1->flags));
-  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_Z(T_TPCBOX, box1->flags));
+  assert(ensure_has_Z(T_TPCBOX, box2->flags));
   return stbox_back((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1612,8 +1633,9 @@ bool
 tpcbox_overback(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_Z(box1->flags));
-  assert(MEOS_FLAGS_GET_Z(box2->flags));
+  assert(ensure_valid_tpcbox_tpcbox(box1, box2));
+  assert(ensure_has_Z(T_TPCBOX, box1->flags));
+  assert(ensure_has_Z(T_TPCBOX, box2->flags));
   return stbox_overback((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1645,8 +1667,8 @@ bool
 tpcbox_before(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_TPCBOX, box1->flags));
+  assert(ensure_has_T(T_TPCBOX, box2->flags));
   return stbox_before((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1676,8 +1698,8 @@ bool
 tpcbox_overbefore(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_TPCBOX, box1->flags));
+  assert(ensure_has_T(T_TPCBOX, box2->flags));
   return stbox_overbefore((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1706,8 +1728,8 @@ bool
 tpcbox_after(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_TPCBOX, box1->flags));
+  assert(ensure_has_T(T_TPCBOX, box2->flags));
   return stbox_after((const STBox *) box1, (const STBox *) box2);
 }
 
@@ -1736,8 +1758,8 @@ bool
 tpcbox_overafter(const TPCBox *box1, const TPCBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_TPCBOX, box1->flags));
+  assert(ensure_has_T(T_TPCBOX, box2->flags));
   return stbox_overafter((const STBox *) box1, (const STBox *) box2);
 }
 

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -156,7 +156,7 @@ bool
 span_contains(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   int cmp1 = datum_cmp(s1->lower, s2->lower, s1->basetype);
   int cmp2 = datum_cmp(s1->upper, s2->upper, s1->basetype);
   if (
@@ -207,7 +207,7 @@ bool
 span_contained(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   return span_contains(s2, s1);
 }
 
@@ -240,7 +240,7 @@ bool
 span_overlaps(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   int cmp1 = datum_cmp(s1->lower, s2->upper, s1->basetype);
   int cmp2 = datum_cmp(s2->lower, s1->upper, s1->basetype);
   if (
@@ -313,7 +313,7 @@ bool
 span_adjacent(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   /*
    * Canonical span-adjacency rule: set-theoretic share-a-boundary.
    * Two spans are adjacent iff their closures meet at a single boundary value
@@ -362,7 +362,7 @@ bool
 span_same(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   /* A span is a single dimension, so `same` (`~=`) reduces to span equality.
    * This is the base case of the bounding-box `same` family (#same_tbox_tbox(),
    * #same_stbox_stbox()), letting the temporal/span bounding-box wrappers
@@ -427,7 +427,7 @@ bool
 span_left(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   int cmp = datum_cmp(s1->upper, s2->lower, s1->basetype);
   return (cmp < 0 || (cmp == 0 && (! s1->upper_inc || ! s2->lower_inc)));
 }
@@ -500,7 +500,7 @@ bool
 span_right(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   return span_left(s2, s1);
 }
 
@@ -565,7 +565,7 @@ bool
 span_overleft(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   int cmp = datum_cmp(s1->upper, s2->upper, s1->basetype);
   return (cmp < 0 || (cmp == 0 && (! s1->upper_inc || s2->upper_inc)));
 }
@@ -628,7 +628,7 @@ bool
 span_overright(const Span *s1, const Span *s2)
 {
   assert(s1); assert(s2);
-  assert(s1->spantype == s2->spantype);
+  assert(ensure_valid_span_span(s1, s2));
   int cmp = datum_cmp(s2->lower, s1->lower, s1->basetype);
   return (cmp < 0 || (cmp == 0 && (! s1->lower_inc || s2->lower_inc)));
 }

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -1624,6 +1624,8 @@ bool
 tbox_contains(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   bool hasx, hast;
   tbox_tbox_flags(box1, box2, &hasx, &hast);
   if (hasx && ! span_contains(&box1->span, &box2->span))
@@ -1659,6 +1661,8 @@ bool
 tbox_contained(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   return tbox_contains(box2, box1);
 }
 
@@ -1688,6 +1692,8 @@ bool
 tbox_overlaps(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   bool hasx, hast;
   tbox_tbox_flags(box1, box2, &hasx, &hast);
   if (hasx && ! span_overlaps(&box1->span, &box2->span))
@@ -1723,6 +1729,8 @@ bool
 tbox_same(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   bool hasx, hast;
   tbox_tbox_flags(box1, box2, &hasx, &hast);
   if (hasx && ! span_eq(&box1->span, &box2->span))
@@ -1758,6 +1766,8 @@ bool
 tbox_adjacent(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_common_dimension(box1->flags, box2->flags));
   bool hasx, hast;
   tbox_tbox_flags(box1, box2, &hasx, &hast);
   /* Boxes are adjacent if they meet in every common dimension and touch in at
@@ -1811,8 +1821,9 @@ bool
 tbox_left(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_has_X(T_TBOX, box1->flags));
+  assert(ensure_has_X(T_TBOX, box2->flags));
   return span_left(&box1->span, &box2->span);
 }
 
@@ -1845,8 +1856,9 @@ bool
 tbox_overleft(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_has_X(T_TBOX, box1->flags));
+  assert(ensure_has_X(T_TBOX, box2->flags));
   return span_overleft(&box1->span, &box2->span);
 }
 
@@ -1879,8 +1891,9 @@ bool
 tbox_right(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_has_X(T_TBOX, box1->flags));
+  assert(ensure_has_X(T_TBOX, box2->flags));
   return span_right(&box1->span, &box2->span);
 }
 
@@ -1913,8 +1926,9 @@ bool
 tbox_overright(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_X(box1->flags));
-  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(ensure_valid_tbox_tbox(box1, box2));
+  assert(ensure_has_X(T_TBOX, box1->flags));
+  assert(ensure_has_X(T_TBOX, box2->flags));
   return span_overright(&box1->span, &box2->span);
 }
 
@@ -1946,8 +1960,8 @@ bool
 tbox_before(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_TBOX, box1->flags));
+  assert(ensure_has_T(T_TBOX, box2->flags));
   return span_left(&box1->period, &box2->period);
 }
 
@@ -1978,8 +1992,8 @@ bool
 tbox_overbefore(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_TBOX, box1->flags));
+  assert(ensure_has_T(T_TBOX, box2->flags));
   return span_overleft(&box1->period, &box2->period);
 }
 
@@ -2010,8 +2024,8 @@ bool
 tbox_after(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_TBOX, box1->flags));
+  assert(ensure_has_T(T_TBOX, box2->flags));
   return span_right(&box1->period, &box2->period);
 }
 
@@ -2042,8 +2056,8 @@ bool
 tbox_overafter(const TBox *box1, const TBox *box2)
 {
   assert(box1); assert(box2);
-  assert(MEOS_FLAGS_GET_T(box1->flags));
-  assert(MEOS_FLAGS_GET_T(box2->flags));
+  assert(ensure_has_T(T_TBOX, box1->flags));
+  assert(ensure_has_T(T_TBOX, box2->flags));
   return span_overright(&box1->period, &box2->period);
 }
 


### PR DESCRIPTION
An external validates its arguments and returns an error; the internal it
delegates to asserts the same conditions, so a release build pays nothing and a
debug build catches a caller that broke the contract. The four bounding box
families each had half of that: an internal asserted its pointers, sometimes
spelled out one flag test, and never mentioned the frame its external had just
checked. A caller reaching an internal directly, as an index descent does, was
checked by nothing at all.

Each internal now asserts its external's condition set, written as the same
ensure_ call the external makes. Nothing is restated: assert(s1->spantype ==
s2->spantype) becomes assert(ensure_valid_span_span(s1, s2)), and
assert(MEOS_FLAGS_GET_X(box1->flags)) becomes assert(ensure_has_X(T_STBOX,
box1->flags)). A condition added to a validator therefore reaches every internal
that mirrors it without a second edit, which is the property a duplicated
condition set cannot have.

The three shapes follow the operation classes of
doc/contributing/bbox_validation_design_notes.md. A topological internal asserts
the frame and the shared axis; a coordinate position internal asserts the frame
and the axis it reads in both operands; a time position internal asserts only
the axis, no box type carrying a frame field for time. 64 internals across the
four families: 9 in span_ops.c, 13 in tbox.c, 21 in stbox.c, 21 in tpcbox.c. The
diff removes 80 spelled-out flag tests and 9 span type restatements and adds 80
ensure_has_ and 52 validator asserts in their place.

Witness. This change answers no question differently, so what it carries instead
is the proof that the asserts are live and reached. Negating one of them,

  tbox_contains: assert(! ensure_valid_tbox_tbox(box1, box2));

fails 021_tbox against a CASSERT=ON build, the server log reading

  tbox.c:1627: tbox_contains: Assertion `! ensure_valid_tbox_tbox(box1, box2)' failed.

so the suite reaches these internals and the asserts execute. Restored, the same
build reads 390 tests over 13 families with 0 failures: no caller anywhere in the
tree reaches one of these internals with a condition its external would refuse.

Why an assert rather than a test. The public entry answers a user, so it returns
an error the caller can read; the internal is called in loops over the instants
of a sequence and must not pay for a check its caller already made. Writing the
condition once and asserting it is what keeps the two in step. The alternative,
restating the condition in the internal, is what the four families already did in
part, and it is why three of them had drifted from their own externals.

Measured, and the measurement needed a build the tree does not otherwise make.
Both shipped configurations set NDEBUG, so every one of these compiles out and a
green build says nothing about them. The two coverage arms compiled sources
differing by 46 lines in tbox.c alone, the HEAD arm carrying 9
assert(ensure_valid_tbox_tbox) against the base arm's 0, and produced
libmeos.so with the same md5 fe0d7d80be1f2bcea515ee4b5fbfa3b5. The release
object code is unchanged, so no answer can move and no path grows work. The
full pg_regress suite passes on PostgreSQL 18 through the baseline-diff, and
libmeos, the extension and the extension without families build with zero
warnings.

