### PR TITLE
Keep the pixels of a raster that a geometry covers

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -141,6 +141,11 @@ extern char *raster_band_pixel_type(const Raster *rast, int band);
 extern bool raster_band_has_nodata_value(const Raster *rast, int band);
 extern double raster_band_nodata_value(const Raster *rast, int band);
 
+/* Processing functions for PostGIS rasters */
+
+extern Raster *raster_clip(const Raster *rast, const GSERIALIZED *gs,
+  bool crop);
+
 /* Conversion functions for Raquet tiles */
 
 extern STBox *raquet_to_stbox(const Raquet *rq);

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -596,6 +596,222 @@ raster_band_nodata_value(const Raster *rast, int band)
 }
 
 /*****************************************************************************
+ * Processing functions
+ *****************************************************************************/
+
+/**
+ * @brief Iterator callback keeping a pixel of the subject where the mask
+ * covers it
+ * @details The iterator is set with a neighbourhood of a single pixel, so the
+ * value of each input stands at @p [0][0]. Raster 0 is the band being clipped
+ * and raster 1 is the mask the geometry is burnt into: a pixel the mask does
+ * not cover, and a pixel the subject states as nodata, alike answer nodata
+ */
+static int
+raster_clip_callback(rt_iterator_arg arg, void *userarg __attribute__((unused)),
+  double *value, int *nodata)
+{
+  /* The mask covers the pixel only where it carries a value of its own */
+  if (arg->nodata[1][0][0] || arg->values[1][0][0] == 0.0)
+  {
+    *value = 0.0;
+    *nodata = 1;
+    return 1;
+  }
+  /* The subject decides the pixel wherever the mask covers it */
+  if (arg->nodata[0][0][0])
+  {
+    *value = 0.0;
+    *nodata = 1;
+    return 1;
+  }
+  *value = arg->values[0][0][0];
+  *nodata = 0;
+  return 1;
+}
+
+/**
+ * @brief Return the mask a geometry burns into the grid of a raster
+ * @details The mask carries one band of a single covering value on the grid
+ * the subject states, so that every pixel of the two answers the same cell.
+ * The rasterizer accepts a null spatial reference system and leaves the
+ * projection of its result unset, which is what the mask needs: it is read
+ * against a raster it already shares a grid with, and never on its own
+ * @param[in] raster Deserialized subject stating the grid
+ * @param[in] gs Geometry to burn
+ * @return On error return @p NULL
+ */
+static rt_raster
+raster_geo_mask(rt_raster raster, const GSERIALIZED *gs)
+{
+  LWGEOM *geom = lwgeom_from_gserialized((GSERIALIZED *) gs);
+  if (! geom)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not read the geometry to clip with");
+    return NULL;
+  }
+  /* The rasterizer reads plain OGC WKB, which carries no SRID of its own */
+  lwvarlena_t *wkb = lwgeom_to_wkb_varlena(geom, WKB_SFSQL);
+  lwgeom_free(geom);
+  if (! wkb)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not read the geometry to clip with");
+    return NULL;
+  }
+
+  /* One band of an unsigned byte, initially empty, carrying 1 where the
+   * geometry covers a pixel */
+  rt_pixtype pixtype = PT_8BUI;
+  double init = 0.0;
+  double value = 1.0;
+  double nodata = 0.0;
+  uint8_t hasnodata = 1;
+  double scale_x = rt_raster_get_x_scale(raster);
+  double scale_y = rt_raster_get_y_scale(raster);
+  double ul_x = rt_raster_get_x_offset(raster);
+  double ul_y = rt_raster_get_y_offset(raster);
+  double skew_x = rt_raster_get_x_skew(raster);
+  double skew_y = rt_raster_get_y_skew(raster);
+
+  rt_raster result = rt_raster_gdal_rasterize(
+    (const unsigned char *) wkb->data, (uint32_t) (LWSIZE_GET(wkb->size) -
+      LWVARHDRSZ), NULL, 1, &pixtype, &init, &value, &nodata, &hasnodata,
+    NULL, NULL, &scale_x, &scale_y, &ul_x, &ul_y, NULL, NULL, &skew_x,
+    &skew_y, NULL);
+  lwfree(wkb);
+  if (! result)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not burn the geometry into the grid of the raster");
+    return NULL;
+  }
+  /* The mask shares the grid of the subject, so it shares its reference
+   * system as well */
+  rt_raster_set_srid(result, rt_raster_get_srid(raster));
+  return result;
+}
+
+/**
+ * @ingroup meos_raster_base_transf
+ * @brief Return a raster keeping the pixels of another that a geometry covers
+ * @details Every band of the subject is read in turn against a mask the
+ * geometry is burnt into. A pixel the geometry does not cover answers nodata.
+ * When @p crop is true the result carries the extent the two share, and
+ * otherwise it carries the extent of the subject
+ * @param[in] rast Raster to clip
+ * @param[in] gs Geometry to clip it to
+ * @param[in] crop True to reduce the result to the extent the raster and the
+ * geometry share
+ * @return On error return @p NULL
+ * @csqlfn None, the host answers this operation on its own raster type
+ */
+Raster *
+raster_clip(const Raster *rast, const GSERIALIZED *gs, bool crop)
+{
+  VALIDATE_NOT_NULL(rast, NULL); VALIDATE_NOT_NULL(gs, NULL);
+
+  /* A raster and a geometry of different reference systems state positions
+   * that cannot be compared */
+  int32_t srid = raster_srid(rast);
+  if (srid != gserialized_get_srid(gs))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "Operation on mixed SRID");
+    return NULL;
+  }
+
+  /* The bands are read, so the subject is deserialized in full */
+  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not deserialize raster");
+    return NULL;
+  }
+  int numbands = (int) rt_raster_get_num_bands(raster);
+  if (numbands < 1)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The raster carries no band to clip");
+    return NULL;
+  }
+
+  rt_raster mask = raster_geo_mask(raster, gs);
+  if (! mask)
+  {
+    raster_destroy(raster);
+    return NULL;
+  }
+
+  /* The result states the extent the two share, or that of the subject */
+  rt_extenttype extent = crop ? ET_INTERSECTION : ET_FIRST;
+  rt_raster result = NULL;
+  for (int i = 0; i < numbands; i++)
+  {
+    rt_band band = rt_raster_get_band(raster, (uint32_t) i);
+    if (! band)
+    {
+      raster_destroy(mask); raster_destroy(raster);
+      if (result) raster_destroy(result);
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "Could not read band %d of the raster", i + 1);
+      return NULL;
+    }
+    /* A band keeps its own pixel type and nodata value across the clip */
+    rt_pixtype pixtype = rt_band_get_pixtype(band);
+    int hasnodata = rt_band_get_hasnodata_flag(band);
+    double nodataval = 0.0;
+    if (hasnodata)
+      rt_band_get_nodata(band, &nodataval);
+
+    struct rt_iterator_t itrset[2];
+    itrset[0].raster = raster;
+    itrset[0].nband = (uint16_t) i;
+    itrset[0].nbnodata = 1;
+    itrset[1].raster = mask;
+    itrset[1].nband = 0;
+    itrset[1].nbnodata = 1;
+
+    rt_raster banded = NULL;
+    if (rt_raster_iterator(itrset, 2, extent, NULL, pixtype,
+        (uint8_t) hasnodata, nodataval, 0, 0, NULL, NULL,
+        raster_clip_callback, &banded) != ES_NONE || ! banded)
+    {
+      raster_destroy(mask); raster_destroy(raster);
+      if (result) raster_destroy(result);
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "Could not clip band %d of the raster", i + 1);
+      return NULL;
+    }
+
+    if (! result)
+      /* The first band states the grid every later one is added to */
+      result = banded;
+    else
+    {
+      rt_band addband = rt_raster_get_band(banded, 0);
+      if (! addband || rt_raster_add_band(result, addband, i) < 0)
+      {
+        raster_destroy(banded); raster_destroy(mask); raster_destroy(raster);
+        raster_destroy(result);
+        meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+          "Could not add band %d to the clipped raster", i + 1);
+        return NULL;
+      }
+      /* The band is held by the result now, so only its carrier is released */
+      rt_raster_destroy(banded);
+    }
+  }
+
+  raster_destroy(mask);
+  raster_destroy(raster);
+  rt_raster_set_srid(result, srid);
+  return raster_serialize_destroy(result);
+}
+
+/*****************************************************************************
  * Conversion functions
  *****************************************************************************/
 

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -516,6 +516,84 @@ int main(void)
   assert(araster_value(traj_values, rast_values, 1, NULL) == -1);
   assert(meos_errno() != 0);
 
