### PR TITLE
Write a triangle of a dissolved collection as the polygon it draws

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -4926,6 +4926,26 @@ buffer_is_areal_geometry(const LWGEOM *geom)
 }
 
 /**
+ * @brief Return a triangle as the polygon it draws
+ * @details A triangle is a polygon of a single ring, so the two draw the same
+ * region -- but the readers of a collection of surfaces do not take them
+ * alike. @c lwmsurface_linearize (@c postgis/liblwgeom/lwstroke.c) answers a
+ * CURVEPOLYGON and a POLYGON and has no arm for anything else, so a member of
+ * another type leaves its slot of the output array UNSET, and the collection
+ * built from that array reads whatever the allocation happened to hold.
+ * Writing the ring into a polygon loses nothing and keeps every member a type
+ * the readers answer
+ */
+static LWGEOM *
+buffer_triangle_as_poly(const LWTRIANGLE *tri)
+{
+  assert(tri);
+  POINTARRAY **rings = lwalloc(sizeof(POINTARRAY *));
+  rings[0] = ptarray_clone_deep(tri->points);
+  return lwpoly_as_lwgeom(lwpoly_construct(tri->srid, NULL, 1, rings));
+}
+
+/**
  * @brief Return the union of the areal components of a geometry
  * @details The components are dissolved into the surfaces they cover: a pair
  * whose interiors meet becomes one surface, and a pair that only touches stays
@@ -4990,6 +5010,17 @@ meos_areal_union(const LWGEOM *geom)
         /* A member that is not a surface is not an answer this gives */
         lwgeom_free(result);
         return NULL;
+      }
+      /* A TRIANGLE draws a region a POLYGON draws, and only the polygon is a
+       * type every reader of the collection answers, so the member is written
+       * as one and the collection stays a multipolygon */
+      if (comp == TRIANGLETYPE)
+      {
+        LWGEOM *poly = buffer_triangle_as_poly(
+          (const LWTRIANGLE *) res_coll->geoms[i]);
+        lwgeom_free(res_coll->geoms[i]);
+        res_coll->geoms[i] = poly;
+        continue;
       }
       collected = MULTISURFACETYPE;
     }

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1766,6 +1766,43 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* EVERY MEMBER OF A DISSOLVED COLLECTION IS A TYPE ITS READERS ANSWER.
+   * A triangle draws a region a polygon draws, but @c lwmsurface_linearize
+   * answers a CURVEPOLYGON and a POLYGON and has no arm for anything else, so
+   * a triangle left in the collection leaves its slot of that reader's output
+   * array unset and the collection built from it reads whatever the
+   * allocation held. The union of surfaces that do not merge into one is
+   * where such a collection is built, so a pair that stays apart is the
+   * shortest way to ask for it */
+  const char *tri_a[] = {
+    "TRIANGLE((0 0,1 0,0 1,0 0))",
+    "TRIANGLE((0 0,1 0,0 1,0 0))",
+    "POLYGON((0 0,1 0,1 1,0 1,0 0))",
+  };
+  const char *tri_b[] = {
+    "TRIANGLE((5 5,6 5,5 6,5 5))",
+    "POLYGON((5 5,6 5,6 6,5 6,5 5))",
+    "POLYGON((5 5,6 5,6 6,5 6,5 5))",
+  };
+  const double tri_area[] = { 1.0, 1.5, 2.0 };
+  for (int i = 0; i < 3; i++)
+  {
+    GSERIALIZED *ta[2];
+    ta[0] = geom_in(tri_a[i], -1);
+    ta[1] = geom_in(tri_b[i], -1);
+    assert(ta[0] != NULL); assert(ta[1] != NULL);
+    meos_errno_reset();
+    GSERIALIZED *tu = geom_array_union(ta, 2);
+    assert(tu != NULL);
+    char *tuw = geo_as_text(tu, 6);
+    printf("surfaces that stay apart dissolve to: %.46s\n", tuw);
+    /* Both parts are there, and every member is a polygon */
+    assert(fabs(geom_area(tu) - tri_area[i]) < 1e-12);
+    assert(strstr(tuw, "TRIANGLE") == NULL);
+    free(tuw); free(tu); free(ta[0]); free(ta[1]);
+    meos_errno_reset();
+  }
+
   /* ONE REGION, TWO SPELLINGS, AND THEY MUST AGREE. A pair of POLYGONs is
    * overlaid by the Clipper2 arm; the same region spelled TRIANGLE reaches
    * the native one. Neither carries an arc, so the two answer the same


### PR DESCRIPTION
A union of areal geometries that do not merge into one surface **segfaults** when any of them is a `TRIANGLE`.

```sql
SELECT ST_AsText(ST_Union(ARRAY[
  geometry 'TRIANGLE((0 0,1 0,0 1,0 0))',
  geometry 'TRIANGLE((5 5,6 5,5 6,5 5))']));
```

```
before  SIGSEGV
after   MULTIPOLYGON(((0 0,1 0,0 1,0 0)),((5 5,6 5,5 6,5 5)))
```

## Cause

`meos_areal_union` wraps the surfaces it could not merge in a collection, then reads that collection back as polygons where it carries no arc. `lwgeom_has_arc` answers false for a triangle (`postgis/liblwgeom/lwstroke.c:67`), so the read always happens.

`lwmsurface_linearize` (`postgis/liblwgeom/lwstroke.c:770`) performs it, and it carries an arm for a `CURVEPOLYGON` and an arm for a `POLYGON` and none for anything else. Its output array is `lwalloc`ed rather than zeroed, so a member of any other type leaves **its slot unset**, and the collection built from that array reads whatever the allocation happened to hold.

A triangle is a polygon of a single ring, so the two draw the same region and only one of them is a type every reader of the collection answers. Writing the ring into a polygon loses nothing and keeps the collection readable.

## Measured

| measurement | result |
|---|---|
| a union of two surfaces that stay apart, over the three ways to spell a pair | `TRIANGLE + TRIANGLE` and `TRIANGLE + POLYGON` both segfault before and answer after, of area 1.0 and 1.5; `POLYGON + POLYGON` is the control and is unmoved at 2.0 |
| a union of two surfaces that **do** merge | unmoved — two triangles sharing a diagonal answer the square of area 16, two squares sharing a side the rectangle of area 8, two overlapping squares 15. The crash needs a collection to survive, and a pair that merges leaves none |
| 13 pairs sharing a boundary, 3000 random star-shaped polygon pairs in two spellings, and 216 buffers | unmoved: 13 answered and 0 declined; 6000 comparisons, 0 declined and 0 apart by more than 1e-6, worst 7.201e-08; buffer dump identical |
| `meos/test/geo_test.c` | 3 witnesses; the suite segfaults against a library without this change and passes with it |

## Why here

The defect is in what MEOS hands the reader, not in asking for the read. A collection of surfaces is free to carry a triangle as far as the type system is concerned, and the reader's silence about it is a gap rather than a rule — so the shape that survives is the one whose every member the reader has an arm for. Choosing that shape where the collection is built keeps the question from arising anywhere else.
