### PR TITLE
Separate two cell crossings falling in the same microsecond

### DIFF
--- a/meos/src/h3/th3index_latlng.c
+++ b/meos/src/h3/th3index_latlng.c
@@ -221,10 +221,26 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
   int ninsts = 0;
   H3Index last_cell = (H3Index) 0;
   bool have_last = false;
+  TimestampTz last_ts = 0;
+  bool have_ts = false;
 
-  /* Helper: push (cell, ts) into the result, growing if needed. */
+  /* Helper: push (cell, ts) into the result, growing if needed.
+   *
+   * A cell's entry time is interpolated from the parameter at which the
+   * path reaches it, while a timestamp holds whole microseconds, so two
+   * crossings closer together than one microsecond round to the same
+   * instant. A path passing near a vertex, where three cells meet, leaves
+   * one cell and enters the next over such a distance. A sequence requires
+   * increasing timestamps, so the second crossing is placed one microsecond
+   * after the first: that is the smallest separation the type can state, it
+   * keeps the order the crossings occur in, and it keeps the cell. Dropping
+   * the crossing instead would omit a cell the path passes through, which is
+   * the omission the traversal exists to remove. */
   #define PUSH_INSTANT(_cell, _ts)                                    \
     do {                                                              \
+      TimestampTz ts_ = (_ts);                                        \
+      if (have_ts && ts_ <= last_ts)                                  \
+        ts_ = last_ts + 1;                                            \
       if (ninsts >= maxcount)                                         \
       {                                                               \
         maxcount = (maxcount * 2 > ninsts + 1)                        \
@@ -233,7 +249,9 @@ tpointseq_densify_to_th3index(const TSequence *seq, int32 resolution)
                                       * (size_t) maxcount);           \
       }                                                               \
       instants[ninsts++] = tinstant_make(H3IndexGetDatum(_cell),      \
-                                         T_TH3INDEX, (_ts));          \
+                                         T_TH3INDEX, ts_);            \
+      last_ts = ts_;                                                  \
+      have_ts = true;                                                 \
     } while (0)
 
   if (! densify)

--- a/meos/test/cellcover_test.c
+++ b/meos/test/cellcover_test.c
@@ -109,7 +109,11 @@ segment_pair(char *seg, size_t segsz, char *dense, size_t densesz,
 
 /**
  * @brief Return how many cells of the dense walk the th3index cover of the
- * same segment does not hold
+ * same segment does not hold, or -1 where a conversion answers nothing
+ *
+ * A conversion that fails answers NULL, and counting that as "no cell is
+ * missing" reports a cover that was never built as a sound one, so it is
+ * carried back as its own answer rather than folded into the count.
  */
 static long
 h3_missing(const char *seg_wkt, const char *dense_wkt, int32 resolution)
@@ -117,10 +121,10 @@ h3_missing(const char *seg_wkt, const char *dense_wkt, int32 resolution)
   Temporal *dense = tgeompoint_in(dense_wkt);
   Temporal *seg = tgeompoint_in(seg_wkt);
   if (dense == NULL || seg == NULL)
-    return 0;
+    return -1;
   Temporal *tcover = tgeompoint_to_th3index(seg, resolution);
   Temporal *ttruth = tgeompoint_to_th3index(dense, resolution);
-  long missing = 0;
+  long missing = (tcover != NULL && ttruth != NULL) ? 0 : -1;
   if (tcover != NULL && ttruth != NULL)
   {
     int ncover = 0, ntruth = 0;
@@ -173,7 +177,7 @@ int main(void)
 
   for (int k = 0; k < 3; k++)
   {
-    long h3_miss = 0, qb_miss = 0;
+    long h3_miss = 0, qb_miss = 0, h3_none = 0;
     unsigned seed = 20260906u + (unsigned) k;
     /* A segment that stays inside one cell crosses no boundary and asks the
      * question of nothing, so each family draws at ITS own scale: a few cell
@@ -201,14 +205,55 @@ int main(void)
         if (fam)
           qb_miss += quadbin_missing(seg, dense, zoom);
         else
-          h3_miss += h3_missing(seg, dense, resolution);
+        {
+          long m = h3_missing(seg, dense, resolution);
+          if (m < 0)
+            h3_none++;
+          else
+            h3_miss += m;
+        }
         free(dense);
       }
     }
     printf("%-20s th3index cells missing %ld, quadbin tiles missing %ld\n",
       name[k], h3_miss, qb_miss);
-    if (h3_miss > 0 || qb_miss > 0)
+    if (h3_none > 0)
+      printf("  %ld th3index cover(s) were not built at all\n", h3_none);
+    if (h3_miss > 0 || qb_miss > 0 || h3_none > 0)
       failures++;
+  }
+
+  /* A cover states the time the path enters each cell, and a timestamp holds
+   * whole microseconds, so a segment crossing more cells than its span holds
+   * microseconds reaches two of them within one. The value must still be
+   * built: the entry ORDER is what a step sequence carries, and the cells are
+   * what a cover is for, so the two entries are separated by the smallest
+   * step the type can state rather than one of them being dropped.
+   *
+   * The case is drawn here directly, because the same coincidence arises over
+   * an ordinary span wherever a path passes near a vertex, where three cells
+   * meet -- and a draw that waits for that is a test that usually does not
+   * run. Crossing a kilometre of resolution-12 cells in five microseconds
+   * forces it every time. */
+  {
+    const char *fast = "SRID=4326;"
+      "[Point(11.300000000 55.500000000)@2020-01-01 00:00:00, "
+      "Point(11.315000000 55.500000000)@2020-01-01 00:00:00.000005]";
+    Temporal *seg = tgeompoint_in(fast);
+    Temporal *cover = (seg != NULL) ?
+      tgeompoint_to_th3index(seg, resolution) : NULL;
+    int ncells = 0;
+    H3Index *cells = (cover != NULL) ? th3index_values(cover, &ncells) : NULL;
+    printf("%-20s cells %d\n", "crossings in one us", ncells);
+    if (cover == NULL || ncells < 2)
+    {
+      printf("FAILED: a segment crossing cells faster than a microsecond "
+        "builds no cover\n");
+      failures++;
+    }
+    if (cells != NULL)
+      free(cells);
+    free(cover); free(seg);
   }
 
   if (failures > 0)


### PR DESCRIPTION
Witness: a trajectory crossing a kilometre of resolution-12 cells in five
microseconds reaches 71 of them. Against the master library the conversion
answers nothing and raises "Timestamps for temporal value must be
increasing"; against this branch it answers all 71. The same coincidence
arises over an ordinary span wherever a path passes near a vertex, where
three cells meet: one day of Danish AIS traffic reaches it within 3000
trajectories at resolution 12, and a month's sweep of the cover stops at
every resolution from 7 through 12.

Measured: the cover holds every cell its own dense walk reaches, 0 missing
at each of the three sites, against both libraries.

Why a microsecond apart rather than one of the two crossings dropped: a
cover states which cells a path passes through and in what order, and the
timestamps carry that order rather than measuring anything on their own. An
entry time is interpolated from the parameter at which the path reaches the
cell, while a timestamp holds whole microseconds, so two crossings closer
together than one are indistinguishable in time at the type's resolution
while the order between them remains known. Separating them by the smallest
step the type expresses states exactly that much and claims nothing further.
Dropping one answers a different question: the cell is one the path passes
through, so a cover omitting it is not conservative and no prefilter built
on it is sound, which is the omission a traversal exists to remove.

The suite draws the case rather than waiting for a random segment to pass
near a vertex, which is a test that usually does not run, and a conversion
answering nothing counts as its own failure instead of as no cell missing.

