### PR TITLE
Share the point two surfaces meet at where they share no area

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -2382,14 +2382,20 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
  * #buffer_resolve_coincident_piece places it from the side each interior
  * occupies. One it cannot place is returned in @p boundary, which the caller
  * reads as a pair this does not answer.
+ * @param[out] coincident Set when either boundary carries a piece lying ON the
+ * other, so that a caller keeping no piece can tell a meeting at isolated
+ * NODES from one along a whole STRETCH. A resolved coincident piece the
+ * operation drops leaves neither @p result nor @p boundary anything, so it is
+ * the only report of it
  */
 static void
 buffer_select_overlay_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
   const MeosArray *pieces_b, const LWGEOM *geom_a, ClipOper oper,
-  MeosArray *result, MeosArray *boundary)
+  MeosArray *result, MeosArray *boundary, bool *coincident)
 {
   assert(pieces_a); assert(geom_b); assert(pieces_b); assert(geom_a);
-  assert(result); assert(boundary);
+  assert(result); assert(boundary); assert(coincident);
+  *coincident = false;
   /* The side of the other geometry each of the two boundaries contributes */
   BufferPieceLocation keep_a = (oper == CL_INTERSECTION) ?
     BUFFER_PIECE_INTERIOR : BUFFER_PIECE_EXTERIOR;
@@ -2404,6 +2410,7 @@ buffer_select_overlay_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
       meos_array_add(result, piece);
     else if (location == BUFFER_PIECE_BOUNDARY)
     {
+      *coincident = true;
       if (! buffer_resolve_coincident_piece(piece, geom_a, geom_b, oper,
             result))
         meos_array_add(boundary, piece);
@@ -2418,6 +2425,7 @@ buffer_select_overlay_boundary(const MeosArray *pieces_a, const LWGEOM *geom_b,
       meos_array_add(result, piece);
     else if (location == BUFFER_PIECE_BOUNDARY)
     {
+      *coincident = true;
       if (! buffer_resolve_coincident_piece(piece, geom_b, geom_a, oper,
             result))
         meos_array_add(boundary, piece);
@@ -3597,6 +3605,36 @@ buffer_boundaries_cross(const LWGEOM *geom1, const LWGEOM *geom2)
  *****************************************************************************/
 
 /**
+ * @brief Read a set of nodes as the geometry it draws
+ * @details One node draws a point and several draw a multipoint, which is the
+ * shape #geo_points_covered gives the points it keeps of a point set.
+ * @param[in] nodes Nodes, as #POINT2D
+ * @param[in] srid Spatial reference identifier the answer carries
+ */
+static LWGEOM *
+buffer_nodes_geometry(const MeosArray *nodes, int32_t srid)
+{
+  assert(nodes);
+  uint32_t count = meos_array_count(nodes);
+  if (count == 0)
+    return lwpoint_as_lwgeom(lwpoint_construct_empty(srid, 0, 0));
+  if (count == 1)
+  {
+    const POINT2D *p = (const POINT2D *) meos_array_get(nodes, 0);
+    return lwpoint_as_lwgeom(lwpoint_make2d(srid, p->x, p->y));
+  }
+  LWGEOM **points = palloc(sizeof(LWGEOM *) * count);
+  for (uint32_t i = 0; i < count; i++)
+  {
+    const POINT2D *p = (const POINT2D *) meos_array_get(nodes, i);
+    points[i] = lwpoint_as_lwgeom(lwpoint_make2d(srid, p->x, p->y));
+  }
+  /* #lwcollection_construct keeps the array it is given */
+  return lwcollection_as_lwgeom(lwcollection_construct(MULTIPOINTTYPE, srid,
+    NULL, count, points));
+}
+
+/**
  * @brief Answer a Boolean operation on two areal geometries while preserving
  * circular arcs
  * @details One mechanism answers the three operations, and the boundary of the
@@ -3622,9 +3660,11 @@ buffer_boundaries_cross(const LWGEOM *geom1, const LWGEOM *geom2)
  * A stretch the two boundaries SHARE is bounded by the nodes at its ends, so
  * it splits into a piece of its own and is placed like any other -- by the
  * side each interior occupies rather than by a midpoint that lies on both.
- * @return The overlay, an EMPTY geometry where it covers nothing, or @p NULL
- * for a pair this does not answer -- a shared piece whose sides do not resolve,
- * and a meeting that is not a crossing
+ * @return The overlay, an EMPTY geometry where it covers nothing, the NODES an
+ * intersection meets at where the two share no area, or @p NULL for a pair
+ * this does not answer -- a shared piece whose sides do not resolve, a meeting
+ * that is not a crossing, and an intersection meeting along a stretch rather
+ * than at nodes
  */
 static LWGEOM *
 buffer_areal_overlay(const LWGEOM *geom1, const LWGEOM *geom2, ClipOper oper,
@@ -3680,8 +3720,9 @@ buffer_areal_overlay(const LWGEOM *geom1, const LWGEOM *geom2, ClipOper oper,
   /* Select the portions of both boundaries the operation keeps */
   MeosArray *selected = meos_array_create(sizeof(BufferPiece));
   MeosArray *boundary = meos_array_create(sizeof(BufferPiece));
+  bool coincident;
   buffer_select_overlay_boundary(split_a, geom2, split_b, geom1, oper,
-    selected, boundary);
+    selected, boundary, &coincident);
 
   /* Two boundaries that meet only at isolated points without their interiors
    * overlapping, as two discs touching at one point do, leave every piece of
@@ -3725,15 +3766,27 @@ buffer_areal_overlay(const LWGEOM *geom1, const LWGEOM *geom2, ClipOper oper,
    * where they MEET, the two share exactly what they meet along -- two discs
    * touching at a point share that point, two surfaces meeting along an edge
    * share the edge. That answer is of lower dimension than the surfaces this
-   * assembles, so the pair is left to the caller rather than answered as
-   * covering nothing, which would drop a point set that is really there */
+   * assembles, so it is read off the meeting itself.
+   *
+   * The two meetings are answered differently, and the difference is what
+   * separates a point from a curve. Where no piece of either boundary lies ON
+   * the other, the two meet at the isolated NODES collected above and those
+   * nodes ARE the answer -- exactly, since each is solved on the circles the
+   * operands carry. Where a piece does lie on the other, they meet along a
+   * whole STRETCH whose ends are the nodes, so the nodes state where the
+   * meeting begins and ends and not what it draws; such a pair is left to the
+   * caller, as is a union, which reaches this at all only where both
+   * boundaries lie wholly within the other */
+  int32_t srid = lwgeom_get_srid(geom1);
   if (meos_array_count(selected) == 0 && crossing && oper != CL_DIFFERENCE)
   {
+    LWGEOM *meeting = (oper == CL_INTERSECTION && ! coincident) ?
+      buffer_nodes_geometry(intersections, srid) : NULL;
     meos_array_destroy(selected); meos_array_destroy(boundary);
     meos_array_destroy(split_a); meos_array_destroy(split_b);
     meos_array_destroy(raw_a); meos_array_destroy(raw_b);
     meos_array_destroy(intersections);
-    return NULL;
+    return meeting;
   }
 
   /* Reconstruct the complete overlay boundary:
@@ -3744,7 +3797,6 @@ buffer_areal_overlay(const LWGEOM *geom1, const LWGEOM *geom2, ClipOper oper,
    * -> orientation normalization
    * -> CURVEPOLYGON / MULTISURFACE
    */
-  int32_t srid = lwgeom_get_srid(geom1);
   LWGEOM *result = meos_array_count(selected) == 0 ?
     lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0)) :
     buffer_make_surfaces_from_pieces(selected, srid);
@@ -5059,8 +5111,9 @@ meos_areal_union(const LWGEOM *geom)
  * @param[in] geom1,geom2 Geometries
  * @param[in] oper Operation
  * @return The overlay, an EMPTY geometry where the operation covers nothing,
- * or @p NULL for a pair this does not answer -- a caller that has another way
- * to answer may take it
+ * the point set an intersection meets at where the two share no area, or
+ * @p NULL for a pair this does not answer -- a caller that has another way to
+ * answer may take it
  */
 static LWGEOM *
 buffer_areal_operation(const LWGEOM *geom1, const LWGEOM *geom2,

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1638,11 +1638,12 @@ int main(void)
     free(ew); free(er); free(ea); free(eb);
     meos_errno_reset();
   }
-  /* WHAT THE OVERLAY KEEPS ANSWERING BECAUSE THIS ARM DECLINES IT. Two discs
+  /* TWO SURFACES SHARING NO AREA STILL SHARE WHAT THEY MEET AT. Two discs
    * touching at one point share that point, and a point is of lower dimension
-   * than the surfaces the arm assembles. Answering the region of no area there
-   * would drop a point set that is really there, so the pair goes on to the
-   * route that draws it */
+   * than the surfaces the arm assembles -- so the meeting is read off the
+   * nodes the overlay already solved on the two circles, which is exact,
+   * rather than answered as the region of no area, which would drop a point
+   * set that is really there */
   GSERIALIZED *tg1 = geom_in("CURVEPOLYGON(CIRCULARSTRING(0 0,1 1,2 0,1 -1,"
     "0 0))", -1);
   GSERIALIZED *tg2 = geom_in("CURVEPOLYGON(CIRCULARSTRING(2 0,3 1,4 0,3 -1,"
@@ -1664,6 +1665,51 @@ int main(void)
   printf("the first of them less the second: %.44s\n", tgdw);
   assert(strstr(tgdw, "CIRCULARSTRING") != NULL);
   free(tgdw); free(tgd); free(tg1); free(tg2);
+  meos_errno_reset();
+  /* AND THE POINT IS NOT A VERTEX ANY READING KEEPS BY LUCK. Turned off the
+   * axes, the tangent point of the pair above is an ordinary point of both
+   * arcs rather than a cardinal point of either circle, and a reading that
+   * replaces an arc by chords loses it -- the chords of two circles touching
+   * at such a point do not meet at all. Solved on the circles it is exactly
+   * the midpoint of the segment joining the two centres, which is what this
+   * asserts: radius 2 about the origin and about (2*sqrt(3), 2) touch at
+   * (sqrt(3), 1) */
+  GSERIALIZED *rt1 = geom_in("CURVEPOLYGON(CIRCULARSTRING(-2 0,0 2,2 0,0 -2,"
+    "-2 0))", -1);
+  GSERIALIZED *rt2 = geom_in("CURVEPOLYGON(CIRCULARSTRING("
+    "1.4641016151377544 2,3.4641016151377544 4,5.4641016151377544 2,"
+    "3.4641016151377544 0,1.4641016151377544 2))", -1);
+  assert(rt1 != NULL); assert(rt2 != NULL);
+  meos_errno_reset();
+  GSERIALIZED *rti = geom_intersection2d(rt1, rt2);
+  assert(rti != NULL);
+  char *rtw = geo_as_text(rti, 6);
+  printf("two discs touching off the axes share: %s\n", rtw);
+  assert(strcmp(rtw, "POINT(1.732051 1)") == 0);
+  free(rtw); free(rti); free(rt1); free(rt2);
+  meos_errno_reset();
+  /* THE MEETING IS NOT ALWAYS A POINT SET, AND THAT IS WHAT THE NODES CANNOT
+   * SAY. Two half discs glued along their diameter meet along the whole of
+   * it, and the nodes bounding that stretch are its two ENDS -- they state
+   * where the meeting begins and ends, never what it draws. So the pair is
+   * left to the route below rather than answered from them, and what this
+   * asserts is that whatever comes back is not a point set */
+  GSERIALIZED *hd1 = geom_in("CURVEPOLYGON(COMPOUNDCURVE("
+    "CIRCULARSTRING(-2 0,0 2,2 0),(2 0,-2 0)))", -1);
+  GSERIALIZED *hd2 = geom_in("CURVEPOLYGON(COMPOUNDCURVE("
+    "CIRCULARSTRING(2 0,0 -2,-2 0),(-2 0,2 0)))", -1);
+  assert(hd1 != NULL); assert(hd2 != NULL);
+  meos_errno_reset();
+  GSERIALIZED *hdi = geom_intersection2d(hd1, hd2);
+  char *hdw = hdi ? geo_as_text(hdi, 6) : NULL;
+  printf("two half discs sharing their diameter answer: %s\n",
+    hdw ? hdw : "nothing");
+  assert(hdw == NULL || strstr(hdw, "POINT") == NULL);
+  if (hdw)
+    free(hdw);
+  if (hdi)
+    free(hdi);
+  free(hd1); free(hd2);
   meos_errno_reset();
   /* A BOUNDARY THE TWO SHARE IS PLACED, NOT DECLINED. Every piece of the
    * stretch they share lies on both boundaries, so which side each interior


### PR DESCRIPTION
Part of the campaign that gives MEOS a native answer for every geometry operation.

## Two surfaces that share no area still share what they meet at

Two discs touching at one point share that point. The areal overlay reads such a meeting off the nodes it solves on the circles its operands carry, so an intersection keeping no boundary piece answers the point set the two meet at rather than the region of no area.

```sql
SELECT ST_AsText(ST_Intersection(
  'CURVEPOLYGON(CIRCULARSTRING(-2 0,0 2,2 0,0 -2,-2 0))',
  'CURVEPOLYGON(CIRCULARSTRING(1.4641016151377544 2,3.4641016151377544 4,
     5.4641016151377544 2,3.4641016151377544 0,1.4641016151377544 2))'));
```

Two discs of radius 2 whose centres are 4 apart touch at the midpoint between the centres, `(sqrt(3), 1)`, and that is the answer: `POINT(1.732051 1)`.

## A meeting along a stretch is not a point set

Where a piece of one boundary lies **on** the other, the two meet along a whole stretch and the nodes are its two ends: they say where the meeting begins and ends, not what it draws. The selection reports such a coincidence, and the overlay leaves that pair to the route below.

The report is needed because a coincident piece an operation drops is *resolved*: it leaves the selection empty and the unresolved list empty alike, so neither existing signal distinguishes it from a meeting at isolated nodes.

## Exactness

A tangency solved on the circles is exact. A tangency read as chords is a different question: the chords of two circles touching at a point that is not one of their vertices do not meet.

| measurement | result |
|---|---|
| two discs of radius 2 at seven directions from one another, 0 to 90 degrees, so the tangent point is a cardinal point of the circles at 0 and 90 alone | the tangent point is exact at 5 of the 7. The oracle needs no engine: two circles at twice the radius touch at the midpoint of the segment joining their centres |
| the same seven through the linearizing route | `POINT` at 1, `POLYGON EMPTY` at 5, and a `POLYGON` of five identical vertices at 1. The one exact row is the one whose tangent point is a vertex of both circles |
| the two directions at 15 and 45 degrees | the tangency reads as a two-node coincident stretch, so the guard declines it. Their difference declines at a separate site, which no part of this touches: a difference never enters that branch, which excludes `CL_DIFFERENCE` |
| two half discs glued along their diameter, and a half disc meeting a square along part of one | not answered from the nodes, which are the two ends of the diameter |
| 19 centre separations of two discs, from deep overlap through the exact tangent to well apart | one row carries a lower-dimensional answer and it is the tangent one; the areal rows and the empty rows are what they are on either side of it |
| 13 pairs sharing a boundary, 3000 random star-shaped polygon pairs in two spellings, and 216 buffers | 13 answered and 0 declined; 6000 comparisons, 0 declined and 0 apart by more than 1e-6, worst 7.201e-08; 216 buffer answers |
| `meos/test/geo_test.c` | 3 witnesses, one of them the tangent point off the axes |

## Why

An areal engine assembles surfaces, so a meeting of no area is not something it draws as one. "No area" and "nothing" are different sentences, and only the first is true of two discs that touch. The nodes the engine already solves say which, so the answer costs no new geometry.
