### PR TITLE
Release the operand a geodetic centroid reads its answer from

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -3676,7 +3676,7 @@ geog_centroid(const GSERIALIZED *gs, bool use_spheroid)
       0, 0);
     lwgeom_out = lwcollection_as_lwgeom(empty);
     g_out = geo_serialize(lwgeom_out);
-    lwgeom_free(lwgeom_out);
+    lwgeom_free(lwgeom_out); lwgeom_free(lwgeom);
     return g_out;
   }
 
@@ -3692,6 +3692,7 @@ geog_centroid(const GSERIALIZED *gs, bool use_spheroid)
     case POINTTYPE:
     {
       /* centroid of a point is itself */
+      lwgeom_free(lwgeom);
       return geo_copy(gs);
     }
     case MULTIPOINTTYPE:
@@ -3720,7 +3721,11 @@ geog_centroid(const GSERIALIZED *gs, bool use_spheroid)
       lwmline_add_lwline(mline, line);
 
       lwpoint_out = geography_centroid_from_mline(mline, &s);
+      /* #lwmline_add_lwline stores the line it is given rather than copying
+       * it, so this releases the operand along with the collection holding
+       * it and the release below must not reach it a second time */
       lwmline_free(mline);
+      lwgeom = NULL;
       break;
     }
     case MULTILINETYPE:
@@ -3736,7 +3741,11 @@ geog_centroid(const GSERIALIZED *gs, bool use_spheroid)
       LWMPOLY* mpoly = lwmpoly_construct_empty(srid, 0, 0);
       lwmpoly_add_lwpoly(mpoly, poly);
       lwpoint_out = geography_centroid_from_mpoly(mpoly, use_spheroid, &s);
+      /* #lwmpoly_add_lwpoly stores the polygon it is given rather than
+       * copying it, so this releases the operand along with the collection
+       * holding it and the release below must not reach it a second time */
       lwmpoly_free(mpoly);
+      lwgeom = NULL;
       break;
     }
     case MULTIPOLYGONTYPE:
@@ -3749,6 +3758,7 @@ geog_centroid(const GSERIALIZED *gs, bool use_spheroid)
     {
       meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
         "ST_Centroid(geography) unhandled geography type");
+      lwgeom_free(lwgeom);
       return NULL;
     }
   }
@@ -3756,7 +3766,7 @@ geog_centroid(const GSERIALIZED *gs, bool use_spheroid)
   g_out = geo_serialize(lwgeom_out);
   /* MEOS: GEOS DOES NOT SET THE GEODETIC FLAG */
   FLAGS_SET_GEODETIC(g_out->gflags, FLAGS_GET_GEODETIC(gs->gflags));
-  lwgeom_free(lwgeom_out);
+  lwgeom_free(lwgeom_out); lwgeom_free(lwgeom);
   return g_out;
 }
 


### PR DESCRIPTION
`geog_centroid` deserializes its operand at the top and leaves through seven arms, and NOT ONE of them releases what it deserialized. Two of the seven are already clean without doing anything, because they hand the operand to a collection and free that — which is exactly why a single release at the end is the wrong shape and would free those two twice.

### Witness

Every arm of the function, asked separately so the answer is per arm rather than per function, under `valgrind --leak-check=full`:

| arm | answer | before (direct + indirect) | after |
|---|---|---|---|
| empty | `GEOMETRYCOLLECTION EMPTY` | 32 | 0 |
| point | `POINT(1 1)` | 24 + 24 | 0 |
| multipoint | `POINT(1.499886 1.500057)` | 32 + 184 | 0 |
| **line** | `POINT(0.749156 0.249163)` | **0** | 0 |
| multiline | `POINT(1.499393 0.999888)` | 32 + 184 | 0 |
| **polygon** | `POINT(0.5 0.500006)` | **0** | 0 |
| multipolygon | `POINT(2.123596 2.125988)` | 32 + 216 | 0 |
| collection | NULL, errno 1 | 32 + 184 | 0 |

184 bytes definitely lost in 6 blocks and 792 indirectly in 27 → 0 and 0, every answer unchanged, and no invalid read, write or free at any arm.

### Why the two clean arms are the whole design question

`lwcollection_add_lwgeom` STORES the geometry it is given rather than copying it, and `lwmline_free` and `lwmpoly_free` release every member they hold. So on the line and polygon arms the collection built to reuse the multi- kernel owns the operand, and freeing that collection frees the operand with it.

Those two arms are the reason this cannot be one release at the end: adding one would turn a leak into a DOUBLE FREE on exactly the two arms that are already correct. Each says so where it happens, and hands the release to the collection by dropping the reference.

The remaining six read the operand and give it away to nobody, so each releases it — the shape `geo_points` already has six hundred lines up in the same file: deserialize, serialize the answer, `lwgeom_free` the operand.

### Why it is here at all

The function is a port of PostGIS's `geography_centroid`, where the operand is reclaimed by the statement's memory context and no explicit release is written. MEOS has no such context, so a ported entry owes the release the original never had to write.

### Measured

| | |
|---|---|
| the ten arm questions above, including both spheroid flags | 184 + 792 bytes → 0 + 0, all eight answers byte-identical |
| the thirteen public geometry-returning entries of `postgis_funcs.c` no earlier sweep reached | 0 bytes, 0 errors from 0 contexts |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost — the in-tree test `.github/workflows/meos.yml` runs on every PR, unmoved by this |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |

### A note on the line above the tail, which this does not touch

`FLAGS_SET_GEODETIC(g_out->gflags, ...)` sets a flag on an ALREADY SERIALIZED value, and that flag decides the serialized width of a bounding box. It is safe only because the answer is a POINT and `lwgeom_needs_bbox` gives a point no box. Left as it stands; it is not this change's topic.

### How it was found

A sweep of every entry in `postgis_funcs.c`, each asked its degenerate question as well as its ordinary one. Four probe sweeps now cover all 127 top-level entries — 50 geometry-returning, 77 other — beside two structural checks: a grep for a geometry constructed inline as the argument of `geo_serialize` (4 sites, all releasing their local), and a per-variable scan for a deserialization that is never released. That scan flags exactly two functions; this is the real one, and `geom_array_mixed_union` is correct because ownership passes through its arrays into `union_collection_make`, which frees them on refusal.
