### PR TITLE
Answer an overlay with a multi-part geometry from its parts

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2365,6 +2365,200 @@ geom_areal_meeting(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 }
 
 /**
+ * @brief Return true if a geometry is one built of parts, which the overlay
+ * can answer a part at a time
+ * @details Every one of these is an @p LWCOLLECTION under the type tag, so the
+ * parts are read the same way whichever it is. A MULTIPOLYGON and the
+ * GEOMETRYCOLLECTION holding the same members are two spellings of one point
+ * set, and answering only one of them a part at a time is what would make the
+ * two disagree
+ */
+static bool
+geo_is_multi(const GSERIALIZED *gs)
+{
+  assert(gs);
+  uint32_t type = gserialized_get_type(gs);
+  return type == MULTIPOINTTYPE || type == MULTILINETYPE ||
+    type == MULTIPOLYGONTYPE || type == MULTICURVETYPE ||
+    type == MULTISURFACETYPE || type == COLLECTIONTYPE;
+}
+
+/**
+ * @brief Return the parts of a multi-part geometry, or NULL where the geometry
+ * is not one or holds nothing
+ * @param[in] gs Geometry
+ * @param[out] count Number of parts
+ */
+static GSERIALIZED **
+geo_collection_components(const GSERIALIZED *gs, int *count)
+{
+  assert(gs); assert(count);
+  *count = 0;
+  if (! geo_is_multi(gs))
+    return NULL;
+  LWGEOM *lwgeom = lwgeom_from_gserialized(gs);
+  const LWCOLLECTION *col = (const LWCOLLECTION *) lwgeom;
+  if (col->ngeoms == 0)
+  {
+    lwgeom_free(lwgeom);
+    return NULL;
+  }
+  GSERIALIZED **result = palloc(sizeof(GSERIALIZED *) * col->ngeoms);
+  for (uint32_t i = 0; i < col->ngeoms; i++)
+    result[i] = geo_serialize(col->geoms[i]);
+  *count = (int) col->ngeoms;
+  lwgeom_free(lwgeom);
+  return result;
+}
+
+/**
+ * @brief Free an array of geometries and the array itself
+ */
+static void
+geo_free_array(GSERIALIZED **gsarr, int count)
+{
+  for (int i = 0; i < count; i++)
+    if (gsarr[i])
+      pfree(gsarr[i]);
+  pfree(gsarr);
+  return;
+}
+
+/**
+ * @brief Return the union of the pieces an overlay leaves
+ * @details An empty piece contributes nothing, exactly as the empty set
+ * contributes nothing to a union, and no piece at all leaves the empty
+ * geometry rather than an absent answer.
+ * The union is the GENERAL one rather than #geom_array_mixed_union, which
+ * answers only an array SPANNING the areal boundary and returns NULL for one
+ * that stays on a single side -- an array of surfaces being exactly that
+ * @param[in] parts,nparts The pieces, of which this takes ownership
+ * @param[in] srid SRID the empty answer carries
+ */
+static GSERIALIZED *
+geo_union_parts(GSERIALIZED **parts, int nparts, int32_t srid)
+{
+  GSERIALIZED *result;
+  if (nparts == 0)
+    result = geo_serialize((LWGEOM *) lwcollection_construct_empty(
+      COLLECTIONTYPE, srid, 0, 0));
+  else if (nparts == 1)
+    result = geo_copy(parts[0]);
+  else
+    result = geom_array_union(parts, nparts);
+  geo_free_array(parts, nparts);
+  return result;
+}
+
+/**
+ * @brief Return an overlay of two geometries where one is a collection,
+ * answered from the overlays of its components, or NULL where that route does
+ * not apply
+ * @details A collection's topology is that of the UNION of its components --
+ * which is how #relate_extract_edges already reads one for the matrix -- and
+ * both overlay operations follow from that union rather than needing a kernel
+ * of their own:
+ * @code
+ *   A n (c1 u ... u cn) = (A n c1) u ... u (A n cn)
+ *   (c1 u ... u cn) \ B = (c1 \ B) u ... u (cn \ B)
+ *   A \ (c1 u ... u cn) = ((A \ c1) \ c2) ... \ cn
+ * @endcode
+ * Every per-component call re-enters the routes above, so a component the
+ * engine answers natively stays native and a nested collection is stripped one
+ * level per call. Nothing here reads a coordinate: the composition is the set
+ * identity, and the geometry is left to the kernels that already answer it.
+ * A COMPONENT THE ENGINE CANNOT ANSWER RETURNS NULL, and a composition that
+ * simply dropped it would answer a SMALLER set than the operands hold -- the
+ * silent wrong answer this route must not produce. The composition is
+ * abandoned in that case, leaving the caller to answer as it did before
+ * @param[in] gs1,gs2 Geometries
+ * @param[in] inter True for the intersection, false for the difference
+ */
+static GSERIALIZED *
+geo_collection_overlay(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
+  bool inter)
+{
+  assert(gs1); assert(gs2);
+  int ncomp;
+  int32_t srid = gserialized_get_srid(gs1);
+
+  if (! inter)
+  {
+    /* The difference takes its SUBJECT apart, so a collection there splits
+     * first: what each component keeps is independent of the others */
+    GSERIALIZED **comps = geo_collection_components(gs1, &ncomp);
+    if (comps)
+    {
+      GSERIALIZED **parts = palloc(sizeof(GSERIALIZED *) * ncomp);
+      int nparts = 0;
+      bool declined = false;
+      for (int i = 0; i < ncomp && ! declined; i++)
+      {
+        GSERIALIZED *part = geom_difference2d(comps[i], gs2);
+        if (! part)
+          declined = true;
+        else if (geo_is_empty(part))
+          pfree(part);
+        else
+          parts[nparts++] = part;
+      }
+      geo_free_array(comps, ncomp);
+      if (declined)
+      {
+        geo_free_array(parts, nparts);
+        return NULL;
+      }
+      return geo_union_parts(parts, nparts, srid);
+    }
+    /* A collection CLIP is removed one component at a time */
+    comps = geo_collection_components(gs2, &ncomp);
+    if (! comps)
+      return NULL;
+    GSERIALIZED *result = geo_copy(gs1);
+    for (int i = 0; i < ncomp && result; i++)
+    {
+      GSERIALIZED *next = geom_difference2d(result, comps[i]);
+      pfree(result);
+      result = next;
+    }
+    geo_free_array(comps, ncomp);
+    return result;
+  }
+
+  /* The intersection is symmetric, so whichever operand is a collection
+   * splits and the other is read whole against each component */
+  const GSERIALIZED *other = gs1;
+  GSERIALIZED **comps = geo_collection_components(gs2, &ncomp);
+  if (! comps)
+  {
+    comps = geo_collection_components(gs1, &ncomp);
+    other = gs2;
+  }
+  if (! comps)
+    return NULL;
+  GSERIALIZED **parts = palloc(sizeof(GSERIALIZED *) * ncomp);
+  int nparts = 0;
+  bool declined = false;
+  for (int i = 0; i < ncomp && ! declined; i++)
+  {
+    GSERIALIZED *part = geom_intersection2d(other, comps[i]);
+    if (! part)
+      declined = true;
+    else if (geo_is_empty(part))
+      pfree(part);
+    else
+      parts[nparts++] = part;
+  }
+  geo_free_array(comps, ncomp);
+  if (declined)
+  {
+    geo_free_array(parts, nparts);
+    return NULL;
+  }
+  return geo_union_parts(parts, nparts, srid);
+}
+
+/**
  * @ingroup meos_geo_base_spatial
  * @brief Return the intersection of two geometries
  * @param[in] gs1,gs2 Geometries
@@ -2451,6 +2645,17 @@ geom_intersection2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
       return result;
   }
 
+  /* A MULTI-PART geometry is the union of its parts, so what the overlay shares
+   * of it follows from what it shares of them. This sits BELOW the routes above on
+   * purpose: a collection those already answer keeps the answer it had, and
+   * only one that would otherwise reach the library is taken apart */
+  if (geo_is_multi(gs1) || geo_is_multi(gs2))
+  {
+    GSERIALIZED *collresult = geo_collection_overlay(gs1, gs2, true);
+    if (collresult)
+      return collresult;
+  }
+
 #if GEOS
   /* Other types fall through to GEOS */
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
@@ -2535,6 +2740,17 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
     lwgeom_free(geom1); lwgeom_free(geom2);
     if (result)
       return result;
