### PR TITLE
Give the box nearest approach distance the internal form its siblings have

### DIFF
--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -297,6 +297,8 @@ extern bool geom_meos_supported(const LWGEOM *geom);
 
 /* Distance functions */
 
+extern double stbox_nad(const STBox *box1, const STBox *box2);
+
 /*****************************************************************************
  * Spatial functions for temporal points
  *****************************************************************************/

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2734,6 +2734,34 @@ nad_stbox_geo(const STBox *box, const GSERIALIZED *gs)
 }
 
 /**
+ * @ingroup meos_internal_geo_dist
+ * @brief Return the nearest approach distance between two spatiotemporal
+ * boxes
+ * @param[in] box1,box2 Spatiotemporal boxes
+ * @return If the time frames do not intersect return infinity
+ * @pre The boxes are comparable, both carry a spatial extent, and they have
+ * the same spatial dimensionality
+ */
+double
+stbox_nad(const STBox *box1, const STBox *box2)
+{
+  assert(box1); assert(box2);
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
+  assert(ensure_same_spatial_dimensionality(box1->flags, box2->flags));
+
+  /* If the boxes do not intersect in the time dimension return infinity */
+  bool hast = MEOS_FLAGS_GET_T(box1->flags) && MEOS_FLAGS_GET_T(box2->flags);
+  if (hast && ! overlaps_span_span(&box1->period, &box2->period))
+      return DBL_MAX;
+
+  /* The nearest approach distance is the spatial-only distance between the
+   * boxes (time already tested above) */
+  return stbox_spatial_distance(box1, box2);
+}
+
+/**
  * @ingroup meos_geo_dist
  * @brief Return the nearest approach distance between two spatiotemporal
  * boxes
@@ -2750,15 +2778,7 @@ nad_stbox_stbox(const STBox *box1, const STBox *box2)
       ! ensure_has_X(T_STBOX, box2->flags) ||
       ! ensure_same_spatial_dimensionality(box1->flags, box2->flags))
     return DBL_MAX;
-
-  /* If the boxes do not intersect in the time dimension return infinity */
-  bool hast = MEOS_FLAGS_GET_T(box1->flags) && MEOS_FLAGS_GET_T(box2->flags);
-  if (hast && ! overlaps_span_span(&box1->period, &box2->period))
-      return DBL_MAX;
-
-  /* The nearest approach distance is the spatial-only distance between the
-   * boxes (time already tested above) */
-  return stbox_spatial_distance(box1, box2);
+  return stbox_nad(box1, box2);
 }
 
 /**


### PR DESCRIPTION
The doxygen group meos_internal_geo_dist is declared in
meos/include/geo/doxygen_meos_internal_geo.h and holds one member, while
meos_internal_geo.h declares 22 internal box predicates taking the same pair of
spatiotemporal boxes. stbox_nad is that member: it asserts that the two boxes
are comparable, that both carry a spatial extent and that their spatial
dimensionality agrees, and answers the distance of nearest approach.

nad_stbox_stbox tests those same four conditions, answers infinity on each of
them, and delegates the computation to stbox_nad. The condition set is the same
on both sides and only the mechanism differs.

The rule the pair states is that a caller which has already established the
preconditions stops paying for them. An external validates and reports; an
internal asserts and computes, so an assert compiled out under NDEBUG costs a
caller nothing while a Debug build still holds it to the contract. A descent
that establishes validity where its scan key becomes a box may call stbox_nad;
one that establishes nothing calls nad_stbox_stbox, which is what every caller
in the tree does.

Measured against master e55dcbd9e370. Over 40 instruments the two builds answer
alike but for time_of_day(), a wall clock. pg_regress reads all tests passed on
PostgreSQL 18 and no expected output is touched. The seven smoke suites read
140, 218, 192, 129, 455, 189 and 23 results with 0 validation warnings each.
libmeos builds clean under MSYS2 UCRT64, and the cppcheck, codegen, csqlfn,
license, int64-header and 27 workflow checks read clean.

