### PR TITLE
Free the instant copy the nearest approach of a rigid geometry and a point takes

### DIFF
--- a/meos/src/rgeo/trgeo_distance.c
+++ b/meos/src/rgeo/trgeo_distance.c
@@ -2681,13 +2681,14 @@ nai_trgeometry_tpoint(const Temporal *temp1, const Temporal *temp2)
   Temporal *dist = tdistance_trgeometry_tpoint(temp1, temp2);
   if (dist != NULL)
   {
-    const TInstant *min = temporal_min_instant(dist);
+    /* temporal_min_instant returns a copy that must be freed */
+    TInstant *min = temporal_min_instant(dist);
     /* The closest point may be at an exclusive bound */
     Datum value;
     temporal_value_at_timestamptz(temp1, min->t, false, &value);
     result = trgeometryinst_make(trgeo_geom_p(temp1), DatumGetPoseP(value),
       min->t);
-    pfree(dist); pfree(DatumGetPointer(value));
+    pfree(dist); pfree(min); pfree(DatumGetPointer(value));
   }
   return result;
 }


### PR DESCRIPTION
WITNESS. Any call to nai_trgeometry_tpoint leaks one TInstant. Run the
generated rgeo smoke suite under the strict leak check:

  valgrind --leak-check=full --error-exitcode=1 \
    --suppressions=meos/test/meos_smoketest.supp ./trgeometry_test

which reaches it through nai_trgeometry_tpoint(trgeo_seq1, tpoint1) and reports

  24 bytes in 1 blocks are definitely lost in loss record 1 of 3
     at malloc / palloc0 / tinstant_copy / nai_trgeometry_tpoint

and exits 1. With this commit the same run exits 0 and reports no definite
loss.

WHY. temporal_min_instant is tinstant_copy(temporal_min_inst_p(temp)), so the
caller owns what it returns; the borrowing entry is the _p one beside it. The
function read the copy into a const TInstant * and never released it, and const
here says only that the pointee is not written, never that the storage belongs
to someone else. Its two siblings in the same file are already right and settle
what the entry should do: nai_trgeometry_geo borrows through temporal_min_inst_p
and frees nothing, and nai_trgeometry_trgeometry takes the copy and frees it
under a comment naming the ownership. This is the third of the three, brought
into line with the second.

MEASURED. One binary against two DESTDIR-staged libraries differing only in
this commit, run interleaved ctl/fix/ctl/fix so the library is the only
variable: base rc=1 with the loss record above, HEAD rc=0 with zero definite
losses, both reproduced twice. The suite prints 140 results in every arm and
they are identical, so no answer moves and no fixture-based check can see this
at all. The whole smoke harness reads 7 of 7 suites green at HEAD; at base
trgeometry_test is the only one that fails and the other six pass, which is
what identifies this as the last leak keeping that suite off the strict check.
There is no timing leg: the change adds one pfree on a path that already
performs two, and allocates nothing.

