### PR TITLE
Cover the tiles a trip crosses, not only the tiles holding its instants

### DIFF
--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -107,7 +107,7 @@ SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'float32
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 quadbins(tgeompoint,zoom integer) → bigint[]
 </programlisting>
-				<para>Devuelve el conjunto de celdas QUADBIN únicas (deduplicadas) cuyas envolventes de tesela Web-Mercator contienen al menos un instante de <varname>traj</varname>. El resultado es adecuado como clave de unión en la cláusula WHERE contra una tabla Raquet. El parámetro <varname>zoom</varname> debe estar en [0, 15].</para>
+				<para>Devuelve el conjunto de celdas QUADBIN únicas que cubre la trayectoria. Una trayectoria que no afirma nada entre sus instantes cubre las teselas que los contienen; una que se mueve entre ellos cubre además las teselas que atraviesa por el camino, y el segmento se recorre a media tesela para encontrarlas, estrechándose la tesela hacia los polos como lo hace su envolvente Web-Mercator. El resultado es adecuado como clave de unión en la cláusula WHERE contra una tabla Raquet, donde una tesela que el trayecto atraviesa pero el conjunto omite es una tesela que la unión nunca lee. El parámetro <varname>zoom</varname> debe estar en [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Three instants spanning three tiles at zoom 3
 SELECT quadbins(tgeompoint 'SRID=4326;

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -107,7 +107,7 @@ SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'float32
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 quadbins(tgeompoint,zoom integer) → bigint[]
 </programlisting>
-				<para>Returns the set of unique QUADBIN cells (deduplicated) whose Web-Mercator tile envelopes contain at least one instant of <varname>traj</varname>. The result is suitable as a WHERE-clause join key against a Raquet table. <varname>zoom</varname> must be in [0, 15].</para>
+				<para>Returns the set of unique QUADBIN cells the trajectory covers. A trajectory that states nothing between its instants covers the tiles holding them; one that moves between them also covers the tiles it crosses on the way, and the segment is walked at half a tile to find them, the tile narrowing towards the poles as its Web-Mercator envelope does. The result is suitable as a WHERE-clause join key against a Raquet table, where a tile the trip crosses but the set omits is a tile the join never reads. <varname>zoom</varname> must be in [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Three instants spanning three tiles at zoom 3
 SELECT quadbins(tgeompoint 'SRID=4326;

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -88,6 +88,9 @@
  * use; the value is the documented range of #trajectory_quadbins() */
 #define QB_TRAJECTORY_MAX_ZOOM  15
 
+/** Latitude the Web-Mercator grid reaches, beyond which a tile has no extent */
+#define QB_MAX_LATITUDE  85.051129
+
 static const uint64_t QB_B[6] = {
   UINT64_C(0x5555555555555555), UINT64_C(0x3333333333333333),
   UINT64_C(0x0F0F0F0F0F0F0F0F), UINT64_C(0x00FF00FF00FF00FF),
@@ -878,6 +881,85 @@ araster_value_sampler(const Temporal *traj,
  *****************************************************************************/
 
 /**
+ * @brief Return the lon/lat a temporal point instant holds
+ * @details The position is read, never kept, and the instant that holds it
+ * outlives the call, so it is borrowed rather than copied
+ */
+static void
+tinstant_point_coords(const TInstant *inst, double *lon, double *lat)
+{
+  const GSERIALIZED *gs =
+    (const GSERIALIZED *) DatumGetPointer(tinstant_value_p(inst));
+  GBOX box;
+  gserialized_get_gbox_p((GSERIALIZED *) gs, &box);
+  *lon = box.xmin;
+  *lat = box.ymin;
+  return;
+}
+
+/**
+ * @brief Return the QUADBIN cell of a position at a zoom, through the
+ * slippy-tile Mercator the family decodes its tiles with
+ */
+static uint64
+quadbin_cell_at(double lon, double lat, uint32_t zoom)
+{
+  double n = (double) (UINT64_C(1) << zoom);
+  uint32_t tx = (uint32_t) floor((lon + 180.0) / 360.0 * n);
+  double merc_y = log(tan(M_PI / 4.0 + lat * M_PI / 360.0));
+  uint32_t ty = (uint32_t) floor((1.0 - merc_y / M_PI) / 2.0 * n);
+  /* Clamp to the valid tile range at this zoom */
+  uint32_t maxidx = (uint32_t) n - 1;
+  if (tx > maxidx) tx = maxidx;
+  if (ty > maxidx) ty = maxidx;
+  return xyz_to_qb(tx, ty, zoom);
+}
+
+/**
+ * @brief Add a cell to the answer unless it is already there
+ * @details The answer is a set, and a trip stays in one tile across many
+ * positions, so the walk repeats a cell far more often than it changes one
+ */
+static void
+quadbin_cells_add(uint64 *cells, int *ncells, uint64 cell)
+{
+  for (int i = 0; i < *ncells; i++)
+    if (cells[i] == cell)
+      return;
+  cells[(*ncells)++] = cell;
+  return;
+}
+
+/**
+ * @brief Return how many positions of a segment the walk reads, so that it
+ * cannot step over a tile
+ * @details A tile spans 360 / 2^zoom degrees of longitude, and covers less
+ * latitude the further it lies from the equator, by the Mercator scale factor
+ * at that latitude. The step is half the smaller of the two, the Nyquist rule
+ * #h3_sample_step_deg() walks a hexagon with.
+ */
+static int
+quadbin_walk_steps(const TInstant *inst1, const TInstant *inst2,
+  uint32_t zoom)
+{
+  double lon1, lat1, lon2, lat2;
+  tinstant_point_coords(inst1, &lon1, &lat1);
+  tinstant_point_coords(inst2, &lon2, &lat2);
+  double tile_deg = 360.0 / (double) (UINT64_C(1) << zoom);
+  double far_lat = (fabs(lat1) > fabs(lat2)) ? fabs(lat1) : fabs(lat2);
+  if (far_lat > QB_MAX_LATITUDE)
+    far_lat = QB_MAX_LATITUDE;
+  double step = tile_deg * cos(far_lat * M_PI / 180.0) / 2.0;
+  if (step <= 0.0)
+    return 1;
+  double dlon = lon2 - lon1, dlat = lat2 - lat1;
+  double length = sqrt(dlon * dlon + dlat * dlat);
+  int nsteps = (int) ceil(length / step);
+  return (nsteps < 1) ? 1 : nsteps;
+}
+
+
+/**
  * @ingroup meos_raster_base_accessor
  * @brief Return the unique QUADBIN cells at @p zoom covered by a trajectory.
  * @details Suitable for use as the WHERE-clause argument when joining against
@@ -910,43 +992,40 @@ trajectory_quadbins(const Temporal *traj, uint32_t zoom, int *count)
 
   int ninsts;
   const TInstant **insts = temporal_insts_p(traj, &ninsts);
+  bool densify = (MEOS_FLAGS_GET_INTERP(traj->flags) == LINEAR);
 
-  /* Upper bound: one cell per instant (usually far fewer after dedup) */
-  uint64 *cells = palloc(sizeof(uint64) * ninsts);
+  /* One cell per instant, and one per walk position of each segment when the
+   * trajectory moves between them */
+  int maxcells = ninsts;
+  if (densify)
+    for (int i = 0; i + 1 < ninsts; i++)
+      maxcells += quadbin_walk_steps(insts[i], insts[i + 1], zoom) + 1;
+  uint64 *cells = palloc(sizeof(uint64) * (size_t) maxcells);
   int ncells = 0;
-
-  double n = (double)(UINT64_C(1) << zoom);
 
   for (int i = 0; i < ninsts; i++)
   {
-    /* The point is read, never kept, and the instant that holds it outlives
-     * this call, so it is borrowed rather than copied */
-    const GSERIALIZED *pt_gs =
-      (const GSERIALIZED *) DatumGetPointer(tinstant_value_p(insts[i]));
-    GBOX pt_box;
-    gserialized_get_gbox_p(pt_gs, &pt_box);
-    double lon = pt_box.xmin;
-    double lat = pt_box.ymin;
+    double lon, lat;
+    tinstant_point_coords(insts[i], &lon, &lat);
+    quadbin_cells_add(cells, &ncells, quadbin_cell_at(lon, lat, zoom));
 
-    /* Tile indices via slippy-tile Mercator */
-    uint32_t tx = (uint32_t) floor((lon + 180.0) / 360.0 * n);
-    double lat_rad = lat * M_PI / 180.0;
-    double merc_y  = log(tan(M_PI / 4.0 + lat_rad / 2.0));
-    uint32_t ty = (uint32_t) floor((1.0 - merc_y / M_PI) / 2.0 * n);
-
-    /* Clamp to valid tile range at this zoom */
-    uint32_t maxidx = (uint32_t) n - 1;
-    if (tx > maxidx) tx = maxidx;
-    if (ty > maxidx) ty = maxidx;
-
-    uint64_t cell = xyz_to_qb(tx, ty, zoom);
-
-    /* Linear dedup (instants in a single tile cluster) */
-    bool found = false;
-    for (int j = 0; j < ncells; j++)
-      if (cells[j] == cell) { found = true; break; }
-    if (!found)
-      cells[ncells++] = cell;
+    /* A trajectory that moves between its instants passes over the tiles
+     * between them, and a join filtered on the cells it answers loses every
+     * tile the trip crosses but the list omits. The segment is therefore
+     * walked at half a tile, the step
+     * #tpointseq_densify_to_raster_value() walks a pixel at */
+    if (! densify || i + 1 >= ninsts)
+      continue;
+    double lon2, lat2;
+    tinstant_point_coords(insts[i + 1], &lon2, &lat2);
+    int nsteps = quadbin_walk_steps(insts[i], insts[i + 1], zoom);
+    for (int j = 1; j < nsteps; j++)
+    {
+      double frac = (double) j / (double) nsteps;
+      quadbin_cells_add(cells, &ncells,
+        quadbin_cell_at(lon + frac * (lon2 - lon), lat + frac * (lat2 - lat),
+          zoom));
+    }
   }
 
   pfree(insts);

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -276,6 +276,28 @@ int main(void)
   free(zero_quadbin);
   free(traj);
 
+  /* A trajectory that moves between its instants covers the tiles it crosses:
+   * a tile spans 45 degrees of longitude at zoom 3, so a trip from 10E to
+   * 170E crosses four of them, and the same path sampled every 20 degrees
+   * answers the same four. A join filtered on a set that omits a crossed tile
+   * never reads that tile */
+  Temporal *traj_across = tgeompoint_in("SRID=4326;[Point(10.0 10.0)@2024-01-01,"
+    " Point(170.0 10.0)@2024-01-02]");
+  Temporal *traj_sampled = tgeompoint_in("SRID=4326;{Point(10.0 10.0)@2024-01-01,"
+    " Point(30.0 10.0)@2024-01-02, Point(50.0 10.0)@2024-01-03,"
+    " Point(70.0 10.0)@2024-01-04, Point(90.0 10.0)@2024-01-05,"
+    " Point(110.0 10.0)@2024-01-06, Point(130.0 10.0)@2024-01-07,"
+    " Point(150.0 10.0)@2024-01-08, Point(170.0 10.0)@2024-01-09}");
+  assert(traj_across != NULL && traj_sampled != NULL);
+  int ncrossed, nsampled;
+  uint64 *crossed = trajectory_quadbins(traj_across, 3, &ncrossed);
+  uint64 *sampled = trajectory_quadbins(traj_sampled, 3, &nsampled);
+  printf("trajectory_quadbins(linear trip, 3): %d cell(s), sampled: %d\n",
+    ncrossed, nsampled);
+  assert(ncrossed == 4);
+  assert(nsampled == 4);
+  free(crossed); free(sampled); free(traj_across); free(traj_sampled);
+
   /* The sampling of a PostGIS raster is answered by MEOS, so a program using
    * the library reads the values a PostgreSQL session reads. The trajectory
    * below visits pixel(1,1) = 10, the nodata pixel(1,2), a position outside

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -300,6 +300,33 @@ SELECT array_length(quadbins(
                   1
 (1 row)
 
+SELECT array_length(quadbins(
+  tgeompoint 'SRID=4326;[Point(10.0 10.0)@2024-01-01,
+    Point(170.0 10.0)@2024-01-02]', 3), 1) AS num_crossed_tiles;
+ num_crossed_tiles 
+-------------------
+                 4
+(1 row)
+
+SELECT array_length(quadbins(
+  tgeompoint 'SRID=4326;{Point(10.0 10.0)@2024-01-01, Point(30.0 10.0)@2024-01-02,
+    Point(50.0 10.0)@2024-01-03, Point(70.0 10.0)@2024-01-04,
+    Point(90.0 10.0)@2024-01-05, Point(110.0 10.0)@2024-01-06,
+    Point(130.0 10.0)@2024-01-07, Point(150.0 10.0)@2024-01-08,
+    Point(170.0 10.0)@2024-01-09}', 3), 1) AS num_sampled_tiles;
+ num_sampled_tiles 
+-------------------
+                 4
+(1 row)
+
+SELECT array_length(quadbins(
+  tgeompoint 'SRID=4326;{Point(10.0 10.0)@2024-01-01,
+    Point(170.0 10.0)@2024-01-02}', 3), 1) AS num_instant_tiles;
+ num_instant_tiles 
+-------------------
+                 2
+(1 row)
+
 SELECT quadbins(tgeompoint 'SRID=4326;{Point(0.0 0.0)@2024-01-01}', 16);
 ERROR:  zoom level must be between 0 and 15
 SELECT rasterTileValueQuadbin(tgeompoint 'SRID=4326;{Point(45.0 75.0)@2024-01-01,

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -324,6 +324,27 @@ SELECT array_length(quadbins(
   tgeompoint 'SRID=4326;{Point(-60.0 45.0)@2024-01-01,
     Point(-61.0 44.0)@2024-01-02}', 3), 1) AS num_distinct_tiles;
 
+-- A trajectory that moves between its instants covers the tiles it crosses on
+-- the way: at zoom 3 a tile spans 45 degrees of longitude, so a trip from
+-- 10E to 170E crosses four of them, and the same path sampled every 20 degrees
+-- answers the same four.
+SELECT array_length(quadbins(
+  tgeompoint 'SRID=4326;[Point(10.0 10.0)@2024-01-01,
+    Point(170.0 10.0)@2024-01-02]', 3), 1) AS num_crossed_tiles;
+
+SELECT array_length(quadbins(
+  tgeompoint 'SRID=4326;{Point(10.0 10.0)@2024-01-01, Point(30.0 10.0)@2024-01-02,
+    Point(50.0 10.0)@2024-01-03, Point(70.0 10.0)@2024-01-04,
+    Point(90.0 10.0)@2024-01-05, Point(110.0 10.0)@2024-01-06,
+    Point(130.0 10.0)@2024-01-07, Point(150.0 10.0)@2024-01-08,
+    Point(170.0 10.0)@2024-01-09}', 3), 1) AS num_sampled_tiles;
+
+-- A trajectory that states nothing between its instants covers the tiles
+-- holding them, and the two instants below sit in one tile.
+SELECT array_length(quadbins(
+  tgeompoint 'SRID=4326;{Point(10.0 10.0)@2024-01-01,
+    Point(170.0 10.0)@2024-01-02}', 3), 1) AS num_instant_tiles;
+
 -- Invalid zoom level raises an error.
 SELECT quadbins(tgeompoint 'SRID=4326;{Point(0.0 0.0)@2024-01-01}', 16);
 


### PR DESCRIPTION
A trajectory that moves between its instants passes over the QUADBIN tiles
between them, and quadbins answers the set of tiles a Raquet join is filtered
on, so a tile the trip crosses but the set omits is a tile the join never
reads. Each segment is therefore walked at half a tile, the step
tpointseq_densify_to_raster_value() walks a pixel at, and every cell the walk
meets joins the set. A trajectory that states nothing between its instants
covers the tiles holding them.

A tile spans 360 / 2^zoom degrees of longitude and covers less latitude the
further it lies from the equator, by the Mercator scale factor there, so the
step reads the narrower of the two at the segment's furthest latitude and
cannot step over a tile anywhere on the grid.

The cell lookup and the set insertion are named once, quadbin_cell_at() and
quadbin_cells_add(), and the instant loop and the walk both read them;
tinstant_point_coords() borrows the position of an instant rather than copying
its datum.

Witness, at zoom 3, where a tile spans 45 degrees of longitude, so a trip from
10E to 170E crosses four of them:

  quadbins(tgeompoint 'SRID=4326;[Point(10.0 10.0)@2024-01-01,
    Point(170.0 10.0)@2024-01-02]', 3)
  answers 4 cells, the count the same path sampled every 20 degrees answers

The numbers: 500_raster.test.sql calls quadbins 6 times and its expected file
grows by the three cases above alone, every other case answering as it
stands; 500_raster_tbl keeps its 100-row fixture. meos/test/raster_test.c
asserts the four cells of the linear trip against the four of the sampled
path, and runs under valgrind with 0 errors and 0 bytes lost.

The rule: the cells a trajectory covers are the cells its path meets, and a
path is what its interpolation says it is. Reading only the instants answers
the tiles the samples fall in, which is a different question, and the one
answer a join cannot use.

