### PR TITLE
Decide a crossing where two circular boundaries meet

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -45,6 +45,8 @@
 /* C */
 #include <float.h>
 #include <math.h>
+#include <stdio.h>
+#include <stdlib.h>
 /* PostgreSQL */
 #include <postgres.h>
 #include <meos_error.h>
@@ -233,11 +235,6 @@ typedef struct
   RTree *index;   /**< Index over the edge boxes, NULL below the threshold */
   double xmax;    /**< Greatest x the edges reach */
   double tol;     /**< Widest tolerance any of the edges asks for */
-  bool straight;  /**< Every areal boundary edge the array holds is a segment.
-                       #relate_area_boundaries_cross decides a crossing where
-                       an edge pair holds at most one arc, so ONE operand
-                       answering true leaves every pair of the two decided;
-                       two arcs are what it declines */
 } RelateEdges;
 
 extern void relate_edges_init(RelateEdges *re, Edge **edges, int nedges,
@@ -690,6 +687,91 @@ arcsegm_cross(double ax, double ay, double rx, double ry, const Edge *e)
     /* Strictly interior to the arc, for the same reason */
     double u = arc_point_parameter(e, px, py);
     if (u <= MEOS_GEOM_TOLERANCE || u >= 1 - MEOS_GEOM_TOLERANCE)
+      continue;
+    return true;
+  }
+  return false;
+}
+
+/**
+ * @brief Return true if two circular arcs properly cross
+ * @details Proper means the two curves pass through one another at a point
+ * interior to both, which is for two arcs what #relate_edges_cross decides for
+ * two straight edges and #arcsegm_cross for one of each. Two distinct circles
+ * meet in at most two points, and the HALF-CHORD of that meeting is what says
+ * whether they cross: it vanishes exactly when the circles are TANGENT, which
+ * touches without passing through, and #relate_arc_arc_points reads the same
+ * quantity against the same bound to decide it reports one point rather than
+ * two. A half-chord standing clear of that bound therefore makes the circles
+ * secant, and an intersection point strictly inside both arcs' angular spans
+ * is a crossing point interior to both edges, around which the four sectors
+ * are the four combinations of inside and outside.
+ * COINCIDENT supporting circles are NOT a crossing: two arcs of one circle
+ * either share a stretch or meet at an endpoint, and both are answered
+ * elsewhere. Whatever these quantities cannot separate reads as NOT crossing,
+ * which is the refusal the other two predicates make
+ * @param[in] a,b The two arc edges
+ */
+static inline bool
+arcarc_cross(const Edge *a, const Edge *b)
+{
+  double dx = b->cx - a->cx, dy = b->cy - a->cy;
+  double d = hypot(dx, dy);
+  /* One circle: a shared stretch or a common endpoint, never a crossing */
+  if (d <= MEOS_GEOM_TOLERANCE)
+    return false;
+  /* Separate or nested circles never meet */
+  if (d > a->radius + b->radius + MEOS_GEOM_TOLERANCE ||
+      d < fabs(a->radius - b->radius) - MEOS_GEOM_TOLERANCE)
+    return false;
+
+  double aa = (d * d + a->radius * a->radius - b->radius * b->radius) /
+    (2.0 * d);
+  double h2 = a->radius * a->radius - aa * aa;
+  /* Tangent circles touch at one point without passing through */
+  if (h2 <= 0.0)
+    return false;
+  double h = sqrt(h2);
+  if (h <= MEOS_GEOM_TOLERANCE)
+    return false;
+
+  /* HOW FAR THE CROSSING POINT ITSELF IS RESOLVED, and why a parameter margin
+   * cannot stand in for it. The half-chord comes from `r^2 - aa^2`, two
+   * quantities of size radius squared differenced down to the chord: at a
+   * radius of 2e5 each is 4e10, whose last representable bit is 8e-6, so the
+   * point slides along the chord by about that much however exactly the input
+   * names it. A test asking only that the parameter be some tiny amount
+   * inside `[0, 1]` therefore reads an ENDPOINT as an interior crossing --
+   * measured, two arcs meeting exactly at their two shared endpoints report a
+   * crossing 3.8e-6 away from one of them. The distance below is that
+   * rounding written out, in the same form #arcsegm_intersect states its own,
+   * so a candidate nearer an endpoint than the arithmetic can resolve is
+   * refused rather than believed */
+  double resolution = DBL_EPSILON *
+    (a->radius * a->radius + aa * aa) / (2.0 * h);
+  double ux = dx / d, uy = dy / d;
+  double mx = a->cx + aa * ux, my = a->cy + aa * uy;
+  for (int k = 0; k < 2; k++)
+  {
+    double px = mx + (k ? h : -h) * (-uy);
+    double py = my + (k ? h : -h) * ux;
+    /* On both arcs at all */
+    if (! arc_contains_angle(a, atan2(py - a->cy, px - a->cx)) ||
+        ! arc_contains_angle(b, atan2(py - b->cy, px - b->cx)))
+      continue;
+    /* Clear of every endpoint by more than the point is resolved to. A
+     * meeting at an endpoint is a touch, which the vertex routes answer and
+     * which the straight predicate refuses for the same reason */
+    if (hypot(px - a->x1, py - a->y1) <= resolution ||
+        hypot(px - a->x2, py - a->y2) <= resolution ||
+        hypot(px - b->x1, py - b->y1) <= resolution ||
+        hypot(px - b->x2, py - b->y2) <= resolution)
+      continue;
+    double ua = arc_point_parameter(a, px, py);
+    if (ua <= MEOS_GEOM_TOLERANCE || ua >= 1 - MEOS_GEOM_TOLERANCE)
+      continue;
+    double ub = arc_point_parameter(b, px, py);
+    if (ub <= MEOS_GEOM_TOLERANCE || ub >= 1 - MEOS_GEOM_TOLERANCE)
       continue;
     return true;
   }

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -3587,13 +3587,10 @@ relate_edges_init(RelateEdges *re, Edge **edges, int nedges, bool index)
    * is thousands of times that. The widest tolerance in the array is what
    * makes the index answer what the scan answers at every scale */
   re->tol = MEOS_GEOM_TOLERANCE;
-  re->straight = true;
   for (int i = 0; i < nedges; i++)
   {
     if (edges[i]->tol > re->tol)
       re->tol = edges[i]->tol;
-    if (edges[i]->etype == EDGE_POLYARC)
-      re->straight = false;
   }
   re->index = index ? relate_edges_index(edges, nedges) : NULL;
   return;
@@ -5541,9 +5538,9 @@ relate_edges_cross(const Edge *e1, const Edge *e2)
  * which is equally exact: an arc edge carries the centre, the radius and the
  * angular span, so the curve between its endpoints is determined and nothing
  * has to be inferred from those endpoints.
- * TWO ARCS are left to the other routes. Two circles bring a tangency and a
- * shared stretch of their own, and deciding those is a separate question from
- * this one
+ * TWO CIRCULAR edges are decided by the half-chord of their supporting
+ * circles (#arcarc_cross), which vanishes exactly at a tangency, so the same
+ * question is answered for every pair of boundary edges the engine builds
  */
 static bool
 relate_area_edges_cross(const Edge *e1, const Edge *e2)
@@ -5556,8 +5553,13 @@ relate_area_edges_cross(const Edge *e1, const Edge *e2)
       return arcsegm_cross(e1->x1, e1->y1, e1->dx, e1->dy, e2);
     return false;
   }
-  if (e1->etype == EDGE_POLYARC && e2->etype == EDGE_POLYSEG)
-    return arcsegm_cross(e2->x1, e2->y1, e2->dx, e2->dy, e1);
+  if (e1->etype == EDGE_POLYARC)
+  {
+    if (e2->etype == EDGE_POLYSEG)
+      return arcsegm_cross(e2->x1, e2->y1, e2->dx, e2->dy, e1);
+    if (e2->etype == EDGE_POLYARC)
+      return arcarc_cross(e1, e2);
+  }
   return false;
 }
 
