### PR TITLE
Answer -1 where a function that counts has no count

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -1597,13 +1597,13 @@ geo_pointarr(const GSERIALIZED *gs, int *count)
  * @brief Return the number of points of a geometry
  * @param[in] gs Geometry/geography
  * @note PostGIS function: @p ST_Points(PG_FUNCTION_ARGS)
- * @return On error return INT_MAX
+ * @return On error return -1
  */
 int
 geo_num_points(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, INT_MAX);
+  VALIDATE_NOT_NULL(gs, -1);
 
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
   int npoints = lwgeom_count_vertices(lwgeom);
@@ -1616,13 +1616,13 @@ geo_num_points(const GSERIALIZED *gs)
  * @brief Return the number of composing geometries of a geometry
  * @param[in] gs Geometry/geography
  * @note PostGIS function: @p LWGEOM_numgeometries_collection(PG_FUNCTION_ARGS)
- * @return On error return INT_MAX
+ * @return On error return -1
  */
 int
 geo_num_geos(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, INT_MAX);
+  VALIDATE_NOT_NULL(gs, -1);
 
   int result = 0;
   LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
@@ -5780,13 +5780,13 @@ line_point_n(const GSERIALIZED *gs, int n)
  * @ingroup meos_geo_base_accessor
  * @brief Return the number of points of a line
  * @param[in] gs Geometry
- * @return On error return INT_MAX
+ * @return On error return -1
 */
 int
 line_numpoints(const GSERIALIZED *gs)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(gs, INT_MAX);
+  VALIDATE_NOT_NULL(gs, -1);
 
   LWGEOM *geom = lwgeom_from_gserialized(gs);
   int count = -1;

--- a/meos/src/pose/posechain.c
+++ b/meos/src/pose/posechain.c
@@ -674,14 +674,14 @@ posechain_to_point(const PoseChain *pc)
  * @ingroup meos_posechain_base_accessor
  * @brief Return the number of links of a pose chain
  * @param[in] pc Pose chain
- * @return On error return @p INT_MAX
+ * @return On error return -1
  * @csqlfn #Posechain_num_poses()
  */
 int
 posechain_num_poses(const PoseChain *pc)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(pc, INT_MAX);
+  VALIDATE_NOT_NULL(pc, -1);
   return pc->count;
 }
 

--- a/meos/src/pose/tposechain.c
+++ b/meos/src/pose/tposechain.c
@@ -395,14 +395,14 @@ tposechain_to_tpose(const Temporal *temp)
  * @details The link count is the same at every instant, so one instant
  * answers for the whole value.
  * @param[in] temp Temporal pose chain
- * @return On error return @p INT_MAX
+ * @return On error return -1
  * @csqlfn #Tposechain_num_poses()
  */
 int
 tposechain_num_poses(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TPOSECHAIN(temp, INT_MAX);
+  VALIDATE_TPOSECHAIN(temp, -1);
   const TInstant *inst = temporal_start_inst(temp);
   return posechain_num_poses(DatumGetPoseChainP(tinstant_value_p(inst)));
 }

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -309,14 +309,14 @@ raster_band_of(const Raster *rast, int band, rt_raster *raster)
  * @ingroup meos_raster_base_accessor
  * @brief Return the number of bands of a raster
  * @param[in] rast Raster
- * @return On error, return -1
+ * @return On error return -1
  * @csqlfn #Raster_num_bands()
  */
 int
 raster_num_bands(const Raster *rast)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rast, INT_MAX);
+  VALIDATE_NOT_NULL(rast, -1);
   rt_raster raster = raster_header(rast);
   if (! raster)
     return -1;

--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -669,7 +669,7 @@ set_mem_size(const Set *s)
 /**
  * @ingroup meos_setspan_accessor
  * @brief Return the number of values of a set
- * @return On error return INT_MAX
+ * @return On error return -1
  * @param[in] s Set
  * @csqlfn #Set_num_values()
  */
@@ -677,7 +677,7 @@ int
 set_num_values(const Set *s)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(s, INT_MAX);
+  VALIDATE_NOT_NULL(s, -1);
   return s->count;
 }
 

--- a/meos/src/temporal/spanset.c
+++ b/meos/src/temporal/spanset.c
@@ -684,14 +684,14 @@ tstzspanset_duration(const SpanSet *ss, bool boundspan)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of dates of a span set
  * @param[in] ss Span set
