### PR TITLE
Join two indexes only where they hold one spatial reference system

### DIFF
--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -1389,6 +1389,22 @@ ensure_valid_rtree_box(const RTree *rtree, const void *box)
 }
 
 /**
+ * @brief Return true if two RTrees may be joined, report an error otherwise
+ * @details A join compares a box of one tree with a box of the other, which is
+ * the comparison #ensure_valid_rtree_box admits for a query, so the second
+ * tree's own box is what the first one is asked about. Every entry of a tree
+ * has passed that check on entry, so an overall box carries the SRID of every
+ * entry under it
+ */
+static bool
+ensure_valid_rtree_rtree(const RTree *rtree1, const RTree *rtree2)
+{
+  if (! rtree2->root)
+    return true;
+  return ensure_valid_rtree_box(rtree1, rtree2->box);
+}
+
+/**
  * @ingroup meos_temporal_box_index
  * @brief Build an RTree from all of its entries at once
  * @details Bottom-up Sort-Tile-Recursive packing. The result answers the same
@@ -1580,7 +1596,7 @@ rtree_join(const RTree *rtree1, const RTree *rtree2, IndexSearchOp op,
   VALIDATE_NOT_NULL(rtree1, INT_MAX); VALIDATE_NOT_NULL(rtree2, INT_MAX);
   VALIDATE_NOT_NULL(result, INT_MAX);
   if (! ensure_same_index_bboxtype(rtree1->bboxtype, rtree2->bboxtype) ||
-      ! ensure_index_join_op(op))
+      ! ensure_valid_rtree_rtree(rtree1, rtree2) || ! ensure_index_join_op(op))
     return INT_MAX;
 
   meos_array_reset(result);

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -681,6 +681,29 @@ ensure_valid_sptree_box(const SPTree *sptree, const void *box)
 }
 
 /**
+ * @brief Return true if two SPTrees may be joined, report an error otherwise
+ * @details A join compares a box of one tree with a box of the other, so the
+ * two trees answer the same question #ensure_valid_sptree_box asks of a query.
+ * Both trees hold their centroids in the internal box type, a tpcbox tree
+ * already projected to an @p STBox, so the two SRIDs compare directly rather
+ * than through that function's projection of an incoming box
+ */
+static bool
+ensure_valid_sptree_sptree(const SPTree *sptree1, const SPTree *sptree2)
+{
+  if (! sptree1->root || ! sptree2->root)
+    return true;
+  if (sptree1->bboxtype == T_STBOX
+#if POINTCLOUD
+      || sptree1->bboxtype == T_TPCBOX
+#endif /* POINTCLOUD */
+     )
+    return ensure_same_srid(((const STBox *) sptree1->root->centroid)->srid,
+      ((const STBox *) sptree2->root->centroid)->srid);
+  return true;
+}
+
+/**
  * @ingroup meos_temporal_box_index
  * @brief Insert a bounding box into an in-memory space-partitioning index
  * @details The box is stored at the first empty child slot reached while
@@ -1198,6 +1221,7 @@ sptree_join(const SPTree *sptree1, const SPTree *sptree2, IndexSearchOp op,
   VALIDATE_NOT_NULL(sptree1, INT_MAX); VALIDATE_NOT_NULL(sptree2, INT_MAX);
   VALIDATE_NOT_NULL(result, INT_MAX);
   if (! ensure_same_index_bboxtype(sptree1->bboxtype, sptree2->bboxtype) ||
+      ! ensure_valid_sptree_sptree(sptree1, sptree2) ||
       ! ensure_index_join_op(op))
     return INT_MAX;
 

--- a/meos/test/sptree_join_test.c
+++ b/meos/test/sptree_join_test.c
@@ -409,7 +409,52 @@ test_refused(void)
   check("the R-tree refuses a null index",
     rtree_join(rtree1, NULL, INDEX_OVERLAPS, result) == INT_MAX &&
     meos_errno() != 0);
+
+  /* A join reads a box of one index against a box of the other, which is the
+   * comparison one SRID makes meaningful, so a pair of indexes is refused
+   * exactly where a query box of another SRID is */
+  SPTree *sp4326 = sptree_create_stbox(SPTREE_QUADTREE);
+  SPTree *sp4326b = sptree_create_stbox(SPTREE_QUADTREE);
+  SPTree *sp3857 = sptree_create_stbox(SPTREE_QUADTREE);
+  RTree *rt4326 = rtree_create_stbox();
+  RTree *rt4326b = rtree_create_stbox();
+  RTree *rt3857 = rtree_create_stbox();
+  STBox *box4326 = stbox_in("SRID=4326;STBOX X((0,0),(1,1))");
+  STBox *box3857 = stbox_in("SRID=3857;STBOX X((0,0),(1,1))");
+  sptree_insert(sp4326, box4326, 0);
+  sptree_insert(sp4326b, box4326, 1);
+  sptree_insert(sp3857, box3857, 1);
+  rtree_insert(rt4326, box4326, 0);
+  rtree_insert(rt4326b, box4326, 1);
+  rtree_insert(rt3857, box3857, 1);
+
   meos_errno_reset();
