### PR TITLE
State the raster chapter in the section order the tessellations share

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3648,46 +3648,7 @@
 	<sect1>
 		<title>Raster Sampling</title>
 		<sect2>
-			<title>Operador de Muestreo</title>
-			<itemizedlist>
-				<listitem>
-					<para><link linkend="raster_rasterValue"><varname>rasterValue</varname></link>: Muestrea una banda de ráster en cada instante de una trayectoria</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-		<sect2>
-			<title>Accesores de Ráster</title>
-			<itemizedlist>
-				<listitem>
-					<para><link linkend="raster_numBands"><varname>numBands</varname></link>: Devuelve el número de bandas de un ráster</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-		<sect2>
-			<title>Muestreo Raquet / QUADBIN</title>
-			<itemizedlist>
-				<listitem>
-					<para><link linkend="raster_quadbins"><varname>quadbins</varname></link>: Devuelve las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: Muestrea un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raquet"><varname>raquet</varname></link>: Construye una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raquetRead"><varname>raquetRead</varname></link>: Decodifica un archivo ráster en memoria en una tesela ráster Raquet mediante GDAL</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raster_rasterTileValueArray"><varname>rasterTileValue</varname></link>: Muestrea un arreglo de teselas ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-		<sect2>
-			<title>Serialización de Raquet</title>
+			<title>Entrada y salida</title>
 			<itemizedlist>
 				<listitem>
 					<para><link linkend="raquet_asBinary"><varname>asBinary</varname></link>: Devuelve la representación binaria conocida (WKB) de una tesela Raquet</para>
@@ -3704,8 +3665,30 @@
 			</itemizedlist>
 		</sect2>
 		<sect2>
-			<title>Accesores y Comparación de Raquet</title>
+			<title>Constructores</title>
 			<itemizedlist>
+				<listitem>
+					<para><link linkend="raquet"><varname>raquet</varname></link>: Construye una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raquetRead"><varname>raquetRead</varname></link>: Decodifica un archivo ráster en memoria en una tesela ráster Raquet mediante GDAL</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+		<sect2>
+			<title>Conversión de tipos</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raquet_to_stbox"><varname>stbox</varname></link>: Convierte una tesela Raquet en una caja espaciotemporal</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+		<sect2>
+			<title>Accesores</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raster_numBands"><varname>numBands</varname></link>: Devuelve el número de bandas de un ráster</para>
+				</listitem>
 				<listitem>
 					<para><link linkend="raquet_quadbin_accessor"><varname>quadbin</varname></link>: Devuelve la celda QUADBIN de una tesela Raquet</para>
 				</listitem>
@@ -3724,17 +3707,39 @@
 				<listitem>
 					<para><link linkend="raquet_pixels"><varname>pixels</varname></link>: Devuelve los bytes de píxeles de un mosaico Raquet</para>
 				</listitem>
+			</itemizedlist>
+		</sect2>
+		<sect2>
+			<title>Funciones que devuelven conjuntos</title>
+			<itemizedlist>
 				<listitem>
-					<para><link linkend="raquet_to_stbox"><varname>stbox</varname></link>: Convierte una tesela Raquet en una caja espaciotemporal</para>
+					<para><link linkend="raster_quadbins"><varname>quadbins</varname></link>: Devuelve las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
 				</listitem>
+			</itemizedlist>
+		</sect2>
+		<sect2>
+			<title>Comparaciones</title>
+			<itemizedlist>
 				<listitem>
 					<para><link linkend="raquet_comparison"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname>, <varname>&gt;</varname>, <varname>cmp</varname></link>: Compara dos teselas Raquet</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
 		<sect2>
-			<title>Operadores de Restricción y Predicado</title>
+			<title>Operaciones específicas de ráster</title>
 			<itemizedlist>
+				<listitem>
+					<para><link linkend="raster_rasterValue"><varname>rasterValue</varname></link>: Muestrea una banda de ráster en cada instante de una trayectoria</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_rasterTileValueArray"><varname>rasterTileValue</varname></link>: Muestrea un arreglo de teselas ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: Muestrea un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
+				</listitem>
 				<listitem>
 					<para><link linkend="raster_atRasterValue"><varname>atRasterValue</varname></link>: Devuelve los instantes de una trayectoria donde el valor ráster muestreado cae dentro de un rango de flotante</para>
 				</listitem>

--- a/doc/es/temporal_raster.xml
+++ b/doc/es/temporal_raster.xml
@@ -13,6 +13,8 @@
 
 	<para>La extensión <ulink url="https://postgis.net/docs/using_raster_dataman.html">ráster de PostGIS</ulink> almacena datos de cobertura en cuadrícula (elevación, temperatura, imágenes satelitales, …) en el tipo <varname>raster</varname>. Cada ráster tiene una o más bandas; una banda contiene un arreglo 2D de valores de píxel, una extensión espacial, un tamaño de píxel y un valor centinela opcional para datos nulos (<varname>nodata</varname>).</para>
 
+	<para><ulink url="https://github.com/CartoDB/raquet">Raquet</ulink> es un formato ráster nativo en la nube que almacena teselas ráster como filas en un archivo Apache Parquet. Cada fila contiene los bytes de píxel de una tesela Web-Mercator junto con su identificador de celda <ulink url="https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/sql-reference/quadbin">QUADBIN</ulink>, un entero de 64 bits que codifica el nivel de zoom y las coordenadas x/y intercaladas mediante Morton. No se requieren metadatos espaciales adicionales: el rectángulo delimitador y el mapeo de píxel a coordenadas quedan completamente determinados por el valor QUADBIN.</para>
+
 	<para>El operador de muestreo de ráster de MobilityDB evalúa una banda de ráster en los instantes de una trayectoria de punto móvil y devuelve un <varname>tfloat</varname>. Los instantes cuya posición cae fuera de la extensión del ráster o sobre un píxel <varname>nodata</varname> se descartan silenciosamente. Los operadores de muestreo son de valor doble sea cual sea el tipo de píxel de la banda, de modo que un tipo de píxel pertenece a la superficie de muestreo cuando todo valor que puede contener es exactamente representable en un número de doble precisión. Eso es lo que permite muestrear una banda de cualquier tipo en un único <varname>tfloat</varname>, y que una columna con teselas de varios tipos de píxel se lea con una sola consulta. Un tipo de píxel también se acepta con el nombre que le da el ráster de PostGIS, de modo que el tipo de banda que informa una llamada a <varname>ST_BandPixelType</varname> (<varname>8BUI</varname>, <varname>16BSI</varname>, <varname>32BF</varname>, …) se pasa a los constructores de teselas tal cual. El ráster de PostGIS no lleva flotantes de 16 bits ni enteros de 64 bits, así que <varname>float16</varname>, <varname>int64</varname> y <varname>uint64</varname> toman la grafía que da su gramática, <varname>16BF</varname>, <varname>64BSI</varname> y <varname>64BUI</varname>. Sus tipos <varname>1BB</varname>, <varname>2BUI</varname> y <varname>4BUI</varname> acotan un píxel a menos de un byte mientras que PostGIS almacena cada uno de ellos a un byte por píxel, de modo que tal banda ya son los bytes de una banda de 8 bits sin signo y los constructores la leen como <varname>uint8</varname>; la cota es lo único que añade el nombre, y una tesela no la lleva. El nombre que informa una tesela es el que la especificación RaQuet da al tipo.
 
 Los tipos <varname>uint64</varname> e <varname>int64</varname> contienen valores fuera de ese dominio: una tesela de cualquiera de ellos se almacena y se vuelve a leer exactamente, mientras que muestrear un píxel cuyo valor ningún número de doble precisión nombra genera un error en lugar de responder con un valor vecino. Esto permite consultas como <emphasis>¿qué perfil de elevación siguió cada vehículo?</emphasis> o <emphasis>¿qué viajes entraron en una banda de umbral de temperatura?</emphasis></para>
@@ -24,121 +26,70 @@ CREATE EXTENSION mobilitydb CASCADE;
 -- NOTICE:  installing required extension "postgis_raster"
 </programlisting>
 
-	<sect1 xml:id="raster_sampling_operator">
-		<title>Operador de Muestreo</title>
+	<sect1 xml:id="raster_inout">
+		<title>Entrada y salida</title>
+
+		<para>Las funciones <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>raquet</varname>, y <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> y <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> lo reconstruyen. Una tesela lleva sus píxeles y su georreferenciación QUADBIN en un único valor, de modo que hace un viaje de ida y vuelta a través de una cadena de bytes portable sin intervención de ninguna extensión espacial, y la forma hexadecimal permite que una columna de teselas haga ese viaje mediante un <varname>COPY</varname> basado en texto. Ambas funciones de salida aceptan un argumento opcional de ordenación de bytes, <varname>NDR</varname> para little-endian o <varname>XDR</varname> para big-endian, cuyo valor predeterminado es la ordenación del servidor.</para>
 
 		<itemizedlist>
-			<listitem xml:id="raster_rasterValue">
-				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
-				<para>Muestrea una banda de ráster en cada instante de una trayectoria</para>
+			<listitem xml:id="raquet_asBinary">
+				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
+				<para>Devuelve la representación binaria conocida (WKB) de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
+asBinary(raquet,endian text='') → bytea
 </programlisting>
