### PR TITLE
Answer the overlay's point questions out of an index

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -212,6 +212,34 @@ geom_ring_is_convex(const POINTARRAY *pa)
 extern bool relate_point_on_boundary(double x, double y, Edge **edges,
   int nedges);
 extern int relate_point_in_area(double x, double y, Edge **edges, int nedges);
+/* Reading a point question out of an index instead of the whole array, which
+ * the buffer overlay asks as well: it locates a point per boundary piece
+ * against each operand, so the edges are read once and the questions asked
+ * through them. The threshold lives here so the two engines gate on ONE
+ * number rather than on copies that can drift apart */
+#define RELATE_INDEX_MIN_PAIRS 100000
+
+/**
+ * @brief An edge array together with what a question about one point needs in
+ * order to read only the edges that can answer it
+ * @details The index is absent below the threshold, and every function taking
+ * this reads the whole array in that case, so the answer never depends on
+ * whether the index was built
+ */
+typedef struct
+{
+  Edge **edges;   /**< Edges the array holds */
+  int nedges;     /**< Number of edges */
+  RTree *index;   /**< Index over the edge boxes, NULL below the threshold */
+  double xmax;    /**< Greatest x the edges reach */
+  double tol;     /**< Widest tolerance any of the edges asks for */
+} RelateEdges;
+
+extern void relate_edges_init(RelateEdges *re, Edge **edges, int nedges,
+  bool index);
+extern void relate_edges_clear(RelateEdges *re);
+extern int relate_point_in_area_index(double x, double y,
+  const RelateEdges *re);
 /* Where two arcs meet, which the buffer overlay asks as well: solving the two
  * circles and keeping the solutions both angular spans hold is one
  * computation, and an intersection the two engines place differently is a

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -1278,29 +1278,39 @@ buffer_edge_normals(const Edge *edge, double *nx, double *ny)
  *
  * The extraction is LAZY -- deferred to the first point actually asked --
  * because a pair the overlay resolves without locating anything must not pay
- * for a set nobody reads
+ * for a set nobody reads. What it reads them into is the same #RelateEdges the
+ * relate engine builds, so a question big enough to be worth an index is
+ * answered out of one on the same terms, and one that is not reads the array
+ * whole exactly as before
  */
 typedef struct
 {
   const LWGEOM *geom;   /**< The geometry points are located against */
   MeosArray *arr;       /**< Its edges, NULL until the first point asks */
   Edge **edges;         /**< Pointers into @p arr, in its order */
-  int nedges;           /**< Number of edges, meaningful once @p arr is set */
+  RelateEdges re;       /**< The edges and what reading them selectively needs */
+  int npoints;          /**< Points the caller expects to locate against it */
+  bool ready;           /**< True once @p re holds the edges */
 } BufferLocator;
 
 /**
  * @brief Prepare to locate points against a geometry, reading none of it yet
  * @param[out] loc Locator to prepare
  * @param[in] geom Geometry points are located against
+ * @param[in] npoints How many points the caller expects to locate against it,
+ * which together with the edge count is what decides whether an index earns
+ * its build -- the product is the work an index removes, which is the rule
+ * #relate_edges_init states for its own two arrays
  */
 static void
-buffer_locator_make(BufferLocator *loc, const LWGEOM *geom)
+buffer_locator_make(BufferLocator *loc, const LWGEOM *geom, int npoints)
 {
   assert(loc); assert(geom);
   loc->geom = geom;
   loc->arr = NULL;
   loc->edges = NULL;
-  loc->nedges = 0;
+  loc->npoints = npoints;
+  loc->ready = false;
 }
 
 /**
@@ -1311,6 +1321,11 @@ static void
 buffer_locator_free(BufferLocator *loc)
 {
   assert(loc);
+  if (loc->ready)
+  {
+    relate_edges_clear(&loc->re);
+    loc->ready = false;
+  }
   if (loc->edges)
   {
     pfree(loc->edges);
@@ -1321,7 +1336,6 @@ buffer_locator_free(BufferLocator *loc)
     meos_array_destroy(loc->arr);
     loc->arr = NULL;
   }
-  loc->nedges = 0;
 }
 
 /**
@@ -1336,20 +1350,27 @@ static int
 buffer_locator_point(BufferLocator *loc, double x, double y)
 {
   assert(loc); assert(loc->geom);
-  if (! loc->arr)
+  if (! loc->ready)
   {
     loc->arr = geom_extract_edges(loc->geom);
-    loc->nedges = (int) loc->arr->count;
-    if (loc->nedges > 0)
+    int nedges = (int) loc->arr->count;
+    if (nedges > 0)
     {
-      loc->edges = palloc(sizeof(Edge *) * loc->nedges);
-      for (int i = 0; i < loc->nedges; i++)
+      loc->edges = palloc(sizeof(Edge *) * nedges);
+      for (int i = 0; i < nedges; i++)
         loc->edges[i] = (Edge *) meos_array_get(loc->arr, i);
     }
+    /* The index removes the product of the points asked and the edges each
+     * one would otherwise walk, so that product is what has to clear the
+     * threshold -- the same rule, on this engine's two quantities */
+    bool index = nedges > 0 &&
+      (double) loc->npoints * (double) nedges >= RELATE_INDEX_MIN_PAIRS;
+    relate_edges_init(&loc->re, loc->edges, nedges, index);
+    loc->ready = true;
   }
