### PR TITLE
Read a geometry of faces as the region its faces cover

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -4910,8 +4910,19 @@ buffer_is_areal_geometry(const LWGEOM *geom)
   uint8_t type = geom->type;
   if (type == POLYGONTYPE || type == CURVEPOLYTYPE || type == TRIANGLETYPE)
     return true;
+  /* A TIN and a polyhedral surface are collections of faces -- triangles and
+   * polygons -- so what they draw is read the same way their multi- siblings
+   * are, member by member. ⛔ Only where they are FLAT: both types name a
+   * surface in space as readily as a region of the plane, and the faces of a
+   * surface in space do not bound one region between them, so a Z one is not
+   * a geometry this reads. The multi- siblings carry elevations on a planar
+   * region instead, which is why the test is on these two types */
+  if ((type == TINTYPE || type == POLYHEDRALSURFACETYPE) &&
+      FLAGS_GET_Z(geom->flags))
+    return false;
   if (type != MULTIPOLYGONTYPE && type != MULTISURFACETYPE &&
-      type != COLLECTIONTYPE)
+      type != COLLECTIONTYPE && type != TINTYPE &&
+      type != POLYHEDRALSURFACETYPE)
     return false;
   const LWCOLLECTION *coll = (const LWCOLLECTION *) geom;
   if (coll->ngeoms == 0)
@@ -5050,6 +5061,36 @@ meos_areal_union(const LWGEOM *geom)
 }
 
 /**
+ * @brief Return a geometry as the surfaces its parts COVER, or NULL where it
+ * is one surface already
+ * @details A geometry of several parts can carry an edge two of them SHARE,
+ * and such an edge bounds nothing: it is interior to the region the parts
+ * cover together. A boundary walk meets it twice and has no way to know that,
+ * so it splits one region into the parts the geometry happens to be written
+ * as -- two triangles of a TIN meeting along a diagonal come back as two
+ * triangles rather than the square they cover. Dissolving the parts first
+ * removes the edge, and #meos_areal_union is the dissolve the buffer of a
+ * geometry of several components already performs
+ * @param[in] geom Areal geometry
+ * @param[out] dissolved The dissolved geometry, owned by the caller, or NULL
+ * where the geometry is a single surface and carries no shared edge
+ * @return False where the parts do not dissolve, which is a geometry this
+ * does not answer
+ */
+static bool
+buffer_areal_dissolve(const LWGEOM *geom, LWGEOM **dissolved)
+{
+  assert(geom); assert(dissolved);
+  *dissolved = NULL;
+  uint8_t type = geom->type;
+  /* One surface shares an edge with nothing */
+  if (type == POLYGONTYPE || type == CURVEPOLYTYPE || type == TRIANGLETYPE)
+    return true;
+  *dissolved = meos_areal_union(geom);
+  return *dissolved != NULL;
+}
+
+/**
  * @brief Answer a Boolean operation on two areal geometries
  * @details The operands are read as the surfaces they draw and the answer is
  * built from their two boundaries, so an operand bounded by circular arcs is
@@ -5082,8 +5123,23 @@ buffer_areal_operation(const LWGEOM *geom1, const LWGEOM *geom2,
   if (! buffer_is_areal_geometry(geom1) || ! buffer_is_areal_geometry(geom2))
     return NULL;
 
+  /* The parts of each operand are dissolved into the surfaces they cover, so
+   * that an edge two of them share is gone before the boundary walk meets it */
+  LWGEOM *dis1 = NULL, *dis2 = NULL;
+  if (! buffer_areal_dissolve(geom1, &dis1) ||
+      ! buffer_areal_dissolve(geom2, &dis2))
+  {
+    if (dis1) lwgeom_free(dis1);
+    if (dis2) lwgeom_free(dis2);
+    return NULL;
+  }
+  const LWGEOM *op1 = dis1 ? dis1 : geom1;
+  const LWGEOM *op2 = dis2 ? dis2 : geom2;
+
   bool touching;
