### PR TITLE
Prove an areal interior overlap from a crossing of the two boundaries

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -5424,6 +5424,60 @@ relate_area_boundary_edge(const Edge *e)
 }
 
 /**
+ * @brief Return which side of the line through two points a third lies on, or
+ * zero where the double evaluation cannot be trusted to carry the sign
+ * @details The three points are INPUT VERTICES, so the question is the sign of
+ * one determinant and needs no tolerance: a band here would not protect the
+ * answer, it would decide it. What the sign does need is a guarantee that
+ * rounding has not eaten it, and that guarantee is a FILTER rather than a
+ * band. The bound is computed FROM THE OPERANDS and decides only whether the
+ * double is trustworthy, never what the answer is -- a wrong tolerance returns
+ * a WRONG answer where a wrong filter returns NO answer, and it is that
+ * asymmetry that makes the filter safe where a band is not. It is Shewchuk's
+ * bound, written in terms of @p DBL_EPSILON so that it is arithmetic rather
+ * than a constant anyone is invited to tune
+ * @return 1 or -1 for the two sides, 0 for collinear or unable to tell
+ */
+static int
+relate_orientation(double ax, double ay, double bx, double by, double cx,
+  double cy)
+{
+  double left = (bx - ax) * (cy - ay);
+  double right = (by - ay) * (cx - ax);
+  double det = left - right;
+  double bound = (3.0 + 16.0 * DBL_EPSILON) * DBL_EPSILON *
+    (fabs(left) + fabs(right));
+  if (det > bound)
+    return 1;
+  if (det < - bound)
+    return -1;
+  return 0;
+}
+
+/**
+ * @brief Return true if two straight edges properly cross
+ * @details Proper means each edge carries the endpoints of the other STRICTLY
+ * on either side of it, so the two meet at a single point interior to both.
+ * Four determinants on the four input vertices decide it, with no point
+ * constructed and no tolerance anywhere. An endpoint that merely touches, a
+ * collinear pair, and a sign the filter declines to carry all read as NOT
+ * crossing, which leaves each of those to the routes that already answer them
+ */
+static bool
+relate_edges_cross(const Edge *e1, const Edge *e2)
+{
+  int d1 = relate_orientation(e1->x1, e1->y1, e1->x2, e1->y2, e2->x1, e2->y1);
+  int d2 = relate_orientation(e1->x1, e1->y1, e1->x2, e1->y2, e2->x2, e2->y2);
+  if (d1 == 0 || d2 == 0 || d1 == d2)
+    return false;
+  int d3 = relate_orientation(e2->x1, e2->y1, e2->x2, e2->y2, e1->x1, e1->y1);
+  if (d3 == 0)
+    return false;
+  int d4 = relate_orientation(e2->x1, e2->y1, e2->x2, e2->y2, e1->x2, e1->y2);
+  return d4 != 0 && d3 != d4;
+}
+
+/**
  * @brief Compute a point on an areal boundary edge.
  * @details 
  *   t = 0 -> first endpoint
@@ -5926,6 +5980,66 @@ relate_area_interior_point_located(const RelateEdges *self,
 }
 
 /**
+ * @brief Return true if a boundary edge of one areal geometry properly crosses
+ * a boundary edge of the other
+ * @details Where two boundaries cross transversally, the four sectors around
+ * the crossing point are the four combinations of inside and outside, so one
+ * of them lies interior to BOTH and the interiors share a two-dimensional set.
+ * The whole proof is the sign of four determinants on four INPUT VERTICES.
+ * Nothing is constructed, so nothing has to be classified within a tolerance,
+ * and that is what lets this see an overlap too thin for a sampled witness to
+ * land in: a sliver a couple of units in the last place wide is narrower than
+ * the band every point-location route reads, yet its crossing vertices are
+ * exactly the ones the determinants are taken on.
+ * Arcs are left to the other routes. The endpoints of an arc do not determine
+ * the curve between them, so four signs taken on them say nothing about
+ * whether the arcs meet
+ * @param[in] a,b Edges of the two geometries, the second read out of its index
+ * where it carries one
+ */
+static bool
+relate_area_boundaries_cross(const RelateEdges *a, const RelateEdges *b)
+{
+  for (int i = 0; i < a->nedges; i++)
+  {
+    const Edge *ea = a->edges[i];
+    if (ea->etype != EDGE_POLYSEG)
+      continue;
+    if (! b->index)
+    {
+      for (int j = 0; j < b->nedges; j++)
+      {
+        const Edge *eb = b->edges[j];
+        if (eb->etype == EDGE_POLYSEG && relate_edges_cross(ea, eb))
+          return true;
+      }
+      continue;
+    }
+    /* Two segments that cross meet at a point lying on both, so that point is
+     * in both boxes and the boxes overlap. The query therefore needs NO
+     * padding: an unpadded box already admits every crossing there is, and
+     * unlike the point-location queries the test behind it reads no tolerance
+     * that a pad would have to match */
+    STBox query;
+    stbox_set(true, false, false, 0, ea->xmin, ea->xmax, ea->ymin, ea->ymax,
+      0, 0, NULL, &query);
+    MeosArray *candidates = meos_array_create(sizeof(int64));
+    int nc = rtree_search(b->index, INDEX_OVERLAPS, &query, candidates);
+    bool result = false;
+    for (int c = 0; c < nc && ! result; c++)
+    {
+      const Edge *eb = b->edges[*(int64 *) meos_array_get(candidates, c)];
+      if (eb->etype == EDGE_POLYSEG)
+        result = relate_edges_cross(ea, eb);
+    }
+    meos_array_destroy(candidates);
+    if (result)
+      return true;
+  }
+  return false;
+}
+
+/**
  * @brief Determine whether the interiors of two areal geometries
  * intersect in dimension 2.
  */
