### PR TITLE
Test the first element of a geo set for emptiness

### DIFF
--- a/meos/src/temporal/set.c
+++ b/meos/src/temporal/set.c
@@ -375,6 +375,15 @@ set_make_exp(const Datum *values, int count, int maxcount, MeosType basetype,
   // TODO Should we bypass the tests on tnpoint ?
   if (spatial_basetype(basetype) && basetype != T_NPOINT)
   {
+    /* The first element supplies the SRID and the flags every other element
+     * is compared against, so the loop below starts at the second one. Its
+     * own emptiness is a property of that element alone and is tested here:
+     * an empty geometry has no bounding box, so #geoarr_set_stbox seeds the
+     * set's stored box from #geo_set_stbox answering false and leaves that
+     * box unwritten */
+    if (geo_basetype(basetype) &&
+        ! ensure_not_empty(DatumGetGserializedP(values[0])))
+      return NULL;
     /* Ensure the spatial validity of the elements */
     int32_t srid = spatial_srid(values[0], basetype);
     int16 flags = spatial_flags(values[0], basetype);

--- a/mobilitydb/test/geo/expected/050_set_tbl.test.out
+++ b/mobilitydb/test/geo/expected/050_set_tbl.test.out
@@ -140,6 +140,21 @@ SELECT memSize(setUnion(g)) FROM tbl_geog_point3D WHERE g IS NOT NULL AND NOT ST
     4856
 (1 row)
 
+/* Errors */
+-- An empty geometry has no bounding box, so it is refused in every position,
+-- the first one included
+SELECT geomset '{"Polygon empty", "Point(4 5)"}';
+ERROR:  Only non-empty geometries accepted
+LINE 4: SELECT geomset '{"Polygon empty", "Point(4 5)"}';
+                       ^
+SELECT geomset '{"Point(1 1)", "Polygon empty"}';
+ERROR:  Only non-empty geometries accepted
+LINE 1: SELECT geomset '{"Point(1 1)", "Polygon empty"}';
+                       ^
+SELECT geogset '{"Polygon empty", "Point(4 5)"}';
+ERROR:  Only non-empty geometries accepted
+LINE 1: SELECT geogset '{"Polygon empty", "Point(4 5)"}';
+                       ^
 SELECT MAX(memSize(set(g))) FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g);
  max 
 -----

--- a/mobilitydb/test/geo/queries/050_set_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/050_set_tbl.test.sql
@@ -81,6 +81,13 @@ SELECT asEWKT(ARRAY[geometry 'Point(1 1)', 'SRID=5676;Point(1 1)']);
 SELECT memSize(setUnion(g)) FROM tbl_geom_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g);
 SELECT memSize(setUnion(g)) FROM tbl_geog_point3D WHERE g IS NOT NULL AND NOT ST_IsEmpty(g::geometry);
 
+/* Errors */
+-- An empty geometry has no bounding box, so it is refused in every position,
+-- the first one included
+SELECT geomset '{"Polygon empty", "Point(4 5)"}';
+SELECT geomset '{"Point(1 1)", "Polygon empty"}';
+SELECT geogset '{"Polygon empty", "Point(4 5)"}';
+
 -------------------------------------------------------------------------------
 -- Cast
 


### PR DESCRIPTION
The elements of a spatial set are compared against the SRID and the flags of
the first one, so the loop that reads them starts at the second. The emptiness
test travels in that loop, which makes the first position the one place a geo
set accepts an empty geometry.

WITNESS, on master b613fb803c, a probe against the worktree's own libmeos:

```
  geomset '{"Point(1 1)", "Polygon empty"}'   ERROR  Only non-empty geometries
                                                     accepted
  geomset '{"Polygon empty", "Point(4 5)"}'   STBOX X((6.463418e-310,
                                                       4.714347e-310),(4,5))
  the same literal, the next run              STBOX X((6.114767e-310,
                                                       5.334751e-310),(4,5))
  control, no empty element                   STBOX X((1,1),(4,5))
```

The two literals carry the same two elements and answer differently, and the
accepted one answers a different box on every run, which is what says the box
is read rather than computed.

WHY THE FIRST ELEMENT IS NOT A DIFFERENT ELEMENT. A set is a homogeneous
collection, and its stored bounding box is the union of the boxes of its
elements; the first element is distinguished only in supplying the SRID and the
flags the others are compared against, never in what it is allowed to be. An
empty geometry has no box to contribute, so it has no place in any position of
a set whose box is that union, and the contract the other positions already
state, "Only non-empty geometries accepted", is the contract of the type rather
than of a position. Testing it where the first element is read makes the rule
total instead of positional, which is why this is one test moved ahead of the
loop rather than a case added inside it.

The same shape one level down is already on master: a sequence took its
temporal type from instants[0] while nothing held the rest of the array to it,
and the fix was to establish the invariant where the first element is read
rather than to trust the position. A set's emptiness rule is that sentence for
the element the loop skips.

The path the untested element reaches: geo_set_stbox returns false for an empty
geometry and leaves its output argument untouched; geoarr_set_stbox seeds the
set's box with that call and expands it with the remaining elements;
spatialset_set_stbox copies what the set stores. The box is therefore
uninitialized memory, and it is the box serialized into the datum and read by
the WKB output, the index key and every topological operator over the set.

MEASURED on a1f565585d, the full strict-ci suite:

```
  pg_regress, PostgreSQL 18            all tests passed
  meos/test, the CI step verbatim      56 invocations clean
  threaded_test 8 5000 under TSan      clean
  cppcheck critical patterns           no findings
  compiler warnings in changed lines   0 across 1 file
  meos-windows under MSYS2 UCRT64      builds clean
  050_set_tbl expected output          15 lines added, nothing else moved
```

The expected output is the harness's own rather than a hand-written one, and
its diff against the committed file is exactly the three new error cases. No
other test moves: the suite's geo set aggregations already exclude empty
geometries with NOT ST_IsEmpty(g), so no existing row carries one in any
position.

