### PR TITLE
Share the boundary two polygons meet along where they share no area

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2101,6 +2101,53 @@ geo_is_planar_polygonal(const GSERIALIZED *gs)
 }
 
 /**
+ * @brief Return what two areal geometries meet along where they share no area,
+ * or @c NULL where they meet in nothing
+ * @details The intersection of two point sets is a point set, and nothing
+ * about it promises an area. An engine that assembles regions answers the
+ * region, so for a pair meeting at a point or along a curve it answers an
+ * empty one -- and "no area" and "nothing" are different sentences.
+ *
+ * Where the two share no area, no part of the first one's boundary reaches
+ * the interior of the second: a point of it that did would carry a
+ * neighbourhood of the first one's own interior into the second's, which is
+ * area they would then share. So the part of that boundary the second
+ * geometry covers is exactly the part lying ON its boundary, which is what
+ * the two meet along, and #geo_clip_linear_geom answers it from the segment
+ * kernels over an edge index. Asking it of the first operand's boundary also
+ * keeps the answer running in that operand's own direction
+ * @param[in] gs1,gs2 Geometries
+ * @pre The two share no area, which is what the caller has just read
+ */
+static GSERIALIZED *
+geom_areal_meeting(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
+{
+  assert(gs1); assert(gs2);
+  /* Two geometries whose bounding boxes lie apart meet nowhere, which spares
+   * an ordinary spatial join a boundary of its own for every pair it rejects */
+  GBOX box1, box2;
+  memset(&box1, 0, sizeof(GBOX));
+  memset(&box2, 0, sizeof(GBOX));
+  if (gserialized_get_gbox_p(gs1, &box1) && gserialized_get_gbox_p(gs2, &box2)
+      && gbox_overlaps_2d(&box1, &box2) == LW_FALSE)
+    return NULL;
+
+  GSERIALIZED *bound = geom_boundary(gs1);
+  if (! bound)
+    return NULL;
+  GSERIALIZED *result = geo_clip_subject(bound) ?
+    geo_clip_linear_geom(bound, gs2, true) : NULL;
+  pfree(bound);
+  /* A meeting of nothing is the empty region the caller already holds */
+  if (result && geo_is_empty(result))
+  {
+    pfree(result);
+    result = NULL;
+  }
+  return result;
+}
+
+/**
  * @ingroup meos_geo_base_spatial
  * @brief Return the intersection of two geometries
  * @param[in] gs1,gs2 Geometries
@@ -2108,8 +2155,10 @@ geo_is_planar_polygonal(const GSERIALIZED *gs)
  * to the original function we do not use the @p prec argument.
  *
  * When both inputs are 2D POLYGON / MULTIPOLYGON the call routes through
- * the Clipper2-backed #clip_poly_poly. Other type combinations fall
- * through to PostGIS's GEOS-backed @c lwgeom_intersection_prec.
+ * the Clipper2-backed #clip_poly_poly, and where that answers a region of no
+ * area #geom_areal_meeting answers what the two meet along. Other type
+ * combinations fall through to PostGIS's GEOS-backed
+ * @c lwgeom_intersection_prec.
  */
 GSERIALIZED *
 geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
@@ -2120,7 +2169,21 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
   /* Clipper2 fast-path for 2D polygonal inputs */
   if (geo_is_planar_polygonal(gs1) && geo_is_planar_polygonal(gs2))
-    return clip_poly_poly(gs1, gs2, CL_INTERSECTION);
+  {
+    GSERIALIZED *result = clip_poly_poly(gs1, gs2, CL_INTERSECTION);
+    /* The region two surfaces share is empty where they meet without
+     * overlapping, and what they meet along is still theirs in common */
+    if (result && geo_is_empty(result))
+    {
+      GSERIALIZED *meeting = geom_areal_meeting(gs1, gs2);
+      if (meeting)
+      {
+        pfree(result);
+        return meeting;
+      }
+    }
+    return result;
+  }
 
   /* The points of a point set that the other geometry covers ARE the
    * intersection, whatever the other geometry draws */

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1772,9 +1772,9 @@ int main(void)
     /* the disc, on its own circle */
     "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 2,2 0,4 2),"
       "CIRCULARSTRING(4 2,2 4,0 2)))",
-    /* two squares meeting along an edge share no area ... */
-    "POLYGON EMPTY",
-    /* ... and neither takes any from the other */
+    /* two squares meeting along an edge share the edge they meet along ... */
+    "LINESTRING(2 0,2 2)",
+    /* ... and neither takes any area from the other */
     "POLYGON((2 2,2 0,0 0,0 2,2 2))",
   };
   for (int i = 0; i < 3; i++)
