### PR TITLE
State the error value of a MEOS function as a tag rather than as prose

### DIFF
--- a/doxygen/Doxyfile
+++ b/doxygen/Doxyfile
@@ -277,7 +277,8 @@ ALIASES                = "csqlfn=@par C-SQL Function:^^" \
                          "csqlaggfn=@par C-SQL Aggregate Role:^^" \
                          "sqlfn=@par SQL Function:^^" \
                          "sqlaggfn=@par SQL Aggregate:^^" \
-                         "sqlop=@par SQL Operator:^^"
+                         "sqlop=@par SQL Operator:^^" \
+                         "errval=@return On error return"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/doxygen/Doxyfile_gha
+++ b/doxygen/Doxyfile_gha
@@ -278,7 +278,8 @@ TAB_SIZE               = 4
 ALIASES                = "csqlfunc=@par C-SQL Function:^^" \
                          "sqlfunc=@par SQL Function:^^" \
                          "sqlop=@par SQL Operator:^^" \
-                         "pymeosfunc=@par PyMEOS Function:^^"
+                         "pymeosfunc=@par PyMEOS Function:^^" \
+                         "errval=@return On error return"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For

--- a/meos/src/cbuffer/cbuffer.c
+++ b/meos/src/cbuffer/cbuffer.c
@@ -976,7 +976,7 @@ cbuffer_distance(const Cbuffer *cb1, const Cbuffer *cb2)
 /**
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between two circular buffers
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_cbuffer_cbuffer()
  */
 double
@@ -1006,7 +1006,7 @@ datum_cbuffer_distance(Datum cb1, Datum cb2)
 /**
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between a circular buffer and a geometry
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_cbuffer_geo() #Distance_geo_cbuffer()
  */
 double
@@ -1025,7 +1025,7 @@ distance_cbuffer_geo(const Cbuffer *cb, const GSERIALIZED *gs)
 /**
  * @ingroup meos_cbuffer_base_dist
  * @brief Return the distance between a circular buffer and a spatiotemporal box
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 distance_cbuffer_stbox(const Cbuffer *cb, const STBox *box)
@@ -1416,7 +1416,7 @@ cbuffer_nsame(const Cbuffer *cb1, const Cbuffer *cb2)
  * @brief Return -1, 0, or 1 depending on whether the first buffer
  * is less than, equal to, or greater than the second one
  * @param[in] cb1,cb2 Circular buffers
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Cbuffer_cmp()
  */
 int
@@ -1509,7 +1509,7 @@ cbuffer_ge(const Cbuffer *cb1, const Cbuffer *cb2)
  * @ingroup meos_cbuffer_base_accessor
  * @brief Return the 32-bit hash value of a circular buffer
  * @param[in] cb Circular buffer
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Cbuffer_hash()
  */
 uint32

--- a/meos/src/cbuffer/cbufferset_meos.c
+++ b/meos/src/cbuffer/cbufferset_meos.c
@@ -113,7 +113,7 @@ cbufferset_make(Cbuffer **values, int count)
  * @ingroup meos_cbuffer_set_accessor
  * @brief Return a copy of the start value of a circular buffer set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 Cbuffer *
@@ -128,7 +128,7 @@ cbufferset_start_value(const Set *s)
  * @ingroup meos_cbuffer_set_accessor
  * @brief Return a copy of the end value of a circular buffer set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 Cbuffer *
@@ -166,7 +166,7 @@ cbufferset_value_n(const Set *s, int n, Cbuffer **result)
  * @brief Return the array of copies of the values of a circular buffer set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 Cbuffer **

--- a/meos/src/cbuffer/tcbuffer.c
+++ b/meos/src/cbuffer/tcbuffer.c
@@ -731,7 +731,7 @@ tcbuffer_in(const char *str)
  * @ingroup meos_cbuffer_inout
  * @brief Return a temporal circular buffer from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -1213,7 +1213,7 @@ tgeometry_to_tcbuffer(const Temporal *temp)
  * @ingroup meos_cbuffer_accessor
  * @brief Return a copy of the start value of a temporal circular buffer
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_value()
  */
 Cbuffer *
@@ -1228,7 +1228,7 @@ tcbuffer_start_value(const Temporal *temp)
  * @ingroup meos_cbuffer_accessor
  * @brief Return a copy of the end value of a temporal circular buffer
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_value()
  */
 Cbuffer *

--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -88,7 +88,7 @@
  * @param[in] func PostGIS function to be called
  * @param[in] numparam Number of parameters of the function
  * @param[in] invert True if the arguments should be inverted
- * @return On error return -1
+ * @errval -1
  * @pre None of the two geometries is a geometry collection
  */
 static int
@@ -141,7 +141,7 @@ spatialrel_quantifiers(varfunc func, bool *all1, bool *all2)
  * @param[in] func PostGIS function to be called
  * @param[in] numparam Number of parameters of the functions
  * @param[in] invert True if the arguments should be inverted
