### PR TITLE
Separate the error a box distance reports from the answer that it has none

### DIFF
--- a/meos/src/temporal/tnumber_distance.c
+++ b/meos/src/temporal/tnumber_distance.c
@@ -192,8 +192,9 @@ nad_tnumber_number(const Temporal *temp, Datum value)
  * @ingroup meos_internal_temporal_dist
  * @brief Return the nearest approach distance between the temporal boxes
  * @param[in] box1,box2 Temporal boxes
- * @return On error return the sentinel of the base type given by
- * #distance_sentinel()
+ * @return The sentinel of the base type given by #distance_sentinel() where the
+ * boxes share no time, which is an answer and not an error: the external
+ * function establishes every precondition, so no path here raises
  * @note Function called when using indexes for k-nearest neighbor queries for
  * temporal numbers. Therefore, it must satisfy the following conditions
  * (1) the actual distance is always greater than or equal to the estimated
@@ -205,13 +206,12 @@ nad_tnumber_number(const Temporal *temp, Datum value)
 Datum
 nad_tbox_tbox(const TBox *box1, const TBox *box2)
 {
-  /* Ensure the validity of the arguments */
+  /* The preconditions the external function tests */
   assert(box1); assert(box2);
+  assert(MEOS_FLAGS_GET_X(box1->flags));
+  assert(MEOS_FLAGS_GET_X(box2->flags));
+  assert(box1->span.spantype == box2->span.spantype);
   MeosType basetype = box1->span.basetype;
-  if (! ensure_has_X(T_TBOX, box1->flags) ||
-      ! ensure_has_X(T_TBOX, box2->flags) ||
-      ! ensure_same_span_type(&box1->span, &box2->span))
-    return distance_sentinel(basetype);
 
   /* If the boxes do not intersect in the time dimension return the sentinel */
   bool hast = MEOS_FLAGS_GET_T(box1->flags) && MEOS_FLAGS_GET_T(box2->flags);

--- a/meos/src/temporal/tnumber_distance_meos.c
+++ b/meos/src/temporal/tnumber_distance_meos.c
@@ -198,15 +198,21 @@ nad_tfloat_tbox(const Temporal *temp, const TBox *box)
  * @ingroup meos_temporal_dist
  * @brief Return the nearest approach distance between the int temporal boxes
  * @param[in] box1,box2 Temporal boxes
- * @return On error return INT_MAX
+ * @return On error return -1
+ * @note A distance is never negative, so -1 states an error where INT_MAX
+ * states that the boxes share no time
  * @csqlfn #NAD_tbox_tbox()
  */
 int
 nad_tboxint_tboxint(const TBox *box1, const TBox *box2)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(box1, -1); VALIDATE_NOT_NULL(box2, -1);
   if (! ensure_span_isof_type(&box1->span, T_INTSPAN) ||
-      ! ensure_span_isof_type(&box2->span, T_INTSPAN))
-    return INT_MAX;
+      ! ensure_span_isof_type(&box2->span, T_INTSPAN) ||
+      ! ensure_has_X(T_TBOX, box1->flags) ||
+      ! ensure_has_X(T_TBOX, box2->flags))
+    return -1;
 
   return DatumGetInt32(nad_tbox_tbox(box1, box2));
 }
@@ -216,15 +222,21 @@ nad_tboxint_tboxint(const TBox *box1, const TBox *box2)
  * @brief Return the nearest approach distance between the big integer temporal
  * boxes
  * @param[in] box1,box2 Temporal boxes
