### PR TITLE
Share nothing with a clip that encloses no point, and lose nothing to it

### DIFF
--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -1628,6 +1628,26 @@ geo_clip_linear_geom(const GSERIALIZED *line, const GSERIALIZED *gs,
   bool inside)
 {
   assert(line); assert(gs);
+
+  /* A clip enclosing no point shares nothing with the line and takes nothing
+   * from it, which is what the line already answers for a clip it merely
+   * keeps apart from: the part inside is empty and the part outside is the
+   * whole line. The kernels read a clip through its edges and a geometry
+   * drawing nothing has none, so the edge context declines it -- an absent
+   * context is a clip nothing can be asked OF, not an absent answer */
+  if (gserialized_is_empty(gs))
+  {
+    if (! inside)
+      return geo_copy(line);
+    /* Serializing copies, so the geometry built to be serialized is this
+     * function's to release */
+    LWGEOM *empty = lwline_as_lwgeom(lwline_construct_empty(
+      gserialized_get_srid(line), FLAGS_GET_Z(line->gflags), false));
+    GSERIALIZED *result = geo_serialize(empty);
+    lwgeom_free(empty);
+    return result;
+  }
+
   GeoEdgeCtx *ctx = (GeoEdgeCtx *) geo_edge_ctx_make(gs);
   if (! ctx)
     return NULL;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -2451,6 +2451,35 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* A clip enclosing no point is more apart from a line than a clip that
+   * merely keeps away from it, so it shares nothing with the line and takes
+   * nothing from it. The pair that keeps apart is the oracle the engine
+   * already carries: it answers the empty geometry for what the two share and
+   * the whole line for what the line keeps, and a clip drawing nothing gets
+   * the same pair of answers for the same reason. Reading it as an absent
+   * answer instead is what an errno of 0 beside a NULL says nobody meant */
+  const char *ec_line = "LINESTRING(-1 2,9 2)";
+  const char *ec_clips[] = { "POLYGON EMPTY", "MULTIPOLYGON EMPTY",
+    "LINESTRING EMPTY", "MULTILINESTRING EMPTY" };
+  for (int i = 0; i < 4; i++)
+  {
+    GSERIALIZED *ecl = geom_in(ec_line, -1);
+    GSERIALIZED *ecc = geom_in(ec_clips[i], -1);
+    assert(ecl != NULL); assert(ecc != NULL);
+    meos_errno_reset();
+    GSERIALIZED *ecshared = geom_intersection2d(ecl, ecc);
+    GSERIALIZED *eckept = geom_difference2d(ecl, ecc);
+    assert(ecshared != NULL); assert(eckept != NULL);
+    assert(geo_is_empty(ecshared));
+    assert(! geo_is_empty(eckept));
+    assert(geom_length(eckept) > 0);
+    printf("a line against %s: shares nothing, keeps a length of %.6f, "
+      "errno %d\n", ec_clips[i], geom_length(eckept), meos_errno());
+    assert(meos_errno() == 0);
+    free(ecshared); free(eckept); free(ecl); free(ecc);
+    meos_errno_reset();
+  }
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
## What this is

`geo_clip_linear_geom` answers a line against a clip that encloses no point: the part inside is the empty geometry, the part outside is the whole line. Both overlay entries reach it, so both stop answering NULL.

```
  geom_intersection2d(LINESTRING(-1 2,9 2), POLYGON EMPTY)   ->  NULL, errno 0
  geom_difference2d  (LINESTRING(-1 2,9 2), POLYGON EMPTY)   ->  NULL, errno 0
```

A NULL beside an errno of 0 is an answer nobody withholds on purpose: every caller reads it as a failure.

## The oracle is the engine's own neighbouring case

```
  geom_intersection2d(LINESTRING(10 10,20 20), POLYGON((0 0,4 0,4 4,0 4,0 0)))
      ->  LINESTRING EMPTY
  geom_difference2d  (LINESTRING(10 10,20 20), POLYGON((0 0,4 0,4 4,0 4,0 0)))
      ->  LINESTRING(10 10,20 20)
```

Two shapes that keep apart share the empty geometry, and the line keeps itself. A clip enclosing no point is further apart than that, so it gets the same pair of answers for the same reason. The sibling arms of the same two entries agree: the polygonal route answers an empty overlay with the empty geometry it covers, and the point-set route with an empty point set.

PostGIS states the rule outright in `lwgeom_intersection_prec`:

```c
  /* A.Intersection(Empty) == Empty */
  if (lwgeom_is_empty(geom2)) return lwgeom_clone_deep(geom2);
```

## Cause

The segment kernels read a clip through its **edges**, and a geometry drawing nothing has none, so `geo_edge_ctx_make` declines it:

```c
  if (gserialized_is_empty(gs))
    return NULL;
```

`geo_clip_linear_geom` reads that absent context as an absent **answer**. An absent context is a clip nothing can be asked of; what the line shares with it and keeps from it are both known without asking. These calls never reach the overlay library at all — a diagnostic at the `#if GEOS` arm prints nothing for any of them.

The subject is handed back as it stands, so an arc subject keeps its arc rather than the chain of chords a route through the overlay reads it by.

## Measured, over `geo_pairs`, against a control built from the same master

```
  answers that are NULL                    master 162      branch 0
  rows whose answers move                              162
      every one carries an operand that draws nothing  162
      rows where NEITHER operand is empty                0
  answer sides that move                               214
      of which master holds an ANSWER rather than NULL    0
```

The last line is what makes this additive: no answer is replaced, only absent ones become answers. The corpus holds 945 rows carrying an empty operand of which 783 do **not** move, which is the control saying the rule is narrow rather than "an empty operand answers differently".

```
  geo_pairs                         12880 rows   162 rows move, all as above
  areal_pairs                        1444 rows   0 answers differ
  adversarial_pairs                    54 rows   0 answers differ
```

## The witness fails on master

`meos/test/geo_test.c` stops at `assert(ecshared != NULL)` against the previous library, which is what says it guards the rule rather than restating it.

## Checks

Strict-CI (both targets, all families, full pg_regress, all 24 meos/test binaries), the MSYS2 UCRT64 Windows build, and the two-build answer diff all run green on the committed tree. The answer diff moves 5 lines: four are the new witness's own output, one is the clock.
