### PR TITLE
Refuse a nearest-neighbour query the search entry point already refuses

### DIFF
--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -1940,14 +1940,22 @@ nn_heap_pop(RTreeNNCursor *cursor)
  * an STBox index yields a purely spatial ordering, while a query carrying a
  * time dimension additionally requires overlapping time extents (as for
  * `|=|`). Close the cursor with #rtree_nn_cursor_close.
+ *
+ * As for #rtree_search, the query box is validated here, at the entry point,
+ * so that every distance the traversal computes can assume it.
  * @param[in] rtree The RTree to query
- * @param[in] query The query bounding box of type @p rtree->bboxtype
- * @return A cursor to be freed with #rtree_nn_cursor_close
+ * @param[in] query The query bounding box of type @p rtree->bboxtype and of
+ * the SRID the tree holds
+ * @return A cursor to be freed with #rtree_nn_cursor_close, on error @p NULL
  */
 RTreeNNCursor *
 rtree_nn_cursor_open(const RTree *rtree, const void *query)
 {
-  assert(rtree); assert(query);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rtree, NULL); VALIDATE_NOT_NULL(query, NULL);
+  if (! ensure_valid_rtree_box(rtree, query))
+    return NULL;
+
   RTreeNNCursor *cursor = palloc0(sizeof(RTreeNNCursor));
   cursor->rtree = rtree;
   cursor->query = palloc(rtree->bboxsize);
@@ -1979,12 +1987,15 @@ rtree_nn_cursor_open(const RTree *rtree, const void *query)
  * @param[in] cursor The cursor previously opened with #rtree_nn_cursor_open
  * @param[out] id_out Receives the id of the next neighbour, or @p NULL
  * @param[out] dist_out Receives the distance of the next neighbour, or @p NULL
