### PR TITLE
Keep what a pair leaves each other where their boundaries only touch

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -3994,12 +3994,22 @@ buffer_areal_overlay(const LWGEOM *geom1, const LWGEOM *geom2, ClipOper oper,
 
   /* Two boundaries that meet only at isolated points without their interiors
    * overlapping, as two discs touching at one point do, leave every piece of
-   * both boundaries on the union boundary. There is nothing to dissolve, and
-   * chaining rings that meet at a single node does not produce a surface, so
+   * both boundaries on the union boundary. There is nothing to dissolve, so
    * the pair is left to the caller as two surfaces. Boundaries that never meet
    * keep every piece for a union too, and that is an answer rather than a
-   * refusal, so the question is only asked where they do */
-  if (crossing && meos_array_count(selected) ==
+   * refusal, so the question is only asked where they do.
+   * IT IS THE UNION'S QUESTION AND ONLY THE UNION ASKS IT. What the flag
+   * reports is that the pair does not MERGE into one surface.
+   * #buffer_union_crossing() is the only site that passes CL_UNION, every
+   * reader of the flag reaches here through it, and #buffer_union_components()
+   * is what acts on it -- keeping the two components apart rather than
+   * declining the whole union. #buffer_areal_operation() discards the flag and
+   * is only ever called with CL_INTERSECTION or CL_DIFFERENCE, so refusing
+   * those here spends an answer they both have: keeping every piece of both
+   * boundaries is exactly what a DIFFERENCE does where the clip lies inside
+   * the subject, and what an INTERSECTION does where the subject lies inside
+   * the clip */
+  if (crossing && oper == CL_UNION && meos_array_count(selected) ==
       meos_array_count(split_a) + meos_array_count(split_b))
   {
     *touching = true;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1960,6 +1960,64 @@ int main(void)
   free(tan_gi); free(tan_gk); free(tan_ga); free(tan_gb);
   meos_errno_reset();
 
+  /* KEEPING EVERY PIECE OF BOTH BOUNDARIES IS AN ANSWER, NOT A REFUSAL, FOR
+   * EVERY OPERATION BUT THE UNION. A pair whose boundaries meet without their
+   * interiors overlapping leaves every piece of both on the union boundary,
+   * and the union reports that as "these do not merge into one surface" -- a
+   * report only the union asks for. The other two operations have an answer
+   * there and it is the ordinary one: a disc inscribed in a square, touching
+   * it at all four side midpoints, is INSIDE it, so the square keeps the four
+   * lobes around it and the two share the disc.
+   * The closed form is what makes this checkable: the disc has area 4*pi and
+   * the square 16, so what is kept is exactly 16 - 4*pi. That figure cannot be
+   * read from geom_area(), which linearizes a curve polygon, so the assertion
+   * here is the PARTITION identity -- both terms pass through the same
+   * measure, so the stroking cancels -- plus the arcs surviving as arcs, which
+   * is what says the answer was assembled rather than approximated */
+  GSERIALIZED *insq_a = geom_in("POLYGON((0 0,4 0,4 4,0 4,0 0))", -1);
+  GSERIALIZED *insq_b = geom_in(
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))", -1);
+  assert(insq_a != NULL); assert(insq_b != NULL);
+  meos_errno_reset();
+  GSERIALIZED *insq_i = geom_intersection2d(insq_a, insq_b);
+  GSERIALIZED *insq_k = geom_difference2d(insq_a, insq_b);
+  assert(insq_i != NULL); assert(insq_k != NULL);
+  assert(meos_errno() == 0);
+  double insq_whole = geom_area(insq_a);
+  double insq_parts = geom_area(insq_i) + geom_area(insq_k);
+  printf("an inscribed disc partitions its square: %.9f against %.9f\n",
+    insq_parts, insq_whole);
+  assert(fabs(insq_parts - insq_whole) < 1e-9);
+  /* What the pair shares is the disc itself, so the meet keeps its arcs and
+   * the four lobes kept around it keep theirs */
+  char *insq_wi = geo_as_text(insq_i, 6);
+  char *insq_wk = geo_as_text(insq_k, 6);
+  printf("an inscribed disc shares: %s\n", insq_wi);
+  printf("an inscribed disc leaves: %s\n", insq_wk);
+  assert(strstr(insq_wi, "CIRCULARSTRING") != NULL);
+  assert(strstr(insq_wk, "CIRCULARSTRING") != NULL);
+  free(insq_wi); free(insq_wk);
+  free(insq_i); free(insq_k); free(insq_a); free(insq_b);
+  meos_errno_reset();
+
+  /* AND THE UNION STILL REPORTS THE TOUCH. Two discs meeting at one point do
+   * not merge, and what they share is that point rather than a region of no
+   * area -- a region answer cannot state a meeting */
+  GSERIALIZED *tdisc_a = geom_in(
+    "CURVEPOLYGON(CIRCULARSTRING(0 1,1 2,2 1,1 0,0 1))", -1);
+  GSERIALIZED *tdisc_b = geom_in(
+    "CURVEPOLYGON(CIRCULARSTRING(2 1,3 2,4 1,3 0,2 1))", -1);
+  assert(tdisc_a != NULL); assert(tdisc_b != NULL);
+  meos_errno_reset();
+  GSERIALIZED *tdisc_i = geom_intersection2d(tdisc_a, tdisc_b);
+  assert(tdisc_i != NULL);
+  char *tdisc_w = geo_as_text(tdisc_i, 6);
+  printf("two discs touching share: %s\n", tdisc_w);
+  assert(strcmp(tdisc_w, "POINT(2 1)") == 0);
+  free(tdisc_w);
+  free(tdisc_i); free(tdisc_a); free(tdisc_b);
+  meos_errno_reset();
+
   /* WHAT THE REFUSAL IS STILL FOR. A collection is a region only when every
    * member draws one, and one holding a point and a line draws neither, so it
    * reaches the route that reads the type. WHICH of the two answers that route


### PR DESCRIPTION
## The witness

A disc inscribed in a square, touching it at all four side midpoints and
crossing nowhere:

```sql
SELECT ST_Difference(
  geometry 'POLYGON((0 0,4 0,4 4,0 4,0 0))',
  geometry 'CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))');
```

The disc is **inside** the square, so the square keeps the four lobes around it
and loses exactly the disc: `16 - 4*pi = 3.433629386`. Before this commit the
overlay **refuses** that pair and the answer comes from the fall-through as a
chain of chords, reading `3.438675372`. The same refusal leaves

```sql
SELECT ST_Difference(
  geometry 'POLYHEDRALSURFACE(((0 0,4 0,4 4,0 4,0 0)))',
  geometry 'CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))');
```

with **no answer at all**, because the fall-through will not read a polyhedral
surface either.

## Why the refusal is right where it stays, and wrong where it goes

Two boundaries that meet without their interiors overlapping leave every piece
of both on the union boundary. That fact answers **one** question — *do these
two merge into a single surface?* — and the answer is no, keep them as two. It
is reported through `*touching`. `buffer_union_crossing()` is the only site that
passes `CL_UNION`, every reader of the flag reaches the overlay through it, and
`buffer_union_components()` is what acts on it. `buffer_areal_operation()`
discards the flag and is only ever called with `CL_INTERSECTION` or
`CL_DIFFERENCE`.

For those two the same configuration is not a difficulty, it is the ordinary
answer: keeping every piece of both boundaries is exactly what a **difference**
does where the clip lies inside the subject, and what an **intersection** does
where the subject lies inside the clip. So the guard now asks its question only
of the operation that asks it.

## Why this could not ship earlier

Restricting the guard **alone** answers `1.719337686` for the square, almost
exactly half, because the ring walk then welded the four lobes into one ring
that crosses itself at each tangency. That is fixed on its own terms by #2629,
and only with the walk correct underneath does this refusal become the pure
loss it is here. A decline beats a wrong answer, so the order was not optional.

## Measured, and what did not move

| the four pairs a 225-pair type sweep finds | |
|---|---|
| `POLYGON` minus `CURVEPOLYGON` | stroked → **native**, arcs kept |
| `POLYHEDRALSURFACE` minus `CURVEPOLYGON` | **no answer** → **native**, arcs kept |
| `POLYHEDRALSURFACE` minus `MULTISURFACE` | native already, unchanged |
| `CURVEPOLYGON` minus `TRIANGLE` | unchanged — a **different** defect, its null comes from the ring assembly at no tagged refusal site. Its own PR. |

Against the closed form, measured with an arc-exact area:

| | |
|---|---|
| square minus its inscribed disc | `3.433629386` = `16 - 4*pi`, exact |
| the pair partitions the square | `12.566370614 + 3.433629386 = 16` |
| two discs touching, one minus the other | `3.141592654` = `pi`, exact |

The same figures come back from Boolean set operations on **genuine arcs** over
a kernel with exact predicates and exact constructions.

**What a pair shares where it shares no area is unchanged**, which is the
contract this could have broken — a region answer cannot state a meeting:

| | both arms |
|---|---|
| two discs touching at a point | `POINT(2 1)` |
| two squares touching at a corner | `POINT(1 1)` |
| two squares sharing an edge | `LINESTRING(1 0,1 1)` |
| two squares apart | `POLYGON EMPTY` |

Projected coordinates are identical on both arms, including the two
configurations that already do not partition there. Two builds diffed over 42
instruments: the only answer lines that differ are the four this commit's own
test prints. `pg_regress` green on PostgreSQL 18, `meos/test` clean, and
`libmeos` builds clean under MSYS2 UCRT64.

`geom_area()` linearizes a curve polygon — it reads the disc of radius 2 as
`12.561324628` against `4*pi` — so the test added here asserts the **partition
identity**, whose two terms pass through the same measure and whose stroking
therefore cancels, **plus** the arcs surviving as arcs. Master passes the
identity and fails the arcs, which is what makes the pair of assertions the
refuter.