-				<para>Lee la banda <varname>band</varname> a lo largo de <varname>traj</varname>, tomando el valor del píxel en el que cae cada posición. Una trayectoria que no afirma nada entre sus instantes se lee en sus instantes y devuelve un <varname>tfloat</varname> de conjunto de instantes. Una trayectoria que se mueve entre ellos pasa por los píxeles intermedios, por lo que se recorre a medio píxel, el paso con el que se recorre un índice de celdas hexagonal, y devuelve un <varname>tfloat</varname> escalonado que mantiene cada valor hasta que el trayecto alcanza un píxel con otro valor. Una posición fuera del ráster o sobre un píxel sin datos no lleva valor y termina el tramo, por lo que un trayecto que sale y vuelve a entrar en el ráster devuelve una secuencia por visita, y <varname>NULL</varname> cuando nunca encuentra un píxel con datos.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
-WITH rast AS (
-  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
-    4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
-    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
-    [40.0::float4, 50.0::float4, 60.0::float4],
-    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
-SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
-  POINT(2.5 2.5)@2001-01-02, POINT(0.5 0.5)@2001-01-03]', r)::text FROM rast;
--- {10@2001-01-01, 30@2001-01-02, 70@2001-01-03}
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
+-- 31
 </programlisting>
-				<para>Aplicado a un conjunto de datos de trayectorias con un ráster de elevación del terreno:</para>
+			</listitem>
+
+			<listitem xml:id="raquet_asHexWKB">
+				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
+				<para>Devuelve la representación hexadecimal binaria conocida (HexWKB) de una tesela Raquet</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+asHexWKB(raquet,endian text='') → text
+</programlisting>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
+-- 62
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raquetFromBinary">
+				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
+				<para>Devuelve una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+raquetFromBinary(bytea) → raquet
+</programlisting>
+							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
+  'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
+-- true
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raquetFromHexWKB">
+				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
+				<para>Devuelve una tesela Raquet a partir de su representación hexadecimal binaria conocida (HexWKB)</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+raquetFromHexWKB(text) → raquet
+</programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Elevation profile per trip (requires a loaded elevation raster)
-SELECT tripid, rasterValue(trip, elev) AS elevation FROM trips, elevation_raster;
--- Average elevation per trip
-SELECT tripid, avgValue(rasterValue(trip, elev)) AS mean_elev FROM trips,
-  elevation_raster;
--- Trips that crossed terrain above 200 m
-SELECT tripid FROM trips, elevation_raster
-WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
+SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
+  'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
+-- true
 </programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="raster_accessors">
-		<title>Accesores de Ráster</title>
+	<sect1 xml:id="raster_constructors">
+		<title>Constructores</title>
+
+		<para>Una tesela <varname>raquet</varname> se construye a partir de bytes de píxel ya disponibles o decodificando un archivo ráster, y lleva su georreferenciación QUADBIN en el propio valor.</para>
 
 		<itemizedlist>
-			<listitem xml:id="raster_numBands">
-				<indexterm significance="normal"><primary><varname>numBands</varname></primary></indexterm>
-				<para>Devuelve el número de bandas de un ráster</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-numBands(raster) → integer
-</programlisting>
-				<para>El número de banda que aceptan <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> y los operadores construidos sobre él va de 1 hasta este valor.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH rast1 AS (
-  SELECT ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
-    '32BF'::text, 0.0::float8, NULL::float8 ) AS r ), rast2 AS (
-  SELECT ST_AddBand(r, '32BF'::text, 0.0::float8, NULL::float8) AS r FROM rast1 )
-SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
-  numBands((SELECT r FROM rast2)) AS num_bands_two;
--- 1 | 2
-</programlisting>
-			</listitem>
-		</itemizedlist>
-	</sect1>
-
-	<sect1 xml:id="raquet_quadbin">
-		<title>Muestreo Raquet / QUADBIN</title>
-
-		<para><ulink url="https://github.com/CartoDB/raquet">Raquet</ulink> es un formato ráster nativo en la nube que almacena teselas ráster como filas en un archivo Apache Parquet. Cada fila contiene los bytes de píxel de una tesela Web-Mercator junto con su identificador de celda <ulink url="https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/sql-reference/quadbin">QUADBIN</ulink>, un entero de 64 bits que codifica el nivel de zoom y las coordenadas x/y intercaladas mediante Morton. No se requieren metadatos espaciales adicionales: el rectángulo delimitador y el mapeo de píxel a coordenadas quedan completamente determinados por el valor QUADBIN.</para>
-
-		<para>El patrón de consulta típico une una trayectoria con una tabla Raquet en dos pasos:</para>
-		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Step 1: identify which tiles the trajectory overlaps
-SELECT DISTINCT q FROM unnest(quadbins(traj, 8)) AS q;
--- Step 2: sample each matching tile
-SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'float32', nodata,
-  true) FROM elevation_raquet WHERE quadbin = ANY(quadbins(traj, 8));
-</programlisting>
-
-		<itemizedlist>
-			<listitem xml:id="raster_quadbins">
-				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
-				<para>Devuelve las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-quadbins(tgeompoint,zoom integer) → bigint[]
-</programlisting>
-				<para>Devuelve el conjunto de celdas QUADBIN únicas que cubre la trayectoria. Una trayectoria que no afirma nada entre sus instantes cubre las teselas que los contienen; una que se mueve entre ellos cubre además las teselas que atraviesa por el camino, y el segmento se recorre a media tesela para encontrarlas, estrechándose la tesela hacia los polos como lo hace su envolvente Web-Mercator. El resultado es adecuado como clave de unión en la cláusula WHERE contra una tabla Raquet, donde una tesela que el trayecto atraviesa pero el conjunto omite es una tesela que la unión nunca lee. El parámetro <varname>zoom</varname> debe estar en [0, 15].</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Three instants spanning three tiles at zoom 3
-SELECT quadbins(tgeompoint 'SRID=4326;
-  {Point(-60 45)@2024-01-01, Point(0 45)@2024-01-02, Point(60 45)@2024-01-03}', 3);
--- {5202501994543054848,5203346419473186816,5203416788217364480}
--- Count of Raquet tiles a ship trajectory overlaps at zoom 8
-SELECT array_length(quadbins(trip, 8),
-  1) AS tile_count FROM trips ORDER BY tile_count DESC;
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raster_rasterTileValueQuadbin">
-				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
-				<para>Muestrea un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValueQuadbin(tgeompoint,pixels bytea,width integer,height integer,
-  quadbin bigint,pixtype text,nodata float8,has_nodata boolean) → tfloat
-</programlisting>
-				<para>Evalúa un arreglo de píxeles de banda única en orden de fila mayor en cada instante de <varname>traj</varname> (SRID 4326). La georreferenciación de la tesela (rectángulo delimitador, mapeo de píxel a coordenadas) se deriva únicamente de <varname>quadbin</varname> mediante la transformada de tesela deslizante Web-Mercator. El argumento <varname>pixtype</varname> debe ser uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Cuando <varname>has_nodata</varname> es verdadero, los instantes cuyo píxel equivale a <varname>nodata</varname> se descartan silenciosamente. Devuelve <varname>NULL</varname> cuando ningún instante sobrevive.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Sample elevation tiles from a Raquet Parquet table for all ship trajectories
-SELECT t.tripid, rasterTileValueQuadbin(t.trip, r.band_data, r.width, r.height,
-  r.quadbin, 'float32', r.nodata, true) FROM trips t
-JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
--- Average sea-surface temperature per trajectory
-SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
-  r.band_data, 256, 256, r.quadbin, 'int16', -9999, true)) AS mean_sst FROM trips t
-JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
-</programlisting>
-			</listitem>
-
 			<listitem xml:id="raquet">
 				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
 				<para>Construye una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
@@ -170,104 +121,71 @@ SELECT raquetRead(file_bytes, quadbin) AS tile FROM elevation_files;
 SELECT raquetRead(file_bytes) AS tile FROM elevation_files;
 </programlisting>
 			</listitem>
-
-			<listitem xml:id="raster_rasterTileValue">
-				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
-				<para>Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValue(tgeompoint,rast raquet) → tfloat
-</programlisting>
-				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Sample pre-packaged raquet tiles along ship trajectories
-SELECT t.tripid, rasterTileValue(t.trip, r.tile)
-FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raster_rasterTileValueArray">
-				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
-				<para>Muestrea un arreglo de teselas ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValue(tgeompoint,rast raquet[]) → tfloat
-</programlisting>
-				<para>Evalúa cada tesela de <varname>rast</varname> en cada instante de <varname>traj</varname> (SRID 4326) y devuelve los valores de píxel muestreados como un único <varname>tfloat</varname>. Una trayectoria que sale de una tesela queda cubierta por varias, y cada una aporta los instantes que caen dentro de ella. Las teselas de un mismo nivel de zoom particionan el plano, de modo que aportan instantes disjuntos. Las teselas de niveles de zoom distintos se solapan, y cuando dos de ellas muestrean el mismo instante se conserva el valor de la tesela de mayor zoom, que es la que tiene la resolución más fina. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de una tesela o sobrevive al filtrado de nodata.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Sample a trajectory across every tile it crosses, in one value
-SELECT t.tripid, rasterTileValue(t.trip, array_agg(r.tile)) FROM trips t
-JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8)) GROUP BY t.tripid, t.trip;
-</programlisting>
-			</listitem>
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="raquet_serialization">
-		<title>Serialización de Raquet</title>
+	<sect1 xml:id="raster_conversions">
+		<title>Conversión de tipos</title>
 