-  LWGEOM *result = buffer_areal_overlay(geom1, geom2, oper, &touching);
+  LWGEOM *result = buffer_areal_overlay(op1, op2, oper, &touching);
+  if (dis1) lwgeom_free(dis1);
+  if (dis2) lwgeom_free(dis2);
   if (! result)
     return NULL;
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1431,18 +1431,44 @@ int main(void)
     int ed = meos_errno();
     printf("difference of a polyhedral surface: %s, errno %d\n",
       pd ? "answered" : "nothing", ed);
-    assert(pd == NULL);
-    assert(ed != 0);
+    /* A FLAT polyhedral surface is a region, and its faces are read as the
+     * region they cover between them, so the pair is answered here and never
+     * reaches the route that refuses the type */
+    assert(pd != NULL);
+    assert(ed == 0);
     if (pd) free(pd);
     meos_errno_reset();
     GSERIALIZED *pi = geom_intersection2d(pa, pb);
     int ei = meos_errno();
     printf("intersection of a polyhedral surface: %s, errno %d\n",
       pi ? "answered" : "nothing", ei);
+    assert(pi != NULL);
+    assert(ei == 0);
     if (pi) free(pi);
     free(pa); free(pb);
     meos_errno_reset();
   }
+  /* WHAT THE REFUSAL IS STILL FOR. A collection is a region only when every
+   * member draws one, and one holding a point and a line draws neither, so it
+   * reaches the route that reads the type. WHICH of the two answers that route
+   * gives is a property of the build -- a geometry where the fall-through
+   * draws one, an absence where it is compiled out -- and what holds of both
+   * is that an absence is ANNOUNCED: a caller never reads a null pointer with
+   * nothing set beside it. That is the assertion, so it fails on either build
+   * the moment a refusal goes unreported */
+  GSERIALIZED *nra = geom_in("GEOMETRYCOLLECTION(POINT(1 1),"
+    "LINESTRING(0 2,4 2))", -1);
+  GSERIALIZED *nrb = geom_in("POLYGON((0 0,4 0,4 4,0 4,0 0))", -1);
+  assert(nra != NULL); assert(nrb != NULL);
+  meos_errno_reset();
+  GSERIALIZED *nrd = geom_difference2d(nra, nrb);
+  int nrerrno = meos_errno();
+  printf("a collection that draws no region: %s\n",
+    nrd ? "answered" : "reported the refusal");
+  assert(nrd != NULL || nrerrno != 0);
+  if (nrd) free(nrd);
+  free(nra); free(nrb);
+  meos_errno_reset();
   /* A region loses no area to a clip that covers none, so the difference is
    * the subject itself -- kept as the subject was WRITTEN, where the overlay
    * would return a curve as the chain of chords it reads it by and a triangle
@@ -1800,6 +1826,42 @@ int main(void)
     assert(fabs(geom_area(tu) - tri_area[i]) < 1e-12);
     assert(strstr(tuw, "TRIANGLE") == NULL);
     free(tuw); free(tu); free(ta[0]); free(ta[1]);
+    meos_errno_reset();
+  }
+
+  /* A TIN AND A POLYHEDRAL SURFACE ARE COLLECTIONS OF FACES, so what they
+   * draw is read the way their multi- siblings are. The faces of one SHARE
+   * edges, and a shared edge bounds nothing -- it is interior to the region
+   * the faces cover together -- so the parts are dissolved before the boundary
+   * is walked. Reading them without that dissolve splits one region into the
+   * faces it happens to be written as */
+  const char *fc_a[] = {
+    "TIN(((0 0,4 0,4 4,0 0)),((0 0,4 4,0 4,0 0)))",
+    "TIN(((0 0,4 0,4 4,0 0)),((0 0,4 4,0 4,0 0)))",
+    /* A polyhedral surface is a region the existing route refuses to read */
+    "POLYHEDRALSURFACE(((0 0,2 0,2 2,0 2,0 0)),((2 0,4 0,4 2,2 2,2 0)))",
+  };
+  const char *fc_b[] = {
+    "POLYGON((1 1,3 1,3 3,1 3,1 1))",
+    "POLYGON((2 2,6 2,6 6,2 6,2 2))",
+    "POLYGON((1 0,3 0,3 2,1 2,1 0))",
+  };
+  const double fc_area[] = { 4.0, 4.0, 4.0 };
+  for (int i = 0; i < 3; i++)
+  {
+    GSERIALIZED *fa = geom_in(fc_a[i], -1);
+    GSERIALIZED *fb = geom_in(fc_b[i], -1);
+    assert(fa != NULL); assert(fb != NULL);
+    meos_errno_reset();
+    GSERIALIZED *fr = geom_intersection2d(fa, fb);
+    assert(fr != NULL);
+    assert(meos_errno() == 0);
+    char *fw = geo_as_text(fr, 6);
+    printf("a geometry of faces meets a region: %.44s\n", fw);
+    assert(fabs(geom_area(fr) - fc_area[i]) < 1e-12);
+    /* ONE region, not the faces it is written as */
+    assert(strncmp(fw, "MULTI", 5) != 0);
+    free(fw); free(fr); free(fa); free(fb);
     meos_errno_reset();
   }
 


