### PR TITLE
Read a boundary portion against the interiors the operands decide

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -233,6 +233,11 @@ typedef struct
   RTree *index;   /**< Index over the edge boxes, NULL below the threshold */
   double xmax;    /**< Greatest x the edges reach */
   double tol;     /**< Widest tolerance any of the edges asks for */
+  bool straight;  /**< Every areal boundary edge the array holds is a segment,
+                       which is the class #relate_area_boundaries_cross reads:
+                       it solves a crossing from four given vertices, and the
+                       two endpoints of an arc do not determine the curve
+                       between them */
 } RelateEdges;
 
 extern void relate_edges_init(RelateEdges *re, Edge **edges, int nedges,

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -3587,9 +3587,14 @@ relate_edges_init(RelateEdges *re, Edge **edges, int nedges, bool index)
    * is thousands of times that. The widest tolerance in the array is what
    * makes the index answer what the scan answers at every scale */
   re->tol = MEOS_GEOM_TOLERANCE;
+  re->straight = true;
   for (int i = 0; i < nedges; i++)
+  {
     if (edges[i]->tol > re->tol)
       re->tol = edges[i]->tol;
+    if (edges[i]->etype == EDGE_POLYARC)
+      re->straight = false;
+  }
   re->index = index ? relate_edges_index(edges, nedges) : NULL;
   return;
 }
@@ -5727,10 +5732,13 @@ relate_area_edge_inside_area(const Edge *edge, const RelateEdges *area)
  * @details The edge is split at every intersection with the other polygon
  * boundary. Since there is no boundary intersection inside an open
  * interval, one representative point is sufficient.
+ * @param[in] exact_ii The interiors of the two geometries have been decided
+ * exactly before this walk runs, which #relate_area_boundaries_cross does for
+ * a pair of straight boundaries and not for one carrying an arc
  */
 static void
 relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