@@ -5958,12 +6072,26 @@ relate_area_interiors_intersect(const RelateEdges *a, const RelateEdges *b)
       return true;
   }
 
-  /* Finally handle coincident boundaries / complete containment
+  /* Handle coincident boundaries / complete containment
    * where every tested vertex may lie on the other boundary.
    * An interior witness of either geometry inside the other answers it */
   if (relate_area_interior_point_located(a, b, 0))
     return true;
   if (relate_area_interior_point_located(b, a, 0))
+    return true;
+
+  /* Every route above answers by LOCATING A POINT, and each one a tolerance
+   * decides: a vertex of one geometry, a point sampled along a boundary edge,
+   * an interior witness stepped off the boundary. Where the two interiors
+   * share only a sliver thinner than that tolerance, no such point can be
+   * placed inside it -- the sliver's own corners are intersection points
+   * belonging to neither vertex set, and any witness constructed within it
+   * falls inside the band of both boundaries. All of them therefore decline
+   * while the interiors do share area.
+   * A crossing of the two boundaries proves that area without locating
+   * anything, so it is asked last: it costs an index probe per boundary edge
+   * and answers only what the routes above have already given up on */
+  if (relate_area_boundaries_cross(a, b))
     return true;
   return false;
 }

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -231,6 +231,56 @@ int main(void)
     free(self);
   }
 
