### PR TITLE
Decline a geometry type this build does not enumerate

### DIFF
--- a/meos/include/meos_internal_geo.h
+++ b/meos/include/meos_internal_geo.h
@@ -264,7 +264,7 @@ extern bool geo_clip_subject(const GSERIALIZED *gs);
 extern bool geo_is_planar_areal(const GSERIALIZED *gs);
 extern bool geo_every_part_bounds_area(const GSERIALIZED *gs);
 extern bool geo_is_point_set(const GSERIALIZED *gs);
-extern bool geo_meos_supported(const GSERIALIZED *gs);
+extern int geo_meos_coverage(const GSERIALIZED *gs);
 extern GSERIALIZED *geo_points_covered(const GSERIALIZED *pts,
   const GSERIALIZED *gs, bool covered);
 extern GSERIALIZED *geo_clip_linear_geom(const GSERIALIZED *line,
@@ -279,7 +279,7 @@ extern Temporal *tpoint_linear_dwithin_geom(const Temporal *temp, const GSERIALI
 extern Temporal *tpoint_linear_dwithin_geom_ctx(const Temporal *temp, const void *ctx, double dist);
 extern Temporal *tpoint_linear_distance_geom(const Temporal *temp, const GSERIALIZED *gs);
 extern Temporal *tpoint_linear_restrict_geom(const Temporal *temp, const GSERIALIZED *gs, bool atfunc);
-extern bool geom_meos_supported(const LWGEOM *geom);
+extern int geom_meos_coverage(const LWGEOM *geom);
 
 /*****************************************************************************/
 

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -522,23 +522,35 @@ geom_extract_edges(const LWGEOM *geom)
 }
 
 /**
- * @brief Return true if a geometry is composed solely of the types the native
- * implementations can extract into edges
+ * @brief Return how far the native implementations cover a geometry
  * @details Mirrors the type dispatch of #geom_extract_edges_iter, which every
  * native implementation of a PostGIS function reads its geometry through, so
- * the predicate answers for all of them: the clip engine, the DE-9IM matrix,
- * the convex hull, the oriented envelope and the buffer alike. A geometry
- * holding any other type, a TIN or a polyhedral surface, is uncovered and
- * belongs to the caller, which either answers it another way or reports that
- * it is not supported
- * @note Uncovered never means unrelated: a @p false is the absence of an
- * answer, not a negative one
+ * the answer holds for all of them: the clip engine, the DE-9IM matrix, the
+ * convex hull, the oriented envelope and the buffer alike.
+ *
+ * THE THIRD ANSWER IS THE POINT. A geometry the kernels do not cover and a
+ * geometry of a type this build has never heard of are different facts, and a
+ * caller can act on the second only if it is told them apart: liblwgeom
+ * numbers its types 1 to 15 today and PostGIS adds to that set, so a build
+ * meets a type its own enumeration does not name the moment it is linked
+ * against a newer liblwgeom. Answering "not covered" there states something
+ * about a type nothing here has seen.
+ *
+ * @return 1 where the kernels answer for the geometry, 0 where a type they
+ * know is one they do not answer for, and -1 where the type is not one this
+ * build enumerates at all, which is reported as an unsupported type
+ * @note Neither 0 nor -1 means unrelated: both are the absence of an answer
+ * rather than a negative one. A caller either answers such a geometry another
+ * way or reports that it is not supported. The two differ in who reports it:
+ * a 0 is the caller's to report, naming the operation it has no answer for,
+ * while a -1 is reported here, because a type this build does not enumerate
+ * is a fact about the geometry rather than about the operation
  */
-bool
-geom_meos_supported(const LWGEOM *geom)
+int
+geom_meos_coverage(const LWGEOM *geom)
 {
   if (! geom)
-    return false;
+    return -1;
   switch (geom->type)
   {
     case POINTTYPE:
@@ -549,7 +561,7 @@ geom_meos_supported(const LWGEOM *geom)
     case MULTIPOLYGONTYPE:
     case TRIANGLETYPE:
     case CIRCSTRINGTYPE:
-      return true;
+      return 1;
     case COMPOUNDTYPE:
     case MULTICURVETYPE:
     case MULTISURFACETYPE:
@@ -563,9 +575,15 @@ geom_meos_supported(const LWGEOM *geom)
        * call */
       const LWCOLLECTION *col = (const LWCOLLECTION *) geom;
       for (uint32_t i = 0; i < col->ngeoms; i++)
-        if (! geom_meos_supported(col->geoms[i]))
-          return false;
-      return true;
+      {
+        /* A member carries the weaker answer outward: a member of an unknown
+         * type makes the whole collection unknown, and an uncovered one makes
+         * it uncovered */
+        int member = geom_meos_coverage(col->geoms[i]);
+        if (member != 1)
+          return member;
+      }
+      return 1;
     }
     case CURVEPOLYTYPE:
     {
@@ -575,15 +593,27 @@ geom_meos_supported(const LWGEOM *geom)
       for (uint32_t r = 0; r < cp->nrings; r++)
       {
         uint8_t rt = cp->rings[r]->type;
+        /* A ring of a type the ring dispatch does not take is a type this
+         * build knows, so the geometry is uncovered rather than unknown */
         if (rt != LINETYPE && rt != CIRCSTRINGTYPE && rt != COMPOUNDTYPE)
-          return false;
-        if (rt == COMPOUNDTYPE && ! geom_meos_supported(cp->rings[r]))
-          return false;
+          return 0;
+        if (rt == COMPOUNDTYPE)
+        {
+          int ring = geom_meos_coverage(cp->rings[r]);
+          if (ring != 1)
+            return ring;
+        }
       }
-      return true;
+      return 1;
     }
+    /* Every type liblwgeom numbers has an arm above, so this one is reached
+     * only by a type added after this code. Saying anything about it other
+     * than "unknown" would be inventing an answer, so it is reported here
+     * exactly as #geom_extract_edges_iter reports it one call deeper */
     default:
-      return false;
+      meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+        "Unsupported geometry type");
+      return -1;
   }
 }
 