-		<para>Las funciones <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>raquet</varname>, y <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> y <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> lo reconstruyen. Una tesela lleva sus píxeles y su georreferenciación QUADBIN en un único valor, de modo que hace un viaje de ida y vuelta a través de una cadena de bytes portable sin intervención de ninguna extensión espacial, y la forma hexadecimal permite que una columna de teselas haga ese viaje mediante un <varname>COPY</varname> basado en texto. Ambas funciones de salida aceptan un argumento opcional de ordenación de bytes, <varname>NDR</varname> para little-endian o <varname>XDR</varname> para big-endian, cuyo valor predeterminado es la ordenación del servidor.</para>
+		<para>Una tesela se convierte en la caja espaciotemporal de su huella, que es lo que da un índice espacial a una tabla de teselas.</para>
 
 		<itemizedlist>
-			<listitem xml:id="raquet_asBinary">
-				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
-				<para>Devuelve la representación binaria conocida (WKB) de una tesela Raquet</para>
+			<listitem xml:id="raquet_to_stbox">
+				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
+				<para>Convierte una tesela Raquet en una caja espaciotemporal</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asBinary(raquet,endian text='') → bytea
+stbox(raquet) → stbox
 </programlisting>
-							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
--- 31
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raquet_asHexWKB">
-				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
-				<para>Devuelve la representación hexadecimal binaria conocida (HexWKB) de una tesela Raquet</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asHexWKB(raquet,endian text='') → text
-</programlisting>
-							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
--- 62
-</programlisting>
-			</listitem>
-
-
-			<listitem xml:id="raquetFromBinary">
-				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
-				<para>Devuelve una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetFromBinary(bytea) → raquet
-</programlisting>
-							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
-  'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
--- true
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raquetFromHexWKB">
-				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
-				<para>Devuelve una tesela Raquet a partir de su representación hexadecimal binaria conocida (HexWKB)</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetFromHexWKB(text) → raquet
-</programlisting>
+				<para>Devuelve la huella de la tesela: la envolvente de longitud y latitud de su celda QUADBIN, en SRID 4326 y sin dimensión temporal. La huella se deriva únicamente de la celda, por lo que teselas que difieren en píxeles, dimensiones o tipo de píxel la comparten. La conversión también está disponible como conversión de tipo.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
-  'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
--- true
+-- The footprint of a tile covering the north-eastern quadrant at zoom 1
+SELECT round(stbox(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')), 6);
+-- SRID=4326;STBOX X((0,0),(180,85.051129))
+-- Keep the tiles whose footprint overlaps a region of interest
+SELECT * FROM elevation_tiles WHERE tile::stbox &amp;&amp; stbox 'SRID=4326;
+  STBOX X((0,0),(30,30))';
+</programlisting>
+				<para>La huella admite los operadores, agregados y clases de operadores de <varname>stbox</varname>, por lo que una tabla de teselas se consulta por solapamiento espacial en cualquier nivel de zoom en lugar de por una prueba de igualdad sobre la celda QUADBIN en uno fijo. Indexar la conversión dota a la tabla de teselas de un índice espacial, y la extensión de un conjunto de teselas es la extensión de sus huellas.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- A spatial index over the tile footprints
+CREATE INDEX elevation_tiles_gist ON elevation_tiles USING gist (stbox(tile));
+CREATE INDEX elevation_tiles_spgist ON elevation_tiles USING spgist (stbox(tile));
+-- The extent covered by a set of tiles
+SELECT extent(stbox(tile)) FROM elevation_tiles;
+-- Tiles a trajectory passes through, at whatever zoom levels the table holds
+SELECT t.tripid, r.tile FROM trips t,
+  elevation_tiles r WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
 </programlisting>
 			</listitem>
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="raquet_accessors">
-		<title>Accesores y Comparación de Raquet</title>
+	<sect1 xml:id="raster_accessors">
+		<title>Accesores</title>
+
+		<para><link linkend="raster_numBands"><varname>numBands</varname></link> lee el número de bandas de un <varname>raster</varname> de PostGIS; los accesores que siguen leen una tesela <varname>raquet</varname>.</para>
 
 		<para>Un valor <varname>raquet</varname> es autodescriptivo: los accesores siguientes leen la georreferenciación y la disposición que transporta, de modo que una tesela empaquetada con el constructor <link linkend="raquet"><varname>raquet</varname></link> o decodificada con <link linkend="raquetRead"><varname>raquetRead</varname></link> puede inspeccionarse sin conservar las columnas sueltas a partir de las cuales se construyó.</para>
 
-		<para>Las teselas también admiten el conjunto completo de operadores de comparación. El orden es total y se define primero por la celda QUADBIN, luego por el tipo de píxel, el ancho, el alto y finalmente los bytes de píxeles; está pensado para indexación y deduplicación, no para una interpretación espacial. Una clase de operadores btree por defecto hace que <varname>ORDER BY</varname>, <varname>DISTINCT</varname> y las uniones por mezcla funcionen sobre columnas <varname>raquet</varname>, y una clase de operadores hash por defecto habilita las uniones y agregaciones hash.</para>
-
 		<itemizedlist>
+			<listitem xml:id="raster_numBands">
+				<indexterm significance="normal"><primary><varname>numBands</varname></primary></indexterm>
+				<para>Devuelve el número de bandas de un ráster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+numBands(raster) → integer
+</programlisting>
+				<para>El número de banda que aceptan <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> y los operadores construidos sobre él va de 1 hasta este valor.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH rast1 AS (
+  SELECT ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8 ) AS r ), rast2 AS (
+  SELECT ST_AddBand(r, '32BF'::text, 0.0::float8, NULL::float8) AS r FROM rast1 )
+SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
+  numBands((SELECT r FROM rast2)) AS num_bands_two;
+-- 1 | 2
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raquet_quadbin_accessor">
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Devuelve la celda QUADBIN de una tesela Raquet</para>
@@ -346,34 +264,41 @@ SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- \x01020304
 </programlisting>
 			</listitem>
-			<listitem xml:id="raquet_to_stbox">
-				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
-				<para>Convierte una tesela Raquet en una caja espaciotemporal</para>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="raster_set_returning">
+		<title>Funciones que devuelven conjuntos</title>
+
+		<para>Las celdas QUADBIN que cubre una trayectoria se devuelven en un arreglo, que es la clave de unión por la que se lee una tabla Raquet.</para>
+
+		<itemizedlist>
+			<listitem xml:id="raster_quadbins">
+				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
+				<para>Devuelve las celdas QUADBIN distintas en un nivel de zoom cubiertas por una trayectoria</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-stbox(raquet) → stbox
+quadbins(tgeompoint,zoom integer) → bigint[]
 </programlisting>
-				<para>Devuelve la huella de la tesela: la envolvente de longitud y latitud de su celda QUADBIN, en SRID 4326 y sin dimensión temporal. La huella se deriva únicamente de la celda, por lo que teselas que difieren en píxeles, dimensiones o tipo de píxel la comparten. La conversión también está disponible como conversión de tipo.</para>
+				<para>Devuelve el conjunto de celdas QUADBIN únicas que cubre la trayectoria. Una trayectoria que no afirma nada entre sus instantes cubre las teselas que los contienen; una que se mueve entre ellos cubre además las teselas que atraviesa por el camino, y el segmento se recorre a media tesela para encontrarlas, estrechándose la tesela hacia los polos como lo hace su envolvente Web-Mercator. El resultado es adecuado como clave de unión en la cláusula WHERE contra una tabla Raquet, donde una tesela que el trayecto atraviesa pero el conjunto omite es una tesela que la unión nunca lee. El parámetro <varname>zoom</varname> debe estar en [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- The footprint of a tile covering the north-eastern quadrant at zoom 1
-SELECT round(stbox(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')), 6);
--- SRID=4326;STBOX X((0,0),(180,85.051129))
--- Keep the tiles whose footprint overlaps a region of interest
-SELECT * FROM elevation_tiles WHERE tile::stbox &amp;&amp; stbox 'SRID=4326;
-  STBOX X((0,0),(30,30))';
-</programlisting>
-				<para>La huella admite los operadores, agregados y clases de operadores de <varname>stbox</varname>, por lo que una tabla de teselas se consulta por solapamiento espacial en cualquier nivel de zoom en lugar de por una prueba de igualdad sobre la celda QUADBIN en uno fijo. Indexar la conversión dota a la tabla de teselas de un índice espacial, y la extensión de un conjunto de teselas es la extensión de sus huellas.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- A spatial index over the tile footprints
-CREATE INDEX elevation_tiles_gist ON elevation_tiles USING gist (stbox(tile));
-CREATE INDEX elevation_tiles_spgist ON elevation_tiles USING spgist (stbox(tile));
--- The extent covered by a set of tiles
-SELECT extent(stbox(tile)) FROM elevation_tiles;
--- Tiles a trajectory passes through, at whatever zoom levels the table holds
-SELECT t.tripid, r.tile FROM trips t,
-  elevation_tiles r WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
+-- Three instants spanning three tiles at zoom 3
+SELECT quadbins(tgeompoint 'SRID=4326;
+  {Point(-60 45)@2024-01-01, Point(0 45)@2024-01-02, Point(60 45)@2024-01-03}', 3);
+-- {5202501994543054848,5203346419473186816,5203416788217364480}
+-- Count of Raquet tiles a ship trajectory overlaps at zoom 8
+SELECT array_length(quadbins(trip, 8),
+  1) AS tile_count FROM trips ORDER BY tile_count DESC;
 </programlisting>
 			</listitem>
+		</itemizedlist>
+	</sect1>
 
+	<sect1 xml:id="raster_comparisons">
+		<title>Comparaciones</title>
+
+		<para>Las teselas también admiten el conjunto completo de operadores de comparación. El orden es total y se define primero por la celda QUADBIN, luego por el tipo de píxel, el ancho, el alto y finalmente los bytes de píxeles; está pensado para indexación y deduplicación, no para una interpretación espacial. Una clase de operadores btree por defecto hace que <varname>ORDER BY</varname>, <varname>DISTINCT</varname> y las uniones por mezcla funcionen sobre columnas <varname>raquet</varname>, y una clase de operadores hash por defecto habilita las uniones y agregaciones hash.</para>
+
+		<itemizedlist>
 			<listitem xml:id="raquet_comparison">
 				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
@@ -399,12 +324,103 @@ SELECT DISTINCT tile FROM elevation_tiles;
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="raster_restriction">
-		<title>Operadores de Restricción y Predicado</title>
+	<sect1 xml:id="raster_specific">
+		<title>Operaciones específicas de ráster</title>
 
-		<para>Los siguientes operadores definidos en SQL componen <varname>rasterValue</varname> con las funciones estándar de restricción temporal y predicado de MobilityDB. Aceptan un argumento opcional <varname>band</varname> (por defecto 1) e invocan <varname>rasterValue</varname> exactamente una vez por invocación.</para>
+		<para>Las secciones anteriores enuncian lo que un ráster comparte con las demás teselaciones. Las operaciones siguientes son propias del ráster: una celda de ráster lleva un <emphasis>valor</emphasis> donde una celda H3, QUADBIN o S2 lleva solo identidad, de modo que una trayectoria leída contra un ráster responde un <varname>tfloat</varname> en lugar de una celda temporal.</para>
+
+		<para>El patrón de consulta típico une una trayectoria con una tabla Raquet en dos pasos:</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Step 1: identify which tiles the trajectory overlaps
+SELECT DISTINCT q FROM unnest(quadbins(traj, 8)) AS q;
+-- Step 2: sample each matching tile
+SELECT rasterTileValueQuadbin(traj, band_data, width, height, quadbin, 'float32', nodata,
+  true) FROM elevation_raquet WHERE quadbin = ANY(quadbins(traj, 8));
+</programlisting>
+
+		<para>Los operadores de restricción y predicado que cierran la sección componen <varname>rasterValue</varname> con las funciones estándar de restricción temporal y predicado de MobilityDB. Aceptan un argumento opcional <varname>band</varname> (por defecto 1) e invocan <varname>rasterValue</varname> exactamente una vez por invocación.</para>
 
 		<itemizedlist>
+			<listitem xml:id="raster_rasterValue">
+				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
+				<para>Muestrea una banda de ráster en cada instante de una trayectoria</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
+</programlisting>
+				<para>Lee la banda <varname>band</varname> a lo largo de <varname>traj</varname>, tomando el valor del píxel en el que cae cada posición. Una trayectoria que no afirma nada entre sus instantes se lee en sus instantes y devuelve un <varname>tfloat</varname> de conjunto de instantes. Una trayectoria que se mueve entre ellos pasa por los píxeles intermedios, por lo que se recorre a medio píxel, el paso con el que se recorre un índice de celdas hexagonal, y devuelve un <varname>tfloat</varname> escalonado que mantiene cada valor hasta que el trayecto alcanza un píxel con otro valor. Una posición fuera del ráster o sobre un píxel sin datos no lleva valor y termina el tramo, por lo que un trayecto que sale y vuelve a entrar en el ráster devuelve una secuencia por visita, y <varname>NULL</varname> cuando nunca encuentra un píxel con datos.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
+  POINT(2.5 2.5)@2001-01-02, POINT(0.5 0.5)@2001-01-03]', r)::text FROM rast;
+-- {10@2001-01-01, 30@2001-01-02, 70@2001-01-03}
+</programlisting>
+				<para>Aplicado a un conjunto de datos de trayectorias con un ráster de elevación del terreno:</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Elevation profile per trip (requires a loaded elevation raster)
+SELECT tripid, rasterValue(trip, elev) AS elevation FROM trips, elevation_raster;
+-- Average elevation per trip
+SELECT tripid, avgValue(rasterValue(trip, elev)) AS mean_elev FROM trips,
+  elevation_raster;
+-- Trips that crossed terrain above 200 m
+SELECT tripid FROM trips, elevation_raster
+WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_rasterTileValue">
+				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
+				<para>Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterTileValue(tgeompoint,rast raquet) → tfloat
+</programlisting>
+				<para>Evalúa la tesela en cada instante de <varname>traj</varname> (SRID 4326), devolviendo los valores de píxel muestreados como un <varname>tfloat</varname>. Es el equivalente tipado de <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: las dimensiones, la celda QUADBIN, el tipo de píxel y el tratamiento de nodata se toman del valor <varname>raquet</varname> en lugar de argumentos separados. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de la tesela o sobrevive al filtrado de nodata.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Sample pre-packaged raquet tiles along ship trajectories
+SELECT t.tripid, rasterTileValue(t.trip, r.tile)
+FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_rasterTileValueArray">
+				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
+				<para>Muestrea un arreglo de teselas ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterTileValue(tgeompoint,rast raquet[]) → tfloat
+</programlisting>
+				<para>Evalúa cada tesela de <varname>rast</varname> en cada instante de <varname>traj</varname> (SRID 4326) y devuelve los valores de píxel muestreados como un único <varname>tfloat</varname>. Una trayectoria que sale de una tesela queda cubierta por varias, y cada una aporta los instantes que caen dentro de ella. Las teselas de un mismo nivel de zoom particionan el plano, de modo que aportan instantes disjuntos. Las teselas de niveles de zoom distintos se solapan, y cuando dos de ellas muestrean el mismo instante se conserva el valor de la tesela de mayor zoom, que es la que tiene la resolución más fina. Devuelve <varname>NULL</varname> cuando ningún instante cae dentro de una tesela o sobrevive al filtrado de nodata.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Sample a trajectory across every tile it crosses, in one value
+SELECT t.tripid, rasterTileValue(t.trip, array_agg(r.tile)) FROM trips t
+JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8)) GROUP BY t.tripid, t.trip;
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_rasterTileValueQuadbin">
+				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
+				<para>Muestrea un chip ráster de Raquet a lo largo de una trayectoria usando una celda QUADBIN para la georreferenciación</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterTileValueQuadbin(tgeompoint,pixels bytea,width integer,height integer,
+  quadbin bigint,pixtype text,nodata float8,has_nodata boolean) → tfloat
+</programlisting>
+				<para>Evalúa un arreglo de píxeles de banda única en orden de fila mayor en cada instante de <varname>traj</varname> (SRID 4326). La georreferenciación de la tesela (rectángulo delimitador, mapeo de píxel a coordenadas) se deriva únicamente de <varname>quadbin</varname> mediante la transformada de tesela deslizante Web-Mercator. El argumento <varname>pixtype</varname> debe ser uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Cuando <varname>has_nodata</varname> es verdadero, los instantes cuyo píxel equivale a <varname>nodata</varname> se descartan silenciosamente. Devuelve <varname>NULL</varname> cuando ningún instante sobrevive.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Sample elevation tiles from a Raquet Parquet table for all ship trajectories
+SELECT t.tripid, rasterTileValueQuadbin(t.trip, r.band_data, r.width, r.height,
+  r.quadbin, 'float32', r.nodata, true) FROM trips t
+JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
+-- Average sea-surface temperature per trajectory
+SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
+  r.band_data, 256, 256, r.quadbin, 'int16', -9999, true)) AS mean_sst FROM trips t
+JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_atRasterValue">
 				<indexterm significance="normal"><primary><varname>atRasterValue</varname></primary></indexterm>
 				<para>Devuelve los instantes de una trayectoria donde el valor ráster muestreado cae dentro de un rango de flotante</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3657,46 +3657,7 @@
 	<sect1>
 		<title>Raster Sampling</title>
 		<sect2>