- * @return On error return @p INT64_MAX
+ * @return On error return -1
+ * @note A distance is never negative, so -1 states an error where INT64_MAX
+ * states that the boxes share no time
  * @csqlfn #NAD_tbox_tbox()
  */
 int64
 nad_tboxbigint_tboxbigint(const TBox *box1, const TBox *box2)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(box1, -1); VALIDATE_NOT_NULL(box2, -1);
   if (! ensure_span_isof_type(&box1->span, T_BIGINTSPAN) ||
-      ! ensure_span_isof_type(&box2->span, T_BIGINTSPAN))
-    return INT64_MAX;
+      ! ensure_span_isof_type(&box2->span, T_BIGINTSPAN) ||
+      ! ensure_has_X(T_TBOX, box1->flags) ||
+      ! ensure_has_X(T_TBOX, box2->flags))
+    return -1;
 
   return DatumGetInt64(nad_tbox_tbox(box1, box2));
 }
@@ -233,15 +245,21 @@ nad_tboxbigint_tboxbigint(const TBox *box1, const TBox *box2)
  * @ingroup meos_temporal_dist
  * @brief Return the nearest approach distance between the float temporal boxes
  * @param[in] box1,box2 Temporal boxes
- * @return On error return DBL_MAX
+ * @return On error return -1.0
+ * @note A distance is never negative, so -1.0 states an error where DBL_MAX
+ * states that the boxes share no time
  * @csqlfn #NAD_tbox_tbox()
  */
 double
 nad_tboxfloat_tboxfloat(const TBox *box1, const TBox *box2)
 {
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(box1, -1.0); VALIDATE_NOT_NULL(box2, -1.0);
   if (! ensure_span_isof_type(&box1->span, T_FLOATSPAN) ||
-      ! ensure_span_isof_type(&box2->span, T_FLOATSPAN))
-    return DBL_MAX;
+      ! ensure_span_isof_type(&box2->span, T_FLOATSPAN) ||
+      ! ensure_has_X(T_TBOX, box1->flags) ||
+      ! ensure_has_X(T_TBOX, box2->flags))
+    return -1.0;
   return DatumGetFloat8(nad_tbox_tbox(box1, box2));
 }
 

--- a/mobilitydb/src/temporal/tnumber_distance.c
+++ b/mobilitydb/src/temporal/tnumber_distance.c
@@ -169,6 +169,13 @@ NAD_tbox_tbox(PG_FUNCTION_ARGS)
 {
   TBox *box1 = PG_GETARG_TBOX_P(0);
   TBox *box2 = PG_GETARG_TBOX_P(1);
+  /* Ensure the validity of the arguments: the kernel states these as
+   * assertions, and this wrapper is an external entry that reaches it with no
+   * MEOS function in between */
+  if (! ensure_valid_tbox_tbox(box1, box2) ||
+      ! ensure_has_X(T_TBOX, box1->flags) ||
+      ! ensure_has_X(T_TBOX, box2->flags))
+    PG_RETURN_NULL();
   MeosType basetype = box1->span.basetype;
   Datum result = nad_tbox_tbox(box1, box2);
   if (datum_eq(result, distance_sentinel(basetype), basetype))

--- a/mobilitydb/src/temporal/tnumber_gist.c
+++ b/mobilitydb/src/temporal/tnumber_gist.c
@@ -1032,6 +1032,13 @@ tbox_gist_distance(FunctionCallInfo fcinfo, bool boxcolumn)
    * and let the recheck sort things out in the case of leaves. Since the
    * GiST framework expects a double for the distance method, we need to
    * convert the integer distance for temporal integer boxes into a double */
+  /* The kernel states its preconditions as assertions, and this scan reaches
+   * it with no MEOS function in between. An entry the query cannot be measured
+   * against takes the same maximum as one carrying no key at all */
+  if (! ensure_valid_tbox_tbox(key, &query) ||
+      ! ensure_has_X(T_TBOX, key->flags) ||
+      ! ensure_has_X(T_TBOX, query.flags))
+    PG_RETURN_FLOAT8(DBL_MAX);
   double distance = distance_double(nad_tbox_tbox(key, &query),
     key->span.basetype);
   PG_RETURN_FLOAT8(distance);

--- a/mobilitydb/src/temporal/tnumber_spgist.c
+++ b/mobilitydb/src/temporal/tnumber_spgist.c
@@ -700,8 +700,16 @@ Tbox_spgist_leaf_consistent(PG_FUNCTION_ARGS)
       Datum value = scankey->sk_argument;
       MeosType type = oid_meostype(scankey->sk_subtype);
       tnumber_spgist_get_tbox(value, type, &box);
-      distances[i] = distance_double(nad_tbox_tbox(&box, key),
-        key->span.basetype);
+      /* The kernel states its preconditions as assertions, and this scan
+       * reaches it with no MEOS function in between. An entry the order by
+       * cannot be measured against sorts after every measurable one */
+      if (! ensure_valid_tbox_tbox(&box, key) ||
+          ! ensure_has_X(T_TBOX, box.flags) ||
+          ! ensure_has_X(T_TBOX, key->flags))
+        distances[i] = DBL_MAX;
+      else
+        distances[i] = distance_double(nad_tbox_tbox(&box, key),
+          key->span.basetype);
     }
     /* Recheck is necessary when computing distance with bounding boxes */
     out->recheckDistances = true;