@@ -1790,6 +1790,65 @@ int main(void)
     printf("a shared boundary %d: %.58s\n", i, cwt);
     assert(strcmp(cwt, cw_exp[i]) == 0);
     free(cwt); free(cr); free(ca); free(cb);
+    meos_errno_reset();
+  }
+  /* AND A PAIR OF PLAIN POLYGONS IS ASKED THE SAME QUESTION THROUGH ANOTHER
+   * ENGINE, so the two spellings of one region have to answer alike. Where
+   * they share no area the region answer is empty and what they meet along is
+   * read off the first one's boundary: a whole edge, a part of one, or the
+   * single point two corners meet at. The rows after them are the ones this
+   * must leave alone -- a pair that meets in nothing, a pair one contains,
+   * and a pair sharing area, which never reach the question at all */
+  const char *pm_a[] = {
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+    "MULTIPOLYGON(((0 0,4 0,4 4,0 4,0 0)),((0 6,4 6,4 9,0 9,0 6)))",
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+    "POLYGON((0 0,4 0,0 4,0 0))",
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+    "POLYGON((0 0,4 0,4 4,0 4,0 0))",
+  };
+  const char *pm_b[] = {
+    "POLYGON((4 0,8 0,8 4,4 4,4 0))",
+    "POLYGON((4 1,8 1,8 3,4 3,4 1))",
+    "POLYGON((4 4,8 4,8 8,4 8,4 4))",
+    "POLYGON((4 0,8 0,8 4,4 4,4 0))",
+    "POLYGON((20 20,24 20,24 24,20 24,20 20))",
+    "POLYGON((3 3,7 3,7 7,3 7,3 3))",
+    "POLYGON((1 1,3 1,3 3,1 3,1 1))",
+    "POLYGON((2 0,6 0,6 4,2 4,2 0))",
+  };
+  const char *pm_exp[] = {
+    /* the whole edge the two squares share */
+    "LINESTRING(4 0,4 4)",
+    /* the part of that edge the shorter one reaches */
+    "LINESTRING(4 1,4 3)",
+    /* two corners meeting is one point, and a point is what it answers */
+    "POINT(4 4)",
+    /* the part a multipolygon shares is its own member's edge */
+    "LINESTRING(4 0,4 4)",
+    /* apart, so there is nothing to meet along */
+    "POLYGON EMPTY",
+    /* boxes that meet over shapes that do not is still nothing */
+    "POLYGON EMPTY",
+    /* one region inside another shares that region, which has area */
+    "POLYGON((3 3,3 1,1 1,1 3,3 3))",
+    /* and two overlapping squares share the region they overlap in */
+    "POLYGON((4 4,4 0,2 0,2 4,4 4))",
+  };
+  for (int i = 0; i < 8; i++)
+  {
+    GSERIALIZED *pa = geom_in(pm_a[i], -1);
+    GSERIALIZED *pb = geom_in(pm_b[i], -1);
+    assert(pa != NULL); assert(pb != NULL);
+    meos_errno_reset();
+    GSERIALIZED *pr2 = geom_intersection2d(pa, pb);
+    assert(pr2 != NULL);
+    char *pmt = geo_as_text(pr2, 6);
+    printf("two polygons meeting %d: %.52s\n", i, pmt);
+    assert(strcmp(pmt, pm_exp[i]) == 0);
+    free(pmt); free(pr2); free(pa); free(pb);
     meos_errno_reset();
   }
   /* WHERE THE ANSWER LEAVES TWO REGIONS TOUCHING AT ONE POINT, four piece-ends


### PR DESCRIPTION
Part of the campaign that gives MEOS a native answer for every geometry operation.

## Two polygons sharing no area still share what they meet along

A planar polygonal pair reaches the Clipper2 route ahead of every other arm of `geom_intersection2d`. That route assembles regions, and the region two surfaces cover in common is empty exactly when what they share is a curve or a point — so the answer to those pairs is `POLYGON EMPTY`, and what they meet along is dropped by the engine best placed to see it.

```sql
SELECT ST_AsText(ST_Intersection(
  'POLYGON((0 0,4 0,4 4,0 4,0 0))',
  'POLYGON((4 0,8 0,8 4,4 4,4 0))'));
```

Two squares sharing a whole edge share that edge, and the answer is `LINESTRING(4 0,4 4)`.

## Where the region is empty, neither boundary reaches the other's interior

A point of the first one's boundary lying inside the second carries a neighbourhood of the first one's own interior in with it, which is area the two would then share. So the part of that boundary the second geometry covers is precisely the part lying on its boundary — the meeting — and `geo_clip_linear_geom` answers it from the segment kernels over an edge index. Asking it of the first operand keeps the answer running in that operand's own direction.

## The answer is the reference's own

GEOS is never asked these pairs: the Clipper2 route returns before the tail that would call it. Asked directly it answers `LINESTRING(4 0,4 4)`, `LINESTRING(4 1,4 3)` and `POINT(4 4)` for a shared edge, a shared part of one and a shared corner — the same point sets this answers, vertex for vertex and in the same order.

## Measured

| measurement | result |
|---|---|
| 20 real protected-area polygon pairs, against the answer `lwgeom_intersection_prec` gives for the same pair | agreement on area and length goes 13 of 20 to 19 of 20; the reference answers a curve for six of them and this answers the same curve, with the six lengths equal to every printed digit (15.5443, 377.3028, 2395.7506, 592.5113, 3273.5585, 274.1262 m) |
| the same 20 pairs, timed on one machine in one process | 204 ms against 806 ms, a ratio of 4.0 on a corpus that is entirely box-overlapping pairs. Every pair answering a region is unmoved; only a pair whose region is empty reads a boundary of its own |
| nine synthetic pairs outside the class: a pair far apart, a pair whose boxes meet over shapes that do not, an overlap, a containment, a geometry against itself, and four differences | each answers what the region route answers, to the byte |
| the same probes on a library built with GEOS | identical to the GEOS-free arm on every row |
| `meos/test/geo_test.c` | 8 witnesses, each of which aborts against a library without this change |
| the full regression suite | unmoved: no fixture carries two polygons sharing a boundary |

## Why

The intersection of two point sets is a point set, and nothing about it promises an area. An engine that assembles surfaces answers the region two operands cover in common — the whole answer whenever that region has area, and none of it when it has not. So the empty region it returns is not the absence of a meeting but a statement about the meeting's dimension, and read that way it is the signal to ask the other question rather than the answer to it. That question has an exact answer with no tolerance in it, one dimension below the engine that answers the region — which is why that engine cannot state it, and why stating it costs no new geometry: the boundary is already there to be clipped.

## One row moves beyond the meeting, and the band is measured

Two squares overlapping by less than 1e-8 answer the line they overlap along where they answered `POLYGON EMPTY`. Sweeping the overlap decade by decade puts the boundary exactly there: down to 1e-7 the Clipper2 route returns the sliver and nothing changes; from 1e-8 down it returns an empty region for a pair that does share area, and the meeting is then read for a pair outside its own precondition. Both answers are wrong about that sliver, and this one reports the line the two run along, which is the point set the reference reports there too.

## A case outside this one

Where two surfaces share both area and a stretch of boundary outside it, the region answer stands alone and the stretch is still absent — one of the 20 real pairs is exactly that, 0.046 m² of shared region beside 29245 m of shared boundary the reference reports. The meeting is read only where the region is empty, so a pair carrying both never reaches it. Answering that one means assembling the region and the meeting together, and it wants a change of its own.