### PR DESCRIPTION
Part of the campaign that removes GEOS from MEOS without losing what it answers.

Depends on #2552, which fixes a crash this slice reaches. While that is open this PR lists its commit as well; the change to review is the second one, `Read a geometry of faces as the region its faces cover`.

## What a TIN and a polyhedral surface are

Both are collections of faces — triangles and polygons — so what they draw is read the way their multi- siblings are, member by member. The areal overlay declines them for their type alone, and the existing route refuses a polyhedral surface outright, so a region written that way is answered by nobody.

## Reading the faces is not enough, and the difference is the whole of this change

The faces of one geometry **share edges with each other**, and a shared edge bounds nothing: it is interior to the region the faces cover together. A boundary walk meets it twice and has no way to know that, so it splits one region into the faces the geometry happens to be written as — two triangles of a TIN meeting along a diagonal come back as two triangles rather than the square they cover, which is the right area drawn as a `MULTIPOLYGON` whose components share an edge.

So the parts of each operand are dissolved into the surfaces they cover before the walk begins, which is what removes the edge. `meos_areal_union` is the dissolve the buffer of a geometry of several components already performs.

## Only where they are flat

Both types name a surface **in space** as readily as a region of the plane, and the faces of a surface in space do not bound one region between them, so a Z one is not a geometry this reads. The multi- siblings carry elevations on a planar region instead, which is why the test names these two types rather than every collection.

## Witness

```sql
SELECT ST_AsText(ST_Intersection(
  'TIN(((0 0,4 0,4 4,0 0)),((0 0,4 4,0 4,0 0)))',
  'POLYGON((1 1,3 1,3 3,1 3,1 1))'));
```

Two triangles covering a 4×4 square between them, met by a 2×2 box.

```
before  the overlay declines the type, and the route below answers the square
        as the two triangles the TIN is written as
after   POLYGON((1 1,3 1,3 3,1 3,1 1))
```

## Measured

| measurement | result |
|---|---|
| 225 ordered type pairs, one geometry of each of the 15 types `geom_meos_supported` admits, with GEOS compiled out | intersection reaches GEOS **39 → 15**, difference **49 → 29** |
| what is left of those 29 | the `COLLECTION` row and column, whose representative holds a `POINT` and a `LINE`. A collection is a region only when every member draws one, so reaching the existing route is the right answer for it and not a gap |
| a TIN and a polyhedral surface met by a clip that **crosses** the edge their faces share, and by one that does not | every area matches the same region spelled as one polygon: 4.0, 12.0 and 4.0. The polyhedral pair is answered where the existing route refuses the type |
| a union of surfaces, 13 pairs sharing a boundary, 3000 random star-shaped polygon pairs in two spellings, and 216 buffers | unmoved: the merging pairs answer 16, 8 and 15 and the apart pair 2; 13 answered and 0 declined; 6000 comparisons, 0 declined and 0 apart by more than 1e-6, worst 7.201e-08; buffer dump identical |
| `meos/test/geo_test.c` | 3 witnesses added. The witness for a **flat** polyhedral surface asserts that it is answered, which is the capability; what the refusal is still for — a collection drawing no region — is asserted beside it |

## Why

A type is a way of writing a region down, not a different kind of region. Once the faces are read and the edges they share are dissolved, a TIN and a polyhedral surface are the region they cover, and every operation that answers a polygon answers them by the same mechanism. The flatness test is where that sentence stops being true: a surface in space is not a region of the plane, and no dissolve makes it one.