-			<title>Sampling Operator</title>
-			<itemizedlist>
-				<listitem>
-					<para><link linkend="raster_rasterValue"><varname>rasterValue</varname></link>: Sample a raster band at each instant of a trajectory</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-		<sect2>
-			<title>Raster Accessors</title>
-			<itemizedlist>
-				<listitem>
-					<para><link linkend="raster_numBands"><varname>numBands</varname></link>: Return the number of bands of a raster</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-		<sect2>
-			<title>Raquet / QUADBIN Sampling</title>
-			<itemizedlist>
-				<listitem>
-					<para><link linkend="raster_quadbins"><varname>quadbins</varname></link>: Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raquet"><varname>raquet</varname></link>: Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raquetRead"><varname>raquetRead</varname></link>: Decode an in-memory raster file into a Raquet raster tile via GDAL</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a <varname>raquet</varname> raster tile along a trajectory</para>
-				</listitem>
-				<listitem>
-					<para><link linkend="raster_rasterTileValueArray"><varname>rasterTileValue</varname></link>: Sample an array of <varname>raquet</varname> raster tiles along a trajectory</para>
-				</listitem>
-			</itemizedlist>
-		</sect2>
-		<sect2>
-			<title>Raquet Serialization</title>
+			<title>Input and Output</title>
 			<itemizedlist>
 				<listitem>
 					<para><link linkend="raquet_asBinary"><varname>asBinary</varname></link>: Return the Well-Known Binary (WKB) representation of a Raquet tile</para>
