### PR TITLE
Define the number span set predicates the validity macro calls

### DIFF
--- a/meos/include/temporal/meos_catalog.h
+++ b/meos/include/temporal/meos_catalog.h
@@ -283,6 +283,8 @@ extern bool timespan_basetype(MeosType type);
 extern bool timespan_type(MeosType type);
 
 extern bool spanset_type(MeosType type);
+extern bool numspanset_type(MeosType type);
+extern bool ensure_numspanset_type(MeosType type);
 extern bool timespanset_type(MeosType type);
 extern bool ensure_timespanset_type(MeosType type);
 

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -1126,6 +1126,29 @@ spanset_type(MeosType type)
 }
 
 /**
+ * @brief Return true if the type is a number span set type
+ */
+bool
+numspanset_type(MeosType type)
+{
+  return (type == T_DATESPANSET || type == T_FLOATSPANSET ||
+    type == T_INTSPANSET || type == T_BIGINTSPANSET);
+}
+
+/**
+ * @brief Ensure that a span set is a number span set type
+ */
+bool
+ensure_numspanset_type(MeosType type)
+{
+  if (numspanset_type(type))
+    return true;
+  meos_error(ERROR, MEOS_ERR_INVALID_ARG_TYPE,
+    "The value must be a number span set type");
+  return false;
+}
+
+/**
  * @brief Return true if the type is a time span type
  */
 bool


### PR DESCRIPTION
numspanset_type answers whether a span set type holds numbers, which is the
date, float, integer and big integer span sets, a date being represented as an
integer exactly as numspan_type has it, and ensure_numspanset_type raises
MEOS_ERR_INVALID_ARG_TYPE where a type is not one of them.

VALIDATE_NUMSPANSET names both: the arm the extension build takes asserts
numspanset_type, and the arm the MEOS build takes calls ensure_numspanset_type
after ensure_not_null. Neither name carries a declaration or a definition, and
the macro has no call site, so no compiler reads either arm and the bodies can
name anything at all.

The rule is that the catalog states a class question about the type of the
value being asked about, and the value here is a span set, which is what makes
defining the pair the right answer rather than deleting the macro or pointing
it at the existing numspan_type. spanset_type, timespanset_type and
ensure_timespanset_type all take a spansettype, so the numeric member of that
row takes one too, and the pair sits beside them mirroring numspan_type and
ensure_numspan_type one level down. A macro reaching through to the element
span type would ask a different question than the one its name states, and the
set of span set types grows, so the predicate a new type registers is the one
the row already establishes.

Witness: a translation unit that expands VALIDATE_NUMSPANSET. Under -DMEOS=1 it
accepts an intspanset, declines a tstzspanset reporting "The value must be a
number span set type", and declines a null pointer; under -DMEOS=0 it accepts
the intspanset and the assertion fires on the tstzspanset. Both arms compile at
zero warnings, and numspanset_type reads 1 for T_INTSPANSET and T_DATESPANSET
and 0 for T_TSTZSPANSET.

ensure_numspanset_type carries no MEOS conditional, since a file-scope one
selects MEOS-only code by preprocessor rather than by file, which is what
tools/scripts/check_meos_only_files.py refuses.

Measured on master 79a66f4576: meos builds clean and links libmeos.so with
-DMEOS=ON -DALL=ON, at zero errors and zero warnings, the extension builds
clean with -DMEOS=OFF, and the local pg_regress suite passes on PostgreSQL 18.
A 41-instrument two-arm run against master moves no answer but a timestamp,
which is the expected reading for a pair of predicates nothing yet calls.

