### PR TITLE
Collect the traversed values in the order their producer gives them

### DIFF
--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -1412,13 +1412,13 @@ geo_values_collect(const Temporal *temp, bool unary_union)
   /* Get the array of pointers to the component values */
   int count;
   Datum *values = temporal_values_p(temp, &count);
-  MeosType basetype = temptype_basetype(temp->temptype);
-  datumarr_sort(values, count, basetype);
-  int newcount = datumarr_remove_duplicates(values, count, basetype);
-  GSERIALIZED **gsarr = palloc(sizeof(GSERIALIZED *) * newcount);
-  for (int i = 0; i < newcount; i++)
+  /* The array arrives sorted and free of duplicates: that is the contract
+   * #temporal_values_p states and each of its three subtype functions
+   * establishes, so the values are collected in the order they are given */
+  GSERIALIZED **gsarr = palloc(sizeof(GSERIALIZED *) * count);
+  for (int i = 0; i < count; i++)
     gsarr[i] = DatumGetGserializedP(values[i]);
-  GSERIALIZED *res = geo_collect_garray(gsarr, newcount);
+  GSERIALIZED *res = geo_collect_garray(gsarr, count);
   pfree(values); pfree(gsarr);
   if (! unary_union)
     return res;


### PR DESCRIPTION
`geo_values_collect` builds the geometry that answers `traversedArea` on a
temporal geometry and `trajectory` on a temporal point that does not
interpolate. It obtains the component values from `temporal_values_p` and
then sorts the array and removes its duplicates before collecting them.

The array it receives is already sorted and already free of duplicates.
That is the post-condition `temporal_values_p` states, and each of the three
functions it dispatches to establishes it: `tinstant_values_p` returns a
single value, and `tsequence_values_p` and `tsequenceset_values_p` each call
`datumarr_sort` followed by `datumarr_remove_duplicates` on the values they
collect. The sort here therefore orders an ordered array and the pass that
follows finds no duplicate to remove.

Why this is the same correction one function over: `temporal_values` carried
these two calls for the same reason and no longer does. What let both stand
is that the guarantee was unwritten, so a caller reading the declaration
could not know the array arrives sorted and distinct and re-established it to
be safe. The brief now states it, which is what makes relying on it the
correct reading rather than an assumption, and this is the second and last
caller in the tree that was re-establishing it.

Witness: `trajectory` and `traversedArea` are asked for values that arrive
neither ordered nor distinct, and the answer states the property with the
sort removed. A step sequence over POINT(3 3), POINT(1 1), POINT(3 3),
POINT(2 2) answers `MULTIPOINT(1 1,2 2,3 3)`; a discrete sequence given 5, 1,
3 answers `MULTIPOINT(1 1,3 3,5 5)`; three equal points answer the single
`POINT(7 7)`; a sequence set holding 4, 2 in one part and 4, 1 in the next
answers `MULTIPOINT(1 1,2 2,4 4)`, ordered across the parts; and a temporal
geometry repeating a polygon answers each polygon once. All six are
byte-identical against this change and against master, and since the sorting
this function did is gone on one arm, an ordered and duplicate-free answer
can only be its producer's doing.

Measured: the geometry these two entries return is text the suite already
pins, across 55 `trajectory` and 38 `traversedArea` cases whose expected
output carries the collections themselves rather than a count, so a
reordering or a lost duplicate is an answer the suite reads and refuses.
Both the libmeos and the extension targets build warning-clean.

