### PR TITLE
Answer the cell prefilter from the instants rather than from a built array

### DIFF
--- a/meos/src/h3/h3_geo.c
+++ b/meos/src/h3/h3_geo.c
@@ -516,14 +516,27 @@ geo_to_h3index_set(const GSERIALIZED *gs, int32 resolution)
 }
 
 /**
+ * @brief Return true if any instant of a temporal sequence holds a value that
+ * a set contains
+ */
+static bool
+tsequence_ever_in_set(const TSequence *seq, const Set *s)
+{
+  for (int i = 0; i < seq->count; i++)
+    if (contains_set_value(s, tinstant_value_p(TSEQUENCE_INST_N(seq, i))))
+      return true;
+  return false;
+}
+
+/**
  * @ingroup meos_h3_comp
  * @brief Return true if a temporal H3 cell is ever equal to a cell of an H3
  * cell set
- * @details Returns 1 if any cell of @p cells appears in the value sequence of
+ * @details Returns 1 if any cell of @p cells appears among the values of
  * @p th3idx, 0 if none does, and -1 on error. This is the cross-platform
  * spatial prefilter the `eIntersects` SQL wrappers and Spark UDFs consume: it
- * walks the value sequence of the temporal H3 cell, one entry per distinct
- * instant, and tests membership of the set.
+ * walks the instants of the temporal H3 cell and stops at the first instant
+ * the set contains.
  * @param[in] cells The candidate H3 cell set (T_H3INDEX).
  * @param[in] th3idx The th3index temporal value.
  * @csqlfn #Ever_eq_h3indexset_th3index()
@@ -533,22 +546,27 @@ ever_eq_h3indexset_th3index(const Set *cells, const Temporal *th3idx)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(cells, -1); VALIDATE_NOT_NULL(th3idx, -1);
+  /* The value the caller gets for a temporal value of another type is the one
+   * #th3index_values gave it, which is the answer that it holds no cell */
+  VALIDATE_TH3INDEX(th3idx, 0);
 
-  int count = 0;
-  H3Index *vals = th3index_values(th3idx, &count);
-  if (vals == NULL)
-    return 0;
-  int found = 0;
-  for (int i = 0; i < count; i++)
+  assert(temptype_subtype(th3idx->subtype));
+  switch (th3idx->subtype)
   {
-    if (contains_set_value(cells, H3IndexGetDatum(vals[i])))
+    case TINSTANT:
+      return contains_set_value(cells,
+        tinstant_value_p((TInstant *) th3idx)) ? 1 : 0;
+    case TSEQUENCE:
+      return tsequence_ever_in_set((TSequence *) th3idx, cells) ? 1 : 0;
+    default: /* TSEQUENCESET */
     {
-      found = 1;
-      break;
+      const TSequenceSet *ss = (TSequenceSet *) th3idx;
+      for (int i = 0; i < ss->count; i++)
+        if (tsequence_ever_in_set(TSEQUENCESET_SEQ_N(ss, i), cells))
+          return 1;
+      return 0;
     }
   }
-  pfree(vals);
-  return found;
 }
 
 /*****************************************************************************/

--- a/mobilitydb/test/h3/expected/289_h3_geo.test.out
+++ b/mobilitydb/test/h3/expected/289_h3_geo.test.out
@@ -168,3 +168,90 @@ SELECT eEq(
  f
 (1 row)
 
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '831c02fffffffff@2001-01-01';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '8001fffffffffff@2001-01-01';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{831c02fffffffff@2001-01-01, 8001fffffffffff@2001-01-02}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{8001fffffffffff@2001-01-01, 831c02fffffffff@2001-01-02}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{8001fffffffffff@2001-01-01, 807ffffffffffff@2001-01-02}';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{8001fffffffffff@2001-01-01, 8001fffffffffff@2001-01-02,
+                  831c00fffffffff@2001-01-03}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{8001fffffffffff@2001-01-01, 8001fffffffffff@2001-01-02}';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index 'Interp=Step;[8001fffffffffff@2001-01-01,
+                              831c02fffffffff@2001-01-02]';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index 'Interp=Step;[8001fffffffffff@2001-01-01,
+                              807ffffffffffff@2001-01-02]';
+ ?column? 
+----------
+ f
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{[831c02fffffffff@2001-01-01], [8001fffffffffff@2001-01-02]}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{[8001fffffffffff@2001-01-01], [831c00fffffffff@2001-01-02]}';
+ ?column? 
+----------
+ t
+(1 row)
+
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{[8001fffffffffff@2001-01-01], [807ffffffffffff@2001-01-02]}';
+ ?column? 
+----------
+ f
+(1 row)
+

