### PR TITLE
State the error value of the raster clip as a tag

### DIFF
--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -639,7 +639,7 @@ raster_clip_callback(rt_iterator_arg arg, void *userarg __attribute__((unused)),
  * against a raster it already shares a grid with, and never on its own
  * @param[in] raster Deserialized subject stating the grid
  * @param[in] gs Geometry to burn
- * @return On error return @p NULL
+ * @errval NULL
  */
 static rt_raster
 raster_geo_mask(rt_raster raster, const GSERIALIZED *gs)
@@ -704,7 +704,7 @@ raster_geo_mask(rt_raster raster, const GSERIALIZED *gs)
  * @param[in] gs Geometry to clip it to
  * @param[in] crop True to reduce the result to the extent the raster and the
  * geometry share
- * @return On error return @p NULL
+ * @errval NULL
  * @csqlfn None, the host answers this operation on its own raster type
  */
 Raster *


### PR DESCRIPTION
The two functions the raster clip adds state their error value as @errval NULL,
which is the tag the rest of the library states it with, rather than as prose in
a @return line.

The witness is the checker. On the parent commit
`python3 tools/scripts/check_error_sentinels.py` names
meos/src/raster/raster_rtcore.c:642 and :707, "state the error value as
@errval, not as prose", and those two lines are the only ones it names.

Why the tag rather than the prose: an error value a reader can find by grep is
an error value a generator can read, and the tag is what carries the fact into
the reference the manual builds from. Prose says the same thing to a human and
nothing at all to the tools that read the source.

Measured. check_error_sentinels answers "error-sentinels: clean (0 baselined)".
The library builds with zero warnings and zero errors. raster_test passes every
assertion, and the sampling line it prints, {10@2001-01-01 00:00:00+00}, is the
one it printed before. The diff is 2 insertions and 2 deletions, both of them
Doxygen comment lines in one file: no statement, declaration or literal moves,
so nothing else can move either, and the full suite stays as it stands.

