### PR TITLE
Read a point query's SRID off the index it reads

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -36,6 +36,7 @@
  */
 
 /* C */
+#include <limits.h>
 #include <math.h>
 /* PostgreSQL */
 #include "postgres.h"
@@ -50,6 +51,7 @@
 #include "temporal/span.h"
 #include "temporal/temporal.h"
 #include "temporal/temporal_restrict.h"
+#include "temporal/temporal_rtree.h"
 #include "geo/geo_funcs.h"
 #include "geo/tgeo.h"
 #include "geo/tgeo_spatialfuncs.h"
@@ -72,11 +74,29 @@ static MEOS_TLS MeosArray *periods = NULL;
 static MEOS_TLS MeosArray *rtree_results = NULL;
 
 /**
+ * @brief Return the SRID an index answers for, which is the one its own
+ * entries carry
+ * @details A query box is admitted by #rtree_search only where its SRID
+ * matches the tree's, so reading the SRID off the TREE is what keeps a query
+ * from disagreeing with the index it reads. A caller cannot always know the
+ * value -- #point_in_polygon_index is handed a tree it did not build -- and a
+ * caller that guesses wrong gets INT_MAX back rather than a count.
+ * An empty tree admits any query, so its SRID is immaterial
+ */
+static inline int32_t
+rtree_query_srid(const RTree *rtree)
+{
+  if (! rtree || ! rtree->root || rtree->bboxtype != T_STBOX)
+    return 0;
+  return ((const STBox *) rtree->box)->srid;
+}
+
+/**
  * @brief Return true if a point is located in a polygon 
  */
 static inline int
 point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
