### PR TITLE
Build the ring resolver's scratch point array once instead of per edge pair

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -4839,6 +4839,9 @@ buffer_ring_resolve(const LWGEOM *raw, const MeosArray *edges, double radius,
   /* Where the ring meets itself */
   MeosArray *nodes = meos_array_create(sizeof(POINT2D));
   MeosArray *pieces = meos_array_create(sizeof(BufferPiece));
+  /* The scratch array the collectors write into, reused across the walk: its
+   * contents belong to the pair being examined, its storage to none of them */
+  MeosArray *points = meos_array_create(sizeof(POINT2D));
   for (uint32_t i = 0; i < n; i++)
   {
     const Edge *e1 = (const Edge *) meos_array_get(arr, i);
@@ -4859,7 +4862,10 @@ buffer_ring_resolve(const LWGEOM *raw, const MeosArray *edges, double radius,
           e1->ymax < e2->ymin - MEOS_GEOM_TOLERANCE ||
           e2->ymax < e1->ymin - MEOS_GEOM_TOLERANCE)
         continue;
-      MeosArray *points = meos_array_create(sizeof(POINT2D));
+      /* #buffer_add_intersection_point scans up to the count to reject a
+       * duplicate before adding, so a pair must start from an empty array or
+       * a point of an earlier pair suppresses a genuine one of this pair */
+      meos_array_reset(points);
       buffer_collect_edge_intersections(e1, e2, points);
       for (int k = 0; k < meos_array_count(points); k++)
       {
@@ -4868,9 +4874,9 @@ buffer_ring_resolve(const LWGEOM *raw, const MeosArray *edges, double radius,
         if (p)
           buffer_intersections_add(nodes, p->x, p->y);
       }
-      meos_array_destroy(points);
     }
   }
+  meos_array_destroy(points);
   meos_array_destroy(arr);
 
   MeosArray *split = meos_array_create(sizeof(BufferPiece));


### PR DESCRIPTION
**Stacked on #2576 (open).** That PR gives the same walks a bounding-box reject; this one is a separate topic — allocation lifetime, not a missing filter — and the two overlap, which is measured and stated below rather than left for a reviewer to discover.

`buffer_ring_resolve` asks a ring where it meets ITSELF, pairing each boundary edge with every later one, and builds a fresh `MeosArray` inside that nested loop to receive the points of the pair. `meos_array_create` allocates `MEOS_ARRAY_INITIAL_SIZE` slots whatever the pair holds — 256 × `sizeof(POINT2D)` — so the walk allocates and frees 4 kB per pair to carry a handful of points and usually none.

**This is the instance the same change in `buffer_collect_boundary_intersections` did not reach.** One topic was fixed in one of its two places; this finishes it.

### Witness — the input whose COST is wrong; the ANSWER is right throughout

25 real protected-area polygons buffered at radii 1/5/50, three interleaved rounds, medians:

| | |
|---|---|
| master | 1.62 s |
| with this change | 1.05 s — **1.54x** |

and the answers do not move. The buffer's own oracle-free gate `ST_Covers(buffer(g,d), g)` reads `75 buffers: 53 cover their input, 0 DO NOT, 22 declined` on both arms over those 25 polygons, and over the full 283 at the same radii `849 buffers: 482 cover their input, 0 DO NOT, 367 declined`, again identical on both arms.

### Why the new shape is the right one

The array is a SCRATCH BUFFER: it receives the points of one pair and is emptied into `nodes` before the next pair begins. Its CONTENTS belong to the pair, its STORAGE to none of them. Allocating storage per pair states an ownership the code does not have; creating it once and emptying it per pair states what is true, and is the shape `temporal_sptree.c` and `temporal_rtree.c` already use for a reused scratch array.

**The reset is load-bearing.** `buffer_add_intersection_point` scans the array up to its count to reject a duplicate before adding, so a pair must start from an EMPTY one or a point of an earlier pair suppresses a genuine point of this pair. `meos_array_reset` sets the count to zero, which is what makes a reused array indistinguishable from a fresh one. The element is fixed-size, so nothing needs freeing.

### The two changes in this stack overlap, said plainly

| buffer path, 25 real polygons, three interleaved rounds | median | vs master |
|---|---|---|
| master | 1.62 s | — |
| **this change alone** | 1.05 s | **1.54x** |
| the edge-box reject alone | 0.92 s | 1.76x |
| both | 0.91 s | 1.78x |

**On top of the box reject this buys ~1.01x, which is noise** — and quoting only that would understate a change worth 1.54x on its own, just as quoting only the 1.54x would overstate what it adds to the delivered stack. Both belong here.

The reject stops the allocation being REACHED; it does not remove it. This change removes it, so the cost cannot come back if a denser pair of geometries makes the box test pass more often.

| | |
|---|---|
| 1444 areal pairs, 54 adversarial pairs, 10 mid and 2 heavy real pairs | BYTE-IDENTICAL, each dump printing its own denominator (1444 lines, 1444 parsed, 0 parse failures) |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |

### How the missed instance was found

By indentation, not by the loop-detecting scanner I first wrote for it — that scanner missed both this site and the one the earlier change fixed, while reporting a third that must NOT be hoisted (`buffer_chain_ring_infos` stores its array into `info.pieces`, and hoisting it gives `double free or corruption (!prev)`, measured). Of the 23 `meos_array_create` sites in the file, exactly two sit deeper than the function's top level; one is that ring-info site and the other is this one.
