### PR TITLE
Release the values a typmod check reads before it answers

### DIFF
--- a/mobilitydb/src/geo/tgeo.c
+++ b/mobilitydb/src/geo/tgeo.c
@@ -486,10 +486,15 @@ tspatial_valid_typmod(Temporal *temp, int32_t typmod)
   {
     int count;
     Datum *datumarr = temporal_values_p(temp, &count);
+    Temporal *result = temp;
     for (int i = 0; i < count; i++)
       if (! postgis_valid_typmod(DatumGetGserializedP(datumarr[i]), typmod))
-        return NULL;
-    return temp;
+      {
+        result = NULL;
+        break;
+      }
+    pfree(datumarr);
+    return result;
   }
 
   return temp;


### PR DESCRIPTION
`tspatial_valid_typmod` enforces a column's typmod against a temporal value.
For a geometry column it reads the value's components through
`temporal_values_p` and asks PostGIS whether each one satisfies the typmod,
answering the value on success and NULL on the first component that does not.

Neither answer released the array. `temporal_values_p` returns a palloc'd
array of pointers, and the function held no `pfree` at all: a count over its
body reads 0 against 3 in the rest of the same file, and the allocation is
followed by three returns, none of which frees it.

Why the single exit is the right shape: an entry that takes ownership of an
array owes it back on every path, and a `return` from inside the walk is the
shape that makes that easy to miss, since each new exit has to remember the
release independently. Recording the answer and leaving by one exit makes
the release unconditional by construction rather than by inspection. Only
the array is freed and never its elements, which is the ownership
`temporal_values_p` documents: the array is the caller's, the values in it
are views into the temporal value. That is what the same construct does
everywhere else it reads this array -- `ea_spatialrel_tspatial_geo` breaks
out of its walk and then calls `pfree(datumarr)` before returning, and the
temporal accessor in `mobilitydb/src/temporal/temporal.c` frees `values` on
the way out.

Witness: there is none to give, and that is the honest shape of this change
rather than an omission. The function answers `temp` or NULL, both answers
are unchanged, and no input distinguishes the two versions; what changes is
that an array the function allocated is now given back. The evidence is
therefore source-level and is stated above with its control, 0 `pfree` in
the body against 3 in the rest of the file. What the missing release costs
at runtime is whatever PostgreSQL's allocation model gives a palloc in the
current memory context, and this change does not measure it.

Measured: `pg_regress` passes every test on PostgreSQL 18 and `ctest`
reports 100% of tests passed, 0 failed out of 336, with cppcheck clean and
no compiler warning on the changed lines. The suite reaches this path: 163
typmod-qualified temporal column declarations across the query corpus
exercise the accept branch, which this change touches. The early exit is
preserved, so the walk still stops at the first component the typmod
rejects, and nothing else moves.