+  }
+
+  /* A MULTI-PART geometry is the union of its parts, so what the overlay leaves
+   * of it follows from what it leaves of them. This sits BELOW the routes above on
+   * purpose: a collection those already answer keeps the answer it had, and
+   * only one that would otherwise reach the library is taken apart */
+  if (geo_is_multi(gs1) || geo_is_multi(gs2))
+  {
+    GSERIALIZED *collresult = geo_collection_overlay(gs1, gs2, false);
+    if (collresult)
+      return collresult;
   }
 
 #if GEOS

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -526,6 +526,44 @@ int main(void)
   free(pip_wkt);
   meos_errno_reset();
 
+  /* A GEOMETRYCOLLECTION is the union of its components, so what it shares
+   * with another geometry is the union of what the components share. The
+   * overlay reads it that way now, which is how the matrix has always read a
+   * collection.
+   * The record below is the case the previous route could not answer at all:
+   * a square meeting a collection whose two components OVERLAP each other.
+   * The square [2,6]x[2,6] shares [2,4]x[2,4] with the first component and
+   * [3,6]x[3,6] with the second, and those two share [3,4]x[3,4], so what it
+   * shares with the collection has area 4 + 9 - 1 = 12 and what remains of it
+   * is 16 - 12 = 4. The closed form is the oracle; the previous route answered
+   * NULL, and with errno 0, so the absence was not even reported */
+  const char *coll_subject = "POLYGON((2 2,6 2,6 6,2 6,2 2))";
+  const char *coll_clip = "GEOMETRYCOLLECTION("
+    "POLYGON((0 0,4 0,4 4,0 4,0 0)),POLYGON((3 3,8 3,8 8,3 8,3 3)))";
+  GSERIALIZED *coll_geo_a = geom_in(coll_subject, -1);
+  GSERIALIZED *coll_geo_b = geom_in(coll_clip, -1);
+  assert(coll_geo_a != NULL);
+  assert(coll_geo_b != NULL);
+  meos_errno_reset();
+  GSERIALIZED *coll_inter = geom_intersection2d(coll_geo_a, coll_geo_b);
+  printf("geom_intersection2d(a square, a collection whose parts overlap): "
+    "%s, area %.6f, errno %d\n", coll_inter ? "answered" : "NULL",
+    coll_inter ? geom_area(coll_inter) : -1.0, meos_errno());
+  assert(coll_inter != NULL);
+  assert(fabs(geom_area(coll_inter) - 12.0) < 1e-9);
+  assert(meos_errno() == 0);
+  meos_errno_reset();
+  GSERIALIZED *coll_diff = geom_difference2d(coll_geo_a, coll_geo_b);
+  printf("geom_difference2d(a square, a collection whose parts overlap): "
+    "%s, area %.6f, errno %d\n", coll_diff ? "answered" : "NULL",
+    coll_diff ? geom_area(coll_diff) : -1.0, meos_errno());
+  assert(coll_diff != NULL);
+  assert(fabs(geom_area(coll_diff) - 4.0) < 1e-9);
+  assert(meos_errno() == 0);
+  free(coll_inter); free(coll_diff);
+  free(coll_geo_a); free(coll_geo_b);
+  meos_errno_reset();
+
   /* Two areas whose boundaries run PARALLEL never touch, however close they
    * come. Deciding that means asking whether the two lines are one line, and
    * the engine answers it from the cross product of the offset between them


### PR DESCRIPTION
WITNESS. A square meeting a collection whose two components OVERLAP each
other:

```
  A = POLYGON((2 2,6 2,6 6,2 6,2 2))
  B = GEOMETRYCOLLECTION(POLYGON((0 0,4 0,4 4,0 4,0 0)),
                         POLYGON((3 3,8 3,8 8,3 8,3 3)))

  before   geom_intersection2d(A,B) = NULL, errno 0
  after    geom_intersection2d(A,B)   area 12
  before   geom_difference2d(A,B)   = NULL, errno 0
  after    geom_difference2d(A,B)     area 4
```

The closed form is the oracle and needs no reference engine: A shares
[2,4]x[2,4] with the first component and [3,6]x[3,6] with the second, those two
share [3,4]x[3,4], so what A shares with the collection is 4 + 9 - 1 = 12 and
what remains of A is 16 - 12 = 4.
The previous answer is worth stating plainly: NULL with errno 0. Not an error a
caller could notice, an absence returned as though it were an answer.

WHY. A multi-part geometry -- a MULTIPOINT, MULTILINESTRING, MULTIPOLYGON,
MULTICURVE, MULTISURFACE or GEOMETRYCOLLECTION -- is the UNION of its parts,
which is how relate_extract_edges already reads a collection for the matrix. Both overlay
operations follow from that union rather than needing a kernel of their own:

    A n (c1 u ... u cn) = (A n c1) u ... u (A n cn)
    (c1 u ... u cn) \ B = (c1 \ B) u ... u (cn \ B)
    A \ (c1 u ... u cn) = ((A \ c1) \ c2) ... \ cn

Every per-component call re-enters the routes above it, so a component the
engine answers natively stays native and a nested collection is stripped one
level per call. Nothing in the composition reads a coordinate: it is the set
identity, and the geometry stays with the kernels that already answer it.

TWO THINGS IT DELIBERATELY REFUSES TO DO. A component the engine cannot answer
returns NULL, and a composition that simply dropped it would answer a SMALLER
set than the operands hold -- a silent wrong answer in place of a visible
decline. The composition is abandoned there instead, leaving the caller to
answer as it did before. And the union it hands its pieces to is the general
one rather than geom_array_mixed_union, which by contract answers only an array
SPANNING the areal boundary and returns NULL for one that stays on a single
side, which an array of surfaces is.

IT SITS BELOW THE NATIVE ROUTES, NOT ABOVE THEM, and that placement is load
bearing rather than incidental. Above them it also intercepts collections those
routes already answer, and changes the order their members come back in: an arc
clipped by a collection reads its two pieces in the opposite order, same points
and same lengths, for no gain at all. Below them, a collection those routes
answer keeps the answer it had, and only one that would otherwise reach the
library is taken apart.

MEASURED, and what did NOT move.

```
  geo_pairs                         12880 rows   0 answers differ
  areal_pairs                        1444 rows   0 answers differ
  adversarial_pairs                    54 rows   0 answers differ
  the overlay's GEOS fall-through, adversarial_pairs
      before                         10, EVERY one a collection
      after                           0
  the same census on geo_pairs      120 before, 120 after, and 0 of them
                                    carry a collection on either side
  meos/test/geo_test.c                          passes; the witness above
                                                fails on the previous code
```

The corpora hold no such pair the overlay reaches, so their zero says only that
nothing else moved. The fall-through census is what shows the class closing,
and the constructed witness is what shows an answer arriving where there was
none.

TWO PRINTED ANSWERS DO MOVE, and they are the reason this takes EVERY
multi-part geometry rather than the collection alone. The suite carries one
point set spelled BOTH ways -- as a MULTIPOLYGON and as the
GEOMETRYCOLLECTION of the same members -- and asserts they answer alike; its
own comment names answering one point set two ways as the thing to avoid. Both
spellings reach the library today and come back in its normalised ring. Taking
apart only the collection would answer that one from its parts and leave the
other with the library, so the two would disagree -- so both are taken apart,
and both now come back in the ring the INPUT carries. Same point set, same
area, and the two spellings agree before and after.

The relate engine met the same narrowness and took the same widening: its
collection arm read only COLLECTIONTYPE, so a MULTIPOLYGON whose members share
an edge reported that edge as boundary rather than interior, and the fix was to
give MULTIPOLYGONTYPE and MULTISURFACETYPE the same union topology. This is
that shape a second time, in the overlay.

AND THE CLASS IS NATIVE RATHER THAN RELOCATED, which a fall-through census
cannot tell on its own: the composition hands its pieces to a union that has
GEOS arms of its own, so a count taken at the overlay would read zero either
way. A library built -DGEOS=OFF is what separates them, since it declines
precisely what reaches the library. Eight cases, both libraries:

```
                                    previous code      this change
  CONTROL a polygon and a polygon   answers            answers
  the seven collection cases        ALL decline        ALL answer, and with
                                                       the areas the GEOS
                                                       build gives
```

The control is what makes the seven declines readable as the class rather
than as a broken build.

