### PR TITLE
Hold every instant of a sequence to the temporal type the sequence states

### DIFF
--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1007,11 +1007,7 @@ ensure_valid_tinstarr_common(TInstant **instants, int count, bool lower_inc,
  */
 bool
 ensure_valid_tinstarr(TInstant **instants, int count, bool merge,
-#if NPOINT
-  interpType interp)
-#else
   interpType interp UNUSED)
-#endif /* NPOINT */
 {
   /* The sequence takes its temporal type from the first instant, both here
    * and in #tsequence_make_exp1, so an array whose instants do not agree on

--- a/meos/src/temporal/tsequence.c
+++ b/meos/src/temporal/tsequence.c
@@ -1013,12 +1013,26 @@ ensure_valid_tinstarr(TInstant **instants, int count, bool merge,
   interpType interp UNUSED)
 #endif /* NPOINT */
 {
+  /* The sequence takes its temporal type from the first instant, both here
+   * and in #tsequence_make_exp1, so an array whose instants do not agree on
+   * one builds a sequence that states a type its later instants do not
+   * carry: the value of such an instant is then read as the type the
+   * sequence states wherever a reader dispatches on the sequence, and as its
+   * own where a reader dispatches on the instant, so the two disagree. The
+   * type is the frame the whole array shares, and it is stated here. */
+  MeosType temptype = instants[0]->temptype;
   for (int i = 0; i < count; i++)
   {
     if (instants[i]->subtype != TINSTANT)
     {
       meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
         "Input values must be temporal instants");
+      return false;
+    }
+    if (instants[i]->temptype != temptype)
+    {
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+        "Input values must be of the same temporal type");
       return false;
     }
     /* Ensure that only point geometries for temporal points */


### PR DESCRIPTION

A temporal sequence takes its type from the first instant of the array it
is built from -- `ensure_valid_tinstarr_common` reads
`instants[0]->temptype` to validate the interpolation and to reach the base
type, and `tsequence_make_exp1` writes it into the result -- while nothing
holds the remaining instants to it. An array whose instants disagree
therefore builds a sequence that states a type its later instants do not
carry.

That is not merely a wrong label. The value of such an instant is read as
the type the SEQUENCE states wherever a reader dispatches on the sequence,
which is the ordinary thing to do: `tsequence_values_p` takes
`temptype_basetype(seq->temptype)` and sorts every value as that base type.
It is read as its OWN type where a reader dispatches on the instant, which
is what `tinstant_out` does. The same bytes then answer two different
values depending on which of the two types the reader trusted, and neither
reader is doing anything wrong.

The type is the frame the whole array shares, so it is stated once from the
first instant and every instant is held to it, beside the subtype test that
already runs there.

Witness: an array of one `tint` instant valued 1 and one `tfloat` instant
valued 2.5 is accepted, and builds a sequence whose `temptype` is `T_TINT`
and whose output reads `[1@2001-01-01, 2.5@2001-01-02]` -- a temporal
integer carrying a fraction, printed only because the output function walks
the instants and reads each instant's own type. Against this change the
same array is refused with `MEOS_ERR_INVALID_ARG_TYPE`, and the instants
themselves are unchanged: the `tfloat` instant still reads `2.5` on its
own.

Measured: `pg_regress` passes every test on PostgreSQL 18 with no expected
output moving, and both the libmeos and the extension targets build
warning-clean. The suites carry no array of disagreeing instants, which is
why the sequences they build are unaffected and why nothing caught this.
The added test is one comparison of a type against a type per instant, on a
path that already reads that field to test the subtype beside it, so there
is no timing surface to report.

Mark the interpolation argument unread the way its nine siblings do

`ensure_valid_tinstarr` reads its interpolation argument only where the
network point family is compiled in, so the argument is marked as one that
may go unread. The mark is unconditional, which is what the nine other
declarations of an unread interpolation argument carry -- in `tgeo_meos.c`,
`tposechain.c`, `tpose.c`, `tcbuffer.c`, `tnpoint.c` and `tjsonb.c` -- and
what this function's own declaration in `tsequence.h` states.

`UNUSED` expands to `__attribute__((unused))`, which says an argument MAY
go unread rather than that it must, so one mark answers both
configurations: the compiler stays quiet where the family is absent, and
raises nothing where it is present and the argument is read.

Measured: both the libmeos and the extension targets build warning-clean,
including the extension built with no families, which is the configuration
in which the argument is read nowhere. The argument is passed and read
exactly as before and only its declaration changes, so no suite moves.

