### PR TITLE
Read back the values unnest names, not only how many there are

### DIFF
--- a/mobilitydb/test/temporal/expected/022_temporal.test.out
+++ b/mobilitydb/test/temporal/expected/022_temporal.test.out
@@ -20019,3 +20019,54 @@ SELECT hashExtended(tint '1@2001-01-01', 1) <> hashExtended(tint '1@2001-01-01',
  t
 (1 row)
 
+SELECT (rec).value FROM (SELECT unnest(tint '{5@2001-01-01, 2@2001-01-02,
+  9@2001-01-03, 2@2001-01-04}') AS rec) AS t;
+ value 
+-------
+     2
+     5
+     9
+(3 rows)
+
+SELECT (rec).value, (rec).time FROM (SELECT unnest(tint '{5@2001-01-01,
+  2@2001-01-02, 9@2001-01-03, 2@2001-01-04}') AS rec) AS t;
+ value |                                                             time                                                             
+-------+------------------------------------------------------------------------------------------------------------------------------
+     2 | {[Tue Jan 02 00:00:00 2001 PST, Tue Jan 02 00:00:00 2001 PST], [Thu Jan 04 00:00:00 2001 PST, Thu Jan 04 00:00:00 2001 PST]}
+     5 | {[Mon Jan 01 00:00:00 2001 PST, Mon Jan 01 00:00:00 2001 PST]}
+     9 | {[Wed Jan 03 00:00:00 2001 PST, Wed Jan 03 00:00:00 2001 PST]}
+(3 rows)
+
+SELECT (rec).value FROM (SELECT unnest(tint 'Interp=Step;{[7@2001-01-01,
+  3@2001-01-02], [7@2001-01-03, 1@2001-01-04]}') AS rec) AS t;
+ value 
+-------
+     1
+     3
+     7
+(3 rows)
+
+SELECT (rec).value FROM (SELECT unnest(tint '5@2001-01-01') AS rec) AS t;
+ value 
+-------
+     5
+(1 row)
+
+SELECT (rec).value FROM (SELECT unnest(tfloat '{10@2001-01-01, 9.5@2001-01-02,
+  10@2001-01-03, 2@2001-01-04}') AS rec) AS t;
+ value 
+-------
+     2
+   9.5
+    10
+(3 rows)
+
+SELECT (rec).value FROM (SELECT unnest(ttext '{BBB@2001-01-01, AAA@2001-01-02,
+  BBB@2001-01-03, CCC@2001-01-04}') AS rec) AS t;
+ value 
+-------
+ AAA
+ BBB
+ CCC
+(3 rows)
+

--- a/mobilitydb/test/temporal/queries/022_temporal.test.sql
+++ b/mobilitydb/test/temporal/queries/022_temporal.test.sql
@@ -4126,3 +4126,36 @@ SELECT hashExtended(tint '1@2001-01-01', 1) = hashExtended(tint '1@2001-01-01', 
 SELECT hashExtended(tint '1@2001-01-01', 1) <> hashExtended(tint '1@2001-01-01', 2);
 
 ------------------------------------------------------------------------------
+
+-------------------------------------------------------------------------------
+-- unnest: one row per DISTINCT value, in base type order
+-------------------------------------------------------------------------------
+
+-- unnest names the distinct values of a temporal value and the time it holds
+-- each. The values are fed in unordered and with repeats, so a row set that
+-- comes back ordered, one row per value, states the order and the
+-- distinctness rather than inheriting them from the input. Only a case that
+-- reads the values can see this: a COUNT over a table cannot.
+
+-- Discrete sequence, values fed 5, 2, 9, 2
+SELECT (rec).value FROM (SELECT unnest(tint '{5@2001-01-01, 2@2001-01-02,
+  9@2001-01-03, 2@2001-01-04}') AS rec) AS t;
+
+-- The repeated value is named once, and carries BOTH of its times
+SELECT (rec).value, (rec).time FROM (SELECT unnest(tint '{5@2001-01-01,
+  2@2001-01-02, 9@2001-01-03, 2@2001-01-04}') AS rec) AS t;
+
+-- Step sequence, values fed 7, 3, 7, 1 across two composing sequences
+SELECT (rec).value FROM (SELECT unnest(tint 'Interp=Step;{[7@2001-01-01,
+  3@2001-01-02], [7@2001-01-03, 1@2001-01-04]}') AS rec) AS t;
+
+-- A temporal instant names its single value
+SELECT (rec).value FROM (SELECT unnest(tint '5@2001-01-01') AS rec) AS t;
+
+-- Float ordering is the base type's, not the textual one
+SELECT (rec).value FROM (SELECT unnest(tfloat '{10@2001-01-01, 9.5@2001-01-02,
+  10@2001-01-03, 2@2001-01-04}') AS rec) AS t;
+
+-- Text ordering likewise
+SELECT (rec).value FROM (SELECT unnest(ttext '{BBB@2001-01-01, AAA@2001-01-02,
+  BBB@2001-01-03, CCC@2001-01-04}') AS rec) AS t;


### PR DESCRIPTION
`unnest` on a temporal value names each of its DISTINCT base values once,
with the time it holds that value, and it names them in base type order.
That order and that distinctness are the contract `temporal_values_p`
states and `temporal_values` relies on.

Why a count cannot stand for the values: the suite reached this surface
through `SELECT COUNT(*) FROM (SELECT k, unnest(temp) ...)` over `tbl_tint`
and `tbl_ttext`, and a count is invariant under almost every way the answer
could be wrong here. Reorder the rows, return the wrong value, or attach a
value to the wrong time, and the count is unchanged, because no fixture
reads a value back. A suite that cannot distinguish the answer from its
permutations reports the same green either way, which is silence rather
than agreement.

The cases therefore read the values. Each feeds values that are neither
ordered nor distinct, so an answer that comes back ordered and deduplicated
states the property rather than inheriting it from the input: a discrete
sequence fed 5, 2, 9, 2 answers 2, 5, 9; the same value repeated answers ONE
row carrying BOTH of its times; a step sequence set fed 7, 3 in one
composing sequence and 7, 1 in the next answers 1, 3, 7, which is ordered
ACROSS the composing sequences and so cannot come from either alone; and an
instant answers its single value. A `tfloat` fed 10, 9.5, 10, 2 answers
2, 9.5, 10 and a `ttext` fed BBB, AAA, BBB, CCC answers AAA, BBB, CCC, so
the order is the base type's rather than the textual one that would put 10
before 9.5.

Measured: `022_temporal` passes, 100% of tests passed and 0 failed. The
expected output is the harness's own, harvested and adopted verbatim; the
diff against the committed oracle removes no line, so the file gains these
answers and changes none of the ones it already pinned. The timestamps read
in the zone the suite already fixes, which its 1885 existing stamps share.

