### PR TITLE
Read what two surfaces meet along from both boundaries

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2112,10 +2112,14 @@ geo_is_planar_polygonal(const GSERIALIZED *gs)
  * the interior of the second: a point of it that did would carry a
  * neighbourhood of the first one's own interior into the second's, which is
  * area they would then share. So the part of that boundary the second
- * geometry covers is exactly the part lying ON its boundary, which is what
- * the two meet along, and #geo_clip_linear_geom answers it from the segment
- * kernels over an edge index. Asking it of the first operand's boundary also
- * keeps the answer running in that operand's own direction
+ * geometry covers is exactly the part lying ON its boundary -- the two
+ * expressions denote one set -- and it is the SECOND BOUNDARY the clip is
+ * asked about, because only that one is answered by the segment kernels
+ * alone. Clipping against the second geometry as a SOLID asks additionally
+ * where a point falls relative to its interior, a question the kernels answer
+ * by locating constructed points, and the answer it gives is not always on
+ * either operand. Asking it of the first operand's boundary also keeps the
+ * answer running in that operand's own direction
  * @param[in] gs1,gs2 Geometries
  * @pre The two share no area, which is what the caller has just read
  */
@@ -2132,12 +2136,13 @@ geom_areal_meeting(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
       && gbox_overlaps_2d(&box1, &box2) == LW_FALSE)
     return NULL;
 
-  GSERIALIZED *bound = geom_boundary(gs1);
-  if (! bound)
-    return NULL;
-  GSERIALIZED *result = geo_clip_subject(bound) ?
-    geo_clip_linear_geom(bound, gs2, true) : NULL;
-  pfree(bound);
+  GSERIALIZED *bound1 = geom_boundary(gs1);
+  GSERIALIZED *bound2 = bound1 ? geom_boundary(gs2) : NULL;
+  GSERIALIZED *result = (bound1 && bound2 && geo_clip_subject(bound1) &&
+    geo_meos_supported(bound2)) ?
+    geo_clip_linear_geom(bound1, bound2, true) : NULL;
+  if (bound1) pfree(bound1);
+  if (bound2) pfree(bound2);
   /* A meeting of nothing is the empty region the caller already holds */
   if (result && geo_is_empty(result))
   {


### PR DESCRIPTION
WITNESS. The 15th pair of the real protected-area corpus, two MULTIPOLYGONs
sharing no area, at projected coordinates near 6.3e6. Reproduce with

  meos/test -> geom_intersection2d(gs1, gs2)

over ~/natural_20.txt. GEOS answers a line of 2395.750624 m. This function
answers one of the same length that is not the same line: 98.648 m of
symmetric difference against GEOS, and 49.324 m of it lies in NEITHER operand,
which PostGIS 3.6 / GEOS 3.12.1 adjudicates as
ST_Length(ST_Difference(answer, a)) = 49.324. With this commit the same pair
answers 0.000 m outside either operand and 0.000 m of symmetric difference.

WHY. The two expressions denote ONE set, and this function's own docstring is
the argument: where the operands share no area, no part of the first
boundary reaches the second's interior, so the part of it the second geometry
COVERS is exactly the part lying ON its boundary. Clipping against the second
as a SOLID therefore asks for the same set by a longer route -- it must also
decide where a point falls relative to an interior, which the segment kernels
answer by locating constructed points. Clipping against the second BOUNDARY
asks only where two curves share support, which those kernels answer from the
edges themselves. Same set, and only one of the two routes is computed
without locating a point against a region.

MEASURED against PostGIS 3.6 / GEOS 3.12.1 on the 20 real pairs, comparing the
LINEAR part by symmetric difference rather than by length, because a length
can agree while the geometry does not -- which is exactly what pair 15 does:

  arm     line exact   area ok   worst length outside an operand
  before      18/20     20/20    49.324
  after       19/20     20/20     0.000

No area moves: 20 of 20 agree with GEOS before and after. The one pair still
short is a pair sharing a region AND running along the other outside it; a
region-only answer keeps stating the area alone there, which is what this
function is asked for and is unchanged by this commit.

GEOS 3.14.1 was built and asked the same 20 questions to check the reference
is not version-dependent here: it agrees with 3.12.1 on all 20.