- * @return On error return INT_MAX
+ * @return On error return -1
  * @csqlfn #Datespanset_num_dates()
  */
 int
 datespanset_num_dates(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_DATESPANSET(ss, INT_MAX);
+  VALIDATE_DATESPANSET(ss, -1);
   /* Date span sets are always canonicalized */
   return ss->count * 2;
 }
@@ -782,14 +782,14 @@ datespanset_dates(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of timestamps of a span set
  * @param[in] ss Span set
- * @return On error return INT_MAX
+ * @return On error return -1
  * @csqlfn #Tstzspanset_num_timestamps()
  */
 int
 tstzspanset_num_timestamps(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_TSTZSPANSET(ss, INT_MAX);
+  VALIDATE_TSTZSPANSET(ss, -1);
 
   const Span *s = SPANSET_SP_N(ss, 0);
   Datum prev = s->lower;
@@ -942,14 +942,14 @@ tstzspanset_timestamps(const SpanSet *ss)
  * @ingroup meos_setspan_accessor
  * @brief Return the number of spans of a span set
  * @param[in] ss Span set
- * @return On error return INT_MAX
+ * @return On error return -1
  * @csqlfn #Spanset_num_spans()
  */
 int
 spanset_num_spans(const SpanSet *ss)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(ss, INT_MAX);
+  VALIDATE_NOT_NULL(ss, -1);
   return ss->count;
 }
 

--- a/meos/src/temporal/temporal.c
+++ b/meos/src/temporal/temporal.c
@@ -2491,14 +2491,14 @@ temporal_duration(const Temporal *temp, bool boundspan)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of sequences of a temporal sequence (set)
  * @param[in] temp Temporal value
- * @return On error return INT_MAX
+ * @return On error return -1
  * @csqlfn #Temporal_num_sequences()
  */
 int
 temporal_num_sequences(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, INT_MAX);
+  VALIDATE_NOT_NULL(temp, -1);
   if (! ensure_continuous_interp(temp))
     return -1;
   return (temp->subtype == TSEQUENCE) ? 1 : ((TSequenceSet *) temp)->count;
@@ -2716,14 +2716,14 @@ temporal_upper_inc(const Temporal *temp)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of distinct instants of a temporal value
  * @param[in] temp Temporal value
- * @return On error return INT_MAX
+ * @return On error return -1
  * @csqlfn #Temporal_num_instants()
  */
 int
 temporal_num_instants(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, INT_MAX);
+  VALIDATE_NOT_NULL(temp, -1);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)
@@ -2924,14 +2924,14 @@ temporal_instants(const Temporal *temp, int *count)
  * @ingroup meos_temporal_accessor
  * @brief Return the number of distinct timestamps of a temporal value
  * @param[in] temp Temporal value
- * @return On error return INT_MAX
+ * @return On error return -1
  * @csqlfn #Temporal_num_timestamps()
  */
 int
 temporal_num_timestamps(const Temporal *temp)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(temp, INT_MAX);
+  VALIDATE_NOT_NULL(temp, -1);
 
   assert(temptype_subtype(temp->subtype));
   switch (temp->subtype)

--- a/meos/src/temporal/temporal_rtree.c
+++ b/meos/src/temporal/temporal_rtree.c
@@ -1556,10 +1556,10 @@ rtree_search(const RTree *rtree, IndexSearchOp op, const void *query,
   MeosArray *result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rtree, INT_MAX); VALIDATE_NOT_NULL(query, INT_MAX);
-  VALIDATE_NOT_NULL(result, INT_MAX);
+  VALIDATE_NOT_NULL(rtree, -1); VALIDATE_NOT_NULL(query, -1);
+  VALIDATE_NOT_NULL(result, -1);
   if (! ensure_valid_rtree_box(rtree, query))
-    return INT_MAX;
+    return -1;
 
   meos_array_reset(result);
   if (rtree->root)
