### PR TITLE
Read a split boundary piece off the shared stretch without a tolerance

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -3621,6 +3621,27 @@ relate_point_in_area_index(double x, double y, const RelateEdges *re)
     re->xmax) ? 0 : 2;
 }
 
+/**
+ * @brief Return whether a point is inside or outside the area an edge array
+ * bounds, for a caller that already knows the point is not on its boundary
+ * @details #relate_point_in_area_index answers ON THE BOUNDARY first, and that
+ * question is the one a tolerance decides: a point within the band of an edge
+ * reads as carried by it. A caller holding a point that PROVABLY misses the
+ * boundary gets a wrong answer from that test and only a wrong one, so this
+ * reads the even-odd parity alone -- the same parity, over the same edges, with
+ * the band that cannot apply left out
+ * @return 0 for the interior and 2 for the exterior, as #relate_point_in_area
+ * reports them
+ */
+static int
+relate_point_in_area_parity(double x, double y, const RelateEdges *re)
+{
+  if (! re->index)
+    return point_in_polygon(x, y, re->edges, re->nedges) ? 0 : 2;
+  return point_in_polygon_index(x, y, re->edges, re->nedges, re->index,
+    re->xmax) ? 0 : 2;
+}
+
 /*****************************************************************************
  * DE-9IM / ST_Relate
  *****************************************************************************/
@@ -5688,6 +5709,12 @@ relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
   int nparams = 0;
   params[nparams++] = 0.0;
   params[nparams++] = 1.0;
+  /* The stretches along which this edge RUNS ON the other boundary rather than
+   * meeting it at a point. Every other part of the edge misses that boundary
+   * entirely, which is what lets the classification below drop a tolerance */
+  double *shlo = palloc(sizeof(double) * maxparams);
+  double *shhi = palloc(sizeof(double) * maxparams);
+  int nshared = 0;
   /* The edges this one can meet are those whose box meets its own, and an index
    * answers them in the place of a pass over the whole array. A boundary of a
    * few thousand edges leaves every pair but a handful standing apart, so the
@@ -5728,6 +5755,21 @@ relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
         relate_area_add_parameter(relate_area_edge_parameter(edge, oedge->x2,
           oedge->y2), params, &nparams, maxparams);
       }
+      /* Keep the stretch itself, not only its ends: a point of the edge inside
+       * it lies ON the other boundary, and no parity test can say so */
+      if (nshared < maxparams)
+      {
+        double ta = relate_area_edge_parameter(edge, oedge->x1, oedge->y1);
+        double tb = relate_area_edge_parameter(edge, oedge->x2, oedge->y2);
+        double lo = fmax(0.0, fmin(ta, tb));
+        double hi = fmin(1.0, fmax(ta, tb));
+        if (hi > lo)
+        {
+          shlo[nshared] = lo;
+          shhi[nshared] = hi;
+          nshared++;
+        }
+      }
       continue;
     }
     for (int k = 0; k < n; k++)
@@ -5759,7 +5801,21 @@ relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
     double t = (params[i] + params[i + 1]) * 0.5;
     double x, y;
     relate_area_edge_point(edge, t, &x, &y);
-    int loc = relate_point_in_area_index(x, y, other);
+    /* Every point at which this edge meets the other boundary is one of the
+     * parameters it was split at, so the OPEN interval between two consecutive
+     * ones touches that boundary nowhere -- unless the edge runs along it,
+     * which the shared stretches record. Off those stretches the point is
+     * therefore known to miss the boundary before it is classified, and asking
+     * whether it lies ON the boundary can only answer wrongly: the midpoint is
+     * a CONSTRUCTED point, so where the interval is narrower than the band it
+     * reads as carried by an edge it provably misses, and a boundary reading
+     * takes the interval out of both BI and BE. Reading the parity alone
+     * settles it with no tolerance in the path */
+    bool on_shared = false;
+    for (int k = 0; k < nshared && ! on_shared; k++)
+      if (t >= shlo[k] && t <= shhi[k])
+        on_shared = true;
+    int loc = on_shared ? 1 : relate_point_in_area_parity(x, y, other);
     if (loc == 0)
     {
       /* Boundary(A) ∩ Interior(B) or Interior(A) ∩ Boundary(B) */
@@ -5782,6 +5838,8 @@ relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
     }
   }
   pfree(params);