--- a/mobilitydb/test/temporal/expected/036_tnumber_distance.test.out
+++ b/mobilitydb/test/temporal/expected/036_tnumber_distance.test.out
@@ -1006,3 +1006,19 @@ SELECT tfloat '[1@2001-01-01, 2@2001-01-02]' |=| tfloat '[3@2001-01-03, 4@2001-0
          
 (1 row)
 
+SELECT tbox 'TBOXINT XT([1,5],[2001-01-01, 2001-01-02])' |=| tbox 'TBOXINT XT([10,20],[2001-01-01, 2001-01-02])';
+ ?column? 
+----------
+        5
+(1 row)
+
+SELECT tbox 'TBOXINT XT([1,5],[2001-01-01, 2001-01-02])' |=| tbox 'TBOXINT XT([10,20],[2001-02-01, 2001-02-02])';
+ ?column? 
+----------
+         
+(1 row)
+
+SELECT tbox 'TBOXINT XT([1,5],[2001-01-01, 2001-01-02])' |=| tbox 'TBOXFLOAT XT([1,5],[2001-01-01, 2001-01-02])';
+ERROR:  Operation on mixed span types: intspan and floatspan
+SELECT tbox 'TBOXINT T([2001-01-01, 2001-01-02])' |=| tbox 'TBOXINT XT([10,20],[2001-01-01, 2001-01-02])';
+ERROR:  The tbox must have X dimension

--- a/mobilitydb/test/temporal/queries/036_tnumber_distance.test.sql
+++ b/mobilitydb/test/temporal/queries/036_tnumber_distance.test.sql
@@ -225,4 +225,13 @@ SELECT tfloat '[1@2001-01-01, 2@2001-01-02]'::tbox |=| tfloat '[3@2001-01-03, 4@
 SELECT tfloat '[1@2001-01-01, 2@2001-01-02]' |=| tfloat '[3@2001-01-03, 4@2001-01-04]'::tbox;
 SELECT tfloat '[1@2001-01-01, 2@2001-01-02]' |=| tfloat '[3@2001-01-03, 4@2001-01-04]';
 
+-- The maximum of the type says the boxes share no time, so a rejected pair
+-- must be told apart from it rather than answered with the same value
+SELECT tbox 'TBOXINT XT([1,5],[2001-01-01, 2001-01-02])' |=| tbox 'TBOXINT XT([10,20],[2001-01-01, 2001-01-02])';
+-- NULL
+SELECT tbox 'TBOXINT XT([1,5],[2001-01-01, 2001-01-02])' |=| tbox 'TBOXINT XT([10,20],[2001-02-01, 2001-02-02])';
+-- ERROR
+SELECT tbox 'TBOXINT XT([1,5],[2001-01-01, 2001-01-02])' |=| tbox 'TBOXFLOAT XT([1,5],[2001-01-01, 2001-01-02])';
+SELECT tbox 'TBOXINT T([2001-01-01, 2001-01-02])' |=| tbox 'TBOXINT XT([10,20],[2001-01-01, 2001-01-02])';
+
 -------------------------------------------------------------------------------

