### PR TITLE
Test the span type a function's own name declares

### DIFF
--- a/meos/src/h3/th3index_boxops.c
+++ b/meos/src/h3/th3index_boxops.c
@@ -238,7 +238,7 @@ STBox *
 h3index_tstzspan_to_stbox(H3Index cell, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, NULL);
+  VALIDATE_TSTZSPAN(s, NULL);
   VALIDATE_H3INDEX_CELL(cell, NULL);
   STBox box;
   if (! h3index_set_stbox(cell, &box))

--- a/meos/src/quadbin/tquadbin_boxops.c
+++ b/meos/src/quadbin/tquadbin_boxops.c
@@ -155,7 +155,7 @@ STBox *
 quadbin_tstzspan_to_stbox(Quadbin cell, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, NULL);
+  VALIDATE_TSTZSPAN(s, NULL);
 
   STBox box;
   if (! quadbin_set_stbox(cell, &box))

--- a/meos/src/s2cell/ts2cell_boxops.c
+++ b/meos/src/s2cell/ts2cell_boxops.c
@@ -156,7 +156,7 @@ STBox *
 s2cell_tstzspan_to_stbox(S2CellId cell, const Span *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, NULL);
+  VALIDATE_TSTZSPAN(s, NULL);
 
   STBox box;
   if (! s2cell_set_stbox(cell, &box))

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -1152,7 +1152,7 @@ Span *
 tstzspan_expand(const Span *s, const Interval *interv)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, NULL); VALIDATE_NOT_NULL(interv, NULL);
+  VALIDATE_TSTZSPAN(s, NULL); VALIDATE_NOT_NULL(interv, NULL);
   /* When the interval is negative, return NULL if the span resulting by
    * shifting the bounds with the interval is empty */ 
   Interval intervalzero;
@@ -1418,7 +1418,7 @@ numspan_shift_scale(const Span *s, Datum shift, Datum width, bool hasshift,
   bool haswidth)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, NULL);
+  VALIDATE_NUMSPAN(s, NULL);
   if (! ensure_one_true(hasshift, haswidth) ||
       (haswidth && ! ensure_positive_datum(width, s->basetype)))
     return NULL;


### PR DESCRIPTION
h3index_tstzspan_to_stbox, quadbin_tstzspan_to_stbox, s2cell_tstzspan_to_stbox
and tstzspan_expand validate their span argument with VALIDATE_TSTZSPAN, and
numspan_shift_scale with VALIDATE_NUMSPAN, where each tests only that the
pointer is not null.

The rule is that a name stating a concrete span type states a contract, and the
guard is where that contract is enforced. VALIDATE_NOT_NULL belongs to a span
parameter whose function name declares no type; a Span reached through a name
that says tstzspan has one. The 27 span parameters that keep VALIDATE_NOT_NULL
sit in functions named generically -- span_copy, span_hash, span_lower_inc,
span_as_wkb -- which accept any span type. The single one of the 27 whose name
does state a type, ensure_valid_tnumber_numspan, enforces it in its next
statement, which compares the span base type against the temporal one:
left_tnumber_numspan(tint '1@2001-01-01', tstzspan '[2001-01-01, 2001-01-02)')
answers false and raises "Operation on mixed temporal number and span types:
tint, tstzspan".

Witness: tstzspan_expand(intspan '[1, 10)', interval '1 day') answers the span
[-500654079, 500654090) and leaves the error state at 0, having read integer
bounds as timestamps, so a caller cannot tell the answer is meaningless. It now
answers NULL and raises MEOS_ERR_INVALID_ARG_TYPE, "The span must be of type
tstzspan". A tstzspan argument is unaffected: tstzspan_expand of
[2001-01-01, 2001-01-02) answers [2000-12-31 00:00:00+01, 2001-01-03 00:00:00+01)
on both sides.

Measured on master 4146b05edd: 32 span parameters carry VALIDATE_NOT_NULL, six
of them in a function whose name states a concrete span type; this tree leaves
27 and one. Both trees build libmeos.so with -DMEOS=ON -DALL=ON at zero errors
and zero warnings. A probe compiled against each tree, resolving that tree's own
libmeos.so through an rpath and its meos headers from that tree rather than from
any shared prefix, reads the two answers above.