@@ -7195,7 +7225,7 @@ relate_dispatch(const LWGEOM *g1, const LWGEOM *g2, int mask1, int mask2,
  * NULL where the matrix is asked for on its own
  * @param[out] result The matrix
  * @return true if the geometry pair is supported, which is what
- * #geom_meos_supported answers of each geometry
+ * #geom_meos_coverage answers 1 for each geometry
  */
 static bool
 relate_matrix(const LWGEOM *g1, const LWGEOM *g2, const RelateOperands *ops,
@@ -7205,7 +7235,7 @@ relate_matrix(const LWGEOM *g1, const LWGEOM *g2, const RelateOperands *ops,
 
   /* Every native implementation reads the same predicate: the engine answers
    * a geometry the edge decomposition reaches, and nothing else */
-  if (! geom_meos_supported(g1) || ! geom_meos_supported(g2))
+  if (geom_meos_coverage(g1) != 1 || geom_meos_coverage(g2) != 1)
     return false;
 
   MeosDE9IM m;
@@ -7245,7 +7275,7 @@ relate_matrix(const LWGEOM *g1, const LWGEOM *g2, const RelateOperands *ops,
  * @brief Compute the DE-9IM intersection matrix
  * @details This is the native counterpart of PostGIS @p ST_Relate
  * @return true if the geometry pair is supported, which is what
- * #geom_meos_supported answers of each geometry. A false return means the
+ * #geom_meos_coverage answers 1 for each geometry. A false return means the
  * pair is outside that coverage, @b not that the geometries are unrelated, so
  * a caller must answer it another way rather than read @p result
  */
@@ -7794,7 +7824,7 @@ relate_ctx_make(const LWGEOM *geom)
   /* The same predicate a relationship reads at its entry. Answering NULL here
    * rather than extracting keeps an uncovered geometry on the path it already
    * takes: a relationship over it reports itself uncovered and raises nothing */
-  if (! geom_meos_supported(geom))
+  if (geom_meos_coverage(geom) != 1)
     return NULL;
   struct RelateCtx *ctx = palloc(sizeof(struct RelateCtx));
   ctx->op.geom = geom;
@@ -7870,7 +7900,7 @@ meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
 
   /* Every native implementation reads the same predicate: the engine answers
    * a geometry the edge decomposition reaches, and nothing else */
-  if (! geom_meos_supported(g1) || ! geom_meos_supported(g2))
+  if (geom_meos_coverage(g1) != 1 || geom_meos_coverage(g2) != 1)
     return false;
 
   /* An empty geometry holds no point to share with another, and none of the
@@ -7897,8 +7927,8 @@ meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
  * @param[in] g1,g2 Geometries
  * @param[in] pattern DE-9IM pattern, in the alphabet #de9im_match reads
  * @param[out] result True if the geometries satisfy the pattern
- * @return True if the pair is covered, which is what #geom_meos_supported
- * answers of each geometry. A false return means the pair is outside that
+ * @return True if the pair is covered, which is what
+ * #geom_meos_coverage answers 1 for each geometry. A false return means the pair is outside that
  * coverage, @b not that the pattern fails, so a caller must answer it another
  * way rather than read @p result
  */

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1829,7 +1829,7 @@ GEOS2POSTGIS(GEOSGeom geom, char want3d)
 
 /**
  * @brief Return the type that keeps a pair of geometries from the native engine
- * @details The native engine answers every type #geom_meos_supported() accepts,
+ * @details The native engine answers every type #geom_meos_coverage() answers 1 for,
  * which is every type the edge decomposition reaches, and a type it declines is
  * answered by nobody.
  * @param[in] geom1,geom2 Geometries the operation is asked about
@@ -1837,7 +1837,7 @@ GEOS2POSTGIS(GEOSGeom geom, char want3d)
 static uint8_t
 geo_unsupported_type(const LWGEOM *geom1, const LWGEOM *geom2)
 {
-  return geom_meos_supported(geom1) ? geom2->type : geom1->type;
+  return geom_meos_coverage(geom1) == 1 ? geom2->type : geom1->type;
 }
 
 /**
@@ -2351,7 +2351,7 @@ geom_areal_meeting(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   GSERIALIZED *bound1 = geom_boundary(gs1);
   GSERIALIZED *bound2 = bound1 ? geom_boundary(gs2) : NULL;
   GSERIALIZED *result = (bound1 && bound2 && geo_clip_subject(bound1) &&
-    geo_meos_supported(bound2)) ?
+    geo_meos_coverage(bound2) == 1) ?
     geo_clip_linear_geom(bound1, bound2, true) : NULL;
   if (bound1) pfree(bound1);
   if (bound2) pfree(bound2);
@@ -2428,9 +2428,9 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 
   /* The part of a line inside the other geometry, read from the segment
    * kernels, which answer an arc of that geometry exactly */
-  if (geo_clip_subject(gs1) && geo_meos_supported(gs2))
+  if (geo_clip_subject(gs1) && geo_meos_coverage(gs2) == 1)
     return geo_clip_linear_geom(gs1, gs2, true);
-  if (geo_clip_subject(gs2) && geo_meos_supported(gs1))
+  if (geo_clip_subject(gs2) && geo_meos_coverage(gs1) == 1)
     return geo_clip_linear_geom(gs2, gs1, true);
 
   /* An areal pair the native overlay reads is answered on the circles its
@@ -2498,7 +2498,7 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
   /* Difference takes the FIRST operand apart, so only its own kind decides */
   if (geo_is_point_set(gs1))
     return geo_points_covered(gs1, gs2, false);
-  if (geo_clip_subject(gs1) && geo_meos_supported(gs2))
+  if (geo_clip_subject(gs1) && geo_meos_coverage(gs2) == 1)
     return geo_clip_linear_geom(gs1, gs2, false);
 
   /* A region loses no area to a clip that covers none. A point set and a curve
@@ -3390,7 +3390,8 @@ geom_is_simple(const GSERIALIZED *gs)
   if (covered)
     return result;
 
-  /* #meos_is_simple answers every type #geom_meos_supported admits, and a
+  /* #meos_is_simple answers every type #geom_meos_coverage answers 1 for,
+   * and a
    * geodetic geometry is refused above, so a geometry reaching here carries a
    * type the engine does not read at all */
   meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -1774,7 +1774,7 @@ tdistance_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
       MEOS_FLAGS_LINEAR_INTERP(temp->flags) && ! MEOS_FLAGS_GET_Z(temp->flags))
   {
     LWGEOM *geom = lwgeom_from_gserialized(gs);
-    bool native = geom->type != POINTTYPE && geom_meos_supported(geom);
+    bool native = geom->type != POINTTYPE && geom_meos_coverage(geom) == 1;
     lwgeom_free(geom);
     if (native)
       return tpoint_linear_distance_geom(temp, gs);

--- a/meos/src/geo/tgeo_restrict.c
+++ b/meos/src/geo/tgeo_restrict.c
@@ -2122,7 +2122,7 @@ tgeo_restrict_geom(const Temporal *temp, const GSERIALIZED *gs,
       MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR)
   {
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    bool supported = geom_meos_supported(lwgeom);
+    bool supported = geom_meos_coverage(lwgeom) == 1;
     lwgeom_free(lwgeom);
     if (supported)
       return tpoint_linear_restrict_geom(temp, gs, atfunc);

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -1144,7 +1144,7 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
      * reaches the decomposition only for a value whose box meets the
      * geometry, and answers from the boxes alone for the values that do not */
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    if (geom_meos_supported(lwgeom))
+    if (geom_meos_coverage(lwgeom) == 1)
       ctx = geo_edge_ctx_make(gs);
     lwgeom_free(lwgeom);
   }
@@ -1365,7 +1365,7 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
       ! FLAGS_GET_Z(gs->gflags))
   {
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    bool supported = geom_meos_supported(lwgeom);
+    bool supported = geom_meos_coverage(lwgeom) == 1;
     lwgeom_free(lwgeom);
     if (supported)
     {
@@ -1913,7 +1913,7 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
       gserialized_get_type(gs) != POINTTYPE)
   {
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    bool supported = geom_meos_supported(lwgeom);
+    bool supported = geom_meos_coverage(lwgeom) == 1;
     lwgeom_free(lwgeom);
     if (supported)
     {

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -946,17 +946,19 @@ geo_edge_ctx_make(const GSERIALIZED *gs)
 }
 
 /**
- * @brief Return true if the segment kernels answer for a geometry, read from
- * its serialized form
- * @details #geom_meos_supported reads the deserialized geometry, which a
+ * @brief Return how far the segment kernels cover a geometry, read from its
+ * serialized form
+ * @details #geom_meos_coverage reads the deserialized geometry, which a
  * caller holding only the serialized one would otherwise deserialize twice
+ * @return As #geom_meos_coverage reports it: 1 covered, 0 a known type left
+ * uncovered, -1 a type this build does not enumerate
  */
-bool
-geo_meos_supported(const GSERIALIZED *gs)
+int
+geo_meos_coverage(const GSERIALIZED *gs)
 {
   assert(gs);
   LWGEOM *geom = lwgeom_from_gserialized(gs);
-  bool result = geom_meos_supported(geom);
+  int result = geom_meos_coverage(geom);
   lwgeom_free(geom);
   return result;
 }

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -537,7 +537,7 @@ tinterrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool tinter)
       MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR)
   {
     LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-    bool supported = geom_meos_supported(lwgeom);
+    bool supported = geom_meos_coverage(lwgeom) == 1;
     lwgeom_free(lwgeom);
     if (supported)
     {
@@ -1574,7 +1574,7 @@ tdwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
         ! MEOS_FLAGS_GET_Z(temp->flags) && ! FLAGS_GET_Z(gs->gflags))
     {
       LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
-      bool supported = geom_meos_supported(lwgeom);
+      bool supported = geom_meos_coverage(lwgeom) == 1;
       lwgeom_free(lwgeom);
       if (supported)
         return tpoint_linear_dwithin_geom(temp, gs, dist);


### PR DESCRIPTION
liblwgeom numbers its geometry types 1 to 15 and PostGIS grows that set, so a
switch naming all 15 is correct today and says nothing about tomorrow. The
coverage predicate the native geometry engine reads answered a plain `false` for
a type it had never seen, which is the same word it uses for a type it knows and
does not cover — a decided answer about a type nothing here has read.

Its `default` arm now reports the type as unsupported, exactly as the dispatch it
mirrors, `geom_extract_edges_iter`, already reports it one call deeper. The
predicate answers **1** where the kernels cover the geometry, **0** where a type
they know is one they do not answer for, and **-1** where the type is not one
this build enumerates at all — the three-valued `int` the spatial relationship
predicates already use for the same distinction. The two absences differ in who
reports them: a 0 is the caller's to report, naming the operation it has no
answer for, while a -1 is a fact about the geometry and is reported here.

Renaming it to `geom_meos_coverage` makes every one of its fifteen call sites a
compile error rather than a silent truthiness read, and each now states which of
the three it means: a guard reads `== 1` or `!= 1`, so an unknown type can never
be taken for a decided no.

### Witness

A geometry whose type byte is forged to 16, one past `TINTYPE`, read through the
predicate against a build of the parent commit:

| arm | answer | errno |
|---|---|---|
| parent commit | `0` — a decided "not covered" | 0, silently |
| this commit | `-1` | 13 |

Two controls carry it. All fifteen real types answer 1 on **both** arms (15
covered, 0 uncovered, 0 unknown), so the predicate is live rather than the forged
row being the only thing read. And `geom_extract_edges`, whose own `default` is
`meos_error`, sets errno 13 on the forged type, so the forgery reaches the type
dispatch rather than being rejected before it.

### No answer moves

The DE-9IM matrix of every pair of five corpora is byte-identical between a build
of the parent commit and this one:

| corpus | pairs | unreadable | matrices |
|---|---|---|---|
| geo_pairs | 12880 | 0 | identical |
| areal_pairs | 1444 | 0 | identical |
| h3 self-pairs | 931 | 0 | identical |
| real_trip_pairs | 202 | 0 | identical |
| adversarial_pairs | 54 | 0 | identical |
| **total** | **15511** | **0** | **identical** |

Both builds carry the same family flags and build type, and each probe is
verified by `readelf` to load its own arm. Nothing existing can reach the new
report: every type liblwgeom numbers has an arm above the `default`.

### Why it is worth the change

Every call site guarded on the old `bool` falls through to another path rather
than dereferencing, so this fixes no crash today. What it fixes is the contract:
the report a caller writes for an uncovered pair, and every future reader of the
predicate, could not tell "the kernels do not answer for this" from "nothing here
has seen this type", and the compiler could not help because both were `false`.
