### PR TITLE
Bound each collinear test by the quantity it actually measures

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -369,15 +369,27 @@ linesegm_intersect(double ax, double ay, double rx, double ry,
   /* Collinear / parallel */
   if (fabs(rxs) < MEOS_GEOM_TOLERANCE)
   {
+    /* The two segments run in one direction; what is left to decide is
+     * whether they run along the SAME LINE or along two parallel ones. Both
+     * quantities that answer it are areas rather than lengths, and each needs
+     * a threshold in its own units:
+     * - r2 is the squared length of AB, so its bound is the SQUARE of the
+     *   tolerance. Bounded by the plain tolerance it rejects every segment
+     *   shorter than that tolerance's square root, which is 1e-6, and such a
+     *   segment then fails to overlap even an identical copy of itself.
+     * - qpxr is the cross product of AC with AB, which is the separation of
+     *   the two lines TIMES the length of AB. Bounded by the plain tolerance
+     *   it stands for a separation of tolerance/|AB|, so two lines far apart
+     *   read as one line whenever AB is short enough. Dividing by the length
+     *   puts the bound back on the separation, where it belongs. */
+    double r2 = rx * rx + ry * ry;
+    if (r2 < MEOS_GEOM_TOLERANCE * MEOS_GEOM_TOLERANCE)
+      return res;
+
     /* Is point C aligned with segment AB? */
     double qpxr = qpx * ry - qpy * rx;
     /* If qpxr != 0: parallel, if qpxr == 0: collinear */
-    if (fabs(qpxr) > MEOS_GEOM_TOLERANCE)
-      return res;
-
-    /* Collinear case */
-    double r2 = rx * rx + ry * ry;
-    if (r2 < MEOS_GEOM_TOLERANCE)
+    if (fabs(qpxr) > MEOS_GEOM_TOLERANCE * sqrt(r2))
       return res;
 
     double t0 = (qpx * rx + qpy * ry) / r2;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -281,6 +281,92 @@ int main(void)
   free(sliver_geo_a); free(sliver_geo_b);
   meos_errno_reset();
 
+  /* Two areas that share a boundary edge meet along a LINE, however short
+   * that edge is. The engine reads the shared stretch from the segment
+   * kernel, whose collinear branch first rejects a segment of no length by
+   * comparing rx*rx + ry*ry against the geometry tolerance -- a length SQUARED
+   * against a length. The threshold therefore stands at the square root of the
+   * constant, so every edge shorter than 1e-6 is treated as having no length
+   * and reports no overlap, even against an identical copy of itself. Two
+   * areas sharing such an edge are then said to meet at a POINT.
+   * The record below is that case at projected metres, with the shared edge
+   * taken from real protected-area data where it is 3.3e-9 long, beside the
+   * same construction at one unit which the engine has always read correctly */
+  const char *tiny_a =
+    "POLYGON((605623.93903347489 6235507.9605894219,"
+    "605623.93903347803 6235507.9605894228,"
+    "605624.5 6235508.5,605623.93903347489 6235507.9605894219))";
+  const char *tiny_b =
+    "POLYGON((605623.93903347489 6235507.9605894219,"
+    "605623.93903347803 6235507.9605894228,"
+    "605624.5 6235507.0,605623.93903347489 6235507.9605894219))";
+  const char *long_a = "POLYGON((0 0,1 0,0.5 1,0 0))";
+  const char *long_b = "POLYGON((0 0,1 0,0.5 -1,0 0))";
+  char meet_line[10] = "****1****";
+  const char *shared_wkt[2][2] = {{long_a, long_b}, {tiny_a, tiny_b}};
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *sa = geom_in(shared_wkt[i][0], -1);
+    GSERIALIZED *sb = geom_in(shared_wkt[i][1], -1);
+    assert(sa != NULL);
+    assert(sb != NULL);
+    meos_errno_reset();
+    bool meets_line = geom_relate_pattern(sa, sb, meet_line);
+    printf("geom_relate_pattern(two areas sharing %s edge, meet along a "
+      "line): %d, errno %d\n", i ? "a 3.3e-9" : "a one-unit", meets_line,
+      meos_errno());
+    assert(meets_line == true);
+    assert(meos_errno() == 0);
+    free(sa); free(sb);
+  }
+  meos_errno_reset();
+
+  /* Two areas whose boundaries run PARALLEL never touch, however close they
+   * come. Deciding that means asking whether the two lines are one line, and
+   * the engine answers it from the cross product of the offset between them
+   * with one of their directions -- a separation TIMES a length, bounded by a
+   * plain length. The bound therefore stands for a separation of that length
+   * divided by the segment's, so two lines far apart read as one whenever the
+   * segments are short enough, and the areas are then said to meet.
+   * The record below is a rectangle and a copy of it offset by 2e-8, both a
+   * ten-millionth across, at coordinates near 1e-7. They are disjoint, and
+   * their boundaries are 2e-8 apart -- twenty times the geometry tolerance.
+   * The same pair scaled up by 1e8 sits beside it as the control: the defect
+   * is the LENGTH of the segments and nothing else about the configuration */
+  const char *par_small_a =
+    "POLYGON((0 0,1e-07 1e-07,1.1e-07 9e-08,1e-08 -1e-08,0 0))";
+  const char *par_small_b =
+    "POLYGON((1.414213562373095e-08 -1.414213562373095e-08,"
+    "1.1414213562373095e-07 8.585786437626905e-08,"
+    "1.2414213562373095e-07 7.585786437626905e-08,"
+    "2.414213562373095e-08 -2.414213562373095e-08,"
+    "1.414213562373095e-08 -1.414213562373095e-08))";
+  const char *par_big_a =
+    "POLYGON((0 0,10 10,11 9,1 -1,0 0))";
+  const char *par_big_b =
+    "POLYGON((1.414213562373095 -1.414213562373095,"
+    "11.414213562373095 8.585786437626905,"
+    "12.414213562373095 7.585786437626905,"
+    "2.414213562373095 -2.414213562373095,"
+    "1.414213562373095 -1.414213562373095))";
+  const char *par_wkt[2][2] = {{par_big_a, par_big_b},
+                               {par_small_a, par_small_b}};
+  for (int i = 0; i < 2; i++)
+  {
+    GSERIALIZED *pa = geom_in(par_wkt[i][0], -1);
+    GSERIALIZED *pb = geom_in(par_wkt[i][1], -1);
+    assert(pa != NULL);
+    assert(pb != NULL);
+    meos_errno_reset();
+    bool par_int = geom_intersects2d(pa, pb);
+    printf("geom_intersects2d(two areas %s apart along parallel boundaries): "
+      "%d, errno %d\n", i ? "2e-8" : "2 units", par_int, meos_errno());
+    assert(par_int == false);
+    assert(meos_errno() == 0);
+    free(pa); free(pb);
+  }
+  meos_errno_reset();
+
   /* A boundary node that two pieces of a buffer meet at is computed twice,
    * once by each of them, and on projected coordinates the two results sit
    * apart by far more than a coordinate is stored to. Reading them as two


### PR DESCRIPTION
The collinear branch of linesegm_intersect decides whether two segments
running in one direction lie along the SAME line or along two parallel
ones. It asks that with two quantities, and both are areas bounded by a
length:

    if (fabs(qpxr) > MEOS_GEOM_TOLERANCE)   /* qpxr is separation * |AB| */
      return res;
    double r2 = rx * rx + ry * ry;
    if (r2 < MEOS_GEOM_TOLERANCE)           /* r2 is |AB| squared */
      return res;

r2 is a squared length, so its threshold has to be the SQUARE of the
tolerance; bounded by the plain one it rejects every segment shorter than
that tolerance's square root, which is 1e-6, and such a segment then
fails to overlap even an identical copy of itself.

qpxr is the cross product of AC with AB, which is the separation of the
two lines TIMES the length of AB. Bounded by a plain length the test
stands for a separation of tolerance/|AB|, so two lines far apart read as
one line whenever AB is short enough. Dividing by the length puts the
bound back on the separation.

THE TWO ARE COUPLED AND SHIP TOGETHER. The r2 guard is what stops the
qpxr misreading from being reached, so correcting r2 alone turns a
silent misclassification into a wrong answer, and correcting qpxr alone
changes nothing the r2 guard still refuses to reach.

WITNESS

  SELECT ST_Relate(
    'POLYGON((605623.93903347489 6235507.9605894219,
              605623.93903347803 6235507.9605894228,
              605624.5 6235508.5,
              605623.93903347489 6235507.9605894219))'::geometry,
    'POLYGON((605623.93903347489 6235507.9605894219,
              605623.93903347803 6235507.9605894228,
              605624.5 6235507.0,
              605623.93903347489 6235507.9605894219))'::geometry);

