### PR TITLE
Read no element out of an empty geometry rather than a null collection

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -2859,6 +2859,17 @@ geo_extract_elements(const GSERIALIZED *gs, int *count)
   /* Extract the elements of the arguments, if they are collections */
   LWCOLLECTION *coll;
   GSERIALIZED **result = NULL;
+  /* An empty geometry holds no element, and it is neither unitary --
+   * #geo_is_unitary refuses an empty one deliberately -- nor necessarily a
+   * collection, so without this it reaches the collection arm below and
+   * #lwgeom_as_lwcollection answers NULL for the POINT, LINESTRING or POLYGON
+   * it is. The array is still allocated because every caller releases it with
+   * #pfree_array, which asserts the pointer it is given */
+  if (gserialized_is_empty(gs))
+  {
+    *count = 0;
+    return palloc(sizeof(GSERIALIZED *));
+  }
   if (geo_is_unitary(gs))
   {
     *count = 1;


### PR DESCRIPTION
`geo_extract_elements` sends anything `geo_is_unitary` refuses to its collection arm, where `lwgeom_as_lwcollection` answers NULL for a geometry that is not one and `coll->ngeoms` reads through it. An EMPTY geometry lands there: the predicate refuses an empty one deliberately, and an empty POINT, LINESTRING or POLYGON is no collection. So an empty operand SEGFAULTS two public entries.

### Witness

Two entries declared in `meos_geo.h`, on ordinary input:

```c
geom_intersection2d('POINT EMPTY', 'POLYGON((0 0,4 0,4 4,0 4,0 0))')
geom_difference2d  ('POINT EMPTY', 'POLYGON((0 0,4 0,4 4,0 4,0 0))')
geom_intersection2d_coll(<a collection>, 'POLYGON EMPTY')
```

| | before | after |
|---|---|---|
| all three | SIGSEGV, exit 139 | each answers, errno 0 |
| the non-empty control `geom_intersection2d('MULTIPOINT((1 1))', <the same polygon>)` | a geometry | the same geometry |

Under valgrind the fault reads

```
Invalid read of size 4
   at geo_extract_elements
   by geom_intersection2d_coll
 Address 0x18 is not stack'd, malloc'd or (recently) free'd
```

and `0x18` is the offset of `ngeoms` in the collection it never received.

### Why

An empty geometry holds no element, and that is a THIRD case beside the two the function already separates — one geometry, or the members of a collection. Answering it as "no elements" is what every caller already copes with, because each bounds its own walk by the count it is handed: the intersection of collections runs no iteration, and the point selection keeps nothing and answers the empty point it should.

The array is still allocated for a count of zero. Every caller releases it with `pfree_array`, which asserts the pointer it is given, so a NULL would move the crash rather than remove it.

### Measured

| | |
|---|---|
| the three witnesses above, both arms | SIGSEGV 139 → answered with errno 0, and the non-empty control unmoved |
| 1444 areal pairs and 54 adversarial pairs, every answer text at 9 decimals | BYTE-IDENTICAL to master — 4332 and 162 answer lines over intersection and difference both ways |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost — the in-tree test `.github/workflows/meos.yml` compiles and runs on every PR, unmoved by this |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |
| the two-build coverage A/B, 41 instruments | no answer moves; the single differing line is a wall-clock timestamp |

### A case that survives, and it is a different defect

`geom_intersection2d_coll` answers NULL with errno 0 where the intersection of its elements covers nothing — reachable now that the pair no longer crashes. A null with no errno is indistinguishable from a refusal to every caller, which is the defect `ee3a26b58f` closed for the polygon clip by answering the empty geometry instead. The same sentence fits here and wants its own change.
