### PR TITLE
Read the edge-box reject at the band the meeting test itself works to

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -589,12 +589,17 @@ buffer_geometries_intersect(const LWGEOM *geom1, const LWGEOM *geom2)
           b->etype != EDGE_LINEARC && b->etype != EDGE_LINESEG)
         continue;
 
-      /* Two edges whose boxes lie apart cannot meet; the box each edge
-       * carries covers an arc's bulge as well as a segment's endpoints */
-      if (a->xmax < b->xmin - MEOS_GEOM_TOLERANCE ||
-          b->xmax < a->xmin - MEOS_GEOM_TOLERANCE ||
-          a->ymax < b->ymin - MEOS_GEOM_TOLERANCE ||
-          b->ymax < a->ymin - MEOS_GEOM_TOLERANCE)
+      /* Two edges whose boxes lie apart cannot meet. The band is the one the
+       * meeting test itself works to: each Edge carries the tolerance
+       * #edge_set_tolerance reads off its OWN coordinates, so the reject and
+       * the kernel behind it ask one question. Bounding the reject tighter --
+       * by an absolute MEOS_GEOM_TOLERANCE, which at projected coordinates is
+       * orders of magnitude smaller -- discards pairs the kernel answers */
+      double band = fmax(fmax(a->tol, b->tol), MEOS_GEOM_TOLERANCE);
+      if (a->xmax < b->xmin - band ||
+          b->xmax < a->xmin - band ||
+          a->ymax < b->ymin - band ||
+          b->ymax < a->ymin - band)
         continue;
 
       /* Line / line */
@@ -759,12 +764,17 @@ buffer_boundaries_intersect(const LWGEOM *geom1, const LWGEOM *geom2)
       const Edge *e2 = (const Edge *) meos_array_get(a2, j);
       if (! e2)
         continue;
