### PR TITLE
Hold every sequence of a sequence set to the temporal type the set states

### DIFF
--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -211,9 +211,9 @@ datum_distance(Datum value1, Datum value2, MeosType type, int16 flags)
  *****************************************************************************/
 
 /**
- * @brief Ensure that all temporal sequences of the array have increasing
- * timestamp, and if they are temporal points, have the same srid and the
- * same dimensionality
+ * @brief Ensure that all temporal sequences of the array have the same
+ * temporal type and increasing timestamp, and if they are temporal points,
+ * have the same srid and the same dimensionality
  */
 bool
 ensure_valid_tseqarr(TSequence **sequences, int count)
@@ -225,12 +225,27 @@ ensure_valid_tseqarr(TSequence **sequences, int count)
       "Input sequences must be continuous");
     return false;
   }
+  /* The sequence set takes its temporal type from the first sequence, both
+   * here and in #tsequenceset_make_exp, and that type states which bounding
+   * box the set carries: #tseqarr_compute_bbox dispatches on it and then
+   * reads every sequence's box as that type. An array whose sequences do not
+   * agree on one therefore expands a box of one type with the bytes of
+   * another, and where the first sequence carries the wider box it reads past
+   * the box the later sequence owns. The type is the frame the whole array
+   * shares, and it is stated here. */
+  MeosType temptype = sequences[0]->temptype;
   for (int i = 0; i < count; i++)
   {
     if (sequences[i]->subtype != TSEQUENCE)
     {
       meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
         "Input values must be temporal sequences");
+      return false;
+    }
+    if (sequences[i]->temptype != temptype)
+    {
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+        "Input values must be of the same temporal type");
       return false;
     }
     if (i > 0)


### PR DESCRIPTION
A temporal sequence set takes its type from the first sequence of the array
it is built from -- `tsequenceset_make_exp` reads `normseqs[0]->temptype` to
size the bounding box and writes it into the result, and
`tseqarr_compute_bbox` reads it to choose which box the array is reduced
into -- while nothing holds the remaining sequences to it. An array whose
sequences disagree therefore builds a sequence set that states a type its
later sequences do not carry.

That type does not merely label the result, it decides how the OTHER
sequences are read. `tseqarr_compute_bbox` dispatches on
`type_bboxtype(sequences[0]->temptype)` and then expands one box with
`TSEQUENCE_BBOX_PTR(sequences[i])` for every later sequence, reading each as
the type the FIRST sequence prescribes. A temporal number carries a `TBox`
of 56 bytes and a temporal geometry point an `STBox` of 80, so an array
whose first sequence is the spatial one reads 24 bytes beyond the box the
later sequence owns.

Why refusal is the right answer, and not merely a stricter rule: a temporal
sequence set is a single temporal value of a single type, and that type is a
property of the whole value rather than of the part that happens to come
first -- the set denotes a function from time into ONE base type's domain.
An array whose sequences disagree denotes no such function, so there is no
correct sequence set for it to build, and no repair of the bounding box
would make one. The type is the frame the whole array shares, so it is
stated once from the first sequence and every sequence is held to it, beside
the subtype test that already runs there. `ensure_valid_tseqarr` is the only validator
on this path, so the temporal rigid geometry sequence set constructor is
held to the same rule by the same test.

Witness: an array of one `tint` sequence and one `tfloat` sequence is
accepted and reaches `span_expand`, which fails its
`s1->spantype == s2->spantype` assertion -- the value span of a `TBox` is an
integer span for the one and a float span for the other. An array of one
`tgeompoint` sequence and one `tfloat` sequence reaches `stbox_expand` and
fails its own; the reverse order fails `span_expand` again. Against this
change all three are refused with `MEOS_ERR_INVALID_ARG_TYPE`, while a
`tfloat` pair and a `tgeompoint` pair still build the sequence sets they
always did, with the same output and the same bounding box size.

Measured: `ctest` reports 100% tests passed, 0 tests failed out of 336, and
pg_regress passes every test on PostgreSQL 18 with no expected output
moving. The MEOS test programs run clean over their 55 invocations,
`threaded_test 8 5000` is clean under ThreadSanitizer, cppcheck reports no
finding on the added lines, and both the libmeos and the extension targets
build warning-clean. Nothing moved: the SQL constructors take a homogeneous
array -- `tgeompointSeqSet` is declared over `tgeompoint[]` -- so no query
can express a disagreeing array and no suite reaches the refusal. The path
that does is the public MEOS constructor `tsequenceset_make`.

The added test is one comparison of a type against a type per sequence, on a
path that already reads that field to test the subtype beside it, and it
runs once per sequence rather than once per instant, so there is no timing
surface to report.