@@ -3713,8 +3674,30 @@
 			</itemizedlist>
 		</sect2>
 		<sect2>
-			<title>Raquet Accessors and Comparison</title>
+			<title>Constructors</title>
 			<itemizedlist>
+				<listitem>
+					<para><link linkend="raquet"><varname>raquet</varname></link>: Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raquetRead"><varname>raquetRead</varname></link>: Decode an in-memory raster file into a Raquet raster tile via GDAL</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+		<sect2>
+			<title>Conversions</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raquet_to_stbox"><varname>stbox</varname></link>: Convert a Raquet tile into a spatiotemporal box</para>
+				</listitem>
+			</itemizedlist>
+		</sect2>
+		<sect2>
+			<title>Accessors</title>
+			<itemizedlist>
+				<listitem>
+					<para><link linkend="raster_numBands"><varname>numBands</varname></link>: Return the number of bands of a raster</para>
+				</listitem>
 				<listitem>
 					<para><link linkend="raquet_quadbin_accessor"><varname>quadbin</varname></link>: Return the QUADBIN cell of a Raquet tile</para>
 				</listitem>
@@ -3733,17 +3716,39 @@
 				<listitem>
 					<para><link linkend="raquet_pixels"><varname>pixels</varname></link>: Return the pixel bytes of a Raquet tile</para>
 				</listitem>
+			</itemizedlist>
+		</sect2>
+		<sect2>
+			<title>Set-Returning Functions</title>
+			<itemizedlist>
 				<listitem>
-					<para><link linkend="raquet_to_stbox"><varname>stbox</varname></link>: Convert a Raquet tile into a spatiotemporal box</para>
+					<para><link linkend="raster_quadbins"><varname>quadbins</varname></link>: Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
 				</listitem>
+			</itemizedlist>
+		</sect2>
+		<sect2>
+			<title>Comparisons</title>
+			<itemizedlist>
 				<listitem>
 					<para><link linkend="raquet_comparison"><varname>=</varname>, <varname>&lt;&gt;</varname>, <varname>&lt;</varname>, <varname>&lt;=</varname>, <varname>&gt;=</varname>, <varname>&gt;</varname>, <varname>cmp</varname></link>: Compare two Raquet tiles</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>
 		<sect2>
-			<title>Restriction and Predicate Operators</title>
+			<title>Raster-Specific Operations</title>
 			<itemizedlist>
+				<listitem>
+					<para><link linkend="raster_rasterValue"><varname>rasterValue</varname></link>: Sample a raster band at each instant of a trajectory</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a <varname>raquet</varname> raster tile along a trajectory</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_rasterTileValueArray"><varname>rasterTileValue</varname></link>: Sample an array of <varname>raquet</varname> raster tiles along a trajectory</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
+				</listitem>
 				<listitem>
 					<para><link linkend="raster_atRasterValue"><varname>atRasterValue</varname></link>: Return the instants of a trajectory where the sampled raster value falls inside a float range</para>
 				</listitem>

--- a/doc/temporal_raster.xml
+++ b/doc/temporal_raster.xml
@@ -13,6 +13,8 @@
 
 	<para>The <ulink url="https://postgis.net/docs/using_raster_dataman.html">PostGIS raster</ulink> extension stores gridded coverage data (elevation, temperature, satellite imagery, …) in the <varname>raster</varname> type. Each raster has one or more bands; a band holds a 2D array of pixel values, a spatial extent, a pixel size, and an optional nodata sentinel value.</para>
 
+	<para><ulink url="https://github.com/CartoDB/raquet">Raquet</ulink> is a cloud-native raster format that stores raster tiles as rows in an Apache Parquet file. Each row holds the pixel bytes for one Web-Mercator tile together with its <ulink url="https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/sql-reference/quadbin">QUADBIN</ulink> cell identifier, a 64-bit integer that encodes the tile's zoom level and Morton-interleaved x/y coordinates. No separate spatial metadata is required: the bounding box and pixel-to-coordinate mapping are fully determined by the QUADBIN value.</para>
+
 	<para>MobilityDB's raster sampling operator evaluates a raster band at the instants of a moving-point trajectory and returns a <varname>tfloat</varname>. Instants whose position falls outside the raster extent or on a nodata pixel are silently dropped. The sampling operators are double-valued whatever the pixel type of the band, so a pixel type belongs to the sampling surface when every value it can hold is exactly representable in a double precision number. That is what lets a band of any type be sampled into one <varname>tfloat</varname>, and a column holding tiles of several pixel types be read by a single query. A pixel type is also accepted under the name PostGIS raster gives it, so the band type an <varname>ST_BandPixelType</varname> call reports (<varname>8BUI</varname>, <varname>16BSI</varname>, <varname>32BF</varname>, …) passes into the tile constructors as it stands. PostGIS raster carries no 16-bit float and no 64-bit integer, so <varname>float16</varname>, <varname>int64</varname> and <varname>uint64</varname> take the spelling its grammar gives them, <varname>16BF</varname>, <varname>64BSI</varname> and <varname>64BUI</varname>. Its <varname>1BB</varname>, <varname>2BUI</varname> and <varname>4BUI</varname> types bound a pixel to less than a byte while PostGIS stores each of them a byte a pixel, so such a band is already the bytes of an unsigned 8-bit band and the constructors read it as <varname>uint8</varname>; the bound is the only thing the name adds, and a tile does not carry it. The name a tile reports is the one the RaQuet specification gives the type.
 
 The types <varname>uint64</varname> and <varname>int64</varname> hold values beyond that domain: a tile of either is stored and read back exactly, while sampling a pixel whose value no double precision number names raises an error rather than answering with a neighbouring value. This enables queries such as <emphasis>what elevation profile did each vehicle follow?</emphasis> or <emphasis>which trips entered a temperature threshold band?</emphasis></para>
@@ -24,185 +26,8 @@ CREATE EXTENSION mobilitydb CASCADE;
 -- NOTICE:  installing required extension "postgis_raster"
 </programlisting>
 
