### PR TITLE
Release the empty region the polygon clip builds to serialize

### DIFF
--- a/meos/src/geo/geo_poly_clip.c
+++ b/meos/src/geo/geo_poly_clip.c
@@ -80,7 +80,12 @@ _Static_assert(CL_XOR          == MEOS_CLIP_XOR,
 static GSERIALIZED *
 clip_empty_areal(int32_t srid)
 {
-  return geo_serialize(lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0)));
+  /* Serializing copies, so the geometry built to be serialized is this
+   * function's to release -- as it is on every other answer this file gives */
+  LWGEOM *empty = lwpoly_as_lwgeom(lwpoly_construct_empty(srid, 0, 0));
+  GSERIALIZED *result = geo_serialize(empty);
+  lwgeom_free(empty);
+  return result;
 }
 
 /**


### PR DESCRIPTION
Part of the campaign that gives MEOS a native answer for every geometry operation. Same class as #2563 and #2567, in the third place it occurs.

## The empty region the clip builds to serialize

`clip_empty_areal` builds an empty `LWPOLY`, serializes it and returns, leaving the `LWPOLY` and its ring array behind. Serializing copies, so the geometry built to be serialized belongs to the function that built it — which is what every other answer in the file does, and what the same arm one file over already does in the linear clip.

```sql
SELECT ST_AsText(ST_Intersection(
  'POLYGON((0 0,4 0,4 4,0 4,0 0))',
  'POLYGON((20 20,24 20,24 24,20 24,20 20))'));
```

Boxes lying apart reach `clip_poly_poly`'s empty short-circuit, as does an empty operand.

## Why

An empty region is an answer, not an absence, so the arm that gives one owes the same release as the arms that give a region. What makes this instance the one that hides longest is that the whole answer is a single expression: there is no local holding the geometry, so nothing is named and nothing is noticed. Giving the value a name is what makes the ownership visible, and it is the shape the rest of the file already has.

## Measured

| measurement | result |
|---|---|
| the witness above under `valgrind --leak-check=full`, `-DGEOS=OFF` | `definitely lost: 64 bytes in 2 blocks` becomes `0 bytes in 0 blocks`, the leak recorded at `lwpoly_construct_empty` under `clip_poly_poly` under `geom_intersection2d` |
| the dispatch probe's answers, both arms | the same text on each of its 19 rows |
| the 54 adversarial pairs through the areal overlay entries | `definitely lost: 0 bytes` before this change as well, so the overlay itself does not leak and this arm is the whole of it on that path |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| a two-build comparison of 41 instruments | one line moves, a clock reading |
| the full regression suite | unmoved: an empty geometry serializes identically either way |

## The class, and how to find the rest of it

A geometry constructed inline as the argument of `geo_serialize` has no name, so nothing frees it. That shape is greppable, and `meos/src` holds no other instance of it.

Driving each entry to its **empty or degenerate arm** under valgrind is what finds the ones that do have a name — the canned single input a smoke test uses never reaches those arms, which is why they survive a green suite.