+  check("indexes of different SRIDs are refused",
+    sptree_join(sp4326, sp3857, INDEX_OVERLAPS, result) == INT_MAX &&
+    meos_errno() != 0);
+
+  meos_errno_reset();
+  check("the R-tree refuses indexes of different SRIDs",
+    rtree_join(rt4326, rt3857, INDEX_OVERLAPS, result) == INT_MAX &&
+    meos_errno() != 0);
+
+  /* The SRID is what the refusal reads and not the pair: the same two boxes
+   * under one SRID are a reported pair, so neither case passes by joining
+   * nothing */
+  meos_errno_reset();
+  check("indexes of one SRID join",
+    sptree_join(sp4326, sp4326b, INDEX_OVERLAPS, result) == 1 &&
+    meos_errno() == 0);
+
+  meos_errno_reset();
+  check("the R-tree joins indexes of one SRID",
+    rtree_join(rt4326, rt4326b, INDEX_OVERLAPS, result) == 1 &&
+    meos_errno() == 0);
+  meos_errno_reset();
+
+  free(box4326); free(box3857);
+  sptree_free(sp4326); sptree_free(sp4326b); sptree_free(sp3857);
+  rtree_free(rt4326); rtree_free(rt4326b); rtree_free(rt3857);
 
   meos_array_destroy(result);
   free(box);


### PR DESCRIPTION
rtree_join and sptree_join establish through ensure_valid_rtree_rtree and
ensure_valid_sptree_sptree that their two indexes carry the same SRID, and
answer INT_MAX with an error where they do not. The RTree validator asks
ensure_valid_rtree_box what the second tree's own box is to the first, the
comparison that function already admits for a query box. The SPTree one reads
the two root centroids directly, both trees holding a centroid in the internal
box type, a tpcbox tree already projected to an STBox.

The rule is that one comparison answers for the pair: every entry of a tree
passes the same check on insert, so an overall box carries the SRID of every
entry beneath it, and a join of two trees is therefore refused or admitted at
the roots rather than per candidate pair inside the descent.

Witness: two STBox indexes holding the numerically equal boxes
SRID=4326;STBOX X((0,0),(1,1)) and SRID=3857;STBOX X((0,0),(1,1)) draw two
different wrong answers from the master library. rtree_join reports 1 pair and
errno 0, a match between boxes in unrelated reference systems, and sptree_join
reports 0 pairs and errno 12, raising inside the descent while still answering
a count. Against this branch both answer INT_MAX and errno 12, which is the
refusal a join of different bounding box types already gives, while those same
two boxes under one SRID stay a reported pair.

Measured against master 31867b4a13 built the same way, sptree_join_test asserts
the refusal for both trees and asserts beside it that the same two boxes under
one SRID are a reported pair, so the refusal reads the SRID and not the pair.
Against the master library the two refusal cases read FAIL and the two joins
read OK; against this tree all sixteen read OK. Nothing outside the join entry
points moves, so no SQL surface changes and no committed answer changes.