+  /* Clipping keeps the pixels a geometry covers and no others. The region
+   * below spans x in [0,2] and y in [1,3], so it covers the two left columns
+   * of the two upper rows: pixel(1,1) = 10 and pixel(2,2) = 50 stand inside
+   * it, while pixel(3,1) = 70 and the right column stand outside */
+  GSERIALIZED *region = geom_in("SRID=4326;POLYGON((0 1,2 1,2 3,0 3,0 1))",
+    -1);
+  assert(region != NULL);
+
+  /* Cropping reduces the result to the extent the two share, which is two
+   * pixels by two on the grid the subject states */
+  meos_errno_reset();
+  Raster *cropped = raster_clip(rast_values, region, true);
+  assert(cropped != NULL);
+  assert(meos_errno() == 0);
+  assert(raster_width(cropped) == 2);
+  assert(raster_height(cropped) == 2);
+  assert(raster_srid(cropped) == 4326);
+  assert(raster_upper_left_x(cropped) == 0.0);
+  assert(raster_upper_left_y(cropped) == 3.0);
+  assert(raster_num_bands(cropped) == 1);
+
+  /* The pixels the region covers answer what they answered before the clip */
+  Temporal *traj_kept = tgeompoint_in("SRID=4326;{POINT(0.5 2.5)@2001-01-01,"
+    " POINT(1.5 1.5)@2001-01-02}");
+  assert(traj_kept != NULL);
+  meos_errno_reset();
+  Temporal *kept = raster_value(traj_kept, cropped, 1);
+  assert(kept != NULL);
+  assert(meos_errno() == 0);
+  assert(temporal_num_instants(kept) == 2);
+  assert(tfloat_start_value(kept) == 10.0);
+  assert(tfloat_end_value(kept) == 50.0);
+  free(kept);
+
+  /* Without cropping the result keeps the extent of the subject, so the clip
+   * shows in the pixels rather than in the grid. This is the case a mask that
+   * covered everything would pass and a mask that covered nothing would fail:
+   * pixel(1,1) = 10 stands inside the region and answers, while
+   * pixel(3,1) = 70 stands outside it and answers nothing */
+  meos_errno_reset();
+  Raster *whole = raster_clip(rast_values, region, false);
+  assert(whole != NULL);
+  assert(meos_errno() == 0);
+  assert(raster_width(whole) == 3);
+  assert(raster_height(whole) == 3);
+  assert(raster_upper_left_x(whole) == 0.0);
+  assert(raster_upper_left_y(whole) == 3.0);
+
+  meos_errno_reset();
+  Temporal *masked = raster_value(traj_values, whole, 1);
+  assert(masked != NULL);
+  assert(meos_errno() == 0);
+  char *masked_str = tfloat_out(masked, 0);
+  printf("raster_clip(raster, region, false) sampled: %s\n", masked_str);
+  /* The unclipped raster answers this trajectory at two instants, 10 and 70;
+   * the clip removes the second, so a single instant remains */
+  assert(temporal_num_instants(masked) == 1);
+  assert(tfloat_start_value(masked) == 10.0);
+  free(masked_str); free(masked);
+
+  /* A geometry in another reference system states its positions in different
+   * units, which is an error and not an empty answer */
+  GSERIALIZED *region_3857 = geom_in("SRID=3857;POLYGON((0 1,2 1,2 3,0 3,0 1))",
+    -1);
+  assert(region_3857 != NULL);
+  meos_errno_reset();
+  assert(raster_clip(rast_values, region_3857, true) == NULL);
+  assert(meos_errno() != 0);
+
+  /* A null argument is rejected rather than dereferenced */
+  meos_errno_reset();
+  assert(raster_clip(NULL, region, true) == NULL);
+  assert(raster_clip(rast_values, NULL, true) == NULL);
+  assert(meos_errno() != 0);
+
+  free(region_3857); free(region); free(whole); free(cropped);
+  free(traj_kept);
+
   free(vspan); free(traj_3857); free(traj_values); free(rast_values);
 
   meos_finalize();