--- a/mobilitydb/test/h3/queries/289_h3_geo.test.sql
+++ b/mobilitydb/test/h3/queries/289_h3_geo.test.sql
@@ -188,3 +188,45 @@ SELECT eEq(
                                                      10.5 50.5, 10.0 50.5,
                                                      10.0 50.0))', 7),
          t.th3idx) FROM t;
+
+-- The prefilter answers from the instants of every subtype, and stops at the
+-- first instant the set contains. Each subtype is asked for a hit and a miss,
+-- and the sequence forms are asked where the hit sits, so a walk that stopped
+-- at the wrong place or skipped a composing sequence is refused.
+
+-- Temporal instant
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '831c02fffffffff@2001-01-01';
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '8001fffffffffff@2001-01-01';
+
+-- Discrete sequence: the hit at the first instant, at the last, and absent
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{831c02fffffffff@2001-01-01, 8001fffffffffff@2001-01-02}';
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{8001fffffffffff@2001-01-01, 831c02fffffffff@2001-01-02}';
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{8001fffffffffff@2001-01-01, 807ffffffffffff@2001-01-02}';
+
+-- A value repeated across instants is still found, and still not invented
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{8001fffffffffff@2001-01-01, 8001fffffffffff@2001-01-02,
+                  831c00fffffffff@2001-01-03}';
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{8001fffffffffff@2001-01-01, 8001fffffffffff@2001-01-02}';
+
+-- Step sequence
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index 'Interp=Step;[8001fffffffffff@2001-01-01,
+                              831c02fffffffff@2001-01-02]';
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index 'Interp=Step;[8001fffffffffff@2001-01-01,
+                              807ffffffffffff@2001-01-02]';
+
+-- Sequence set: the hit in the first composing sequence, in the last, absent
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{[831c02fffffffff@2001-01-01], [8001fffffffffff@2001-01-02]}';
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{[8001fffffffffff@2001-01-01], [831c00fffffffff@2001-01-02]}';
+SELECT h3indexset '{831c02fffffffff, 831c00fffffffff}' ?=
+       th3index '{[8001fffffffffff@2001-01-01], [807ffffffffffff@2001-01-02]}';


### PR DESCRIPTION
`ever_eq_h3indexset_th3index` answers whether any cell of a set appears among
the values of a temporal H3 cell. It is the prefilter the `eIntersects` SQL
wrappers and the Spark UDFs put in front of the exact predicate, so it runs
once per candidate row.

To answer that boolean it built the complete array of distinct values first,
through `th3index_values` and `temporal_values`: an array of value pointers,
sorted and stripped of duplicates, then a second array of owned copies, then
a third of `H3Index`. Only then did it walk the result, stopping at the
first cell the set contains. The array is therefore built in full even when
the first instant answers the question, and the sort and the deduplication
are paid on every call.

Why the walk is what the question asks for: the predicate is existential,
so it needs neither an order over the values nor a set of them, and it does
not own what it reads. Membership of a set is unchanged by the order in
which candidates are offered and by how often each is offered, which is what
makes the sort and the deduplication answer-preserving rather than
load-bearing; and testing a value does not outlive the test, which is what
makes the copies unnecessary. The walk visits the instants in place and
returns at the first hit, so what it does is bounded by the answer instead
of by the size of the value.

Witness: the equivalence is read at the surface with `tfloat`-style literals
over every subtype -- an instant, a discrete sequence, a step sequence and a
sequence set -- with the hit at the first instant, at the last, and absent,
and with a value repeated across instants, which the materialising path used
to collapse before testing. All fifteen answers are byte-identical against
this change and against master, including the `geoToH3IndexSet` pairing the
SQL test uses and the `NULL` set, which still answers -1.

Those cases are now in `289_h3_geo.test.sql`, which carried two: one true
and one false, both over a sequence. Twelve more ask each subtype for a hit
and a miss and ask the sequence forms WHERE the hit sits, so a walk that
stops at the wrong instant or skips a composing sequence is refused by the
suite rather than only by a probe. The expected output is the harness's own,
harvested and adopted verbatim.

Measured: `289_h3_geo` passes, 100% of tests passed and 0 failed. Both the
libmeos and the extension targets build warning-clean. The value the caller
gets for a temporal value of another type is unchanged: `th3index_values`
answered that the value holds no cell, and the explicit `VALIDATE_TH3INDEX`
answers the same, so the reading that the documented -1 belongs there is a
separate question this change does not settle.