--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -79,6 +79,13 @@ PREDICATE_DOC = re.compile(r"@brief Return true if|@return\s+1 if")
 # says the value is not located there, which is an answer and not a failure,
 # and it is already outside the fractions it otherwise returns.
 LOCATOR = re.compile(r"locate")
+# A nearest approach distance between two temporal boxes answers with the
+# maximum where the boxes share no time, which is an ANSWER and not a failure.
+# The maximum is therefore inside its value domain and cannot also mean error,
+# so the error takes -1 -- outside the domain of a distance, which is never
+# negative. That is what the rule actually asks for, exactly as it asks it of
+# the predicates and the locators above.
+BOX_DISTANCE = re.compile(r"^nad_tbox")
 # A pointer return: any sentinel other than NULL is wrong
 POINTER = re.compile(r"\*\s*$")
 
@@ -154,6 +161,8 @@ def scan(path: Path, rel: str) -> list[tuple[str, str]]:
             want = "-1"
         if want == "DBL_MAX" and LOCATOR.search(name):
             want = "-1.0"
+        if BOX_DISTANCE.match(name):
+            want = "-1.0" if want == "DBL_MAX" else "-1"
 
         validated = validated_raw = None
         for bl in body:


### PR DESCRIPTION
nad_tboxint_tboxint, nad_tboxbigint_tboxbigint and nad_tboxfloat_tboxfloat test
every precondition their shared kernel needs -- both operands non-null, both
spans of the declared type, both boxes carrying an X extent -- and answer -1, -1
and -1.0 where one fails. The kernel nad_tbox_tbox states those same conditions
as assertions, and the three callers that reach it with no MEOS function in
between now establish them: the wrapper NAD_tbox_tbox and the order-by paths in
tnumber_gist.c and tnumber_spgist.c call ensure_valid_tbox_tbox and ensure_has_X
before it, which is where master already spent those tests, one per call, inside
the kernel.

The rule is the external/internal split MEOS already declares. An external
function tests each condition and raises a message a caller can read; the
internal one states the identical condition as an assertion, which CASSERT
compiles in and a production build compiles out. What makes the sentinel choice
follow from it is that one value cannot carry two meanings: the maximum of the
type is an ANSWER here, saying the two boxes share no time, so the error takes
-1, which a distance can never be. tools/scripts/check_error_sentinels.py states
that rule and now names this third class of it, beside the three-valued
predicates and the locators whose sentinels are out of their value domains for
the same reason.

Witness: nad_tboxint_tboxint answers 2147483647 for two int boxes whose time
spans are disjoint, and 2147483647 again for a box carrying no X extent, so a
caller reading the answer alone cannot tell a rejected argument from a pair of
boxes that never meet. The rejected argument now answers -1 while the disjoint
pair still answers 2147483647, and nad_tboxfloat_tboxfloat reads the same way
with -1.0 against an unchanged 1.79769e+308.

Measured on master 6209a11ce8: the four tbox rows added to
036_tnumber_distance answer 5 where the boxes overlap in time, NULL where they
do not, and the two messages master raises -- "Operation on mixed span types:
intspan and floatspan" and "The tbox must have X dimension" -- where an argument
is rejected, so the guards moved to the callers keep the SQL behaviour they had.
The suite runs 5 of 5 green on those files. check_error_sentinels.py exits 1 on
master against these three functions and 0 here, so the rule it now states is
enforced rather than assumed. Both targets build at zero errors and zero
warnings, libmeos.so with -DMEOS=ON -DALL=ON and the extension with -DMEOS=OFF.