+  /* Two areas whose boundaries CROSS share area, however little of it, so
+   * they do not merely touch. Every route the engine had to a two-dimensional
+   * interior meeting answers by LOCATING A POINT -- a vertex of one geometry
+   * inside the other, a point sampled along a boundary edge, an interior
+   * witness stepped off the boundary -- and each of those is classified within
+   * a band that grows with the size of the coordinates. Where the shared
+   * region is thinner than that band no such point can be placed inside it, so
+   * every route declines and the interiors read as disjoint.
+   * The record below is that case at its smallest: a rectangle, and a thin
+   * triangle above it whose apex dips TWO UNITS IN THE LAST PLACE below the
+   * rectangle's top edge, at projected coordinates near 6.2e6 where one unit
+   * in the last place is 9.3e-10. The apex lies inside the rectangle and
+   * nearer to its boundary than the on-boundary band, so it is located ON the
+   * boundary and no vertex test can answer; the shared sliver is real all the
+   * same, and exact rational arithmetic puts its area strictly above zero.
+   * Answering otherwise tells a user that two overlapping areas TOUCH, which
+   * is the opposite of the truth. A real protected-area pair fails the same
+   * way for the same reason, at a sliver 2.1 units in the last place wide */
+  const char *sliver_a =
+    "POLYGON((711278.96999999997 6212855.6200000001,"
+    "711278.98999999999 6212855.6200000001,"
+    "711278.98999999999 6212854.6200000001,"
+    "711278.96999999997 6212854.6200000001,"
+    "711278.96999999997 6212855.6200000001))";
+  const char *sliver_b =
+    "POLYGON((711278.97499999998 6212856.6200000001,"
+    "711278.98499999999 6212856.6200000001,"
+    "711278.97999999998 6212855.6199999982,"
+    "711278.97499999998 6212856.6200000001))";
+  char sliver_patt[10] = "2********";
+  GSERIALIZED *sliver_geo_a = geom_in(sliver_a, -1);
+  GSERIALIZED *sliver_geo_b = geom_in(sliver_b, -1);
+  assert(sliver_geo_a != NULL);
+  assert(sliver_geo_b != NULL);
+  meos_errno_reset();
+  bool sliver_overlaps = geom_relate_pattern(sliver_geo_a, sliver_geo_b,
+    sliver_patt);
+  printf("geom_relate_pattern(rectangle, crossing triangle, interiors meet in "
+    "area): %d, errno %d\n", sliver_overlaps, meos_errno());
+  assert(sliver_overlaps == true);
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+  bool sliver_touches = geom_touches(sliver_geo_a, sliver_geo_b);
+  printf("geom_touches(rectangle, crossing triangle): %d, errno %d\n",
+    sliver_touches, meos_errno());
+  assert(sliver_touches == false);
+  assert(meos_errno() == 0);
+  free(sliver_geo_a); free(sliver_geo_b);
+  meos_errno_reset();
+
   /* A boundary node that two pieces of a buffer meet at is computed twice,
    * once by each of them, and on projected coordinates the two results sit
    * apart by far more than a coordinate is stored to. Reading them as two


### PR DESCRIPTION
Every route relate_area_interiors_intersect has to ii=2 answers by
LOCATING A POINT: a vertex of one geometry inside the other, a point
sampled along a boundary edge, an interior witness stepped off the
boundary. Each is classified within a tolerance that grows with the size
of the coordinates, so where two interiors share only a sliver thinner
than that band, none of them can answer. The sliver's own corners are
intersection points belonging to neither vertex set, and any witness
constructed inside it falls within the band of both boundaries, so all
four routes decline while the interiors do share area.

This adds a fifth route: two boundary edges that properly CROSS prove
ii=2. It is asked last, after every existing route declines, and reads
the edges it tests out of the index the pair already builds. A crossing
point lies in both edge boxes, so the query needs no padding, and unlike
the point-location queries the test behind it reads no tolerance a pad
would have to match. Arcs are left to the other routes, since the
endpoints of an arc do not determine the curve between them.

WITNESS

  SELECT ST_Relate(
    'POLYGON((711278.96999999997 6212855.6200000001,
              711278.98999999999 6212855.6200000001,
              711278.98999999999 6212854.6200000001,
              711278.96999999997 6212854.6200000001,
              711278.96999999997 6212855.6200000001))'::geometry,
    'POLYGON((711278.97499999998 6212856.6200000001,
              711278.98499999999 6212856.6200000001,
              711278.97999999998 6212855.6199999982,
              711278.97499999998 6212856.6200000001))'::geometry);

A rectangle, and a thin triangle whose apex dips two units in the last
place below the rectangle's top edge at coordinates near 6.2e6, where one
unit in the last place is 9.3e-10. Before: FF2F01212, and ST_Touches
answers true. After: 2F2F01212, and ST_Touches answers false. The apex
lies inside the rectangle but nearer to its boundary than the
on-boundary band, so it is located ON the boundary and no vertex test
can answer, while the shared sliver is real.

The same failure on real data: a protected-area pair whose boundaries
cross in a sliver 2.1 units in the last place wide at coordinates of
6.2e6, where the band is 5.9. Its matrix read FF2F11212 and now reads
2F2F11212.

WHY the new answer is the right one

Where two boundaries cross transversally, the four sectors around the
crossing point are the four combinations of inside and outside, so one of
them lies interior to BOTH and the interiors share a two-dimensional set.
That is a fact about the model, not about the arithmetic, and it is
decided by the sign of four determinants on four INPUT VERTICES --
nothing is constructed, so nothing has to be classified within a band.

The sign is FILTERED, not banded, and the difference is the whole safety
argument. The bound is computed from the operands and expressed in
DBL_EPSILON, so it decides only whether the double evaluation is
trustworthy, never what the answer is: a wrong tolerance returns a WRONG
answer where a wrong filter returns NO answer. A sign the filter declines
to carry reads as no crossing, leaving that case exactly where it was.
No new tolerance constant is introduced.

The truth here is not a second engine's opinion. The input coordinates
are doubles and every double is an exact dyadic rational, so the shared
area is a specific rational number, exactly zero or exactly positive.
Computed in exact rational arithmetic it is 2.0221907532862514e-18 for
the real pair, and strictly above zero for the witness above.

MEASURED

Judged against that exact shared area over 931 h3 cell boundaries and
the real pair, the II cell goes from 917 of 918 correct to 918 of 918.
Both arms judge the same 918 pairs and decline the same 14, so the gain
is not a change of denominator.

What did NOT move: self-identity, relate(g,g) == 2FFF1FFF2, stays at
1864 of 1864 on the same corpus. The count of matrices differing from
GEOS is unchanged at 1 of 1 judged; that residual difference is IB and
BI, a separate defect in the midpoint-sampling path which this change
does not touch and which needs its own fix. pg_regress passes in full on
PostgreSQL 18, and the meos.yml test step runs clean.

Timing, interleaved A/B read as a ratio, median of the laps:
  1444 areal pairs, 7 laps, 3 reps    -> 0.9888
  the 10473 x 43924-edge pair, 5 laps -> 0.9952
Neither shows a measurable cost; the route exits at the first crossing
and costs one index probe per boundary edge otherwise.

The regression witness in geo_test.c is the pasteable pair above. It is
proven in both directions: built against the previous library it aborts
on the first assertion, and passes here.

