### PR TITLE
Build the overlay's scratch point array once instead of per edge pair

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -2397,9 +2397,13 @@ buffer_resolve_coincident_piece(BufferPiece *piece, BufferLocator *owner,
 /**
  * @brief Collect all exact boundary intersection nodes into the intersection
  * array.
- * @details The existing low-level intersection routines operate on MeosArray.
- * We therefore use a temporary MeosArray for each edge pair and transfer
- * the resulting points to MeosArray.
+ * @details The existing low-level intersection routines operate on MeosArray,
+ * so the points of one edge pair are collected into a scratch array and
+ * transferred. That array is built ONCE for the whole walk and reset per pair:
+ * it holds only the points of the pair being examined, so its contents are
+ * per-pair while its storage is not, and #meos_array_create would otherwise
+ * allocate MEOS_ARRAY_INITIAL_SIZE slots and free them again for every one of
+ * the n*m pairs.
  */
 static bool
 buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
@@ -2416,6 +2420,13 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
       meos_array_destroy(a2);
     return false;
   }
+  /* The scratch array the collectors write into, reused across the walk */
+  MeosArray *points = meos_array_create(sizeof(POINT2D));
+  if (! points)
+  {
+    meos_array_destroy(a1); meos_array_destroy(a2);
+    return false;
+  }
   for (uint32_t i = 0; i < a1->count; i++)
   {
     const Edge *e1 = (const Edge *) meos_array_get(a1, i);
@@ -2426,13 +2437,9 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
       const Edge *e2 = (const Edge *) meos_array_get(a2, j);
       if (! e2 || ! buffer_is_boundary_edge(e2))
         continue;
-      /* The existing intersection collectors expect MeosArray. */
-      MeosArray *points = meos_array_create(sizeof(POINT2D));
-      if (! points)
-      {
-        meos_array_destroy(a1); meos_array_destroy(a2);
-        return false;
-      }
+      /* The existing intersection collectors expect MeosArray, and each
+       * appends to what it is given, so the pair starts from an empty one */
+      meos_array_reset(points);
 
       if (e1->etype == EDGE_POLYSEG && e2->etype == EDGE_POLYSEG)
         buffer_collect_line_line_intersections(e1, e2, points);
@@ -2450,9 +2457,9 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
         if (point)
           buffer_intersections_add(intersections, point->x, point->y);
       }
-      meos_array_destroy(points);
     }
   }
+  meos_array_destroy(points);
   meos_array_destroy(a1); meos_array_destroy(a2);
   return true;
 }


### PR DESCRIPTION
`buffer_collect_boundary_intersections` walks every pair of boundary edges and builds a fresh `MeosArray` INSIDE that doubly-nested loop to receive the points of the pair, destroying it at the bottom. `meos_array_create` allocates `MEOS_ARRAY_INITIAL_SIZE` slots whatever the pair goes on to hold — 256 × `sizeof(POINT2D)`, 4096 bytes — so boundaries with n and m edges perform n×m allocations of 4 kB and n×m frees, to carry answers that are a handful of points and very often none.

The function's own comment already described it: *"we therefore use a temporary MeosArray for each edge pair"*.

### Profiled first, and the profile is what named the site

`perf record -g --call-graph=dwarf` on the heavier of two real protected-area polygon pairs, a 10.2 s call:

| symbol | share |
|---|---|
| `_int_malloc` | 18.29% — of which **17.55% of the whole run** via `palloc` ← `meos_array_create` ← `buffer_collect_boundary_intersections` |
| `_int_free` | 11.25% — 5.65% via `meos_array_destroy`, 4.56% direct |
| `malloc` | 7.14% |
| `unlink_chunk` | 4.96% |
| `cfree` | 4.91% |
| **libc as a whole** | **50.21%** |

The geometry kernels the overlay exists to run — `buffer_boundaries_intersect` and `buffer_collect_line_line_intersections` — sat at 11.55% each, BELOW the allocator.

**One symbol's SELF time is not the cost.** `meos_array_create` reads 1.19%, and reading that as "the array creation is cheap" is the mistake this change exists to correct. What costs is the `malloc` it performs, and only the call graph says so.

### The change

Build the array ONCE for the whole walk and `meos_array_reset` it per pair. The contents stay per-pair; only the storage is shared. That is the shape `temporal_sptree.c` and `temporal_rtree.c` already use for a scratch array reused across iterations.

**The reset is load-bearing, not cosmetic.** `buffer_add_intersection_point` scans `points` up to its count to reject a duplicate before adding, so the array must start each pair EMPTY or a point of the previous pair suppresses a genuine one of this pair. `meos_array_reset` sets the count to zero, which is what makes a reused array indistinguishable from a fresh one: the scan sees nothing and the first add lands in slot 0. The element is fixed-size, so nothing needs freeing.

### Measured

| | base | this change | |
|---|---|---|---|
| real polygon pair 1 | 787.4 ms | 696.1 ms | 1.13x |
| real polygon pair 2 | 10196.9 ms | 4477.2 ms | **2.28x** |

Medians of three interleaved rounds, the two arms alternating so a load spike cannot favour one.

| | |
|---|---|
| the same profile after the change | libc **50.21% → 6.61%**; every allocator symbol falls below the 1% cutoff, and `meos_array_create` + `meos_array_destroy` read 0.00%. `buffer_boundaries_intersect` rises 11.55% → 27.38% of a run half as long — the kernel keeping its work while the overhead goes |
| 1444 areal pairs, 54 adversarial pairs, 10 mid and 2 heavy real pairs | BYTE-IDENTICAL, every answer as text at 9 decimals, and the counts agree class by class (1 decline, 198 empty, 1245 non-empty on the 1444) |
| the equivalence dump prints its own denominator | 1444 lines, 1444 parsed, **0 parse failures** — a reader that fails to parse a corpus reports two files of `PARSE FAILED` as identical, and this corpus has produced exactly that vacuity before through its third field |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |

### The one other in-loop call site is correct as it stands, and that is measured

`buffer_chain_ring_infos` also calls `meos_array_create` inside a `while`, and that one must stay: the array it builds is STORED (`info.pieces = ordered`), so each ring owns its own.

Read off the source that reads like a judgement call, so it was run. Hoisting that second array the same way, same probe and same input:

| arm | result |
|---|---|
| this change (scratch array only) | `3 buffers: 3 cover their input, 0 DO NOT, 0 declined` |
| the second array hoisted as well | **`double free or corruption (!prev)`** |

The shared array is freed once per ring, so hoisting there is a crash rather than a saving. Only the scratch array of `buffer_collect_boundary_intersections` is consumed within its iteration, and only it is hoisted here.
