### PR TITLE
Release the empty point a selection answers where it keeps none

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1085,8 +1085,12 @@ geo_points_covered(const GSERIALIZED *pts, const GSERIALIZED *gs, bool covered)
   GSERIALIZED *result;
   if (nkept == 0)
   {
-    result = geo_serialize(lwpoint_as_lwgeom(lwpoint_construct_empty(srid,
-      hasz, false)));
+    /* Serializing copies, so the empty point built to be serialized is this
+     * function's to release, as the kept ones are on the two answers below */
+    LWGEOM *empty = lwpoint_as_lwgeom(lwpoint_construct_empty(srid, hasz,
+      false));
+    result = geo_serialize(empty);
+    lwgeom_free(empty);
     pfree(kept);
   }
   else if (nkept == 1)


### PR DESCRIPTION
`geo_points_covered` builds an empty POINT, serializes it and returns, leaving the `LWPOINT` and its point array behind. Serializing COPIES, so the geometry built to be serialized belongs to the function that built it — which is what the same function already does on its other two answers, freeing each kept geometry once the result carries its own bytes.

### Witness

A point set the deciding geometry covers none of, which every selection reaches through `geom_intersection2d` and `geom_difference2d` alike:

```c
geom_intersection2d('MULTIPOINT((1 1),(2 2))',
  'POLYGON((20 20,24 20,24 24,20 24,20 20))')
geom_difference2d('MULTIPOINT((1 1),(2 2))',
  'POLYGON((0 0,4 0,4 4,0 4,0 0))')
```

Under `valgrind --leak-check=full`, against a `-DGEOS=OFF` build:

| | definitely lost | indirectly lost | frames |
|---|---|---|---|
| before | 24 bytes in 1 blocks | 24 bytes in 1 blocks | `lwpoint_construct_empty` ← `geo_points_covered` |
| after | 0 bytes in 0 blocks | 0 bytes in 0 blocks | — |

Each answers the same geometry before and after.

### Why

An empty point set is an answer, not an absence, so the arm that gives one owes the same release as the arms that give a point or a collection of them. What keeps this instance hidden is that the whole answer is a single expression: there is no local holding the geometry, so nothing is named and nothing is noticed. Giving the value a name is what makes the ownership visible, and it is the shape the two arms below it already have.

### Measured

| | |
|---|---|
| the four selection outcomes — none covered, one covered, all covered, and the difference | 24 direct and 24 indirect bytes → 0 of each, on the two that keep none; the two that keep something are already clean, and stay so |
| the answer each of the four gives | unchanged |
| 1444 areal pairs and 54 adversarial pairs, every answer text at 9 decimals | the same 4332 and 162 answer lines as master, over intersection and difference both ways |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost — the in-tree test `.github/workflows/meos.yml` compiles and runs on every PR |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |

### The class this belongs to

A geometry constructed INLINE as the argument of `geo_serialize` has no name, so nothing frees it. The shape is greppable, and the empty answer is where it hides: a suite that asks each function one ordinary question never reaches that arm, which is why a green suite keeps it. Driving each entry to its EMPTY or degenerate case under valgrind is what surfaces the rest — and a sweep of every entry in `postgis_funcs.c` on that principle is what found this one and the two that follow it.