- * @return On error return -1
+ * @errval -1
  */
 int
 spatialrel_geo_geo(const GSERIALIZED *gs1, const GSERIALIZED *gs2,

--- a/meos/src/cbuffer/tcbuffer_tempspatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_tempspatialrels.c
@@ -1185,7 +1185,7 @@ tinterrel_tcbuffer_cbuffer(const Temporal *temp, const Cbuffer *cb,
  * @param[in] func Spatial relationship function to be applied
  * @param[in] numparam Number of parameters of the function
  * @param[in] invert True if the arguments should be inverted
- * @return On error return `NULL`
+ * @errval NULL
  */
 static Temporal *
 tspatialrel_tcbuffer_cbuffer_int(const Temporal *temp, const Cbuffer *cb,

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -3049,7 +3049,8 @@ ensure_srid_known(int32_t srid)
  * @param[in] srid1,srid2 SRIDs to reconcile
  * @param[out] result Common SRID (the known one, or `SRID_UNKNOWN` if both are
  * unknown)
- * @return On error (two different known SRIDs) return false
+ * @return True when the SRIDs reconcile and the result is written
+ * @errval false
  */
 bool
 ensure_srid_reconcile(int32_t srid1, int32_t srid2, int32_t *result)

--- a/meos/src/geo/geoset_meos.c
+++ b/meos/src/geo/geoset_meos.c
@@ -161,7 +161,7 @@ geo_to_set(const GSERIALIZED *gs)
  * @ingroup meos_geo_set_accessor
  * @brief Return a copy of the start value of a geo set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 GSERIALIZED *
@@ -176,7 +176,7 @@ geoset_start_value(const Set *s)
  * @ingroup meos_geo_set_accessor
  * @brief Return a copy of the end value of a geo set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 GSERIALIZED *
@@ -213,7 +213,7 @@ geoset_value_n(const Set *s, int n, GSERIALIZED **result)
  * @brief Return an array of copies of the values of a geo set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 GSERIALIZED **

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -871,7 +871,7 @@ geo_is_unitary(const GSERIALIZED *gs)
  *
  * Uses Euclidean 2D computation even if input is 3D.
  * @param[in] gs Geometry
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note An empty geometry encloses nothing, so its area is 0. The question has
  * an answer, and #lwgeom_area gives it
  * @note PostGIS function: @p ST_Area(PG_FUNCTION_ARGS)
@@ -900,7 +900,7 @@ geom_area(const GSERIALIZED *gs)
  *
  *  Uses Euclidean 3D/2D length depending on input dimensions.
  * @param[in] gs Geometry
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note An empty geometry draws no line, so its length is 0. The question has
  * an answer, and #lwgeom_length gives it
  * @note PostGIS function: @p LWGEOM_length_linestring(PG_FUNCTION_ARGS)
@@ -928,7 +928,7 @@ geom_length(const GSERIALIZED *gs)
  *   - perimeter(polygon) = sum of ring perimeters
  * Uses Euclidian 2D computation even if input is 3D
  * @param[in] gs Geometry
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note An empty geometry bounds no area, so its perimeter is 0. The question
  * has an answer, and #lwgeom_perimeter_2d gives it
  * @note PostGIS function: @p LWGEOM_perimeter2d_poly(PG_FUNCTION_ARGS)
@@ -1091,7 +1091,9 @@ geom_shortestline3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @brief Return the distance between two geometries
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p ST_Distance(PG_FUNCTION_ARGS)
- * @return On error or empty geometries return DBL_MAX
+ * @note An empty geometry has no point to measure from, so the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  */
 double
 geom_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
@@ -1134,9 +1136,10 @@ geom_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p ST_MaxDistance(PG_FUNCTION_ARGS)
  * @note A geometry carrying a circular arc is not supported, since the
- * underlying computation implements the maximum only for straight edges
- * @return On error, on empty geometries, or on a geometry carrying a circular
- * arc return DBL_MAX
+ * underlying computation implements the maximum only for straight edges, so
+ * the answer is DBL_MAX
+ * @note An empty geometry has no farthest point, so the answer is DBL_MAX
+ * @errval DBL_MAX
  */
 double
 geom_max_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
@@ -1160,7 +1163,9 @@ geom_max_distance2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @brief Return the 3D distance between two geometries
  * @param[in] gs1,gs2 Geometries
  * @note PostGIS function: @p ST_3DDistance(PG_FUNCTION_ARGS)
- * @return On error or empty geometries return DBL_MAX
+ * @note An empty geometry has no point to measure from, so the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  */
 double
 geom_distance3d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
@@ -1597,7 +1602,7 @@ geo_pointarr(const GSERIALIZED *gs, int *count)
  * @brief Return the number of points of a geometry
  * @param[in] gs Geometry/geography
  * @note PostGIS function: @p ST_Points(PG_FUNCTION_ARGS)
- * @return On error return -1
+ * @errval -1
  */
 int
 geo_num_points(const GSERIALIZED *gs)
@@ -1616,7 +1621,7 @@ geo_num_points(const GSERIALIZED *gs)
  * @brief Return the number of composing geometries of a geometry
  * @param[in] gs Geometry/geography
  * @note PostGIS function: @p LWGEOM_numgeometries_collection(PG_FUNCTION_ARGS)
- * @return On error return -1
+ * @errval -1
  */
 int
 geo_num_geos(const GSERIALIZED *gs)
@@ -2016,7 +2021,8 @@ geom_disjoint2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
  * @ref geom_relate_pattern() answers whether a pattern matches it, which is
  * the question a caller holding a pattern asks; this entry answers the matrix
  * itself, which is what a caller without one needs
- * @return A newly allocated string of nine characters, @p NULL on error
+ * @return A newly allocated string of nine characters
+ * @errval NULL
  * @note PostGIS function: @p ST_Relate(geometry, geometry)
  * @csqlfn #Geom_relate()
  */
@@ -3428,7 +3434,7 @@ union_lifted(GSERIALIZED *result, GSERIALIZED **gsarr, int count)
  * the array happens to list first
  * @param[in] gsarr Array of geometries
  * @param[in] count Number of elements in the array
- * @return On error return @p NULL
+ * @errval NULL
  */
 GSERIALIZED *
 geom_array_union(GSERIALIZED **gsarr, int count)
@@ -3471,7 +3477,7 @@ geom_array_union(GSERIALIZED **gsarr, int count)
  * @brief Return the union of an array of geographies
  * @param[in] gsarr Array of geographies
  * @param[in] count Number of elements in the array
- * @return On error return @p NULL
+ * @errval NULL
  * @details The union of a set of positions is the set with its duplicates
  * removed, and two positions are the same when their coordinates are, so the
  * answer is read without measuring anything and holds on the spheroid as it
@@ -3786,7 +3792,7 @@ geog_serialize(LWGEOM *lwgeom)
 /**
  * @ingroup meos_geo_base_srid
  * @brief Return the geometry/geography transformed to an SRID
- * @return On error return @p NULL
+ * @errval NULL
  * @param[in] gs Geometry/geography
  * @param[in] srid_to Target SRID
  * @note PostGIS function: @p transform(PG_FUNCTION_ARGS)
@@ -4238,7 +4244,7 @@ geog_centroid(const GSERIALIZED *gs, bool use_spheroid)
  * @brief Return the area of a geography in square meters
  * @param[in] gs Geography
  * @param[in] use_spheroid True when using a spheroid
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note PostGIS function: @p geography_area(PG_FUNCTION_ARGS)
  */
 double
@@ -4314,7 +4320,7 @@ geog_area(const GSERIALIZED *gs, bool use_spheroid)
  * @brief Return the perimeter of a geography in meters
  * @param[in] gs Geography
  * @param[in] use_spheroid True when using a spheroid
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note PostGIS function: @p geography_perimeter(PG_FUNCTION_ARGS)
  */
 double
@@ -4374,7 +4380,7 @@ geog_perimeter(const GSERIALIZED *gs, bool use_spheroid)
  * @brief Return double length in meters
  * @param[in] gs Geography
  * @param[in] use_spheroid True when using a spheroid
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note PostGIS function: @p geography_length(PG_FUNCTION_ARGS)
  */
 double
@@ -4488,7 +4494,9 @@ geog_intersects(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
  * @note PostGIS function: @p geography_distance_uncached(PG_FUNCTION_ARGS).
  * We set by default both @p tolerance and @p use_spheroid and initialize the
  * spheroid to WGS84
- * @return On error or empty geometries return DBL_MAX
+ * @note An empty geography has no point to measure from, so the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  */
 double
 geog_distance(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
@@ -5863,7 +5871,7 @@ geom_min_bounding_radius(const GSERIALIZED *geom, double *radius)
  * @brief Locate a point into a line
  * @param[in] gs1 Line
  * @param[in] gs2 Point
- * @return On error return -1.0
+ * @errval -1.0
  */
 double
 line_locate_point(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
@@ -6000,7 +6008,7 @@ line_point_n(const GSERIALIZED *gs, int n)
  * @ingroup meos_geo_base_accessor
  * @brief Return the number of points of a line
  * @param[in] gs Geometry
- * @return On error return -1
+ * @errval -1
 */
 int
 line_numpoints(const GSERIALIZED *gs)

--- a/meos/src/geo/stbox.c
+++ b/meos/src/geo/stbox.c
@@ -1201,7 +1201,8 @@ stbox_isgeodetic(const STBox *box)
  * box
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_xmin()
  */
 bool
@@ -1221,7 +1222,8 @@ stbox_xmin(const STBox *box, double *result)
  * box
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_xmax()
  */
 bool
@@ -1241,7 +1243,8 @@ stbox_xmax(const STBox *box, double *result)
  * box
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_ymin()
  */
 bool
@@ -1261,7 +1264,8 @@ stbox_ymin(const STBox *box, double *result)
  * box
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_ymax()
  */
 bool
@@ -1281,7 +1285,8 @@ stbox_ymax(const STBox *box, double *result)
  * box
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_zmin()
  */
 bool
@@ -1301,7 +1306,8 @@ stbox_zmin(const STBox *box, double *result)
  * box
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_zmax()
  */
 bool
@@ -1321,7 +1327,8 @@ stbox_zmax(const STBox *box, double *result)
  * box
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_tmin()
  */
 bool
@@ -1341,7 +1348,8 @@ stbox_tmin(const STBox *box, TimestampTz *result)
  * spatiotemporal box is inclusive
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_tmin_inc()
  */
 bool
@@ -1361,7 +1369,8 @@ stbox_tmin_inc(const STBox *box, bool *result)
  * box
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_tmax()
  */
 bool
@@ -1381,7 +1390,8 @@ stbox_tmax(const STBox *box, TimestampTz *result)
  * spatiotemporal box is inclusive
  * @param[in] box Spatiotemporal box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Stbox_tmax_inc()
  */
 bool
@@ -1401,7 +1411,7 @@ stbox_tmax_inc(const STBox *box, bool *result)
  * @param[in] box Spatiotemporal box
  * @param[in] spheroid When true, the calculation uses the WGS 84 spheroid,
  * otherwise it uses a faster spherical calculation
- * @return On error, return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Stbox_area()
  */
 double
@@ -1425,7 +1435,7 @@ stbox_area(const STBox *box, bool spheroid)
  * @ingroup meos_geo_box_accessor
  * @brief Return the volume of a 3D spatiotemporal box
  * @param[in] box Spatiotemporal box
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Stbox_volume()
  */
 double
@@ -1446,7 +1456,7 @@ stbox_volume(const STBox *box)
  * @param[in] box Spatiotemporal box
  * @param[in] spheroid When true, the calculation uses the WGS 84 spheroid,
  * otherwise it uses a faster spherical calculation
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Stbox_perimeter()
  */
 double
@@ -1600,7 +1610,7 @@ stbox_get_space(const STBox *box)
  * @param[in] box Spatiotemporal box
  * @param[in] d Value for expanding
  * @param[out] result Spatiotemporal box
- * @return On error return false
+ * @errval false
  */
 bool
 stbox_expand_space_set(const STBox *box, double d, STBox *result)
@@ -2924,7 +2934,7 @@ stbox_ne(const STBox *box1, const STBox *box2)
  * @brief Return -1, 0, or 1 depending on whether the first spatiotemporal
  * box is less than, equal to, or greater than the second one
  * @param[in] box1,box2 Spatiotemporal boxes
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Stbox_cmp()
  */
 int
@@ -3050,7 +3060,7 @@ stbox_gt(const STBox *box1, const STBox *box2)
  * @ingroup meos_geo_box_accessor
  * @brief Return the 32-bit hash value of a spatiotemporal box
  * @param[in] box Spatiotemporal box
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @sqlfn hash()
  * @csqlfn #Stbox_hash()
  */
@@ -3102,7 +3112,7 @@ stbox_hash(const STBox *box)
  * @brief Return the 64-bit hash of a spatiotemporal box using a seed
  * @param[in] box Spatiotemporal box
  * @param[in] seed Seed
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  * @csqlfn #Stbox_hash_extended()
  */
 uint64

--- a/meos/src/geo/tgeo_boxops.c
+++ b/meos/src/geo/tgeo_boxops.c
@@ -559,7 +559,7 @@ tgeoseqset_stboxes(const TSequenceSet *ss, int *count)
  * respectively, on whether the interpolation is discrete or continuous
  * @param[in] temp Temporal geo
  * @param[out] count Number of values of the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tgeo_stboxes()
  */
 STBox *
@@ -794,7 +794,7 @@ tgeoseqset_split_n_stboxes(const TSequenceSet *ss, int box_count, int *count)
  * @param[in] temp Temporal geo
  * @param[in] box_count Number of boxes
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tgeo_split_n_stboxes()
  */
 STBox *
@@ -964,7 +964,7 @@ tgeoseqset_split_each_n_stboxes(const TSequenceSet *ss, int elems_per_box,
  * @param[in] elems_per_box Number of input instants or segments merged into an
  * output box
  * @param[out] count Number of values of the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tgeo_split_each_n_stboxes()
  */
 STBox *
@@ -1168,7 +1168,7 @@ multiline_gboxes(const GSERIALIZED *gs, int *count)
  * segments of a (multi)line
  * @param[in] gs (Multi)line
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  */
 GBOX *
 geo_gboxes(const GSERIALIZED *gs, int *count)
@@ -1185,7 +1185,7 @@ geo_gboxes(const GSERIALIZED *gs, int *count)
  * (mult)linestring
  * @param[in] gs Geometry
  * @param[out] count Number of values of the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Geo_stboxes()
  */
 STBox *
@@ -1416,7 +1416,7 @@ multiline_split_n_gboxes(const GSERIALIZED *gs, int box_count, int *count)
  * @param[in] gs (Multi)line
  * @param[in] box_count Number of boxes
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  */
 GBOX *
 geo_split_n_gboxes(const GSERIALIZED *gs, int box_count, int *count)
@@ -1602,7 +1602,8 @@ multiline_split_each_n_gboxes(const GSERIALIZED *gs, int elems_per_box,
  * @param[out] count Number of boxes in the output array
  * @return If the number of segments is <= `elems_per_box`, the result contains
  * a single box. Otherwise, consecutive input segments are combined into an
- * output box in the result. On error return @p NULL
+ * output box in the result.
+ * @errval NULL
  */
 GBOX *
 geo_split_each_n_gboxes(const GSERIALIZED *gs, int elems_per_box, int *count)

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2675,7 +2675,7 @@ nai_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry/geography
  * @csqlfn #NAD_tgeo_geo() #NAD_geo_tgeo()
- * @return On error return infinity
+ * @errval DBL_MAX
  */
 double
 nad_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
@@ -2715,7 +2715,7 @@ nad_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
  * @param[in] box Spatiotemporal box/geography
  * @param[in] gs Geometry
  * @csqlfn #NAD_stbox_geo() #NAD_geo_stbox()
- * @return On error return infinity
+ * @errval DBL_MAX
  */
 double
 nad_stbox_geo(const STBox *box, const GSERIALIZED *gs)
@@ -2766,7 +2766,10 @@ stbox_nad(const STBox *box1, const STBox *box2)
  * @brief Return the nearest approach distance between two spatiotemporal
  * boxes
  * @param[in] box1,box2 Spatiotemporal boxes
- * @return On error or if the time frames do not intersect return infinity
+ * @note A nearest approach is measured over the time the operands share, so
+ * operands whose time frames do not intersect have none and the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_stbox_stbox()
  */
 double
@@ -2787,7 +2790,10 @@ nad_stbox_stbox(const STBox *box1, const STBox *box2)
  * and a spatiotemporal box
  * @param[in] temp Temporal geo
  * @param[in] box Spatiotemporal box
- * @return On error or if the time frames do not intersect return infinity
+ * @note A nearest approach is measured over the time the operands share, so
+ * operands whose time frames do not intersect have none and the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_tgeo_stbox() #NAD_stbox_tgeo()
  */
 double
@@ -2837,7 +2843,10 @@ nad_tgeo_stbox(const Temporal *temp, const STBox *box)
  * @brief Return the nearest approach distance between two temporal geos
  * @param[in] temp1,temp2 Temporal geos
  * @csqlfn #NAD_tgeo_tgeo()
- * @return On error or if the time frames do not intersect return infinity
+ * @note A nearest approach is measured over the time the operands share, so
+ * operands whose time frames do not intersect have none and the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  */
 double
 nad_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
@@ -3036,7 +3045,7 @@ shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  * @brief Return the spatial-only minimum distance between two spatiotemporal
  * boxes, ignoring the time dimension entirely
  * @param[in] box1,box2 Spatiotemporal boxes
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 stbox_spatial_distance(const STBox *box1, const STBox *box2)

--- a/meos/src/geo/tgeo_meos.c
+++ b/meos/src/geo/tgeo_meos.c
@@ -445,7 +445,7 @@ tgeographyseqset_from_mfjson(json_object *mfjson, int32_t srid, interpType inter
  * @ingroup meos_geo_inout
  * @brief Return a temporal geometry point from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -458,7 +458,7 @@ tgeompoint_from_mfjson(const char *mfjson)
  * @ingroup meos_geo_inout
  * @brief Return a temporal geography point from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -470,7 +470,7 @@ tgeogpoint_from_mfjson(const char *mfjson)
  * @ingroup meos_geo_inout
  * @brief Return a temporal geometry from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -483,7 +483,7 @@ tgeometry_from_mfjson(const char *mfjson)
  * @ingroup meos_geo_inout
  * @brief Return a temporal geography from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -705,7 +705,7 @@ tgeo_from_base_temp(const GSERIALIZED *gs, const Temporal *temp)
  * @ingroup meos_geo_accessor
  * @brief Return a copy of the start value of a temporal geo
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_value()
  */
 GSERIALIZED *
@@ -720,7 +720,7 @@ tgeo_start_value(const Temporal *temp)
  * @ingroup meos_geo_accessor
  * @brief Return a copy of the end value of a temporal geo
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_value()
  */
 GSERIALIZED *

--- a/meos/src/geo/tgeo_spatialfuncs.c
+++ b/meos/src/geo/tgeo_spatialfuncs.c
@@ -737,7 +737,7 @@ ensure_valid_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2)
  * @param[in] inst Temporal geo instant
  * @param[in] oper True when transforming from geometry to geography,
  * false otherwise
- * @return On error return `NULL`
+ * @errval NULL
  * @sqlop @p ::
  */
 TInstant *
@@ -769,7 +769,7 @@ tgeominst_tgeoginst(const TInstant *inst, bool oper)
  * @param[in] seq Temporal geo sequence
  * @param[in] oper True when transforming from geometry to geography,
  * false otherwise
- * @return On error return `NULL`
+ * @errval NULL
  * @sqlop @p ::
  */
 TSequence *
@@ -797,7 +797,7 @@ tgeomseq_tgeogseq(const TSequence *seq, bool oper)
  * @param[in] ss Temporal point sequence set
  * @param[in] oper True when transforming from geometry to geography,
  * false otherwise
- * @return On error return `NULL`
+ * @errval NULL
  * @sqlop @p ::
  */
 TSequenceSet *
@@ -824,7 +824,7 @@ tgeomseqset_tgeogseqset(const TSequenceSet *ss, bool oper)
  * @param[in] temp Temporal geo
  * @param[in] oper True when transforming from geometry to geography,
  * false otherwise
- * @return On error return `NULL`
+ * @errval NULL
  * @see #tgeominst_tgeoginst
  * @see #tgeomseq_tgeogseq
  * @see #tgeomseqset_tgeogseqset
@@ -853,7 +853,7 @@ tgeom_tgeog(const Temporal *temp, bool oper)
  * @ingroup meos_geo_conversion
  * @brief Return a temporal geography from a temporal geometry
  * @param[in] temp Temporal geo
- * @return On error return `NULL`
+ * @errval NULL
  * @csqlfn #Tgeometry_to_tgeography()
  */
 Temporal *
@@ -868,7 +868,7 @@ tgeometry_to_tgeography(const Temporal *temp)
  * @ingroup meos_geo_conversion
  * @brief Return a temporal geometry from to a temporal geography
  * @param[in] temp Temporal point
- * @return On error return `NULL`
+ * @errval NULL
  * @csqlfn #Tgeography_to_tgeometry()
  */
 Temporal *
@@ -1025,7 +1025,7 @@ tgeoseqset_tpointseqset(const TSequenceSet *ss, bool oper)
  * @param[in] temp Temporal value
  * @param[in] oper True when transforming from temporal geo to temporal point,
  * false otherwise
- * @return On error return `NULL`
+ * @errval NULL
  * @see #tgeoinst_tpointinst
  * @see #tgeoseq_tpointseq
  * @see #tgeoseqset_tpointseqset
@@ -1374,7 +1374,7 @@ tgeo_scale(const Temporal *temp, const GSERIALIZED *scale,
  * @ingroup meos_geo_accessor
  * @brief Return the convex hull of a temporal geo
  * @param[in] temp Temporal geo
- * @return On error return `NULL`
+ * @errval NULL
  * @csqlfn #Tgeo_convex_hull()
  */
 GSERIALIZED *

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -408,7 +408,7 @@ spatialrel_datum_geo_geo(Datum d1, Datum d2, SpatialRelOp op, double dist,
  * @param[in] invert True if the arguments should be inverted
  * @param[in] ever True for the ever semantics (any element satisfies),
  *  false for the always semantics (every element satisfies)
- * @return On error return -1
+ * @errval -1
  */
 static int
 spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
@@ -467,7 +467,7 @@ spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
  * @param[in] param Parameter
  * @param[in] func PostGIS function to be called
  * @param[in] numparam Number of parameters of the function
- * @return On error return -1
+ * @errval -1
  * @note Since some GEOS versions do not support geometry collections, the
  * function iterates for each geometry of the collection and returns when the
  * function is true for one of them.

--- a/meos/src/geo/tpoint_spatialfuncs.c
+++ b/meos/src/geo/tpoint_spatialfuncs.c
@@ -2171,7 +2171,7 @@ tpointseqset_length(const TSequenceSet *ss)
  * @ingroup meos_geo_accessor
  * @brief Return the length traversed by a temporal point sequence (set)
  * @param[in] temp Temporal point
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Tpoint_length()
  */
 double
@@ -2193,7 +2193,7 @@ tpoint_length(const Temporal *temp)
  * @ingroup meos_geo_accessor
  * @brief Return the speed of a temporal point sequence (set)
  * @param[in] temp Temporal point
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpoint_speed()
  */
 Temporal *
@@ -2276,7 +2276,7 @@ tpointseqset_cumulative_length(const TSequenceSet *ss)
  * @ingroup meos_geo_accessor
  * @brief Return the cumulative length traversed by a temporal point
  * @param[in] temp Temporal point
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpoint_cumulative_length()
  */
 Temporal *
@@ -2397,7 +2397,7 @@ tpointseqset_twcentroid(const TSequenceSet *ss)
  * @ingroup meos_geo_accessor
  * @brief Return the time-weighed centroid of a temporal geometry point
  * @param[in] temp Temporal point
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpoint_twcentroid()
  */
 GSERIALIZED *
@@ -2659,7 +2659,7 @@ tpointseqset_azimuth(const TSequenceSet *ss)
  * @ingroup meos_geo_accessor
  * @brief Return the temporal azimuth of a temporal geometry point
  * @param[in] temp Temporal point
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpoint_azimuth()
  */
 Temporal *
@@ -2954,7 +2954,8 @@ bearing_point_point(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
  * @param[in] invert True when the result should be inverted
- * @return On empty geometry or on error return NULL
+ * @note An empty geometry has no bearing, so the answer is NULL
+ * @errval NULL
  * @csqlfn #Bearing_tpoint_point() #Bearing_point_tpoint()
  */
 Temporal *
@@ -2981,7 +2982,7 @@ bearing_tpoint_point(const Temporal *temp, const GSERIALIZED *gs, bool invert)
  * @ingroup meos_geo_accessor
  * @brief Return the temporal bearing between two temporal points
  * @param[in] temp1,temp2 Temporal points
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Bearing_tpoint_tpoint()
  */
 Temporal *
@@ -3106,7 +3107,7 @@ point_max_distance(const POINT2D *points, uint32_t npoints, const POINT2D *p,
  * @brief Return the points a temporal sequence with a spatial point base type
  * takes, in the order of its instants
  * @param[in] seq Temporal sequence
- * @return On error return @p NULL
+ * @errval NULL
  */
 static POINT2D *
 tspatialseq_points(const TSequence *seq)

--- a/meos/src/geo/tspatial.c
+++ b/meos/src/geo/tspatial.c
@@ -98,7 +98,7 @@
 
 /**
  * @brief Return the string representation of a base value
- * @return On error return @p NULL
+ * @errval NULL
  */
 char *
 spatialbase_as_text(Datum value, MeosType type, int maxdd)
@@ -152,7 +152,7 @@ spatialbase_as_text(Datum value, MeosType type, int maxdd)
 
 /**
  * @brief Return the string representation of a base value
- * @return On error return @p NULL
+ * @errval NULL
  */
 char *
 spatialbase_as_ewkt(Datum value, MeosType type, int maxdd)
@@ -448,7 +448,7 @@ spatialset_set_stbox(const Set *s, STBox *result)
  * @details A set answers the distance of the extent that bounds it, which for
  * a spatial set is its spatiotemporal box where for a span set it is its
  * bounding span: the gaps between the elements are not boundaries of the set.
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 Datum
 distance_spatialset_value(const Set *s, Datum value)
@@ -466,7 +466,7 @@ distance_spatialset_value(const Set *s, Datum value)
  * @brief Return the distance between two spatial sets
  * @param[in] s1,s2 Spatial sets
  * @details Each set answers for the extent that bounds it, as above.
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 Datum
 distance_spatialset_spatialset(const Set *s1, const Set *s2)

--- a/meos/src/geo/tspatial_srid.c
+++ b/meos/src/geo/tspatial_srid.c
@@ -249,7 +249,7 @@ spatialset_srid(const Set *s)
  * @brief Return a spatial set with the coordinates set to an SRID
  * @param[in] s Spatial set
  * @param[in] srid SRID
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Spatialset_set_srid()
  */
 Set *
@@ -283,7 +283,7 @@ spatialset_set_srid(const Set *s, int32_t srid)
 /**
  * @ingroup meos_internal_geo_srid
  * @brief Return the SRID of a spatiotemporal instant
- * @return On error return @p SRID_INVALID
+ * @errval SRID_INVALID
  * @param[in] inst Spatiotemporal instant
  */
 int32_t
@@ -298,7 +298,7 @@ tspatialinst_srid(const TInstant *inst)
 /**
  * @ingroup meos_geo_srid
  * @brief Return the SRID of a spatiotemporal value
- * @return On error return @p SRID_INVALID
+ * @errval SRID_INVALID
  * @param[in] temp Spatiotemporal value
  * @csqlfn #Tspatial_srid()
  */
@@ -397,7 +397,7 @@ tspatialseqset_set_srid(TSequenceSet *ss, int32_t srid)
  * @brief Return a spatiotemporal value with the coordinates set to an SRID
  * @param[in] temp Spatiotemporal value
  * @param[in] srid SRID
- * @return On error return @p NULL
+ * @errval NULL
  * @see #tspatialinst_set_srid()
  * @see #tspatialseq_set_srid()
  * @see #tspatialseqset_set_srid()

--- a/meos/src/geo/tspatial_tempspatialrels.c
+++ b/meos/src/geo/tspatial_tempspatialrels.c
@@ -589,7 +589,7 @@ tinterrel_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2,
  * @param[in] func Spatial relationship function to be applied
  * @param[in] numparam Number of parameters of the function
  * @param[in] invert True if the arguments should be inverted
- * @return On error return `NULL`
+ * @errval NULL
  */
 Temporal *
 tspatialrel_tspatial_base(const Temporal *temp, Datum base,
@@ -645,7 +645,7 @@ tspatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs,
  * @param[in] func Spatial relationship function to be applied
  * @param[in] numparam Number of parameters of the function
  * @param[in] invert True if the arguments should be inverted
- * @return On error return `NULL`
+ * @errval NULL
  */
 Temporal *
 tspatialrel_tspatial_tspatial(const Temporal *temp1, const Temporal *temp2,

--- a/meos/src/geo/tspatial_transform_meos.c
+++ b/meos/src/geo/tspatial_transform_meos.c
@@ -211,7 +211,7 @@ meos_finalize_projsrs(void)
 
 /**
  * @brief Get a PROJ structure from the PROJ cache
- * @return On error return `NULL`
+ * @errval NULL
  */
 static LWPROJ *
 GetProjectionFromPROJCache(MEOSPROJSRSCache *cache, int32_t srid_from,

--- a/meos/src/h3/h3index.c
+++ b/meos/src/h3/h3index.c
@@ -203,7 +203,8 @@ h3index_get_resolution(H3Index cell)
  * @brief Return the parent of an H3 cell at a coarser resolution
  * @param[in] cell H3 cell
  * @param[in] parent_resolution Target resolution (<= resolution of @p cell)
- * @return The parent cell, or 0 on error
+ * @return The parent cell
+ * @errval 0
  * @csqlfn #H3index_cell_to_parent()
  */
 H3Index

--- a/meos/src/json/jsonbset.c
+++ b/meos/src/json/jsonbset.c
@@ -136,7 +136,7 @@ jsonbset_make(const Jsonb **values, int count)
  * @ingroup meos_json_set_accessor
  * @brief Return a copy of the first value of a JSONB set
  * @param[in] s JSONB set
- * @return On error return NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 Jsonb *
@@ -152,7 +152,7 @@ jsonbset_start_value(const Set *s)
  * @ingroup meos_json_set_accessor
  * @brief Return a copy of the last value of a JSONB set
  * @param[in] s JSONB set
- * @return On error return NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 Jsonb *
@@ -191,7 +191,7 @@ jsonbset_value_n(const Set *s, int n, Jsonb **result)
  * @brief Return an array of copies of the values of a JSONB set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 Jsonb **

--- a/meos/src/json/tjsonb.c
+++ b/meos/src/json/tjsonb.c
@@ -177,7 +177,7 @@ tjsonbseqset_from_mfjson(json_object *mfjson)
  * @ingroup meos_json_inout
  * @brief Return a temporal JSONB from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 
@@ -324,7 +324,7 @@ ttext_to_tjsonb(const Temporal *temp)
  * @ingroup meos_json_accessor
  * @brief Return the start value of a temporal JSONB
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_value()
  */
 Jsonb *
@@ -339,7 +339,7 @@ tjsonb_start_value(const Temporal *temp)
  * @ingroup meos_json_accessor
  * @brief Return the end value of a temporal JSONB
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_value()
  */
 Jsonb *

--- a/meos/src/npoint/npoint.c
+++ b/meos/src/npoint/npoint.c
@@ -880,7 +880,7 @@ nsegment_to_geom(const Nsegment *ns)
 /**
  * @ingroup meos_npoint_base_conversion
  * @brief Transform a geometry into a network segment
- * @return On error return @p NULL
+ * @errval NULL
  * @param[in] gs Geometry
  * @csqlfn #Geom_to_nsegment()
  */
@@ -1079,7 +1079,7 @@ npoint_route(const Npoint *np)
  * @ingroup meos_npoint_base_accessor
  * @brief Return the position of a network point
  * @param[in] np Network point
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Npoint_position()
  */
 double
@@ -1108,7 +1108,7 @@ nsegment_route(const Nsegment *ns)
  * @ingroup meos_npoint_base_accessor
  * @brief Return the start position of a network segment
  * @param[in] ns Network segment
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Nsegment_start_position()
  */
 double
@@ -1123,7 +1123,7 @@ nsegment_start_position(const Nsegment *ns)
  * @ingroup meos_npoint_base_accessor
  * @brief Return the end position of a network segment
  * @param[in] ns Network segment
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Nsegment_end_position()
  */
 double
@@ -1203,7 +1203,7 @@ npoint_ne(const Npoint *np1, const Npoint *np2)
  * @brief Return -1, 0, or 1 depending on whether the first network point
  * is less than, equal to, or greater than the second one
  * @param[in] np1,np2 Network points
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Npoint_cmp()
  */
 int
@@ -1309,7 +1309,7 @@ nsegment_ne(const Nsegment *ns1, const Nsegment *ns2)
  * @brief Return -1, 0, or 1 depending on whether the first network segment
  * is less than, equal to, or greater than the second one
  * @param[in] ns1,ns2 Network segments
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Nsegment_cmp()
  */
 int
@@ -1396,7 +1396,7 @@ nsegment_ge(const Nsegment *ns1, const Nsegment *ns2)
  * @ingroup meos_npoint_base_accessor
  * @brief Return the 32-bit hash value of a network point
  * @param[in] np Network point
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  */
 uint32
 npoint_hash(const Npoint *np)

--- a/meos/src/npoint/npointset_meos.c
+++ b/meos/src/npoint/npointset_meos.c
@@ -132,7 +132,7 @@ npoint_to_set(const Npoint *np)
  * @ingroup meos_npoint_set_accessor
  * @brief Return a copy of the start value of a network point set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 Npoint *
@@ -147,7 +147,7 @@ npointset_start_value(const Set *s)
  * @ingroup meos_npoint_set_accessor
  * @brief Return a copy of the end value of a network point set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 Npoint *
@@ -184,7 +184,7 @@ npointset_value_n(const Set *s, int n, Npoint **result)
  * @brief Return the array of copies of the values of a network point set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 Npoint **

--- a/meos/src/npoint/tnpoint.c
+++ b/meos/src/npoint/tnpoint.c
@@ -243,7 +243,7 @@ tnpoint_out(const Temporal *temp, int maxdd)
  * @ingroup meos_npoint_inout
  * @brief Return a temporal network point from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -579,7 +579,7 @@ tgeompoint_to_tnpoint(const Temporal *temp)
  * @ingroup meos_npoint_accessor
  * @brief Return a copy of the start value of a temporal network point
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_value()
  */
 Npoint *
@@ -594,7 +594,7 @@ tnpoint_start_value(const Temporal *temp)
  * @ingroup meos_npoint_accessor
  * @brief Return a copy of the end value of a temporal network point
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_value()
  */
 Npoint *
@@ -826,7 +826,7 @@ tnpointinst_route(const TInstant *inst)
 /**
  * @ingroup meos_npoint_accessor
  * @brief Return the single route of a temporal network point
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Tnpoint_route()
  */
 int64

--- a/meos/src/npoint/tnpoint_spatialfuncs.c
+++ b/meos/src/npoint/tnpoint_spatialfuncs.c
@@ -260,7 +260,7 @@ tnpointseqset_length(const TSequenceSet *ss)
  * @ingroup meos_npoint_accessor
  * @brief Length traversed by a temporal network point
  * @param[in] temp Temporal point
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Tnpoint_length()
  */
 double

--- a/meos/src/npoint/ways.c
+++ b/meos/src/npoint/ways.c
@@ -63,7 +63,7 @@ static int32_t SRID_WAYS = SRID_INVALID;
 /**
  * @ingroup meos_npoint_base_srid
  * @brief Return the SRID of the routes in the ways table
- * @return On error return SRID_INVALID
+ * @errval SRID_INVALID
  */
 int32_t
 get_srid_ways()
@@ -135,7 +135,7 @@ route_exists(int64 rid)
  * @brief Access the edge table to return the route length from the
  * corresponding route identifier
  * @param[in] rid Route identifier
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 route_length(int64 rid)
@@ -170,7 +170,7 @@ route_length(int64 rid)
  * @brief Access the edge table to get the route geometry from corresponding
  * route identifier
  * @param[in] rid Route identifier
- * @return On error return @p NULL
+ * @errval NULL
  */
 const GSERIALIZED *
 route_geom(int64 rid)

--- a/meos/src/npoint/ways_meos.c
+++ b/meos/src/npoint/ways_meos.c
@@ -355,7 +355,7 @@ route_exists(int64 rid)
  * @ingroup meos_npoint_base_route
  * @brief Access the ways cache to get the geometry of a route identifier
  * @param[in] rid Route identifier
- * @return On error return @p NULL
+ * @errval NULL
  */
 const GSERIALIZED *
 route_geom(int64 rid)
@@ -371,7 +371,7 @@ route_geom(int64 rid)
  * @brief Access the edge table to return the route length from the
  * corresponding route identifier
  * @param[in] rid Route identifier
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 route_length(int64 rid)

--- a/meos/src/pointcloud/pcpatch.c
+++ b/meos/src/pointcloud/pcpatch.c
@@ -277,7 +277,7 @@ pcpatch_as_hexwkb(const Pcpatch *pa)
  * @param[in] values Coordinate of each dimension of each point, one point
  *   after another, in the order the schema states the dimensions
  * @param[in] count Number of coordinates, a whole number of points
- * @return On error return @p NULL
+ * @errval NULL
  * @note The schema is resolved through the MEOS cache, so a schema stated in
  *   SQL and one parsed from an XML document build a value alike.
  * @csqlfn #Pcpatch_make_coords()
@@ -347,7 +347,7 @@ pcpatch_make_coords(uint32_t pcid, const double *values, int count)
  * @brief Return a pcpatch from an array of pcpoints
  * @param[in] points Array of points, all of the same schema
  * @param[in] count Number of points
- * @return On error return @p NULL
+ * @errval NULL
  * @note The schema is resolved through the MEOS cache, so a schema stated in
  *   SQL and one parsed from an XML document build a value alike.
  * @csqlfn #Pcpatch_make()
@@ -464,8 +464,9 @@ pcpoint_serialize(const PCPOINT *pcpt)
  * @param[in] n Number of the point, one-based: 1 is the first point and the
  * number of points of the patch the last one. A negative @p n counts from the
  * end, so that -1 is the last point and minus the number of points the first
- * @return On error, or when @p n addresses no point of the patch, return
- * @p NULL
+ * @note A @p n that addresses no point of the patch has no point to copy, so
+ * the answer is NULL
+ * @errval NULL
  * @details The indexing is the one pgPointCloud defines for @c PC_PointN,
  * which owns the type
  * @see #pcpatch_points() to obtain every point in a single call
@@ -507,7 +508,7 @@ pcpatch_point_n(const Pcpatch *pa, int n)
  * @brief Return the array of points of a pcpatch
  * @param[in] pa Point cloud patch
  * @param[out] count Number of elements of the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @details Every point carries the schema of the patch it comes from, and the
  * points are returned in the order the patch stores them, which is the order
  * #pcpatch_point_n() indexes
@@ -550,7 +551,7 @@ pcpatch_points(const Pcpatch *pa, int *count)
 /**
  * @ingroup meos_pointcloud_base_accessor
  * @brief Return the 32-bit hash of a pcpatch
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Pcpatch_hash()
  */
 uint32
@@ -584,7 +585,7 @@ pcpatch_hash_extended(const Pcpatch *pa, uint64 seed)
  * @ingroup meos_pointcloud_base_comp
  * @brief Compare two pcpatch values byte-wise
  * @return -1 / 0 / 1
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @note Compares only the meaningful-prefix bytes — pgpointcloud's
  *   struct-tail padding is skipped so two pcpatches that disagree only
  *   on those padding bytes compare equal.

--- a/meos/src/pointcloud/pcpoint.c
+++ b/meos/src/pointcloud/pcpoint.c
@@ -306,7 +306,7 @@ pcpoint_as_hexwkb(const Pcpoint *pt)
  * @param[in] values Coordinate of each dimension, in the order the schema
  *   states the dimensions
  * @param[in] count Number of coordinates
- * @return On error return @p NULL
+ * @errval NULL
  * @note The schema is resolved through the MEOS cache, so a schema stated in
  *   SQL and one parsed from an XML document build a value alike.
  * @csqlfn #Pcpoint_make()
@@ -386,7 +386,7 @@ pcpoint_get_pcid(const Pcpoint *pt)
  * @note Hashes only the meaningful-prefix bytes — pgpointcloud's
  *   struct-tail padding is skipped because it holds uninitialized heap
  *   bytes that differ between otherwise-identical values.
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Pcpoint_hash()
  */
 uint32
@@ -424,7 +424,7 @@ pcpoint_hash_extended(const Pcpoint *pt, uint64 seed)
  * @ingroup meos_pointcloud_base_comp
  * @brief Compare two pcpoints byte-wise
  * @return -1 / 0 / 1
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @note Compares only the meaningful-prefix bytes — pgpointcloud's
  * struct-tail padding is skipped (see the padding comment above).
  * Two pcpoints that disagree only on those padding bytes now compare

--- a/meos/src/pointcloud/pcset_meos.c
+++ b/meos/src/pointcloud/pcset_meos.c
@@ -190,7 +190,7 @@ pcpoint_to_set(const Pcpoint *pt)
  * @ingroup meos_pointcloud_set_accessor
  * @brief Return a copy of the start (smallest) value of a pcpoint set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 Pcpoint *
@@ -206,7 +206,7 @@ pcpointset_start_value(const Set *s)
  * @ingroup meos_pointcloud_set_accessor
  * @brief Return a copy of the end (largest) value of a pcpoint set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 Pcpoint *
@@ -244,7 +244,7 @@ pcpointset_value_n(const Set *s, int n, Pcpoint **result)
  * @brief Return an array of copies of the values of a pcpoint set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 Pcpoint **
@@ -474,7 +474,7 @@ pcpatch_to_set(const Pcpatch *pa)
  * @ingroup meos_pointcloud_set_accessor
  * @brief Return a copy of the start (smallest) value of a pcpatch set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 Pcpatch *
@@ -490,7 +490,7 @@ pcpatchset_start_value(const Set *s)
  * @ingroup meos_pointcloud_set_accessor
  * @brief Return a copy of the end (largest) value of a pcpatch set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 Pcpatch *
@@ -528,7 +528,7 @@ pcpatchset_value_n(const Set *s, int n, Pcpatch **result)
  * @brief Return an array of copies of the values of a pcpatch set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 Pcpatch **

--- a/meos/src/pointcloud/schema_hook.c
+++ b/meos/src/pointcloud/schema_hook.c
@@ -196,7 +196,8 @@ pcschema_string_copy(const char *str)
  *   @p NULL for none
  * @param[in] dims Dimensions the schema states, in any order
  * @param[in] ndims Number of dimensions
- * @return A newly allocated schema, @p NULL on error
+ * @return A newly allocated schema
+ * @errval NULL
  * @note The schema is built through the constructor of the point cloud
  *   library, so the size of a dimension, the offset of a dimension within a
  *   point and the width of a point are the ones that library computes
@@ -291,7 +292,8 @@ meos_pc_schema_from_dims(uint32_t pcid, int32_t srid,
  *   @p NULL for none
  * @param[in] dims Dimensions the schema states, in any order
  * @param[in] ndims Number of dimensions
- * @return True on success, false on error
+ * @return True when the schema is registered
+ * @errval false
  * @sqlfn pointCloudSchemaRegister()
  */
 bool

--- a/meos/src/pointcloud/tpc_boxops.c
+++ b/meos/src/pointcloud/tpc_boxops.c
@@ -388,7 +388,10 @@ tpcbox_set_stbox(const TPCBox *src, STBox *dst)
  * @ingroup meos_pointcloud_box_dist
  * @brief Return the nearest-approach distance between two TPCBox values
  * @param[in] box1,box2 Bounding boxes
- * @return On error or if the time frames do not intersect return infinity
+ * @note A nearest approach is measured over the time the operands share, so
+ * operands whose time frames do not intersect have none and the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_tpcbox_tpcbox()
  */
 double
@@ -409,7 +412,10 @@ nad_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
  *   value and a TPCBox
  * @param[in] temp Temporal pointcloud value
  * @param[in] box Bounding box
- * @return On error or if the time frames do not intersect return infinity
+ * @note A nearest approach is measured over the time the operands share, so
+ * operands whose time frames do not intersect have none and the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_tpointcloud_tpcbox() #NAD_tpcbox_tpointcloud()
  */
 double
@@ -427,7 +433,10 @@ nad_tpointcloud_tpcbox(const Temporal *temp, const TPCBox *box)
  * @brief Return the nearest-approach distance between two temporal
  *   pointcloud values
  * @param[in] temp1,temp2 Temporal pointcloud values
- * @return On error or if the time frames do not intersect return infinity
+ * @note A nearest approach is measured over the time the operands share, so
+ * operands whose time frames do not intersect have none and the answer is
+ * DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_tpointcloud_tpointcloud()
  */
 double

--- a/meos/src/pointcloud/tpcbox.c
+++ b/meos/src/pointcloud/tpcbox.c
@@ -1176,7 +1176,7 @@ adjacent_tpcbox_tpcbox(const TPCBox *box1, const TPCBox *box2)
  * @details Order: pcid, srid, flags, period, then spatial bounds.
  *   Deterministic; suitable for B-tree.
  * @return -1, 0, or 1
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Tpcbox_cmp()
  */
 int

--- a/meos/src/pointcloud/tpcpatch.c
+++ b/meos/src/pointcloud/tpcpatch.c
@@ -147,7 +147,7 @@ tpcpatch_from_base_temp(const Pcpatch *pa, const Temporal *temp)
  * @ingroup meos_pointcloud_accessor
  * @brief Return the start value of a temporal pgpointcloud patch
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_value()
  */
 Pcpatch *
@@ -162,7 +162,7 @@ tpcpatch_start_value(const Temporal *temp)
  * @ingroup meos_pointcloud_accessor
  * @brief Return the end value of a temporal pgpointcloud patch
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_value()
  */
 Pcpatch *

--- a/meos/src/pointcloud/tpcpoint.c
+++ b/meos/src/pointcloud/tpcpoint.c
@@ -145,7 +145,7 @@ tpcpoint_from_base_temp(const Pcpoint *pt, const Temporal *temp)
  * @ingroup meos_pointcloud_accessor
  * @brief Return the start value of a temporal pgpointcloud point
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_value()
  */
 Pcpoint *
@@ -160,7 +160,7 @@ tpcpoint_start_value(const Temporal *temp)
  * @ingroup meos_pointcloud_accessor
  * @brief Return the end value of a temporal pgpointcloud point
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_value()
  */
 Pcpoint *

--- a/meos/src/pointcloud/tpcpoint_spatialfuncs.c
+++ b/meos/src/pointcloud/tpcpoint_spatialfuncs.c
@@ -223,7 +223,7 @@ eintersects_tpcpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
  *   a geometry
  * @param[in] temp Temporal pointcloud value (single instant)
  * @param[in] gs Geometry
- * @return @p DBL_MAX on error (missing X/Y dimensions or NULL input)
+ * @errval DBL_MAX
  */
 double
 nad_tpcpoint_geo(const Temporal *temp, const GSERIALIZED *gs)

--- a/meos/src/pose/pose.c
+++ b/meos/src/pose/pose.c
@@ -1343,7 +1343,7 @@ datum_pose_roll(Datum pose)
  * #pose_ypr().
  * @param[in] pose Pose
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Pose_quaternion()
  */
 double *
@@ -1382,7 +1382,7 @@ pose_quaternion(const Pose *pose, int *count)
  * are in radians, where the GeoPose JSON encoding writes them in degrees.
  * @param[in] pose Pose
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Pose_ypr()
  */
 double *
@@ -1415,7 +1415,7 @@ pose_ypr(const Pose *pose, int *count)
  * component of the (yaw, pitch, roll) ZYX intrinsic Tait-Bryan decomposition
  * of the orientation quaternion (the convention required by OGC GeoPose).
  * @param[in] pose Pose
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Pose_yaw()
  */
 double
@@ -1440,7 +1440,7 @@ pose_yaw(const Pose *pose)
  * @p asin term is clamped to @p [-1, 1] to absorb the small numeric drift
  * @p |q| - 1 that long quaternion compositions can introduce.
  * @param[in] pose Pose
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Pose_pitch()
  */
 double
@@ -1463,7 +1463,7 @@ pose_pitch(const Pose *pose)
  * @details A 2D pose has no roll and returns @p 0. A 3D pose returns the
  * roll component of the ZYX intrinsic Tait-Bryan decomposition.
  * @param[in] pose Pose
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Pose_roll()
  */
 double
@@ -1492,7 +1492,7 @@ pose_roll(const Pose *pose)
  * the small numeric drift @p |q| - 1 that long compositions can
  * introduce.
  * @param[in] pose1,pose2 Poses (must agree on dimension)
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 pose_angular_distance(const Pose *pose1, const Pose *pose2)
@@ -1609,7 +1609,7 @@ lwgeom_apply_pose(const Pose *pose, LWGEOM *geom)
  * one adopts the other, and the result carries the SRID they agree on.
  * @param[in] pose Pose
  * @param[in] body Body-frame geometry
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Pose_apply_geo()
  */
 GSERIALIZED *
@@ -1676,7 +1676,7 @@ datum_pose_apply_geo(Datum pose, Datum body)
  * links, so a two-link chain composes to what this returns.
  * @param[in] body Pose expressed in the frame the other one names
  * @param[in] frame Pose naming that frame
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Pose_apply_pose()
  */
 Pose *
@@ -1705,7 +1705,7 @@ pose_compose(const Pose *body, const Pose *frame)
  * @p t_BA = −R_AB^T t_AB, so composing a pose with its inverse gives the
  * identity.
  * @param[in] pose Pose
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Pose_inverse()
  */
 Pose *
@@ -2216,7 +2216,7 @@ pose_distance(Datum pose1, Datum pose2)
 /**
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between two poses
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_pose_pose()
  */
 double
@@ -2249,7 +2249,7 @@ datum_pose_distance(Datum pose1, Datum pose2)
 /**
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a geometry
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_pose_geo() #Distance_geo_pose()
  */
 double
@@ -2268,7 +2268,7 @@ distance_pose_geo(const Pose *pose, const GSERIALIZED *gs)
 /**
  * @ingroup meos_pose_base_dist
  * @brief Return the distance between a pose and a spatiotemporal box
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_pose_stbox() #NAD_stbox_pose()
  */
 double
@@ -2377,7 +2377,7 @@ pose_nsame(const Pose *pose1, const Pose *pose2)
  * @brief Return -1, 0, or 1 depending on whether the first pose
  * is less than, equal to, or greater than the second one
  * @param[in] pose1,pose2 Poses
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Pose_cmp()
  */
 int
@@ -2477,7 +2477,7 @@ void hashlittle2(const void *key, size_t length, uint32_t *pc, uint32_t *pb);
  * @ingroup meos_pose_base_accessor
  * @brief Return the 32-bit hash value of a pose
  * @param[in] pose Pose
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Pose_hash()
  */
 uint32

--- a/meos/src/pose/pose_geopose.c
+++ b/meos/src/pose/pose_geopose.c
@@ -395,7 +395,7 @@ geopose_param_number(const char *str, double *out)
  * coordinates measure a plane rather than the ellipsoid, so writing them as a
  * longitude and a latitude would assert something the value does not say. A
  * planar pose is therefore reported here rather than encoded.
- * @return On error return false
+ * @errval false
  */
 static bool
 geopose_pose_components(const Pose *pose, double *lon, double *lat, double *h,
@@ -455,7 +455,7 @@ geopose_new_double(double v, int precision)
 /**
  * @brief Read the `quaternion` member shared by the Basic-Quaternion and
  * Advanced classes.
- * @return On error return false
+ * @errval false
  */
 static bool
 geopose_quaternion_from_json(json_object *jq, double *W, double *X, double *Y,
@@ -498,7 +498,7 @@ geopose_crs_is_geographic(const char *crs)
  * A frame this module cannot place a pose in is reported rather than guessed
  * at, and so is a missing coordinate: a pose whose position defaulted to zero
  * would be accepted here and refused by every operation that followed.
- * @return On error return @p NULL
+ * @errval NULL
  */
 static Pose *
 pose_from_geopose_advanced(json_object *frame, json_object *root)
@@ -674,7 +674,7 @@ pose_from_geopose_object(json_object *root)
  * @brief Return a pose from its OGC GeoPose JSON representation
  * @param[in] json GeoPose JSON string (Basic-YPR, Basic-Quaternion or
  * Advanced)
- * @return On error return @p NULL
+ * @errval NULL
  * @details Auto-detects the conformance class from the JSON keys present:
  *
  *   - `frameSpecification`: Advanced (returns a 3D pose placed at the
@@ -733,7 +733,7 @@ static json_object *pose_to_geopose_advanced(const Pose *pose, int precision);
  * point) and by the temporal-GeoPose entry points which embed the
  * per-instant object into an envelope's @p instants array. The caller
  * owns the returned object and is responsible for releasing it.
- * @return On error return @p NULL.
+ * @errval NULL
  */
 static json_object *
 pose_to_geopose_object(const Pose *pose, int conformance, int precision)
@@ -798,7 +798,7 @@ pose_to_geopose_object(const Pose *pose, int conformance, int precision)
  * (0 = Basic-Quaternion, 1 = Basic-YPR, 2 = Advanced)
  * @param[in] precision Decimal places to keep in the JSON numbers; pass
  * a negative value to use json-c's default
- * @return On error return @p NULL
+ * @errval NULL
  * @details Every conformance class mandates a geographic outer
  * frame. Poses with SRID 0 are treated as geographic; poses with
  * non-zero non-4326 SRIDs are rejected (use WKT/WKB instead).
@@ -1140,7 +1140,7 @@ geopose_transition_model_interp(json_object *tm)
  * encoding examples of the standard.
  * @details The rotation list is ordered w, x, y, z, the order in which
  * Requirement 15 lists the components of a GeoPose quaternion.
- * @return On error return @p NULL
+ * @errval NULL
  */
 static json_object *
 geopose_inner_frame(const char *id, const GeoPoseAnchor *anchor,
@@ -1209,7 +1209,7 @@ geopose_outer_frame(const char *id, const GeoPoseAnchor *anchor,
  * puts the pose at the origin of the frame it names. Its quaternion is then
  * the orientation in that frame, unrotated, and the document carries exactly
  * what the Basic-Quaternion document of the same pose carries.
- * @return On error return @p NULL
+ * @errval NULL
  */
 static json_object *
 pose_to_geopose_advanced(const Pose *pose, int precision)
@@ -1239,7 +1239,7 @@ pose_to_geopose_advanced(const Pose *pose, int precision)
  * @details Requirements 26 and 31 make the outer frame the first frame of a
  * series, and Requirement 34 the first frame of a stream, so one instant
  * fixes the frame that every later pose is expressed against.
- * @return On error return false
+ * @errval false
  */
 static bool
 geopose_anchor_from_instant(const TInstant *inst, GeoPoseAnchor *anchor)
@@ -1313,7 +1313,7 @@ geopose_interpose_duration(const TInstant **instants, int count)
  * @param[in] regular True to emit a Regular Series, false for an Irregular
  * one
  * @param[in] precision Significant digits in the emitted numbers
- * @return On error return @p NULL
+ * @errval NULL
  */
 static json_object *
 tpose_to_geopose_series(const Temporal *temp, bool regular, int precision)
@@ -1385,7 +1385,7 @@ tpose_to_geopose_series(const Temporal *temp, bool regular, int precision)
 /**
  * @brief Return the `parameters` string of a FrameSpecification object,
  * checking that the object carries the three members the schema requires.
- * @return On error return @p NULL
+ * @errval NULL
  */
 static const char *
 geopose_frame_parameters(json_object *frame, const char *what)
@@ -1408,7 +1408,7 @@ geopose_frame_parameters(json_object *frame, const char *what)
 
 /**
  * @brief Build the outer-frame anchor from a series' `outerFrame` member.
- * @return On error return false
+ * @errval false
  */
 static bool
 geopose_anchor_from_json(json_object *root, GeoPoseAnchor *anchor)
@@ -1433,7 +1433,7 @@ geopose_anchor_from_json(json_object *root, GeoPoseAnchor *anchor)
 
 /**
  * @brief Build the pose of an inner FrameSpecification of a series.
- * @return On error return @p NULL
+ * @errval NULL
  */
 static Pose *
 geopose_pose_from_inner_frame(const GeoPoseAnchor *anchor, json_object *frame)
@@ -1466,7 +1466,7 @@ geopose_pose_from_inner_frame(const GeoPoseAnchor *anchor, json_object *frame)
  * @details A series carries no bounds inclusivity and no gaps, so it always
  * reads back as a single closed sequence, or as an instant when the series
  * holds one pose and interpolates nothing.
- * @return On error return @p NULL
+ * @errval NULL
  */
 static Temporal *
 tpose_from_geopose_series(json_object *root, json_object *elements,
@@ -1617,7 +1617,7 @@ tpose_from_geopose_series(json_object *root, json_object *elements,
  * GeoPose_Instant, that is Unix time in integer milliseconds. Every time
  * this module writes is that same kind, whichever class the document
  * belongs to.
- * @return On error return @p NULL
+ * @errval NULL
  */
 static char *
 tposeinst_as_geopose(const TInstant *inst, int conformance, int precision)
@@ -1653,7 +1653,7 @@ tposeinst_as_geopose(const TInstant *inst, int conformance, int precision)
  * @param[in] conformance Class of a single-pose document
  * (0 = Basic-Quaternion, 1 = Basic-YPR, 2 = Advanced)
  * @param[in] precision Significant digits in JSON numbers; -1 = lossless
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpose_as_geopose()
  */
 char *
@@ -1701,7 +1701,7 @@ tpose_as_geopose(const Temporal *temp, int conformance, int precision)
  * of the same tangent point.
  * @param[in] temp Temporal pose
  * @param[in] precision Significant digits in JSON numbers; -1 = lossless
- * @return On error return @p NULL
+ * @errval NULL
  */
 static json_object *
 geopose_stream_header_obj(const Temporal *temp, const GeoPoseAnchor *anchor,
@@ -1717,7 +1717,8 @@ geopose_stream_header_obj(const Temporal *temp, const GeoPoseAnchor *anchor,
 
 /**
  * @brief Build the `StreamElement` of one instant against an anchored outer
- * frame. Returns @p NULL on error.
+ * frame
+ * @errval NULL
  */
 static json_object *
 geopose_stream_element_obj(const GeoPoseAnchor *anchor, const TInstant *inst,
@@ -1767,7 +1768,7 @@ tpose_as_geopose_stream_header(const Temporal *temp, int precision)
  * @param[in] temp Temporal pose the stream is written from
  * @param[in] inst Instant to write
  * @param[in] precision Significant digits in JSON numbers; -1 = lossless
- * @return On error return @p NULL
+ * @errval NULL
  */
 char *
 tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst,
@@ -1808,7 +1809,7 @@ tpose_as_geopose_stream_element(const Temporal *temp, const TInstant *inst,
  * does.
  * @param[in] temp Temporal pose
  * @param[in] precision Significant digits in JSON numbers; -1 = lossless
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpose_as_geopose_stream()
  */
 char *
@@ -1854,7 +1855,8 @@ tpose_as_geopose_stream(const Temporal *temp, int precision)
 
 /**
  * @brief Parse one element of an @p instants array (single-pose object
- * + @p validTime member) into a TInstant. Returns @p NULL on error.
+ * + @p validTime member) into a TInstant
+ * @errval NULL
  */
 static TInstant *
 tposeinst_from_geopose_object(json_object *obj)
@@ -1941,7 +1943,7 @@ tpose_parse_instants(json_object *instants_arr, TInstant ***out_instants)
  *
  * The resulting temporal pose has SRID 4326.
  * @param[in] json GeoPose JSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpose_from_geopose()
  */
 Temporal *
@@ -2148,7 +2150,7 @@ geopose_chain_link_frame(const Pose *pose, int precision)
  * parent.
  * @param[in] temp Temporal pose chain holding a single instant
  * @param[in] precision Maximum number of decimal digits
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tposechain_as_geopose()
  */
 char *
@@ -2225,7 +2227,7 @@ tposechain_as_geopose(const Temporal *temp, int precision)
  * @param[in] temparr Array of temporal pose chains, each of a single instant
  * @param[in] count Number of elements in the array
  * @param[in] precision Maximum number of decimal digits
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tposechainarr_as_geopose()
  */
 char *
@@ -2334,7 +2336,7 @@ tposechainarr_as_geopose(const Temporal **temparr, int count, int precision)
 
 /**
  * @brief Build the pose of a link read in the axes of the link before it
- * @return On error return @p NULL
+ * @errval NULL
  */
 static Pose *
 geopose_chain_link_pose(json_object *frame)
@@ -2360,7 +2362,7 @@ geopose_chain_link_pose(json_object *frame)
  * @brief Return a temporal pose chain from an OGC GeoPose Composite Chain
  * JSON document
  * @param[in] json GeoPose Chain document
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tposechain_from_geopose()
  */
 Temporal *

--- a/meos/src/pose/posechain.c
+++ b/meos/src/pose/posechain.c
@@ -674,7 +674,7 @@ posechain_to_point(const PoseChain *pc)
  * @ingroup meos_posechain_base_accessor
  * @brief Return the number of links of a pose chain
  * @param[in] pc Pose chain
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Posechain_num_poses()
  */
 int
@@ -829,7 +829,7 @@ ensure_same_count_posechain(const PoseChain *pc1, const PoseChain *pc2)
  * @param[in] ratio Value in [0,1] representing the duration of the timestamps
  * associated to `start` and the result divided by the duration of the
  * timestamps associated to `start` and `end`
- * @return On error return @p NULL
+ * @errval NULL
  */
 PoseChain *
 posechainsegm_interpolate(const PoseChain *start, const PoseChain *end,
@@ -1156,7 +1156,7 @@ posechain_nsame(const PoseChain *pc1, const PoseChain *pc2)
  * @brief Return -1, 0, or 1 depending on whether the first pose chain is less
  * than, equal to, or greater than the second one
  * @param[in] pc1,pc2 Pose chains
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Posechain_cmp()
  */
 int
@@ -1255,7 +1255,7 @@ void hashlittle2(const void *key, size_t length, uint32_t *pc, uint32_t *pb);
  * @ingroup meos_posechain_base_accessor
  * @brief Return the 32-bit hash value of a pose chain
  * @param[in] pc Pose chain
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Posechain_hash()
  */
 uint32

--- a/meos/src/pose/posechainset_meos.c
+++ b/meos/src/pose/posechainset_meos.c
@@ -131,7 +131,7 @@ posechain_to_set(const PoseChain *pc)
  * @ingroup meos_posechain_set_accessor
  * @brief Return a copy of the start value of a pose chain set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 PoseChain *
@@ -146,7 +146,7 @@ posechainset_start_value(const Set *s)
  * @ingroup meos_posechain_set_accessor
  * @brief Return a copy of the end value of a pose chain set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 PoseChain *
@@ -184,7 +184,7 @@ posechainset_value_n(const Set *s, int n, PoseChain **result)
  * @brief Return the array of copies of the values of a pose chain set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 PoseChain **

--- a/meos/src/pose/poseset_meos.c
+++ b/meos/src/pose/poseset_meos.c
@@ -143,7 +143,7 @@ pose_to_set(const Pose *pose)
  * @ingroup meos_pose_set_accessor
  * @brief Return a copy of the start value of a pose set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 Pose *
@@ -158,7 +158,7 @@ poseset_start_value(const Set *s)
  * @ingroup meos_pose_set_accessor
  * @brief Return a copy of the end value of a pose set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 Pose *
@@ -195,7 +195,7 @@ poseset_value_n(const Set *s, int n, Pose **result)
  * @brief Return the array of copies of the values of a pose set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 Pose **

--- a/meos/src/pose/tpose.c
+++ b/meos/src/pose/tpose.c
@@ -247,7 +247,7 @@ tposeseqset_in(const char *str)
  * @ingroup meos_pose_inout
  * @brief Return a temporal pose from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -547,7 +547,7 @@ tpose_compose_lfinfo(LiftedFunctionInfo *lfinfo, bool linear, bool invert)
  * names; the result is the body in the frame @p frame is itself expressed in.
  * @param[in] body Temporal pose expressed in the frame the other one names
  * @param[in] frame Pose naming that frame
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpose_apply_pose()
  */
 Temporal *
@@ -567,7 +567,7 @@ tpose_compose_pose(const Temporal *body, const Pose *frame)
  * whole movement of its parent.
  * @param[in] body Pose expressed in the frame the other one names
  * @param[in] frame Temporal pose naming that frame
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Pose_apply_tpose()
  */
 Temporal *
@@ -586,7 +586,7 @@ pose_compose_tpose(const Pose *body, const Temporal *frame)
  * share.
  * @param[in] body Temporal pose expressed in the frame the other one names
  * @param[in] frame Temporal pose naming that frame
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpose_apply_tpose()
  */
 Temporal *
@@ -607,7 +607,7 @@ tpose_compose_tpose(const Temporal *body, const Temporal *frame)
  * frame in the body, so inverting a temporal pose changes the point of view
  * onto a moving object for the whole of its movement.
  * @param[in] temp Temporal pose
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpose_inverse()
  */
 Temporal *
@@ -704,7 +704,7 @@ tpose_roll(const Temporal *temp)
  * component is not part of this scalar — angular velocity has its own
  * accessor @p tpose_angular_speed.
  * @param[in] temp Temporal pose
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpose_speed()
  */
 Temporal *
@@ -786,7 +786,9 @@ tposeseqset_angular_speed(const TSequenceSet *ss)
  * by construction constant-angular-velocity over a segment so the
  * resulting tfloat is step-interpolated.
  * @param[in] temp Temporal pose with linear interpolation
- * @return On error or for an instantaneous tpose return @p NULL
+ * @note An instantaneous tpose spans no duration to turn over, so it has no
+ * angular speed and the answer is NULL
+ * @errval NULL
  * @csqlfn #Tpose_angular_speed()
  */
 Temporal *
@@ -854,7 +856,7 @@ tposeseq_apply_geo(const TSequence *seq, const GSERIALIZED *body)
  * uses for spatial trajectories.
  * @param[in] temp Temporal pose
  * @param[in] body Body-frame point
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tpose_apply_geo()
  */
 Temporal *
@@ -901,7 +903,7 @@ tpose_apply_geo(const Temporal *temp, const GSERIALIZED *body)
  * @ingroup meos_pose_accessor
  * @brief Return a copy of the start value of a temporal pose
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_value()
  */
 Pose *
@@ -916,7 +918,7 @@ tpose_start_value(const Temporal *temp)
  * @ingroup meos_pose_accessor
  * @brief Return a copy of the end value of a temporal pose
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_value()
  */
 Pose *

--- a/meos/src/pose/tposechain.c
+++ b/meos/src/pose/tposechain.c
@@ -253,7 +253,7 @@ tposechainseqset_in(const char *str)
  * @ingroup meos_posechain_inout
  * @brief Return a temporal pose chain from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -395,7 +395,7 @@ tposechain_to_tpose(const Temporal *temp)
  * @details The link count is the same at every instant, so one instant
  * answers for the whole value.
  * @param[in] temp Temporal pose chain
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Tposechain_num_poses()
  */
 int

--- a/meos/src/quadbin/quadbin.c
+++ b/meos/src/quadbin/quadbin.c
@@ -332,7 +332,7 @@ quadbin_cell_tile(Quadbin cell, uint32_t *x, uint32_t *y, uint32_t *z)
  * @brief Return the Web-Mercator tile of a quadbin cell
  * @param[in] cell Quadbin cell
  * @param[out] x,y,z Tile column, row, and zoom
- * @return On error return @p false
+ * @errval false
  * @csqlfn #Quadbin_cell_to_tile()
  */
 bool

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -184,7 +184,7 @@ ensure_valid_pixtype(uint8 pixtype)
  * @ingroup meos_raster_base_accessor
  * @brief Return the size in bytes of a single pixel of the given type
  * @param[in] pixtype Pixel data type
- * @return On error return 0
+ * @errval 0
  */
 size_t
 raquet_pixtype_size(MeosPixType pixtype)
@@ -196,7 +196,7 @@ raquet_pixtype_size(MeosPixType pixtype)
 /**
  * @brief Return the name the RaQuet specification gives a pixel data type
  * @param[in] pixtype Pixel data type
- * @return On error return @p NULL
+ * @errval NULL
  * @note This reads the name column of the catalog the way
  * #raquet_pixtype_size() reads its size column, so a caller holding a code
  * states the type through the one catalog rather than carrying a second
@@ -666,7 +666,7 @@ raquet_copy(const Raquet *rq)
 /**
  * @ingroup meos_raster_base_accessor
  * @brief Return the QUADBIN cell of a Raquet tile
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  * @csqlfn #Raquet_quadbin()
  */
 uint64
@@ -706,7 +706,7 @@ raquet_height(const Raquet *rq)
 /**
  * @ingroup meos_raster_base_accessor
  * @brief Return the nodata sentinel value of a Raquet tile
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Raquet_nodata()
  */
 double
@@ -721,7 +721,7 @@ raquet_nodata(const Raquet *rq)
  * @ingroup meos_raster_base_accessor
  * @brief Return the name of the pixel data type of a Raquet tile
  * @param[in] rq Raquet tile
- * @return On error return @p NULL
+ * @errval NULL
  * @note The returned name is the one the RaQuet specification writes for the
  * type, that is, one of uint8, int8, uint16, int16, uint32, int32, uint64,
  * int64, float16, float32, or float64, so it compares equal to the `type`
@@ -743,7 +743,7 @@ raquet_pixtype(const Raquet *rq)
  * @brief Return a copy of the pixel bytes of a Raquet tile
  * @param[in] rq Raquet tile
  * @param[out] size_out Number of bytes returned
- * @return On error return @p NULL
+ * @errval NULL
  * @note The bytes are row-major and packed, @p width * @p height pixels of
  * @p raquet_pixtype_size() bytes each, which is the layout the tile
  * constructors accept
@@ -817,7 +817,7 @@ raquet_to_stbox(const Raquet *rq)
  * @brief Return -1, 0, or 1 depending on whether the first Raquet tile is
  * less than, equal to, or greater than the second one
  * @param[in] rq1,rq2 Raquet tiles
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Raquet_cmp()
  */
 int
@@ -922,7 +922,7 @@ raquet_gt(const Raquet *rq1, const Raquet *rq2)
  * @brief Return the 32-bit hash of a Raquet tile
  * @param[in] rq Raquet tile
  * @csqlfn #Raquet_hash()
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  */
 uint32
 raquet_hash(const Raquet *rq)
@@ -939,7 +939,7 @@ raquet_hash(const Raquet *rq)
  * @param[in] rq Raquet tile
  * @param[in] seed Seed
  * @csqlfn #Raquet_hash_extended()
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  */
 uint64
 raquet_hash_extended(const Raquet *rq, uint64 seed)

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -98,7 +98,7 @@ raster_destroy(rt_raster raster)
  * @brief Return the serialized form of an rt_core raster, destroying the
  * raster
  * @param[in] raster Raster to serialize and destroy, may be @p NULL
- * @return On error, return @p NULL
+ * @errval NULL
  */
 static Raster *
 raster_serialize_destroy(rt_raster raster)
@@ -124,7 +124,7 @@ raster_serialize_destroy(rt_raster raster)
  * @brief Return a raster from its Well-Known Binary (WKB) representation
  * @param[in] wkb WKB string
  * @param[in] size Size of the string
- * @return On error, return @p NULL
+ * @errval NULL
  */
 Raster *
 raster_from_wkb(const uint8_t *wkb, size_t size)
@@ -148,7 +148,7 @@ raster_from_wkb(const uint8_t *wkb, size_t size)
  * @brief Return a raster from its ASCII hex-encoded Well-Known Binary
  * (HexWKB) representation
  * @param[in] hexwkb HexWKB string
- * @return On error, return @p NULL
+ * @errval NULL
  */
 Raster *
 raster_from_hexwkb(const char *hexwkb)
@@ -172,7 +172,7 @@ raster_from_hexwkb(const char *hexwkb)
  * @brief Return the Well-Known Binary (WKB) representation of a raster
  * @param[in] rast Raster
  * @param[out] size_out Size of the output
- * @return On error, return @p NULL
+ * @errval NULL
  */
 uint8_t *
 raster_as_wkb(const Raster *rast, size_t *size_out)
@@ -209,7 +209,7 @@ raster_as_wkb(const Raster *rast, size_t *size_out)
  * representation of a raster
  * @param[in] rast Raster
  * @param[out] size_out Size of the output, not counting the null terminator
- * @return On error, return @p NULL
+ * @errval NULL
  */
 char *
 raster_as_hexwkb(const Raster *rast, size_t *size_out)
@@ -251,7 +251,7 @@ raster_as_hexwkb(const Raster *rast, size_t *size_out)
  * while the band count is not, so #raster_band_of() deserializes in full and
  * releases with ::raster_destroy()
  * @param[in] rast Raster
- * @return On error return @p NULL
+ * @errval NULL
  */
 static rt_raster
 raster_header(const Raster *rast)
@@ -270,8 +270,8 @@ raster_header(const Raster *rast)
  * @param[in] band Band number (1-based)
  * @param[out] raster Raster the band is read from, which the caller releases
  * with ::raster_destroy() once it is done with the band
- * @return On error return @p NULL, having released the raster and set
- * @p raster to @p NULL
+ * @errval NULL
+ * @note A failure releases the raster and sets @p raster to @p NULL
  */
 static rt_band
 raster_band_of(const Raster *rast, int band, rt_raster *raster)
@@ -309,7 +309,7 @@ raster_band_of(const Raster *rast, int band, rt_raster *raster)
  * @ingroup meos_raster_base_accessor
  * @brief Return the number of bands of a raster
  * @param[in] rast Raster
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Raster_num_bands()
  */
 int
@@ -329,7 +329,7 @@ raster_num_bands(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the width in pixels of a raster
  * @param[in] rast Raster
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  */
 int
 raster_width(const Raster *rast)
@@ -348,7 +348,7 @@ raster_width(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the height in pixels of a raster
  * @param[in] rast Raster
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  */
 int
 raster_height(const Raster *rast)
@@ -367,7 +367,7 @@ raster_height(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the spatial reference system identifier of a raster
  * @param[in] rast Raster
- * @return On error return @p SRID_INVALID
+ * @errval SRID_INVALID
  */
 int32_t
 raster_srid(const Raster *rast)
@@ -386,7 +386,7 @@ raster_srid(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the X coordinate of the upper left corner of a raster
  * @param[in] rast Raster
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note This is the origin the geotransform states, which the skew rotates
  * the grid about, so it is a corner of the extent only when both skews are
  * zero
@@ -408,7 +408,7 @@ raster_upper_left_x(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the Y coordinate of the upper left corner of a raster
  * @param[in] rast Raster
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note This is the origin the geotransform states, which the skew rotates
  * the grid about, so it is a corner of the extent only when both skews are
  * zero
@@ -430,7 +430,7 @@ raster_upper_left_y(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the pixel width of a raster, that is, the X component of its scale
  * @param[in] rast Raster
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 raster_scale_x(const Raster *rast)
@@ -449,7 +449,7 @@ raster_scale_x(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the pixel height of a raster, that is, the Y component of its scale
  * @param[in] rast Raster
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note The value is negative for a grid whose rows run north to south,
  * which is how a raster is ordinarily written
  */
@@ -470,7 +470,7 @@ raster_scale_y(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the X component of the skew of a raster
  * @param[in] rast Raster
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note A raster whose two skews are zero is axis-aligned, so a reader that
  * assumes an axis-aligned grid states the assumption by testing them
  */
@@ -491,7 +491,7 @@ raster_skew_x(const Raster *rast)
  * @ingroup meos_raster_base_accessor
  * @brief Return the Y component of the skew of a raster
  * @param[in] rast Raster
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note A raster whose two skews are zero is axis-aligned, so a reader that
  * assumes an axis-aligned grid states the assumption by testing them
  */
@@ -513,7 +513,7 @@ raster_skew_y(const Raster *rast)
  * @brief Return the name of the pixel data type of a raster band
  * @param[in] rast Raster
  * @param[in] band Band number (1-based)
- * @return On error return @p NULL
+ * @errval NULL
  * @note The name returned is the one the RaQuet specification writes, which is
  * what #raquet_pixtype() answers for a tile, so a band and a tile of the same
  * type report the same name. The PostGIS spelling is read through
@@ -547,7 +547,7 @@ raster_band_pixel_type(const Raster *rast, int band)
  * @brief Return whether a raster band states a nodata value
  * @param[in] rast Raster
  * @param[in] band Band number (1-based)
- * @return On error return false
+ * @errval false
  * @note A band that states none has no pixel to exclude, so every pixel it
  * holds carries a value
  */
@@ -570,7 +570,7 @@ raster_band_has_nodata_value(const Raster *rast, int band)
  * @brief Return the nodata value of a raster band
  * @param[in] rast Raster
  * @param[in] band Band number (1-based)
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @note A band stating no nodata value has none to return, which is an error
  * rather than a value: test it with #raster_band_has_nodata_value()
  */
@@ -604,7 +604,8 @@ raster_band_nodata_value(const Raster *rast, int band)
  * @brief Convert a raster into a spatiotemporal box
  * @param[in] rast Raster
  * @return The X/Y bounding box of the raster in its own reference system, with
- * no T dimension. On error return @p NULL
+ * no T dimension
+ * @errval NULL
  * @note The extent bears the rotation of the geotransform, so a skewed raster
  * answers the box that contains its four rotated corners rather than the one
  * the scale alone would give
@@ -857,7 +858,7 @@ raster_minus_value(const Temporal *traj, const Raster *rast, int band,
  * @param[in] rast Raster
  * @param[in] band Band number (1-based)
  * @param[in] vspan Float value range (inclusive bounds)
- * @return On error, return -1
+ * @errval -1
  * @csqlfn #Eraster_value()
  */
 int
@@ -885,7 +886,7 @@ eraster_value(const Temporal *traj, const Raster *rast, int band,
  * @param[in] rast Raster
  * @param[in] band Band number (1-based)
  * @param[in] vspan Float value range (inclusive bounds)
- * @return On error, return -1
+ * @errval -1
  * @csqlfn #Araster_value()
  */
 int

--- a/meos/src/rgeo/trgeo.c
+++ b/meos/src/rgeo/trgeo.c
@@ -154,7 +154,7 @@ trgeometry_in(const char *str)
  * @ingroup meos_rgeo_inout
  * @brief Return a temporal rigid geometry from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -519,7 +519,7 @@ trgeometry_end_value(const Temporal *temp)
  * @param[in] temp Temporal rigid geometry
  * @param[in] n Number (1-based)
  * @param[out] result Resulting timestamp
- * @return On error return false
+ * @errval false
  * @csqlfn #Trgeometry_value_n()
  */
 bool
@@ -589,7 +589,7 @@ trgeo_value_at_timestamptz(const Temporal *temp, TimestampTz t, bool strict,
  * @ingroup meos_rgeo_accessor
  * @brief Return a copy of the start instant of a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_instant()
  */
 TInstant *
@@ -609,7 +609,7 @@ trgeometry_start_instant(const Temporal *temp)
  * @ingroup meos_rgeo_accessor
  * @brief Return a copy of the end instant of a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_instant()
  */
 TInstant *
@@ -630,7 +630,7 @@ trgeometry_end_instant(const Temporal *temp)
  * @brief Return a copy of the n-th instant of a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
  * @param[in] n Number (1-based)
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_instant_n()
  */
 TInstant *
@@ -673,7 +673,7 @@ trgeometry_instant_n(const Temporal *temp, int n)
  * @brief Return a copy of the distinct instants of a temporal rigid geometry
  * @param[in] temp Temporal rigid geometry
  * @param[out] count Number of values in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_instants()
  */
 TInstant **
@@ -701,7 +701,7 @@ trgeometry_instants(const Temporal *temp, int *count)
  * @ingroup meos_rgeo_accessor
  * @brief Return a copy of the start sequence of a temporal sequence (set)
  * @param[in] temp Temporal rigid geometry
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_sequence()
  */
 TSequence *
@@ -725,7 +725,7 @@ trgeometry_start_sequence(const Temporal *temp)
  * @ingroup meos_rgeo_accessor
  * @brief Return a copy of the end sequence of a temporal sequence (set)
  * @param[in] temp Temporal rigid geometry
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_sequence()
  */
 TSequence *
@@ -750,7 +750,7 @@ trgeometry_end_sequence(const Temporal *temp)
  * @brief Return a copy of the n-th sequence of a temporal sequence (set)
  * @param[in] temp Temporal rigid geometry
  * @param[in] n Number (1-based)
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_sequence_n()
  */
 TSequence *
@@ -784,7 +784,7 @@ trgeometry_sequence_n(const Temporal *temp, int n)
  * (set)
  * @param[in] temp Temporal rigid geometry
  * @param[out] count Number of values in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_sequences()
  */
 TSequence **

--- a/meos/src/rgeo/trgeo_boxops.c
+++ b/meos/src/rgeo/trgeo_boxops.c
@@ -220,7 +220,7 @@ trgeoinstarr_compute_bbox(const GSERIALIZED *geom, TInstant **instants,
  * interpolation is discrete or continuous
  * @param[in] temp Temporal rigid geometry
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Trgeometry_stboxes()
  */
 STBox *
@@ -357,7 +357,7 @@ trgeo_seq_cont_split_n_iter(const TSequence *seq,
  * @param[in] temp Temporal rigid geometry
  * @param[in] box_count Number of boxes
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Trgeometry_split_n_stboxes()
  */
 STBox *
@@ -509,7 +509,7 @@ trgeo_seq_cont_split_each_n_iter(const TSequence *seq,
  * @param[in] temp Temporal rigid geometry
  * @param[in] elems_per_box Number of input elements merged per output box
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Trgeometry_split_each_n_stboxes()
  */
 STBox *

--- a/meos/src/rgeo/trgeo_parser.c
+++ b/meos/src/rgeo/trgeo_parser.c
@@ -138,7 +138,8 @@ error:
  * no moreinput after the sequence
  * @param[in,out] temp_srid SRID of the temporal rigid geometry
  * @param[in] geom Reference geometry
- * @param[out] result New sequence, may be NULL
+ * @return New sequence
+ * @errval NULL
  */
 TSequence *
 trgeoseq_cont_parse(const char **str, MeosType temptype, interpType interp,

--- a/meos/src/rgeo/trgeo_spatialfuncs.c
+++ b/meos/src/rgeo/trgeo_spatialfuncs.c
@@ -480,8 +480,10 @@ instant_overlap_span(const GSERIALIZED *ref, const Pose *pose, TimestampTz t,
  * pure translation; any rotating segment raises FEATURE_NOT_SUPPORTED. The
  * caller has already rejected holey targets.
  *
- * @return The overlap spanset on success. On error (rotation) the MEOS error
- * handler is invoked; @p *err is set to true and NULL is returned.
+ * @return The overlap spanset, NULL when the body never overlaps the target
+ * @note A rotating segment raises through the MEOS error handler and sets
+ * @p *err, which is what tells an error apart from an absent overlap
+ * @errval NULL
  */
 static SpanSet *
 trgeo_overlap_spanset(const Temporal *temp, const GSERIALIZED *gs,
@@ -1103,7 +1105,7 @@ trgeometry_dyntimewarp_path(const Temporal *temp1, const Temporal *temp2,
  * @brief Return the length traversed by the centroid of a temporal rigid
  * geometry
  * @param[in] temp Temporal rigid geometry
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Trgeometry_length()
  */
 double
@@ -1162,7 +1164,7 @@ trgeometry_speed(const Temporal *temp)
  * @details The shape of a rigid geometry never changes, so its angular speed
  * is the angular speed of the pose that carries it.
  * @param[in] temp Temporal rigid geometry
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Trgeometry_angular_speed()
  */
 Temporal *
@@ -1332,7 +1334,7 @@ trgeo_convex_sweep(const GSERIALIZED *a, const GSERIALIZED *b)
  * `pose_apply_geo`
  * @param[in] temp Temporal rigid geometry
  * @param[out] count Number of placements returned
- * @return On error return @p NULL
+ * @errval NULL
  */
 static GSERIALIZED **
 trgeo_placement_array(const Temporal *temp, int *count)
@@ -1406,7 +1408,7 @@ trgeo_geoms_merge(GSERIALIZED **geoms, int n_geoms, bool unary_union)
  * satisfies the relationship, always where every one does. The area the body
  * traverses spans several placements at once, so it answers neither
  * @param[in] temp Temporal rigid geometry
- * @return On error return @p NULL
+ * @errval NULL
  */
 GSERIALIZED *
 trgeo_placements(const Temporal *temp)

--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -66,7 +66,7 @@
  * @param[in] func Spatial relationship function to be called
  * @param[in] numparam Number of parameters of the functions
  * @param[in] invert True if the arguments should be inverted
- * @return On error return -1
+ * @errval -1
  */
 int
 spatialrel_trgeo_trav_geo(const Temporal *temp, const GSERIALIZED *gs,
@@ -107,7 +107,7 @@ spatialrel_trgeo_trav_geo(const Temporal *temp, const GSERIALIZED *gs,
  * @param[in] gs Geometry
  * @param[in] func Spatial relationship function to be called
  * @param[in] ever True for the ever semantics, false for the always semantics
- * @return On error return -1
+ * @errval -1
  */
 static int
 ea_spatialrel_trgeo_poses_geo(const Temporal *temp, const GSERIALIZED *gs,

--- a/meos/src/temporal/meos_array.c
+++ b/meos/src/temporal/meos_array.c
@@ -84,7 +84,8 @@ meos_array_reset_int(MeosArray *array, bool free_elems)
  * they point to).
  * @param[in] elem_size Size of a single element in bytes, or negative for
  * variable-length pointer storage
- * @return New array on success, NULL on error
+ * @return New array
+ * @errval NULL
  */
 MeosArray *
 meos_array_create(int elem_size)
@@ -196,7 +197,8 @@ meos_array_add(MeosArray *array, void *value)
  * @param[in] array Array
  * @param[in] n Index
  * @return For fixed-size arrays, a pointer to the element in the internal
- * buffer. For varlength arrays, the stored pointer. NULL on error.
+ * buffer. For varlength arrays, the stored pointer
+ * @errval NULL
  */
 void *
 meos_array_get(const MeosArray *array, int n)

--- a/meos/src/temporal/meos_catalog.c
+++ b/meos/src/temporal/meos_catalog.c
@@ -698,7 +698,7 @@ basetype_varlength(MeosType type)
 
 /**
  * @brief Return the length of a MEOS type
- * @return On error return SHRT_MAX
+ * @errval SHRT_MAX
  */
 int16
 meostype_length(MeosType type)

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -231,7 +231,6 @@ set_out(const Set *s, int maxdd)
 
 /**
  * @brief Return the size of a bounding box of a temporal type
- * @return On error return SIZE_MAX
  */
 static size_t
 set_bbox_size(MeosType settype)
@@ -669,7 +668,7 @@ set_mem_size(const Set *s)
 /**
  * @ingroup meos_setspan_accessor
  * @brief Return the number of values of a set
- * @return On error return -1
+ * @errval -1
  * @param[in] s Set
  * @csqlfn #Set_num_values()
  */
@@ -1153,7 +1152,7 @@ set_ne(const Set *s1, const Set *s2)
  * @brief Return -1, 0, or 1 depending on whether the first set is less
  * than, equal to, or greater than the second one
  * @param[in] s1,s2 Sets
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @note Function used for B-tree comparison
  * @csqlfn #Set_cmp()
  */
@@ -1242,7 +1241,7 @@ set_ge(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_accessor
  * @brief Return the 32-bit hash of a set
  * @param[in] s Set
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Set_hash()
  */
 uint32

--- a/meos/src/temporal/set_meos.c
+++ b/meos/src/temporal/set_meos.c
@@ -447,7 +447,7 @@ timestamptz_to_set(TimestampTz t)
  * @ingroup meos_setspan_accessor
  * @brief Return the start value of an integer set
  * @param[in] s Set
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Set_start_value()
  */
 int
@@ -462,7 +462,7 @@ intset_start_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the start value of a big integer set
  * @param[in] s Set
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Set_start_value()
  */
 int64
@@ -477,7 +477,7 @@ bigintset_start_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the start value of a float set
  * @param[in] s Set
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Set_start_value()
  */
 double
@@ -492,7 +492,7 @@ floatset_start_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return a copy of the start value of a text set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_start_value()
  */
 text *
@@ -507,7 +507,7 @@ textset_start_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the start value of a date set
  * @param[in] s Set
- * @return On error return DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  * @csqlfn #Set_start_value()
  */
 DateADT
@@ -522,7 +522,7 @@ dateset_start_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the start value of a timestamptz set
  * @param[in] s Set
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Set_start_value()
  */
 TimestampTz
@@ -539,7 +539,7 @@ tstzset_start_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the end value of an integer set
  * @param[in] s Set
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Set_end_value()
  */
 int
@@ -554,7 +554,7 @@ intset_end_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the end value of a big integer set
  * @param[in] s Set
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Set_end_value()
  */
 int64
@@ -569,7 +569,7 @@ bigintset_end_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the end value of a float set
  * @param[in] s Set
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Set_end_value()
  */
 double
@@ -584,7 +584,7 @@ floatset_end_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return a copy of the end value of a text set
  * @param[in] s Set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_end_value()
  */
 text *
@@ -599,7 +599,7 @@ textset_end_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the end value of a date set
  * @param[in] s Set
- * @return On error return DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  * @csqlfn #Set_end_value()
  */
 DateADT
@@ -614,7 +614,7 @@ dateset_end_value(const Set *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the end value of a timestamptz set
  * @param[in] s Set
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Set_end_value()
  */
 TimestampTz
@@ -754,7 +754,7 @@ tstzset_value_n(const Set *s, int n, TimestampTz *result)
  * @brief Return the array of values of an integer set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 int *
@@ -774,7 +774,7 @@ intset_values(const Set *s, int *count)
  * @brief Return the array of values of a big integer set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 int64 *
@@ -794,7 +794,7 @@ bigintset_values(const Set *s, int *count)
  * @brief Return the array of values of a float set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 double *
@@ -814,7 +814,7 @@ floatset_values(const Set *s, int *count)
  * @brief Return the array of copies of the values of a text set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 text **
@@ -834,7 +834,7 @@ textset_values(const Set *s, int *count)
  * @brief Return the array of values of a date set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 DateADT *
@@ -854,7 +854,7 @@ dateset_values(const Set *s, int *count)
  * @brief Return the array of values of a timestamptz set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_values()
  */
 TimestampTz *

--- a/meos/src/temporal/set_ops.c
+++ b/meos/src/temporal/set_ops.c
@@ -668,8 +668,7 @@ distance_set_value(const Set *s, Datum value)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two sets
  * @param[in] s1,s2 Sets
- * @return On error return the sentinel of the base type given by
- * #distance_sentinel()
+ * @errval #distance_sentinel()
  * @csqlfn #Distance_set_set()
  */
 Datum

--- a/meos/src/temporal/set_ops_meos.c
+++ b/meos/src/temporal/set_ops_meos.c
@@ -1532,7 +1532,7 @@ minus_set_timestamptz(const Set *s, TimestampTz t)
  * @brief Return the distance between a set and an integer
  * @param[in] s Set
  * @param[in] i Value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 int
@@ -1548,7 +1548,7 @@ distance_set_int(const Set *s, int i)
  * @brief Return the distance between a set and a big integer
  * @param[in] s Set
  * @param[in] i Value
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 int64
@@ -1564,7 +1564,7 @@ distance_set_bigint(const Set *s, int64 i)
  * @brief Return the distance between a set and a float
  * @param[in] s Set
  * @param[in] d Value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 double
@@ -1580,7 +1580,7 @@ distance_set_float(const Set *s, double d)
  * @brief Return the distance in days between a set and a date
  * @param[in] s Set
  * @param[in] d Value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 int
@@ -1597,7 +1597,7 @@ distance_set_date(const Set *s, DateADT d)
  * double
  * @param[in] s Set
  * @param[in] t Value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_set_value() #Distance_value_set()
  */
 double
@@ -1614,7 +1614,7 @@ distance_set_timestamptz(const Set *s, TimestampTz t)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer sets
  * @param[in] s1,s2 Sets
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_set_set()
  */
 int
@@ -1630,7 +1630,7 @@ distance_intset_intset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer sets
  * @param[in] s1,s2 Sets
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Distance_set_set()
  */
 int64
@@ -1646,7 +1646,7 @@ distance_bigintset_bigintset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two float sets
  * @param[in] s1,s2 Sets
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_set_set()
  */
 double
@@ -1662,7 +1662,7 @@ distance_floatset_floatset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in days between two date sets
  * @param[in] s1,s2 Sets
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_set_set()
  */
 int
@@ -1678,7 +1678,7 @@ distance_dateset_dateset(const Set *s1, const Set *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in seconds between two timestamptz sets
  * @param[in] s1,s2 Sets
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_set_set()
  */
 double

--- a/meos/src/temporal/skiplist.c
+++ b/meos/src/temporal/skiplist.c
@@ -247,7 +247,7 @@ skiplist_search(SkipList *list, void *key, void *value)
 
 /**
  * @brief Return the position to store an additional element in the skiplist
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  */
 static int
 skiplist_alloc(SkipList *list)
@@ -431,7 +431,7 @@ skiplist_print(const SkipList *list)
  * @param[out] update Array of indices keeping the levels of the elements to
  * insert
  * @return Number of elements in the list that will be merged with the new
- * values, on error return -1
+ * values
  */
 int
 keyval_skiplist_common(SkipList *list, void **keys, void **values, int count,

--- a/meos/src/temporal/span.c
+++ b/meos/src/temporal/span.c
@@ -615,7 +615,7 @@ intspan_set_bigintspan(const Span *s1, Span *s2)
  * @ingroup meos_setspan_conversion
  * @brief Convert an integer span into a float span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  */
 Span *
 intspan_to_bigintspan(const Span *s)
@@ -647,7 +647,7 @@ bigintspan_set_intspan(const Span *s1, Span *s2)
  * @ingroup meos_setspan_conversion
  * @brief Convert a big integer span into an integer span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  */
 Span *
 bigintspan_to_intspan(const Span *s)
@@ -678,7 +678,7 @@ intspan_set_floatspan(const Span *s1, Span *s2)
  * @ingroup meos_setspan_conversion
  * @brief Convert an integer span into a float span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Intspan_to_floatspan()
  */
 Span *
@@ -711,7 +711,7 @@ bigintspan_set_floatspan(const Span *s1, Span *s2)
  * @ingroup meos_setspan_conversion
  * @brief Convert a big integer span into a float span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  */
 Span *
 bigintspan_to_floatspan(const Span *s)
@@ -743,7 +743,7 @@ floatspan_set_bigintspan(const Span *s1, Span *s2)
  * @ingroup meos_setspan_conversion
  * @brief Convert a float span into an integer span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  */
 Span *
 floatspan_to_bigintspan(const Span *s)
@@ -774,7 +774,7 @@ floatspan_set_intspan(const Span *s1, Span *s2)
  * @ingroup meos_setspan_conversion
  * @brief Convert a float span into an integer span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Floatspan_to_intspan()
  */
 Span *
@@ -809,7 +809,7 @@ datespan_set_tstzspan(const Span *s1, Span *s2)
  * @ingroup meos_setspan_conversion
  * @brief Convert a date span into a timestamptz span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Datespan_to_tstzspan()
  */
 Span *
@@ -852,7 +852,7 @@ tstzspan_set_datespan(const Span *s1, Span *s2)
  * @ingroup meos_setspan_conversion
  * @brief Convert a timestamptz span into a date span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tstzspan_to_datespan()
  */
 Span *
@@ -953,7 +953,7 @@ floatspan_round_set(const Span *s, int maxdd, Span *result)
  * number of decimal places
  * @param[in] s Span
  * @param[in] maxdd Maximum number of decimal digits
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Floatspan_round()
  */
 Span *
@@ -1450,7 +1450,7 @@ numspan_shift_scale(const Span *s, Datum shift, Datum width, bool hasshift,
  * @brief Return a timestamptz shifted by an interval
  * @param[in] t Timestamp
  * @param[in] interv Interval to shift the instant
- * @return On error return `DT_NOEND`
+ * @errval DT_NOEND
  * @csqlfn #Timestamptz_shift()
  */
 TimestampTz
@@ -1499,7 +1499,7 @@ tstzspan_shift_scale(const Span *s, const Interval *shift,
  * @brief Return an array of spans from the values of a set
  * @param[in] s Set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_spans()
  */
 Span *
@@ -1521,7 +1521,7 @@ set_spans(const Set *s, int *count)
  * @param[in] s Set
  * @param[in] span_count Number of spans
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_split_n_spans()
  */
 Span *
@@ -1572,7 +1572,7 @@ set_split_n_spans(const Set *s, int span_count, int *count)
  * @param[in] s Set
  * @param[in] elems_per_span Number of elements merged into an ouput span
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Set_split_each_n_spans()
  */
 Span *
@@ -1647,7 +1647,7 @@ span_ne(const Span *s1, const Span *s2)
  * @brief Return -1, 0, or 1 depending on whether the first span is less than,
  * equal to, or greater than the second one
  * @param[in] s1,s2 Sets
- * @return On error return INT_MAX
+ * @errval INT_MAX
  * @note Function used for B-tree comparison
  * @csqlfn #Span_cmp()
  */
@@ -1730,7 +1730,7 @@ span_gt(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_accessor
  * @brief Return the 32-bit hash of a span
  * @param[in] s Span
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Span_hash()
  */
 uint32
@@ -1770,7 +1770,7 @@ span_hash(const Span *s)
  * @brief Return the 64-bit hash of a span using a seed
  * @param[in] s Span
  * @param[in] seed Seed
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  * @csqlfn #Span_hash_extended()
  */
 uint64

--- a/meos/src/temporal/span_meos.c
+++ b/meos/src/temporal/span_meos.c
@@ -59,7 +59,7 @@
  * @ingroup meos_setspan_inout
  * @brief Return an integer span from its Well-Known Text (WKT) representation
  * @param[in] str String
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Span_in()
  */
 Span *
@@ -74,7 +74,7 @@ intspan_in(const char *str)
  * @ingroup meos_setspan_inout
  * @brief Return an integer span from its Well-Known Text (WKT) representation
  * @param[in] str String
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Span_in()
  */
 Span *
@@ -89,7 +89,7 @@ bigintspan_in(const char *str)
  * @ingroup meos_setspan_inout
  * @brief Return a float span from its Well-Known Text (WKT) representation
  * @param[in] str String
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Span_in()
  */
 Span *
@@ -104,7 +104,7 @@ floatspan_in(const char *str)
  * @ingroup meos_setspan_inout
  * @brief Return a date span from its Well-Known Text (WKT) representation
  * @param[in] str String
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Span_in()
  */
 Span *
@@ -120,7 +120,7 @@ datespan_in(const char *str)
  * @brief Return a timestamptz span from its Well-Known Text (WKT)
  * representation
  * @param[in] str String
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Span_in()
  */
 Span *
@@ -136,7 +136,7 @@ tstzspan_in(const char *str)
 /**
  * @ingroup meos_setspan_inout
  * @brief Return the Well-Known Text (WKT) representation of an integer span
- * @return On error return @p NULL
+ * @errval NULL
  * @param[in] s Span
  * @csqlfn #Span_out()
  */
@@ -152,7 +152,7 @@ intspan_out(const Span *s)
  * @ingroup meos_setspan_inout
  * @brief Return the Well-Known Text (WKT) representation of a big integer span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Span_out()
  */
 char *
@@ -168,7 +168,7 @@ bigintspan_out(const Span *s)
  * @brief Return the Well-Known Text (WKT) representation of a float span
  * @param[in] s Span
  * @param[in] maxdd Maximum number of decimal digits
- * @return On error return @p NULL
+ * @errval NULL
   * @csqlfn #Span_out()
 */
 char *
@@ -183,7 +183,7 @@ floatspan_out(const Span *s, int maxdd)
  * @ingroup meos_setspan_inout
  * @brief Return the Well-Known Text (WKT) representation of a date span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Span_out()
  */
 char *
@@ -198,7 +198,7 @@ datespan_out(const Span *s)
  * @ingroup meos_setspan_inout
  * @brief Return the Well-Known Text (WKT) representation of a timestamtz span
  * @param[in] s Span
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Span_out()
  */
 char *
@@ -387,7 +387,7 @@ timestamptz_to_span(TimestampTz t)
 /**
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of an integer span
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @param[in] s Span
  * @csqlfn #Span_lower()
  */
@@ -403,7 +403,7 @@ intspan_lower(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of an integer span
  * @param[in] s Span
- * @return On error return INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Span_lower()
  */
 int64
@@ -418,7 +418,7 @@ bigintspan_lower(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of a float span
  * @param[in] s Span
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Span_lower()
  */
 double
@@ -433,7 +433,7 @@ floatspan_lower(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of a date span
  * @param[in] s Span
- * @return On error return DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  * @csqlfn #Span_lower()
  */
 DateADT
@@ -448,7 +448,7 @@ datespan_lower(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of a timestamptz span
  * @param[in] s Span
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Span_lower()
  */
 TimestampTz
@@ -465,7 +465,7 @@ tstzspan_lower(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of an integer span
  * @param[in] s Span
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Span_upper()
  */
 int
@@ -480,7 +480,7 @@ intspan_upper(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of an integer span
  * @param[in] s Span
- * @return On error return INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Span_upper()
  */
 int64
@@ -495,7 +495,7 @@ bigintspan_upper(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of a float span
  * @param[in] s Span
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Span_upper()
  */
 double
@@ -510,7 +510,7 @@ floatspan_upper(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of a date span
  * @param[in] s Span
- * @return On error return DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  * @csqlfn #Span_upper()
  */
 DateADT
@@ -525,7 +525,7 @@ datespan_upper(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of a timestamptz span
  * @param[in] s Span
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Span_upper()
  */
 TimestampTz
@@ -570,7 +570,7 @@ span_upper_inc(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the width of an integer span
  * @param[in] s Span
- * @return On error return INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Numspan_width()
  */
 int
@@ -585,7 +585,7 @@ intspan_width(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the width of a big integer span
  * @param[in] s Span
- * @return On error return INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Numspan_width()
  */
 int64
@@ -600,7 +600,7 @@ bigintspan_width(const Span *s)
  * @ingroup meos_setspan_accessor
  * @brief Return the width of a float span
  * @param[in] s Span
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Numspan_width()
  */
 double

--- a/meos/src/temporal/span_ops.c
+++ b/meos/src/temporal/span_ops.c
@@ -1006,8 +1006,8 @@ minus_span_span(const Span *s1, const Span *s2)
  ******************************************************************************/
 
 /**
- * @brief Return the value returned on error by the distance functions of a
- * base type
+ * @brief Return the sentinel the distance functions of a base type answer
+ * where they compute no distance
  * @param[in] type Type of the values
  * @details The sentinel is the maximum value of the type in which the distance
  * is expressed, so that it sorts after every distance that could be computed
@@ -1039,7 +1039,7 @@ distance_sentinel(MeosType type)
  * @brief Return a distance of a base type as a double for the indexes
  * @param[in] dist Distance between two values of the base type
  * @param[in] type Base type of the values the distance was computed on
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @details The distance functions answer in the type of the distance, which
  * is the base type for the numbers, the number of days for the dates, and the
  * number of seconds for the timestamptz values. The nearest neighbor searches
@@ -1074,8 +1074,7 @@ distance_double(Datum dist, MeosType type)
  * @brief Return the distance between two values
  * @param[in] l,r Values
  * @param[in] type Type of the values
- * @return On error return the sentinel of the base type given by
- * #distance_sentinel()
+ * @errval #distance_sentinel()
  */
 Datum
 distance_value_value(Datum l, Datum r, MeosType type)
@@ -1137,8 +1136,7 @@ distance_span_value(const Span *s, Datum value)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two spans as a double
  * @param[in] s1,s2 Spans
- * @return On error return the sentinel of the base type given by
- * #distance_sentinel()
+ * @errval #distance_sentinel()
  * @csqlfn #Distance_span_span()
  */
 Datum

--- a/meos/src/temporal/span_ops_meos.c
+++ b/meos/src/temporal/span_ops_meos.c
@@ -1355,7 +1355,7 @@ minus_span_timestamptz(const Span *s, TimestampTz t)
  * @brief Return the distance between a span and an integer as a double
  * @param[in] s Span
  * @param[in] i Value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 int
@@ -1371,7 +1371,7 @@ distance_span_int(const Span *s, int i)
  * @brief Return the distance between a span and a big integer as a double
  * @param[in] s Span
  * @param[in] i Value
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 int64
@@ -1387,7 +1387,7 @@ distance_span_bigint(const Span *s, int64 i)
  * @brief Return the distance between a span and a float
  * @param[in] s Span
  * @param[in] d Value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 double
@@ -1403,7 +1403,7 @@ distance_span_float(const Span *s, double d)
  * @brief Return the distance in days between a span and a date as a double
  * @param[in] s Span
  * @param[in] d Value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 int
@@ -1420,7 +1420,7 @@ distance_span_date(const Span *s, DateADT d)
  * double
  * @param[in] s Span
  * @param[in] t Value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_span_value() #Distance_value_span()
  */
 double
@@ -1437,7 +1437,7 @@ distance_span_timestamptz(const Span *s, TimestampTz t)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer spans
  * @param[in] s1,s2 Spans
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_span_span()
  */
 int
@@ -1452,7 +1452,7 @@ distance_intspan_intspan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer spans
  * @param[in] s1,s2 Spans
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Distance_span_span()
  */
 int64
@@ -1467,7 +1467,7 @@ distance_bigintspan_bigintspan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two float spans
  * @param[in] s1,s2 Spans
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_span_span()
  */
 double
@@ -1482,7 +1482,7 @@ distance_floatspan_floatspan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two date spans
  * @param[in] s1,s2 Spans
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_span_span()
  */
 int
@@ -1497,7 +1497,7 @@ distance_datespan_datespan(const Span *s1, const Span *s2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in seconds between two timestamptz spans
  * @param[in] s1,s2 Spans
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_span_span()
  */
 double

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -513,7 +513,7 @@ tstzspanset_to_datespanset(const SpanSet *ss)
  * @ingroup meos_internal_setspan_accessor
  * @brief Return the size in bytes of a span set
  * @param[in] ss Span set
- * @return On error return INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Spanset_mem_size()
  */
 int
@@ -598,7 +598,7 @@ spanset_upper_inc(const SpanSet *ss)
  * @brief Return the width of a span set
  * @param[in] ss Span set
  * @param[in] boundspan True when the potential time gaps are ignored
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Numspanset_width()
  */
 Datum
@@ -684,7 +684,7 @@ tstzspanset_duration(const SpanSet *ss, bool boundspan)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of dates of a span set
  * @param[in] ss Span set
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Datespanset_num_dates()
  */
 int
@@ -700,7 +700,7 @@ datespanset_num_dates(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the start date of a span set
  * @param[in] ss Span set
- * @return On error return DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  * @csqlfn #Datespanset_start_date()
  */
 DateADT
@@ -716,7 +716,7 @@ datespanset_start_date(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the end date of a span set
  * @param[in] ss Span set
- * @return On error return DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  * @csqlfn #Datespanset_end_date()
  */
 DateADT
@@ -758,7 +758,7 @@ datespanset_date_n(const SpanSet *ss, int n, DateADT *result)
  * @ingroup meos_setspan_accessor
  * @brief Return the set of dates of a span set
  * @param[in] ss Span set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Datespanset_dates()
  */
 Set *
@@ -782,7 +782,7 @@ datespanset_dates(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of timestamps of a span set
  * @param[in] ss Span set
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Tstzspanset_num_timestamps()
  */
 int
@@ -823,7 +823,7 @@ tstzspanset_num_timestamps(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the start timestamptz of a span set
  * @param[in] ss Span set
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Tstzspanset_start_timestamptz()
  */
 TimestampTz
@@ -839,7 +839,7 @@ tstzspanset_start_timestamptz(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the end timestamptz of a span set
  * @param[in] ss Span set
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Tstzspanset_end_timestamptz()
  */
 TimestampTz
@@ -911,7 +911,7 @@ tstzspanset_timestamptz_n(const SpanSet *ss, int n, TimestampTz *result)
  * @ingroup meos_setspan_accessor
  * @brief Return the set of timestamps of a span set
  * @param[in] ss Span set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tstzspanset_timestamps()
  */
 Set *
@@ -942,7 +942,7 @@ tstzspanset_timestamps(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of spans of a span set
  * @param[in] ss Span set
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Spanset_num_spans()
  */
 int
@@ -957,7 +957,7 @@ spanset_num_spans(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return a copy to the the start span of a span set
  * @param[in] ss Span set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Spanset_start_span()
  */
 Span *
@@ -972,7 +972,7 @@ spanset_start_span(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return a copy of the end span of a span set
  * @param[in] ss Span set
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Spanset_end_span()
  */
 Span *
@@ -1005,7 +1005,7 @@ spanset_span_n(const SpanSet *ss, int n)
  * @brief Return an array of pointers to the spans of a span set
  * @param[in] ss Span set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  */
 const Span **
 spanset_sps(const SpanSet *ss, int *count)
@@ -1024,7 +1024,7 @@ spanset_sps(const SpanSet *ss, int *count)
  * @brief Return a C array with copies of the spans of a span set
  * @param[in] ss Span set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  */
 Span **
 spanset_spanarr(const SpanSet *ss, int *count)
@@ -1254,7 +1254,7 @@ tstzspanset_shift_scale(const SpanSet *ss, const Interval *shift,
  * @brief Return the array of spans of a spanset
  * @param[in] ss Span set
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Spanset_spans()
  */
 Span *
@@ -1317,8 +1317,8 @@ spanarr_sort_size(Span *spans, int count)
  * @param[in] span_count Number of spans
  * @param[out] count Number of elements in the output array
  * @return If the number of spans of the spanset is <= `span_count`, the result
- * contains one span per composing span. On error return @p NULL
- * @return On error return @p NULL
+ * contains one span per composing span
+ * @errval NULL
  * @csqlfn #Spanset_split_n_spans()
  */
 Span *
@@ -1369,7 +1369,7 @@ spanset_split_n_spans(const SpanSet *ss, int span_count, int *count)
  * @param[in] ss SpanSet
  * @param[in] elems_per_span Number of spans merged into an ouput span
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Spanset_split_each_n_spans()
  */
 Span *
@@ -1446,7 +1446,7 @@ spanset_ne(const SpanSet *ss1, const SpanSet *ss2)
  * @brief Return -1, 0, or 1 depending on whether the first span set
  * is less than, equal to, or greater than the second one
  * @param[in] ss1,ss2 Span sets
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @note Function used for B-tree comparison
  * @csqlfn #Spanset_cmp()
  */
@@ -1540,7 +1540,7 @@ spanset_gt(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_accessor
  * @brief Return the 32-bit hash value of a span set
  * @param[in] ss Span set
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Spanset_hash()
  */
 uint32
@@ -1562,7 +1562,7 @@ spanset_hash(const SpanSet *ss)
  * @brief Return the 64-bit hash value of a span set using a seed
  * @param[in] ss Span set
  * @param[in] seed Seed
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  * @csqlfn #Spanset_hash_extended()
  */
 uint64

--- a/meos/src/temporal/spanset_meos.c
+++ b/meos/src/temporal/spanset_meos.c
@@ -360,7 +360,7 @@ datespanset_shift_scale(const SpanSet *ss, int shift, int width, bool hasshift,
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of an integer span set
  * @param[in] ss Span set
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Spanset_lower()
  */
 int
@@ -375,7 +375,7 @@ intspanset_lower(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of an integer span set
  * @param[in] ss Span set
- * @return On error return INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Spanset_lower()
  */
 int64
@@ -390,7 +390,7 @@ bigintspanset_lower(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of a float span set
  * @param[in] ss Span set
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Spanset_lower()
  */
 double
@@ -405,7 +405,7 @@ floatspanset_lower(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of a timestamptz span set
  * @param[in] ss Span set
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Spanset_lower()
  */
 TimestampTz
@@ -420,7 +420,7 @@ tstzspanset_lower(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the lower bound of a date span set
  * @param[in] ss Span set
- * @return On error return DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  * @csqlfn #Spanset_lower()
  */
 DateADT
@@ -437,7 +437,7 @@ datespanset_lower(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of an integer span set
  * @param[in] ss Span set
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Spanset_upper()
  */
 int
@@ -452,7 +452,7 @@ intspanset_upper(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of an integer span set
  * @param[in] ss Span set
- * @return On error return INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Spanset_upper()
  */
 int64
@@ -467,7 +467,7 @@ bigintspanset_upper(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of a float span set
  * @param[in] ss Span set
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Spanset_upper()
  */
 double
@@ -482,7 +482,7 @@ floatspanset_upper(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of a timestamptz span set
  * @param[in] ss Span set
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Spanset_upper()
  */
 TimestampTz
@@ -497,7 +497,7 @@ tstzspanset_upper(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the upper bound of a date span set
  * @param[in] ss Span set
- * @return On error return DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  * @csqlfn #Spanset_upper()
  */
 DateADT
@@ -515,7 +515,7 @@ datespanset_upper(const SpanSet *ss)
  * @brief Return the width of an integer span set
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
- * @return On error return INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Numspanset_width()
  */
 int
@@ -531,7 +531,7 @@ intspanset_width(const SpanSet *ss, bool boundspan)
  * @brief Return the width of an integer span set
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
- * @return On error return INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Numspanset_width()
  */
 int64
@@ -547,7 +547,7 @@ bigintspanset_width(const SpanSet *ss, bool boundspan)
  * @brief Return the width of a float span set
  * @param[in] ss Span
  * @param[in] boundspan True when the potential time gaps are ignored
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Numspanset_width()
  */
 double

--- a/meos/src/temporal/spanset_ops.c
+++ b/meos/src/temporal/spanset_ops.c
@@ -1283,8 +1283,7 @@ distance_spanset_value(const SpanSet *ss, Datum value)
  * @brief Return the distance between a span set and a span
  * @param[in] ss Span set
  * @param[in] s Span
- * @return On error return the sentinel of the base type given by
- * #distance_sentinel()
+ * @errval #distance_sentinel()
  * @csqlfn #Distance_spanset_span()
  */
 Datum
@@ -1300,8 +1299,7 @@ distance_spanset_span(const SpanSet *ss, const Span *s)
  * @ingroup meos_internal_setspan_dist
  * @brief Return the distance between two span sets
  * @param[in] ss1,ss2 Span sets
- * @return On error return the sentinel of the base type given by
- * #distance_sentinel()
+ * @errval #distance_sentinel()
  * @csqlfn #Distance_spanset_spanset()
  */
 Datum

--- a/meos/src/temporal/spanset_ops_meos.c
+++ b/meos/src/temporal/spanset_ops_meos.c
@@ -1274,7 +1274,7 @@ minus_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
  * @brief Return the distance between a span set and an integer
  * @param[in] ss Span set
  * @param[in] i Value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 int
@@ -1290,7 +1290,7 @@ distance_spanset_int(const SpanSet *ss, int i)
  * @brief Return the distance between a span set and a big integer
  * @param[in] ss Span set
  * @param[in] i Value
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 int64
@@ -1306,7 +1306,7 @@ distance_spanset_bigint(const SpanSet *ss, int64 i)
  * @brief Return the distance between a span set and a float
  * @param[in] ss Span set
  * @param[in] d Value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 double
@@ -1323,7 +1323,7 @@ distance_spanset_float(const SpanSet *ss, double d)
  * double
  * @param[in] ss Span set
  * @param[in] d Value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 int
@@ -1339,7 +1339,7 @@ distance_spanset_date(const SpanSet *ss, DateADT d)
  * @brief Return the distance in seconds between a span set and a timestamptz
  * @param[in] ss Span set
  * @param[in] t Value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_spanset_value() #Distance_value_spanset()
  */
 double
@@ -1357,7 +1357,7 @@ distance_spanset_timestamptz(const SpanSet *ss, TimestampTz t)
  * @brief Return the distance between an integer span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int
@@ -1373,7 +1373,7 @@ distance_intspanset_intspan(const SpanSet *ss, const Span *s)
  * @brief Return the distance between a big integer span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int64
@@ -1389,7 +1389,7 @@ distance_bigintspanset_bigintspan(const SpanSet *ss, const Span *s)
  * @brief Return the distance between a float span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_spanset_span()
  */
 double
@@ -1405,7 +1405,7 @@ distance_floatspanset_floatspan(const SpanSet *ss, const Span *s)
  * @brief Return the distance in days between a date span set and a span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_spanset_span()
  */
 int
@@ -1422,7 +1422,7 @@ distance_datespanset_datespan(const SpanSet *ss, const Span *s)
  * span
  * @param[in] ss Spanset
  * @param[in] s Span
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_spanset_span()
  */
 double
@@ -1439,7 +1439,7 @@ distance_tstzspanset_tstzspan(const SpanSet *ss, const Span *s)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two integer span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int
@@ -1454,7 +1454,7 @@ distance_intspanset_intspanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two big integer span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int64
@@ -1469,7 +1469,7 @@ distance_bigintspanset_bigintspanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance between two float span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 double
@@ -1484,7 +1484,7 @@ distance_floatspanset_floatspanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in days between two date span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 int
@@ -1499,7 +1499,7 @@ distance_datespanset_datespanset(const SpanSet *ss1, const SpanSet *ss2)
  * @ingroup meos_setspan_dist
  * @brief Return the distance in seconds between two timestamptz span sets
  * @param[in] ss1,ss2 Spanset
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Distance_spanset_spanset()
  */
 double

--- a/meos/src/temporal/tbox.c
+++ b/meos/src/temporal/tbox.c
@@ -94,7 +94,7 @@ ensure_same_dimensionality_tbox(const TBox *box1, const TBox *box2)
  * TBOX T([2001-01-01, 2001-01-02]) -> only time
  * @endcode
  * where the commas are optional.
- * @return On error return @p NULL
+ * @errval NULL
  * @param[in] str String
  * @csqlfn #Tbox_in()
  */
@@ -111,7 +111,7 @@ tbox_in(const char *str)
  * @brief Return the Well-Known Text (WKT) representation of a temporal box
  * @param[in] box Temporal box
  * @param[in] maxdd Maximum number of decimal digits
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tbox_out(), #Tbox_as_text()
  */
 char *
@@ -164,7 +164,7 @@ tbox_out(const TBox *box, int maxdd)
  * @brief Return a temporal box from a number span and a timestamptz span
  * @param[in] s Value span, may be `NULL`
  * @param[in] p Time span, may be `NULL`
- * @return On error return `NULL`
+ * @errval NULL
  */
 TBox *
 tbox_make(const Span *s, const Span *p)
@@ -898,7 +898,8 @@ tbox_hast(const TBox *box)
  * value span of the box instead.
  * @param[in] i Bound
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  */
 static bool
 tbox_bigint_bound_double(int64 i, double *result)
@@ -921,7 +922,8 @@ tbox_bigint_bound_double(int64 i, double *result)
  * a double
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Tbox_xmin()
  */
 bool
@@ -942,7 +944,8 @@ tbox_xmin(const TBox *box, double *result)
  * @brief Return in the last argument the minimum X value of a temporal box
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  */
 bool
 tboxint_xmin(const TBox *box, int *result)
@@ -961,7 +964,8 @@ tboxint_xmin(const TBox *box, int *result)
  * @brief Return in the last argument the minimum X value of a temporal box
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  */
 bool
 tboxbigint_xmin(const TBox *box, int64 *result)
@@ -980,7 +984,8 @@ tboxbigint_xmin(const TBox *box, int64 *result)
  * @brief Return in the last argument the minimum X value of a temporal box
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  */
 bool
 tboxfloat_xmin(const TBox *box, double *result)
@@ -1000,7 +1005,8 @@ tboxfloat_xmin(const TBox *box, double *result)
  * box is inclusive
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Tbox_xmin_inc()
  */
 bool
@@ -1020,7 +1026,8 @@ tbox_xmin_inc(const TBox *box, bool *result)
  * a double 
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Tbox_xmax()
  */
 bool
@@ -1046,7 +1053,8 @@ tbox_xmax(const TBox *box, double *result)
  * @brief Return in the last argument the maximum X value of a temporal box
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  */
 bool
 tboxint_xmax(const TBox *box, int *result)
@@ -1065,7 +1073,8 @@ tboxint_xmax(const TBox *box, int *result)
  * @brief Return in the last argument the maximum X value of a temporal box
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  */
 bool
 tboxbigint_xmax(const TBox *box, int64 *result)
@@ -1084,7 +1093,8 @@ tboxbigint_xmax(const TBox *box, int64 *result)
  * @brief Return in the last argument the maximum X value of a temporal box
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  */
 bool
 tboxfloat_xmax(const TBox *box, double *result)
@@ -1104,7 +1114,8 @@ tboxfloat_xmax(const TBox *box, double *result)
  * box is inclusive
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Tbox_xmax_inc()
  */
 bool
@@ -1123,7 +1134,8 @@ tbox_xmax_inc(const TBox *box, bool *result)
  * @brief Return in the last argument the minimum T value of a temporal box
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Tbox_tmin()
  */
 bool
@@ -1144,7 +1156,8 @@ tbox_tmin(const TBox *box, TimestampTz *result)
  * box is inclusive
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Tbox_tmin_inc()
  */
 bool
@@ -1164,7 +1177,8 @@ tbox_tmin_inc(const TBox *box, bool *result)
  * @brief Return in the last argument the maximum T value of a temporal box
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Tbox_tmax()
  */
 bool
@@ -1185,7 +1199,8 @@ tbox_tmax(const TBox *box, TimestampTz *result)
  * box is inclusive
  * @param[in] box Box
  * @param[out] result Result
- * @return On error return false, otherwise return true
+ * @return True when the value is written
+ * @errval false
  * @csqlfn #Tbox_tmax_inc()
  */
 bool
@@ -2218,7 +2233,7 @@ tbox_ne(const TBox *box1, const TBox *box2)
  * @brief Return -1, 0, or 1 depending on whether the first temporal box
  * is less than, equal to, or greater than the second one
  * @param[in] box1,box2 Temporal boxes
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @note The time dimension is compared first and then the value dimension
  * @csqlfn #Tbox_cmp()
  */
@@ -2311,7 +2326,7 @@ tbox_gt(const TBox *box1, const TBox *box2)
  * @ingroup meos_box_accessor
  * @brief Return the 32-bit hash of a temporal box
  * @param[in] box Temporal box
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Tbox_hash()
  */
 uint32
@@ -2343,7 +2358,7 @@ tbox_hash(const TBox *box)
  * @brief Return the 64-bit hash of a temporal box using a seed
  * @param[in] box Temporal box
  * @param[in] seed Seed
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  * @csqlfn #Tbox_hash_extended()
  */
 uint64

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -1863,7 +1863,7 @@ temporal_as_tsequenceset(const Temporal *temp, interpType interp)
  * @brief Return a temporal value transformed to an interpolation
  * @param[in] temp Temporal value
  * @param[in] interp Interpolation
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_set_interp()
  */
 Temporal *
@@ -2327,7 +2327,7 @@ tnumber_avg_value(const Temporal *temp)
  * @param[in] temp Temporal value
  * @param[in] n Number (1-based)
  * @param[out] result Resulting timestamp
- * @return On error return false
+ * @errval false
  */
 bool
 temporal_value_n(const Temporal *temp, int n, Datum *result)
@@ -2370,7 +2370,7 @@ temporal_value_n(const Temporal *temp, int n, Datum *result)
  * @details Function used, e.g., for computing the shortest line between two
  * temporal points from their temporal distance
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @note The function does not take into account whether the instant is at
  * an exclusive bound or not.
  */
@@ -2397,7 +2397,7 @@ temporal_min_inst_p(const Temporal *temp)
  * @brief Return a copy of the instant with minimum base value of a temporal
  * value
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @note The function does not take into account whether the instant is at
  * an exclusive bound or not.
  * @csqlfn #Temporal_min_instant()
@@ -2416,7 +2416,7 @@ temporal_min_instant(const Temporal *temp)
  * @brief Return a copy of the instant with maximum base value of a temporal
  * value
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_max_instant()
  */
 const TInstant *
@@ -2442,7 +2442,7 @@ temporal_max_inst_p(const Temporal *temp)
  * @brief Return a copy of the instant with maximum base value of a temporal
  * value
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @note The function does not take into account whether the instant is at
  * an exclusive bound or not.
  * @csqlfn #Temporal_max_instant()
@@ -2461,7 +2461,7 @@ temporal_max_instant(const Temporal *temp)
  * @brief Return the duration of a temporal value
  * @param[in] temp Temporal value
  * @param[in] boundspan True when the potential time gaps are ignored
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_duration()
  */
 Interval *
@@ -2491,7 +2491,7 @@ temporal_duration(const Temporal *temp, bool boundspan)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of sequences of a temporal sequence (set)
  * @param[in] temp Temporal value
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Temporal_num_sequences()
  */
 int
@@ -2508,7 +2508,7 @@ temporal_num_sequences(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the start sequence of a temporal sequence (set)
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_sequence()
  */
 TSequence *
@@ -2533,7 +2533,7 @@ temporal_start_sequence(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the end sequence of a temporal sequence (set)
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_sequence()
  */
 TSequence *
@@ -2558,7 +2558,7 @@ temporal_end_sequence(const Temporal *temp)
  * @brief Return a copy of the n-th sequence of a temporal sequence (set)
  * @param[in] temp Temporal value
  * @param[in] n Number (1-based)
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_sequence_n()
  */
 TSequence *
@@ -2589,7 +2589,7 @@ temporal_sequence_n(const Temporal *temp, int n)
  * (set)
  * @param[in] temp Temporal value
  * @param[out] count Number of values in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_sequences()
  */
 const TSequence **
@@ -2618,7 +2618,7 @@ temporal_sequences_p(const Temporal *temp, int *count)
  * (set)
  * @param[in] temp Temporal value
  * @param[out] count Number of values in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_sequences()
  */
 TSequence **
@@ -2638,7 +2638,7 @@ temporal_sequences(const Temporal *temp, int *count)
  * @brief Return the array of segments of a temporal value
  * @param[in] temp Temporal value
  * @param[out] count Number of values in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_segments()
  */
 TSequence **
@@ -2716,7 +2716,7 @@ temporal_upper_inc(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of distinct instants of a temporal value
  * @param[in] temp Temporal value
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Temporal_num_instants()
  */
 int
@@ -2741,7 +2741,7 @@ temporal_num_instants(const Temporal *temp)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return a pointer to the start instant of a temporal value
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  */
 const TInstant *
 temporal_start_inst(const Temporal *temp)
@@ -2763,7 +2763,7 @@ temporal_start_inst(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the start instant of a temporal value
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_instant()
  */
 TInstant *
@@ -2780,7 +2780,7 @@ temporal_start_instant(const Temporal *temp)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return a pointer to the end instant of a temporal value
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @note This function is used for validity testing.
  */
 const TInstant *
@@ -2808,7 +2808,7 @@ temporal_end_inst(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the end instant of a temporal value
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @note This function is used for validity testing.
  * @csqlfn #Temporal_end_instant()
  */
@@ -2827,7 +2827,7 @@ temporal_end_instant(const Temporal *temp)
  * @brief Return a pointer to the n-th instant of a temporal value
  * @param[in] temp Temporal value
  * @param[in] n Number (1-based)
- * @return On error return @p NULL
+ * @errval NULL
  */
 const TInstant *
 temporal_inst_n(const Temporal *temp, int n)
@@ -2855,7 +2855,7 @@ temporal_inst_n(const Temporal *temp, int n)
  * @brief Return a copy of the n-th instant of a temporal value
  * @param[in] temp Temporal value
  * @param[in] n Number (1-based)
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_instant_n()
  */
 TInstant *
@@ -2874,7 +2874,7 @@ temporal_instant_n(const Temporal *temp, int n)
  * value
  * @param[in] temp Temporal value
  * @param[out] count Number of values in the output array
- * @return On error return @p NULL
+ * @errval NULL
  */
 const TInstant **
 temporal_insts_p(const Temporal *temp, int *count)
@@ -2906,7 +2906,7 @@ temporal_insts_p(const Temporal *temp, int *count)
  * @brief Return a copy of the distinct instants of a temporal value
  * @param[in] temp Temporal value
  * @param[out] count Number of values in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_instants()
  */
 TInstant **
@@ -2924,7 +2924,7 @@ temporal_instants(const Temporal *temp, int *count)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of distinct timestamps of a temporal value
  * @param[in] temp Temporal value
- * @return On error return -1
+ * @errval -1
  * @csqlfn #Temporal_num_timestamps()
  */
 int
@@ -2949,7 +2949,7 @@ temporal_num_timestamps(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the start timestamptz of a temporal value
  * @param[in] temp Temporal value
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Temporal_start_timestamptz()
  */
 TimestampTz
@@ -2974,7 +2974,7 @@ temporal_start_timestamptz(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the end timestamptz of a temporal value
  * @param[in] temp Temporal value
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  * @csqlfn #Temporal_end_timestamptz()
  */
 TimestampTz
@@ -3002,7 +3002,7 @@ temporal_end_timestamptz(const Temporal *temp)
  * @param[in] temp Temporal value
  * @param[in] n Number (1-based)
  * @param[out] result Resulting timestamp
- * @return On error return false
+ * @errval false
  * @csqlfn #Temporal_timestamptz_n()
  */
 bool
@@ -3042,7 +3042,7 @@ temporal_timestamptz_n(const Temporal *temp, int n, TimestampTz *result)
  * @brief Return the array of distinct timestamps of a temporal value
  * @param[in] temp Temporal value
  * @param[out] count Number of values in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_timestamps()
  */
 TimestampTz *
@@ -3484,7 +3484,7 @@ temporal_stops(const Temporal *temp, double maxdist,
  * @ingroup meos_temporal_accessor
  * @brief Return the integral (area under the curve) of a temporal number
  * @param[in] temp Temporal value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Tnumber_integral()
  */
 double
@@ -3510,7 +3510,7 @@ tnumber_integral(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the time-weighted average of a temporal number
  * @param[in] temp Temporal value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Tnumber_twavg()
  */
 double
@@ -3806,7 +3806,7 @@ temporal_ne(const Temporal *temp1, const Temporal *temp2)
  * @brief Return -1, 0, or 1 depending on whether the first temporal value is
  * less than, equal to, or greater than the second one
  * @param[in] temp1,temp2 Temporal values
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @note Function used for B-tree comparison
  * @csqlfn #Temporal_cmp()
  */
@@ -3975,7 +3975,7 @@ tinstant_hash_extended_fold(const TInstant *inst, void *state)
  * @ingroup meos_temporal_accessor
  * @brief Return the 32-bit hash value of a temporal value
  * @param[in] temp Temporal value
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Temporal_hash()
  *
  * The hash reads the instants the value holds, in time order, and nothing
@@ -4007,7 +4007,7 @@ temporal_hash(const Temporal *temp)
  * @brief Return the 64-bit hash value of a temporal value using a seed
  * @param[in] temp Temporal value
  * @param[in] seed Seed
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  * @csqlfn #Temporal_hash_extended()
  */
 uint64

--- a/meos/src/temporal/temporal_aggfuncs.c
+++ b/meos/src/temporal/temporal_aggfuncs.c
@@ -275,7 +275,8 @@ temporal_skiplist_elempos(const SkipList *list, Span *s, int cur)
  * @param[out] update Array of indices keeping the levels of the elements to
  * insert
  * @return Number of elements in the list that will be aggregated with the new
- * values, on error return -1
+ * values
+ * @errval -1
  */
 int
 temporal_skiplist_common(SkipList *list, void **values, int count,
@@ -515,7 +516,7 @@ tinstant_tagg(TInstant **instants1, int count1, TInstant **instants2,
  * @param[in] crossings True if turning points are added in the segments
  * @param[out] result Array on which the pointers of the newly constructed
  * ranges are stored
- * @return On error return -1
+ * @errval -1
  * @note Return new sequences that must be freed by the calling function
  */
 static int

--- a/meos/src/temporal/temporal_analytics.c
+++ b/meos/src/temporal/temporal_analytics.c
@@ -1466,7 +1466,7 @@ temporal_similarity(const Temporal *temp1, const Temporal *temp2,
  * @ingroup meos_temporal_analytics_similarity
  * @brief Return the Frechet distance between two temporal values
  * @param[in] temp1,temp2 Temporal values
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Temporal_frechet_distance()
  */
 double
@@ -1482,7 +1482,7 @@ temporal_frechet_distance(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_temporal_analytics_similarity
  * @brief Return the Dynamic Time Warp distance between two temporal values
  * @param[in] temp1,temp2 Temporal values
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Temporal_dyntimewarp_distance()
  */
 double
@@ -1818,7 +1818,7 @@ tinstarr_hausdorff_distance(TInstant **instants1, int count1,
  * @ingroup meos_temporal_analytics_similarity
  * @brief Return the Hausdorf distance between two temporal values
  * @param[in] temp1,temp2 Temporal values
- * @return On error return `DBL_MAX`
+ * @errval DBL_MAX
  * @csqlfn #Temporal_hausdorff_distance()
  */
 double
@@ -2582,7 +2582,7 @@ tinstarr_average_hausdorff_distance(const TInstant **instants1, int count1,
  * @ingroup meos_temporal_analytics_similarity
  * @brief Return the average Hausdorff distance between two temporal values
  * @param[in] temp1,temp2 Temporal values
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Temporal_average_hausdorff_distance()
  */
 double
@@ -2649,7 +2649,7 @@ tinstarr_lcss_distance(const TInstant **instants1, int count1,
  * temporal values
  * @param[in] temp1,temp2 Temporal values
  * @param[in] epsilon Maximum distance for two instants to match
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Temporal_lcss_distance()
  */
 double

--- a/meos/src/temporal/temporal_boxops.c
+++ b/meos/src/temporal/temporal_boxops.c
@@ -274,7 +274,8 @@ ensure_index_join_op(IndexSearchOp op)
  * @param[in] temp Temporal value to decompose
  * @param[in] maxboxes Maximum number of boxes produced for `temp`
  * @param[out] count Number of boxes in the returned array
- * @return Allocated array of `*count` bounding boxes, or @p NULL on error
+ * @return Allocated array of `*count` bounding boxes
+ * @errval NULL
  * @pre `temp` is compatible with `bboxtype` (verified by the callers)
  */
 void *
@@ -940,7 +941,7 @@ tsequenceset_spans(const TSequenceSet *ss, int *count)
  * respectively, on whether the interpolation is discrete or continuous
  * @param[in] temp Temporal value
  * @param[out] count Number of values of the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_spans()
  */
 Span *
@@ -1171,7 +1172,8 @@ tsequenceset_split_n_spans(const TSequenceSet *ss, int span_count, int *count)
  * @return If the number of instants or segments is <= `span_count`, the result
  * contains one span per instant or segment. Otherwise, consecutive instants or
  * segments are combined into a single span in the result to reach the number
- * of spans. On error return @p NULL
+ * of spans
+ * @errval NULL
  * @csqlfn #Temporal_split_n_spans()
  */
 Span *
@@ -1343,7 +1345,7 @@ tsequenceset_split_each_n_spans(const TSequenceSet *ss, int elems_per_span,
  * @return If the number of instants or segments is <= `elems_per_span`, the
  * result contains a single span. Otherwise, the number consecutive input
  * instants or segments are combined into a single output span in the result.
- * On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_split_each_n_spans()
  */
 Span *
@@ -1496,7 +1498,7 @@ tnumberseqset_tboxes(const TSequenceSet *ss, int *count)
  * depends on whether the interpolation is discrete or continuous
  * @param[in] temp Temporal value
  * @param[out] count Number of elements in the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tnumber_tboxes()
  */
 TBox *
@@ -1733,7 +1735,7 @@ tnumberseqset_split_n_tboxes(const TSequenceSet *ss, int box_count, int *count)
  * @param[in] temp Temporal number
  * @param[in] box_count Number of boxes
  * @param[out] count Number of values of the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tnumber_split_n_tboxes()
  */
 TBox *
@@ -1901,7 +1903,7 @@ tnumberseqset_split_each_n_tboxes(const TSequenceSet *ss, int elems_per_box,
  * @param[in] temp Temporal number
  * @param[in] elems_per_box Number of input elements merged in an output box
  * @param[out] count Number of values of the output array
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tnumber_split_each_n_tboxes()
  */
 TBox *

--- a/meos/src/temporal/temporal_meos.c
+++ b/meos/src/temporal/temporal_meos.c
@@ -554,7 +554,7 @@ tbool_start_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the start value of a temporal integer
  * @param[in] temp Temporal value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Temporal_start_value()
  */
 int
@@ -569,7 +569,7 @@ tint_start_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the start value of a temporal big integer
  * @param[in] temp Temporal value
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Temporal_start_value()
  */
 int64
@@ -584,7 +584,7 @@ tbigint_start_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the start value of a temporal float
  * @param[in] temp Temporal value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Temporal_start_value()
  */
 double
@@ -599,7 +599,7 @@ tfloat_start_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the start value of a temporal text
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_start_value()
  */
 text *
@@ -630,7 +630,7 @@ tbool_end_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the end value of a temporal integer
  * @param[in] temp Temporal value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Temporal_end_value()
  */
 int
@@ -645,7 +645,7 @@ tint_end_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the end value of a temporal big integer
  * @param[in] temp Temporal value
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Temporal_end_value()
  */
 int64
@@ -660,7 +660,7 @@ tbigint_end_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the end value of a temporal float
  * @param[in] temp Temporal value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Temporal_end_value()
  */
 double
@@ -675,7 +675,7 @@ tfloat_end_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the end value of a temporal text
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_end_value()
  */
 text *
@@ -692,7 +692,7 @@ ttext_end_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the minimum value of a temporal integer
  * @param[in] temp Temporal value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Temporal_min_value()
  */
 int
@@ -707,7 +707,7 @@ tint_min_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the minimum value of a temporal big integer
  * @param[in] temp Temporal value
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Temporal_min_value()
  */
 int64
@@ -722,7 +722,7 @@ tbigint_min_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the minimum value of a temporal float
  * @param[in] temp Temporal value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Temporal_min_value()
  */
 double
@@ -737,7 +737,7 @@ tfloat_min_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the minimum value of a temporal text
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_min_value()
  */
 text *
@@ -754,7 +754,7 @@ ttext_min_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the maximum value of a temporal integer
  * @param[in] temp Temporal value
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  * @csqlfn #Temporal_max_value()
  */
 int
@@ -769,7 +769,7 @@ tint_max_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the maximum value of a temporal big integer
  * @param[in] temp Temporal value
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #Temporal_max_value()
  */
 int64
@@ -784,7 +784,7 @@ tbigint_max_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the maximum value of a temporal float
  * @param[in] temp Temporal value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #Temporal_max_value()
  */
 double
@@ -799,7 +799,7 @@ tfloat_max_value(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return a copy of the maximum value of a temporal text
  * @param[in] temp Temporal value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_max_value()
  */
 text *

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -1962,7 +1962,8 @@ nn_heap_pop(RTreeNNCursor *cursor)
  * @param[in] rtree The RTree to query
  * @param[in] query The query bounding box of type @p rtree->bboxtype and of
  * the SRID the tree holds
- * @return A cursor to be freed with #rtree_nn_cursor_close, on error @p NULL
+ * @return A cursor to be freed with #rtree_nn_cursor_close
+ * @errval NULL
  */
 RTreeNNCursor *
 rtree_nn_cursor_open(const RTree *rtree, const void *query)
@@ -2119,7 +2120,7 @@ node_stats(const RTreeNode *node, size_t bboxsize, int level, int *entries,
  * @ingroup meos_temporal_box_index
  * @brief Return the number of entries an RTree holds
  * @param[in] rtree The RTree
- * @return On error return -1
+ * @errval -1
  */
 int
 rtree_num_entries(const RTree *rtree)
@@ -2140,7 +2141,7 @@ rtree_num_entries(const RTree *rtree)
  * @details The nodes of the tree and the tree itself, which is what a caller
  * accounting for the memory of an index reports
  * @param[in] rtree The RTree
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  */
 int64
 rtree_mem_size(const RTree *rtree)
@@ -2161,7 +2162,7 @@ rtree_mem_size(const RTree *rtree)
  * @brief Return the number of levels an RTree holds
  * @details An empty tree has no levels and a tree whose root is a leaf has one
  * @param[in] rtree The RTree
- * @return On error return -1
+ * @errval -1
  */
 int
 rtree_height(const RTree *rtree)

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -1520,7 +1520,7 @@ spnode_stats(const SPTree *sptree, const SPNode *node, int level, int *entries,
  * @ingroup meos_temporal_box_index
  * @brief Return the number of entries an SPTree holds
  * @param[in] sptree The SPTree
- * @return On error return -1
+ * @errval -1
  */
 int
 sptree_num_entries(const SPTree *sptree)
@@ -1539,7 +1539,7 @@ sptree_num_entries(const SPTree *sptree)
  * @details The nodes of the tree and the tree itself, which is what a caller
  * accounting for the memory of an index reports
  * @param[in] sptree The SPTree
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  */
 int64
 sptree_mem_size(const SPTree *sptree)
@@ -1557,7 +1557,7 @@ sptree_mem_size(const SPTree *sptree)
  * @brief Return the number of levels an SPTree holds
  * @details An empty tree has no levels and a tree of one entry has one
  * @param[in] sptree The SPTree
- * @return On error return -1
+ * @errval -1
  */
 int
 sptree_height(const SPTree *sptree)
@@ -1752,7 +1752,8 @@ spnn_heap_pop(SPNNCursor *cursor)
  * @param[in] sptree The SPTree to query
  * @param[in] query The query bounding box of type @p sptree->bboxtype and of
  * the SRID the tree holds
- * @return A cursor to be freed with #sptree_nn_cursor_close, on error @p NULL
+ * @return A cursor to be freed with #sptree_nn_cursor_close
+ * @errval NULL
  */
 SPNNCursor *
 sptree_nn_cursor_open(const SPTree *sptree, const void *query)

--- a/meos/src/temporal/temporal_tile.c
+++ b/meos/src/temporal/temporal_tile.c
@@ -69,7 +69,7 @@
  * @param[in] value Input value
  * @param[in] size Size of the bins
  * @param[in] origin Origin of the bins
- * @return On error return @p INT_MAX
+ * @errval INT_MAX
  */
 int
 int_get_bin(int value, int size, int origin)
@@ -121,7 +121,7 @@ int_get_bin(int value, int size, int origin)
  * @param[in] value Input value
  * @param[in] size Size of the bins
  * @param[in] origin Origin of the bins
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  */
 int64
 bigint_get_bin(int64 value, int64 size, int64 origin)
@@ -173,7 +173,7 @@ bigint_get_bin(int64 value, int64 size, int64 origin)
  * @param[in] value Input value
  * @param[in] size Size of the bins
  * @param[in] origin Origin of the bins
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 float_get_bin(double value, double size, double origin)
@@ -236,7 +236,7 @@ date_bin_start(DateADT d, int32 ndays, DateADT origin)
  * @param[in] d Input date
  * @param[in] duration Interval defining the size of the bins
  * @param[in] origin Origin of the bins
- * @return On error return @p DATEVAL_NOEND
+ * @errval DATEVAL_NOEND
  */
 DateADT
 date_get_bin(DateADT d, const Interval *duration, DateADT origin)
@@ -259,7 +259,7 @@ date_get_bin(DateADT d, const Interval *duration, DateADT origin)
  * @param[in] t Input timestamp
  * @param[in] size Size of the time bins in PostgreSQL time units
  * @param[in] origin Origin of the bins
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  */
 TimestampTz
 timestamptz_bin_start(TimestampTz t, int64 size, TimestampTz origin)

--- a/meos/src/temporal/tinstant.c
+++ b/meos/src/temporal/tinstant.c
@@ -661,7 +661,7 @@ tinstant_cmp(const TInstant *inst1, const TInstant *inst2)
  * @ingroup meos_internal_temporal_accessor
  * @brief Return the 32-bit hash of a temporal instant
  * @param[in] inst Temporal instant
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  * @csqlfn #Temporal_hash()
  */
 uint32
@@ -687,7 +687,7 @@ tinstant_hash(const TInstant *inst)
  * @brief Return the 64-bit hash of a temporal instant using a seed
  * @param[in] inst Temporal instant
  * @param[in] seed Seed
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  * @csqlfn #Temporal_hash_extended()
  */
 uint64

--- a/meos/src/temporal/tnumber_distance.c
+++ b/meos/src/temporal/tnumber_distance.c
@@ -227,8 +227,9 @@ nad_tbox_tbox(const TBox *box1, const TBox *box2)
  * and a temporal box
  * @param[in] temp Temporal value
  * @param[in] box Temporal box
- * @return On error or if the time frames do not overlap return the
- * sentinel of the base type given by #distance_sentinel()
+ * @return The sentinel of the base type given by #distance_sentinel() where
+ * the operands share no time, which is an answer and not an error: the
+ * external function establishes every precondition, so no path here raises
  * @csqlfn #NAD_tnumber_tbox() #NAD_tbox_tnumber()
  */
 Datum
@@ -274,8 +275,9 @@ nad_tnumber_tbox(const Temporal *temp, const TBox *box)
  * @ingroup meos_internal_temporal_dist
  * @brief Return the nearest approach distance between two temporal numbers
  * @param[in] temp1,temp2 Temporal boxes
- * @return On error or when the time frames do not intersect return the
- * sentinel of the base type given by #distance_sentinel()
+ * @return The sentinel of the base type given by #distance_sentinel() where
+ * the operands share no time, which is an answer and not an error: the
+ * external function establishes every precondition, so no path here raises
  */
 Datum
 nad_tnumber_tnumber(const Temporal *temp1, const Temporal *temp2)

--- a/meos/src/temporal/tnumber_distance_meos.c
+++ b/meos/src/temporal/tnumber_distance_meos.c
@@ -58,7 +58,7 @@
  * integer
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tdistance_tnumber_number() #Tdistance_number_tnumber()
  */
 Temporal *
@@ -74,7 +74,7 @@ tdistance_tint_int(const Temporal *temp, int i)
  * @brief Return the temporal distance between a temporal float and a float
  * @param[in] temp Temporal value
  * @param[in] d Value
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Tdistance_tnumber_number() #Tdistance_number_tnumber()
  */
 Temporal *
@@ -95,7 +95,7 @@ tdistance_tfloat_float(const Temporal *temp, double d)
  * and a number
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @return On error return INT_MAX
+ * @errval INT_MAX
  * @csqlfn #NAD_tnumber_number() #NAD_number_tnumber()
  */
 int
@@ -112,7 +112,7 @@ nad_tint_int(const Temporal *temp, int i)
  * and a number
  * @param[in] temp Temporal value
  * @param[in] i Value
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #NAD_tnumber_number() #NAD_number_tnumber()
  */
 int64
@@ -129,7 +129,7 @@ nad_tbigint_bigint(const Temporal *temp, int64 i)
  * and a number
  * @param[in] temp Temporal value
  * @param[in] d Value
- * @return On error return DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_tnumber_number() #NAD_number_tnumber()
  */
 double
@@ -146,7 +146,7 @@ nad_tfloat_float(const Temporal *temp, double d)
  * and a temporal box
  * @param[in] temp Temporal value
  * @param[in] box Temporal box
- * @return On error return INT_MAX
+ * @errval INT_MAX
  * @csqlfn #NAD_tnumber_tbox()
  */
 int
@@ -164,7 +164,7 @@ nad_tint_tbox(const Temporal *temp, const TBox *box)
  * and a temporal box
  * @param[in] temp Temporal value
  * @param[in] box Temporal box
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #NAD_tnumber_tbox()
  */
 int64
@@ -182,7 +182,7 @@ nad_tbigint_tbox(const Temporal *temp, const TBox *box)
  * and a temporal box
  * @param[in] temp Temporal value
  * @param[in] box Temporal box
- * @return On error return DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_tnumber_tbox()
  */
 double
@@ -198,7 +198,7 @@ nad_tfloat_tbox(const Temporal *temp, const TBox *box)
  * @ingroup meos_temporal_dist
  * @brief Return the nearest approach distance between the int temporal boxes
  * @param[in] box1,box2 Temporal boxes
- * @return On error return -1
+ * @errval -1
  * @note A distance is never negative, so -1 states an error where INT_MAX
  * states that the boxes share no time
  * @csqlfn #NAD_tbox_tbox()
@@ -222,7 +222,7 @@ nad_tboxint_tboxint(const TBox *box1, const TBox *box2)
  * @brief Return the nearest approach distance between the big integer temporal
  * boxes
  * @param[in] box1,box2 Temporal boxes
- * @return On error return -1
+ * @errval -1
  * @note A distance is never negative, so -1 states an error where INT64_MAX
  * states that the boxes share no time
  * @csqlfn #NAD_tbox_tbox()
@@ -245,7 +245,7 @@ nad_tboxbigint_tboxbigint(const TBox *box1, const TBox *box2)
  * @ingroup meos_temporal_dist
  * @brief Return the nearest approach distance between the float temporal boxes
  * @param[in] box1,box2 Temporal boxes
- * @return On error return -1.0
+ * @errval -1.0
  * @note A distance is never negative, so -1.0 states an error where DBL_MAX
  * states that the boxes share no time
  * @csqlfn #NAD_tbox_tbox()
@@ -267,7 +267,7 @@ nad_tboxfloat_tboxfloat(const TBox *box1, const TBox *box2)
  * @ingroup meos_temporal_dist
  * @brief Return the nearest approach distance between two temporal integers
  * @param[in] temp1,temp2 Temporal values
- * @return On error return INT_MAX
+ * @errval INT_MAX
  * @csqlfn #NAD_tnumber_tnumber()
  */
 int
@@ -283,7 +283,7 @@ nad_tint_tint(const Temporal *temp1, const Temporal *temp2)
  * @brief Return the nearest approach distance between two temporal big
  * integers
  * @param[in] temp1,temp2 Temporal values
- * @return On error return @p INT64_MAX
+ * @errval INT64_MAX
  * @csqlfn #NAD_tnumber_tnumber()
  */
 int64
@@ -298,7 +298,7 @@ nad_tbigint_tbigint(const Temporal *temp1, const Temporal *temp2)
  * @ingroup meos_temporal_dist
  * @brief Return the nearest approach distance between two temporal floats
  * @param[in] temp1,temp2 Temporal values
- * @return On error return DBL_MAX
+ * @errval DBL_MAX
  * @csqlfn #NAD_tnumber_tnumber()
  */
 double

--- a/meos/src/temporal/tsequenceset.c
+++ b/meos/src/temporal/tsequenceset.c
@@ -171,7 +171,7 @@ tseqarr_normalize(TSequence **sequences, int count, int *newcount)
  * @param[in] value1,value2 Values
  * @param[in] type Type of the values
  * @param[in] flags Flags
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 datum_distance(Datum value1, Datum value2, MeosType type, int16 flags)

--- a/meos/src/temporal/type_in.c
+++ b/meos/src/temporal/type_in.c
@@ -137,7 +137,7 @@ extern LWGEOM *parse_geojson(json_object *geojson, int *hasz);
  * @param[in] end True when the string must end where the value ends, which
  * the types parsing a value out of a larger string read
  * @param[out] result Value read
- * @return On error return @p false
+ * @errval false
  */
 bool
 #if CBUFFER || NPOINT || POSE
@@ -1444,7 +1444,7 @@ ensure_temptype_mfjson(const char *typestr)
  * @brief Return a temporal object from its MF-JSON representation
  * @param[in] mfjson MFJSON string
  * @param[in] temptype expected temporal type
- * @return On error return @p NULL
+ * @errval NULL
  * @see #tinstant_from_mfjson()
  * @see #tsequence_from_mfjson()
  * @see #tsequenceset_from_mfjson()
@@ -3117,7 +3117,7 @@ tbox_from_hexwkb(const char *hexwkb)
  * representation
  * @param[in] wkb WKB string
  * @param[in] size Size of the string
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_recv(), #Temporal_from_wkb()
  */
 Temporal *
@@ -3134,7 +3134,7 @@ temporal_from_wkb(const uint8_t *wkb, size_t size)
  * @brief Return a temporal value from its ASCII hex-encoded Extended
  * Well-Known Binary (EWKB) representation
  * @param[in] hexwkb HexWKB string
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_from_hexwkb()
  */
 Temporal *

--- a/meos/src/temporal/type_in_meos.c
+++ b/meos/src/temporal/type_in_meos.c
@@ -246,7 +246,7 @@ ttextseqset_from_mfjson(json_object *mfjson)
  * @ingroup meos_temporal_inout
  * @brief Return a temporal boolean from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -259,7 +259,7 @@ tbool_from_mfjson(const char *mfjson)
  * @ingroup meos_temporal_inout
  * @brief Return a temporal integer from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -272,7 +272,7 @@ tint_from_mfjson(const char *mfjson)
  * @ingroup meos_temporal_inout
  * @brief Return a temporal big integer from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -285,7 +285,7 @@ tbigint_from_mfjson(const char *mfjson)
  * @ingroup meos_temporal_inout
  * @brief Return a temporal float from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *
@@ -298,7 +298,7 @@ tfloat_from_mfjson(const char *mfjson)
  * @ingroup meos_temporal_inout
  * @brief Return a temporal text from its MF-JSON representation
  * @param[in] mfjson MFJSON string
- * @return On error return @p NULL
+ * @errval NULL
  * @see #temporal_from_mfjson()
  */
 Temporal *

--- a/meos/src/temporal/type_out.c
+++ b/meos/src/temporal/type_out.c
@@ -124,7 +124,7 @@ extern bool string_escape(const char *str, int quotes, char **result);
 
 /**
  * @brief Return the string representation of a base value
- * @return On error return @p NULL
+ * @errval NULL
  */
 char *
 basetype_out(Datum value, MeosType type, int maxdd)
@@ -1220,7 +1220,7 @@ tsequenceset_as_mfjson_sb(stringbuffer_t *sb, const TSequenceSet *ss,
  * @param[in] precision Number of decimal digits. It is only used when the base
  * type has floating point components, such as tfloat or tgeometry
  * @param[in] srs Spatial reference system, may be `NULL`
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn #Temporal_as_mfjson()
  */
 char *
@@ -1512,7 +1512,7 @@ h3index_to_wkb_size(uint8_t variant)
 
 /**
  * @brief Return the size of the WKB representation of a base value
- * @return On error return SIZE_MAX
+ * @errval SIZE_MAX
  */
 static size_t
 base_to_wkb_size(Datum value, MeosType basetype, uint8_t variant)
@@ -1815,7 +1815,7 @@ temporal_to_wkb_size(const Temporal *temp, uint8_t variant)
 
 /**
  * @brief Return the size of the WKB representation of a value
- * @return On error return SIZE_MAX
+ * @errval SIZE_MAX
  */
 static size_t
 datum_to_wkb_size(Datum value, MeosType type, uint8_t variant)
@@ -3144,7 +3144,7 @@ temporal_to_wkb_buf(const Temporal *temp, uint8_t *buf, uint8_t variant)
 
 /**
  * @brief Write into the buffer the WKB representation of a value
- * @return On error return @p NULL
+ * @errval NULL
  */
 static uint8_t *
 datum_to_wkb_buf(Datum value, MeosType type, uint8_t *buf, uint8_t variant)
@@ -3308,7 +3308,7 @@ datum_as_hexwkb(Datum value, MeosType type, uint8_t variant, size_t *size)
  * caller can select the byte order from a textual value.
  * @param[in] endian Endian encoding: an empty string (machine endianness),
  * `"ndr"` (little-endian) or `"xdr"` (big-endian)
- * @return On error return 0
+ * @errval 0
  */
 uint8_t
 wkb_variant_from_endian(const char *endian)

--- a/meos/src/temporal/type_parser.c
+++ b/meos/src/temporal/type_parser.c
@@ -270,7 +270,7 @@ p_comma(const char **str)
 
 /**
  * @brief Input a double from the buffer
- * @return On error return false
+ * @errval false
  */
 bool
 double_parse(const char **str, double *result)
@@ -290,7 +290,7 @@ double_parse(const char **str, double *result)
 
 /**
  * @brief Parse a base value from the buffer
- * @return On error return false
+ * @errval false
  */
 bool
 basetype_parse(const char **str, MeosType basetype, char delim, Datum *result)
@@ -349,7 +349,7 @@ basetype_parse(const char **str, MeosType basetype, char delim, Datum *result)
 
 /**
  * @brief Parse a temporal box value from the buffer
- * @return On error return @p NULL
+ * @errval NULL
  */
 TBox *
 tbox_parse(const char **str)
@@ -450,7 +450,7 @@ tbox_parse(const char **str)
 
 /**
  * @brief Parse a timestamp value from the buffer
- * @return On error return DT_NOEND
+ * @errval DT_NOEND
  */
 TimestampTz
 timestamp_parse(const char **str)
@@ -476,7 +476,7 @@ timestamp_parse(const char **str)
 
 /**
  * @brief Parse a element value from the buffer
- * @return On error return false
+ * @errval false
  */
 bool
 elem_parse(const char **str, MeosType basetype, Datum *result)
@@ -514,7 +514,7 @@ elem_parse(const char **str, MeosType basetype, Datum *result)
 
 /**
  * @brief Parse a set value from the buffer
- * @return On error return @p NULL
+ * @errval NULL
  */
 Set *
 set_parse(const char **str, MeosType settype)
@@ -577,7 +577,7 @@ error:
 
 /**
  * @brief Parse a bound value from the buffer
- * @return On error return false
+ * @errval false
  */
 bool
 bound_parse(const char **str, MeosType basetype, Datum *result)
@@ -600,7 +600,7 @@ bound_parse(const char **str, MeosType basetype, Datum *result)
 
 /**
  * @brief Parse a span value from the buffer
- * @return On error return false
+ * @errval false
  */
 bool
 span_parse(const char **str, MeosType spantype, bool end, Span *span)
@@ -646,7 +646,7 @@ span_parse(const char **str, MeosType spantype, bool end, Span *span)
 
 /**
  * @brief Parse a span set value from the buffer
- * @return On error return @p NULL
+ * @errval NULL
  */
 SpanSet *
 spanset_parse(const char **str, MeosType spansettype)
@@ -692,7 +692,7 @@ error:
  * @param[in] temptype Temporal type
  * @param[in] end Set to true when reading a single instant to ensure there is
  * no more input after the instant
- * @return On error return NULL
+ * @errval NULL
  */
 TInstant *
 tinstant_parse(const char **str, MeosType temptype, bool end)
@@ -721,7 +721,7 @@ tinstant_parse(const char **str, MeosType temptype, bool end)
  * @brief Parse a temporal discrete sequence from the buffer
  * @param[in] str Input string
  * @param[in] temptype Base type
- * @return On error return @p NULL
+ * @errval NULL
  */
 TSequence *
 tdiscseq_parse(const char **str, MeosType temptype)
@@ -771,7 +771,7 @@ error:
  * @param[in] interp Interpolation
  * @param[in] end Set to true when reading a single sequence to ensure there is
  * no more input after the sequence
- * @return New sequence, may be NULL, on error return @p NULL
+ * @errval NULL
  */
 TSequence *
 tcontseq_parse(const char **str, MeosType temptype, interpType interp,
@@ -835,7 +835,7 @@ error:
  * @param[in] str Input string
  * @param[in] temptype Temporal type
  * @param[in] interp Interpolation
- * @return On error return @p NULL
+ * @errval NULL
  */
 TSequenceSet *
 tsequenceset_parse(const char **str, MeosType temptype, interpType interp)
@@ -880,7 +880,7 @@ error:
  * @brief Parse a temporal value from the buffer (dispatch function)
  * @param[in,out] str Input string, advanced past what is read
  * @param[in] temptype Temporal type
- * @return On error return @p NULL
+ * @errval NULL
  */
 Temporal *
 temporal_parse(const char **str, MeosType temptype)

--- a/meos/src/temporal/type_util.c
+++ b/meos/src/temporal/type_util.c
@@ -543,7 +543,7 @@ datum_div(Datum l, Datum r, MeosType type)
  * @brief Return the 32-bit hash of a value
  * @param[in] d Value
  * @param[in] type Type of the value
- * @return On error return @p UINT32_MAX
+ * @errval UINT32_MAX
  */
 uint32
 datum_hash(Datum d, MeosType type)
@@ -613,7 +613,7 @@ datum_hash(Datum d, MeosType type)
  * @param[in] d Value
  * @param[in] type Type of the value
  * @param[in] seed Seed
- * @return On error return @p UINT64_MAX
+ * @errval UINT64_MAX
  */
 uint64
 datum_hash_extended(Datum d, MeosType type, uint64 seed)
@@ -703,7 +703,7 @@ datum_copy(Datum value, MeosType basetype)
 
 /**
  * @brief Return a double from a Datum value
- * @return On error return @p DBL_MAX
+ * @errval DBL_MAX
  */
 double
 datum_double(Datum d, MeosType type)
@@ -1021,8 +1021,8 @@ string_escape(const char *str, int quotes, char **result)
  * values, so that the input is symmetric with the output for every binding.
  * @param[in] str Input string, which must start with a double quote
  * @param[out] result Newly allocated unescaped string
- * @return Number of input characters consumed, including both double quotes,
- * or 0 on error (unterminated quoted string)
+ * @return Number of input characters consumed, including both double quotes
+ * @errval 0
  * @note The function is derived from the PostgreSQL array input function
  */
 size_t

--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -111,10 +111,30 @@ POINTER = re.compile(r"\*\s*$")
 FUNC_DEF = re.compile(r"^([a-z_][a-z0-9_]*)\s*\(")
 RET_TYPE = re.compile(r"^((?:const\s+)?[A-Za-z_][A-Za-z0-9_]*(?:\s*\*+)?)\s*$")
 VALIDATE = re.compile(r"\bVALIDATE_[A-Z0-9_]+\s*\([^,]+,\s*([^)]+?)\s*\)")
-# The token may be a name or a number, and a number may have a decimal point,
-# so it cannot end at the first dot: -1.0 read as -1 is a different sentinel
-DOC_RETURN = re.compile(r"@return\s+On error return\s+(?:@p\s+)?"
-                        r"(-?\d+\.\d+|-?\d+|[A-Za-z_][A-Za-z0-9_]*)")
+# The contract is an @errval tag. A tag carries ONE token, because whoever
+# reads it takes the first one and everything written after that is lost --
+# a value ending in a comma is read WITH the comma, which is the same bite
+# @sqlop takes when it names more than one operator. The vocabulary is a
+# name, a number, or a reference to the function computing the sentinel. A
+# number may have a decimal point, so a token cannot end at the first dot:
+# -1.0 read as -1 is a different sentinel.
+ERRVAL = re.compile(r"@errval\s+(.*?)\s*$")
+ERRVAL_TOKEN = re.compile(r"^(?:-?\d+\.\d+|-?\d+|[A-Za-z_][A-Za-z0-9_]*|"
+                          r"#[A-Za-z_][A-Za-z0-9_]*\(\))$")
+# The prose form the tag replaces. A contract written as prose again is
+# invisible to this check, so the check refuses it rather than passing a file
+# whose contract it can no longer see. One doc line mentions an error without
+# contracting one: a three-valued predicate states its whole return domain,
+# and -1 there is the "unknown" of that domain rather than a sentinel this
+# check governs.
+# Both boundaries, as the sibling checks anchor their keywords: the left one
+# is what keeps "approximation error" out of the match.
+PROSE = re.compile(r"\b[Oo]n error\b")
+# A predicate states its domain over two lines as readily as over one, so the
+# exemption reads the line together with the one above it.
+PROSE_EXEMPT = re.compile(r"-1\s+on error")
+DOC_RETURN = re.compile(r"@errval\s+(-?\d+\.\d+|-?\d+|[A-Za-z_][A-Za-z0-9_]*)"
+                        r"\s*$")
 
 
 def sentinel_for(rettype: str) -> str | None:
@@ -142,6 +162,18 @@ def scan(path: Path, rel: str) -> list[tuple[str, str]]:
     findings = []
     lines = path.read_text().splitlines()
     for i, line in enumerate(lines):
+        e = ERRVAL.search(line)
+        if e and not ERRVAL_TOKEN.match(e.group(1)):
+            findings.append((f"{rel}\t@errval\t{e.group(1)}",
+                             f"{rel}:{i + 1}: @errval takes one token, "
+                             f"not {e.group(1)!r}"))
+        prev = lines[i - 1].strip().lstrip("*").strip() if i else ""
+        if (line.lstrip().startswith("*") and PROSE.search(line) and
+                not PROSE_EXEMPT.search(f"{prev} {line.strip().lstrip('*')}")):
+            findings.append((f"{rel}\tprose\t{line.strip()}",
+                             f"{rel}:{i + 1}: state the error value as "
+                             f"@errval, not as prose"))
+    for i, line in enumerate(lines):
         m = FUNC_DEF.match(line)
         if not m or i == 0:
             continue
@@ -161,6 +193,10 @@ def scan(path: Path, rel: str) -> list[tuple[str, str]]:
             j -= 1
             if i - j > 40:
                 break
+        # a doxygen block is read in source order and with its continuations
+        # joined, so that a sentence wrapped over two lines still reads as one
+        doctext = " ".join(dl.strip().lstrip("*").strip() for dl in
+                           reversed(doc))
         documented = documented_raw = None
         for dl in doc:
             d = DOC_RETURN.search(dl)
@@ -176,7 +212,7 @@ def scan(path: Path, rel: str) -> list[tuple[str, str]]:
             body.append(lines[k])
             k += 1
         if want == "INT_MAX" and (PREDICATE.match(name) or
-                                  PREDICATE_DOC.search("\n".join(doc))):
+                                  PREDICATE_DOC.search(doctext)):
             want = "-1"
         if want == "INT_MAX" and COUNT_DOC.search("\n".join(doc)):
             want = "-1"


### PR DESCRIPTION
The rule is that a MEOS function states its error value once, in a tag a machine
reads, so @errval NULL replaces the sentence a reader and a checker have to
parse. The Doxygen alias expands the tag into the sentence the prose
carries, so the manual renders the same text, while
check_error_sentinels.py reads every contract from one place and refuses the
prose spelling rather than passing a file whose contract it cannot see.

A condition that is not an error moves to a note in the same pass, a sentence
reading "on error or if the time frames do not intersect" stating two things
where the tag states one. A nearest approach measured over no shared time, an
empty geometry with no point to measure from, and an n addressing no point of a
patch are answers rather than failures. Two contracts go away outright,
set_bbox_size and keyval_skiplist_common being total functions that carry no
error value at all.

Witness: the 252 lines stating the NULL contract are written eighteen ways, among
them "@p NULL", "`NULL`", "On error, return @p NULL", "@p NULL on error" and one
carrying a trailing full stop, and spanset_split_n_spans states the contract
twice in one comment block. check_error_sentinels.py reads a documented contract
by matching one of those spellings, so a function spelling it differently is
invisible to the check that governs it.

Measured on master fc2a5a3bda: the 556 tag sites carry a single token each, and
check_error_sentinels.py and check_dispatch_default.py both exit 0 over them. The
refusal is load-bearing in both arms, the same checker run against master exiting
1 on 561 prose sites while doxygen answers 0 "Found unknown command" warnings
over the changed files with the alias in place, against 76 with the alias line
removed as the control. Outside doxygen/Doxyfile, doxygen/Doxyfile_gha and
tools/scripts/check_error_sentinels.py the change is comment-only.