--- a/tools/scripts/liblwgeom_geos_baseline.txt
+++ b/tools/scripts/liblwgeom_geos_baseline.txt
@@ -7,7 +7,9 @@
 meos/src/geo/postgis_funcs.c	lwgeom_difference_prec
 meos/src/geo/postgis_funcs.c	lwgeom_intersection_prec
 meos/src/geo/postgis_funcs.c	lwgeom_unaryunion_prec
+meos/src/raster/raster_rtcore.c	rt_raster_add_band
 meos/src/raster/raster_rtcore.c	rt_raster_destroy
+meos/src/raster/raster_rtcore.c	rt_raster_gdal_rasterize
 meos/src/raster/raster_rtcore.c	rt_raster_geopoint_to_rasterpoint
 meos/src/raster/raster_rtcore.c	rt_raster_get_band
 meos/src/raster/raster_rtcore.c	rt_raster_get_envelope
@@ -23,3 +25,4 @@ meos/src/raster/raster_rtcore.c	rt_raster_get_x_skew
 meos/src/raster/raster_rtcore.c	rt_raster_get_y_offset
 meos/src/raster/raster_rtcore.c	rt_raster_get_y_scale
 meos/src/raster/raster_rtcore.c	rt_raster_get_y_skew
+meos/src/raster/raster_rtcore.c	rt_raster_set_srid


