### PR TITLE
Discover the leak-checked tests instead of naming two of them

### DIFF
--- a/.github/workflows/meos-smoke.yml
+++ b/.github/workflows/meos-smoke.yml
@@ -66,16 +66,33 @@ jobs:
           ./meos/test/run_smoketests.sh
 
       # Building an index from a whole entry set releases the nodes the index
-      # holds, which the assertions cannot see and only a leak check reports
-      - name: Run the index builds under valgrind
+      # holds, which the assertions cannot see and only a leak check reports.
+      # A test of that kind is named meos/test/*_load_test.c and is DISCOVERED
+      # here rather than listed, so adding one needs no edit to this workflow --
+      # the rule the build step above already states for families, and the one
+      # run_smoketests.sh follows for its smoke/*.json sidecars. Naming them
+      # meant a test dropped into meos/test/ got no leak check and nothing said
+      # so. A glob matching nothing is a step that checks nothing, so the count
+      # carries a floor rather than passing quietly.
+      - name: Run the leak-checked tests under valgrind
         run: |
           cd meos/test
-          for t in rtree_load_test sptree_load_test; do
+          found=0
+          for src in *_load_test.c; do
+            [ -e "$src" ] || continue
+            t="${src%.c}"
+            echo "[valgrind] $t"
             gcc -Wall -Werror=implicit-function-declaration -g \
-              -I/usr/local/include -o $t $t.c -L/usr/local/lib -lmeos -lm
+              -I/usr/local/include -o $t $src -L/usr/local/lib -lmeos -lm
             valgrind --leak-check=full --errors-for-leak-kinds=definite \
               --error-exitcode=1 ./$t
+            found=$((found + 1))
           done
+          echo "$found leak-checked test(s) ran"
+          if [ "$found" -lt "${MEOS_VALGRIND_FLOOR:-2}" ]; then
+            echo "::error::$found leak-checked test(s), below the floor of ${MEOS_VALGRIND_FLOOR:-2}"
+            exit 1
+          fi
 
       - name: Upload valgrind logs on failure
         if: failure()


### PR DESCRIPTION
The valgrind step read `for t in rtree_load_test sptree_load_test`, so a test
whose defect only a leak check reports was checked only if someone remembered
to name it here. Dropping one into meos/test/ left it unchecked and nothing
said so, which is the hiding place a skip count cannot see either.

The step now discovers meos/test/*_load_test.c, the rule the build step above
already states for families -- "a family added later is smoke-tested here
without editing this workflow" -- and the one run_smoketests.sh follows for its
smoke/*.json sidecars, which a family drops rather than registering centrally.
A glob matching nothing is a step that checks nothing, so the count carries a
floor of two, overridable through MEOS_VALGRIND_FLOOR.

Measured with a deliberately leaking third *_load_test.c present in the tree:
the named loop answers status 0, never compiling it, while the discovering loop
finds three, fails on it and answers status 1. On the tree as it stands both
answer status 0 over the same two programs, and an empty directory fails on the
floor rather than reporting a step that checked nothing.

