### PR TITLE
Ask the grid once per resolution which cells hold the poles

### DIFF
--- a/meos/src/h3/th3index_boxops.c
+++ b/meos/src/h3/th3index_boxops.c
@@ -75,6 +75,48 @@
  * no T dimension — caller merges the time)
  *****************************************************************************/
 
+/** Number of H3 resolutions, 0 to the finest the h3index descriptor carries */
+#define H3_RESOLUTION_COUNT  16
+
+/* The cells holding the two poles at each resolution. Which cell holds a pole
+ * is a property of the grid alone, while the box of a temporal cell value is
+ * taken once per instant, so each thread answers the question from a table it
+ * fills the first time a resolution is asked for. MEOS_TLS gives every thread
+ * its own table, so concurrent callers neither race on it nor share it. */
+static MEOS_TLS H3Index MEOS_H3_POLE_CELL[2][H3_RESOLUTION_COUNT];
+static MEOS_TLS bool MEOS_H3_POLE_CELL_SET[H3_RESOLUTION_COUNT];
+
+/**
+ * @brief Return in the last two arguments the cells holding the north and the
+ * south pole at a resolution
+ * @param[in] res H3 resolution
+ * @param[out] north,south The cell holding the respective pole, or 0 for a
+ *   resolution outside the grid or a lookup libh3 refuses
+ */
+static void
+h3index_pole_cells(int32_t res, H3Index *north, H3Index *south)
+{
+  if (res < 0 || res >= H3_RESOLUTION_COUNT)
+  {
+    *north = *south = (H3Index) 0;
+    return;
+  }
+  if (! MEOS_H3_POLE_CELL_SET[res])
+  {
+    LatLng pole;
+    pole.lng = 0.0;
+    pole.lat = degsToRads(90.0);
+    if (latLngToCell(&pole, res, &MEOS_H3_POLE_CELL[0][res]) != E_SUCCESS)
+      MEOS_H3_POLE_CELL[0][res] = (H3Index) 0;
+    pole.lat = degsToRads(-90.0);
+    if (latLngToCell(&pole, res, &MEOS_H3_POLE_CELL[1][res]) != E_SUCCESS)
+      MEOS_H3_POLE_CELL[1][res] = (H3Index) 0;
+    MEOS_H3_POLE_CELL_SET[res] = true;
+  }
+  *north = MEOS_H3_POLE_CELL[0][res];
+  *south = MEOS_H3_POLE_CELL[1][res];
+}
+
 /**
  * @brief Set the X/Y geodetic part of a spatiotemporal box from an H3 cell.
  * @param[in] cell H3 cell index (must be a valid, non-zero cell)
@@ -99,16 +141,8 @@ th3index_cell_set_stbox(H3Index cell, STBox *box)
   }
   /* A cell holding a pole reaches it and spans every longitude, which its
    * boundary vertices do not state */
-  int32_t res = getResolution(cell);
   H3Index north, south;
-  LatLng pole;
-  pole.lng = 0.0;
-  pole.lat = degsToRads(90.0);
-  if (latLngToCell(&pole, res, &north) != E_SUCCESS)
-    north = (H3Index) 0;
-  pole.lat = degsToRads(-90.0);
-  if (latLngToCell(&pole, res, &south) != E_SUCCESS)
-    south = (H3Index) 0;
+  h3index_pole_cells(getResolution(cell), &north, &south);
   double xmin, ymin, xmax, ymax;
   dggs_lonlat_boundary_set_box(lons, lats, bnd.numVerts, north == cell,
     south == cell, &xmin, &ymin, &xmax, &ymax);


### PR DESCRIPTION
A cell reaching a pole spans every longitude, which its boundary vertices
do not state, so the box of an H3 cell asks whether that cell is the one
holding the north or the south pole. It asked by inverting each pole to a
cell through `latLngToCell`, and it asked on every call: twice per instant
of every temporal cell value whose box is taken.

Which cell holds a pole is a property of the grid and the resolution, and
nothing else. The answer is therefore taken once per resolution into a
table each thread holds, and every later box reads it. The resolutions run
0 to 15, the range the h3index descriptor states as its finest, so the
table is 32 cells. `MEOS_TLS` gives each thread its own, which is the
qualifier this tree already uses for the PROJ, GSL, GEOS, timezone and
collation caches, so a concurrent caller neither races on the table nor
waits for another thread to fill it.

Why the lookup was the wrong shape rather than merely a slow one: it made
a question about the GRID into a question asked of the VALUE. The two
poles do not move between one instant and the next, so the answer cannot
differ across the instants of a sequence, yet the inversion ran once for
each of them. A quantity that varies over none of a loop's iterations is
read before the loop; here the loop is the caller's, so the reading moves
to the grid it describes.

Witness: profiling a trajectory corpus at resolution 12 attributes 66.25%
of the run to `latLngToCell` while the densifying walker, its only other
caller on that path, accounts for 36.92%. The remaining 29.33% is these
two probes. Measured on their own, a pole inversion costs 1,170 ns against
1,796 ns for the `cellToBoundary` the same function calls once, so the two
probes are the larger half of every box taken.

Measured, the two arms built from the same tree with the same flags and
differing only in this file: five interleaved runs over a 400,000-line
corpus at resolution 12 give medians of 30.18 s against 20.50 s, a ratio
of 0.68, with the changed arm faster in all five pairs. The output of both
arms is byte-identical, `meos/test/geo_test` exits 0, and both the libmeos
and the extension targets build warning-clean.

What did not move: the box itself. The table answers what the two
inversions answered, for every resolution the grid carries and for every
cell, so no box changes and no answer that reads one changes with it.

