### PR TITLE
Release the empty geometry the linear clip builds to serialize

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1349,8 +1349,15 @@ linear_pieces_geo(const MeosArray *pieces, const MeosArray *touches,
   int ntouch = touches ? (int) touches->count : 0;
   int narcs = arcs ? (int) arcs->count / 3 : 0;
   if (npieces == 0 && ntouch == 0 && narcs == 0)
-    return geo_serialize(lwline_as_lwgeom(lwline_construct_empty(srid, hasz,
-      false)));
+  {
+    /* Serializing copies, so the geometry built to be serialized is this
+     * function's to release -- as it is on every other answer below */
+    LWGEOM *empty = lwline_as_lwgeom(lwline_construct_empty(srid, hasz,
+      false));
+    GSERIALIZED *result = geo_serialize(empty);
+    lwgeom_free(empty);
+    return result;
+  }
 
   LWGEOM **lines = npieces ? palloc(sizeof(LWGEOM *) * npieces) : NULL;
   int nlines = 0;


### PR DESCRIPTION
## An empty answer is an answer, and it owes the same release as the others

Every answer `linear_pieces_geo` gives serializes an LWGEOM and then frees it, because serializing copies and the geometry built to be serialized belongs to the function. Every answer but one: the arm reached when the clip keeps no piece, no arc and no touching point builds an empty `LWLINE`, serializes it, and returns, leaving the `LWLINE` and its point array behind.

```c
GSERIALIZED *ln = geom_in("LINESTRING(20 20,24 24)", -1);
GSERIALIZED *po = geom_in("POLYGON((0 0,4 0,4 4,0 4,0 0))", -1);
GSERIALIZED *r = geom_intersection2d(ln, po);
```

A line lying well away from an areal geometry keeps nothing of itself, so the answer is `LINESTRING EMPTY` through that arm.

## Measured

| measurement | result |
|---|---|
| the witness above under `valgrind --leak-check=full`, against a `-DGEOS=OFF` build | `definitely lost: 24 bytes in 1 blocks` becomes `0 bytes in 0 blocks`, the leak recorded at `lwline_construct_empty` under `geo_clip_linear_geom` under `geom_intersection2d` |
| the answer that witness prints | `LINESTRING EMPTY` on both sides |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| a two-build comparison of 41 instruments | one line moves, and it is a clock reading; no answer moves, which is what a release fix should show |
| the full regression suite | unmoved: an empty geometry serializes identically either way, so no answer depends on this |

## Why

The three other arms of the same function each write `geo_serialize` on one line and `lwgeom_free` on the next, so the omission is visible only against its own siblings. That makes the fix a matter of giving the fourth arm the shape the other three already have, rather than adding a rule about ownership.

## What reaches the arm

Any linear subject the clip keeps nothing of: a line disjoint from the areal operand under intersection, and a line wholly inside it under difference. The leak is bounded per call, so nothing here is urgent; it is simply owed.