-  MeosDE9IM *m, bool first)
+  MeosDE9IM *m, bool first, bool exact_ii)
 {
   /* Maximum number of intersections between one edge and one
    * circular/linear boundary edge is two */
@@ -5846,16 +5854,33 @@ relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
       if (t >= shlo[k] && t <= shhi[k])
         on_shared = true;
     int loc = on_shared ? 1 : relate_point_in_area_parity(x, y, other);
-    if (loc == 0)
+    /* A boundary point of A lying in the interior of B carries a whole
+     * neighbourhood of itself inside B, and every neighbourhood of a boundary
+     * point of A meets the interior of A, so the two interiors meet in a
+     * two-dimensional set. The interiors are therefore what settles this
+     * branch, and #relate_area_interiors_intersect has already answered them
+     * from the operands' own vertices before this walk runs.
+     *
+     * Reading that answer is what keeps the branch sound where the midpoint
+     * cannot: the midpoint is CONSTRUCTED from two split parameters that are
+     * themselves solved from the coordinates, so where the two boundaries run
+     * within their own rounding of one another it lands on either side of the
+     * other boundary by the residue of that arithmetic, and the parity below
+     * reports whichever side it landed on. Where the interiors provably miss,
+     * so does the boundary, whatever the midpoint reads.
+     *
+     * The interiors answer carries that weight only where it is exact, which
+     * is the straight-boundary class its crossing route reads, so a pair
+     * carrying an arc keeps the midpoint as its only source */
+    if (loc == 0 && (m->ii == 2 || ! exact_ii))
     {
       /* Boundary(A) ∩ Interior(B) or Interior(A) ∩ Boundary(B) */
       if (first)
         m->bi = 1;
       else
         m->ib = 1;
-      /* If a non-zero boundary portion of A lies inside B,
-       * then the interiors of A and B also intersect in a
-       * two-dimensional neighbourhood of that portion. */
+      /* A non-zero boundary portion of A inside B carries a neighbourhood of
+       * itself inside B, and that neighbourhood meets the interior of A */
       m->ii = 2;
     }
     else if (loc == 2)
@@ -6219,18 +6244,20 @@ relate_area_area(const LWGEOM *g1, const LWGEOM *g2,
 
   /* Boundary(A) / Interior(B) and Interior(A) / Boundary(B) are determined by
    * splitting every boundary edge at the intersections with the other
-   * boundary. */
+   * boundary. Where both boundaries are straight the step above has settled
+   * the interiors exactly, and each portion is read against that answer */
+  bool exact_ii = re1.straight && re2.straight;
   for (int i = 0; i < n1; i++)
   {
     if (!relate_area_boundary_edge(e1[i]))
       continue;
-    relate_area_edge_intervals(e1[i], &re2, m, true);
+    relate_area_edge_intervals(e1[i], &re2, m, true, exact_ii);
   }
   for (int i = 0; i < n2; i++)
   {
     if (!relate_area_boundary_edge(e2[i]))
       continue;
-    relate_area_edge_intervals(e2[i], &re1, m, false);
+    relate_area_edge_intervals(e2[i], &re1, m, false, exact_ii);
   }
 
   /* Boundary / Boundary.

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -321,6 +321,58 @@ int main(void)
   }
   meos_errno_reset();
 
+  /* Two areas lying on OPPOSITE SIDES of one line share no area, so neither
+   * interior holds a point of the other's boundary, however near the two
+   * boundaries run. Deciding that from a boundary portion means classifying a
+   * point built at the middle of it, and the portion is delimited by crossings
+   * solved from the coordinates of both edges: where the two boundaries run
+   * within their own rounding of one another, a crossing lands a fraction of a
+   * unit in the last place from the edge's own endpoint and leaves a portion
+   * shorter than the coordinates resolve. The midpoint of such a portion falls
+   * on whichever side of the other boundary the rounding puts it, and reading
+   * it as interior reports a boundary inside an area that does not reach it.
+   * The interiors settle it instead, and they are decided from the operands'
+   * own vertices before any portion is classified.
+   * The record below is that case at its smallest: a rectangle whose top edge
+   * lies along y = Y0 and one above it whose bottom edge rises ONE UNIT IN THE
+   * LAST PLACE off that line at its middle vertex, at projected coordinates
+   * near 6.2e6 where one unit in the last place is 9.3e-10. Every vertex of
+   * the first satisfies y <= Y0 and every vertex of the second y >= Y0, so the
+   * two meet at the two points where both reach the line and nowhere else --
+   * which is what makes the answer owed here a property of the construction
+   * rather than a comparison with another engine. A real protected-area pair
+   * fails the same way for the same reason */
+  const char *apart_a =
+    "POLYGON((711277 6212854.6200000001,711277 6212855.6200000001,"
+    "711279 6212855.6200000001,711281 6212855.6200000001,"
+    "711281 6212854.6200000001,711277 6212854.6200000001))";
+  const char *apart_b =
+    "POLYGON((711277 6212856.6200000001,711281 6212856.6200000001,"
+    "711281 6212855.6200000001,711279 6212855.620000001,"
+    "711277 6212855.6200000001,711277 6212856.6200000001))";
+  GSERIALIZED *apart_geo_a = geom_in(apart_a, -1);
+  GSERIALIZED *apart_geo_b = geom_in(apart_b, -1);
+  assert(apart_geo_a != NULL);
+  assert(apart_geo_b != NULL);
+  meos_errno_reset();
+  char apart_patt[10] = "F***T****";
+  bool apart_touches = geom_relate_pattern(apart_geo_a, apart_geo_b,
+    apart_patt);
+  printf("geom_relate_pattern(two areas on opposite sides of a line, they only "
+    "touch): %d, errno %d\n", apart_touches, meos_errno());
+  assert(apart_touches == true);
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+  char apart_interiors[10] = "T********";
+  bool apart_overlaps = geom_relate_pattern(apart_geo_a, apart_geo_b,
+    apart_interiors);
+  printf("geom_relate_pattern(two areas on opposite sides of a line, interiors "
+    "meet): %d, errno %d\n", apart_overlaps, meos_errno());
+  assert(apart_overlaps == false);
+  assert(meos_errno() == 0);
+  free(apart_geo_a); free(apart_geo_b);
+  meos_errno_reset();
+
   /* Two areas whose boundaries run PARALLEL never touch, however close they
    * come. Deciding that means asking whether the two lines are one line, and
    * the engine answers it from the cross product of the offset between them


### PR DESCRIPTION
Two areas that share no area can be reported as overlapping, and one of the twenty real protected-area pairs in circulation is such a case.

## The wrong answer

`~/natural_20.txt` pair 19, a pair of `MULTIPOLYGON`s in projected metres:

| | matrix |
|---|---|
| master | `2F2111212` |
| GEOS | `FF2F11212` |
| the exact answer | `FF2F11212` |

An exact rational oracle over CGAL, its four controls passing, reads the shared area as **exactly zero** and reports `pair 19  MEOS IB='F' BI='1'  but exactly IB=0 BI=0`. So master says a stretch of one boundary runs through the other's interior where the two areas do not meet in area at all.

## Why it happens

`relate_area_edge_intervals` splits a boundary edge at every point where it meets the other boundary and classifies the midpoint of each open portion. Both ends of a portion come from crossings solved on the coordinates of the two edges, so a crossing carries their rounding: where the two boundaries run within that rounding of one another, one lands a fraction of a unit in the last place from the edge's own endpoint. Measured on the two portions that decide pair 19:

| | length of the portion | distance from its midpoint to the other boundary | the edge's own `coordinate_tolerance` |
|---|---|---|---|
| 1 | 1.5e-10 m | 2.3e-10 m | 5.5e-09 m |
| 2 | 1.2e-10 m | 1.2e-10 m | 5.5e-09 m |

Both are shorter than the coordinates resolve, and the midpoint of such a portion falls on whichever side of the other boundary the rounding puts it. The parity test then reports interior.

## What decides it instead

A boundary point of A lying in the interior of B carries a whole neighbourhood of itself inside B, and every neighbourhood of a boundary point of A meets the interior of A, so the two interiors meet in a two-dimensional set. The interiors are what settle this branch, and `relate_area_interiors_intersect` has already answered them from the operands' own vertices before the walk runs — `relate_area_area` calls it first. The walk reads that answer rather than the midpoint.

**The scope is the class the exact route decides.** `relate_area_boundaries_cross`, which is what makes that answer exact, reads `EDGE_POLYSEG` on both sides and skips every arc: it solves a crossing from four given vertices, and the two endpoints of an arc do not determine the curve between them. `RelateEdges` therefore states whether its array is straight, and a pair carrying an arc keeps the midpoint as its only source and answers exactly as before.

## Measured

One answer moves across **15835 corpus pairs**, and it is pair 19:

| corpus | pairs | answers moved |
|---|---|---|
| natural protected areas | 20 | **1** (pair 19, to the exact answer) |
| geo | 12880 | 0 |
| h3 self-pairs | 931 | 0 |
| areal | 1444 | 0 |
| areal small | 324 | 0 |
| real trip | 202 | 0 |
| adversarial | 54 | 0 |

The exact IB/BI oracle judges **1444 of 1444** areal pairs correct on both arms. The natural corpus goes from one answer differing from GEOS to none.

The zero on the h3 self-pairs is the one that matters most, and it is not incidental: the 14 self-intersecting antimeridian rings there are where a crossing-based inference on these cells breaks self-identity. This change infers nothing from a crossing — for a geometry against itself the interiors do meet, so the reading is unchanged and `relate(g, g)` stays `2FFF1FFF2`.

## The witness

`meos/test/geo_test.c` carries a six-vertex case whose oracle is its own construction: every vertex of the first polygon satisfies `y <= Y0` and every vertex of the second `y >= Y0`, so the two lie in opposite closed half-planes, share no area, and neither interior can reach the other's boundary. It is at projected coordinates near 6.2e6 where one unit in the last place is 9.3e-10, and the second polygon's bottom edge rises exactly one such unit off the line at its middle vertex.

Master answers `212101212` and `geom_touches` false — two areas that provably share no area, reported as overlapping. It aborts on the assertion; with the change it exits 0. 147 members of the surrounding family answer correctly where 4 of the first 5 did not.

## Receipts

All three earned on `13b6a74e4859618f14d1cddbed2963d7d6d93294`, `carry_depth=0`:

- strict-ci — both targets, `pg_regress (local): all tests passed on PostgreSQL 18`, cppcheck, codegen, csqlfn, license, int64, 27 workflow checks, 0 compiler warnings
- Windows, MSYS2 UCRT64
- coverage, two-build diff over 42 instruments — `moved=3`, of which two are this witness's own output lines appended rather than changed and the third a `time_of_day()` clock, so no pre-existing answer line moves

`meos/include/geo/geo_funcs.h` is not installed, so no public surface changes.

## Found on the way, not fixed here

`relate_area_interiors_intersect` declines a pair whose interiors share **0.0987** of area — `geo_pairs` row 3697, a `POLYGON` against a `CURVEPOLYGON`. A stroke-rate sweep at 8, 32, 128, 512 and 2048 segments per quadrant reads 0.000185, 0.0889, 0.0981, 0.0987, 0.0987, so the overlap is real, and the same route succeeds once the arc is stroked. Nothing shows it today because the interval walk sets `ii = 2` itself. That is a separate defect, it is why the change above is scoped to straight boundaries, and this PR leaves the arc path exactly as it found it.
