### PR TITLE
Name every base type a span switch answers for and refuse the rest

### DIFF
--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -254,8 +254,15 @@ span_incr_bound(Datum lower, MeosType basetype)
     case T_DATE:
       result = DateADTGetDatum(DatumGetDateADT(lower) + 1);
       break;
-    default:
+    case T_FLOAT8:
+    case T_TIMESTAMPTZ:
+      /* A continuous type has no next value, so the bound is unchanged */
       result = lower;
+      break;
+    default: /* Error! */
+      meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
+        "Unknown base type for a span bound: %s", meostype_name(basetype));
+      return lower;
   }
   return result;
 }
@@ -278,8 +285,15 @@ span_decr_bound(Datum lower, MeosType basetype)
     case T_DATE:
       result = DateADTGetDatum(DatumGetDateADT(lower) - 1);
       break;
-    default:
+    case T_FLOAT8:
+    case T_TIMESTAMPTZ:
+      /* A continuous type has no previous value, so the bound is unchanged */
       result = lower;
+      break;
+    default: /* Error! */
+      meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
+        "Unknown base type for a span bound: %s", meostype_name(basetype));
+      return lower;
   }
   return result;
 }

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -1024,8 +1024,13 @@ distance_sentinel(MeosType type)
       return Int32GetDatum(INT_MAX);
     case T_INT8:
       return Int64GetDatum(INT64_MAX);
-    default:
+    case T_FLOAT8:
+    case T_TIMESTAMPTZ:
       /* The distance between timestamptz values is expressed in seconds */
+      return Float8GetDatum(DBL_MAX);
+    default: /* Error! */
+      meos_error(ERROR, MEOS_ERR_INTERNAL_TYPE_ERROR,
+        "Unknown base type for the distance sentinel: %s", meostype_name(type));
       return Float8GetDatum(DBL_MAX);
   }
 }

--- a/tools/scripts/dispatch_default_baseline.txt
+++ b/tools/scripts/dispatch_default_baseline.txt
@@ -11,9 +11,6 @@ meos/src/pointcloud/pgsql_compat.c	meos_pc_patch_serialize	switch patch->type
 meos/src/pointcloud/tpc_boxops.c	tpointcloudinst_set_tpcbox	else T_TPCPATCH
 meos/src/rgeo/trgeo_geom_clip.c	clip_lwgeom_m1_accum	switch geom->type
 meos/src/rgeo/trgeo_geom_clip.c	clip_lwgeom_m2_accum	switch geom->type
-meos/src/temporal/span.c	span_decr_bound	switch basetype
-meos/src/temporal/span.c	span_incr_bound	switch basetype
-meos/src/temporal/span_ops.c	distance_sentinel	switch type
 meos/src/temporal/temporal_analytics.c	innovation_distance	else T_TGEOMPOINT
 mobilitydb/src/temporal/index_sortsupport.c	sortsupport_rank_bound	switch basetype
 mobilitydb/src/temporal/index_sortsupport.c	span_sort_hash	switch s->basetype


### PR DESCRIPTION
distance_sentinel, span_incr_bound and span_decr_bound state a case for each of
the five base types that carry a span -- T_INT4, T_INT8, T_FLOAT8, T_DATE and
T_TIMESTAMPTZ -- and their default raises MEOS_ERR_INTERNAL_TYPE_ERROR. The
answers for those five are unchanged: the sentinel of a float and a timestamptz
is still DBL_MAX, and a bound of a continuous type is still the bound itself.
tools/scripts/dispatch_default_baseline.txt loses the three lines these three
functions held, since the check reads them as fixed once the arms are named.

The rule is that a default answering for a valid type is a hole rather than a
convenience. The set of base types grows, so a type added tomorrow reaches these
switches and is served silently by the fallback, and nothing names the site that
was never taught about it. A default that raises names it on the first call. The
arm set comes from meos_catalog.c, where exactly five base types declare a
basetype_spantype at lines 245 to 275, never from the cases a function already
carries.

Witness: distance_sentinel(T_TEXT) answers DBL_MAX and leaves the error state at
0, and text carries no span at all, so a caller reads a distance where the
question has no meaning. It now reports MEOS_ERR_INTERNAL_TYPE_ERROR, "Unknown
base type for the distance sentinel: text". The value it hands back is still
DBL_MAX, which is how a MEOS function propagates an error through a return
value, so what the caller gains is the error state rather than a different
number. The bound functions carry the same silence, where the cost is sharper: a
type reaching them reads back the bound unchanged, which is the answer for a
CONTINUOUS type, so a span of a discrete type would canonicalize wrongly.

Measured on master 4146b05edd with a probe built against each tree, resolving
that tree's own libmeos.so through an rpath and its meos headers from that tree
rather than from any shared prefix. The three functions are read across all six
base types, and every one of the eighteen answers matches to the bit, the text
rows included. Only the error state moves, from 0 to MEOS_ERR_INTERNAL_TYPE_ERROR
on the three text rows. check_dispatch_default.py exits 0 on both trees, twelve
baselined here against fifteen on master, and the single dispatch it reports as
no longer occurring is meos_is_simple on both sides alike. Both trees build
libmeos.so with -DMEOS=ON -DALL=ON at zero errors and zero warnings.