-	<sect1 xml:id="raster_sampling_operator">
-		<title>Sampling Operator</title>
-
-		<itemizedlist>
-			<listitem xml:id="raster_rasterValue">
-				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
-				<para>Sample a raster band at each instant of a trajectory</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
-</programlisting>
-				<para>Reads band <varname>band</varname> along <varname>traj</varname>, taking the value of the pixel each position falls in. A trajectory that states nothing between its instants is read at its instants and answers an instant-set <varname>tfloat</varname>. A trajectory that moves between them passes over the pixels between them, so it is walked at half a pixel, the step at which a hexagonal cell index is walked, and answers a step <varname>tfloat</varname> holding each value until the trip reaches a pixel holding another. A position outside the raster or over a nodata pixel carries no value and ends the run, so a trip that leaves and re-enters the raster answers one sequence per visit, and <varname>NULL</varname> when it never meets a pixel carrying data.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
-WITH rast AS (
-  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
-    4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
-    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
-    [40.0::float4, 50.0::float4, 60.0::float4],
-    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
-SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
-  POINT(2.5 2.5)@2001-01-02, POINT(0.5 0.5)@2001-01-03]', r)::text FROM rast;
--- {10@2001-01-01, 30@2001-01-02, 70@2001-01-03}
-</programlisting>
-				<para>Applied to a trajectory dataset with a terrain elevation raster:</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Elevation profile per trip (requires a loaded elevation raster)
-SELECT tripid, rasterValue(trip, elev) AS elevation FROM trips, elevation_raster;
--- Average elevation per trip
-SELECT tripid, avgValue(rasterValue(trip, elev)) AS mean_elev FROM trips,
-  elevation_raster;
--- Trips that crossed terrain above 200 m
-SELECT tripid FROM trips, elevation_raster
-WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
-</programlisting>
-			</listitem>
-		</itemizedlist>
-	</sect1>
-
-	<sect1 xml:id="raster_accessors">
-		<title>Raster Accessors</title>
-
-		<itemizedlist>
-			<listitem xml:id="raster_numBands">
-				<indexterm significance="normal"><primary><varname>numBands</varname></primary></indexterm>
-				<para>Return the number of bands of a raster</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-numBands(raster) → integer
-</programlisting>
-				<para>The band number accepted by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> and by the operators built on it ranges from 1 to this value.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
-WITH rast1 AS (
-  SELECT ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
-    '32BF'::text, 0.0::float8, NULL::float8 ) AS r ), rast2 AS (
-  SELECT ST_AddBand(r, '32BF'::text, 0.0::float8, NULL::float8) AS r FROM rast1 )
-SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
-  numBands((SELECT r FROM rast2)) AS num_bands_two;
--- 1 | 2
-</programlisting>
-			</listitem>
-		</itemizedlist>
-	</sect1>
-
-	<sect1 xml:id="raquet_quadbin">
-		<title>Raquet / QUADBIN Sampling</title>
-
-		<para><ulink url="https://github.com/CartoDB/raquet">Raquet</ulink> is a cloud-native raster format that stores raster tiles as rows in an Apache Parquet file. Each row holds the pixel bytes for one Web-Mercator tile together with its <ulink url="https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/sql-reference/quadbin">QUADBIN</ulink> cell identifier, a 64-bit integer that encodes the tile's zoom level and Morton-interleaved x/y coordinates. No separate spatial metadata is required: the bounding box and pixel-to-coordinate mapping are fully determined by the QUADBIN value.</para>
-
-		<para>The typical query pattern joins a trajectory against a Raquet table in two steps:</para>
-		<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Step 1: identify which tiles the trajectory overlaps
-SELECT DISTINCT q FROM unnest(quadbins(traj, 8)) AS q;
--- Step 2: sample each matching tile
-SELECT raster_tileValueQuadbin(traj, band_data, width, height, quadbin, 'float32', nodata,
-  true) FROM elevation_raquet WHERE quadbin = ANY(quadbins(traj, 8));
-</programlisting>
-
-		<itemizedlist>
-			<listitem xml:id="raster_quadbins">
-				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
-				<para>Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-quadbins(tgeompoint,zoom integer) → bigint[]
-</programlisting>
-				<para>Returns the set of unique QUADBIN cells the trajectory covers. A trajectory that states nothing between its instants covers the tiles holding them; one that moves between them also covers the tiles it crosses on the way, and the segment is walked at half a tile to find them, the tile narrowing towards the poles as its Web-Mercator envelope does. The result is suitable as a WHERE-clause join key against a Raquet table, where a tile the trip crosses but the set omits is a tile the join never reads. <varname>zoom</varname> must be in [0, 15].</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Three instants spanning three tiles at zoom 3
-SELECT quadbins(tgeompoint 'SRID=4326;
-  {Point(-60 45)@2024-01-01, Point(0 45)@2024-01-02, Point(60 45)@2024-01-03}', 3);
--- {5202501994543054848,5203346419473186816,5203416788217364480}
--- Count of Raquet tiles a ship trajectory overlaps at zoom 8
-SELECT array_length(quadbins(trip, 8),
-  1) AS tile_count FROM trips ORDER BY tile_count DESC;
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raster_rasterTileValueQuadbin">
-				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
-				<para>Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValueQuadbin(tgeompoint,pixels bytea,width integer,height integer,
-  quadbin bigint,pixtype text,nodata float8,has_nodata boolean) → tfloat
-</programlisting>
-				<para>Evaluates a row-major single-band pixel array at each instant of <varname>traj</varname> (SRID 4326). The tile georeferencing (bounding box, pixel-to-coordinate mapping) is derived from <varname>quadbin</varname> alone via the Web-Mercator slippy-tile transform. The <varname>pixtype</varname> argument must be one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. When <varname>has_nodata</varname> is true, instants whose pixel equals <varname>nodata</varname> are silently dropped. Returns <varname>NULL</varname> when no instant survives.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Sample elevation tiles from a Raquet Parquet table for all ship trajectories
-SELECT t.tripid, rasterTileValueQuadbin(t.trip, r.band_data, r.width, r.height,
-  r.quadbin, 'float32', r.nodata, true) FROM trips t
-JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
--- Average sea-surface temperature per trajectory
-SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
-  r.band_data, 256, 256, r.quadbin, 'int16', -9999, true)) AS mean_sst FROM trips t
-JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raquet">
-				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
-				<para>Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquet(bytea,width integer,height integer,quadbin bigint,pixtype text,
-  nodata float8) → raquet
-</programlisting>
-				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. Pixels of more than one byte are little-endian, which is the byte order the RaQuet specification gives them whatever the byte order of the server, so that a tile keeps its values when it is read on another machine. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Package the loose tile columns of a Raquet table into raquet values
-SELECT raquet(band_data, width, height, quadbin, 'float32',
-  nodata) AS tile FROM elevation_raquet;
--- A 2 x 2 UINT8 tile with no nodata
-SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raquetRead">
-				<indexterm significance="normal"><primary><varname>raquetRead</varname></primary></indexterm>
-				<para>Decode an in-memory raster file into a Raquet raster tile via GDAL</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-raquetRead(bytea,quadbin bigint) → raquet
-</programlisting>
-				<para>Reads the bytes of <varname>rasterfile</varname>, a raster in any format GDAL supports (GeoTIFF, PNG, …), through GDAL's <varname>/vsimem/</varname> virtual filesystem, and packs its first band, row-major, into a single self-describing <varname>raquet</varname> value georeferenced by the <varname>quadbin</varname> cell. The band data type must be one of <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname>, or <varname>Float64</varname>; the band nodata value, when set, is carried into the tile. Because the file is supplied as bytes, no server-side file access is required. GDAL performs the decode, so the raster's format driver must be permitted by PostGIS's <varname>postgis.gdal_enabled_drivers</varname> setting (which disables all drivers by default); enable it with, for example, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. This is the ingest counterpart of the <link linkend="raquet"><varname>raquet</varname></link> constructor, which builds a tile from already-decoded pixel bytes. When <varname>quadbin</varname> is omitted or <varname>NULL</varname>, the tile identifier is derived from the raster's georeferencing: the raster must carry an <varname>EPSG:3857</varname> (Web-Mercator) spatial reference and an axis-aligned geotransform describing a single QUADBIN tile. A raster with no spatial reference, one that is not in <varname>EPSG:3857</varname>, or a geotransform that is rotated or not aligned to the tile grid raises an error rather than being coerced.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Decode a GeoTIFF stored in a bytea column into a raquet tile
-SELECT raquetRead(file_bytes, quadbin) AS tile FROM elevation_files;
--- Derive the QUADBIN cell from an EPSG:3857 GeoTIFF's georeferencing
-SELECT raquetRead(file_bytes) AS tile FROM elevation_files;
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raster_rasterTileValue">
-				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
-				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValue(tgeompoint,rast raquet) → tfloat
-</programlisting>
-				<para>Evaluates the tile at each instant of <varname>traj</varname> (SRID 4326), returning the sampled pixel values as a <varname>tfloat</varname>. This is the typed equivalent of <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: the dimensions, QUADBIN cell, pixel type and nodata handling are taken from the <varname>raquet</varname> value instead of from separate arguments. Returns <varname>NULL</varname> when no instant falls inside the tile or survives nodata filtering.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Sample pre-packaged raquet tiles along ship trajectories
-SELECT t.tripid, rasterTileValue(t.trip, r.tile)
-FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
-</programlisting>
-			</listitem>
-
-			<listitem xml:id="raster_rasterTileValueArray">
-				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
-				<para>Sample an array of <varname>raquet</varname> raster tiles along a trajectory</para>
-				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-rasterTileValue(tgeompoint,rast raquet[]) → tfloat
-</programlisting>
-				<para>Evaluates every tile of <varname>rast</varname> at each instant of <varname>traj</varname> (SRID 4326) and returns the sampled pixel values as a single <varname>tfloat</varname>. A trajectory that leaves one tile is covered by several of them, each contributing the instants that fall inside it. Tiles of one zoom level partition the plane, so they contribute disjoint instants. Tiles of different zoom levels overlap, and where two of them sample the same instant the value of the tile of higher zoom is kept, that being the one carrying the finer resolution. Returns <varname>NULL</varname> when no instant falls inside a tile or survives nodata filtering.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Sample a trajectory across every tile it crosses, in one value
-SELECT t.tripid, rasterTileValue(t.trip, array_agg(r.tile)) FROM trips t
-JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8)) GROUP BY t.tripid, t.trip;
-</programlisting>
-			</listitem>
-		</itemizedlist>
-	</sect1>
-
-	<sect1 xml:id="raquet_serialization">
-		<title>Raquet Serialization</title>
+	<sect1 xml:id="raster_inout">
+		<title>Input and Output</title>
 
 		<para>The functions <varname>asBinary</varname> and <varname>asHexWKB</varname> serialize a <varname>raquet</varname> value, and <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> and <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> reconstruct it. A tile carries its pixels and its QUADBIN georeferencing in one value, so it round-trips through a portable byte string with no spatial extension involved, and the hexadecimal form lets a tile column round-trip through a text-based <varname>COPY</varname>. Both output functions accept an optional endianness argument, <varname>NDR</varname> for little-endian or <varname>XDR</varname> for big-endian, defaulting to the endianness of the server.</para>
 
