### PR TITLE
Reject an edge pair whose boxes lie apart before solving for its crossing

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -589,6 +589,14 @@ buffer_geometries_intersect(const LWGEOM *geom1, const LWGEOM *geom2)
           b->etype != EDGE_LINEARC && b->etype != EDGE_LINESEG)
         continue;
 
+      /* Two edges whose boxes lie apart cannot meet; the box each edge
+       * carries covers an arc's bulge as well as a segment's endpoints */
+      if (a->xmax < b->xmin - MEOS_GEOM_TOLERANCE ||
+          b->xmax < a->xmin - MEOS_GEOM_TOLERANCE ||
+          a->ymax < b->ymin - MEOS_GEOM_TOLERANCE ||
+          b->ymax < a->ymin - MEOS_GEOM_TOLERANCE)
+        continue;
+
       /* Line / line */
       if (a->etype == EDGE_LINESEG && b->etype == EDGE_LINESEG)
       {
@@ -750,6 +758,13 @@ buffer_boundaries_intersect(const LWGEOM *geom1, const LWGEOM *geom2)
     {
       const Edge *e2 = (const Edge *) meos_array_get(a2, j);
       if (! e2)
+        continue;
+      /* Two edges whose boxes lie apart cannot meet; the box each edge
+       * carries covers an arc's bulge as well as a segment's endpoints */
+      if (e1->xmax < e2->xmin - MEOS_GEOM_TOLERANCE ||
+          e2->xmax < e1->xmin - MEOS_GEOM_TOLERANCE ||
+          e1->ymax < e2->ymin - MEOS_GEOM_TOLERANCE ||
+          e2->ymax < e1->ymin - MEOS_GEOM_TOLERANCE)
         continue;
       if (buffer_edges_intersect(e1, e2))
       {
@@ -2436,6 +2451,17 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
     {
       const Edge *e2 = (const Edge *) meos_array_get(a2, j);
       if (! e2 || ! buffer_is_boundary_edge(e2))
+        continue;
+      /* Two edges whose boxes lie apart cannot meet, and the box each edge
+       * carries is EXACT for its kind: the endpoints for a segment, and for an
+       * arc #arc_set_bbox spans the endpoints together with whichever of the
+       * four cardinal extremes the arc's angular span reaches, so it covers
+       * the bulge rather than the chord. The same four comparisons stand in
+       * front of the relate engine's own edge walk in #relate_edges_meet_any */
+      if (e1->xmax < e2->xmin - MEOS_GEOM_TOLERANCE ||
+          e2->xmax < e1->xmin - MEOS_GEOM_TOLERANCE ||
+          e1->ymax < e2->ymin - MEOS_GEOM_TOLERANCE ||
+          e2->ymax < e1->ymin - MEOS_GEOM_TOLERANCE)
         continue;
       /* The existing intersection collectors expect MeosArray, and each
        * appends to what it is given, so the pair starts from an empty one */
@@ -4825,6 +4851,13 @@ buffer_ring_resolve(const LWGEOM *raw, const MeosArray *edges, double radius,
     {
       const Edge *e2 = (const Edge *) meos_array_get(arr, j);
       if (! e2 || ! buffer_is_boundary_edge(e2))
+        continue;
+      /* Two edges whose boxes lie apart cannot meet; the box each edge
+       * carries covers an arc's bulge as well as a segment's endpoints */
+      if (e1->xmax < e2->xmin - MEOS_GEOM_TOLERANCE ||
+          e2->xmax < e1->xmin - MEOS_GEOM_TOLERANCE ||
+          e1->ymax < e2->ymin - MEOS_GEOM_TOLERANCE ||
+          e2->ymax < e1->ymin - MEOS_GEOM_TOLERANCE)
         continue;
       MeosArray *points = meos_array_create(sizeof(POINT2D));
       buffer_collect_edge_intersections(e1, e2, points);


### PR DESCRIPTION
Four walks in the buffer overlay pair every edge of one boundary with every edge of the other and hand each pair to the intersection kernel, which solves a determinant, or a line/circle system, or a circle/circle one. Every `Edge` already carries a bounding box, and two edges whose boxes lie apart cannot meet — so nearly all of that work answers a question the boxes have already settled.

### Witness — the input whose COST is wrong; the ANSWER is right throughout

The heavier of two real protected-area polygon pairs, an 11203-edge geometry against a 14363-edge one. An instrumented build counts what the engine's own walk hands to the segment kernel:

| | |
|---|---|
| segment-kernel calls | **161,181,827** |
| of those whose boxes overlap | **930** |
| a box reject skips | **99.9994%** |

and the lighter pair 2,241,221 calls against 1038, skipping 99.95%.

These are the calls the ENGINE makes, counted in the engine — not the `n × m` of its loop bounds read off the source. The walk filters boundary edges, dispatches arcs elsewhere, and runs more than once per overlay, so the two numbers differ and only the counted one is the cost.

### Why the reject is sound, including for arcs

The box is EXACT for both edge kinds, which is what makes rejecting on it answer-preserving rather than an approximation:

- `emit_ring_edges` takes a segment's box from its two endpoints.
- `arc_set_bbox` spans an arc's endpoints TOGETHER WITH whichever of the four cardinal extremes of its circle fall inside its angular span — so the box covers the BULGE, not the chord. An arc reaching past its chord is inside its own box, and a pair separated by their boxes is separated in fact.

The same four comparisons, with the same `MEOS_GEOM_TOLERANCE` slack, already stand in front of the relate engine's edge walk in `relate_edges_meet_any` (`geo_funcs.c:7228`).

### Measured

| | base | this change |
|---|---|---|
| real polygon pair 1 | 724.2 ms | 491.2 ms — **1.47x** |
| real polygon pair 2 | 4473.2 ms | 2293.5 ms — **1.95x** |

Medians of three interleaved rounds, the arms alternating so a load spike cannot favour one.

**Guarding one walk is not the slice.** With only the collector walk guarded the same pairs read 1.34x and 1.03x; the other three walks are where the rest is. Profiling the first cut rather than accepting it is what surfaced them — `buffer_boundaries_intersect` rose to 33.91% of the run once the first walk was quiet.

| | |
|---|---|
| 1444 areal pairs, 54 adversarial pairs, 10 mid and 2 heavy real pairs | BYTE-IDENTICAL, every answer as text at 9 decimals, counts agreeing class by class, each dump printing its own denominator (1444 lines, 1444 parsed, 0 parse failures) |
| the buffer's own oracle-free gate `ST_Covers(buffer(g,d), g)` | **283 real protected-area polygons at radii 1/5/50: `849 buffers: 482 cover their input, 0 DO NOT, 367 declined` — the same three counts on both arms.** The 0 is the load-bearing one: the reject reaches no answer that was covering its input and stops covering it |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |

### What this does not do

A reject removes the KERNEL CALL, never the ITERATION: the walk still visits every pair to test its box. That is why 99.9994% fewer kernel calls buy 1.95x rather than a factor of thousands.

An index would remove the iteration too, but only for SOME of these walks, and the distinction is one this codebase has already measured. `relate_edges_intersect` was given a per-call edge R-tree and got SLOWER — 0.67-0.72x of GEOS to 1.02-1.59x — because a kernel answering at its FIRST WITNESS stops after a handful of tests while the O(n) build is paid in full. Two of the four walks guarded here are exactly that shape: `buffer_boundaries_intersect` and `buffer_geometries_intersect` return on the first crossing they find. `buffer_collect_boundary_intersections` and `buffer_ring_resolve` are the opposite — they collect EVERY intersection and have no early exit by construction — so they are where an index can earn its build, and a box reject is the right instrument for all four.
