### PR TITLE
Release the geometries a conversion built before it met a foreign SRID

### DIFF
--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -615,7 +615,7 @@ cbufferarr_to_geom(const Cbuffer **cbarr, int count)
     if (! ensure_same_srid(srid, srid_elem))
     {
       for (int j = 0; j < i; j++)
-        pfree(geoms[i]);
+        pfree(geoms[j]);
       pfree(geoms);
       return NULL;
     }

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1272,7 +1272,7 @@ posearr_points(Pose **posearr, int count)
     if (! ensure_same_srid(srid, srid_elem))
     {
       for (int j = 0; j < i; j++)
-        pfree(geoms[i]);
+        pfree(geoms[j]);
       pfree(geoms);
       return NULL;
     }


### PR DESCRIPTION
`cbufferarr_to_geom` and `posearr_points` each convert an array of values
into one collection and refuse an array whose elements do not share an SRID.
On that refusal each walks the elements it has already converted in order to
release them, and indexes the walk with the OUTER loop variable instead of
the walk's own: `for (int j = 0; j < i; j++) pfree(geoms[i]);`.

`geoms[i]` is the slot the current iteration has not filled -- it is
assigned only after the SRID test that fails -- and the array comes from
`palloc`, so the release reads an uninitialised pointer, and reads that same
one once for every element already built. The geometries actually built,
`geoms[0]` through `geoms[i - 1]`, are not released at all.

Why the corrected walk is the right one, at the level of the model: the
refusal itself is correct and stays, because an array mixing SRIDs states a
length in two different units and has no conversion. What a refusal owes is
that it leave nothing behind, so the elements the function converted before
it discovered the mismatch are exactly the elements it must release -- that
set is `geoms[0]` through `geoms[i - 1]`, which is what the walk's own
variable enumerates and what the outer bound cannot. The bound says how far
the walk goes; only the walking variable says where it is.

Each walk therefore indexes with its own variable, which is what this
construct does everywhere else it appears -- `trgeo.c` releases `poses[j]`,
`tpose.c` releases `instants[j]` and `sequences[j]`, `pose_geopose.c`
releases `insts[j]` and `sequences[j]`, and `temporal_aggfuncs.c` already
carries this same correction with a comment naming the class.

These are the only two occurrences. A search of `meos/src` and
`mobilitydb/src` for a bounded free walk whose body indexes with the bound
rather than the walking variable returns `cbuffer.c:618` and `pose.c:1275`
and nothing else, so this is one problem closed rather than one instance of
it.

Witness: converting a two-element array holding one circular buffer at SRID
4326 and one at SRID 3857 returns NULL with `MEOS_ERR_INVALID_ARG_VALUE`, as
it should, and reports nothing wrong on its own -- the uninitialised pointer
happens not to fault. Under Valgrind the same call reports `Conditional jump
or move depends on uninitialised value(s)` at `cbuffer.c:618` together with
`88 bytes in 1 blocks are definitely lost` allocated at `cbuffer.c:622`, the
geometry the first element had already been converted into. Against this
change both reports are gone and the call still returns NULL with the same
errno. `posearr_points` is the same construct in its own file and is
corrected with it.

Measured: Valgrind over that call goes from `6 errors from 6 contexts` and
`definitely lost: 216 bytes in 5 blocks` to `4 errors from 4 contexts` and
`definitely lost: 128 bytes in 4 blocks`; the four that remain are the
probe's own unfreed inputs, two from `geom_in` and two from `cbuffer_make`,
and none of them names a MobilityDB frame. `ctest` reports 100% tests
passed, 0 tests failed out of 336, and pg_regress passes every test on
PostgreSQL 18 with no expected output moving. Nothing moved because nothing
could: neither function has a caller inside the tree, so no suite reaches
this path at all. `cbufferarr_to_geom` is declared in the installed
`meos_cbuffer.h` and is reached from the MEOS API; `posearr_points` is
internal to the pose conversions. The change runs on an error path only and
alters no successful conversion, so there is no timing surface to report.

