### PR TITLE
Take nothing from a subject that draws nothing

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2719,8 +2719,12 @@ geom_difference2d(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
      * removes the ring entirely. The rule holds of a region, so the guard asks
      * whether EVERY part of the subject is one -- a total would let a subject
      * mixing a region with a part of no area keep the part a clip covers, and
-     * answer one point set two ways depending on how it is spelled */
-    if (geo_every_part_bounds_area(gs1))
+     * answer one point set two ways depending on how it is spelled.
+     * A subject drawing NOTHING is the other way the guard reads false, and it
+     * keeps its answer for a reason of its own rather than that rule's: a
+     * difference takes points away from the subject, and one holding none has
+     * none to lose. It is the same empty answer whichever route reaches it */
+    if (geo_is_empty(gs1) || geo_every_part_bounds_area(gs1))
       return geo_copy(gs1);
   }
 

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -563,6 +563,34 @@ int main(void)
   free(coll_geo_a); free(coll_geo_b);
   meos_errno_reset();
 
+  /* A subject drawing NOTHING has nothing for a clip to take, whatever the
+   * clip draws. The rule above answers a region unchanged where the clip is of
+   * lower dimension, and an empty subject reaches it the same way: it keeps
+   * the answer it already gives, without the overlay library being asked.
+   * The assertion holds on the previous code too, since the library answers
+   * the same empty geometry -- what it guards is that the answer stays that
+   * one once nothing is asked. A library built without GEOS is where the two
+   * separate: the previous route declines there, this one answers */
+  const char *mtsub[] = { "POLYGON EMPTY", "MULTIPOLYGON EMPTY" };
+  const char *mtclip[] = { "LINESTRING(0 0,5 5)", "POINT(1 1)" };
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 2; j++)
+    {
+      GSERIALIZED *ms = geom_in(mtsub[i], -1);
+      GSERIALIZED *mc = geom_in(mtclip[j], -1);
+      assert(ms != NULL); assert(mc != NULL);
+      meos_errno_reset();
+      GSERIALIZED *md = geom_difference2d(ms, mc);
+      printf("an empty subject minus %s: %s, errno %d\n", mtclip[j],
+        md ? (geo_is_empty(md) ? "empty" : "NOT EMPTY") : "NULL",
+        meos_errno());
+      assert(md != NULL);
+      assert(geo_is_empty(md));
+      assert(meos_errno() == 0);
+      free(md); free(ms); free(mc);
+      meos_errno_reset();
+    }
+
   /* Two areas whose boundaries run PARALLEL never touch, however close they
    * come. Deciding that means asking whether the two lines are one line, and
    * the engine answers it from the cross product of the offset between them


### PR DESCRIPTION
## What this is

`geom_difference2d` answers a difference itself when the subject draws nothing, rather than asking the overlay library what a subject holding no points loses.

```
  geom_difference2d(POLYGON EMPTY,      LINESTRING(0 0,5 5))
  geom_difference2d(POLYGON EMPTY,      POINT(1 1))
  geom_difference2d(MULTIPOLYGON EMPTY, LINESTRING(0 0,5 5))
  geom_difference2d(MULTIPOLYGON EMPTY, POINT(1 1))
```

Both routes give the empty geometry, so the answer is the same one. What differs is who gives it.

## Why the existing guard reads false here

The route keeps a region whole where the clip is of lower dimension, guarded on every part of the subject bounding area — a ring enclosing no area traces linework a clip can take, so a subject carrying one cannot keep its parts wholesale.

A subject drawing **nothing** reads false on that same guard for a different reason: it has no parts at all. Its answer follows from something simpler than the guard's rule — a difference takes points away from the subject, and one holding none has none to lose.

## Measured

The census instruments the `#if GEOS` arm of `geom_difference2d` and runs the real corpus:

| arm | fall-throughs over `geo_pairs` (12880 rows) |
|---|---|
| the same instrumented build with this rule removed | **625**, every one reading `empty1=1` |
| this branch | **0** |

The control arm is what makes the zero readable rather than a silent instrument.

The attribution is what makes those 625 one class rather than four: every row reads `areal1=1 clipsubj2=1 coverage2=1 everypart1=0`, so the subject is areal, the clip is one the engine reads, and the single thing refusing them is the guard above. By type: `Polygon x LineString` 452, `Polygon x Point` 91, 20 each for `Polygon` and `MultiPolygon` against `CircularString` and `CompoundCurve`, `MultiPoint` and `MultiLineString` 1 each.

Answers against master, all three corpora:

```
  geo_pairs            12880 rows   0 answers differ
  areal_pairs           1444 rows   0 answers differ
  adversarial_pairs       54 rows   0 answers differ
```

## The test passes on master too, and that is worth stating

The library gives the same empty geometry, so the assertion in `meos/test/geo_test.c` holds on master as well. What it guards is that the answer stays that one once nothing is asked. A library built `-DGEOS=OFF` is where the two routes separate — one declines there and this one answers — and that is the campaign's own completion test rather than a proxy for it.

## Checks

Strict-CI (both targets, all families, full pg_regress, all 24 meos/test binaries), the MSYS2 UCRT64 Windows build, and the two-build answer diff all run green on the committed tree. The answer diff moves 5 lines: four are the new witness's own output, one is the clock.