- * @return @p true if a neighbour was produced, @p false once exhausted
+ * @return @p true if a neighbour was produced, @p false once exhausted or on
+ * error
  */
 bool
 rtree_nn_cursor_next(RTreeNNCursor *cursor, int64 *id_out, double *dist_out)
 {
-  assert(cursor);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(cursor, false);
+
   while (cursor->count > 0)
   {
     RTreeNNEntry entry = nn_heap_pop(cursor);

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -1722,14 +1722,22 @@ spnn_heap_pop(SPNNCursor *cursor)
  * after `k` results), so no more of the tree is visited than required. The
  * query box is copied into the cursor, so the caller may free or reuse it
  * immediately. Close the cursor with #sptree_nn_cursor_close.
+ *
+ * As for #sptree_search, the query box is validated here, at the entry point,
+ * so that every distance the traversal computes can assume it.
  * @param[in] sptree The SPTree to query
- * @param[in] query The query bounding box of type @p sptree->bboxtype
- * @return A cursor to be freed with #sptree_nn_cursor_close
+ * @param[in] query The query bounding box of type @p sptree->bboxtype and of
+ * the SRID the tree holds
+ * @return A cursor to be freed with #sptree_nn_cursor_close, on error @p NULL
  */
 SPNNCursor *
 sptree_nn_cursor_open(const SPTree *sptree, const void *query)
 {
-  assert(sptree); assert(query);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(sptree, NULL); VALIDATE_NOT_NULL(query, NULL);
+  if (! ensure_valid_sptree_box(sptree, query))
+    return NULL;
+
   SPNNCursor *cursor = palloc0(sizeof(SPNNCursor));
   cursor->sptree = sptree;
   cursor->query = palloc(sptree->boxsize);
@@ -1765,12 +1773,15 @@ sptree_nn_cursor_open(const SPTree *sptree, const void *query)
  * @param[in] cursor The cursor previously opened with #sptree_nn_cursor_open
  * @param[out] id_out Receives the id of the next neighbour, or @p NULL
  * @param[out] dist_out Receives the distance of the next neighbour, or @p NULL
- * @return @p true if a neighbour was produced, @p false once exhausted
+ * @return @p true if a neighbour was produced, @p false once exhausted or on
+ * error
  */
 bool
 sptree_nn_cursor_next(SPNNCursor *cursor, int64 *id_out, double *dist_out)
 {
-  assert(cursor);
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(cursor, false);
+
   const SPTree *sptree = cursor->sptree;
   while (cursor->count > 0)
   {

--- a/meos/test/rtree_knn_test.c
+++ b/meos/test/rtree_knn_test.c
@@ -49,6 +49,7 @@
  *        brute-force distances element by element (tie-robust);
  *  (v)   early stop: taking only the first k results matches the first k of
  *        the full drain, so a LIMIT k caller reads the true k neighbours.
+ * What the cursor refuses to open on is asserted separately.
  *
  * The program can be built as follows
  * @code
@@ -291,6 +292,57 @@ test_tbox_knn(void)
   rtree_free(rtree);
 }
 
+/*****************************************************************************
+ * What the cursor refuses to open on
+ *****************************************************************************/
+
+/* A cursor validates its query box where the box becomes a query, so that the
+ * traversal that follows may assume it, exactly as #rtree_search does. The
+ * error handler installed here reports through #meos_errno instead of ending
+ * the program, so that the refusal is read as a value rather than observed as
+ * an exit */
+static void
+test_refused(void)
+{
+  meos_initialize_noexit_error_handler();
+
+  printf("What the NN cursor refuses to open on:\n");
+
+  RTree *rtree = rtree_create_stbox();
+  STBox *box = stbox_in("SRID=4326;STBOX X((0,0),(1,1))");
+  STBox *other = stbox_in("SRID=3857;STBOX X((0,0),(1,1))");
+  rtree_insert(rtree, box, 0);
+
+  meos_errno_reset();
+  check("a query of another SRID is refused",
+    rtree_nn_cursor_open(rtree, other) == NULL && meos_errno() != 0);
+
+  meos_errno_reset();
+  check("a null index is refused",
+    rtree_nn_cursor_open(NULL, box) == NULL && meos_errno() != 0);
+
+  meos_errno_reset();
+  check("a null query is refused",
+    rtree_nn_cursor_open(rtree, NULL) == NULL && meos_errno() != 0);
+
+  /* A refused open answers NULL, so advancing that answer must report rather
+   * than read through it */
+  meos_errno_reset();
+  check("advancing a null cursor is refused",
+    ! rtree_nn_cursor_next(NULL, NULL, NULL) && meos_errno() != 0);
+
+  meos_errno_reset();
+  RTreeNNCursor *cursor = rtree_nn_cursor_open(rtree, box);
+  check("a query of the tree's own SRID is accepted",
+    cursor != NULL && meos_errno() == 0);
+  rtree_nn_cursor_close(cursor);
+  meos_errno_reset();
+
+  free(box); free(other);
+  rtree_free(rtree);
+  return;
+}
+
 int
 main(void)
 {
@@ -299,6 +351,7 @@ main(void)
 
   test_stbox_knn();
   test_tbox_knn();
+  test_refused();
 
   meos_finalize();
 

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -40,6 +40,7 @@
  * asserted per configuration and operator:
  *  (i)  no false negatives: every box satisfying the operator is a candidate;
  *  (ii) no false positives: every candidate satisfies the operator.
+ * What the nearest-neighbour cursor refuses to open on is asserted separately.
  *
  * The program can be built as follows
  * @code
@@ -861,6 +862,58 @@ test_nn_stbox(void)
   sptree_free(sptree);
 }
 
+/*****************************************************************************
+ * What the nearest-neighbour cursor refuses to open on
+ *
+ * A cursor validates its query box where the box becomes a query, so that the
+ * traversal that follows may assume it, exactly as #sptree_search does. The
+ * error handler installed here reports through #meos_errno instead of ending
+ * the program, so that the refusal is read as a value rather than observed as
+ * an exit
+ *****************************************************************************/
+
+static void
+test_nn_refused(void)
+{
+  meos_initialize_noexit_error_handler();
+
+  printf("What the NN SPTree cursor refuses to open on:\n");
+
+  SPTree *sptree = sptree_create_stbox(SPTREE_QUADTREE);
+  STBox *box = stbox_in("SRID=4326;STBOX X((0,0),(1,1))");
+  STBox *other = stbox_in("SRID=3857;STBOX X((0,0),(1,1))");
+  sptree_insert(sptree, box, 0);
+
+  meos_errno_reset();
+  check("  a query of another SRID is refused",
+    sptree_nn_cursor_open(sptree, other) == NULL && meos_errno() != 0);
+
+  meos_errno_reset();
+  check("  a null index is refused",
+    sptree_nn_cursor_open(NULL, box) == NULL && meos_errno() != 0);
+
+  meos_errno_reset();
+  check("  a null query is refused",
+    sptree_nn_cursor_open(sptree, NULL) == NULL && meos_errno() != 0);
+
+  /* A refused open answers NULL, so advancing that answer must report rather
+   * than read through it */
+  meos_errno_reset();
+  check("  advancing a null cursor is refused",
+    ! sptree_nn_cursor_next(NULL, NULL, NULL) && meos_errno() != 0);
+
+  meos_errno_reset();
+  SPNNCursor *cursor = sptree_nn_cursor_open(sptree, box);
+  check("  a query of the tree's own SRID is accepted",
+    cursor != NULL && meos_errno() == 0);
+  sptree_nn_cursor_close(cursor);
+  meos_errno_reset();
+
+  free(box); free(other);
+  sptree_free(sptree);
+  return;
+}
+
 
 /*****************************************************************************
  * Selective windows
@@ -1070,6 +1123,7 @@ main(void)
   test_nn_stbox();
   test_reported_size(SPTREE_QUADTREE, "quad-tree");
   test_reported_size(SPTREE_KDTREE, "k-d tree");
+  test_nn_refused();
 
   meos_finalize();
 


### PR DESCRIPTION
rtree_nn_cursor_open and sptree_nn_cursor_open validate their arguments and
their query box through ensure_valid_rtree_box and ensure_valid_sptree_box, the
same check rtree_search and sptree_search make, and answer NULL on a refusal.
rtree_nn_cursor_next and sptree_nn_cursor_next report a null cursor rather than
reading through it, so the NULL an open answers is carried safely by a caller
that does not test it.

The rule is the one those two validators state in their own docstring: a tree
holds boxes of one SRID, the first entry fixes it, and the check belongs at the
entry point so that every comparison the descent makes can assume it. A
nearest-neighbour traversal computes a box distance per node and per leaf entry,
which is the descent that assumption serves.

Witness: a tree holding SRID=4326;STBOX X((0,0),(1,1)) asked for the nearest
neighbours of SRID=3857;STBOX X((0,0),(1,1)) opened a cursor and reported
errno 0, and draining that cursor raised errno 12 once per entry and answered
every id at 1.79769e+308, so the whole tree came back tied at infinity in an
order the query never influenced. The same pair now answers NULL from the open
and errno 12 once, and SRID=4326;STBOX X((0,0),(1,1)) as its own query is
accepted and drains unchanged. A null index and a null query each read through
the pointer, the assert standing alone being compiled out under NDEBUG, which
the release configuration ships.

Measured against master 31867b4a13 built the same way, rtree_knn_test and
sptree_test each assert the five cases at the entry point: a query of another
SRID, a null index, a null query, advancing a null cursor, and a query of the
tree's own SRID, which is accepted. Against the master library both suites read
"a query of another SRID is refused FAIL" and then segmentation fault, so no
case passes by matching nothing; against this tree every case reads OK. No
caller of the four functions exists outside the two suites, so no SQL surface
moves and no committed answer changes.

