### PR TITLE
Release the array a collection intersection keeps nothing in

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -3214,6 +3214,10 @@ geom_intersection2d_coll(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
       pfree_array((void *) res, count);
     }
   }
+  else
+    /* The two cover nothing in common, so the array holds no element to keep
+     * and no element to release -- only itself */
+    pfree(res);
   /* Clean up and return */
   pfree_array((void *) elems1, count1);
   pfree_array((void *) elems2, count2);


### PR DESCRIPTION
`geom_intersection2d_coll` sizes an array to hold every element pair's intersection, then releases it inside `if (count)` — on the arm that keeps one element and on the arm that collects several. Where the two collections cover NOTHING in common the count is zero, neither arm runs, and the array survives the function.

### Witness

Two DISJOINT collections, which involve no empty operand and so reach this on master as it stands:

```c
geom_intersection2d_coll(
  'GEOMETRYCOLLECTION(POINT(1 1),LINESTRING(0 0,2 2))',
  'GEOMETRYCOLLECTION(POINT(90 90),LINESTRING(80 80,82 82))')
```

Under `valgrind --leak-check=full`, both arms built from ONE build tree so the only variable is the change:

| | definitely lost | the record |
|---|---|---|
| before | 104 bytes in 4 blocks | `32 bytes in 1 blocks` — `palloc` ← `geom_intersection2d_coll` |
| after | 72 bytes in 3 blocks | that record GONE |

The 72 bytes that remain are `geo_points_covered`'s empty point, a separate leak with its own fix; nothing in this change touches it.

### Why

The array is this function's whatever the count, so its release belongs on every path — which is what the two `pfree_array` calls on the elements directly below already do, running whatever `count1` and `count2` hold. What hides this instance is that the release sits INSIDE the arms that keep something, where it reads as part of handing the answer over rather than as the cleanup it also is. The empty answer keeps nothing, so it passes both.

### Measured

| | |
|---|---|
| the three arms of the result construction — nothing kept, one kept, several kept | `count==0` NULL, `count==1` `POINT(1 1)`, `count>1` `MULTIPOINT((1 1),(2 2))`, every one unchanged |
| those same three under valgrind | 200 bytes in 8 blocks → 168 in 7, and the `palloc` record 1 → 0; the two arms that already release are unmoved |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost — the in-tree test `.github/workflows/meos.yml` runs on every PR, unmoved by this |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |
