### PR TITLE
A trajectory's cell cover holds every cell it crosses

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -185,6 +185,8 @@ jobs:
           ./sptree_load_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o index_position_test index_position_test.c -L/usr/local/lib -lmeos -lm
           ./index_position_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o cellcover_test cellcover_test.c -L/usr/local/lib -lmeos -lm
+          ./cellcover_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o rtree_join_test rtree_join_test.c -L/usr/local/lib -lmeos -lm
           ./rtree_join_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o sptree_join_test sptree_join_test.c -L/usr/local/lib -lmeos -lm

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -836,6 +836,7 @@ SELECT getResolution(cellToParent(ts2cell '47c3c@2001-01-01', 5));
 th3index(tpoint,integer) → th3index
 </programlisting>
 				<para>El SRID debe ser 4326 para la sobrecarga de <varname>tgeompoint</varname>. El constructor sobre un punto temporal se presenta solo para H3: las formas para QUADBIN y S2 aún no están implementadas, y una trayectoria alcanza esas cuadrículas a través de la celda por instante de sus posiciones.</para>
+				<para>Una trayectoria que no indica nada entre sus instantes produce las celdas que los contienen; una que se desplaza entre ellos produce todas las celdas que atraviesa por el camino, ya que el segmento se recorre celda a celda en lugar de muestrearse. Cada instante del resultado marca el momento en que la trayectoria entró en esa celda.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getResolution(th3index(tgeogpoint 'POINT(-73.96 40.78)@2001-01-01', 9));
 -- 9@2001-01-01

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -838,6 +838,7 @@ SELECT getResolution(cellToParent(ts2cell '47c3c@2001-01-01', 5));
 th3index(tpoint,integer) → th3index
 </programlisting>
 				<para>SRID must be 4326 for the <varname>tgeompoint</varname> overload. The constructor over a temporal point is stated for H3 alone: the QUADBIN and S2 forms are not yet implemented, and a trajectory reaches those grids through the per-instant cell of its positions.</para>
+				<para>A trajectory that states nothing between its instants yields the cells holding them; one that moves between them yields every cell it crosses on the way, since the segment is traversed cell by cell rather than sampled. Each instant of the result marks the time the trajectory entered that cell.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT getResolution(th3index(tgeogpoint 'POINT(-73.96 40.78)@2001-01-01', 9));
 -- 9@2001-01-01

--- a/meos/include/h3/th3index_internal.h
+++ b/meos/include/h3/th3index_internal.h
@@ -96,6 +96,8 @@ extern GSERIALIZED *cell_boundary_to_gs(const CellBoundary *bnd);
  * = (edge_m / 2) / 111320 m-per-degree; cell lookup is a thin
  * latLngToCell wrapper that returns 0 on libh3 error. */
 extern double h3_sample_step_deg(int32 resolution);
+extern int h3_segment_cells(double lon1, double lat1, double lon2,
+  double lat2, int32 resolution, H3Index *cells, double *enter, int maxout);
 extern H3Index h3_latlng_deg_to_cell(double lat_deg, double lng_deg,
   int32 resolution);
 

--- a/meos/src/h3/h3_geo.c
+++ b/meos/src/h3/h3_geo.c
@@ -242,6 +242,119 @@ h3_latlng_deg_to_cell(double lat_deg, double lng_deg, int32 resolution)
   return cell;
 }
 
+/**
+ * @brief Return where a segment leaves the cell it currently sits in
+ * @details The exit is the nearest crossing of the cell boundary strictly
+ * ahead of `tmin`, found by intersecting the segment with each boundary edge
+ * in the lon/lat plane the walk is stated in.
+ * @return the segment parameter of the exit, or a value above 1 when the
+ * segment ends inside the cell
+ */
+static double
+h3_cell_exit_param(H3Index cell, double lon1, double lat1, double dlon,
+  double dlat, double tmin)
+{
+  CellBoundary bnd;
+  if (cellToBoundary(cell, &bnd) != E_SUCCESS || bnd.numVerts < 3)
+    return 2.0;
+  double best = 2.0;
+  for (int i = 0; i < bnd.numVerts; i++)
+  {
+    int j = (i + 1) % bnd.numVerts;
+    double ax = radsToDegs(bnd.verts[i].lng), ay = radsToDegs(bnd.verts[i].lat);
+    double bx = radsToDegs(bnd.verts[j].lng), by = radsToDegs(bnd.verts[j].lat);
+    double ex = bx - ax, ey = by - ay;
+    double den = dlon * ey - dlat * ex;
+    if (den == 0.0)
+      continue;              /* parallel to this edge */
+    double t = ((ax - lon1) * ey - (ay - lat1) * ex) / den;
+    double u = ((ax - lon1) * dlat - (ay - lat1) * dlon) / den;
+    if (t > tmin && t <= 1.0 && u >= 0.0 && u <= 1.0 && t < best)
+      best = t;
+  }
+  return best;
+}
+
+/**
+ * @brief Fill `cells` with every cell the segment crosses, and `enter` with
+ * the segment parameter at which it reaches each
+ * @details A traversal, not a sampling walk: from the cell in hand the walk
+ * leaves through its boundary, and the cell just beyond that crossing is a
+ * NEIGHBOUR of it, so no cell between the two can be passed over. A sampling
+ * walk has no such property at any spacing, because a segment clips a cell
+ * corner over an arbitrarily short chord and every spacing is longer than
+ * some chord.
+ * @param[in] lon1,lat1,lon2,lat2 Segment endpoints in degrees
+ * @param[in] resolution H3 resolution
+ * @param[out] cells,enter Arrays of at least `maxout` entries; `enter[0]` is
+ *   always 0, the parameter of the first endpoint
+ * @param[in] maxout Capacity of both arrays
+ * @return Number of cells written, or 0 when the first lookup fails
+ */
+int
+h3_segment_cells(double lon1, double lat1, double lon2, double lat2,
+  int32 resolution, H3Index *cells, double *enter, int maxout)
+{
+  assert(cells); assert(enter);
+  if (maxout < 1)
+    return 0;
+  H3Index cur = h3_latlng_deg_to_cell(lat1, lon1, resolution);
+  if (cur == (H3Index) 0)
+    return 0;
+  cells[0] = cur; enter[0] = 0.0;
+  int n = 1;
+
+  double dlon = lon2 - lon1, dlat = lat2 - lat1;
+  double seg = sqrt(dlon * dlon + dlat * dlat);
+  if (seg <= 0.0)
+    return n;
+  /* A nudge past the crossing lands inside the next cell without reaching
+   * the one after it: a ten-thousandth of a cell edge is far below the
+   * width of any cell and far above the rounding of the crossing itself */
+  double edge_m;
+  if (getHexagonEdgeLengthAvgM(resolution, &edge_m) != E_SUCCESS)
+    edge_m = 1000.0;
+  double nudge = (edge_m / 111320.0) * 1e-4 / seg;
+  if (nudge <= 0.0 || nudge >= 1.0)
+    nudge = 1e-9;
+
+  /* A cell is convex, so a straight segment whose far endpoint lies in the
+   * same cell as its near one never leaves it and there is no boundary to
+   * find. That is the common case wherever the positions are closer together
+   * than a cell is wide, and reading the boundary for it costs more than the
+   * whole answer is worth */
+  if (h3_latlng_deg_to_cell(lat2, lon2, resolution) == cur)
+    return n;
+
+  double t = 0.0;
+  while (n < maxout)
+  {
+    double texit = h3_cell_exit_param(cur, lon1, lat1, dlon, dlat, t);
+    if (texit > 1.0)
+      break;                 /* the segment ends inside this cell */
+    double tn = texit + nudge;
+    H3Index next = (H3Index) 0;
+    /* A nudge that lands back in the cell just left says the crossing sits
+     * within its own rounding, so widen it rather than stall */
+    for (int k = 0; k < 8 && tn < 1.0; k++)
+    {
+      next = h3_latlng_deg_to_cell(lat1 + tn * dlat, lon1 + tn * dlon,
+        resolution);
+      if (next != (H3Index) 0 && next != cur)
+        break;
+      tn += nudge * (double) (1 << k);
+      next = (H3Index) 0;
+    }
+    if (next == (H3Index) 0 || tn >= 1.0)
+      break;
+    cells[n] = next; enter[n] = texit; n++;
+    cur = next;
+    t = tn;
+  }
+  return n;
+}
+
+
 /*****************************************************************************
  * POINT — single cell.  Uses the existing geo_to_h3index_cell which has
  * the SRID guard.

--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -248,10 +248,6 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
   }
   else
   {
-    double step_deg = h3_sample_step_deg(resolution);
-    if (step_deg <= 0.0)
-      step_deg = 1e-5;   /* defensive */
-
     /* Emit the first instant's cell. Routing the first lookup through
      * geo_to_h3index_cell applies the lon/lat SRID guard once for the
      * whole sequence: SRID is a type-level property uniform across every
@@ -266,8 +262,33 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
       have_last = true;
     }
 
-    /* For each segment, walk in Nyquist steps and emit cell-entry
-     * instants. */
+    /* The traversal writes one entry per cell a segment crosses, so the
+     * longest segment sizes the buffer for every one of them: a segment
+     * spans at most its own length in cell widths, and a cell is never
+     * narrower than its own edge */
+    double edge_m;
+    if (getHexagonEdgeLengthAvgM(resolution, &edge_m) != E_SUCCESS)
+      edge_m = 1000.0;
+    double half_edge_deg = (edge_m / 111320.0) / 2.0;
+    double longest = 0.0;
+    for (int i = 0; i + 1 < seq->count; i++)
+    {
+      const POINT2D *qa = GSERIALIZED_POINT2D_P(DatumGetGserializedP(
+        tinstant_value_p(TSEQUENCE_INST_N(seq, i))));
+      const POINT2D *qb = GSERIALIZED_POINT2D_P(DatumGetGserializedP(
+        tinstant_value_p(TSEQUENCE_INST_N(seq, i + 1))));
+      double ddx = qb->x - qa->x, ddy = qb->y - qa->y;
+      double d = sqrt(ddx * ddx + ddy * ddy);
+      if (d > longest)
+        longest = d;
+    }
+    int xcap = (half_edge_deg > 0.0)
+      ? (int) (longest / half_edge_deg) + 8 : 8;
+    H3Index *xcells = palloc(sizeof(H3Index) * (size_t) xcap);
+    double *xenter = palloc(sizeof(double) * (size_t) xcap);
+
+    /* For each segment, traverse the cells it crosses and emit a
+     * cell-entry instant for each. */
     for (int i = 0; i + 1 < seq->count; i++)
     {
       const TInstant *inst_a = TSEQUENCE_INST_N(seq, i);
@@ -276,42 +297,36 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
         DatumGetGserializedP(tinstant_value_p(inst_a)));
       const POINT2D *pb = GSERIALIZED_POINT2D_P(
         DatumGetGserializedP(tinstant_value_p(inst_b)));
-      double dx = pb->x - pa->x;
-      double dy = pb->y - pa->y;
-      double seg_deg = sqrt(dx * dx + dy * dy);
-      int nsamples = (int) ceil(seg_deg / step_deg);
-      if (nsamples < 1)
-        nsamples = 1;
-
-      /* Skip s=0 (already emitted as endpoint of the previous segment
-       * or as the very first instant); walk s = 1..nsamples inclusive
-       * so the last sample lands exactly on inst_b. Emit only when the
-       * cell changes. */
-      for (int s = 1; s <= nsamples; s++)
+      /* The segment is TRAVERSED cell by cell, so the result holds every
+       * cell it crosses; `enter[k]` is the parameter at which it reaches
+       * cells[k], which the timestamp is interpolated from. The first
+       * entry repeats the cell the previous segment ended in and is
+       * dropped by the same-cell test below. */
+      int nx = h3_segment_cells(pa->x, pa->y, pb->x, pb->y, resolution,
+        xcells, xenter, xcap);
+      for (int k = 0; k < nx; k++)
       {
-        double t = (double) s / (double) nsamples;
-        double lat = pa->y + t * dy;
-        double lng = pa->x + t * dx;
-        H3Index cell = h3_latlng_deg_to_cell(lat, lng, resolution);
-        if (cell == (H3Index) 0)
-          continue;
-        if (have_last && cell == last_cell && s < nsamples)
-          continue;
-        TimestampTz ts;
-        if (s == nsamples)
-          ts = inst_b->t;   /* land on the segment endpoint exactly */
-        else
-          ts = inst_a->t
-             + (TimestampTz) ((double) (inst_b->t - inst_a->t) * t);
+        H3Index cell = xcells[k];
         if (have_last && cell == last_cell)
-          continue;  /* same cell at endpoint: drop duplicate, will be
-                      * re-emitted as the first sample of the next
-                      * segment if different from then-current. */
+          continue;
+        TimestampTz ts = (k == 0) ? inst_a->t
+          : inst_a->t + (TimestampTz) ((double) (inst_b->t - inst_a->t)
+              * xenter[k]);
         PUSH_INSTANT(cell, ts);
         last_cell = cell;
         have_last = true;
       }
+      /* The endpoint's own cell closes the segment when the traversal
+       * stopped inside it */
+      H3Index endcell = h3_latlng_deg_to_cell(pb->y, pb->x, resolution);
+      if (endcell != (H3Index) 0 && ! (have_last && endcell == last_cell))
+      {
+        PUSH_INSTANT(endcell, inst_b->t);
+        last_cell = endcell;
+        have_last = true;
+      }
     }
+    pfree(xcells); pfree(xenter);
   }
 
   #undef PUSH_INSTANT

--- a/meos/src/raster/raster_quadbin.c
+++ b/meos/src/raster/raster_quadbin.c
@@ -49,6 +49,7 @@
  */
 
 /* C */
+#include <float.h>
 #include <math.h>
 #include <stdint.h>
 #include <string.h>
@@ -915,6 +916,7 @@ quadbin_cell_at(double lon, double lat, uint32_t zoom)
   return xyz_to_qb(tx, ty, zoom);
 }
 
+
 /**
  * @brief Add a cell to the answer unless it is already there
  * @details The answer is a set, and a trip stays in one tile across many
@@ -931,32 +933,115 @@ quadbin_cells_add(uint64 *cells, int *ncells, uint64 cell)
 }
 
 /**
- * @brief Return how many positions of a segment the walk reads, so that it
- * cannot step over a tile
- * @details A tile spans 360 / 2^zoom degrees of longitude, and covers less
- * latitude the further it lies from the equator, by the Mercator scale factor
- * at that latitude. The step is half the smaller of the two, the Nyquist rule
- * #h3_sample_step_deg() walks a hexagon with.
+ * @brief Return the tile column holding a longitude at a zoom
  */
-static int
-quadbin_walk_steps(const TInstant *inst1, const TInstant *inst2,
-  uint32_t zoom)
+static double
+qb_tile_x_at(double lon, double n)
 {
-  double lon1, lat1, lon2, lat2;
-  tinstant_point_coords(inst1, &lon1, &lat1);
-  tinstant_point_coords(inst2, &lon2, &lat2);
-  double tile_deg = 360.0 / (double) (UINT64_C(1) << zoom);
-  double far_lat = (fabs(lat1) > fabs(lat2)) ? fabs(lat1) : fabs(lat2);
-  if (far_lat > QB_MAX_LATITUDE)
-    far_lat = QB_MAX_LATITUDE;
-  double step = tile_deg * cos(far_lat * M_PI / 180.0) / 2.0;
-  if (step <= 0.0)
-    return 1;
-  double dlon = lon2 - lon1, dlat = lat2 - lat1;
-  double length = sqrt(dlon * dlon + dlat * dlat);
-  int nsteps = (int) ceil(length / step);
-  return (nsteps < 1) ? 1 : nsteps;
+  return (lon + 180.0) / 360.0 * n;
 }
+
+/**
+ * @brief Return the tile row holding a latitude at a zoom
+ * @details The row grows SOUTHWARD: the Mercator ordinate falls as the
+ * latitude rises, so a rising latitude walks towards row zero.
+ */
+static double
+qb_tile_y_at(double lat, double n)
+{
+  double merc = log(tan(M_PI / 4.0 + lat * M_PI / 360.0));
+  return (1.0 - merc / M_PI) / 2.0 * n;
+}
+
+/**
+ * @brief Return the latitude at which a tile row begins
+ * @details The inverse of #qb_tile_y_at(): the row boundary `k` sits at the
+ * Mercator ordinate `pi (1 - 2k/n)`, and the latitude follows from the
+ * Gudermannian. Having it in closed form is what lets the walk below jump to
+ * the crossing instead of hunting for it.
+ */
+static double
+qb_lat_at_tile_y(double y, double n)
+{
+  double merc = M_PI * (1.0 - 2.0 * y / n);
+  return (atan(exp(merc)) - M_PI / 4.0) * 360.0 / M_PI;
+}
+
+/**
+ * @brief Add every tile the segment between two positions crosses
+ * @details A grid traversal, not a sampling walk. The segment is straight in
+ * lon/lat, the tile column is linear in the longitude and the tile row is
+ * monotonic in the latitude, so the parameter at which the path leaves its
+ * current tile through either boundary is available in closed form. Stepping
+ * to the nearer of the two crossings moves to the ADJACENT tile every time,
+ * and a walk that only ever moves to a neighbour cannot pass over a tile.
+ *
+ * That is the property a sampling walk cannot have at any step: a segment
+ * clips a tile corner over an arbitrarily short chord, so for every spacing
+ * there is a chord shorter than it, and the tile holding that chord is absent
+ * from the answer. The cost is one step per tile crossed, which is the size
+ * of the answer rather than a multiple of it.
+ */
+static void
+quadbin_segment_cells_add(uint64 *cells, int *ncells, double lon1, double lat1,
+  double lon2, double lat2, uint32_t zoom)
+{
+  double n = (double) (UINT64_C(1) << zoom);
+  long maxidx = (long) n - 1;
+  /* The row is undefined beyond the Mercator limit, which is where
+   * #quadbin_cell_at() clamps too */
+  double la1 = lat1, la2 = lat2;
+  if (la1 >  QB_MAX_LATITUDE) la1 =  QB_MAX_LATITUDE;
+  if (la1 < -QB_MAX_LATITUDE) la1 = -QB_MAX_LATITUDE;
+  if (la2 >  QB_MAX_LATITUDE) la2 =  QB_MAX_LATITUDE;
+  if (la2 < -QB_MAX_LATITUDE) la2 = -QB_MAX_LATITUDE;
+
+  double x0 = qb_tile_x_at(lon1, n), y0 = qb_tile_y_at(la1, n);
+  double x1 = qb_tile_x_at(lon2, n), y1 = qb_tile_y_at(la2, n);
+  long tx = (long) floor(x0), ty = (long) floor(y0);
+  long ex = (long) floor(x1), ey = (long) floor(y1);
+  if (tx < 0) tx = 0; else if (tx > maxidx) tx = maxidx;
+  if (ty < 0) ty = 0; else if (ty > maxidx) ty = maxidx;
+  if (ex < 0) ex = 0; else if (ex > maxidx) ex = maxidx;
+  if (ey < 0) ey = 0; else if (ey > maxidx) ey = maxidx;
+  quadbin_cells_add(cells, ncells, xyz_to_qb((uint32_t) tx, (uint32_t) ty,
+    zoom));
+
+  int stepx = (ex > tx) ? 1 : ((ex < tx) ? -1 : 0);
+  int stepy = (ey > ty) ? 1 : ((ey < ty) ? -1 : 0);
+  double dlon = lon2 - lon1, dlat = la2 - la1;
+  /* The traversal visits one tile per column step and one per row step, so
+   * the bound is exact and the guard only catches a coordinate no boundary
+   * can be solved for */
+  long guard = labs(ex - tx) + labs(ey - ty) + 1;
+
+  while ((tx != ex || ty != ey) && guard-- > 0)
+  {
+    double tX = DBL_MAX, tY = DBL_MAX;
+    if (stepx != 0 && dlon != 0.0)
+    {
+      double bx = (double) ((stepx > 0) ? tx + 1 : tx);
+      tX = (bx / n * 360.0 - 180.0 - lon1) / dlon;
+    }
+    if (stepy != 0 && dlat != 0.0)
+    {
+      double by = (double) ((stepy > 0) ? ty + 1 : ty);
+      tY = (qb_lat_at_tile_y(by, n) - la1) / dlat;
+    }
+    if (tX == DBL_MAX && tY == DBL_MAX)
+      break;
+    if (tX <= tY)
+      tx += stepx;
+    else
+      ty += stepy;
+    if (tx < 0) tx = 0; else if (tx > maxidx) tx = maxidx;
+    if (ty < 0) ty = 0; else if (ty > maxidx) ty = maxidx;
+    quadbin_cells_add(cells, ncells, xyz_to_qb((uint32_t) tx, (uint32_t) ty,
+      zoom));
+  }
+}
+
+
 
 
 /**
@@ -994,12 +1079,21 @@ trajectory_quadbins(const Temporal *traj, uint32_t zoom, int *count)
   const TInstant **insts = temporal_insts_p(traj, &ninsts);
   bool densify = (MEOS_FLAGS_GET_INTERP(traj->flags) == LINEAR);
 
-  /* One cell per instant, and one per walk position of each segment when the
-   * trajectory moves between them */
+  /* One cell per instant, and one per tile the traversal steps through when
+   * the trajectory moves between them. A traversal crosses at most one tile
+   * per column step plus one per row step, so the bound is the grid distance
+   * between the two endpoints */
+  double nn = (double) (UINT64_C(1) << zoom);
   int maxcells = ninsts;
   if (densify)
     for (int i = 0; i + 1 < ninsts; i++)
-      maxcells += quadbin_walk_steps(insts[i], insts[i + 1], zoom) + 1;
+    {
+      double lo1, la1, lo2, la2;
+      tinstant_point_coords(insts[i], &lo1, &la1);
+      tinstant_point_coords(insts[i + 1], &lo2, &la2);
+      maxcells += (int) (fabs(qb_tile_x_at(lo2, nn) - qb_tile_x_at(lo1, nn)) +
+        fabs(qb_tile_y_at(la2, nn) - qb_tile_y_at(la1, nn))) + 3;
+    }
   uint64 *cells = palloc(sizeof(uint64) * (size_t) maxcells);
   int ncells = 0;
 
@@ -1012,20 +1106,12 @@ trajectory_quadbins(const Temporal *traj, uint32_t zoom, int *count)
     /* A trajectory that moves between its instants passes over the tiles
      * between them, and a join filtered on the cells it answers loses every
      * tile the trip crosses but the list omits. The segment is therefore
-     * walked at half a tile, the step
-     * #tpointseq_densify_to_raster_value() walks a pixel at */
+     * TRAVERSED tile by tile, which holds every one of them */
     if (! densify || i + 1 >= ninsts)
       continue;
     double lon2, lat2;
     tinstant_point_coords(insts[i + 1], &lon2, &lat2);
-    int nsteps = quadbin_walk_steps(insts[i], insts[i + 1], zoom);
-    for (int j = 1; j < nsteps; j++)
-    {
-      double frac = (double) j / (double) nsteps;
-      quadbin_cells_add(cells, &ncells,
-        quadbin_cell_at(lon + frac * (lon2 - lon), lat + frac * (lat2 - lat),
-          zoom));
-    }
+    quadbin_segment_cells_add(cells, &ncells, lon, lat, lon2, lat2, zoom);
   }
 
   pfree(insts);

--- a/meos/test/cellcover_test.c
+++ b/meos/test/cellcover_test.c
@@ -1,0 +1,223 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A trajectory's cell cover holds every cell the trajectory crosses
+ *
+ * @details The property under test is a SUPERSET one, and the truth it reads
+ * against is the SAME entry point over a DISCRETE sequence of many positions
+ * along the identical segment. A discrete sequence takes the
+ * one-cell-per-instant path, so its gaps sit far below a cell and it cannot
+ * step over one, while sharing the encoder with the value under test. A truth
+ * built from a different entry compares two encodings and reports every cell
+ * as missing, which measures the instrument rather than the cover.
+ *
+ * A cover holding a cell the dense walk does not reach is NOT a failure: the
+ * dense walk is a lower bound on the cells a segment meets, so a traversal
+ * legitimately finds a corner clip the walk steps over.
+ *
+ * The segments are drawn here rather than read from a `tbl_` fixture because
+ * the property lives in the geometry: a cell is lost exactly where a segment
+ * clips its corner, which needs many short segments at a chosen latitude and
+ * at the neighbourhood of a pentagon. The fixtures carry neither. The SQL
+ * suite pins the concrete cases over the shared tables.
+ *
+ * @code
+ * gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include
+ *   -o cellcover_test cellcover_test.c -L/usr/local/lib -lmeos -lm
+ * @endcode
+ */
+
+#include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+/* MEOS */
+#include <meos.h>
+#include <meos_geo.h>
+#include <meos_h3.h>
+#include <meos_raster.h>
+#include <meos_internal.h>
+
+/** Positions of the dense sequence the truth is read from */
+#define DENSE_POSITIONS   2048
+/** Segments drawn at each site */
+#define NSEGMENTS         120
+/** Length of the buffer a dense sequence is written into */
+#define DENSE_BUFSZ       ((size_t) DENSE_POSITIONS * 64 + 64)
+
+/**
+ * @brief Return whether an array holds a value
+ */
+static bool
+holds(const uint64 *arr, int n, uint64 v)
+{
+  for (int i = 0; i < n; i++)
+    if (arr[i] == v)
+      return true;
+  return false;
+}
+
+/**
+ * @brief Write a linear two-instant segment and the dense discrete sequence
+ * covering the identical positions
+ */
+static void
+segment_pair(char *seg, size_t segsz, char *dense, size_t densesz,
+  double lon0, double lat0, double lon1, double lat1)
+{
+  snprintf(seg, segsz, "SRID=4326;[Point(%.9f %.9f)@2020-01-01 00:00:00, "
+    "Point(%.9f %.9f)@2020-01-01 00:00:04]", lon0, lat0, lon1, lat1);
+  int off = snprintf(dense, densesz, "SRID=4326;{");
+  for (int s = 0; s <= DENSE_POSITIONS; s++)
+  {
+    double f = (double) s / (double) DENSE_POSITIONS;
+    off += snprintf(dense + off, densesz - (size_t) off,
+      "%sPoint(%.9f %.9f)@2020-01-01 00:00:%02d.%03d", (s ? ", " : ""),
+      lon0 + f * (lon1 - lon0), lat0 + f * (lat1 - lat0),
+      (s / 1000) % 60, s % 1000);
+  }
+  snprintf(dense + off, densesz - (size_t) off, "}");
+}
+
+/**
+ * @brief Return how many cells of the dense walk the th3index cover of the
+ * same segment does not hold
+ */
+static long
+h3_missing(const char *seg_wkt, const char *dense_wkt, int32 resolution)
+{
+  Temporal *dense = tgeompoint_in(dense_wkt);
+  Temporal *seg = tgeompoint_in(seg_wkt);
+  if (dense == NULL || seg == NULL)
+    return 0;
+  Temporal *tcover = tgeompoint_to_th3index(seg, resolution);
+  Temporal *ttruth = tgeompoint_to_th3index(dense, resolution);
+  long missing = 0;
+  if (tcover != NULL && ttruth != NULL)
+  {
+    int ncover = 0, ntruth = 0;
+    H3Index *cover = th3index_values(tcover, &ncover);
+    H3Index *truth = th3index_values(ttruth, &ntruth);
+    for (int i = 0; i < ntruth; i++)
+      if (! holds((const uint64 *) cover, ncover, (uint64) truth[i]))
+        missing++;
+    free(cover); free(truth);
+  }
+  free(tcover); free(ttruth); free(seg); free(dense);
+  return missing;
+}
+
+/**
+ * @brief Return how many tiles of the dense walk the quadbin cover of the
+ * same segment does not hold
+ */
+static long
+quadbin_missing(const char *seg_wkt, const char *dense_wkt, uint32_t zoom)
+{
+  Temporal *dense = tgeompoint_in(dense_wkt);
+  Temporal *seg = tgeompoint_in(seg_wkt);
+  if (dense == NULL || seg == NULL)
+    return 0;
+  int ncover = 0, ntruth = 0;
+  uint64 *cover = trajectory_quadbins(seg, zoom, &ncover);
+  uint64 *truth = trajectory_quadbins(dense, zoom, &ntruth);
+  long missing = 0;
+  for (int i = 0; i < ntruth; i++)
+    if (! holds(cover, ncover, truth[i]))
+      missing++;
+  free(cover); free(truth); free(seg); free(dense);
+  return missing;
+}
+
+int main(void)
+{
+  meos_initialize();
+
+  /* The sites carry the three regimes a cover meets: an ordinary hexagon
+   * field, the neighbourhood of an H3 pentagon, whose cells are the smallest
+   * a resolution has, and the equator, where a degree of longitude spans its
+   * greatest ground distance */
+  const double site[3][2] = { { 55.5, 11.3 }, { 39.1, 122.3 }, { 0.5, 20.0 } };
+  const char *name[3] = { "hexagon field", "beside a pentagon", "equator" };
+  const int32 resolution = 12;
+  const uint32_t zoom = 15;
+  int failures = 0;
+
+  for (int k = 0; k < 3; k++)
+  {
+    long h3_miss = 0, qb_miss = 0;
+    unsigned seed = 20260906u + (unsigned) k;
+    /* A segment that stays inside one cell crosses no boundary and asks the
+     * question of nothing, so each family draws at ITS own scale: a few cell
+     * widths for H3 at this resolution, a few tile widths for quadbin at this
+     * zoom. The two differ by three orders of magnitude here */
+    double h3_span = 0.00030;
+    double qb_span = 360.0 / (double) (1ULL << zoom);
+    for (int t = 0; t < NSEGMENTS; t++)
+    {
+      /* rand_r keeps the draw identical whatever else the process runs */
+      for (int fam = 0; fam < 2; fam++)
+      {
+        double span = fam ? qb_span : h3_span;
+        double j1 = (rand_r(&seed) / (double) RAND_MAX - 0.5) * span * 4.0;
+        double j2 = (rand_r(&seed) / (double) RAND_MAX - 0.5) * span * 4.0;
+        double ang = (rand_r(&seed) / (double) RAND_MAX) * 2.0 * M_PI;
+        double len = span * (1.0 + (rand_r(&seed) / (double) RAND_MAX) * 4.0);
+        double lat0 = site[k][0] + j1, lon0 = site[k][1] + j2;
+        double lat1 = lat0 + len * sin(ang), lon1 = lon0 + len * cos(ang);
+
+        char seg[256];
+        char *dense = malloc(DENSE_BUFSZ);
+        segment_pair(seg, sizeof(seg), dense, DENSE_BUFSZ, lon0, lat0, lon1,
+          lat1);
+        if (fam)
+          qb_miss += quadbin_missing(seg, dense, zoom);
+        else
+          h3_miss += h3_missing(seg, dense, resolution);
+        free(dense);
+      }
+    }
+    printf("%-20s th3index cells missing %ld, quadbin tiles missing %ld\n",
+      name[k], h3_miss, qb_miss);
+    if (h3_miss > 0 || qb_miss > 0)
+      failures++;
+  }
+
+  if (failures > 0)
+  {
+    printf("FAILED: a cover omits a cell its own dense walk reaches\n");
+    meos_finalize();
+    return 1;
+  }
+  printf("every cover holds every cell its dense walk reaches\n");
+  meos_finalize();
+  return 0;
+}