### PR DESCRIPTION
MEOS answers raster_clip(rast, gs, crop), which reads every band of a raster
against the region a geometry states and answers a raster carrying the pixels
that region covers. A pixel outside the geometry, and a pixel the subject
states as nodata, alike answer nodata, and each band keeps its own pixel type
and nodata value across the clip. When crop is true the result carries the
extent the raster and the geometry share, and otherwise it carries the extent
of the raster, so the clip shows in the pixels rather than in the grid.

The witness is the 3x3 raster of the sampling cases, a 32BF band of one degree
pixels holding 10, nodata, 30 / 40, 50, 60 / 70, 80, 90 on the grid whose upper
left corner is (0,3). The trajectory {POINT(0.5 2.5)@2001-01-01, POINT(1.5
2.5)@2001-01-02, POINT(5.5 5.5)@2001-01-03, POINT(0.5 0.5)@2001-01-04} reads it
as {10@2001-01-01, 70@2001-01-04}. Clipped to POLYGON((0 1,2 1,2 3,0 3,0 1)),
which covers the two left columns of the two upper rows, the same trajectory
reads {10@2001-01-01}: the pixel holding 70 stands outside the region and
answers nothing, while the pixel holding 10 stands inside it and answers what
it answered before. That pair is what a mask covering everything and a mask
covering nothing each fail. With crop the result is 2 pixels by 2 on the same
upper left corner, and the two positions inside it read 10 and 50.

Why this is the right answer, at the level of the model: a clip states which
pixels of a raster a region covers, so the question is asked of cells and not
of coordinates. Burning the geometry into a mask on the grid the subject states
is what makes the two comparable, since every pixel of the mask then answers
the same cell as the pixel beneath it, and the result is exact rather than
resampled: the mask never states a cell the subject does not state. The extent
follows from the same reading. Cropping answers the region the two share
because that is where the question has an answer at all, and the uncropped form
keeps the grid of the subject because a raster that changed its grid would no
longer be comparable with the one it came from. A raster and a geometry of
different reference systems state positions in different units, which is an
error rather than an empty answer, on the same ground that mixing them is an
error everywhere else in the library. The rasterizer accepts a null spatial
reference system and leaves the projection of its result unset, which is what a
mask needs, since it is read against a raster it already shares a grid with and
never on its own.

The operation reaches MEOS alone. A PostGIS user keeps ST_Clip, which answers
this on the same type, while a binding carries no PostGIS and has no other way
to clip a raster it holds.

Measured. raster_test passes every assertion. The library builds with zero
warnings and zero errors, and the toolchain of the Windows job builds it under
MSYS2 UCRT64. The two-build comparison runs 41 instruments, of which none fails
to compile, and 2 answer lines move: the sampling line above, which the base
cannot print because the function does not exist there, and a time of day
stamp the run masks as nondeterministic. Nothing else moves, so no answer this
library already gave is traded for another. The liblwgeom baseline carries 22
calls of 125 entry points, 3 of them geometry and 19 raster: the geometry carve
is unchanged at 3, and the three raster core calls the clip performs reach no
GEOS, the checker reading the file that defines them rather than the functions
themselves.