@@ -5760,13 +5762,10 @@ relate_area_edge_inside_area(const Edge *edge, const RelateEdges *area)
  * @details The edge is split at every intersection with the other polygon
  * boundary. Since there is no boundary intersection inside an open
  * interval, one representative point is sufficient.
- * @param[in] exact_ii The interiors of the two geometries have been decided
- * exactly before this walk runs, which #relate_area_boundaries_cross does for
- * a pair of straight boundaries and not for one carrying an arc
  */
 static void
 relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
-  MeosDE9IM *m, bool first, bool exact_ii)
+  MeosDE9IM *m, bool first)
 {
   /* Maximum number of intersections between one edge and one
    * circular/linear boundary edge is two */
@@ -5897,11 +5896,11 @@ relate_area_edge_intervals(const Edge *edge, const RelateEdges *other,
      * reports whichever side it landed on. Where the interiors provably miss,
      * so does the boundary, whatever the midpoint reads.
      *
-     * The interiors answer carries that weight only where it is exact, which
-     * is the class its crossing route reads: every pair of boundary edges
-     * across the two operands holding at most one arc. A pair whose operands
-     * BOTH carry an arc keeps the midpoint as its only source */
-    if (loc == 0 && (m->ii == 2 || ! exact_ii))
+     * The crossing route decides every pair of boundary edges the engine
+     * builds -- two straight ones, one of each, and two arcs -- so the
+     * interiors answer is exact for every areal pair and this branch reads it
+     * rather than the midpoint in all of them */
+    if (loc == 0 && m->ii == 2)
     {
       /* Boundary(A) ∩ Interior(B) or Interior(A) ∩ Boundary(B) */
       if (first)
@@ -6133,11 +6132,11 @@ relate_area_interior_point_located(const RelateEdges *self,
  * land in: a sliver a couple of units in the last place wide is narrower than
  * the band every point-location route reads, yet its crossing vertices are
  * exactly the ones the determinants are taken on.
- * A CIRCULAR edge against a straight one is decided too, by the quadratic
- * rather than by the determinants: the arc carries its centre, radius and
- * angular span, so the curve between its endpoints is determined and the
- * crossing is solved exactly. Only two ARCS are left to the other routes,
- * #relate_area_edges_cross saying why
+ * A CIRCULAR edge is decided too, and by the same kind of argument rather
+ * than by the determinants: an arc carries its centre, radius and angular
+ * span, so the curve between its endpoints is determined and the crossing is
+ * solved exactly, against a straight edge and against another arc alike.
+ * #relate_area_edges_cross dispatches the three cases
  * @param[in] a,b Edges of the two geometries, the second read out of its index
  * where it carries one
  */
@@ -6276,22 +6275,17 @@ relate_area_area(const LWGEOM *g1, const LWGEOM *g2,
    * splitting every boundary edge at the intersections with the other
    * boundary. Where the step above has settled the interiors exactly, each
    * portion is read against that answer */
-  /* The crossing route decides two straight edges from four determinants and
-   * a straight edge against a circular one from the quadratic that meets a
-   * line with a circle. Only two ARCS are left to the routes that sample, so
-   * ONE operand free of arcs is enough to leave every crossing pair decided */
-  bool exact_ii = re1.straight || re2.straight;
   for (int i = 0; i < n1; i++)
   {
     if (!relate_area_boundary_edge(e1[i]))
       continue;
-    relate_area_edge_intervals(e1[i], &re2, m, true, exact_ii);
+    relate_area_edge_intervals(e1[i], &re2, m, true);
   }
   for (int i = 0; i < n2; i++)
   {
     if (!relate_area_boundary_edge(e2[i]))
       continue;
-    relate_area_edge_intervals(e2[i], &re1, m, false, exact_ii);
+    relate_area_edge_intervals(e2[i], &re1, m, false);
   }
 
   /* Boundary / Boundary.

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -417,6 +417,48 @@ int main(void)
   free(arctouch_geo_a); free(arctouch_geo_b);
   meos_errno_reset();
 
+  /* The same construction with BOTH boundaries circular. The area below the
+   * line y = 0 is bounded above by an arc through (0 0), (2 -1e-9), (4 0),
+   * bulging DOWN and away; the area above it is bounded below by an arc
+   * through (4 0), (2 1e-9), (0 0), bulging UP and away. The two arcs meet at
+   * the two points they share and nowhere else, so the areas share those
+   * points and no area, whatever the arithmetic reads.
+   * Two arcs are the last pair the crossing route left undecided, and it is
+   * the HALF-CHORD of their supporting circles that decides them: it vanishes
+   * exactly at a tangency, which touches without passing through. Until this
+   * pair could be decided, the interiors could not be settled for two operands
+   * that both carry an arc, and the classification of a boundary portion fell
+   * back on that portion's midpoint -- which lands on either side of the other
+   * boundary by the residue of the arithmetic that solved the split */
+  const char *aatouch_a =
+    "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 0,2 -1e-9,4 0),"
+    "(4 0,4 -1,0 -1,0 0)))";
+  const char *aatouch_b =
+    "CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(4 0,2 1e-9,0 0),"
+    "(0 0,0 1,4 1,4 0)))";
+  GSERIALIZED *aatouch_geo_a = geom_in(aatouch_a, -1);
+  GSERIALIZED *aatouch_geo_b = geom_in(aatouch_b, -1);
+  assert(aatouch_geo_a != NULL);
+  assert(aatouch_geo_b != NULL);
+  meos_errno_reset();
+  char aatouch_patt[10] = "F***T****";
+  bool aatouch_touches = geom_relate_pattern(aatouch_geo_a, aatouch_geo_b,
+    aatouch_patt);
+  printf("geom_relate_pattern(two areas bounded by arcs that touch, they only "
+    "touch): %d, errno %d\n", aatouch_touches, meos_errno());
+  assert(aatouch_touches == true);
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+  char aatouch_interiors[10] = "T********";
+  bool aatouch_overlaps = geom_relate_pattern(aatouch_geo_a, aatouch_geo_b,
+    aatouch_interiors);
+  printf("geom_relate_pattern(two areas bounded by arcs that touch, interiors "
+    "meet): %d, errno %d\n", aatouch_overlaps, meos_errno());
+  assert(aatouch_overlaps == false);
+  assert(meos_errno() == 0);
+  free(aatouch_geo_a); free(aatouch_geo_b);
+  meos_errno_reset();
+
   /* Two areas whose boundaries run PARALLEL never touch, however close they
    * come. Deciding that means asking whether the two lines are one line, and
    * the engine answers it from the cross product of the offset between them


### PR DESCRIPTION
WITNESS. An area below the line y = 0 bounded above by an arc bulging DOWN
and away from it, against one above the line bounded below by an arc bulging
UP and away. The two arcs meet at the two points they share and nowhere else:

```
  A = CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(0 0,2 -1e-9,4 0),
                                 (4 0,4 -1,0 -1,0 0)))
  B = CURVEPOLYGON(COMPOUNDCURVE(CIRCULARSTRING(4 0,2 1e-9,0 0),
                                 (0 0,0 1,4 1,4 0)))

  before   geom_relate(A,B) = 212101212   -- II = 2, the interiors OVERLAP
  after    geom_relate(A,B) = FF2F01212   -- II = F, they meet at two points
```

WHY. relate_area_edges_cross decided a pair of straight edges and a straight
edge against a circular one, and returned false for two ARCS. Two distinct
circles meet in at most two points, and the HALF-CHORD of that meeting is what
says whether they cross: it vanishes exactly when the circles are TANGENT,
which touches without passing through, and relate_arc_arc_points already reads
that same quantity against the same bound to decide whether it reports one
point or two. So arcarc_cross reads it too, and accepts a point only where it
lies strictly inside both arcs' angular spans. Coincident supporting circles
are not a crossing: two arcs of one circle either share a stretch or meet at
an endpoint, and both are answered elsewhere.

A PARAMETER MARGIN CANNOT STAND IN FOR THE POINT'S OWN RESOLUTION, and this
cost a measured wrong answer before it was written in. The half-chord comes
from r^2 - aa^2, two quantities of size radius squared differenced down to the
chord: at radius 2e5 each is 4e10, whose last bit is 8e-6, so the crossing
point slides along the chord by about that much however exactly the input
names it. Two arcs meeting exactly at their two shared endpoints then report a
crossing 3.8e-6 away from one of them, and a test asking only that the arc
parameter be 1e-12 inside [0,1] believes it. The predicate now refuses a
candidate nearer an endpoint than that arithmetic resolves the candidate to.

With every pair of boundary edges decided, the interiors are settled exactly
for every areal pair, so the scaffolding the previous change needed retires
with it: RelateEdges.straight and the exact_ii parameter both go, and the
boundary-portion branch reads the interiors answer unconditionally.

MEASURED, and what did NOT move.

```
  geo_pairs                        12880 pairs   0 answers moved
  areal_pairs                       1444 pairs   0 answers moved
  adversarial_pairs                   54 pairs   0 answers moved
  self-pairs, both operand columns 25760 pairs   0 answers moved
  constructed arc-vs-arc sweep        27 pairs   13 wrong -> 6 wrong:
                                                 7 fixed, 0 broken
  constructed straight-vs-arc sweep   33 pairs   9 wrong -> 9, byte-identical
  the predicate's own five cases                 crossing / touching-at-shared-
                                                 endpoints / tangent /
                                                 coincident / apart, all by
                                                 construction
```

The corpus cannot see this class at all, and that is measured rather than
assumed: over the 12880 pairs the crossing route is entered 989 times, 168 of
those with an arc on BOTH sides, and NOT ONE arc-vs-arc edge pair intersects.
A corpus without the class is silent about it rather than clean on it, which
is why the sweep is constructed.

THE ALTERNATIVE THAT SCORES BETTER IS UNSOUND, and it is worth saying why
plainly. Simply asserting the interiors are exact, without this predicate,
reads 4 wrong on the same sweep rather than 6. It gets there by declining
every arc-vs-arc crossing, which is the right answer only while the pairs
merely touch: the first of the five cases above is two circles overlapping in
a lens, which this predicate answers true and that arm answers false, so it
would report no interior meeting for a pair whose interiors plainly meet.
A whole-geometry witness of that is not included, because for a simple
overlapping pair a vertex route answers before the crossing route is reached.

WHAT REMAINS, measured and not this change's. Five of the six residual sweep
members are at projected coordinates, where the arc RECONSTRUCTION places the
circle so that it meets the other boundary 2.1e-6 inside the shared endpoint
while placing it exactly there at the origin; the crossing point is resolved
to 4.4e-7, so the point is well resolved and the circle is not. That is a
frame-normalization question and owes its own PR. The sixth sits at the origin
with an exact reconstruction, reads 2F2101212, and is UNEXPLAINED; it reads
identically in the straight-vs-arc sweep before this change, so it predates
this slice and is untouched by it.

No timing figures: the route gains one closed-form test on edge pairs it
previously skipped outright, and pg_regress reports all tests passing.

Relate cost of the native engine, callgrind instructions over the regression pairs, base 2db6ce7828 against merge 799e5bbc61: areal pairs 18,355,015,998 -> 18,353,336,122 (-0.01%), geo pairs 35,557,347,196 -> 35,546,053,197 (-0.03%).
