### PR TITLE
Release the two points a geodetic azimuth reads its angle from

### DIFF
--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -2441,13 +2441,17 @@ datum_geog_azimuth(Datum geog1, Datum geog2)
 {
   const GSERIALIZED *g1 = DatumGetGserializedP(geog1);
   const GSERIALIZED *g2 = DatumGetGserializedP(geog2);
-  const LWGEOM *geom1 = lwgeom_from_gserialized(g1);
-  const LWGEOM *geom2 = lwgeom_from_gserialized(g2);
+  /* Deserializing ALLOCATES, and the two points are read here and held
+   * nowhere else, so this function releases them. The planar twin above
+   * reads its points straight out of the datum and has nothing to release */
+  LWGEOM *geom1 = lwgeom_from_gserialized(g1);
+  LWGEOM *geom2 = lwgeom_from_gserialized(g2);
 
   SPHEROID s;
   spheroid_init(&s, WGS84_MAJOR_AXIS, WGS84_MINOR_AXIS);
   double result = lwgeom_azumith_spheroid(lwgeom_as_lwpoint(geom1),
     lwgeom_as_lwpoint(geom2), &s);
+  lwgeom_free(geom1); lwgeom_free(geom2);
   return Float8GetDatum(result);
 }
 


### PR DESCRIPTION
`datum_geog_azimuth` deserializes both operands to read one angle off them and frees neither, so every geodetic azimuth question loses 48 bytes. The planar twin directly above it reads its two points STRAIGHT OUT OF THE DATUM and allocates nothing, which is why only the geodetic arm pays.

### Witness

The two public entries that reach it, on a three-instant trajectory, under `valgrind --leak-check=full` against a `-DGEOS=OFF` build:

| | asks it | before (direct + indirect) | after |
|---|---|---|---|
| `tpoint_direction(tgeogpoint)` | ONCE per call | 48 + 48 | 0 |
| `tpoint_azimuth(tgeogpoint)` | once per SEGMENT | 96 + 96 | 0 |
| both, one process | | 144 in 6 blocks + 144 in 6 | 0 and 0 |
| **`tgeompoint`, the planar control** | — | **0** | 0 |

**The loss is per call, not once.** Ten `direction` calls read 480 bytes in 20 blocks against 48 in 2 for one — exactly linear. And because the azimuth walk asks per segment, its share grows with the trajectory rather than with the number of calls.

The planar control is what says the defect is the geodetic arm and not the harness: the same two questions on a `tgeompoint` read 0 bytes before and after.

### Why

Deserializing ALLOCATES, and these two points are read once and held nowhere after — the answer is a `double`. So the function that deserializes them is the one that releases them, which is the shape the tree already uses wherever it reads a value out of a geometry it deserialized itself.

**What hid it:** the two locals were declared `const LWGEOM *`. A const pointer reads as BORROWED, and a borrowed pointer is exactly the thing a function must NOT free — so the missing release looks correct at the point where it is missing. The type said the opposite of the ownership. Dropping the `const` states what is true: the function owns them.

### Measured

| | |
|---|---|
| direction and azimuth, geodetic and planar, 1 call and 10 | 144 + 144 bytes → 0 and 0, and 1440 over ten calls → 0 |
| the answer each gives | byte-identical, both types, both entries — `0.590587651` and the same three-instant step sequence |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost — the in-tree test `.github/workflows/meos.yml` runs on every PR, unmoved by this |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |

### How it was found

A scan over all 32 files of `meos/src/geo` for a deserialization that is never released, stored into a container, or returned: 107 deserializations, and after the geodetic centroid this is the only one left.

It nearly escaped. A first pass counted a CAST (`lwgeom_as_lwline(geom)`) as handing ownership away, which silenced the scan's own positive control — a cast is not a transfer. The count of one is only worth stating because, with that clause removed, the control fires.