-  const RTree *rtree, int32_t srid, double xmax)
+  const RTree *rtree, double xmax)
 {
   int inside = 0;
   /* The height the ray is cast at. A ray at the height of a vertex meets the
@@ -106,8 +126,17 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
        * identical to the full scan. */
       STBox query;
       double xhi = (x > xmax) ? x : xmax;
-      stbox_set(true, false, false, srid, x, xhi, ry, ry, 0, 0, NULL, &query);
+      stbox_set(true, false, false, rtree_query_srid(rtree), x, xhi, ry, ry,
+        0, 0, NULL, &query);
       n = rtree_search(rtree, INDEX_OVERLAPS, &query, rtree_results);
+      /* A search that cannot answer reports INT_MAX rather than a count, and
+       * reading that as one walks the result array two billion entries past
+       * its end. Scanning every edge answers the same question */
+      if (n == INT_MAX)
+      {
+        n = nedges;
+        rtree = NULL;
+      }
     }
     for (int i = 0; i < n && ! shared; i++)
     {
@@ -210,7 +239,7 @@ point_in_polygon_impl(double x, double y, Edge **edges, int nedges,
 int
 point_in_polygon(double x, double y, Edge **edges, int nedges)
 {
-  return point_in_polygon_impl(x, y, edges, nedges, NULL, 0, 0.0);
+  return point_in_polygon_impl(x, y, edges, nedges, NULL, 0.0);
 }
 
 /**
@@ -230,7 +259,7 @@ point_in_polygon_index(double x, double y, Edge **edges, int nedges,
    * an empty one is what the search would read through */
   if (rtree && ! rtree_results)
     rtree_results = meos_array_create(sizeof(int64));
-  return point_in_polygon_impl(x, y, edges, nedges, rtree, 0, xmax);
+  return point_in_polygon_impl(x, y, edges, nedges, rtree, xmax);
 }
 
 /**
@@ -486,13 +515,12 @@ point_on_poly_boundary(double px, double py, Edge **edges, int nedges)
  * that lie left of the point or off the ray's height and so is identical to
  * the full scan
  * @param[in] rtree R-tree over @p all_edges, or NULL to scan them all
- * @param[in] srid,xmax SRID and geometry bounding-box maximum abscissa, used
- * to query @p rtree
+ * @param[in] xmax Geometry bounding-box maximum abscissa, which bounds the ray
  */
 static void
 intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
   int nedges, Edge **all_edges, int all_nedges, const RTree *rtree,
-  int32_t srid, double xmax)
+  double xmax)
 {
   assert(a); assert(b); assert(edges); assert(nedges >= 0);
 
@@ -600,7 +628,7 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
     double tm = (ta + tb) * 0.5;
     double x = ax + tm * rx;
     double y = ay + tm * ry;
-    if (point_in_polygon_impl(x, y, all_edges, all_nedges, rtree, srid, xmax))
+    if (point_in_polygon_impl(x, y, all_edges, all_nedges, rtree, xmax))
     {
       Span in;
       span_set(Float8GetDatum(ta), Float8GetDatum(tb), true, true,
@@ -722,7 +750,7 @@ tpointinst_clip_edges(const TInstant *inst, Edge **edges, int nedges,
   if (! found)
   {
     intervals_from_polygons(a, a, sel_edges, sel_nedges, edges, nedges, rtree,
-      tspatial_srid((Temporal *) inst), xmax);
+      xmax);
     if (intervals->count == 0)
       return;
   }
@@ -800,7 +828,7 @@ tpointseq_clip_edges(const TSequence *seq, Edge **edges, int nedges,
     intervals_from_lines(a, b, sel_edges, sel_nedges);
     intervals_from_arcs(a, b, sel_edges, sel_nedges);
     intervals_from_polygons(a, b, sel_edges, sel_nedges, edges, nedges, rtree,
-      srid, xmax);
+      xmax);
     /* The array is declared before the jump below, which would otherwise skip
      * its initializer while `next_segment` reads it */
     Span *intervarr = NULL;
@@ -1654,7 +1682,7 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
         intervals_from_lines(&pa, &pb, ctx->edge_ptrs, ctx->nedges);
         intervals_from_arcs(&pa, &pb, ctx->edge_ptrs, ctx->nedges);
         intervals_from_polygons(&pa, &pb, ctx->edge_ptrs, ctx->nedges,
-          ctx->edge_ptrs, ctx->nedges, ctx->rtree, ctx->srid, ctx->box.xmax);
+          ctx->edge_ptrs, ctx->nedges, ctx->rtree, ctx->box.xmax);
         const Span *iv = intervals->elems;
         int cnt = (int) intervals->count;
         Span *nm = NULL;
@@ -1717,7 +1745,7 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
       intervals_from_lines(&pa, &pb, sel, seln);
       intervals_from_arcs(&pa, &pb, sel, seln);
       intervals_from_polygons(&pa, &pb, sel, seln, ctx->edge_ptrs,
-        ctx->nedges, ctx->rtree, ctx->srid, ctx->box.xmax);
+        ctx->nedges, ctx->rtree, ctx->box.xmax);
 
       const Span *intervarr = intervals->elems;
       int count = (int) intervals->count;
@@ -1907,7 +1935,7 @@ geo_intersects2d_ctx(const GSERIALIZED *gs, const void *ctxv)
   if (! result && edges_have_area(ctx->edge_ptrs, ctx->nedges))
     for (int i = 0; i < n && ! result; i++)
       if (point_in_polygon_impl(ptr[i]->x1, ptr[i]->y1, ctx->edge_ptrs,
-            ctx->nedges, ctx->rtree, ctx->srid, ctx->box.xmax))
+            ctx->nedges, ctx->rtree, ctx->box.xmax))
         result = true;
   if (! result && edges_have_area(ptr, n))
     for (int i = 0; i < ctx->nedges && ! result; i++)
@@ -2468,7 +2496,7 @@ point_geom_within(double px, double py, Edge **edges, int nedges,
       if (point_edge_dist2(px, py, edges[i]) <= d2 + MEOS_GEOM_TOLERANCE)
         return true;
   }