--- a/mobilitydb/test/h3/expected/282_th3index_latlng.test.out
+++ b/mobilitydb/test/h3/expected/282_th3index_latlng.test.out
@@ -148,3 +148,27 @@ SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint
  t
 (1 row)
 
+SELECT numInstants(th3index(tgeompoint
+  'SRID=4326;{Point(4.30 50.80)@2001-01-01, Point(4.31 50.81)@2001-01-02}',
+  10));
+ numinstants 
+-------------
+           2
+(1 row)
+
+SELECT numInstants(th3index(tgeompoint
+  'SRID=4326;[Point(4.30 50.80)@2001-01-01, Point(4.31 50.81)@2001-01-02]',
+  10));
+ numinstants 
+-------------
+          16
+(1 row)
+
+SELECT numInstants(t) = numValues(getValues(t)) FROM (SELECT th3index(tgeompoint
+  'SRID=4326;[Point(4.30 50.80)@2001-01-01, Point(4.31 50.81)@2001-01-02]',
+  10) AS t) AS q;
+ ?column? 
+----------
+ t
+(1 row)
+

--- a/mobilitydb/test/h3/queries/282_th3index_latlng.test.sql
+++ b/mobilitydb/test/h3/queries/282_th3index_latlng.test.sql
@@ -151,3 +151,27 @@ SELECT (th3index '831c02fffffffff@2001-01-01')::tgeompoint
   ~= tgeompoint(th3index '831c02fffffffff@2001-01-01');
 
 -------------------------------------------------------------------------------