-      /* Two edges whose boxes lie apart cannot meet; the box each edge
-       * carries covers an arc's bulge as well as a segment's endpoints */
-      if (e1->xmax < e2->xmin - MEOS_GEOM_TOLERANCE ||
-          e2->xmax < e1->xmin - MEOS_GEOM_TOLERANCE ||
-          e1->ymax < e2->ymin - MEOS_GEOM_TOLERANCE ||
-          e2->ymax < e1->ymin - MEOS_GEOM_TOLERANCE)
+      /* Two edges whose boxes lie apart cannot meet. The band is the one the
+       * meeting test itself works to: each Edge carries the tolerance
+       * #edge_set_tolerance reads off its OWN coordinates, so the reject and
+       * the kernel behind it ask one question. Bounding the reject tighter --
+       * by an absolute MEOS_GEOM_TOLERANCE, which at projected coordinates is
+       * orders of magnitude smaller -- discards pairs the kernel answers */
+      double band = fmax(fmax(e1->tol, e2->tol), MEOS_GEOM_TOLERANCE);
+      if (e1->xmax < e2->xmin - band ||
+          e2->xmax < e1->xmin - band ||
+          e1->ymax < e2->ymin - band ||
+          e2->ymax < e1->ymin - band)
         continue;
       if (buffer_edges_intersect(e1, e2))
       {
@@ -1122,6 +1132,14 @@ buffer_boundary_self_intersects(const LWGEOM *geom)
        * end point instead meet where the boundary touches itself. */
       if (buffer_nodes_equal(e1->x2, e1->y2, e2->x1, e2->y1) ||
           buffer_nodes_equal(e2->x2, e2->y2, e1->x1, e1->y1))
+        continue;
+      /* Two edges whose boxes lie apart cannot meet, read at the band the
+       * meeting test itself works to */
+      double band = fmax(fmax(e1->tol, e2->tol), MEOS_GEOM_TOLERANCE);
+      if (e1->xmax < e2->xmin - band ||
+          e2->xmax < e1->xmin - band ||
+          e1->ymax < e2->ymin - band ||
+          e2->ymax < e1->ymin - band)
         continue;
       if (buffer_boundary_intersection(e1, e2) >= 0)
       {
@@ -2445,16 +2463,17 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
       const Edge *e2 = (const Edge *) meos_array_get(a2, j);
       if (! e2 || ! buffer_is_boundary_edge(e2))
         continue;
-      /* Two edges whose boxes lie apart cannot meet, and the box each edge
-       * carries is EXACT for its kind: the endpoints for a segment, and for an
-       * arc #arc_set_bbox spans the endpoints together with whichever of the
-       * four cardinal extremes the arc's angular span reaches, so it covers
-       * the bulge rather than the chord. The same four comparisons stand in
-       * front of the relate engine's own edge walk in #relate_edges_meet_any */
-      if (e1->xmax < e2->xmin - MEOS_GEOM_TOLERANCE ||
-          e2->xmax < e1->xmin - MEOS_GEOM_TOLERANCE ||
-          e1->ymax < e2->ymin - MEOS_GEOM_TOLERANCE ||
-          e2->ymax < e1->ymin - MEOS_GEOM_TOLERANCE)
+      /* Two edges whose boxes lie apart cannot meet. The band is the one the
+       * meeting test itself works to: each Edge carries the tolerance
+       * #edge_set_tolerance reads off its OWN coordinates, so the reject and
+       * the kernel behind it ask one question. Bounding the reject tighter --
+       * by an absolute MEOS_GEOM_TOLERANCE, which at projected coordinates is
+       * orders of magnitude smaller -- discards pairs the kernel answers */
+      double band = fmax(fmax(e1->tol, e2->tol), MEOS_GEOM_TOLERANCE);
+      if (e1->xmax < e2->xmin - band ||
+          e2->xmax < e1->xmin - band ||
+          e1->ymax < e2->ymin - band ||
+          e2->ymax < e1->ymin - band)
         continue;
       /* The existing intersection collectors expect MeosArray, and each
        * appends to what it is given, so the pair starts from an empty one */
@@ -3725,6 +3744,14 @@ buffer_boundaries_cross(const LWGEOM *geom1, const LWGEOM *geom2)
       const Edge *e2 = (const Edge *) meos_array_get(a2, j);
       if (! e2 || ! buffer_is_boundary_edge(e2))
         continue;
+      /* Two edges whose boxes lie apart cannot meet, read at the band the
+       * meeting test itself works to */
+      double band = fmax(fmax(e1->tol, e2->tol), MEOS_GEOM_TOLERANCE);
+      if (e1->xmax < e2->xmin - band ||
+          e2->xmax < e1->xmin - band ||
+          e1->ymax < e2->ymin - band ||
+          e2->ymax < e1->ymin - band)
+        continue;
       int dimension = buffer_boundary_intersection(e1, e2);
 
       /* A curve the two boundaries share is bounded by two nodes, so it splits
@@ -4848,12 +4875,17 @@ buffer_ring_resolve(const LWGEOM *raw, const MeosArray *edges, double radius,
       const Edge *e2 = (const Edge *) meos_array_get(arr, j);
       if (! e2 || ! buffer_is_boundary_edge(e2))
         continue;
-      /* Two edges whose boxes lie apart cannot meet; the box each edge
-       * carries covers an arc's bulge as well as a segment's endpoints */
-      if (e1->xmax < e2->xmin - MEOS_GEOM_TOLERANCE ||
-          e2->xmax < e1->xmin - MEOS_GEOM_TOLERANCE ||
-          e1->ymax < e2->ymin - MEOS_GEOM_TOLERANCE ||
-          e2->ymax < e1->ymin - MEOS_GEOM_TOLERANCE)
+      /* Two edges whose boxes lie apart cannot meet. The band is the one the
+       * meeting test itself works to: each Edge carries the tolerance
+       * #edge_set_tolerance reads off its OWN coordinates, so the reject and
+       * the kernel behind it ask one question. Bounding the reject tighter --
+       * by an absolute MEOS_GEOM_TOLERANCE, which at projected coordinates is
+       * orders of magnitude smaller -- discards pairs the kernel answers */
+      double band = fmax(fmax(e1->tol, e2->tol), MEOS_GEOM_TOLERANCE);
+      if (e1->xmax < e2->xmin - band ||
+          e2->xmax < e1->xmin - band ||
+          e1->ymax < e2->ymin - band ||
+          e2->ymax < e1->ymin - band)
         continue;
       /* #buffer_add_intersection_point scans up to the count to reject a
        * duplicate before adding, so a pair must start from an empty array or


### PR DESCRIPTION
The reject in front of the buffer's pairwise edge walks bounds by `MEOS_GEOM_TOLERANCE`, an absolute 1e-12. The kernels it guards do not: each `Edge` carries the tolerance `edge_set_tolerance` reads off its OWN coordinates, and at projected coordinates that is orders of magnitude larger. **A reject bounded tighter than the test behind it can discard a pair that test would answer.**

### Witness — an ANSWER, not a cost

The 11th geometry of the real protected-area corpus, a MULTIPOLYGON at coordinates around 9e5, buffered at radius 1:

| | npoints |
|---|---|
| no reject at all | 34 |
| reject at `MEOS_GEOM_TOLERANCE` | **37** — three vertices the geometry does not have |
| reject at the kernel's band | 34 |

The area agrees to one ulp across all three (281891240.876803637 against …696) and the buffer covers its input in each, so the shape is right throughout. What the absolute band costs is the NODING, and only a byte-level comparison sees it.

Counted in an instrumented build over 40 real polygons at radii 1 and 50: of **5,215,512** pairs the absolute band calls apart, the meeting test answers YES for **one**.

### Why this band is the right one

A reject and the test it guards must ask ONE question. `edge_set_tolerance` gives each edge `coordinate_tolerance` of its own coordinates — a DISTANCE at the scale that edge lives at — and every kernel behind these walks compares against it. Bounding the reject by `fmax(fmax(e1->tol, e2->tol), MEOS_GEOM_TOLERANCE)` is that same question asked one step earlier: the scaled band each edge carries, floored at the absolute constant so a geometry at the origin keeps one. Bounding it by that constant ALONE asks a STRICTER question, which is what lets a pair fall out between the two.

This is the shape the buffer has already paid for once, where the splitter treated two copies of a node as one and the chaining walk treated them as two: the fix is to read the tolerance the site already owns, never to widen a shared constant.

### What this changes, at six sites

**Four are corrected** — the walks that already carry a reject. Over 40 real polygons they are TRANSPARENT today: every one of 141 coverage instruments is byte-identical with the reject, without it, and with the corrected band. So this closes an exposure rather than a live wrong answer, and the exposure is measured at **3 pairs in 10,551,171** where the two bands disagree.

**Two are added** — `buffer_boundary_self_intersects` and `buffer_boundaries_cross` still solve for every pair. They are the walks enumeration missed, and they are also where the mismatch BITES: the witness above is theirs. They are born with the correct band rather than corrected later.

### Measured

| | |
|---|---|
| 141 coverage instruments over 40 real polygons, radii 1 and 50, plus the self-relate identity | BYTE-IDENTICAL to a build carrying NO reject at all, which is the ground truth a transparent reject must match |
| 1444 areal pairs, 54 adversarial pairs, 10 mid and 2 heavy real pairs | BYTE-IDENTICAL, each dump printing its own denominator (1444 lines, 1444 parsed, 0 parse failures) |
| the heavy real polygon pair, three interleaved rounds, medians | 2147.1 ms → 1846.5 ms, **1.16x** |
| | the correct band is SLOWER than the absolute one, which reads 1.32x on the same pair and answers wrongly. 1.16x is what the reject is worth when it rejects only what it may |
| the buffer's oracle-free gate `ST_Covers(buffer(g,d), g)` | `75 buffers: 53 cover their input, 0 DO NOT, 22 declined` — both arms |
| `meos/test/geo_test` under `valgrind --leak-check=full` | 0 errors from 0 contexts, 0 bytes definitely lost |
| `meos/test/run_smoketests.sh` | 7 of 7 suites clean under valgrind |
| the full regression suite | unmoved |

### How it was caught

By the two-build coverage A/B, which compares the ANSWER of 41 instruments and reported `moved=3`. Nothing else saw it: the overlay dumps exercise the intersection, not the buffer, and the buffer's own gate counts covering answers without comparing their bytes. A gate that reads answers as text is what distinguishes a transparent reject from one that only looks transparent.
