### PR TITLE
Answer the ever relationship from the instants rather than from a built array

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -537,6 +537,34 @@ spatialrel_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
 /*****************************************************************************/
 
 /**
+ * @brief Return the relationship of one composing value against the geometry
+ */
+static int
+ea_spatialrel_inst(const TInstant *inst, const GSERIALIZED *gs,
+  datum_func2 func, bool invert)
+{
+  Datum v = tinstant_value_p(inst);
+  return invert ? func(PointerGetDatum(gs), v) : func(v, PointerGetDatum(gs));
+}
+
+/**
+ * @brief Walk a sequence, stopping at the first instant that decides the
+ * ever/always question; return true when it decided
+ */
+static bool
+ea_spatialrel_seq(const TSequence *seq, const GSERIALIZED *gs,
+  datum_func2 func, bool ever, bool invert, int *result)
+{
+  for (int i = 0; i < seq->count; i++)
+  {
+    *result = ea_spatialrel_inst(TSEQUENCE_INST_N(seq, i), gs, func, invert);
+    if ((*result && ever) || (! *result && ! ever))
+      return true;
+  }
+  return false;
+}
+
+/**
  * @brief Return true if two temporal geos ever/always satisfy a spatial
  * relationship
  * @details The function applies function `func` to every composing geometry
@@ -555,26 +583,27 @@ ea_spatialrel_tspatial_geo(const Temporal *temp, const GSERIALIZED *gs,
 {
   /* Ensure the validity of the arguments */
   assert(temp); assert(gs); assert(! gserialized_is_empty(gs)); assert(func);
-  int count;
-  Datum *datumarr = temporal_values_p(temp, &count);
+  /* Walk the instants and stop at the first decisive one, so the work is
+   * bounded by the answer rather than by the size of the temporal value */
   int result = 0;
-  for (int i = 0; i < count; i++)
+  assert(temptype_subtype(temp->subtype));
+  switch (temp->subtype)
   {
-    result = invert ?  func(PointerGetDatum(gs), datumarr[i]) :
-      func(datumarr[i], PointerGetDatum(gs));
-    if (result)
+    case TINSTANT:
+      return ea_spatialrel_inst((TInstant *) temp, gs, func, invert);
+    case TSEQUENCE:
+      ea_spatialrel_seq((TSequence *) temp, gs, func, ever, invert, &result);
+      return result;
+    default: /* TSEQUENCESET */
     {
-      if (ever)
-        break;
-    }
-    else
-    {
-      if (! ever)
-        break;
+      const TSequenceSet *ss = (TSequenceSet *) temp;
+      for (int i = 0; i < ss->count; i++)
+        if (ea_spatialrel_seq(TSEQUENCESET_SEQ_N(ss, i), gs, func, ever,
+            invert, &result))
+          return result;
+      return result;
     }
   }
-  pfree(datumarr);
-  return result;
 }
 
 /*****************************************************************************/


### PR DESCRIPTION
`ea_spatialrel_tspatial_geo` answers whether a temporal geo ever, or always,
satisfies a spatial relationship against a geometry. It backs the ever
direction of `covers` and both directions of `touches`, so it runs once per
candidate row of a join.

To answer that boolean it built the complete array of distinct values first,
through `temporal_values_p`, which sorts the values and removes the
duplicates. Only then did it walk the result, stopping at the first value
that decides the question. The sort is therefore paid in full before any
predicate runs, including when the very first instant settles the answer.

Why the walk is what the question asks for: the relationship is a quantifier
over the values the temporal geo takes, and a quantifier is unchanged by the
order in which candidates are offered and by how often each is offered. The
ordering and the deduplication are answer-preserving rather than
load-bearing, so the only thing they can buy is fewer predicate calls, and
the only thing they cost is the sort. Walking the instants in place and
returning at the first decisive one makes the work bounded by the answer
instead of by the size of the value.

Measured on real data on both sides. The subjects are the 200 vessel
footprint trajectories of `tbl_ais_tgeometry` from
`mobilitydb/test/geo/data/load_ais.sql.xz`, 9538 instants of Danish AIS, and
the probe geometries are real vessel footprints drawn from that same corpus,
which is the join this entry serves: whether one vessel's footprint ever
meets another's track. The corpus therefore fixes how often the answer comes
early rather than the author choosing it, and over the 4000 pairs it answers
true for 21 of them, 0.5%.

Five interleaved rounds per arm, each arm its own build and its own binary,
read as the ratio against a control path this change does not touch, because
absolute times on a shared machine measure the machine; the load average was
1.18. The ratio against the control falls from 0.9791-1.1560 to
0.2538-0.2971, about 4.3x, with the two ranges not overlapping, while the
control itself stays at 0.1209-0.1429s against 0.1221-0.1278s, which is what
says the measurement is of the change.

What the deduplication was buying is measurable and small: over the same
corpus it removes 413 of 9538 values, 4.3%. The walk therefore performs
about 4.5% MORE of the only work the two arms share, the predicate calls,
and is still faster by the ratio above, so the difference is work the array
path does alone.

Witness: the answers are identical, which is what this change owes rather
than a new answer. Every one of the ten runs, five per arm, returns the same
21 true results over the same 4000 pairs, so no pair in the corpus
distinguishes the two versions. `pg_regress` passes every test on
PostgreSQL 18 with no expected output moving, `ctest` reports 100% of tests
passed and 0 failed out of 336, cppcheck is clean and the changed lines
carry no compiler warning.

