### PR TITLE
Free the schema the point cloud dimensions test parses

### DIFF
--- a/meos/test/pcschema_dims_test.c
+++ b/meos/test/pcschema_dims_test.c
@@ -127,11 +127,17 @@ main(void)
   {
     printf("FAILED: a schema is missing (stated %p, parsed %p)\n",
       (void *) stated, (void *) parsed);
+    if (parsed)
+      pc_schema_free(parsed);
     return 1;
   }
 
   printf("The schema stated as dimensions against the same document:\n");
   compare(stated, parsed);
+  /* The parser builds a schema this program owns, as the reparsed one below
+   * is owned and freed; meos_pc_schema answers the schema cache's own pointer
+   * and is never freed, which is why stated is not released here */
+  pc_schema_free(parsed);
   check(stated->srid == 4326, "srid");
   check(stated->pcid == 1, "pcid");
 


### PR DESCRIPTION
WITNESS. Run the program under a leak check:

  valgrind --leak-check=full --errors-for-leak-kinds=definite \
    --error-exitcode=1 ./pcschema_dims_test

and it reports

  846 (80 direct, 766 indirect) bytes in 1 blocks are definitely lost
     at pcalloc / pc_schema_new / pc_schema_from_xml / main

and exits 1. With this commit the same run exits 0 and reports 0 bytes
definitely lost and 0 indirectly.

WHY. The two schema sources in this file have opposite ownership and the file
already states both. pc_schema_from_xml builds a schema the caller owns, which
is why the reparsed one twenty lines below is released with pc_schema_free;
meos_pc_schema answers meos_pc_schema_lookup, a pointer into the schema
cache's own cache_buf, which is why neither stated nor inactive is released
anywhere. The schema parsed at the top is the one owned handle the file did
not dispose of, so it takes the disposal its own sibling already uses, and
stated keeps none.

The early return above it is given the same free. It is reachable with a
parsed schema in hand whenever the cache lookup answers NULL while the parse
succeeds, and it ran the shared exit without releasing what the main path
allocates.

MEASURED. Same library, the two versions of this program compiled from the
same source but for this change: before, exit 1 with 846 bytes in 1 blocks
across 12 indirect blocks; after, exit 0 with 0 definitely and 0 indirectly
lost, and no double free. The program prints the same 6 lines in both, so no
assertion or answer moves. There is no timing leg: this adds one free to a
program that already performs two.

