### PR TITLE
Decide a crossing where a straight boundary meets a circular one

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -233,11 +233,11 @@ typedef struct
   RTree *index;   /**< Index over the edge boxes, NULL below the threshold */
   double xmax;    /**< Greatest x the edges reach */
   double tol;     /**< Widest tolerance any of the edges asks for */
-  bool straight;  /**< Every areal boundary edge the array holds is a segment,
-                       which is the class #relate_area_boundaries_cross reads:
-                       it solves a crossing from four given vertices, and the
-                       two endpoints of an arc do not determine the curve
-                       between them */
+  bool straight;  /**< Every areal boundary edge the array holds is a segment.
+                       #relate_area_boundaries_cross decides a crossing where
+                       an edge pair holds at most one arc, so ONE operand
+                       answering true leaves every pair of the two decided;
+                       two arcs are what it declines */
 } RelateEdges;
 
 extern void relate_edges_init(RelateEdges *re, Edge **edges, int nedges,
@@ -630,6 +630,70 @@ arc_point_parameter(const Edge *e, double x, double y)
   if (t > 1.0 && (2 * M_PI - off) < (off - sweep))
     return 0.0;
   return (t < 0.0) ? 0.0 : ((t > 1.0) ? 1.0 : t);
+}
+
+/**
+ * @brief Return true if a straight segment properly crosses a circular arc
+ * @details Proper means the segment passes from one side of the arc to the
+ * other at a point interior to both edges, which is for an arc what
+ * #relate_edges_cross decides for two straight edges. The quadratic
+ * #arcsegm_intersect solves is what says so, read for its DISCRIMINANT rather
+ * than for its roots alone: a line meeting a circle at a double root is a
+ * TANGENT, which touches without passing through, and only a discriminant
+ * standing clear of the rounding that function already reads it against makes
+ * the line a secant. A root strictly inside the segment and strictly inside
+ * the arc's angular span is then a crossing point interior to both edges, and
+ * the four sectors around it are the four combinations of inside and outside.
+ * Nothing is read off the arc's endpoints: the edge carries the centre, the
+ * radius and the span, so the curve between them is determined.
+ * Whatever these quantities cannot separate reads as NOT crossing, which is
+ * the same refusal the straight predicate makes and leaves the pair to the
+ * routes that already answer it
+ * @param[in] ax,ay Coordinates of the start of the straight segment
+ * @param[in] rx,ry Vector of the straight segment
+ * @param[in] e Arc edge
+ */
+static inline bool
+arcsegm_cross(double ax, double ay, double rx, double ry, const Edge *e)
+{
+  double aa = rx * rx + ry * ry;
+  /* Degenerate (zero-length) segment */
+  if (aa < MEOS_GEOM_TOLERANCE)
+    return false;
+
+  double wx = ax - e->cx, wy = ay - e->cy;
+  double bb = 2 * (wx * rx + wy * ry);
+  double cc = wx * wx + wy * wy - e->radius * e->radius;
+  double disc = bb * bb - 4 * aa * cc;
+  /* The rounding the discriminant is read against, in the form
+   * #arcsegm_intersect states and for the reason it gives there */
+  double eps = 1e-14 * (fabs(bb * bb) + fabs(4 * aa * cc) +
+    aa * (wx * wx + wy * wy + e->radius * e->radius));
+  /* A tangent line reaches the circle without passing through it */
+  if (disc <= eps)
+    return false;
+
+  double sq = sqrt(disc);
+  if (sq <= MEOS_GEOM_TOLERANCE)
+    return false;
+  for (int k = 0; k < 2; k++)
+  {
+    double t = (k == 0 ? -bb - sq : -bb + sq) / (2 * aa);
+    /* Strictly interior to the segment. A crossing at an endpoint is a touch,
+     * which the vertex routes answer and which the straight predicate refuses
+     * for the same reason */
+    if (t <= MEOS_GEOM_TOLERANCE || t >= 1 - MEOS_GEOM_TOLERANCE)
+      continue;
+    double px = ax + t * rx, py = ay + t * ry;
+    if (! arc_contains_angle(e, atan2(py - e->cy, px - e->cx)))
+      continue;
+    /* Strictly interior to the arc, for the same reason */
+    double u = arc_point_parameter(e, px, py);
+    if (u <= MEOS_GEOM_TOLERANCE || u >= 1 - MEOS_GEOM_TOLERANCE)
+      continue;
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -5534,6 +5534,34 @@ relate_edges_cross(const Edge *e1, const Edge *e2)
 }
 
 /**
+ * @brief Return true if two areal boundary edges properly cross
+ * @details Two straight edges are decided by four determinants on their own
+ * vertices (#relate_edges_cross). A straight edge against a CIRCULAR one is
+ * decided by the quadratic that meets a line with a circle (#arcsegm_cross),
+ * which is equally exact: an arc edge carries the centre, the radius and the
+ * angular span, so the curve between its endpoints is determined and nothing
+ * has to be inferred from those endpoints.
+ * TWO ARCS are left to the other routes. Two circles bring a tangency and a
+ * shared stretch of their own, and deciding those is a separate question from
+ * this one
+ */
+static bool
+relate_area_edges_cross(const Edge *e1, const Edge *e2)
+{
+  if (e1->etype == EDGE_POLYSEG)
+  {
+    if (e2->etype == EDGE_POLYSEG)
+      return relate_edges_cross(e1, e2);
+    if (e2->etype == EDGE_POLYARC)
+      return arcsegm_cross(e1->x1, e1->y1, e1->dx, e1->dy, e2);
+    return false;
+  }
+  if (e1->etype == EDGE_POLYARC && e2->etype == EDGE_POLYSEG)
+    return arcsegm_cross(e2->x1, e2->y1, e2->dx, e2->dy, e1);
+  return false;
+}
+
+/**
  * @brief Compute a point on an areal boundary edge.
  * @details 
  *   t = 0 -> first endpoint
@@ -5870,8 +5898,9 @@ relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
      * so does the boundary, whatever the midpoint reads.
      *
      * The interiors answer carries that weight only where it is exact, which
-     * is the straight-boundary class its crossing route reads, so a pair
-     * carrying an arc keeps the midpoint as its only source */
+     * is the class its crossing route reads: every pair of boundary edges
+     * across the two operands holding at most one arc. A pair whose operands
+     * BOTH carry an arc keeps the midpoint as its only source */
     if (loc == 0 && (m->ii == 2 || ! exact_ii))
     {
       /* Boundary(A) ∩ Interior(B) or Interior(A) ∩ Boundary(B) */
@@ -6104,9 +6133,11 @@ relate_area_interior_point_located(const RelateEdges *self,
  * land in: a sliver a couple of units in the last place wide is narrower than
  * the band every point-location route reads, yet its crossing vertices are
  * exactly the ones the determinants are taken on.
- * Arcs are left to the other routes. The endpoints of an arc do not determine
- * the curve between them, so four signs taken on them say nothing about
- * whether the arcs meet
+ * A CIRCULAR edge against a straight one is decided too, by the quadratic
+ * rather than by the determinants: the arc carries its centre, radius and
+ * angular span, so the curve between its endpoints is determined and the
+ * crossing is solved exactly. Only two ARCS are left to the other routes,
+ * #relate_area_edges_cross saying why
  * @param[in] a,b Edges of the two geometries, the second read out of its index
  * where it carries one
  */
@@ -6116,23 +6147,23 @@ relate_area_boundaries_cross(const RelateEdges *a, const RelateEdges *b)
   for (int i = 0; i < a->nedges; i++)
   {
     const Edge *ea = a->edges[i];
-    if (ea->etype != EDGE_POLYSEG)
-      continue;
     if (! b->index)
     {
       for (int j = 0; j < b->nedges; j++)
       {
         const Edge *eb = b->edges[j];
-        if (eb->etype == EDGE_POLYSEG && relate_edges_cross(ea, eb))
+        if (relate_area_edges_cross(ea, eb))
           return true;
       }
       continue;
     }
-    /* Two segments that cross meet at a point lying on both, so that point is
-     * in both boxes and the boxes overlap. The query therefore needs NO
-     * padding: an unpadded box already admits every crossing there is, and
-     * unlike the point-location queries the test behind it reads no tolerance
-     * that a pad would have to match */
+    /* Two edges that cross meet at a point lying on both, so that point is
+     * in both boxes and the boxes overlap -- an arc's box being tight about
+     * the curve and not merely about its endpoints. The query therefore needs
+     * NO padding: an unpadded box already admits every crossing there is, and
+     * unlike the point-location queries the tests behind it only ever REFUSE
+     * a crossing near a boundary of either edge, so none of them reaches for a
+     * point a pad would have to admit */
     STBox query;
     stbox_set(true, false, false, 0, ea->xmin, ea->xmax, ea->ymin, ea->ymax,
       0, 0, NULL, &query);
@@ -6142,8 +6173,7 @@ relate_area_boundaries_cross(const RelateEdges *a, const RelateEdges *b)
     for (int c = 0; c < nc && ! result; c++)
     {
       const Edge *eb = b->edges[*(int64 *) meos_array_get(candidates, c)];
-      if (eb->etype == EDGE_POLYSEG)
-        result = relate_edges_cross(ea, eb);
+      result = relate_area_edges_cross(ea, eb);
     }
     meos_array_destroy(candidates);
     if (result)
@@ -6244,9 +6274,13 @@ relate_area_area(const LWGEOM *g1, const LWGEOM *g2,
 
   /* Boundary(A) / Interior(B) and Interior(A) / Boundary(B) are determined by
    * splitting every boundary edge at the intersections with the other
-   * boundary. Where both boundaries are straight the step above has settled
-   * the interiors exactly, and each portion is read against that answer */
-  bool exact_ii = re1.straight && re2.straight;
+   * boundary. Where the step above has settled the interiors exactly, each
+   * portion is read against that answer */
+  /* The crossing route decides two straight edges from four determinants and
+   * a straight edge against a circular one from the quadratic that meets a
+   * line with a circle. Only two ARCS are left to the routes that sample, so
+   * ONE operand free of arcs is enough to leave every crossing pair decided */
+  bool exact_ii = re1.straight || re2.straight;
   for (int i = 0; i < n1; i++)
   {
     if (!relate_area_boundary_edge(e1[i]))

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -373,6 +373,50 @@ int main(void)
   free(apart_geo_a); free(apart_geo_b);
   meos_errno_reset();
 
+  /* The same construction with one of the two boundaries CIRCULAR. An area
+   * below the line y = 0 meets an area above it whose lower boundary is an
+   * arc through (4 0), (2 1e-9) and (0 0) -- an arc that touches the line at
+   * its two endpoints and stands above it everywhere between, so the two
+   * areas share those two points and nothing else, whatever the arithmetic
+   * reads. The answer is again a property of the construction.
+   * It is the interiors that have to settle it, and until they can be decided
+   * for a pair carrying an arc the classification of a boundary portion falls
+   * back on that portion's midpoint, which lands on either side of the arc by
+   * the residue of the arithmetic that solved the split. #relate_edges_cross
+   * decides two straight boundaries from four determinants; the quadratic
+   * that meets a line with a circle decides a straight boundary against a
+   * circular one just as exactly, which is what lets the interiors answer
+   * here. The engine used to contradict itself on this record, reporting an
+   * OVERLAP from the matrix while its own overlay answered the two points and
+   * no area at all */
+  const char *arctouch_a = "POLYGON((0 -1,0 0,2 0,4 0,4 -1,0 -1))";
+  const char *arctouch_b =
+    "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(4 0,2 1e-9,0 0),"
+    "(0 0,0 1,4 1,4 0)))";
+  GSERIALIZED *arctouch_geo_a = geom_in(arctouch_a, -1);
+  GSERIALIZED *arctouch_geo_b = geom_in(arctouch_b, -1);
+  assert(arctouch_geo_a != NULL);
+  assert(arctouch_geo_b != NULL);
+  meos_errno_reset();
+  char arctouch_patt[10] = "F***T****";
+  bool arctouch_touches = geom_relate_pattern(arctouch_geo_a, arctouch_geo_b, arctouch_patt);
+  printf("geom_relate_pattern(an area and one bounded below by an arc that "
+    "touches it, they only touch): %d, errno %d\n", arctouch_touches,
+    meos_errno());
+  assert(arctouch_touches == true);
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+  char arctouch_interiors[10] = "T********";
+  bool arctouch_overlaps = geom_relate_pattern(arctouch_geo_a, arctouch_geo_b,
+    arctouch_interiors);
+  printf("geom_relate_pattern(an area and one bounded below by an arc that "
+    "touches it, interiors meet): %d, errno %d\n", arctouch_overlaps,
+    meos_errno());
+  assert(arctouch_overlaps == false);
+  assert(meos_errno() == 0);
+  free(arctouch_geo_a); free(arctouch_geo_b);
+  meos_errno_reset();
+
   /* Two areas whose boundaries run PARALLEL never touch, however close they
    * come. Deciding that means asking whether the two lines are one line, and
    * the engine answers it from the cross product of the offset between them


### PR DESCRIPTION
WITNESS. An area below the line y = 0, and one above it whose lower boundary
is an arc touching that line at its two endpoints:

```
  A = POLYGON((0 -1,0 0,2 0,4 0,4 -1,0 -1))
  B = CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(4 0,2 1e-9,0 0),
                                 (0 0,0 1,4 1,4 0)))

  before   geom_relate(A,B) = 212101212   -- II = 2, the interiors OVERLAP
  after    geom_relate(A,B) = FF2F01212   -- II = F, they meet at two points
```

The arc stands above the line everywhere between its endpoints, so the two
areas share those two points and no area at all. The engine contradicted
itself on this pair: while the matrix answered an overlap, the engine's own
overlay answered geom_intersection2d(A,B) = MULTIPOINT((4 0),(0 0)) with
geom_area = 0. The new answer is the one that overlay already gave.

WHY. relate_area_boundaries_cross decides whether two areal interiors meet by
finding a place where the two boundaries properly cross, and it skipped every
edge pair carrying an arc. Its reason covers only half of what it refused:
four determinants taken on an arc's two endpoints say nothing about the curve
between them, which is true of an arc against an arc and NOT of an arc against
a SEGMENT. An arc edge carries the centre, the radius and the angular span, so
the curve between its endpoints is determined and meeting it with a line is a
quadratic -- one this tree already solves exactly, in arcsegm_intersect, and
which the interval walk solves on the very pairs this route was dropping.

So a straight edge against a circular one is decided too, by arcsegm_cross,
which reads that quadratic for its DISCRIMINANT as well as its roots: a line
meeting a circle at a double root is a tangent and touches without passing
through, so only a discriminant standing clear of the rounding makes the line
a secant. A root strictly inside the segment and strictly inside the arc's
span is then a crossing point interior to both edges, around which the four
sectors are the four combinations of inside and outside. Anything the
quantities cannot separate reads as not crossing, which is the refusal the
straight predicate already makes. Two arcs stay out: two circles bring a
tangency and a shared stretch of their own, and that is a separate question.

With every crossing pair of a straight operand decided, the class in which the
interiors are settled exactly widens from both operands straight to either one
of them, and the classification of a boundary portion defers to that answer
there instead of to a midpoint constructed from two solved split parameters.

MEASURED, and what did NOT move.

```
  geo_pairs                        12880 pairs   0 answers moved
  areal_pairs                       1444 pairs   0 answers moved
  adversarial_pairs                   54 pairs   0 answers moved
  self-pairs, both operand columns 25760 pairs   0 answers moved,
                                                 self-identity count unmoved
  exact CGAL IB/BI oracle, areal    1444 judged  MEOS agrees 1444, wrong 0,
                                                 its 4 controls passing
  the same oracle over the real       19 judged  MEOS agrees 19, wrong 0
    protected-area pairs                         (pair 2 the oracle declines,
                                                 so outside the denominator)
  constructed touching sweep          33 pairs   13 wrong -> 9 wrong:
                                                 4 fixed, 0 broken
  pg_regress on PostgreSQL 18                    all tests passed
  meos/test, the CI step verbatim     56 invocations, clean
  threaded_test under ThreadSanitizer            clean
  answer-level two-build diff         41 instruments, 3 lines moved:
                                                 the 2 new assertions and a clock
```

A corpus that does not move is otherwise silent about a change the boundary
walk masks, so the instrument that discriminates is a THIRD build: widening
the class WITHOUT the new predicate turns geo_pairs row 3697 from 212101212
into FF2F01212. That is what shows the predicate carries the widening rather
than riding on it.

The nine constructed pairs still answered wrongly are a DIFFERENT defect and
are measured as such: the arc reconstruction places the circle so that it
meets the straight boundary 2.1e-6 inside each endpoint at coordinates near
6.2e6, and exactly at the endpoints at the origin. An exact predicate reading
that arc is right about the geometry it was handed and wrong about the
geometry the input names, six orders above the geometry tolerance, so no
constant separates them. That is a frame-normalization question and owes its
own PR.

No timing figures are given: the route gains one quadratic on edge pairs it
previously skipped outright and loses nothing elsewhere.

Relate cost of the native engine, callgrind instructions over the regression pairs, base 6209a11ce8 against merge 120edb9a55: areal pairs 18,355,016,730 -> 18,355,015,998 (-0.00%), geo pairs 35,557,346,606 -> 35,556,681,316 (-0.00%).
