### PR TITLE
Read the query box the SP-GiST leaf consistency built

### DIFF
--- a/mobilitydb/src/geo/tspatial_spgist.c
+++ b/mobilitydb/src/geo/tspatial_spgist.c
@@ -827,6 +827,10 @@ Stbox_spgist_leaf_consistent(PG_FUNCTION_ARGS)
     if (type == T_TPCBOX)
       out->recheck = true;
 #endif /* POINTCLOUD */
+    /* The query can be an empty geometry, for which
+     * #tspatial_spgist_get_stbox writes nothing, so the box is zeroed before
+     * each call rather than carrying the stack or the previous key */
+    memset(&box, 0, sizeof(STBox));
     tspatial_spgist_get_stbox(value, type, &box);
     result = stbox_index_leaf_consistent(key, &box, strategy);
 
@@ -847,7 +851,19 @@ Stbox_spgist_leaf_consistent(PG_FUNCTION_ARGS)
       const ScanKeyData *scankey = &in->orderbys[i];
       Datum value = scankey->sk_argument;
       MeosType type = oid_meostype(scankey->sk_subtype);
+      memset(&box, 0, sizeof(STBox));
       tspatial_spgist_get_stbox(value, type, &box);
+      /* An entry the order by cannot be measured against sorts after every
+       * measurable one. The test reads the flag rather than calling
+       * #ensure_has_X, which raises: an empty geometry is a valid operand
+       * here, so it answers a distance rather than an error, which is what
+       * #distance_stbox_nodebox answers at an inner node of this same index
+       * and #stbox_gist_distance under a GiST one */
+      if (! MEOS_FLAGS_GET_X(box.flags))
+      {
+        distances[i] = DBL_MAX;
+        continue;
+      }
       /* A leaf key is a bounding box the executor rechecks, so what it
        * reports is lowered to stay under the operator's own distance */
       distances[i] = stbox_index_distance_bound(nad_stbox_stbox(&box, key),

--- a/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
+++ b/mobilitydb/test/geo/expected/074_tpoint_indexes_tbl.test.out
@@ -905,6 +905,16 @@ SELECT round(distance, 6) FROM test;
  3784781.353772
 (3 rows)
 
+WITH test AS (
+  SELECT temp |=| geometry 'Polygon empty' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+      
+      
+      
+(3 rows)
+
 DROP INDEX tbl_tgeompoint_rtree_idx;
 DROP INDEX
 DROP INDEX tbl_tgeompoint3D_rtree_idx;
@@ -977,6 +987,16 @@ SELECT round(distance, 6) FROM test;
  3768425.182236
  3768425.182236
  3784781.353772
+(3 rows)
+
+WITH test AS (
+  SELECT temp |=| geometry 'Polygon empty' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+ round 
+-------
+      
+      
+      
 (3 rows)
 
 DROP INDEX tbl_tgeompoint_quadtree_idx;

--- a/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
+++ b/mobilitydb/test/geo/queries/074_tpoint_indexes_tbl.test.sql
@@ -264,6 +264,10 @@ SELECT round(distance, 6) FROM test;
 WITH test AS (
   SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
+-- An empty geometry has no bounding box for the index to read
+WITH test AS (
+  SELECT temp |=| geometry 'Polygon empty' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeompoint_rtree_idx;
 DROP INDEX tbl_tgeompoint3D_rtree_idx;
 
@@ -294,6 +298,10 @@ WITH test AS (
 SELECT round(distance, 6) FROM test;
 WITH test AS (
   SELECT temp |=| geography 'Point(1 1)' AS distance FROM tbl_tgeogpoint ORDER BY 1 LIMIT 3 )
+SELECT round(distance, 6) FROM test;
+-- An empty geometry has no bounding box for the index to read
+WITH test AS (
+  SELECT temp |=| geometry 'Polygon empty' AS distance FROM tbl_tgeompoint ORDER BY 1 LIMIT 3 )
 SELECT round(distance, 6) FROM test;
 DROP INDEX tbl_tgeompoint_quadtree_idx;
 DROP INDEX tbl_tgeompoint3D_quadtree_idx;


### PR DESCRIPTION
The leaf consistency function of a spatiotemporal index declares one STBox and
hands it to #tspatial_spgist_get_stbox for every scan key and every order by.
That call writes nothing when the query is an empty geometry, since the arm it
takes is #geo_set_stbox and an empty geometry has no box. The box is neither
initialized nor tested, so what the leaf compares is the stack, or the box the
previous key left behind.

WITNESS, on master b613fb803c, the same query and the same table under the two
index kinds, added here to 074_tpoint_indexes_tbl:

```
  SELECT temp |=| geometry 'Polygon empty' FROM tbl_tgeompoint
  ORDER BY 1 LIMIT 3

  under GiST      3 rows, distance NULL
  under SP-GiST   ERROR:  Operation on mixed 2D/3D dimensions
```

Neither operand is 3D. The message is the garbage flags of the unwritten box
reaching ensure_same_spatial_dimensionality inside nad_stbox_stbox, and since it
is read off the stack the message a run reports is not even fixed.

WHY DBL_MAX IS THE ANSWER, AND WHY IT IS NOT A NEW RULE. An empty geometry is a
valid operand whose point set is empty, so the distance to it is unbounded
rather than unanswerable, and the index has to report a lower bound that keeps
the leaf behind every entry the operator can still order. Both sibling sites
already write exactly that. #distance_stbox_nodebox, the inner-node arm of this
same index, carries the comment "The query argument can be an empty geometry"
and returns DBL_MAX on a box with no X dimension, which is what the palloc0 of
its query array delivers. #stbox_gist_distance tests the return of
#tspatial_gist_get_stbox and returns DBL_MAX when the query has no box. The leaf
is the one site of the three that reads its box without either guard, and it is
given the sentence the other two already state rather than a rule invented for
it.

THE SIBLING THAT IS NOT THE MODEL, and the reason matters. The tnumber twin
#Tbox_spgist_leaf_consistent guards the same line with ensure_valid_tbox_tbox
and ensure_has_X before answering DBL_MAX. Those raise, and there they never
fire, a number query always having a box. Here the case they would meet is the
one this change is about, so calling them reproduces the error rather than
removing it. The flag is read directly, which is the form the empty-geometry
case already takes at the inner node.

The zeroing is what makes that test meaningful: MEOS_FLAGS_GET_X on an
uninitialized box answers the stack, and on a box zeroed before the call it
answers the absence the empty geometry left. It is the initialization palloc0
already performs for the inner node's query array.

MEASURED on the pg_regress suite, the same worktree and flags, the one file
pair differing:

```
  074_tpoint_indexes_tbl, whole output   one hunk differs, at the SP-GiST case
      master                             ERROR: Operation on mixed 2D/3D
      this change                        3 rows, distance NULL
  the GiST case, both arms               3 rows, distance NULL, unchanged
  every other row of the 1000-line       identical
      output, both arms
  compiler warnings                      0
```

The GiST answer is the oracle here rather than a second opinion: the two index
kinds serve the same ordering operator over the same table, so a query one
answers and the other refuses is a defect in the one that refuses, whatever the
distance turns out to be.