@@ -1586,18 +1586,18 @@ rtree_search(const RTree *rtree, IndexSearchOp op, const void *query,
  * @param[out] result MeosArray of int to collect the ids (created by the caller
  * with `meos_array_create(sizeof(int64))`)
  * @return Number of qualifying pairs, half the number of collected ids, on
- * error @p INT_MAX
+ * error -1
  */
 int
 rtree_join(const RTree *rtree1, const RTree *rtree2, IndexSearchOp op,
   MeosArray *result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rtree1, INT_MAX); VALIDATE_NOT_NULL(rtree2, INT_MAX);
-  VALIDATE_NOT_NULL(result, INT_MAX);
+  VALIDATE_NOT_NULL(rtree1, -1); VALIDATE_NOT_NULL(rtree2, -1);
+  VALIDATE_NOT_NULL(result, -1);
   if (! ensure_same_index_bboxtype(rtree1->bboxtype, rtree2->bboxtype) ||
       ! ensure_valid_rtree_rtree(rtree1, rtree2) || ! ensure_index_join_op(op))
-    return INT_MAX;
+    return -1;
 
   meos_array_reset(result);
   if (rtree1->root && rtree2->root)
@@ -2119,13 +2119,13 @@ node_stats(const RTreeNode *node, size_t bboxsize, int level, int *entries,
  * @ingroup meos_temporal_box_index
  * @brief Return the number of entries an RTree holds
  * @param[in] rtree The RTree
- * @return On error return @p INT_MAX
+ * @return On error return -1
  */
 int
 rtree_num_entries(const RTree *rtree)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rtree, INT_MAX);
+  VALIDATE_NOT_NULL(rtree, -1);
   if (! rtree->root)
     return 0;
   int entries = 0, height = 0;
@@ -2161,13 +2161,13 @@ rtree_mem_size(const RTree *rtree)
  * @brief Return the number of levels an RTree holds
  * @details An empty tree has no levels and a tree whose root is a leaf has one
  * @param[in] rtree The RTree
- * @return On error return @p INT_MAX
+ * @return On error return -1
  */
 int
 rtree_height(const RTree *rtree)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rtree, INT_MAX);
+  VALIDATE_NOT_NULL(rtree, -1);
   if (! rtree->root)
     return 0;
   int entries = 0, height = 0;

