### PR TITLE
Drop the baselined dispatch the check reports as no longer occurring

### DIFF
--- a/tools/scripts/dispatch_default_baseline.txt
+++ b/tools/scripts/dispatch_default_baseline.txt
@@ -3,7 +3,6 @@
 # The list only shrinks: a dispatch it does not carry fails the
 # check. Name the last type like every other arm and reject what
 # remains, then regenerate with --rebaseline.
-meos/src/geo/geo_funcs.c	meos_is_simple	switch geom->type
 meos/src/geo/geo_funcs.c	relate_extract_edges	switch geom->type
 meos/src/geo/tgeo_distance.c	dist_geom_edges	switch lw->type
 meos/src/h3/h3_geo.c	lwgeom_to_cells_into	switch geom->type


### PR DESCRIPTION
tools/scripts/dispatch_default_baseline.txt loses its meos_is_simple line, so
check_dispatch_default.py reports eleven baselined dispatches and prints no
advisory beside them.

The rule is that the baseline names the dispatches still to be fixed and only
those. A line for a dispatch the check no longer finds asserts that a hole is
open where none is, and it survives indefinitely because a stale entry only
advises while a missing one fails, so nothing forces the correction. Any later
change that regenerates the file with --rebaseline then carries the deletion as
a hunk unrelated to its own topic.

Witness: meos_is_simple closes its switch on geom->type with a default that
returns false, a constant classifying whatever the arms do not name rather than
reading it as one of them. The checker's own docstring states that this shape is
clean -- "a default: answering totally -- a constant, or nothing at all --
classifies the residue instead of assuming it" -- so the function is not a
finding, and the check already reports it as none.

Measured on master 6209a11ce8: check_dispatch_default.py exits 0, prints "1
baselined dispatch(es) no longer occur" naming meos_is_simple, and counts twelve
baselined. It exits 0 here, counts eleven, and prints no such line.

