### PR TITLE
Sample a raster in a system other than lon/lat and on a skewed grid

### DIFF
--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -199,6 +199,58 @@ ERROR:  Operation on mixed SRID
 WITH rast AS (
   SELECT ST_SetValues(
     ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 3857),
+      '32BF'::text, 0.0::float8, NULL::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01,
+  POINT(2.5 1.5)@2001-01-02}', r)::text AS sampled_in_3857
+FROM rast;
+                    sampled_in_3857                     
+--------------------------------------------------------
+ {50@2001-01-01 00:00:00+00, 60@2001-01-02 00:00:00+00}
+(1 row)
+
+WITH plain AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 3857),
+      '32BF'::text, 0.0::float8, NULL::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+), skewed AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 1.0, 0.0, 3857),
+      '32BF'::text, 0.0::float8, NULL::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01,
+    POINT(2.5 1.5)@2001-01-02}', (SELECT r FROM plain))::text AS plain_values,
+  rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01,
+    POINT(2.5 1.5)@2001-01-02}', (SELECT r FROM skewed))::text AS skewed_values;
+                      plain_values                      |                     skewed_values                      
+--------------------------------------------------------+--------------------------------------------------------
+ {50@2001-01-01 00:00:00+00, 60@2001-01-02 00:00:00+00} | {40@2001-01-01 00:00:00+00, 50@2001-01-02 00:00:00+00}
+(1 row)
+
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
       ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
       '32BF'::text, 0.0::float8, NULL::float8
     ),

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -224,6 +224,56 @@ WITH rast AS (
 SELECT rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01}', r)
 FROM rast;
 
+-- The sampling reads the grid the geotransform states, in whatever reference
+-- system the pair agrees on: the same raster shape in EPSG:3857 answers what it
+-- answers in EPSG:4326, so nothing in the walk assumes lon/lat.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 3857),
+      '32BF'::text, 0.0::float8, NULL::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01,
+  POINT(2.5 1.5)@2001-01-02}', r)::text AS sampled_in_3857
+FROM rast;
+
+-- A skewed grid is a different grid: the same two positions fall in different
+-- pixels once the geotransform carries a skew, so this cannot pass by reading
+-- the unskewed answer. The two rows below are the refuting pair.
+WITH plain AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 3857),
+      '32BF'::text, 0.0::float8, NULL::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+), skewed AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 1.0, 0.0, 3857),
+      '32BF'::text, 0.0::float8, NULL::float8
+    ),
+    1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]
+  ) AS r
+)
+SELECT rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01,
+    POINT(2.5 1.5)@2001-01-02}', (SELECT r FROM plain))::text AS plain_values,
+  rasterValue(tgeompoint 'SRID=3857;{POINT(1.5 1.5)@2001-01-01,
+    POINT(2.5 1.5)@2001-01-02}', (SELECT r FROM skewed))::text AS skewed_values;
+
 -------------------------------------------------------------------------------
 -- atRasterValue / minusRasterValue / eRasterValue / aRasterValue
 -------------------------------------------------------------------------------


### PR DESCRIPTION
The sampling suite reads one grid shape: of its ST_MakeEmptyRaster fixtures all
but one stand in EPSG:4326 and every one carries zero skew, so a walk that
assumed lon/lat, or one that dropped the skew terms of the inverse
geotransform, would leave the suite green.

Two cases close that. The first samples a raster and a trajectory that agree on
EPSG:3857 and reads {50, 60}, the values the same grid shape answers in 4326,
so nothing in the walk is bound to lon/lat. The second reads one trajectory
against an unskewed grid and against its skew-one twin: {50, 60} against
{40, 50}. Both instants move, because a skew of one unit sends the position
(x, y) to the pixel at row 3 - y and column x + y - 3 rather than to the pixel
at row 3 - y and column x, so neither answer can be produced by reading the
other grid.

The mixed-SRID case the suite already carries states the third axis, that a
raster and a trajectory in different systems are an error rather than an empty
answer, and needs nothing added.