+  pfree(shlo);
+  pfree(shhi);
   return;
 }
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -365,6 +365,46 @@ int main(void)
     assert(meos_errno() == 0);
     free(pa); free(pb);
   }
+
+  /* Where two boundaries cross, each one runs through the other's interior on
+   * one side of the crossing, so both boundary-interior cells of the matrix
+   * are a line. The engine finds those pieces by splitting a boundary edge at
+   * its crossings and classifying the midpoint of each piece -- and it asks
+   * first whether that midpoint lies ON the other boundary, which is a
+   * question a tolerance decides. A piece shorter than that band reads as
+   * carried by the very edge it provably misses, and is then counted in
+   * neither cell. The record below is a rectangle and a wide triangle whose
+   * apex dips TWO UNITS IN THE LAST PLACE below the rectangle's top edge at
+   * coordinates near 6.2e6. Its shape is deliberate: the triangle is as wide
+   * as it is tall, so the piece of the top edge lying inside it is about 32
+   * units in the last place long -- a region doubles express perfectly well,
+   * unlike the same construction with a narrow triangle, where that piece
+   * falls below one unit in the last place and no sampled point can ever land
+   * in it. Exact rational arithmetic puts a one-dimensional piece of each
+   * boundary strictly inside the other */
+  const char *cross_a =
+    "POLYGON((711277 6212855.6200000001,"
+    "711281 6212855.6200000001,"
+    "711281 6212854.6200000001,"
+    "711277 6212854.6200000001,"
+    "711277 6212855.6200000001))";
+  const char *cross_b =
+    "POLYGON((711277.97999999998 6212856.6200000001,"
+    "711279.97999999998 6212856.6200000001,"
+    "711278.97999999998 6212855.6199999982,"
+    "711277.97999999998 6212856.6200000001))";
+  char cross_patt[10] = "*1*1*****";
+  GSERIALIZED *cross_geo_a = geom_in(cross_a, -1);
+  GSERIALIZED *cross_geo_b = geom_in(cross_b, -1);
+  assert(cross_geo_a != NULL);
+  assert(cross_geo_b != NULL);
+  meos_errno_reset();
+  bool cross_cells = geom_relate_pattern(cross_geo_a, cross_geo_b, cross_patt);
+  printf("geom_relate_pattern(rectangle, crossing triangle, each boundary "
+    "inside the other): %d, errno %d\n", cross_cells, meos_errno());
+  assert(cross_cells == true);
+  assert(meos_errno() == 0);
+  free(cross_geo_a); free(cross_geo_b);
   meos_errno_reset();
 
   /* A boundary node that two pieces of a buffer meet at is computed twice,


### PR DESCRIPTION
relate_area_edge_intervals settles the two boundary-interior cells by
splitting a boundary edge at every point where it meets the other
boundary and classifying the midpoint of each open piece. It classifies
that midpoint with relate_point_in_area_index, which asks FIRST whether
the point lies ON the other boundary -- and that question is decided
within a band that grows with the size of the coordinates.

Every point at which the edge meets the other boundary is already one of
the parameters the edge was split at, so an open piece between two
consecutive parameters touches that boundary NOWHERE. The single
exception is a piece along which the edge RUNS ON the other boundary, and
those stretches are now recorded as they are found.

That premise needs the segment kernel to report a shared stretch wherever
one exists, which it does only since the collinear tests were bounded by
the quantities they measure. Before that a segment shorter than 1e-6
reported no overlap even against an identical copy of itself, so its
shared stretch went unrecorded and a point of the boundary read as
interior -- a self-relate of one real protected area answered 21211F2F2
where the definition requires 2FFF1FFF2. On this base it answers
2FFF1FFF2.

Off such a stretch the midpoint is therefore known to miss the boundary
before it is ever classified, so the on-boundary test can only answer
wrongly: the midpoint is a CONSTRUCTED point, and where the piece is
shorter than the band it reads as carried by an edge it provably misses.
A piece read as lying on the boundary is counted in neither cell, so the
boundary of one geometry can run through the interior of the other and be
recorded in neither. Reading the even-odd parity alone -- the same parity
over the same edges, with the band that cannot apply left out -- settles
it with no tolerance in the path.

WITNESS

  SELECT ST_Relate(
    'POLYGON((711277 6212855.6200000001,
              711281 6212855.6200000001,
              711281 6212854.6200000001,
              711277 6212854.6200000001,
              711277 6212855.6200000001))'::geometry,
    'POLYGON((711277.97999999998 6212856.6200000001,
              711279.97999999998 6212856.6200000001,
              711278.97999999998 6212855.6199999982,
              711277.97999999998 6212856.6200000001))'::geometry);

A rectangle, and a triangle whose apex dips two units in the last place
below the rectangle's top edge at coordinates near 6.2e6. Before:
2F2F01212. After: 212101212, which is what GEOS answers. The piece of the
top edge lying inside the triangle is about 32 units in the last place
long, so the two boundary-interior cells are a line and not empty.

The triangle is as wide as it is tall on purpose. The same construction
with a narrow triangle puts that piece BELOW one unit in the last place
of x, where no double point lies strictly inside it and no sampling
engine can report it; that is a limit of the coordinates, not of this
change, and it is why the witness is shaped this way.

The same failure on real data: a protected-area pair whose boundaries
cross in a sliver 2.1 units in the last place wide reads 2F2F11212 and
now reads 212111212, again GEOS's answer.

WHY the new answer is the right one

The truth here is not a second engine's opinion. The input coordinates
are doubles and every double is an exact dyadic rational, so whether a
piece of one boundary lies strictly inside the other area has one answer.
Computing it in exact rational arithmetic -- splitting the boundary at
its exact intersections and testing the EXACT rational midpoint of each
piece, which no band can touch -- gives a one-dimensional piece inside
for both the witness and the real pair.

The band being dropped is not a safeguard, it is a wrong answer: the
piece it is asked about is disjoint from the boundary by construction.
Where the edge does run along the other boundary the band is not needed
either, because the stretch itself is known.

MEASURED

Judged against that exact oracle, the two cells are correct on 1444 of
1444 areal pairs and 917 of 917 h3 cell pairs both before and after, and
go from wrong to right on the witness and on the real pair. So the defect
is confined to the crossing regime and nothing else moves.

Over 931 h3 cell boundaries and the real pair: self-identity,
relate(g,g) == 2FFF1FFF2, holds at 1864 of 1864; the II cell against the
exact shared area holds at 918 of 918; and the count of matrices
differing from GEOS goes from 1 of 1 judged to 0. pg_regress passes in
full on PostgreSQL 18 and the meos.yml test step runs clean.

Timing, interleaved A/B read as a ratio, median of the laps:
  1444 areal pairs, 7 laps, 3 reps    -> 0.9440
  the 10473 x 43924-edge pair, 5 laps -> 1.0053
The gain on the first is the on-boundary index query no longer made on
the common path.

The regression witness in geo_test.c is the pasteable pair above. It is
proven in both directions -- built against the previous library it aborts
on its assertion, and passes here.

Relate cost of the native engine, callgrind instructions over the regression pairs, base d64dcffece against merge d561d837ba: areal pairs 18,721,604,198 -> 18,353,003,687 (-1.97%), geo pairs 35,740,097,703 -> 35,544,708,766 (-0.55%).