@@ -259,14 +84,108 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="raquet_accessors">
-		<title>Raquet Accessors and Comparison</title>
+	<sect1 xml:id="raster_constructors">
+		<title>Constructors</title>
+
+		<para>A <varname>raquet</varname> tile is built either from pixel bytes already in hand or by decoding a raster file, and carries its QUADBIN georeferencing in the value itself.</para>
+
+		<itemizedlist>
+			<listitem xml:id="raquet">
+				<indexterm significance="normal"><primary><varname>raquet</varname></primary></indexterm>
+				<para>Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+raquet(bytea,width integer,height integer,quadbin bigint,pixtype text,
+  nodata float8) → raquet
+</programlisting>
+				<para>Packages a row-major single-band <varname>pixels</varname> array of <varname>width</varname> × <varname>height</varname> pixels of type <varname>pixtype</varname> (one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>), georeferenced by the <varname>quadbin</varname> cell, into a single self-describing <varname>raquet</varname> value. The <varname>nodata</varname> argument is optional; when omitted (<varname>NULL</varname>) the tile carries no nodata sentinel. An error is raised when the <varname>pixels</varname> array is smaller than <varname>width</varname> × <varname>height</varname> × the pixel size. Pixels of more than one byte are little-endian, which is the byte order the RaQuet specification gives them whatever the byte order of the server, so that a tile keeps its values when it is read on another machine. A <varname>raquet</varname> is a GDAL-free, variable-length value with a portable Hex-WKB text and binary representation, distinct from and coexisting with the PostGIS <varname>raster</varname> type used by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Package the loose tile columns of a Raquet table into raquet values
+SELECT raquet(band_data, width, height, quadbin, 'float32',
+  nodata) AS tile FROM elevation_raquet;
+-- A 2 x 2 UINT8 tile with no nodata
+SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raquetRead">
+				<indexterm significance="normal"><primary><varname>raquetRead</varname></primary></indexterm>
+				<para>Decode an in-memory raster file into a Raquet raster tile via GDAL</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+raquetRead(bytea,quadbin bigint) → raquet
+</programlisting>
+				<para>Reads the bytes of <varname>rasterfile</varname>, a raster in any format GDAL supports (GeoTIFF, PNG, …), through GDAL's <varname>/vsimem/</varname> virtual filesystem, and packs its first band, row-major, into a single self-describing <varname>raquet</varname> value georeferenced by the <varname>quadbin</varname> cell. The band data type must be one of <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname>, or <varname>Float64</varname>; the band nodata value, when set, is carried into the tile. Because the file is supplied as bytes, no server-side file access is required. GDAL performs the decode, so the raster's format driver must be permitted by PostGIS's <varname>postgis.gdal_enabled_drivers</varname> setting (which disables all drivers by default); enable it with, for example, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. This is the ingest counterpart of the <link linkend="raquet"><varname>raquet</varname></link> constructor, which builds a tile from already-decoded pixel bytes. When <varname>quadbin</varname> is omitted or <varname>NULL</varname>, the tile identifier is derived from the raster's georeferencing: the raster must carry an <varname>EPSG:3857</varname> (Web-Mercator) spatial reference and an axis-aligned geotransform describing a single QUADBIN tile. A raster with no spatial reference, one that is not in <varname>EPSG:3857</varname>, or a geotransform that is rotated or not aligned to the tile grid raises an error rather than being coerced.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Decode a GeoTIFF stored in a bytea column into a raquet tile
+SELECT raquetRead(file_bytes, quadbin) AS tile FROM elevation_files;
+-- Derive the QUADBIN cell from an EPSG:3857 GeoTIFF's georeferencing
+SELECT raquetRead(file_bytes) AS tile FROM elevation_files;
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="raster_conversions">
+		<title>Conversions</title>
+
+		<para>A tile converts to the spatiotemporal box of its footprint, which is what gives a table of tiles a spatial index.</para>
+
+		<itemizedlist>
+			<listitem xml:id="raquet_to_stbox">
+				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
+				<para>Convert a Raquet tile into a spatiotemporal box</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+stbox(raquet) → stbox
+</programlisting>
+				<para>Returns the tile footprint: the longitude and latitude envelope of its QUADBIN cell, in SRID 4326 and without a time dimension. The footprint follows from the cell alone, so tiles differing in pixels, dimensions or pixel type share it. The conversion is also available as a cast.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- The footprint of a tile covering the north-eastern quadrant at zoom 1
+SELECT round(stbox(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')), 6);
+-- SRID=4326;STBOX X((0,0),(180,85.051129))
+-- Keep the tiles whose footprint overlaps a region of interest
+SELECT * FROM elevation_tiles WHERE tile::stbox &amp;&amp; stbox 'SRID=4326;
+  STBOX X((0,0),(30,30))';
+</programlisting>
+				<para>The footprint carries the <varname>stbox</varname> operators, aggregates and operator classes, so a tile table is searched by spatial overlap at any zoom level rather than by an equality test on the QUADBIN cell at a single fixed one. Indexing the conversion gives the tile table a spatial index, and the extent of a set of tiles is the extent of their footprints.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- A spatial index over the tile footprints
+CREATE INDEX elevation_tiles_gist ON elevation_tiles USING gist (stbox(tile));
+CREATE INDEX elevation_tiles_spgist ON elevation_tiles USING spgist (stbox(tile));
+-- The extent covered by a set of tiles
+SELECT extent(stbox(tile)) FROM elevation_tiles;
+-- Tiles a trajectory passes through, at whatever zoom levels the table holds
+SELECT t.tripid, r.tile FROM trips t,
+  elevation_tiles r WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
+</programlisting>
+			</listitem>
+		</itemizedlist>
+	</sect1>
+
+	<sect1 xml:id="raster_accessors">
+		<title>Accessors</title>
+
+		<para><link linkend="raster_numBands"><varname>numBands</varname></link> reads the band count of a PostGIS <varname>raster</varname>; the accessors that follow read a <varname>raquet</varname> tile.</para>
 
 		<para>A <varname>raquet</varname> value is self-describing: the accessors below read back the georeferencing and layout it carries, so a tile packaged with the <link linkend="raquet"><varname>raquet</varname></link> constructor or decoded with <link linkend="raquetRead"><varname>raquetRead</varname></link> can be inspected without keeping the loose columns it was built from.</para>
 
-		<para>Tiles also support the full set of comparison operators. The ordering is total and is defined on the QUADBIN cell first, then the pixel type, the width, the height, and finally the pixel bytes; it is meant for indexing and deduplication rather than for a spatial interpretation. A default btree operator class makes <varname>ORDER BY</varname>, <varname>DISTINCT</varname> and merge joins work on <varname>raquet</varname> columns, and a default hash operator class enables hash joins and hash aggregation.</para>
-
 		<itemizedlist>
+			<listitem xml:id="raster_numBands">
+				<indexterm significance="normal"><primary><varname>numBands</varname></primary></indexterm>
+				<para>Return the number of bands of a raster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+numBands(raster) → integer
+</programlisting>
+				<para>The band number accepted by <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> and by the operators built on it ranges from 1 to this value.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+WITH rast1 AS (
+  SELECT ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8 ) AS r ), rast2 AS (
+  SELECT ST_AddBand(r, '32BF'::text, 0.0::float8, NULL::float8) AS r FROM rast1 )
+SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
+  numBands((SELECT r FROM rast2)) AS num_bands_two;
+-- 1 | 2
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raquet_quadbin_accessor">
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Return the QUADBIN cell of a Raquet tile</para>
@@ -345,35 +264,41 @@ SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- \x01020304
 </programlisting>
 			</listitem>
+		</itemizedlist>
+	</sect1>
 
-			<listitem xml:id="raquet_to_stbox">
-				<indexterm significance="normal"><primary><varname>stbox</varname></primary></indexterm>
-				<para>Convert a Raquet tile into a spatiotemporal box</para>
+	<sect1 xml:id="raster_set_returning">
+		<title>Set-Returning Functions</title>
+
+		<para>The QUADBIN cells a trajectory covers are returned as an array, which is the join key a Raquet table is read by.</para>
+
+		<itemizedlist>
+			<listitem xml:id="raster_quadbins">
+				<indexterm significance="normal"><primary><varname>quadbins</varname></primary></indexterm>
+				<para>Return the distinct QUADBIN cells at a zoom level covered by a trajectory</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-stbox(raquet) → stbox
+quadbins(tgeompoint,zoom integer) → bigint[]
 </programlisting>
-				<para>Returns the tile footprint: the longitude and latitude envelope of its QUADBIN cell, in SRID 4326 and without a time dimension. The footprint follows from the cell alone, so tiles differing in pixels, dimensions or pixel type share it. The conversion is also available as a cast.</para>
+				<para>Returns the set of unique QUADBIN cells the trajectory covers. A trajectory that states nothing between its instants covers the tiles holding them; one that moves between them also covers the tiles it crosses on the way, and the segment is walked at half a tile to find them, the tile narrowing towards the poles as its Web-Mercator envelope does. The result is suitable as a WHERE-clause join key against a Raquet table, where a tile the trip crosses but the set omits is a tile the join never reads. <varname>zoom</varname> must be in [0, 15].</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- The footprint of a tile covering the north-eastern quadrant at zoom 1
-SELECT round(stbox(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')), 6);
--- SRID=4326;STBOX X((0,0),(180,85.051129))
--- Keep the tiles whose footprint overlaps a region of interest
-SELECT * FROM elevation_tiles WHERE tile::stbox &amp;&amp; stbox 'SRID=4326;
-  STBOX X((0,0),(30,30))';
-</programlisting>
-				<para>The footprint carries the <varname>stbox</varname> operators, aggregates and operator classes, so a tile table is searched by spatial overlap at any zoom level rather than by an equality test on the QUADBIN cell at a single fixed one. Indexing the conversion gives the tile table a spatial index, and the extent of a set of tiles is the extent of their footprints.</para>
-				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- A spatial index over the tile footprints
-CREATE INDEX elevation_tiles_gist ON elevation_tiles USING gist (stbox(tile));
-CREATE INDEX elevation_tiles_spgist ON elevation_tiles USING spgist (stbox(tile));
--- The extent covered by a set of tiles
-SELECT extent(stbox(tile)) FROM elevation_tiles;
--- Tiles a trajectory passes through, at whatever zoom levels the table holds
-SELECT t.tripid, r.tile FROM trips t,
-  elevation_tiles r WHERE stbox(r.tile) &amp;&amp; stbox(t.trip);
+-- Three instants spanning three tiles at zoom 3
+SELECT quadbins(tgeompoint 'SRID=4326;
+  {Point(-60 45)@2024-01-01, Point(0 45)@2024-01-02, Point(60 45)@2024-01-03}', 3);
+-- {5202501994543054848,5203346419473186816,5203416788217364480}
+-- Count of Raquet tiles a ship trajectory overlaps at zoom 8
+SELECT array_length(quadbins(trip, 8),
+  1) AS tile_count FROM trips ORDER BY tile_count DESC;
 </programlisting>
 			</listitem>
+		</itemizedlist>
+	</sect1>
 
+	<sect1 xml:id="raster_comparisons">
+		<title>Comparisons</title>
+
+		<para>Tiles also support the full set of comparison operators. The ordering is total and is defined on the QUADBIN cell first, then the pixel type, the width, the height, and finally the pixel bytes; it is meant for indexing and deduplication rather than for a spatial interpretation. A default btree operator class makes <varname>ORDER BY</varname>, <varname>DISTINCT</varname> and merge joins work on <varname>raquet</varname> columns, and a default hash operator class enables hash joins and hash aggregation.</para>
+
+		<itemizedlist>
 			<listitem xml:id="raquet_comparison">
 				<indexterm significance="normal"><primary><varname>=</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>&lt;&gt;</varname></primary></indexterm>
@@ -399,12 +324,103 @@ SELECT DISTINCT tile FROM elevation_tiles;
 		</itemizedlist>
 	</sect1>
 
-	<sect1 xml:id="raster_restriction">
-		<title>Restriction and Predicate Operators</title>
+	<sect1 xml:id="raster_specific">
+		<title>Raster-Specific Operations</title>
 
-		<para>The following SQL-defined operators compose <varname>rasterValue</varname> with the standard MobilityDB temporal restriction and predicate functions. They accept an optional <varname>band</varname> argument (default 1) and call <varname>rasterValue</varname> exactly once per invocation.</para>
+		<para>The sections above state what a raster shares with the other tessellations. The operations below are the raster's own: a raster cell carries a <emphasis>value</emphasis> where an H3, QUADBIN or S2 cell carries only identity, so a trajectory read against a raster answers a <varname>tfloat</varname> rather than a temporal cell.</para>
+
+		<para>The typical query pattern joins a trajectory against a Raquet table in two steps:</para>
+		<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Step 1: identify which tiles the trajectory overlaps
+SELECT DISTINCT q FROM unnest(quadbins(traj, 8)) AS q;
+-- Step 2: sample each matching tile
+SELECT rasterTileValueQuadbin(traj, band_data, width, height, quadbin, 'float32', nodata,
+  true) FROM elevation_raquet WHERE quadbin = ANY(quadbins(traj, 8));
+</programlisting>
+
+		<para>The restriction and predicate operators that close the section compose <varname>rasterValue</varname> with the standard MobilityDB temporal restriction and predicate functions. They accept an optional <varname>band</varname> argument (default 1) and call <varname>rasterValue</varname> exactly once per invocation.</para>
 
 		<itemizedlist>
+			<listitem xml:id="raster_rasterValue">
+				<indexterm significance="normal"><primary><varname>rasterValue</varname></primary></indexterm>
+				<para>Sample a raster band at each instant of a trajectory</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
+</programlisting>
+				<para>Reads band <varname>band</varname> along <varname>traj</varname>, taking the value of the pixel each position falls in. A trajectory that states nothing between its instants is read at its instants and answers an instant-set <varname>tfloat</varname>. A trajectory that moves between them passes over the pixels between them, so it is walked at half a pixel, the step at which a hexagonal cell index is walked, and answers a step <varname>tfloat</varname> holding each value until the trip reaches a pixel holding another. A position outside the raster or over a nodata pixel carries no value and ends the run, so a trip that leaves and re-enters the raster answers one sequence per visit, and <varname>NULL</varname> when it never meets a pixel carrying data.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
+  POINT(2.5 2.5)@2001-01-02, POINT(0.5 0.5)@2001-01-03]', r)::text FROM rast;
+-- {10@2001-01-01, 30@2001-01-02, 70@2001-01-03}
+</programlisting>
+				<para>Applied to a trajectory dataset with a terrain elevation raster:</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Elevation profile per trip (requires a loaded elevation raster)
+SELECT tripid, rasterValue(trip, elev) AS elevation FROM trips, elevation_raster;
+-- Average elevation per trip
+SELECT tripid, avgValue(rasterValue(trip, elev)) AS mean_elev FROM trips,
+  elevation_raster;
+-- Trips that crossed terrain above 200 m
+SELECT tripid FROM trips, elevation_raster
+WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_rasterTileValue">
+				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
+				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterTileValue(tgeompoint,rast raquet) → tfloat
+</programlisting>
+				<para>Evaluates the tile at each instant of <varname>traj</varname> (SRID 4326), returning the sampled pixel values as a <varname>tfloat</varname>. This is the typed equivalent of <link linkend="raster_rasterTileValueQuadbin"><varname>rasterTileValueQuadbin</varname></link>: the dimensions, QUADBIN cell, pixel type and nodata handling are taken from the <varname>raquet</varname> value instead of from separate arguments. Returns <varname>NULL</varname> when no instant falls inside the tile or survives nodata filtering.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Sample pre-packaged raquet tiles along ship trajectories
+SELECT t.tripid, rasterTileValue(t.trip, r.tile)
+FROM trips t JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8));
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_rasterTileValueArray">
+				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
+				<para>Sample an array of <varname>raquet</varname> raster tiles along a trajectory</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterTileValue(tgeompoint,rast raquet[]) → tfloat
+</programlisting>
+				<para>Evaluates every tile of <varname>rast</varname> at each instant of <varname>traj</varname> (SRID 4326) and returns the sampled pixel values as a single <varname>tfloat</varname>. A trajectory that leaves one tile is covered by several of them, each contributing the instants that fall inside it. Tiles of one zoom level partition the plane, so they contribute disjoint instants. Tiles of different zoom levels overlap, and where two of them sample the same instant the value of the tile of higher zoom is kept, that being the one carrying the finer resolution. Returns <varname>NULL</varname> when no instant falls inside a tile or survives nodata filtering.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Sample a trajectory across every tile it crosses, in one value
+SELECT t.tripid, rasterTileValue(t.trip, array_agg(r.tile)) FROM trips t
+JOIN elevation_tiles r ON r.quadbin = ANY(quadbins(t.trip, 8)) GROUP BY t.tripid, t.trip;
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_rasterTileValueQuadbin">
+				<indexterm significance="normal"><primary><varname>rasterTileValueQuadbin</varname></primary></indexterm>
+				<para>Sample a Raquet raster chip along a trajectory using a QUADBIN cell for georeferencing</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterTileValueQuadbin(tgeompoint,pixels bytea,width integer,height integer,
+  quadbin bigint,pixtype text,nodata float8,has_nodata boolean) → tfloat
+</programlisting>
+				<para>Evaluates a row-major single-band pixel array at each instant of <varname>traj</varname> (SRID 4326). The tile georeferencing (bounding box, pixel-to-coordinate mapping) is derived from <varname>quadbin</varname> alone via the Web-Mercator slippy-tile transform. The <varname>pixtype</varname> argument must be one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. When <varname>has_nodata</varname> is true, instants whose pixel equals <varname>nodata</varname> are silently dropped. Returns <varname>NULL</varname> when no instant survives.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Sample elevation tiles from a Raquet Parquet table for all ship trajectories
+SELECT t.tripid, rasterTileValueQuadbin(t.trip, r.band_data, r.width, r.height,
+  r.quadbin, 'float32', r.nodata, true) FROM trips t
+JOIN elevation_raquet r ON r.quadbin = ANY(quadbins(t.trip, 8));
+-- Average sea-surface temperature per trajectory
+SELECT t.tripid, avgValue(rasterTileValueQuadbin(t.trip, 
+  r.band_data, 256, 256, r.quadbin, 'int16', -9999, true)) AS mean_sst FROM trips t
+JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_atRasterValue">
 				<indexterm significance="normal"><primary><varname>atRasterValue</varname></primary></indexterm>
 				<para>Return the instants of a trajectory where the sampled raster value falls inside a float range</para>


### PR DESCRIPTION
The chapter states its entries in the order the tessellation chapter states
them, input and output, constructors, conversions, accessors, set-returning
functions and comparisons, and closes with the operations a raster alone
carries. A raster cell carries a value where an H3, QUADBIN or S2 cell carries
only identity, so the five sampling operators and the four restriction and
predicate operators built on them stand together in a raster-specific section,
the shape the H3-, QUADBIN- and S2-specific sections already have.

The Raquet paragraph opens the chapter beside the PostGIS raster one, both
paths being stated throughout, while the two-step join pattern and the
composition sentence travel with the operators they describe. The example that
samples a Raquet tile from its loose columns calls the function
rasterTileValueQuadbin, the name the SQL declares.

Every entry keeps its xml:id and its body byte for byte in both languages, so
the appendix rows point at the same anchors and only their grouping moves.

