### PR TITLE
Sort the base values once, in the functions that collect them

### DIFF
--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2085,10 +2085,14 @@ temporal_set_bbox(const Temporal *temp, void *box)
 
 /**
  * @ingroup meos_internal_temporal_accessor
- * @brief Return the array of **pointers** to the base values of a temporal
- * value
+ * @brief Return the array of **pointers** to the **distinct** base values of a
+ * temporal value, **sorted** by base type order
  * @param[in] temp Temporal value
  * @param[out] count Number of values in the output array
+ * @post The output array is sorted and holds no duplicate, which each of the
+ * three subtype functions establishes: #tinstant_values_p returns a single
+ * value, and #tsequence_values_p and #tsequenceset_values_p both sort the
+ * values they collect and remove the duplicates
  * @see #temporal_values
  */
 Datum *
@@ -2120,11 +2124,13 @@ Datum *
 temporal_values(const Temporal *temp, int *count)
 {
   assert(temp); assert(count);
-  int count1;
-  Datum *values = temporal_values_p(temp, &count1);
+  /* The array arrives sorted and free of duplicates: that is the contract
+   * #temporal_values_p states and each of its three subtype functions
+   * establishes. #tnumberseq_valuespans reads the same array under the same
+   * contract, passing ORDER_NO to the span set it builds from it */
+  int newcount;
+  Datum *values = temporal_values_p(temp, &newcount);
   MeosType basetype = temptype_basetype(temp->temptype);
-  datumarr_sort(values, count1, basetype);
-  int newcount = datumarr_remove_duplicates(values, count1, basetype);
   Datum *result = palloc(sizeof(Datum) * newcount);
   for (int i = 0; i < newcount; i++)
     result[i] = datum_copy(values[i], basetype);


### PR DESCRIPTION
`temporal_values` returns the distinct base values of a temporal value as
owned copies. It obtains them from `temporal_values_p` and then sorts the
array and removes its duplicates before copying.

The array it receives is already sorted and already free of duplicates. All
three functions `temporal_values_p` dispatches to establish that:
`tinstant_values_p` returns a single value, and `tsequence_values_p` and
`tsequenceset_values_p` each call `datumarr_sort` followed by
`datumarr_remove_duplicates` on the values they collect. The second sort
therefore orders an ordered array and the second pass finds no duplicate to
remove.

Why the contract belongs in the brief and not in the caller: what let this
stand is that the guarantee was never written down. The brief of
`temporal_values_p` said only that it returns an array of pointers to the
base values, so a caller reading the declaration could not know the array
arrives sorted and distinct, and re-established it to be safe. That is the
correct instinct against an unstated contract, which makes the caller the
wrong place to fix it: the same reasoning would have any future caller sort
again. The brief now states the guarantee and a post-condition names the
three functions that keep it, so the next caller can rely on it instead of
rebuilding it. The tree already relies on it elsewhere --
`tnumberseq_valuespans` builds a span set straight from `tsequence_values_p`
output and passes `ORDER_NO`, which asserts the values it was handed are in
order.

Witness: `tfloat_values`, the public accessor over `temporal_values_p`, is
fed values that are neither ordered nor distinct. A sequence built from
5, 2, 9, 2 answers `count=3 [2, 5, 9]`, and a sequence set built from 7, 3
in one sequence and 7, 1 in the next answers `count=3 [1, 3, 7]` -- ordered,
duplicate-free, and ordered ACROSS the composing sequences, which only the
collecting function can have done. An instant answers `count=1 [5.5]`.

Measured: that probe prints byte-identical output against this change and
against master, on all three subtypes. `ctest` reports 100% tests passed,
0 tests failed out of 336, and pg_regress passes every test on PostgreSQL 18
with no expected output moving. The suite does reach the changed function:
`temporal_values` is called by `temporal_unnest_state_make`, behind SQL
`unnest`, and by the `th3index_values`, `tquadbin_values` and `ts2cell_values`
accessors, and the queries carry `unnest(temp)`, `unnest(t)` and
`unnest(tquadbin '...')` among 54 unnest call sites plus 7 cell-index
`values` sites. The values, their order and their count are unchanged, so
every caller sees what it saw before.

