### PR TITLE
Answer ever disjoint from the instants rather than from a built array

### DIFF
--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1032,6 +1032,32 @@ acovers_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
+ * @brief Return true if one composing value is disjoint from the geometry
+ */
+static bool
+ea_disjoint_inst(const TInstant *inst, const GSERIALIZED *gs,
+  datum_func2 func, const void *ctx)
+{
+  Datum v = tinstant_value_p(inst);
+  return ctx ? ! geo_intersects2d_ctx(DatumGetGserializedP(v), ctx) :
+    DatumGetBool(func(v, PointerGetDatum(gs)));
+}
+
+/**
+ * @brief Walk a sequence, stopping at the first instant disjoint from the
+ * geometry; return true when one was found
+ */
+static bool
+ea_disjoint_seq(const TSequence *seq, const GSERIALIZED *gs,
+  datum_func2 func, const void *ctx)
+{
+  for (int i = 0; i < seq->count; i++)
+    if (ea_disjoint_inst(TSEQUENCE_INST_N(seq, i), gs, func, ctx))
+      return true;
+  return false;
+}
+
+/**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry and a geometry are ever disjoint,
  * 0 if not, and -1 on error or if the geometry is empty
@@ -1101,8 +1127,6 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   }
 
   /* Temporal geometry case */
-  int count;
-  Datum *datumarr = temporal_values_p(temp, &count);
   result = 0;
   /* The planar 2D relationship indexes the edges of the geometry to resolve
    * one composing value against it. Since the geometry is the same for every
@@ -1125,19 +1149,29 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
     lwgeom_free(lwgeom);
   }
   datum_func2 func = geo_disjoint_fn_geo(temp->flags, gs->gflags);
-  for (int i = 0; i < count; i++)
+  /* Walk the instants and stop at the first disjoint one, so the work is bounded
+   * by the answer rather than by the size of the temporal value */
+  assert(temptype_subtype(temp->subtype));
+  switch (temp->subtype)
   {
-    bool disjoint = ctx ?
-      ! geo_intersects2d_ctx(DatumGetGserializedP(datumarr[i]), ctx) :
-      DatumGetBool(func(datumarr[i], PointerGetDatum(gs)));
-    if (disjoint)
-    {
-      result = 1;
+    case TINSTANT:
+      result = ea_disjoint_inst((TInstant *) temp, gs, func, ctx) ? 1 : 0;
       break;
+    case TSEQUENCE:
+      result = ea_disjoint_seq((TSequence *) temp, gs, func, ctx) ? 1 : 0;
+      break;
+    default: /* TSEQUENCESET */
+    {
+      const TSequenceSet *ss = (TSequenceSet *) temp;
+      for (int i = 0; i < ss->count; i++)
+        if (ea_disjoint_seq(TSEQUENCESET_SEQ_N(ss, i), gs, func, ctx))
+        {
+          result = 1;
+          break;
+        }
     }
   }
   geo_edge_ctx_free(ctx);
-  pfree(datumarr);
   return result;
 }
 

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
@@ -450,6 +450,54 @@ SELECT eDisjoint(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))', tgeometry '{Point(0 
  f
 (1 row)
 
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry 'Polygon((5 5,5 6,6 6,6 5,5 5))@2001-01-01');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry 'Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '[Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-01, Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-02]');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '[Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-02]');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '[Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((2 2,2 3,3 3,3 2,2 2))@2001-01-02]');
+ edisjoint 
+-----------
+ f
+(1 row)
+
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '{[Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((2 2,2 3,3 3,3 2,2 2))@2001-01-02],[Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-04, Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-05]}');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '{Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-02, Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-03}');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eDisjoint(tgeometry '{Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-02, Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-03}', geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))');
+ edisjoint 
+-----------
+ t
+(1 row)
+
 SELECT eDisjoint(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))', tgeometry '[Point(0 0)@2001-01-01, Point(0 2)@2001-01-02]');
  edisjoint 
 -----------

--- a/mobilitydb/test/geo/queries/070_tgeo_spatialrels.test.sql
+++ b/mobilitydb/test/geo/queries/070_tgeo_spatialrels.test.sql
@@ -148,6 +148,22 @@ SELECT eDisjoint(tgeometry 'Point(1 1 1)@2001-01-01', geometry 'Point(1 1)');
 
 -- Coverage
 SELECT eDisjoint(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))', tgeometry '{Point(0 0)@2001-01-01, Point(0 2)@2001-01-02}');