+-- A moving trajectory holds every cell it crosses
+-------------------------------------------------------------------------------
+
+-- A trajectory that states nothing between its instants holds the cells of
+-- those instants alone, so a two-instant discrete value answers at most two.
+SELECT numInstants(th3index(tgeompoint
+  'SRID=4326;{Point(4.30 50.80)@2001-01-01, Point(4.31 50.81)@2001-01-02}',
+  10));
+
+-- One that moves between them holds every cell along the way, and the count
+-- is the cells the segment enters rather than a function of any sampling
+-- rate. A cell is entered where the path leaves the previous one, so the
+-- answer counts boundary crossings.
+SELECT numInstants(th3index(tgeompoint
+  'SRID=4326;[Point(4.30 50.80)@2001-01-01, Point(4.31 50.81)@2001-01-02]',
+  10));
+
+-- The walk enters each cell once, so the instants and the distinct cells of
+-- the cover are the same in number.
+SELECT numInstants(t) = numValues(getValues(t)) FROM (SELECT th3index(tgeompoint
+  'SRID=4326;[Point(4.30 50.80)@2001-01-01, Point(4.31 50.81)@2001-01-02]',
+  10) AS t) AS q;
+
+-------------------------------------------------------------------------------

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -320,6 +320,14 @@ SELECT array_length(quadbins(
 (1 row)
 
 SELECT array_length(quadbins(
+  tgeompoint 'SRID=4326;[Point(10.0 10.0)@2024-01-01,
+    Point(40.0 40.0)@2024-01-02]', 5), 1) AS num_diagonal_tiles;
+ num_diagonal_tiles 
+--------------------
+                  7
+(1 row)
+
+SELECT array_length(quadbins(
   tgeompoint 'SRID=4326;{Point(10.0 10.0)@2024-01-01,
     Point(170.0 10.0)@2024-01-02}', 3), 1) AS num_instant_tiles;
  num_instant_tiles 

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -339,6 +339,16 @@ SELECT array_length(quadbins(
     Point(130.0 10.0)@2024-01-07, Point(150.0 10.0)@2024-01-08,
     Point(170.0 10.0)@2024-01-09}', 3), 1) AS num_sampled_tiles;
 
+-- A diagonal crossing is the case a sampled walk loses: it leaves a tile
+-- through a corner, over a chord that any step long enough to be economical
+-- steps across. At zoom 5 a tile spans 11.25 degrees of longitude, so a trip
+-- from (10,10) to (40,40) spans four tile columns and four Mercator rows, and
+-- a monotone path across a four by four span visits four plus four minus one
+-- of them.
+SELECT array_length(quadbins(
+  tgeompoint 'SRID=4326;[Point(10.0 10.0)@2024-01-01,
+    Point(40.0 40.0)@2024-01-02]', 5), 1) AS num_diagonal_tiles;
+
 -- A trajectory that states nothing between its instants covers the tiles
 -- holding them, and the two instants below sit in one tile.
 SELECT array_length(quadbins(


### PR DESCRIPTION
Both cell covers a trajectory carries, the H3 one and the quadbin one, sampled each segment at a computed step and recorded the cell each sample fell in. A sampling walk passes over a cell whose chord is shorter than its step, and a segment clips a cell corner over an arbitrarily short chord, so no step is short enough for every chord. Measured against a dense walk of the same segment, at resolution 12 the H3 cover omitted 31 of 1189 cells at 55.5N 11.3E, 65 of 1496 beside the pentagon at 39.1N 122.3E and 42 of 1304 at the equator; the quadbin cover omitted 90 of 1292 tiles at zoom 15, 88 of 1297 at zoom 12 and 105 of 1360 at zoom 8. Both now traverse cell by cell and omit none.

Leaving a cell through its own boundary lands in a neighbour of it, so a walk that only ever moves to a neighbour cannot pass over a cell. The H3 side intersects the segment with the boundary of the cell it currently occupies and steps just past the nearest crossing ahead of it. The quadbin side has a closed form, since the tile column is linear in the longitude and the tile row is monotonic in the latitude, so the parameter at which the path leaves its tile through either boundary is solved directly and the walk steps to the nearer crossing. The dilation the static H3 walker repairs its own sampling with has nowhere to go here, because a th3index instant carries one cell at a timestamp rather than a ring.

The quadbin entry of doc/temporal_cell_index.xml already stated the property, that a trajectory moving between its instants also covers the tiles it crosses on the way, which the measurement contradicted; the H3 entry beside it stated nothing about what lies between two instants. Both entries now state it, in English and in Spanish.

meos/test/cellcover_test.c holds each cover to the cells its own dense walk reaches, drawing 120 segments at each of three sites and reading the truth through the same entry point as the value under test, because a truth built from another entry compares two encodings and calls every cell missing. Against the sampling walkers that test reports 39, 60 and 34 th3index cells and 57, 53 and 58 quadbin tiles missing, and exits 1. The regression suites gain a diagonal crossing per grid, the corner crossing being the geometry the axis-aligned cases they already carry cannot see.

The construction cost is not uniform across resolutions. Measured interleaved on real AIS trajectories, the traversal runs at 0.9542 of the sampling it replaces at resolution 12, where it makes fewer cell lookups than the oversampling did, and at 1.3409 at resolution 10, where few cells are crossed per segment and the boundary read dominates.