-  return point_in_polygon_impl(px, py, edges, nedges, rtree, srid, xmax) ?
+  return point_in_polygon_impl(px, py, edges, nedges, rtree, xmax) ?
     true : false;
 }
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -459,6 +459,73 @@ int main(void)
   free(aatouch_geo_a); free(aatouch_geo_b);
   meos_errno_reset();
 
+  /* A line clipped by a surface reads the surface's edges out of an R-tree
+   * once there are enough of them to index, and that index only answers a
+   * query carrying the SRID its own entries carry. Where the query states a
+   * different one the search reports INT_MAX rather than a count, and a
+   * caller reading that as a count walks the result array two billion entries
+   * past its end.
+   * The record below is that case at its smallest: an arc clipped by a
+   * polygon of 200 sides, both carrying a projected SRID, which is the shape
+   * a real projected corpus takes. The answer is the SAME geometry the pair
+   * has with no SRID at all -- an SRID names the frame the coordinates are
+   * read in and cannot move the points -- so the pair carries its own oracle
+   * and needs no reference engine */
+  int32 pip_srid = 3812;
+  /* A diamond of 200 sides, walked as four straight runs of 50 so the ring
+   * needs arithmetic only: the step that compiles and runs meos/test links no
+   * math library, and a vertex placed with a trigonometric function fails it
+   * at the linker rather than in any test */
+  int pip_per_side = 50;
+  int pip_sides = 4 * pip_per_side;
+  size_t pip_cap = (size_t) pip_sides * 48 + 64;
+  char *pip_wkt = malloc(pip_cap);
+  int pip_off = snprintf(pip_wkt, pip_cap, "SRID=%d;POLYGON((", pip_srid);
+  for (int i = 0; i <= pip_sides; i++)
+  {
+    int k = i % pip_sides;
+    int side = k / pip_per_side;
+    double f = (double) (k % pip_per_side) / pip_per_side;
+    /* (100,0) -> (0,100) -> (-100,0) -> (0,-100) -> back */
+    double xs[4] = { 100.0, 0.0, -100.0, 0.0 };
+    double ys[4] = { 0.0, 100.0, 0.0, -100.0 };
+    double xe = xs[(side + 1) % 4], ye = ys[(side + 1) % 4];
+    pip_off += snprintf(pip_wkt + pip_off, pip_cap - pip_off, "%s%.9f %.9f",
+      i ? "," : "", xs[side] + f * (xe - xs[side]),
+      ys[side] + f * (ye - ys[side]));
+  }
+  snprintf(pip_wkt + pip_off, pip_cap - pip_off, "))");
+  char pip_arc[192];
+  snprintf(pip_arc, sizeof pip_arc,
+    "SRID=%d;CIRCULARSTRING(-200 0,0 20,200 0)", pip_srid);
+  GSERIALIZED *pip_poly = geom_in(pip_wkt, -1);
+  GSERIALIZED *pip_line = geom_in(pip_arc, -1);
+  assert(pip_poly != NULL);
+  assert(pip_line != NULL);
+  meos_errno_reset();
+  GSERIALIZED *pip_res = geom_intersection2d(pip_line, pip_poly);
+  printf("geom_intersection2d(an arc, a 200-sided polygon, both with an "
+    "SRID): %s, errno %d\n", pip_res ? "answered" : "NULL", meos_errno());
+  assert(pip_res != NULL);
+  assert(meos_errno() == 0);
+  /* The same pair in the unnamed frame answers the same points */
+  char *pip_res_wkt = geo_as_text(pip_res, 6);
+  char *pip_plain_wkt = pip_wkt + strlen("SRID=3812;");
+  GSERIALIZED *pip_poly0 = geom_in(pip_plain_wkt, -1);
+  GSERIALIZED *pip_line0 = geom_in("CIRCULARSTRING(-200 0,0 20,200 0)", -1);
+  GSERIALIZED *pip_res0 = geom_intersection2d(pip_line0, pip_poly0);
+  char *pip_res0_wkt = pip_res0 ? geo_as_text(pip_res0, 6) : NULL;
+  printf("  the same pair carrying no SRID answers the same points: %d\n",
+    (pip_res_wkt && pip_res0_wkt && strcmp(pip_res_wkt, pip_res0_wkt) == 0));
+  assert(pip_res_wkt && pip_res0_wkt);
+  assert(strcmp(pip_res_wkt, pip_res0_wkt) == 0);
+  assert(meos_errno() == 0);
+  free(pip_res_wkt); free(pip_res0_wkt);
+  free(pip_res); free(pip_res0);
+  free(pip_poly); free(pip_line); free(pip_poly0); free(pip_line0);
+  free(pip_wkt);
+  meos_errno_reset();
+
   /* Two areas whose boundaries run PARALLEL never touch, however close they
    * come. Deciding that means asking whether the two lines are one line, and
    * the engine answers it from the cross product of the offset between them


### PR DESCRIPTION
WITNESS. An arc clipped by a polygon of 200 sides, both carrying a projected
SRID -- the shape a real projected corpus takes:

```
  A = SRID=3812;CIRCULARSTRING(-200 0,0 20,200 0)
  B = SRID=3812;POLYGON((...200 vertices on a circle of radius 100...))

  before   geom_intersection2d(A,B)   SIGSEGV
  after    geom_intersection2d(A,B) = CIRCULARSTRING(-98.838752 15.152178,
                                        6.184466e-14 20,98.838752 15.152178)
```

The same pair carrying NO SRID answers those very points on the previous code
too, which is both the oracle and the proof that the SRID is the trigger: an
SRID names the frame the coordinates are read in and cannot move a point.

WHY. A surface's edges are read out of an R-tree once there are enough of them
to index, and rtree_search admits a query only where ensure_valid_rtree_box
finds the query's SRID equal to the tree's; otherwise it returns INT_MAX,
which is an error and not a count. The clip builds its tree with the
geometry's own SRID, and point_in_polygon_index -- handed a tree it did not
build -- passed 0. The two disagree for every geometry carrying an SRID, so
the search reported INT_MAX and the walk read the result array two billion
entries past its end.

A caller cannot be relied on for that value, because it is a property of the
TREE and not of the caller. So the query now reads its SRID off the tree it is
about to search, which is what makes the disagreement unstatable rather than
merely fixed; the parameter every caller had to guess right is gone.

This weakens no SRID check a user can reach. The box in question is an
internal ray cast against an index over ONE geometry's own edges, so there is
no second operand for it to disagree with; the two operands are held to a
single SRID by ensure_valid_geo_geo before any of this runs, and mixing them
still errors there.

Beside it, the walk no longer reads INT_MAX as a count: a search that cannot
answer falls back to scanning every edge, which answers the same question.
That guard does not fire on any corpus here -- deriving the SRID removes the
mismatch that would reach it -- so it is proven with a forced mismatch
instead: it fires, and the answer is byte-identical to the indexed one.

MEASURED, and what did NOT move.

```
  geo_pairs, per row in a forked child   12880 rows
      previous code                      240 SIGSEGV
      this change                          0 SIGSEGV
      rows whose answer differs          240, and all 240 ARE the crashes
      answer changes on any other row      0
  areal_pairs                             1444 rows, 0 crashes either way,
                                          0 answers differ
  adversarial_pairs                         54 rows, 0 crashes either way,
                                          0 answers differ
  the guard, under a forced SRID mismatch  fires, and its full-scan answer
                                          equals the indexed one
```

The forked harness is what makes the count readable at all: the previous code
ends the process, so a single-process sweep stops at the first crash and
reports nothing about the rest.

The three GEOS entry points the carve still owes are untouched, and the
checker reads the same 11 baselined of 125.