--- a/meos/src/temporal/temporal_sptree.c
+++ b/meos/src/temporal/temporal_sptree.c
@@ -1095,10 +1095,10 @@ sptree_search(const SPTree *sptree, IndexSearchOp op, const void *query,
   MeosArray *result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(sptree, INT_MAX); VALIDATE_NOT_NULL(query, INT_MAX);
-  VALIDATE_NOT_NULL(result, INT_MAX);
+  VALIDATE_NOT_NULL(sptree, -1); VALIDATE_NOT_NULL(query, -1);
+  VALIDATE_NOT_NULL(result, -1);
   if (! ensure_valid_sptree_box(sptree, query))
-    return INT_MAX;
+    return -1;
 
   /* Project the query box into the internal box type (TPCBox: STBox) */
   bboxunion proj;
@@ -1211,19 +1211,19 @@ spnode_join(const SPTree *sptree1, const SPNode *node1, const SPTree *sptree2,
  * @param[out] result MeosArray of int64 to collect the ids (created by the
  * caller with `meos_array_create(sizeof(int64))`)
  * @return Number of qualifying pairs, half the number of collected ids, on
- * error @p INT_MAX
+ * error -1
  */
 int
 sptree_join(const SPTree *sptree1, const SPTree *sptree2, IndexSearchOp op,
   MeosArray *result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(sptree1, INT_MAX); VALIDATE_NOT_NULL(sptree2, INT_MAX);
-  VALIDATE_NOT_NULL(result, INT_MAX);
+  VALIDATE_NOT_NULL(sptree1, -1); VALIDATE_NOT_NULL(sptree2, -1);
+  VALIDATE_NOT_NULL(result, -1);
   if (! ensure_same_index_bboxtype(sptree1->bboxtype, sptree2->bboxtype) ||
       ! ensure_valid_sptree_sptree(sptree1, sptree2) ||
       ! ensure_index_join_op(op))
-    return INT_MAX;
+    return -1;
 
   meos_array_reset(result);
   if (sptree1->root && sptree2->root)
@@ -1520,13 +1520,13 @@ spnode_stats(const SPTree *sptree, const SPNode *node, int level, int *entries,
  * @ingroup meos_temporal_box_index
  * @brief Return the number of entries an SPTree holds
  * @param[in] sptree The SPTree
- * @return On error return @p INT_MAX
+ * @return On error return -1
  */
 int
 sptree_num_entries(const SPTree *sptree)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(sptree, INT_MAX);
+  VALIDATE_NOT_NULL(sptree, -1);
   int entries = 0, height = 0;
   int64 bytes = 0;
   spnode_stats(sptree, sptree->root, 1, &entries, &bytes, &height);
@@ -1557,13 +1557,13 @@ sptree_mem_size(const SPTree *sptree)
  * @brief Return the number of levels an SPTree holds
  * @details An empty tree has no levels and a tree of one entry has one
  * @param[in] sptree The SPTree
- * @return On error return @p INT_MAX
+ * @return On error return -1
  */
 int
 sptree_height(const SPTree *sptree)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(sptree, INT_MAX);
+  VALIDATE_NOT_NULL(sptree, -1);
   int entries = 0, height = 0;
   int64 bytes = 0;
   spnode_stats(sptree, sptree->root, 1, &entries, &bytes, &height);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -462,9 +462,8 @@ int main(void)
   /* A line clipped by a surface reads the surface's edges out of an R-tree
    * once there are enough of them to index, and that index only answers a
    * query carrying the SRID its own entries carry. Where the query states a
-   * different one the search reports INT_MAX rather than a count, and a
-   * caller reading that as a count walks the result array two billion entries
-   * past its end.
+   * different one the search reports -1 rather than a count, which a loop
+   * bounded by the answer does not enter at all.
    * The record below is that case at its smallest: an arc clipped by a
    * polygon of 200 sides, both carrying a projected SRID, which is the shape
    * a real projected corpus takes. The answer is the SAME geometry the pair

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -208,7 +208,7 @@ int main(void)
   assert(raster_from_hexwkb(NULL) == NULL);
   assert(meos_errno() != 0);
   meos_errno_reset();
-  assert(raster_num_bands(NULL) == INT_MAX);
+  assert(raster_num_bands(NULL) == -1);
   assert(meos_errno() != 0);
   meos_errno_reset();
   assert(raster_width(NULL) == INT_MAX);

--- a/meos/test/sptree_join_test.c
+++ b/meos/test/sptree_join_test.c
@@ -381,19 +381,19 @@ test_refused(void)
 
   meos_errno_reset();
   check("indexes of different bounding box types are refused",
-    sptree_join(stboxtree, tboxtree, INDEX_OVERLAPS, result) == INT_MAX &&
+    sptree_join(stboxtree, tboxtree, INDEX_OVERLAPS, result) == -1 &&
     meos_errno() != 0);
 
   /* A join prunes a pair of subtrees on the overlap of what they cover, which
    * is exactly what the entries an ordering operation pairs do not do */
   meos_errno_reset();
   check("an operation ordering a dimension is refused",
-    sptree_join(stboxtree, other, INDEX_LEFT, result) == INT_MAX &&
+    sptree_join(stboxtree, other, INDEX_LEFT, result) == -1 &&
     meos_errno() != 0);
 
   meos_errno_reset();
   check("a null index is refused",
-    sptree_join(NULL, other, INDEX_OVERLAPS, result) == INT_MAX &&
+    sptree_join(NULL, other, INDEX_OVERLAPS, result) == -1 &&
     meos_errno() != 0);
 
   /* The R-tree answers the same operations, so it refuses the same ones */
@@ -403,11 +403,11 @@ test_refused(void)
   rtree_insert(rtree2, box, 1);
   meos_errno_reset();
   check("the R-tree refuses an operation ordering a dimension",
-    rtree_join(rtree1, rtree2, INDEX_LEFT, result) == INT_MAX &&
+    rtree_join(rtree1, rtree2, INDEX_LEFT, result) == -1 &&
     meos_errno() != 0);
   meos_errno_reset();
   check("the R-tree refuses a null index",
-    rtree_join(rtree1, NULL, INDEX_OVERLAPS, result) == INT_MAX &&
+    rtree_join(rtree1, NULL, INDEX_OVERLAPS, result) == -1 &&
     meos_errno() != 0);
 
   /* A join reads a box of one index against a box of the other, which is the
@@ -430,12 +430,12 @@ test_refused(void)
 
   meos_errno_reset();
   check("indexes of different SRIDs are refused",
-    sptree_join(sp4326, sp3857, INDEX_OVERLAPS, result) == INT_MAX &&
+    sptree_join(sp4326, sp3857, INDEX_OVERLAPS, result) == -1 &&
     meos_errno() != 0);
 
   meos_errno_reset();
   check("the R-tree refuses indexes of different SRIDs",
-    rtree_join(rt4326, rt3857, INDEX_OVERLAPS, result) == INT_MAX &&
+    rtree_join(rt4326, rt3857, INDEX_OVERLAPS, result) == -1 &&
     meos_errno() != 0);
 
   /* The SRID is what the refusal reads and not the pair: the same two boxes

--- a/meos/test/sptree_test.c
+++ b/meos/test/sptree_test.c
@@ -1058,7 +1058,7 @@ test_reported_size(SPTreeKind kind, const char *kindname)
   int count = sptree_search(none, INDEX_OVERLAPS, query, result);
   snprintf(name, sizeof(name), "%s empty answers 0, not the error sentinel",
     kindname);
-  check(name, count == 0 && count != INT_MAX);
+  check(name, count == 0 && count != -1);
   snprintf(name, sizeof(name), "%s empty holds no entry", kindname);
   check(name, sptree_num_entries(none) == 0);
 

--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -79,6 +79,16 @@ PREDICATE_DOC = re.compile(r"@brief Return true if|@return\s+1 if")
 # says the value is not located there, which is an answer and not a failure,
 # and it is already outside the fractions it otherwise returns.
 LOCATOR = re.compile(r"locate")
+# A count answers how many of something there are, so its domain is the
+# non-negative integers and the maximum sits INSIDE it: a tree of INT_MAX
+# entries is a count, not a failure, and a caller cannot tell the two apart.
+# -1 is outside that domain, which is what the rule actually asks for -- the
+# same argument the predicates, the locators and the box distance below make.
+# The documented contract decides rather than the name, a count being spelled
+# num_bands, numpoints, num_entries and search alike. It is stated in the brief
+# for an accessor and in the return line for a search, which collects into an
+# out-parameter and answers how many it collected.
+COUNT_DOC = re.compile(r"@(?:brief|return)\s+[^\n]*\bnumber of\b", re.I)
 # A nearest approach distance between two temporal boxes answers with the
 # maximum where the boxes share no time, which is an ANSWER and not a failure.
 # The maximum is therefore inside its value domain and cannot also mean error,
@@ -158,6 +168,8 @@ def scan(path: Path, rel: str) -> list[tuple[str, str]]:
             k += 1
         if want == "INT_MAX" and (PREDICATE.match(name) or
                                   PREDICATE_DOC.search("\n".join(doc))):
+            want = "-1"
+        if want == "INT_MAX" and COUNT_DOC.search("\n".join(doc)):
             want = "-1"
         if want == "DBL_MAX" and LOCATOR.search(name):
             want = "-1.0"


### PR DESCRIPTION
The rule is that an error sentinel lies outside the function's value domain,
which is the argument check_error_sentinels.py already writes for the
three-valued predicates, for the locators and for nad_tbox: a value the function
can legitimately answer cannot also mean failure. A count's domain is the
non-negative integers, so INT_MAX sits inside it while -1 sits outside, and the
twenty-one functions that answer a count now answer -1. The checker carries that
class beside the three it already states, so the tree cannot drift back.

Witness: rtree_search collects matching ids into an array the caller owns and
answers how many it collected, so a caller loops to the answer.
meos/test/geo_test.c already records what INT_MAX costs there, a query whose
SRID differs from the index's "reports INT_MAX rather than a count, and a caller
reading that as a count walks the result array two billion entries past its
end"; the same loop bounded by -1 is never entered. line_numpoints carried the
disagreement inside one function, validating a null geometry with INT_MAX and
then answering -1 for a geometry that is not a linestring, so it stated two error
values at once and a caller could test for neither.

Measured on master f98506c858: the checker carrying the new class convicts
unmodified master on 37 findings across those twenty-one functions and exits 0
here. No caller in meos/src or mobilitydb/src reads any of them against a
sentinel, the twenty-one names against INT_MAX, == -1 and < 0 returning nothing
over a control of 11 call sites for temporal_num_instants alone. Nine assertions
in meos/test move with the contract, while raster_width and raster_height keep
INT_MAX, an extent in pixels being no count.