-  if (loc->nedges == 0)
+  if (loc->re.nedges == 0)
     return 2;
-  return relate_point_in_area(x, y, loc->edges, loc->nedges);
+  return relate_point_in_area_index(x, y, &loc->re);
 }
 
 /**
@@ -1364,7 +1385,7 @@ buffer_point_location(const LWGEOM *geom, double x, double y)
 {
   assert(geom);
   BufferLocator loc;
-  buffer_locator_make(&loc, geom);
+  buffer_locator_make(&loc, geom, 1);
   int result = buffer_locator_point(&loc, x, y);
   buffer_locator_free(&loc);
   return result;
@@ -3900,8 +3921,12 @@ buffer_areal_overlay(const LWGEOM *geom1, const LWGEOM *geom2, ClipOper oper,
    * locates a point per piece against one of them and up to eight more per
    * coincident piece */
   BufferLocator loc_a, loc_b;
-  buffer_locator_make(&loc_a, geom1);
-  buffer_locator_make(&loc_b, geom2);
+  /* Each piece of one boundary asks at least one point of the other, and a
+   * coincident piece asks up to eight more of both */
+  int points_a = (int) meos_array_count(split_b);
+  int points_b = (int) meos_array_count(split_a);
+  buffer_locator_make(&loc_a, geom1, points_a);
+  buffer_locator_make(&loc_b, geom2, points_b);
   buffer_select_overlay_boundary(split_a, &loc_b, split_b, &loc_a, oper,
     selected, boundary, shared, &coincident);
   buffer_locator_free(&loc_a);

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -3490,7 +3490,6 @@ relate_point_in_area(double x, double y, Edge **edges, int nedges)
  * for every edge of the other costs their PRODUCT. The index is built where
  * that product dwarfs the pass, and a pair small enough for the walk to be the
  * cheaper of the two keeps it */
-#define RELATE_INDEX_MIN_PAIRS 100000
 
 /**
  * @brief Return the greatest x an edge array reaches, which is how far a ray
@@ -3528,29 +3527,13 @@ relate_edges_index(Edge **edges, int nedges)
 }
 
 /**
- * @brief An edge array together with what a question about one point needs in
- * order to read only the edges that can answer it
- * @details The index is absent below the threshold, and every function taking
- * this reads the whole array in that case, so the answer never depends on
- * whether the index was built
- */
-typedef struct
-{
-  Edge **edges;   /**< Edges the array holds */
-  int nedges;     /**< Number of edges */
-  RTree *index;   /**< Index over the edge boxes, NULL below the threshold */
-  double xmax;    /**< Greatest x the edges reach */
-  double tol;     /**< Widest tolerance any of the edges asks for */
-} RelateEdges;
-
-/**
  * @brief Fill in an edge array together with what reading it selectively needs
  * @param[out] re Structure to fill in
  * @param[in] edges,nedges The edges
  * @param[in] index True to index them, which the caller decides from the size
  * of BOTH arrays, since it is their product the index removes
  */