Two triangles sharing one boundary edge 3.3e-9 long, at projected metres,
the edge taken from real protected-area data. Before: FF2F01212, whose BB
cell reads 0 -- the two areas MEET AT A POINT. After: FF2F11212, BB = 1,
they meet along a LINE, which is what a shared edge is. The same
construction with a one-unit shared edge answers FF2F11212 both before
and after and is kept beside it as the control: the defect is the LENGTH
of the edge and nothing else about the shape.

WHY the new answer is the right one

Two areas whose boundaries have a segment in common meet along a set of
dimension 1, and no length makes that less true. Two areas whose
boundaries merely run parallel never meet at all, however short the
segments are. Both statements are about the geometry; neither is an
approximation that a tolerance may trade away. A threshold expressed in
the units of the value it bounds says exactly that, and one expressed in
other units says it only over the range of sizes it happens to suit.

THE REGIME THE CHANGE MOVES, stated in closed form: the effective bound
on the separation of the two lines goes from tolerance/|AB| to a flat
tolerance, so the two agree at |AB| = 1 and diverge either side. For a
segment longer than a unit the new bound is the looser one, and what it
newly admits as collinear is a separation below 1e-12, which is the
tolerance the engine calls indistinguishable everywhere else.

MEASURED

The 2x2, because neither correction alone is right:

                        shipped qpxr        corrected qpxr
    shipped r2          BB=0, buffer ok     BB=0, buffer ok
    corrected r2        BB=1, buffer FAILS  BB=1, buffer ok

The failing cell is a real one: a plain CIRCULARSTRING buffered at scale
1e-8 declines with "the buffer of the geometry is not supported", because
two offsets of one arc that lie 2e-8 apart are read as collinear,
reported as overlapping, and the ring is then found to intersect itself.

Over 931 h3 cell boundaries and a protected-area pair: self-identity,
relate(g,g) == 2FFF1FFF2, holds at 1864 of 1864; the II cell judged
against the exact shared area computed in rational arithmetic holds at
918 of 918; the count of matrices differing from GEOS is unchanged.
Judged against an exact oracle over 1444 areal pairs, the two
boundary-interior cells are right 1444 of 1444 before and after. A scale
sweep of four shapes over seven scales is unmoved. pg_regress passes in
full on PostgreSQL 18 and the meos.yml test step runs clean.

geo_test.c carries the pasteable pair above with its one-unit control,
proven in both directions: built against the previous library it aborts
on its assertion, and passes here. It also carries two areas whose
boundaries run parallel 2e-8 apart, which must read as disjoint. That
second record is a COUPLING GUARD rather than a witness -- the previous
library answers it correctly, because its r2 guard stops the misreading
being reached -- and it fails on the intermediate state where r2 is
corrected and qpxr is not.