+
+-- An areal subject against an areal geometry, which is the shape a join over a
+-- geometry column takes, exercised at each place the answer can be decided:
+-- the bounding boxes alone, the first composing value, a later one, the second
+-- sequence of a sequence set, and no value at all
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry 'Polygon((5 5,5 6,6 6,6 5,5 5))@2001-01-01');
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry 'Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01');
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '[Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-01, Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-02]');
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '[Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-02]');
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '[Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((2 2,2 3,3 3,3 2,2 2))@2001-01-02]');
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '{[Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((2 2,2 3,3 3,3 2,2 2))@2001-01-02],[Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-04, Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-05]}');
+
+-- A value the subject takes twice, which the relationship answers the same
+-- whether the repetition is offered to the predicate once or twice
+SELECT eDisjoint(geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))', tgeometry '{Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-02, Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-03}');
+SELECT eDisjoint(tgeometry '{Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-01, Polygon((9 9,9 10,10 10,10 9,9 9))@2001-01-02, Polygon((1 1,1 2,2 2,2 1,1 1))@2001-01-03}', geometry 'Polygon((0 0,0 4,4 4,4 0,0 0))');
 SELECT eDisjoint(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))', tgeometry '[Point(0 0)@2001-01-01, Point(0 2)@2001-01-02]');
 SELECT eDisjoint(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))', tgeometry '{[Point(0 0)@2001-01-01, Point(0 2)@2001-01-02],[Point(0 2)@2001-01-03, Point(0 0)@2001-01-04]}');
 SELECT eDisjoint(geometry 'Polygon((0 0,0 2,2 2,2 0,0 0))', tgeometry '{Point(3 3)@2001-01-01, Point(4 4)@2001-01-02}');


### PR DESCRIPTION
`ea_disjoint_tgeo_geo` answers whether a temporal geometry is ever disjoint from a
geometry. It backs `eDisjoint` in both argument orders and, through the negation
`aIntersects` reaches, it runs once per candidate row of a join over a geometry
column.

To answer that boolean for the temporal geometry case it built the complete array
of distinct values first, through `temporal_values_p`, which sorts the values and
removes the duplicates. Only then did it walk the result, stopping at the first
value disjoint from the geometry. The sort is therefore paid in full before any
predicate runs, including when the very first instant settles the answer.

Why the walk is what the question asks for: ever disjoint is a quantifier over the
values the temporal geometry takes, and a quantifier is unchanged by the order in
which candidates are offered and by how often each is offered. The ordering and the
deduplication are answer-preserving rather than load-bearing, so the only thing they
can buy is fewer predicate calls, and the only thing they cost is the sort. Walking
the instants in place and returning at the first disjoint one makes the work bounded
by the answer instead of by the size of the value. The edge context the loop reuses
is untouched: it is still built once per call and released once, and the walk reads
it exactly where the array path did.

Measured on real data on both sides. The subjects are the 200 vessel footprint
trajectories of `tbl_ais_tgeometry` from `mobilitydb/test/geo/data/load_ais.sql.xz`,
9538 instants of Danish AIS, and the probe geometries are real vessel footprints
drawn from that same corpus, which is the join this entry serves: whether one
vessel's footprint is ever clear of another's track. The corpus therefore fixes the
regimes rather than the author choosing them, and over the 4000 pairs it answers
from the bounding boxes alone for 3200, reaches the walk for 800, and exits the walk
early for none of them. So the whole of what follows is the sort, not the
short-circuit.

Five interleaved rounds per arm, each arm its own build and its own binary, read as
the ratio against a control path this change does not touch, because absolute times
on a shared machine measure the machine; the load average was 0.93. The ratio
against the control falls from 0.2658-0.2855 to 0.1371-0.1463, about 1.94x, with the
two ranges not overlapping, while the control itself stays at 0.1184-0.1262s against
0.1178-0.1246s, which is what says the measurement is of the change.

What the deduplication was buying is measurable and small: over the same corpus the
distinct values number 9125 of 9538 instants, 0.9567. The walk therefore performs
about 4.5% MORE of the only work the two arms share, the predicate calls, and is
still faster by the ratio above, so the difference is work the array path does alone.

Witness: the answers are identical, which is what this change owes rather than a new
answer. Every one of the ten runs, five per arm, returns the same 3200 true results
over the same 4000 pairs. `070_tgeo_spatialrels` gains eight cases over an areal
subject and an areal geometry, which is the shape a join over a geometry column
takes and the one the existing cases do not carry, deciding the answer at each place
it can be decided, since the corpus decides none of them early: the bounding boxes
alone, an instant the geometry contains, the first composing value, a later one, no
value at all, and the second sequence of a sequence set, plus a value the subject
takes twice in both argument orders, which the relationship answers the same whether
the repetition reaches the predicate once or twice. The harvested expected output is
a pure addition; no committed answer moves.

