### PR TITLE
Borrow the point the densifying cell conversion reads rather than copying it

### DIFF
--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -194,7 +194,7 @@ h3index_cell_to_boundary(H3Index cell)
 static TInstant *
 tpointinst_to_th3index(const TInstant *inst, int32 resolution)
 {
-  const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value(inst));
+  const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value_p(inst));
   H3Index cell = geo_to_h3index_cell(gs, resolution);
   return tinstant_make(H3IndexGetDatum(cell), T_TH3INDEX, inst->t);
 }
@@ -241,7 +241,7 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
     for (int i = 0; i < seq->count; i++)
     {
       const TInstant *inst = TSEQUENCE_INST_N(seq, i);
-      const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value(inst));
+      const GSERIALIZED *gs = DatumGetGserializedP(tinstant_value_p(inst));
       H3Index cell = geo_to_h3index_cell(gs, resolution);
       PUSH_INSTANT(cell, inst->t);
     }
@@ -259,7 +259,7 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
      * per-sample lookups below can use the cheaper raw-coordinate path. */
     {
       const TInstant *inst0 = TSEQUENCE_INST_N(seq, 0);
-      const GSERIALIZED *gs0 = DatumGetGserializedP(tinstant_value(inst0));
+      const GSERIALIZED *gs0 = DatumGetGserializedP(tinstant_value_p(inst0));
       H3Index cell0 = geo_to_h3index_cell(gs0, resolution);
       PUSH_INSTANT(cell0, inst0->t);
       last_cell = cell0;
@@ -273,9 +273,9 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
       const TInstant *inst_a = TSEQUENCE_INST_N(seq, i);
       const TInstant *inst_b = TSEQUENCE_INST_N(seq, i + 1);
       const POINT2D *pa = GSERIALIZED_POINT2D_P(
-        DatumGetGserializedP(tinstant_value(inst_a)));
+        DatumGetGserializedP(tinstant_value_p(inst_a)));
       const POINT2D *pb = GSERIALIZED_POINT2D_P(
-        DatumGetGserializedP(tinstant_value(inst_b)));
+        DatumGetGserializedP(tinstant_value_p(inst_b)));
       double dx = pb->x - pa->x;
       double dy = pb->y - pa->y;
       double seg_deg = sqrt(dx * dx + dy * dy);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1212,6 +1212,29 @@ int main(void)
   free(cell_text); free(cell_out); free(cell);
   meos_errno_reset();
 
+  /* A trajectory crosses cells that hold none of its instants, so the
+   * conversion densifies each segment and emits one instant per cell
+   * entered. What it emits is a property of the grid, not of the input
+   * cardinality: the same two-instant trajectory sits inside a single
+   * coarse cell and crosses three finer ones */
+  Temporal *tp = tgeompoint_in("SRID=4326;[POINT(2.30 48.85)@2001-01-01, "
+    "POINT(2.40 48.90)@2001-01-02]");
+  assert(tp != NULL);
+  Temporal *coarse = tgeompoint_to_th3index(tp, 3);
+  Temporal *fine = tgeompoint_to_th3index(tp, 6);
+  assert(coarse != NULL); assert(fine != NULL);
+  assert(meos_errno() == 0);
+  int ncoarse, nfine;
+  H3Index *vcoarse = th3index_values(coarse, &ncoarse);
+  H3Index *vfine = th3index_values(fine, &nfine);
+  assert(vcoarse != NULL); assert(vfine != NULL);
+  printf("the cells a trajectory crosses at resolutions 3 and 6: %d %d\n",
+    ncoarse, nfine);
+  assert(ncoarse == 1); assert(nfine == 3);
+  free(vcoarse); free(vfine);
+  free(coarse); free(fine); free(tp);
+  meos_errno_reset();
+
   /* A set reads its elements through that same renderer, and a cell set
    * carries no timestamp, so the three grids are stated exactly */
   Set *h3s = h3index_to_set((H3Index) 0x831c02fffffffffULL);


### PR DESCRIPTION
Five sites in the H3 conversion read a temporal point instant only to
derive the cell holding it, and each asked for the value with
tinstant_value, which COPIES it through datum_copy into an allocation the
caller owns. None of the five keeps the point and none freed the copy, so
every read left one serialized geometry behind: the instant adapter, the
non-densify branch, the first-instant SRID lookup, and both endpoints of
every segment the walker steps along.

The two endpoint reads sit inside the per-segment loop, so the copies
accumulate once per Nyquist sample rather than once per instant. At
resolution 12 a trajectory of a few dozen instants produces thousands of
them.

Witness: meos/test/geo_test under valgrind reports 960 bytes definitely
lost in 30 blocks across 29 contexts, 26 of whose records name
tpointseq_densify_to_th3index under datum_copy. The same binary against
this change reports 128 bytes in 4 blocks across 3 contexts, and no
record names that function.

Measured, the two arms differing only in this file: total heap usage goes
from 42,400 allocations and 100,699,393 bytes to 42,374 and 100,698,561,
which is 26 fewer allocations of 832 bytes total -- the 26 leaked copies
at 32 bytes each -- against an identical 42,369 frees in both arms, so
nothing that was being freed stopped being freed. geo_test exits 0 in
both arms and its output is identical but for the line the new case
prints. pg_regress passes every test on PostgreSQL 18 and both the
libmeos and the extension targets build warning-clean. Six interleaved
runs of a 500,000-line trajectory corpus at resolution 12 give a median
ratio of 0.98 against the unchanged arm, inside a within-arm spread of
2.6 seconds, so the removed allocations cost no measurable time either
way.

What did not move: the 128 bytes in 4 blocks that remain are two other
defects, in geo_points_covered and in geom_intersection2d, at identical
counts in both arms. They are a different class -- an element array whose
kept entries are never released, and an empty polygon construction -- and
each carries its own change.

Why the accessor rather than a free: a copy that is read and dropped is
an allocation the code never needed. tinstant_value_p answers the same
value without one, and the pointer stays good for the whole call, the
instants being read from the caller's own sequence. That is the rule the
kernel already follows -- allocate nothing where an accessor can lend --
so pairing tinstant_value with a pfree would have kept the malloc and
added the bookkeeping instead of removing both.

The conversion had no test reaching it, which is why the copies survived:
geo_test exercised the cell type only through its input function. It now
converts a trajectory that crosses cells holding none of its instants,
which is the segment walk itself, and states what the walk emits as a
property of the grid -- one cell at resolution 3, three at resolution 6.

