### PR TITLE
Close the rings a tangent pair bounds, not one that crosses itself

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -2812,8 +2812,15 @@ buffer_find_connected_piece(const MeosArray *pieces, const bool *used,
     /* Read the turn as a full circle so that the FIRST piece round from the
      * direction the walk came back along is the smallest, which is the one
      * that keeps the walk on the face it is tracing rather than crossing to
-     * the other side of the node */
-    if (turn <= 0.0)
+     * the other side of the node.
+     * A piece leaving in the direction the walk arrived in makes no turn at
+     * all, and is therefore the LAST one round rather than the first. That is
+     * what two boundaries TANGENT at the node offer, since the arc's tangent
+     * there equals the segment's, so the turn sits exactly on the 0 / 2*pi
+     * boundary and the side round-off puts it on would otherwise decide it.
+     * Both directions are unit, so the tolerance the engine reads a
+     * coordinate at settles the boundary for either sign */
+    if (turn <= MEOS_GEOM_TOLERANCE)
       turn += 2.0 * M_PI;
     if (best < 0 || turn < best_turn)
     {

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1917,6 +1917,49 @@ int main(void)
     free(pa); free(pb);
     meos_errno_reset();
   }
+  /* WHERE TWO BOUNDARIES ARE TANGENT the walk that welds the answer's rings
+   * meets a node FOUR piece-ends share, and two of them leave it in the very
+   * direction the walk arrived in: the arc's tangent there equals the
+   * segment's. Those two are no turn at all and must be the LAST the walk
+   * considers, or it crosses to the other boundary and closes ONE ring that
+   * visits the node twice instead of the several that are really there.
+   * The disc below is inscribed in the square and touches it at all four side
+   * midpoints, and the small square meets the disc tangentially as well, so
+   * the pair asks the question five times over.
+   * What the answer must satisfy is that the two overlays PARTITION the
+   * subject: what the pair shares and what the subject keeps cover between
+   * them exactly the area the subject covers, with nothing counted twice by a
+   * ring that crosses itself. The identity is what an area that STROKES can
+   * still decide -- both terms pass through the same measure, so the stroking
+   * cancels -- and it is therefore an assertion about the RINGS rather than
+   * about the exactness of either area. The exactness is witnessed elsewhere:
+   * the answer here reads 2.748776129 under an arc-exact measure, against the
+   * same figure from exact circle-segment Boolean operations */
+  const char *tan_a = "POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))";
+  const char *tan_b = "MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,"
+    "2 0,0 2)),((3 3,4 3,4 4,3 4,3 3)))";
+  GSERIALIZED *tan_ga = geom_in(tan_a, -1);
+  GSERIALIZED *tan_gb = geom_in(tan_b, -1);
+  assert(tan_ga != NULL); assert(tan_gb != NULL);
+  meos_errno_reset();
+  GSERIALIZED *tan_gi = geom_intersection2d(tan_ga, tan_gb);
+  GSERIALIZED *tan_gk = geom_difference2d(tan_ga, tan_gb);
+  assert(tan_gi != NULL); assert(tan_gk != NULL);
+  assert(meos_errno() == 0);
+  double tan_whole = geom_area(tan_ga);
+  double tan_parts = geom_area(tan_gi) + geom_area(tan_gk);
+  printf("a tangent pair partitions its subject: %.9f against %.9f\n",
+    tan_parts, tan_whole);
+  assert(fabs(tan_parts - tan_whole) < 1e-9);
+  /* Each lobe the square keeps is a region of its own, and the arcs bounding
+   * them are kept as arcs rather than as a drawing of them */
+  char *tan_gw = geo_as_text(tan_gk, 6);
+  printf("a tangent pair keeps: %s\n", tan_gw);
+  assert(strstr(tan_gw, "CIRCULARSTRING") != NULL);
+  free(tan_gw);
+  free(tan_gi); free(tan_gk); free(tan_ga); free(tan_gb);
+  meos_errno_reset();
+
   /* WHAT THE REFUSAL IS STILL FOR. A collection is a region only when every
    * member draws one, and one holding a point and a line draws neither, so it
    * reaches the route that reads the type. WHICH of the two answers that route


### PR DESCRIPTION
## The defect

Where two areal boundaries **touch without crossing**, the overlay splits both at
the tangency and the ring walk then meets a node **four piece-ends share**. Two of
them leave the node in the very direction the walk arrived in, because an arc
tangent to a segment has the segment's direction there. Such a piece makes no turn
at all and must be considered **last** — the sharpest-turn rule reads a turn as a
full circle so that going straight on scores `2*pi`.

It scored `0` instead, for half the tangencies. The turn is `-atan2(cross, dot)`,
normalized with `turn <= 0.0`, so a straight-ahead continuation is rescued to
`2*pi` only when round-off gives its cross product a negative sign. An arc's
tangent is read through `sin()` of the arc's angle, and `sin(pi)` is `1.2246e-16`
rather than `0`.

Instrumenting the piece list the ring assembly receives, for a disc inscribed in a
square and tangent at all four side midpoints: 12 pieces, and `ends=4` at each of
`(2 0)`, `(4 2)`, `(2 4)`, `(0 2)`. So the tangency IS a node and the rule DID have
a choice. At `(0 2)`, arriving along `(-1.2246e-16, 1)`:

| candidate | leaves along | raw turn | after `turn <= 0.0` |
|---|---|---|---|
| down the left side — **correct** | `(0, -1)` | `-3.14159265` | `pi` |
| straight on up the side | `(-0, 1)` | `+1.2246e-16` | stays ~0, **wins** |
| the arc, tangentially straight on | `(1.2246e-16, 1)` | `+2.4493e-16` | stays ~0 |

The walk crossed onto the other boundary and closed **one** ring visiting the node
twice, which crosses itself.

## The fix

`if (turn <= MEOS_GEOM_TOLERANCE) turn += 2.0 * M_PI;`

Both directions are unit vectors, so the turn is dimensionless and scale-free, and
the tolerance the rest of the engine reads a coordinate at settles the boundary for
either sign. It is the same constant `geom_ring_is_convex()` already bounds a
cross product of directions by.

## What it is worth, and how it is witnessed

`POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))` minus
`MULTISURFACE(CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2)),((3 3,4 3,4 4,3 4,3 3)))`
**answers nothing** before this commit. It now answers, and the answer is exact:

| quantity | this branch, arc-exact | exact circle-segment Booleans |
|---|---|---|
| meet | 13.251223871 | 13.251223871 |
| keep | 2.748776129 | 2.748776129 |
| sum | 16.000000000 | 16.000000000 |

The witness is a Boolean set operation on **genuine arcs** over a kernel with exact
predicates and exact constructions, so the arcs are adjudicated as arcs and never
as a chain of chords.

Both figures above come from an arc-exact measure that integrates `x dy - y dx`
analytically over each arc, because `geom_area()` linearizes a curve polygon — it
reads the disc of radius 2 as `12.561324628` against `4*pi = 12.566370614`. That
measure carries a conservation claim but never an exactness one, which is why the
regression test added here asserts the **partition identity**: what the pair shares
and what the subject keeps cover the subject exactly, an identity the stroking
cancels out of. That test aborts at master on the null answer.
