### PR TITLE
Name the chapter for what its grids are, Temporal Tessellations

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2790,7 +2790,7 @@
 	</sect1>
 
 	<sect1>
-		<title>Temporal Cell Index Types</title>
+		<title>Temporal Tessellations</title>
 		<sect2>
 			<title>Entrada y salida</title>
 			<itemizedlist>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -9,9 +9,9 @@
    ****************************************************************************
 -->
 <chapter xml:id="tcell">
-	<title>Tipos de índices de celdas temporales</title>
+	<title>Teselaciones temporales</title>
 
-	<para>Un <emphasis>sistema de cuadrícula global discreta</emphasis> (DGGS) divide la Tierra en una jerarquía de celdas, cada una identificada por un entero de 64 bits, de modo que una posición se convierte en un identificador de celda y una prueba de contención se convierte en una comparación de enteros. MobilityDB admite tres de ellos, y un tipo de índice de celda temporal registra el movimiento de un objeto como la secuencia de celdas que ocupa a lo largo del tiempo.</para>
+	<para>Un <emphasis>sistema de cuadrícula global discreta</emphasis> (DGGS) divide la Tierra en una jerarquía de celdas, cada una identificada por un entero de 64 bits, de modo que una posición se convierte en un identificador de celda y una prueba de contención se convierte en una comparación de enteros. MobilityDB admite tres de ellos, y un tipo de índice de celda temporal registra el movimiento de un objeto como la secuencia de celdas que ocupa a lo largo del tiempo. Cada cuadrícula tesela la Tierra, y estas tres la teselan globalmente: un identificador de celda nombra una celda de una de ellas dondequiera que se lea, que es lo que permite a un tipo temporal transportar celdas y nada más.</para>
 
 	<informaltable frame="all">
 		<tgroup cols="5" align="left" colsep="1" rowsep="1">

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2799,7 +2799,7 @@
 	</sect1>
 
 	<sect1>
-		<title>Temporal Cell Index Types</title>
+		<title>Temporal Tessellations</title>
 		<sect2>
 			<title>Input and Output</title>
 			<itemizedlist>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -9,9 +9,9 @@
    ****************************************************************************
 -->
 <chapter xml:id="tcell">
-	<title>Temporal Cell Index Types</title>
+	<title>Temporal Tessellations</title>
 
-	<para>A <emphasis>discrete global grid system</emphasis> (DGGS) partitions the Earth into a hierarchy of cells, each identified by a 64-bit integer, so that a position becomes a cell identifier and a containment test becomes an integer comparison. MobilityDB supports three of them, and a temporal cell index type records the movement of an object as the sequence of cells it occupies over time.</para>
+	<para>A <emphasis>discrete global grid system</emphasis> (DGGS) partitions the Earth into a hierarchy of cells, each identified by a 64-bit integer, so that a position becomes a cell identifier and a containment test becomes an integer comparison. MobilityDB supports three of them, and a temporal cell index type records the movement of an object as the sequence of cells it occupies over time. Each grid tessellates the Earth, and these three tessellate it globally: a cell identifier names a cell of one of them wherever it is read, which is what lets a temporal type carry cells and nothing else.</para>
 
 	<informaltable frame="all">
 		<tgroup cols="5" align="left" colsep="1" rowsep="1">

--- a/tools/doc/gen_reference.py
+++ b/tools/doc/gen_reference.py
@@ -90,7 +90,7 @@ LAYOUT = [
      "parts": ["Static Circular Buffers", "Temporal Circular Buffers"]},
     {"title": "Temporal Rigid Geometries", "chapters": ["temporal_rigid_geometries.xml"]},
     {"title": "Temporal JSON", "chapters": ["temporal_jsonb.xml"]},
-    {"title": "Temporal Cell Index Types", "chapters": ["temporal_cell_index.xml"]},
+    {"title": "Temporal Tessellations", "chapters": ["temporal_cell_index.xml"]},
     {"title": "Temporal Point Clouds", "chapters": ["temporal_pointcloud.xml"],
      "parts": ["Static Types <varname>pcpoint</varname> and <varname>pcpatch</varname>",
                "Set Types <varname>pcpointset</varname> and <varname>pcpatchset</varname>",


### PR DESCRIPTION
The chapter documents three grids that tessellate the Earth and the temporal
types that carry their cells, so its title names the tessellation rather than
the cell index, in both manuals and in the section the reference appendix
projects. Its opening states what the three share: each grid tessellates the
Earth and these three tessellate it globally, so a cell identifier names a
cell wherever it is read, which is what lets a temporal type carry cells and
nothing else.

The type names, the section ids and every entry are untouched, so a query
reads the same and every link into the chapter resolves to the entry it
resolved to before.

The numbers: the appendix projects 761 chapter entries into 762 rows in each
language, the counts gen_reference.py --audit reports, and --check reads both
files as what the chapters project.

