### PR TITLE
Test the argument in the accessors that copy an extreme instant

### DIFF
--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2405,6 +2405,9 @@ temporal_min_inst_p(const Temporal *temp)
 TInstant *
 temporal_min_instant(const Temporal *temp)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(temp, NULL);
+
   return tinstant_copy(temporal_min_inst_p(temp));
 }
 
@@ -2447,6 +2450,9 @@ temporal_max_inst_p(const Temporal *temp)
 TInstant *
 temporal_max_instant(const Temporal *temp)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(temp, NULL);
+
   return tinstant_copy(temporal_max_inst_p(temp));
 }
 


### PR DESCRIPTION
temporal_min_instant and temporal_max_instant test their argument before
reading it, as temporal_start_instant and temporal_end_instant do. tinstant_copy
reads the length of the instant it is handed before copying it, so an accessor
that leaves the test to the internal accessor it wraps hands that read a null
pointer: the value the internal answers with where its own test fails is the
very NULL the copy cannot take.

The rule is the external/internal split MEOS already declares. An external
function tests each condition and answers the caller a value it can read, and
where the internal it wraps validates too, the NULL coming back from that test
is an error report rather than an instant to copy. temporal_start_instant and
temporal_end_instant wrap internals that assert, and each carries the test
itself, which is the shape these two take.

Witness: a program calling the three accessors with a null argument. The
control temporal_start_instant(NULL) answers NULL. temporal_min_instant(NULL)
reaches tinstant_copy carrying the NULL that temporal_min_inst_p returns from
its own VALIDATE_NOT_NULL, and VARSIZE reads through it, so the program takes
SIGSEGV at that call and never reaches the third. All three answer NULL with
the test in place.

Measured on master 79a66f4576: meos builds clean and links libmeos.so with
-DMEOS=ON -DALL=ON, zero errors and zero warnings. The witness program built
against that library segmentation-faults at its second call, and against the
same library carrying this change prints a null pointer for each of the three.

