### PR TITLE
State the error value the public comparators answer

### DIFF
--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -2218,6 +2218,7 @@ tbox_ne(const TBox *box1, const TBox *box2)
  * @brief Return -1, 0, or 1 depending on whether the first temporal box
  * is less than, equal to, or greater than the second one
  * @param[in] box1,box2 Temporal boxes
+ * @return On error return @p INT_MAX
  * @note The time dimension is compared first and then the value dimension
  * @csqlfn #Tbox_cmp()
  */

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -3806,6 +3806,7 @@ temporal_ne(const Temporal *temp1, const Temporal *temp2)
  * @brief Return -1, 0, or 1 depending on whether the first temporal value is
  * less than, equal to, or greater than the second one
  * @param[in] temp1,temp2 Temporal values
+ * @return On error return @p INT_MAX
  * @note Function used for B-tree comparison
  * @csqlfn #Temporal_cmp()
  */

--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -96,6 +96,15 @@ COUNT_DOC = re.compile(r"@(?:brief|return)\s+[^\n]*\bnumber of\b", re.I)
 # negative. That is what the rule actually asks for, exactly as it asks it of
 # the predicates and the locators above.
 BOX_DISTANCE = re.compile(r"^nad_tbox")
+# A comparator answers -1, 0 or 1, so its domain is those three values and the
+# maximum lies outside it. That is the same domain rule the counts, the
+# predicates and the box distance follow, landing on INT_MAX here precisely
+# because -1 is already one of the answers. What this catches is the public
+# comparator that answers INT_MAX SILENTLY: the value is in the code and in no
+# contract, so neither a reader nor a binding generator can find it, and the
+# check below reads a documented value it never finds.
+CMP = re.compile(r"_cmp$")
+PUBLIC_DOC = re.compile(r"@ingroup\s+meos_(?!internal)")
 # A pointer return: any sentinel other than NULL is wrong
 POINTER = re.compile(r"\*\s*$")
 
@@ -175,6 +184,14 @@ def scan(path: Path, rel: str) -> list[tuple[str, str]]:
             want = "-1.0"
         if BOX_DISTANCE.match(name):
             want = "-1.0" if want == "DBL_MAX" else "-1"
+
+        if (documented is None and want == "INT_MAX" and CMP.search(name) and
+                PUBLIC_DOC.search("\n".join(doc)) and
+                any("INT_MAX" in bl for bl in body)):
+            findings.append(
+                (f"{rel}\t{name}\tundocumented INT_MAX",
+                 f"{rel}:{i + 1}: {name}() answers INT_MAX on error and states "
+                 f"no contract: add \"@return On error return @p INT_MAX\""))
 
         validated = validated_raw = None
         for bl in body:


### PR DESCRIPTION
The rule is that an error sentinel lies outside the function's value domain. A
comparator answers -1, 0 or 1, so the maximum of its return type lies outside
those three and INT_MAX is its error value. That is the same rule the counts,
the predicates and the box distance follow, landing on the maximum here
precisely because -1 is already one of the answers rather than a spare value.
Eleven public comparators state that contract; tbox_cmp and temporal_cmp answer
it and state nothing, so the value lives in the code and in no contract.

Witness: temporal_cmp returns INT_MAX from two guards, ensure_valid_temporal_
temporal and the SRID and dimensionality tests beneath it, while its doxygen
block carries @param, @note and @csqlfn and no @return at all; tbox_cmp
validates both arguments with INT_MAX the same way. A reader of either entry
learns only that the answer is -1, 0 or 1, and a binding deriving its guard from
the documented contract derives none, so INT_MAX arrives at the caller as a
comparison result meaning "greater than".

Measured on master c76a646f19: check_error_sentinels.py compares a documented
value against a validated one and had no documented value to read for these two,
so it passed them in silence. The rule added here convicts exactly those two on
unmodified master and exits 0 once the contracts are stated. It reaches no one
else, and the audit says why: h3index_cmp, meos_h3index_cmp, quadbin_cmp,
s2cell_cmp, int32_cmp and int64_cmp take values rather than pointers and can
fail in no way, so they carry no error value at all, while tinstant_cmp,
tsequence_cmp and tsequenceset_cmp are meos_internal and asserted by their
callers.