-static void
+void
 relate_edges_init(RelateEdges *re, Edge **edges, int nedges, bool index)
 {
   re->edges = edges;
@@ -3573,7 +3556,7 @@ relate_edges_init(RelateEdges *re, Edge **edges, int nedges, bool index)
 /**
  * @brief Free the index an edge array carries, if it carries one
  */
-static void
+void
 relate_edges_clear(RelateEdges *re)
 {
   if (re->index)
@@ -3616,7 +3599,7 @@ relate_point_on_boundary_index(double x, double y, const RelateEdges *re)
  * decides which edges are asked, and one it leaves out neither carries the
  * point nor crosses the ray cast from it
  */
-static int
+int
 relate_point_in_area_index(double x, double y, const RelateEdges *re)
 {
   if (relate_point_on_boundary_index(x, y, re))


### PR DESCRIPTION
Part of the campaign that gives MEOS a native answer for every geometry operation, on the performance side of it. Follows #2564, which gives the overlay a locator holding each operand's edges; this asks that locator's questions through an index.

## The point questions go through the index geo_funcs.c already builds

The areal overlay locates a point per boundary piece against each operand, and up to eight more per coincident piece. Each of those walks the whole edge array. `geo_funcs.c` answers exactly that question out of an R-tree — `relate_point_in_area_index` over a `RelateEdges`, with `relate_edges_init` deciding from the size of the work whether a tree is worth building — but all of it is file-static there, so the overlay walks instead.

This publishes what exists rather than writing a second tree. The type, its two lifecycle entries and the indexed query move to `geo_funcs.h`, beside `relate_arc_arc_points`, which that header already exports with the note that the buffer overlay asks it as well. `BufferLocator` holds a `RelateEdges` in place of a bare array.

## The threshold moves with the type

Two engines gating on one constant cannot drift apart, where two copies can. `relate_edges_init` states the rule as the product of the two arrays it walks, since the product is what an index removes. On this engine the two quantities are the points asked and the edges each would otherwise walk, so the caller passes the piece count it already holds and the same product decides.

An index that is not built costs nothing: `relate_point_in_area_index` reads the array whole when the tree is absent, which is what small pairs get — five edges against ten points is fifty, against a threshold of a hundred thousand.

## Why

An index does not change which edges *can* answer a point question — it changes which ones are *asked*. `relate_point_in_area_index` states that invariant in its own doxygen, and it is what makes a tree safe to put under an answer: an edge the query leaves out neither carries the point nor crosses the ray cast from it, so the scan and the index agree by construction rather than by tolerance. That is also why this reuses the tree instead of writing a second one — a new tree would have to re-derive the same argument, and could get it wrong where this one is proven.

## Measured

Arms interleaved and read as ratios, on a machine reporting `load average: 1.30` with nothing else running.

| measurement | result |
|---|---|
| one 2.3 MB real protected-area pair, the largest in the corpus, two rounds | 52.11 s and 52.77 s against 46.90 s and 47.79 s — **1.11x and 1.10x** |
| 8 real protected-area pairs, 4 rounds | 0.800 0.788 0.899 0.780 against 0.757 0.726 0.824 0.734, median 0.792 to 0.746 — **1.06x** |
| the same two, read from the master that precedes #2564 | 74.60 s and 76.09 s, so the two changes together are 1.59x on the large pair and 1.34x on the eight — stated so the pair can be read as one, not to credit this one twice |
| 1444 areal pairs, 54 adversarial pairs, and the 8 real pairs, every answer text at 9 decimals | the same 4332 and 162 lines and the same 247471 bytes as master, declines included |
| does the tree fire where it should | a gdb sample of the real pairs shows `rtree_search` and `node_search`, against a `buffer_areal_overlay` control of 28 of 30 |
| does it stay away where it should not | **zero** rtree frames on the small corpus |
| smoke suite under valgrind | 7 of 7 clean |

The answers are what those corpora establish; the coverage arm moves one line, a clock reading.

## Surface

`meos/include/geo/geo_funcs.h` is internal: it appears in no CMake install rule, the installed `meos_geo.h` does not reach it, and none of the three published entries carries an `@ingroup` tag, which is what the catalog derives `api` from. No binding sees them.

## A case outside this one

With the walk indexed, allocation is the top cost — `meos_array_create` 9 of 30 stacks, `palloc` and `malloc` 8 each. Every indexed point question builds a fresh candidate `MeosArray`, and `meos_array_create` palloc0s `MEOS_ARRAY_INITIAL_SIZE` slots whatever the answer holds. Reusing one candidate array across the questions a locator answers wants a change of its own, and it pays on the relate engine too, so it wants its own measurement rather than a corner of this one.
