### PR TITLE
Locate both probes of a containment test against one reading of the geometry

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -1360,6 +1360,10 @@ buffer_locator_free(BufferLocator *loc)
  * for every point
  * @param[in,out] loc Locator, whose edges are read on the first call
  * @param[in] x,y Point to locate
+ * @return
+ *   0 = interior
+ *   1 = boundary
+ *   2 = exterior
  */
 static int
 buffer_locator_point(BufferLocator *loc, double x, double y)
@@ -1386,24 +1390,6 @@ buffer_locator_point(BufferLocator *loc, double x, double y)
   if (loc->re.nedges == 0)
     return 2;
   return relate_point_in_area_index(x, y, &loc->re);
-}
-
-/**
- * @brief Return the location of a point with respect to a buffer.
- * @return
- *   0 = interior
- *   1 = boundary
- *   2 = exterior
- */
-static int
-buffer_point_location(const LWGEOM *geom, double x, double y)
-{
-  assert(geom);
-  BufferLocator loc;
-  buffer_locator_make(&loc, geom, 1);
-  int result = buffer_locator_point(&loc, x, y);
-  buffer_locator_free(&loc);
-  return result;
 }
 
 /**
@@ -1455,8 +1441,15 @@ buffer_is_contained(const LWGEOM *inner, const LWGEOM *outer)
   double y1 = y + ny * epsilon;
   double x2 = x - nx * epsilon;
   double y2 = y - ny * epsilon;
-  int loc1 = buffer_point_location(outer, x1, y1);
-  int loc2 = buffer_point_location(outer, x2, y2);
+  /* Both probes ask about the SAME geometry, so they share one locator, which
+   * reads the edges of @p outer once and answers both from them. A locator per
+   * point extracts that geometry once per point instead, which is what
+   * #buffer_locator_point's own `ready` flag exists to avoid */
+  BufferLocator outer_loc;
+  buffer_locator_make(&outer_loc, outer, 2);
+  int loc1 = buffer_locator_point(&outer_loc, x1, y1);
+  int loc2 = buffer_locator_point(&outer_loc, x2, y2);
+  buffer_locator_free(&outer_loc);
 
   /* If either side of the boundary is inside the outer buffer, the candidate
    * buffer is contained in it, provided the boundaries are known not to
@@ -2320,7 +2313,7 @@ buffer_piece_interior_side(const BufferPiece *piece, BufferLocator *geom)
     int left_loc = buffer_locator_point(geom, left.x, left.y);
     int right_loc = buffer_locator_point(geom, right.x, right.y);
 
-    /* buffer_point_location():
+    /* #buffer_locator_point():
      *   0 = interior
      *   1 = boundary
      *   2 = exterior */


### PR DESCRIPTION
`buffer_is_contained` steps to either side of a boundary point and asks where each side lies with respect to the SAME geometry. It asks through `buffer_point_location`, which builds a `BufferLocator`, extracts the geometry whole, answers one point and frees it — so the two questions read that geometry twice.

The locator exists to make that unnecessary: `buffer_locator_point` extracts under `if (! loc->ready)` and answers every later point from what it already holds. **A locator per point is what defeats it.**

### Witness — the input whose COST is wrong; the ANSWER is right throughout

Two real protected-area polygon pairs, three interleaved rounds, medians:

| | shipped master | this change | |
|---|---|---|---|
| pair 1 | 501.6 ms | 410.6 ms | **1.22x** |
| pair 2 | 2209.7 ms | 2072.9 ms | 1.07x |

Both answer the same geometry, byte for byte.

The scale of the re-reading, counted in an instrumented build rather than inferred: on the heavy pair the overlay calls `geom_extract_edges` **1,347,780 times for ONE call**, and `perf` puts that extraction at **12.12% of the run in `memcpy` alone**, of which 5.19% arrives through `buffer_locator_point`.

### Why the new shape is the right one

Two questions about one geometry are two probes of one locator, not two locators. That is what the structure is for, and what the SIBLING SITE in the same file already does — `buffer_piece_interior_side` holds a locator and asks it for its left and its right point in turn.

Passing `npoints = 2` also lets the locator's own index rule see both probes. It multiplies the points expected by the edges each would walk and builds an index when the product clears `RELATE_INDEX_MIN_PAIRS`, so asking one point at a time understates the work by exactly the factor this change removes.

### The function goes with its last caller

`buffer_point_location` has no other caller, so it is deleted rather than left for `-Wunused-function` to report. Its `@return` codes move to `buffer_locator_point`, which answers for it now, and the one comment naming it is repointed — that site already calls `buffer_locator_point`, so the comment names a function it does not use even before this change.

### Measured

| | |
|---|---|
| the two real polygon pairs, three interleaved rounds, medians | pair 1 **1.22x**, pair 2 1.07x |
| the buffer path, 25 real polygons, **eight** interleaved rounds | 0.77 s against 0.78 s, ranges 0.74–0.82 and 0.76–0.81 — unchanged. Three rounds read 0.75 against 0.78 and cannot tell that from a 4% regression, which is why eight |
| 1444 areal pairs, 54 adversarial pairs, 10 mid and 2 heavy real pairs | BYTE-IDENTICAL, each dump printing its own denominator (1444 lines, 1444 parsed, 0 parse failures) |
| the buffer's oracle-free gate `ST_Covers(buffer(g,d), g)` | `75 buffers: 53 cover their input, 0 DO NOT, 22 declined` — both arms |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |
| the file | 14 insertions, 21 deletions |

Both A/B arms are configured identically — every family ON, `RelWithDebInfo`, `GEOS=OFF`, read from both `CMakeCache.txt` — since nothing in a timing number reveals a mismatched pair of arms.
