### PR TITLE
Release the elements a point selection reads its kept points from

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1069,11 +1069,18 @@ geo_points_covered(const GSERIALIZED *pts, const GSERIALIZED *gs, bool covered)
   for (int i = 0; i < count; i++)
   {
     if (geo_covers2d(gs, elems[i]) == covered)
+    {
+      /* A deserialized geometry reads its coordinates from the serialized
+       * element rather than copying them, so the element stays alive as long
+       * as it does. Gathering the kept elements at the front of the array
+       * they already occupy keeps each one reachable, to be released once the
+       * result carries its own copy of the bytes. */
+      elems[nkept] = elems[i];
       kept[nkept++] = lwgeom_from_gserialized(elems[i]);
+    }
     else
       pfree(elems[i]);
   }
-  pfree(elems);
 
   GSERIALIZED *result;
   if (nkept == 0)
@@ -1090,11 +1097,16 @@ geo_points_covered(const GSERIALIZED *pts, const GSERIALIZED *gs, bool covered)
   }
   else
   {
+    /* The collection takes the array of kept geometries, which #lwgeom_free
+     * releases together with the geometries themselves */
     LWGEOM *out = lwcollection_as_lwgeom(lwcollection_construct(MULTIPOINTTYPE,
       srid, NULL, (uint32_t) nkept, kept));
     result = geo_serialize(out);
     lwgeom_free(out);
   }
+  for (int i = 0; i < nkept; i++)
+    pfree(elems[i]);
+  pfree(elems);
   return result;
 }
 


### PR DESCRIPTION
`geo_points_covered` takes a point set apart with `geo_extract_elements`,
asks the deciding geometry about each element, and deserializes the ones
it keeps. The elements it rejects are freed in the loop; the ones it keeps
were not freed at all, so every point a geometry covers left one
serialized element behind.

Freeing a kept element in the loop is not the repair. `lwgeom_from_gserialized`
reads a point through `ptarray_construct_reference_data`, so the geometry it
returns REFERENCES the element's own bytes rather than copying them, and the
element has to outlive it. The kept elements are therefore gathered at the
front of the array they already occupy and released after the result has been
serialized, which is the point at which the answer carries its own copy of the
bytes. The array of deserialized geometries stays as it was: for more than one
point `lwcollection_construct` KEEPS that array and `lwgeom_free` releases it
with its members, so only the two smaller branches free it.

Why the release belongs where it now sits: a deserialized geometry here is a
VIEW, not a value. Its coordinates live in the serialized element, so the
element and the geometry are one object with two handles, and the lifetime that
governs both ends where the last reader stops reading. Serializing the result
is that end -- it is the step that copies the coordinates into storage the
answer owns -- so a release before it reads freed memory and a release after it
frees exactly once. Choosing the free site by asking which handle was allocated
last, rather than which reader is still holding the bytes, is what put the free
of the rejected elements inside the loop and left the kept ones with no free at
all.

Witness: meos/test/geo_test under valgrind reports 128 bytes definitely lost
in 4 blocks across 3 contexts, two of whose records name geo_points_covered
under geo_extract_elements. The same binary against this change reports 32
bytes in 1 block across 1 context, and no record names that function.

Measured, the two arms differing only in this file: 40,625 allocations in
both, against 40,620 frees before and 40,623 after -- three more frees of the
same three blocks, 96 bytes, and not one allocation avoided, since the
elements are read and so have to be made. geo_test exits 0 in both arms with
identical output. pg_regress passes every test on PostgreSQL 18 and both the
libmeos and the extension targets build warning-clean. Five interleaved runs
time both arms at 0.04 s, the timer's resolution being coarser than three
calls to pfree.

What did not move: the 32 direct and 8 indirect bytes that remain are a
different defect, an empty polygon that `clip_poly_poly` constructs and
`geom_intersection2d` drops, at identical counts in both arms. It carries its
own change.

