### PR TITLE
Answer an empty geometry in the ever and always spatial relationships

### DIFF
--- a/meos/src/cbuffer/tcbuffer_spatialrels.c
+++ b/meos/src/cbuffer/tcbuffer_spatialrels.c
@@ -94,8 +94,10 @@
 static int
 spatialrel_geo_geo_simple(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   Datum param, varfunc func, int numparam, bool invert)
-{  /* Call the GEOS function when the geometries are not collections */
-  assert(geo_is_unitary(gs1)); assert(geo_is_unitary(gs2));
+{  /* Call the GEOS function when the geometries are not collections. An empty
+    * geometry has no members to iterate, so it reaches here as it is */
+  assert(geo_is_unitary(gs1) || gserialized_is_empty(gs1));
+  assert(geo_is_unitary(gs2) || gserialized_is_empty(gs2));
   Datum geo1 = PointerGetDatum(gs1);
   Datum geo2 = PointerGetDatum(gs2);
   bool res;
@@ -147,6 +149,14 @@ int
 spatialrel_geo_geo(const GSERIALIZED *gs1, const GSERIALIZED *gs2,
   Datum param, varfunc func, int numparam, bool invert)
 {
+  /* An empty geometry decomposes into no elements, and a quantifier over none
+   * of them answers vacuously: the universally quantified argument of covers,
+   * contains and disjoint reads true where the point set is empty. The
+   * relationship is asked of the geometries themselves instead, which is where
+   * the library answers the empty point set */
+  if (gserialized_is_empty(gs1) || gserialized_is_empty(gs2))
+    return spatialrel_geo_geo_simple(gs1, gs2, param, func, numparam, invert);
+
   /* Extract the elements of the arguments, if they are collections */
   int count1, count2;
   GSERIALIZED **elems1 = geo_extract_elements(gs1, &count1);
@@ -341,13 +351,17 @@ ea_spatialrel_tcbufferinst_geo(const TInstant *inst, const GSERIALIZED *gs,
   Datum param, varfunc func, int numparam, bool invert)
 {
   assert(inst); assert(gs); assert(inst->temptype == T_TCBUFFER);
+  /* An empty geometry has no bounding box, so the box test below cannot decide
+   * and the relationship answers it; the zeroed box makes that test read the
+   * absence rather than the stack */
   STBox gbox;
-  geo_set_stbox(gs, &gbox);
+  memset(&gbox, 0, sizeof(STBox));
+  bool hasbox = geo_set_stbox(gs, &gbox);
   double ixmin, iymin, ixmax, iymax;
   tcbufferinst_xybox(inst, &ixmin, &iymin, &ixmax, &iymax);
   int decided;
-  if (tcbuffer_geo_box_decided(func, param, numparam, ixmin, iymin, ixmax,
-      iymax, gbox.xmin, gbox.ymin, gbox.xmax, gbox.ymax, &decided))
+  if (hasbox && tcbuffer_geo_box_decided(func, param, numparam, ixmin, iymin,
+      ixmax, iymax, gbox.xmin, gbox.ymin, gbox.xmax, gbox.ymax, &decided))
     return decided;
   const Cbuffer *cb = DatumGetCbufferP(tinstant_value_p(inst));
   /* The containment of a geometry by the disc is read from the distances of
@@ -390,16 +404,21 @@ ea_spatialrel_tcbufferseq_discstep_geo(const TSequence *seq,
   assert(seq); assert(gs); assert(seq->temptype == T_TCBUFFER);
   assert(MEOS_FLAGS_GET_INTERP(seq->flags) == DISCRETE ||
     MEOS_FLAGS_GET_INTERP(seq->flags) == STEP);
+  /* An empty geometry has no bounding box, so the box test below cannot decide
+   * and the relationship answers it; the zeroed box makes that test read the
+   * absence rather than the stack */
   STBox gbox;
-  geo_set_stbox(gs, &gbox);
+  memset(&gbox, 0, sizeof(STBox));
+  bool hasbox = geo_set_stbox(gs, &gbox);
   for (int i = 0; i < seq->count; i++)
   {
     const TInstant *inst = TSEQUENCE_INST_N(seq, i);
     double ixmin, iymin, ixmax, iymax;
     tcbufferinst_xybox(inst, &ixmin, &iymin, &ixmax, &iymax);
     int result;
-    if (! tcbuffer_geo_box_decided(func, param, numparam, ixmin, iymin,
-        ixmax, iymax, gbox.xmin, gbox.ymin, gbox.xmax, gbox.ymax, &result))
+    if (! hasbox || ! tcbuffer_geo_box_decided(func, param, numparam, ixmin,
+        iymin, ixmax, iymax, gbox.xmin, gbox.ymin, gbox.xmax, gbox.ymax,
+        &result))
     {
       const Cbuffer *cb = DatumGetCbufferP(tinstant_value_p(inst));
       GSERIALIZED *trav = cbuffer_to_geom(cb);
@@ -441,8 +460,12 @@ ea_spatialrel_tcbufferseq_linear_geo(const TSequence *seq,
 
   /* General case (segment from the first instant to each later instant,
    * matching the exact baseline traversal) */
+  /* An empty geometry has no bounding box, so the box test below cannot decide
+   * and the relationship answers it; the zeroed box makes that test read the
+   * absence rather than the stack */
   STBox gbox;
-  geo_set_stbox(gs, &gbox);
+  memset(&gbox, 0, sizeof(STBox));
+  bool hasbox = geo_set_stbox(gs, &gbox);
   const TInstant *inst1 = TSEQUENCE_INST_N(seq, 0);
   double b1xmin, b1ymin, b1xmax, b1ymax;
   tcbufferinst_xybox(inst1, &b1xmin, &b1ymin, &b1xmax, &b1ymax);
@@ -456,8 +479,9 @@ ea_spatialrel_tcbufferseq_linear_geo(const TSequence *seq,
     double sxmin = fmin(b1xmin, b2xmin), symin = fmin(b1ymin, b2ymin);
     double sxmax = fmax(b1xmax, b2xmax), symax = fmax(b1ymax, b2ymax);
     int result;
-    if (! tcbuffer_geo_box_decided(func, param, numparam, sxmin, symin,
-        sxmax, symax, gbox.xmin, gbox.ymin, gbox.xmax, gbox.ymax, &result))
+    if (! hasbox || ! tcbuffer_geo_box_decided(func, param, numparam, sxmin,
+        symin, sxmax, symax, gbox.xmin, gbox.ymin, gbox.xmax, gbox.ymax,
+        &result))
     {
       GSERIALIZED *trav = tcbuffersegm_traversed_area(inst1, inst2);
       result = spatialrel_geo_geo(trav, gs, param, func, numparam, invert);
@@ -545,7 +569,7 @@ ea_spatialrel_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   Datum param, varfunc func, int numparam, bool ever, bool invert)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_tcbuffer_geo(temp, gs) )
     return -1;
 
   /* Bounding box test. When the whole value box and the geometry box do
@@ -556,9 +580,9 @@ ea_spatialrel_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   {
     STBox box1, box2;
     tspatial_set_stbox(temp, &box1);
-    /* Non-empty geometries have a bounding box */
-    geo_set_stbox(gs, &box2);
-    if (! overlaps_stbox_stbox(&box1, &box2))
+    /* An empty geometry has no bounding box, so the prefilter cannot decide
+     * and the relationship below answers it */
+    if (geo_set_stbox(gs, &box2) && ! overlaps_stbox_stbox(&box1, &box2))
       return (func == (varfunc) (&datum_geom_disjoint2d)) ? 1 : 0;
   }
 
@@ -655,7 +679,7 @@ ea_spatialrel_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2,
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a geometry ever/always contains a temporal circular
- * buffer, 0 if not, and -1 on error or if the geometry is empty
+ * buffer, 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal circular buffer
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -678,7 +702,7 @@ ea_contains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp,
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a geometry always contains a temporal circular buffer,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal circular buffer
  * @note The function tests whether the traversed area is contained in the
@@ -696,7 +720,7 @@ acontains_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever/always contains a
- * geometry, 0 if not, and -1 on error or if the geometry is empty
+ * geometry, 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -718,7 +742,7 @@ ea_contains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever contains a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @note The function tests whether the traversed area is contained in the
@@ -734,7 +758,7 @@ econtains_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer always contains a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @note The function tests whether the traversed area is contained in the
@@ -888,7 +912,7 @@ acontains_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a geometry ever/always covers a temporal circular buffer
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal circular buffer
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -910,7 +934,7 @@ ea_covers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a geometry ever covers a temporal circular buffer,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal circular buffer
  * @note The function tests whether the traversed area is covered in the
@@ -926,7 +950,7 @@ ecovers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a geometry always covers a temporal circular buffer,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal circular buffer
  * @note The function tests whether the traversed area is covered in the
@@ -944,7 +968,7 @@ acovers_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever/always covers a
- * geometry, 0 if not, and -1 on error or if the geometry is empty
+ * geometry, 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -962,7 +986,7 @@ ea_covers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever covers a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @note The function tests whether the traversed area is covered in the
@@ -978,7 +1002,7 @@ ecovers_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer always covers a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @note The function tests whether the traversed area is covered in the
@@ -1134,7 +1158,7 @@ acovers_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry are ever
- * disjoint,0 if not, and -1 on error or if the geometry is empty
+ * disjoint,0 if not, and -1 on error
  * @details The always semantics reduce exactly to the native nearest-approach
  * distance: aDisjoint(temp, gs) ⟺ ¬eIntersects(temp, gs) ⟺
  * min_t dist(disk(t), gs) > 0. The ever semantics are computed from the
@@ -1151,7 +1175,7 @@ ea_disjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_tcbuffer_geo(temp, gs) )
     return -1;
 
   /* Bounding box test: a moving disk whose radius-aware bounding box is
@@ -1161,8 +1185,9 @@ ea_disjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
    * the native coverage scan below for far-away pairs in a spatial join. */
   STBox box1, box2;
   tspatial_set_stbox(temp, &box1);
-  geo_set_stbox(gs, &box2);
-  if (! overlaps_stbox_stbox(&box1, &box2))
+  /* An empty geometry has no bounding box, so the prefilter cannot decide and
+   * the relationship below answers it */
+  if (geo_set_stbox(gs, &box2) && ! overlaps_stbox_stbox(&box1, &box2))
     return 1;
   if (! ever)
     return nad_tcbuffer_geo(temp, gs) > 0.0 ? 1 : 0;
@@ -1176,7 +1201,7 @@ ea_disjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry are ever
- * disjoint,0 if not, and -1 on error or if the geometry is empty
+ * disjoint,0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -1192,7 +1217,7 @@ ea_disjoint_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp,
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry are ever
- * disjoint, 0 if not, and -1 on error or if the geometry is empty
+ * disjoint, 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @csqlfn #Edisjoint_tcbuffer_geo()
@@ -1206,7 +1231,7 @@ edisjoint_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry are always
- * disjoint,0 if not, and -1 on error or if the geometry is empty
+ * disjoint,0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
@@ -1367,7 +1392,7 @@ adisjoint_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever/always intersects a
- * geometry, 0 if not, and -1 on error or if the geometry is empty
+ * geometry, 0 if not, and -1 on error
  * @details The ever semantics reduce exactly to the native nearest-approach
  * distance: eIntersects(temp, gs) ⟺ min_t dist(disk(t), gs) ≤ 0. The always
  * semantics are the complement of ever disjoint: aIntersects(temp, gs) ⟺
@@ -1385,7 +1410,7 @@ ea_intersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_tcbuffer_geo(temp, gs) )
     return -1;
 
   /* Bounding box test: a moving disk whose radius-aware bounding box is
@@ -1394,8 +1419,9 @@ ea_intersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
    * nearest-approach distance below for far-away pairs in a spatial join. */
   STBox box1, box2;
   tspatial_set_stbox(temp, &box1);
-  geo_set_stbox(gs, &box2);
-  if (! overlaps_stbox_stbox(&box1, &box2))
+  /* An empty geometry has no bounding box, so the prefilter cannot decide and
+   * the relationship below answers it */
+  if (geo_set_stbox(gs, &box2) && ! overlaps_stbox_stbox(&box1, &box2))
     return 0;
   if (ever)
     return nad_tcbuffer_geo(temp, gs) <= 0.0 ? 1 : 0;
@@ -1409,7 +1435,7 @@ ea_intersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry intersect
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal circular buffer
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -1425,7 +1451,7 @@ ea_intersects_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp,
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a geometry and a temporal circular buffer ever intersect,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @csqlfn #Eintersects_tcbuffer_geo()
@@ -1439,7 +1465,7 @@ eintersects_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a geometry and a temporal circular buffer always
- * intersect, 0 if not, and -1 on error or if the geometry is empty
+ * intersect, 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @note aIntersects(tcbuffer, geo) is equivalent to NOT eDisjoint(tcbuffer, geo)
@@ -1585,7 +1611,7 @@ aintersects_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry ever touch,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @details Touching is a contact of the two whose interiors stay disjoint. A
  * disc of a strictly positive radius carries an interior, and the paths below
  * read the disjointness from the position of its centre with respect to the
@@ -1602,7 +1628,7 @@ int
 ea_touches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_tcbuffer_geo(temp, gs) )
     return -1;
 
   /* A value composed of discs of a zero radius is a temporal point, whose
@@ -1623,8 +1649,9 @@ ea_touches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
    * below for the common case of far-away pairs in a spatial join. */
   STBox box1, box2;
   tspatial_set_stbox(temp, &box1);
-  geo_set_stbox(gs, &box2);
-  if (! overlaps_stbox_stbox(&box1, &box2))
+  /* An empty geometry has no bounding box, so the prefilter cannot decide and
+   * the relationship below answers it */
+  if (geo_set_stbox(gs, &box2) && ! overlaps_stbox_stbox(&box1, &box2))
     return 0;
 
   /* Touch requires the temporal value and the geometry to be at distance zero,
@@ -1657,7 +1684,7 @@ ea_touches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_internal_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry ever touch, 0
- * if not, and -1 on error or if the geometry is empty
+ * if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -1672,7 +1699,7 @@ ea_touches_geo_tcbuffer(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer ever touches a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @csqlfn #Etouches_tcbuffer_geo()
@@ -1686,7 +1713,7 @@ etouches_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a temporal circular buffer always touches a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @csqlfn #Atouches_tcbuffer_geo()
@@ -1827,7 +1854,7 @@ atouches_tcbuffer_tcbuffer(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_internal_cbuffer_spatial_rel_ever
  * @brief Return 1 if a temporal circular buffer and a geometry are ever/always
- * within the given distance, 0 if not, -1 on error or if the geometry is empty
+ * within the given distance, 0 if not, -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] dist Distance
@@ -1840,7 +1867,7 @@ ea_dwithin_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
   double dist, bool ever, bool invert)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tcbuffer_geo(temp, gs) || gserialized_is_empty(gs) ||
+  if (! ensure_valid_tcbuffer_geo(temp, gs) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
 
@@ -1852,11 +1879,14 @@ ea_dwithin_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
    * by construction, so no geodetic branch is needed. */
   STBox box_temp, box_geo, box_geo_exp;
   tspatial_set_stbox(temp, &box_temp);
-  geo_set_stbox(gs, &box_geo);
-  stbox_expand_space_set(&box_geo, dist, &box_geo_exp);
-  bool pass = overlaps_stbox_stbox(&box_temp, &box_geo_exp);
-  if (! pass)
-    return 0;
+  /* An empty geometry has no bounding box, so the prefilter cannot decide and
+   * the relationship below answers it */
+  if (geo_set_stbox(gs, &box_geo))
+  {
+    stbox_expand_space_set(&box_geo, dist, &box_geo_exp);
+    if (! overlaps_stbox_stbox(&box_temp, &box_geo_exp))
+      return 0;
+  }
 
   /* The always semantics are refuted by a single unit that stays farther than
    * the distance from the geometry, which the centre-against-radius test reads
@@ -1894,7 +1924,7 @@ ea_dwithin_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs,
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a geometry and a temporal circular buffer are ever within
- * the given distance, 0 if not, -1 on error or if the geometry is empty
+ * the given distance, 0 if not, -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] dist Distance
@@ -1909,7 +1939,7 @@ edwithin_tcbuffer_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
 /**
  * @ingroup meos_cbuffer_rel_ever
  * @brief Return 1 if a geometry and a temporal circular buffer are always
- * within a distance, 0 if not, -1 on error or if the geometry is empty
+ * within a distance, 0 if not, -1 on error
  * @param[in] temp Temporal circular buffer
  * @param[in] gs Geometry
  * @param[in] dist Distance

--- a/meos/src/geo/tgeo_spatialrels.c
+++ b/meos/src/geo/tgeo_spatialrels.c
@@ -415,7 +415,7 @@ spatialrel_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
   SpatialRelOp op, bool invert, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_tgeo_geo(temp, gs) )
     return -1;
 
   int16 flags1 = temp->flags;
@@ -582,7 +582,7 @@ ea_spatialrel_tspatial_geo(const Temporal *temp, const GSERIALIZED *gs,
   datum_func2 func, bool ever, bool invert)
 {
   /* Ensure the validity of the arguments */
-  assert(temp); assert(gs); assert(! gserialized_is_empty(gs)); assert(func);
+  assert(temp); assert(gs); assert(func);
   /* Walk the instants and stop at the first decisive one, so the work is
    * bounded by the answer rather than by the size of the temporal value */
   int result = 0;
@@ -681,7 +681,7 @@ ea_spatialrel_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2,
 
 /**
  * @brief Return 1 if a temporal geometry ever/always contains a geo, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @details
  * - A temporal geometry *ever* contains a geometry if the traversed area of
  *   the temporal geometry and the geometry intersect only in their interior,
@@ -703,7 +703,7 @@ ea_contains_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ev
   bool invert)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs) ||
+  if (! ensure_valid_tgeo_geo(temp, gs) ||
       ! ensure_not_geodetic_geo(gs) || ! ensure_has_not_Z_geo(gs) ||
       ! ensure_has_not_Z(temp->temptype, temp->flags))
     return -1;
@@ -717,7 +717,7 @@ ea_contains_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ev
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever/always contains a geo, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  */
 inline int
 ea_contains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
@@ -728,7 +728,7 @@ ea_contains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever/always contains a geo, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  */
 inline int
 ea_contains_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
@@ -739,7 +739,7 @@ ea_contains_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry ever contains a temporal geo, 0 if not, and
- * -1 on error or if the geometry is empty
+ * -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal geo
  * @csqlfn #Econtains_geo_tgeo()
@@ -753,7 +753,7 @@ econtains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry always contains a temporal geo,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal geo
  * @csqlfn #Acontains_geo_tgeo()
@@ -767,7 +767,7 @@ acontains_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever contains a geo, 0 if not, and
- * -1 on error or if the geometry is empty
+ * -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Econtains_tgeo_geo()
@@ -781,7 +781,7 @@ econtains_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry always contains a temporal geo,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Acontains_tgeo_geo()
@@ -850,7 +850,7 @@ acontains_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 
 /**
  * @brief Return 1 if a temporal geometry ever/always covers a geo, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @details
  * - A temporal geometry *ever* covers a geometry if there is an instant in
  *   which the temporal geometry and the geometry satisfy the relationship.
@@ -871,7 +871,7 @@ ea_covers_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ever
   bool invert)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs) ||
+  if (! ensure_valid_tgeo_geo(temp, gs) ||
       ! ensure_not_geodetic_geo(gs) || ! ensure_has_not_Z_geo(gs) ||
       ! ensure_has_not_Z(temp->temptype, temp->flags))
     return -1;
@@ -900,7 +900,7 @@ ea_covers_tgeo_geo_common(const Temporal *temp, const GSERIALIZED *gs, bool ever
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever/always covers a geo, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  */
 inline int
 ea_covers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
@@ -911,7 +911,7 @@ ea_covers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever/always covers a geo, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  */
 inline int
 ea_covers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
@@ -922,7 +922,7 @@ ea_covers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry ever covers a temporal geo, 0 if not, and
- * -1 on error or if the geometry is empty
+ * -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal geo
  * @csqlfn #Ecovers_geo_tgeo()
@@ -936,7 +936,7 @@ ecovers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry always covers a temporal geo,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal geo
  * @csqlfn #Acovers_geo_tgeo()
@@ -950,7 +950,7 @@ acovers_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever covers a geo, 0 if not, and
- * -1 on error or if the geometry is empty
+ * -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Ecovers_tgeo_geo()
@@ -964,7 +964,7 @@ ecovers_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry always covers a temporal geo,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Acovers_tgeo_geo()
@@ -1060,7 +1060,7 @@ ea_disjoint_seq(const TSequence *seq, const GSERIALIZED *gs,
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry and a geometry are ever disjoint,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @details
  * - A temporal point is *ever* disjoint with a geometry if the trajectory
  *   of the temporal point is NOT covered by the geometry
@@ -1078,7 +1078,7 @@ int
 ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_tgeo_geo(temp, gs) )
     return -1;
 
   /* tdisjoint is the negation of tintersects = tdwithin with zero
@@ -1114,8 +1114,10 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   {
     STBox box_temp, box_geom;
     tspatial_set_stbox(temp, &box_temp);
-    geo_set_stbox(gs, &box_geom);
-    if (! overlaps_stbox_stbox(&box_geom, &box_temp))
+    /* An empty geometry has no bounding box, so the prefilter cannot decide
+     * and the relationship below answers it */
+    if (geo_set_stbox(gs, &box_geom) &&
+        ! overlaps_stbox_stbox(&box_geom, &box_temp))
       return 1;
   }
 
@@ -1135,7 +1137,10 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
    * directly would do. The condition selecting the context is the one
    * #geo_disjoint_fn_geo uses to select the planar 2D relationship */
   void *ctx = NULL;
-  if (! MEOS_FLAGS_GET_GEODETIC(temp->flags) &&
+  /* The clip engine reads the edges of the geometry, and an empty geometry has
+   * none, so the paths below answer it */
+  if (! gserialized_is_empty(gs) &&
+      ! MEOS_FLAGS_GET_GEODETIC(temp->flags) &&
       ! (MEOS_FLAGS_GET_Z(temp->flags) && FLAGS_GET_Z(gs->gflags)))
   {
     /* Only a geometry the clip engine decomposes into edges gets a context.
@@ -1178,7 +1183,7 @@ ea_disjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry and a geometry are ever disjoint,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  */
 inline int
 ea_disjoint_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
@@ -1189,7 +1194,7 @@ ea_disjoint_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry and a geometry are ever disjoint,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Edisjoint_tgeo_geo()
@@ -1203,7 +1208,7 @@ edisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry and a geometry are always disjoint,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Adisjoint_tgeo_geo()
@@ -1217,7 +1222,7 @@ adisjoint_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geometry are ever disjoint,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Edisjoint_geo_tgeo()
@@ -1231,7 +1236,7 @@ edisjoint_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geometry are always disjoint,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Adisjoint_geo_tgeo()
@@ -1297,7 +1302,7 @@ adisjoint_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever/always intersects a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @details
  * - A temporal geometry *ever* intersects a geometry if the traversed area or
  *   the trajectory of the temporal geometry and the geometry intersect
@@ -1313,7 +1318,7 @@ int
 ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_tgeo_geo(temp, gs) )
     return -1;
 
   /* tintersects is tdwithin with zero distance (cf. static
@@ -1343,8 +1348,10 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
   {
     STBox box_temp, box_geom;
     tspatial_set_stbox(temp, &box_temp);
-    geo_set_stbox(gs, &box_geom);
-    if (! overlaps_stbox_stbox(&box_geom, &box_temp))
+    /* An empty geometry has no bounding box, so the prefilter cannot decide
+     * and the relationship below answers it */
+    if (geo_set_stbox(gs, &box_geom) &&
+        ! overlaps_stbox_stbox(&box_geom, &box_temp))
       return 0;
   }
 
@@ -1360,7 +1367,10 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
    * #nad_tgeo_geo resolves the exact minimum, so at a zero distance it walks
    * every segment the clip engine walks once. A geometry with a Z dimension
    * keeps the path below, whose relationship is the 3D one. */
-  if (temp->temptype == T_TGEOMPOINT && temp->subtype != TINSTANT &&
+  /* The clip engine reads the edges of the geometry, and an empty geometry has
+   * none, so the paths below answer it */
+  if (! gserialized_is_empty(gs) &&
+      temp->temptype == T_TGEOMPOINT && temp->subtype != TINSTANT &&
       MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR &&
       ! FLAGS_GET_Z(gs->gflags))
   {
@@ -1382,7 +1392,7 @@ ea_intersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a geometry intersects a temporal geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  */
 inline int
 ea_intersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
@@ -1393,7 +1403,7 @@ ea_intersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever intersects a temporal
- * geometry, 0 if not, and -1 on error or if the geometry is empty
+ * geometry, 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Eintersects_tgeo_geo()
@@ -1407,7 +1417,7 @@ eintersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry always intersects a temporal
- * geometry, 0 if not, and -1 on error or if the geometry is empty
+ * geometry, 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Aintersects_tgeo_geo()
@@ -1421,7 +1431,7 @@ aintersects_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geometry ever intersect,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Eintersects_geo_tgeo()
@@ -1435,7 +1445,7 @@ eintersects_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geometry always intersect,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Aintersects_geo_tgeo()
@@ -1502,7 +1512,7 @@ aintersects_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_internal_temporal_spatial_rel_ever
  * @brief Return 1 if a temporal point ever/always touches a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @details
  * - A temporal point *ever* touches a geometry if (a) the trajectory of the
  *   temporal point intersects the boundary of the geometry when the latter
@@ -1522,17 +1532,17 @@ int
 ea_touches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tpoint_geo(temp, gs) || gserialized_is_empty(gs) ||
+  if (! ensure_valid_tpoint_geo(temp, gs) ||
       /* The validity function ensures that both have the same geodetic flag */
       ! ensure_not_geodetic(temp->flags) || ! ensure_has_not_Z_geo(gs) ||
       ! ensure_has_not_Z(temp->temptype, temp->flags))
     return -1;
 
-  /* Bounding box test */
+  /* Bounding box test. An empty geometry has no bounding box, so the prefilter
+   * cannot decide and the relationship below answers it */
   STBox box1, box2;
   tspatial_set_stbox(temp, &box1);
-  geo_set_stbox(gs, &box2);
-  if (! overlaps_stbox_stbox(&box1, &box2))
+  if (geo_set_stbox(gs, &box2) && ! overlaps_stbox_stbox(&box1, &box2))
     return 0;
 
   /* Touching requires the two to reach a distance of exactly zero, so a
@@ -1590,7 +1600,7 @@ ea_touches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_temporal_spatial_rel_ever
  * @brief Return 1 if a temporal point ever touches a geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
  * @csqlfn #Etouches_tpoint_geo()
@@ -1604,7 +1614,7 @@ etouches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_temporal_spatial_rel_ever
  * @brief Return 1 if a temporal point always touches a geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal point
  * @param[in] gs Geometry
  * @csqlfn #Atouches_tpoint_geo()
@@ -1618,7 +1628,7 @@ atouches_tpoint_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal point ever touch, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal point
  * @csqlfn #Etouches_geo_tpoint()
@@ -1632,7 +1642,7 @@ etouches_geo_tpoint(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal point always touch, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal point
  * @csqlfn #Atouches_geo_tpoint()
@@ -1648,7 +1658,7 @@ atouches_geo_tpoint(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever/always touches a geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @details
  * - A temporal geometry *ever* touches a geometry if the there is an instant
  *   in which they satisfy the relationship
@@ -1663,17 +1673,17 @@ int
 ea_touches_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs) ||
+  if (! ensure_valid_tgeo_geo(temp, gs) ||
       /* The validity function ensures that both have the same geodetic flag */
       ! ensure_not_geodetic(temp->flags) || ! ensure_has_not_Z_geo(gs) ||
       ! ensure_has_not_Z(temp->temptype, temp->flags))
     return -1;
 
-  /* Bounding box test */
+  /* Bounding box test. An empty geometry has no bounding box, so the prefilter
+   * cannot decide and the relationship below answers it */
   STBox box1, box2;
   tspatial_set_stbox(temp, &box1);
-  geo_set_stbox(gs, &box2);
-  if (! overlaps_stbox_stbox(&box1, &box2))
+  if (geo_set_stbox(gs, &box2) && ! overlaps_stbox_stbox(&box1, &box2))
     return 0;
 
   return ea_spatialrel_tspatial_geo(temp, gs, &datum_geom_touches, ever,
@@ -1683,7 +1693,7 @@ ea_touches_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry ever touches a geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Etouches_tgeo_geo()
@@ -1697,7 +1707,7 @@ etouches_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a temporal geometry always touches a geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Atouches_tgeo_geo()
@@ -1711,7 +1721,7 @@ atouches_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geometry ever touch, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Etouches_geo_tgeo()
@@ -1725,7 +1735,7 @@ etouches_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geometry always touch, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @csqlfn #Atouches_geo_tgeo()
@@ -1808,7 +1818,7 @@ atouches_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_internal_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geo are ever within the
- * given distance, 0 if not, -1 on error or if the geometry is empty
+ * given distance, 0 if not, -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @param[in] dist Distance
@@ -1820,7 +1830,7 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
   bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_tgeo_geo(temp, gs) || gserialized_is_empty(gs) ||
+  if (! ensure_valid_tgeo_geo(temp, gs) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
 
@@ -1864,13 +1874,17 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
   {
     STBox box_temp, box_geom, box_geom_exp;
     tspatial_set_stbox(temp, &box_temp);
-    geo_set_stbox(gs, &box_geom);
-    stbox_expand_space_set(&box_geom, dist, &box_geom_exp);
-    bool pass = ever
-      ? overlaps_stbox_stbox(&box_geom_exp, &box_temp)
-      : contains_stbox_stbox(&box_geom_exp, &box_temp);
-    if (! pass)
-      return 0;
+    /* An empty geometry has no bounding box, so the prefilter cannot decide
+     * and the relationship below answers it */
+    if (geo_set_stbox(gs, &box_geom))
+    {
+      stbox_expand_space_set(&box_geom, dist, &box_geom_exp);
+      bool pass = ever
+        ? overlaps_stbox_stbox(&box_geom_exp, &box_temp)
+        : contains_stbox_stbox(&box_geom_exp, &box_temp);
+      if (! pass)
+        return 0;
+    }
   }
 
   /* The ever quantifier is the running minimum of the distance: a temporal geo
@@ -1905,7 +1919,10 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
    * relationships are defined in terms of ea_dwithin(., ., 0.0); the
    * POINT-vs-POINT and unsupported cases also fall through to the paths
    * below. */
-  if (dist > 0.0 && temp->temptype == T_TGEOMPOINT &&
+  /* The clip engine reads the edges of the geometry, and an empty geometry has
+   * none, so the paths below answer it */
+  if (dist > 0.0 && ! gserialized_is_empty(gs) &&
+      temp->temptype == T_TGEOMPOINT &&
       temp->subtype != TINSTANT && 
       MEOS_FLAGS_GET_INTERP(temp->flags) == LINEAR &&
       ! MEOS_FLAGS_GET_GEODETIC(temp->flags) &&
@@ -1945,7 +1962,7 @@ ea_dwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist,
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geo are ever within the
- * given distance, 0 if not, -1 on error or if the geometry is empty
+ * given distance, 0 if not, -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @param[in] dist Distance
@@ -1960,7 +1977,7 @@ edwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geo are always within a
- * distance, 0 if not, -1 on error or if the geometry is empty
+ * distance, 0 if not, -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @param[in] dist Distance
@@ -1975,7 +1992,7 @@ adwithin_tgeo_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geo are ever within the
- * given distance, 0 if not, -1 on error or if the geometry is empty
+ * given distance, 0 if not, -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @param[in] dist Distance
@@ -1990,7 +2007,7 @@ edwithin_geo_tgeo(const GSERIALIZED *gs, const Temporal *temp, double dist)
 /**
  * @ingroup meos_geo_rel_ever
  * @brief Return 1 if a geometry and a temporal geo are always within a
- * distance, 0 if not, -1 on error or if the geometry is empty
+ * distance, 0 if not, -1 on error
  * @param[in] temp Temporal geo
  * @param[in] gs Geometry
  * @param[in] dist Distance

--- a/meos/src/rgeo/trgeo_spatialrels.c
+++ b/meos/src/rgeo/trgeo_spatialrels.c
@@ -73,7 +73,7 @@ spatialrel_trgeo_trav_geo(const Temporal *temp, const GSERIALIZED *gs,
   Datum param, varfunc func, int numparam, bool invert)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_trgeo_geo(temp, gs) )
     return -1;
 
   assert(numparam == 2 || numparam == 3);
@@ -96,8 +96,7 @@ spatialrel_trgeo_trav_geo(const Temporal *temp, const GSERIALIZED *gs,
 
 /**
  * @brief Return 1 if the poses of a temporal rigid geometry and a geometry
- * ever/always satisfy a spatial relationship, 0 if not, and -1 on error or if
- * the geometry is empty
+ * ever/always satisfy a spatial relationship, 0 if not, and -1 on error
  * @details The placements are the reference geometry at each of the poses the
  * value takes, so the relationship is asked of each of them: the ever
  * semantics hold where one pose satisfies it, the always semantics where
@@ -114,7 +113,7 @@ ea_spatialrel_trgeo_poses_geo(const Temporal *temp, const GSERIALIZED *gs,
   datum_func2 func, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_trgeo_geo(temp, gs) )
     return -1;
 
   GSERIALIZED *places = trgeo_placements(temp);
@@ -146,7 +145,7 @@ ea_spatialrel_trgeo_poses_geo(const Temporal *temp, const GSERIALIZED *gs,
 
 /**
  * @brief Return 1 if a geometry ever contains a temporal rigid geometry, 0 if
- * not, and -1 on error or if the geometry is empty
+ * not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -160,7 +159,7 @@ int
 ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_trgeo_geo(temp, gs) )
     return -1;
   GSERIALIZED *places = trgeo_placements(temp);
   bool result = ever ? geom_relate_pattern(gs, places, "T********") :
@@ -172,7 +171,7 @@ ea_contains_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry ever contains a temporal rigid geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
  * @note The function tests whether the placements are contained in the
@@ -190,7 +189,7 @@ econtains_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry always contains a temporal rigid geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
  * @note The function tests whether the placements are contained in the
@@ -235,7 +234,7 @@ ea_contains_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
 int
 ea_contains_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_trgeo_geo(temp, gs) )
     return -1;
   GSERIALIZED *places = trgeo_placements(temp);
   bool result = ever ? geom_relate_pattern(places, gs, "T********") :
@@ -250,7 +249,7 @@ ea_contains_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 
 /**
  * @brief Return 1 if a geometry ever covers a temporal geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -264,7 +263,7 @@ int
 ea_covers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_trgeo_geo(temp, gs) )
     return -1;
   GSERIALIZED *places = trgeo_placements(temp);
   bool result = ever ? geom_relate_pattern(gs, places, "T********") :
@@ -276,7 +275,7 @@ ea_covers_geo_trgeo(const GSERIALIZED *gs, const Temporal *temp, bool ever)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry ever covers a temporal geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal geometry
  * @note The function tests whether the placements are covered in the
@@ -294,7 +293,7 @@ ecovers_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry always covers a temporal geometry,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal geometry
  * @note The function tests whether the placements are covered in the
@@ -313,7 +312,7 @@ acovers_geo_trgeometry(const GSERIALIZED *gs, const Temporal *temp)
 
 /**
  * @brief Return 1 if a geometry ever covers a temporal geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal geometry
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -332,7 +331,7 @@ ea_covers_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry ever covers a temporal geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal geometry
  * @param[in] gs Geometry
  * @note The function tests whether the placements cover the geometry
@@ -349,7 +348,7 @@ ecovers_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a temporal geometry always covers a geometry, 0 if not,
- * and -1 on error or if the geometry is empty
+ * and -1 on error
  * @param[in] temp Temporal geometry
  * @param[in] gs Geometry
  * @note The function tests whether the placements cover the geometry
@@ -388,7 +387,7 @@ ea_covers_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
 
 /**
  * @brief Return 1 if a temporal rigid geometry and a geometry are ever
- * disjoint,0 if not, and -1 on error or if the geometry is empty
+ * disjoint,0 if not, and -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -397,7 +396,7 @@ int
 ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_trgeo_geo(temp, gs) )
     return -1;
   if (ever)
     return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_disjoint2d,
@@ -408,7 +407,7 @@ ea_disjoint_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a temporal rigid geometry and a geometry are ever
- * disjoint, 0 if not, and -1 on error or if the geometry is empty
+ * disjoint, 0 if not, and -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @csqlfn #Edisjoint_trgeometry_geo()
@@ -422,7 +421,7 @@ edisjoint_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a temporal rigid geometry and a geometry are always
- * disjoint,0 if not, and -1 on error or if the geometry is empty
+ * disjoint,0 if not, and -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @note aDisjoint(a, b) is equivalent to NOT eIntersects(a, b)
@@ -436,7 +435,7 @@ adisjoint_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 
 /**
  * @brief Return 1 if a geometry and a temporal rigid geometry are ever or
- * always disjoint, 0 if not, and -1 on error or if the geometry is empty
+ * always disjoint, 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -502,7 +501,7 @@ adisjoint_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 int
 ea_intersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 {
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs))
+  if (! ensure_valid_trgeo_geo(temp, gs) )
     return -1;
   return ea_spatialrel_trgeo_poses_geo(temp, gs, &datum_geom_intersects2d,
     ever);
@@ -511,7 +510,7 @@ ea_intersects_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry and a temporal rigid geometry ever intersect,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @csqlfn #Eintersects_trgeometry_geo()
@@ -525,7 +524,7 @@ eintersects_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry and a temporal rigid geometry always
- * intersect, 0 if not, and -1 on error or if the geometry is empty
+ * intersect, 0 if not, and -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @note aIntersects(trgeo, gs) is equivalent to NOT eDisjoint(trgeo, gs)
@@ -539,7 +538,7 @@ aintersects_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 
 /**
  * @brief Return 1 if a geometry and a temporal rigid geometry are ever or
- * always intersecting, 0 if not, and -1 on error or if the geometry is empty
+ * always intersecting, 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -597,7 +596,7 @@ aintersects_trgeometry_trgeometry(const Temporal *temp1, const Temporal *temp2)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a temporal rigid geometry and a geometry ever touch, 0
- * if not, and -1 on error or if the geometry is empty
+ * if not, and -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @csqlfn #Etouches_trgeometry_geo()
@@ -611,7 +610,7 @@ etouches_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a temporal rigid geometry and a geometry always touch,
- * 0 if not, and -1 on error or if the geometry is empty
+ * 0 if not, and -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @csqlfn #Atouches_trgeometry_geo()
@@ -624,7 +623,7 @@ atouches_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs)
 
 /**
  * @brief Return 1 if a temporal rigid geometry and a geometry ever/always
- * touch, 0 if not, and -1 on error or if the geometry is empty
+ * touch, 0 if not, and -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -637,7 +636,7 @@ ea_touches_trgeo_geo(const Temporal *temp, const GSERIALIZED *gs, bool ever)
 
 /**
  * @brief Return 1 if a geometry and a temporal rigid geometry ever/always
- * touch, 0 if not, and -1 on error or if the geometry is empty
+ * touch, 0 if not, and -1 on error
  * @param[in] gs Geometry
  * @param[in] temp Temporal rigid geometry
  * @param[in] ever True for the ever semantics, false for the always semantics
@@ -674,7 +673,7 @@ ea_touches_trgeo_trgeo(const Temporal *temp1, const Temporal *temp2, bool ever)
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry and a temporal rigid geometry are ever within
- * the given distance, 0 if not, -1 on error or if the geometry is empty
+ * the given distance, 0 if not, -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] dist Distance
@@ -684,7 +683,7 @@ int
 edwithin_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs) ||
+  if (! ensure_valid_trgeo_geo(temp, gs) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
   return spatialrel_trgeo_trav_geo(temp, gs, Float8GetDatum(dist),
@@ -694,7 +693,7 @@ edwithin_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs, double dist
 /**
  * @ingroup meos_rgeo_rel_ever
  * @brief Return 1 if a geometry and a temporal rigid geometry are always
- * within a distance, 0 if not, -1 on error or if the geometry is empty
+ * within a distance, 0 if not, -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] dist Distance
@@ -704,7 +703,7 @@ int
 adwithin_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs, double dist)
 {
   /* Ensure the validity of the arguments */
-  if (! ensure_valid_trgeo_geo(temp, gs) || gserialized_is_empty(gs) ||
+  if (! ensure_valid_trgeo_geo(temp, gs) ||
       ! ensure_not_negative_datum(Float8GetDatum(dist), T_FLOAT8))
     return -1;
 
@@ -718,7 +717,7 @@ adwithin_trgeometry_geo(const Temporal *temp, const GSERIALIZED *gs, double dist
 
 /**
  * @brief Return 1 if a temporal rigid geometry and a geometry are ever or
- * always within a distance, 0 if not, -1 on error or if the geometry is empty
+ * always within a distance, 0 if not, -1 on error
  * @param[in] temp Temporal rigid geometry
  * @param[in] gs Geometry
  * @param[in] dist Distance

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels.test.out
@@ -1090,3 +1090,45 @@ SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),5)@2001-01-01', geometry 'CircularSt
  t
 (1 row)
 
+SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+ eintersects 
+-------------
+ f
+(1 row)
+
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+ econtains 
+-----------
+ f
+(1 row)
+
+SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT eDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2001-01-01, Cbuffer(Point(2 2),0.5)@2001-01-02]', geometry 'Polygon empty');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2001-01-01, Cbuffer(Point(2 2),0.5)@2001-01-02]', geometry 'Polygon empty');
+ eintersects 
+-------------
+ f
+(1 row)
+

--- a/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
+++ b/mobilitydb/test/cbuffer/expected/212_tcbuffer_spatialrels_tbl.test.out
@@ -109,25 +109,25 @@ SELECT COUNT(*) FROM tbl_tcbuffer t1, tbl_tcbuffer t2 WHERE aCovers(t1.temp, t2.
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE eDisjoint(g, temp);
  count 
 -------
- 15321
+ 15921
 (1 row)
 
 SELECT COUNT(*) FROM tbl_geometry, tbl_tcbuffer WHERE aDisjoint(g, temp);
  count 
 -------
- 10181
+ 10781
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE eDisjoint(temp, g);
  count 
 -------
- 15321
+ 15921
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tcbuffer, tbl_geometry WHERE aDisjoint(temp, g);
  count 
 -------
- 10181
+ 10781
 (1 row)
 
 SELECT COUNT(*) FROM tbl_cbuffer, tbl_tcbuffer WHERE eDisjoint(cb, temp);

--- a/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
+++ b/mobilitydb/test/cbuffer/queries/212_tcbuffer_spatialrels.test.sql
@@ -387,4 +387,15 @@ SELECT eContains(tcbuffer 'Cbuffer(Point(0 0),1)@2001-01-01', geometry 'Linestri
 -- A geometry carrying a circular arc keeps the path that renders the disc
 SELECT eCovers(tcbuffer 'Cbuffer(Point(0 0),5)@2001-01-01', geometry 'CircularString(1 0, 0 1, -1 0)');
 
+-- An empty geometry is a valid operand whose point set is empty, so every
+-- relationship over it has the answer the library gives: disjoint true and
+-- the rest false
+SELECT eDisjoint(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+SELECT eIntersects(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+SELECT eContains(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+SELECT eCovers(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+SELECT eTouches(tcbuffer 'Cbuffer(Point(1 1),0.5)@2001-01-01', geometry 'Polygon empty');
+SELECT eDisjoint(tcbuffer '[Cbuffer(Point(1 1),0.5)@2001-01-01, Cbuffer(Point(2 2),0.5)@2001-01-02]', geometry 'Polygon empty');
+SELECT eIntersects(tcbuffer '[Cbuffer(Point(1 1),0.5)@2001-01-01, Cbuffer(Point(2 2),0.5)@2001-01-02]', geometry 'Polygon empty');
+
 -------------------------------------------------------------------------------

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels.test.out
@@ -73,25 +73,25 @@ SELECT aContains(tgeometry '[Polygon((1 1,1 3,3 3,3 1,1 1))@2001-01-01, Polygon(
 SELECT eContains(geometry 'Point empty', tgeometry 'Point(1 1)@2001-01-01');
  econtains 
 -----------
- 
+ f
 (1 row)
 
 SELECT eContains(geometry 'Point empty', tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  econtains 
 -----------
- 
+ f
 (1 row)
 
 SELECT eContains(geometry 'Point empty', tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  econtains 
 -----------
- 
+ f
 (1 row)
 
 SELECT eContains(geometry 'Point empty', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  econtains 
 -----------
- 
+ f
 (1 row)
 
 /* Errors */
@@ -188,25 +188,25 @@ SELECT aCovers(tgeometry '[Polygon((1 1,1 3,3 3,3 1,1 1))@2001-01-01, Polygon((1
 SELECT eCovers(geometry 'Point empty', tgeometry 'Point(1 1)@2001-01-01');
  ecovers 
 ---------
- 
+ f
 (1 row)
 
 SELECT eCovers(geometry 'Point empty', tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  ecovers 
 ---------
- 
+ f
 (1 row)
 
 SELECT eCovers(geometry 'Point empty', tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  ecovers 
 ---------
- 
+ f
 (1 row)
 
 SELECT eCovers(geometry 'Point empty', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  ecovers 
 ---------
- 
+ f
 (1 row)
 
 /* Errors */
@@ -243,25 +243,25 @@ SELECT eDisjoint(geometry 'Point(1 1)', tgeometry '{[Point(1 1)@2001-01-01, Poin
 SELECT eDisjoint(geometry 'Point empty', tgeometry 'Point(1 1)@2001-01-01');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point empty', tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point empty', tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point empty', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point(1 1 1)', tgeometry 'Point(1 1 1)@2001-01-01');
@@ -291,25 +291,25 @@ SELECT eDisjoint(geometry 'Point(1 1 1)', tgeometry '{[Point(1 1 1)@2001-01-01, 
 SELECT eDisjoint(geometry 'Point Z empty', tgeometry 'Point(1 1 1)@2001-01-01');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point Z empty', tgeometry '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point Z empty', tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point Z empty', tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeometry 'Point(1 1)@2001-01-01',  geometry 'Point(1 1)');
@@ -339,25 +339,25 @@ SELECT eDisjoint(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Poin
 SELECT eDisjoint(tgeometry 'Point(1 1)@2001-01-01',  geometry 'Point empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Point empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Point empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Point empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeometry 'Point(1 1 1)@2001-01-01',  geometry 'Point(1 1 1)');
@@ -387,25 +387,25 @@ SELECT eDisjoint(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, 
 SELECT eDisjoint(tgeometry 'Point(1 1 1)@2001-01-01',  geometry 'Point Z empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeometry '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}',  geometry 'Point Z empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]',  geometry 'Point Z empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}',  geometry 'Point Z empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point(1 1)', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
@@ -548,25 +548,25 @@ SELECT eIntersects(geometry 'Point(1 1)', tgeometry '{[Point(1 1)@2001-01-01, Po
 SELECT eIntersects(geometry 'Point empty', tgeometry 'Point(1 1)@2001-01-01');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point empty', tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point empty', tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point empty', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point(1 1 1)', tgeometry 'Point(1 1 1)@2001-01-01');
@@ -596,25 +596,25 @@ SELECT eIntersects(geometry 'Point(1 1 1)', tgeometry '{[Point(1 1 1)@2001-01-01
 SELECT eIntersects(geometry 'Point Z empty', tgeometry 'Point(1 1 1)@2001-01-01');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point Z empty', tgeometry '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point Z empty', tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point Z empty', tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point(1.5 1.5)', tgeography 'Point(1.5 1.5)@2001-01-01');
@@ -644,25 +644,25 @@ SELECT eIntersects(geography 'Point(1.5 1.5)', tgeography '{[Point(1.5 1.5)@2001
 SELECT eIntersects(geography 'Point empty', tgeography 'Point(1.5 1.5)@2001-01-01');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point empty', tgeography '{Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point empty', tgeography '[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03]');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point empty', tgeography '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03],[Point(3.5 3.5)@2001-01-04, Point(3.5 3.5)@2001-01-05]}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point(1.5 1.5 1.5)', tgeography 'Point(1.5 1.5 1.5)@2001-01-01');
@@ -692,25 +692,25 @@ SELECT eIntersects(geography 'Point(1.5 1.5 1.5)', tgeography '{[Point(1.5 1.5 1
 SELECT eIntersects(geography 'Point Z empty', tgeography 'Point(1.5 1.5 1.5)@2001-01-01');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point Z empty', tgeography '{Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point Z empty', tgeography '[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03]');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point Z empty', tgeography '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03],[Point(3.5 3.5 3.5)@2001-01-04, Point(3.5 3.5 3.5)@2001-01-05]}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry 'Point(1 1)@2001-01-01',  geometry 'Point(1 1)');
@@ -740,25 +740,25 @@ SELECT eIntersects(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Po
 SELECT eIntersects(tgeometry 'Point(1 1)@2001-01-01',  geometry 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry 'Point(1 1 1)@2001-01-01',  geometry 'Point(1 1 1)');
@@ -788,25 +788,25 @@ SELECT eIntersects(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02
 SELECT eIntersects(tgeometry 'Point(1 1 1)@2001-01-01',  geometry 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}',  geometry 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]',  geometry 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}',  geometry 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeography 'Point(1.5 1.5)@2001-01-01',  geography 'Point(1.5 1.5)');
@@ -836,25 +836,25 @@ SELECT eIntersects(tgeography '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-
 SELECT eIntersects(tgeography 'Point(1.5 1.5)@2001-01-01',  geography 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeography '{Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03}',  geography 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeography '[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03]',  geography 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeography '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03],[Point(3.5 3.5)@2001-01-04, Point(3.5 3.5)@2001-01-05]}',  geography 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeography 'Point(1.5 1.5 1.5)@2001-01-01',  geography 'Point(1.5 1.5 1.5)');
@@ -884,25 +884,25 @@ SELECT eIntersects(tgeography '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.
 SELECT eIntersects(tgeography 'Point(1.5 1.5 1.5)@2001-01-01',  geography 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeography '{Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03}',  geography 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeography '[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03]',  geography 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeography '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03],[Point(3.5 3.5 3.5)@2001-01-04, Point(3.5 3.5 3.5)@2001-01-05]}',  geography 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeometry 'Point(1 1)@2001-01-01', tgeometry 'Point(1 1)@2001-01-01');
@@ -1102,25 +1102,25 @@ SELECT eTouches(geometry 'Point(1 1)', tgeometry '{[Point(1 1)@2001-01-01, Point
 SELECT eTouches(geometry 'Point empty', tgeometry 'Point(1 1)@2001-01-01');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(geometry 'Point empty', tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(geometry 'Point empty', tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(geometry 'Point empty', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(tgeometry 'Point(1 1)@2001-01-01',  geometry 'Point(1 1)');
@@ -1150,25 +1150,25 @@ SELECT eTouches(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point
 SELECT eTouches(tgeometry 'Point(1 1)@2001-01-01',  geometry 'Point empty');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Point empty');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Point empty');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Point empty');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(geometry 'Point(1 1)', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
@@ -1241,25 +1241,25 @@ SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tgeometry '{[Point(1 1)@2001-01-
 SELECT eDwithin(geometry 'Linestring empty', tgeometry 'Point(1 1)@2001-01-01', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring empty', tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring empty', tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring empty', tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring(1 1 1,2 2 2)', tgeometry 'Point(1 1 1)@2001-01-01', 2);
@@ -1289,25 +1289,25 @@ SELECT eDwithin(geometry 'Linestring(1 1 1,2 2 2)', tgeometry '{[Point(1 1 1)@20
 SELECT eDwithin(geometry 'Linestring Z empty', tgeometry 'Point(1 1 1)@2001-01-01', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring Z empty', tgeometry '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring Z empty', tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring Z empty', tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring(1.5 1.5,2.5 2.5)', tgeography 'Point(1.5 1.5)@2001-01-01', 2);
@@ -1337,25 +1337,25 @@ SELECT eDwithin(geography 'Linestring(1.5 1.5,2.5 2.5)', tgeography '{[Point(1.5
 SELECT eDwithin(geography 'Linestring empty', tgeography 'Point(1.5 1.5)@2001-01-01', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring empty', tgeography '{Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring empty', tgeography '[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03]', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring empty', tgeography '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03],[Point(3.5 3.5)@2001-01-04, Point(3.5 3.5)@2001-01-05]}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring(1.5 1.5 1.5,2.5 2.5 2.5)', tgeography 'Point(1.5 1.5 1.5)@2001-01-01', 2);
@@ -1385,25 +1385,25 @@ SELECT eDwithin(geography 'Linestring(1.5 1.5 1.5,2.5 2.5 2.5)', tgeography '{[P
 SELECT eDwithin(geography 'Linestring Z empty', tgeography 'Point(1.5 1.5 1.5)@2001-01-01', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring Z empty', tgeography '{Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring Z empty', tgeography '[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03]', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring Z empty', tgeography '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03],[Point(3.5 3.5 3.5)@2001-01-04, Point(3.5 3.5 3.5)@2001-01-05]}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry 'Point(1 1)@2001-01-01',  geometry 'Linestring(1 1,2 2)', 2);
@@ -1433,25 +1433,25 @@ SELECT eDwithin(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point
 SELECT eDwithin(tgeometry 'Point(1 1)@2001-01-01',  geometry 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry 'Point(1 1 1)@2001-01-01',  geometry 'Linestring(1 1 1,2 2 2)', 2);
@@ -1481,25 +1481,25 @@ SELECT eDwithin(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, P
 SELECT eDwithin(tgeometry 'Point(1 1 1)@2001-01-01',  geometry 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}',  geometry 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]',  geometry 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}',  geometry 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeography 'Point(1.5 1.5)@2001-01-01',  geography 'Linestring(1.5 1.5,2.5 2.5)', 2);
@@ -1529,25 +1529,25 @@ SELECT eDwithin(tgeography '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-
 SELECT eDwithin(tgeography 'Point(1.5 1.5)@2001-01-01',  geography 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeography '{Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03}',  geography 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeography '[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03]',  geography 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeography '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03],[Point(3.5 3.5)@2001-01-04, Point(3.5 3.5)@2001-01-05]}',  geography 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeography 'Point(1.5 1.5 1.5)@2001-01-01',  geography 'Linestring(1.5 1.5 1.5,2.5 2.5 2.5)', 2);
@@ -1577,25 +1577,25 @@ SELECT eDwithin(tgeography '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@
 SELECT eDwithin(tgeography 'Point(1.5 1.5 1.5)@2001-01-01',  geography 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeography '{Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03}',  geography 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeography '[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03]',  geography 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeography '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03],[Point(3.5 3.5 3.5)@2001-01-04, Point(3.5 3.5 3.5)@2001-01-05]}',  geography 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeometry 'Point(1 1)@2001-01-01', tgeometry 'Point(1 1)@2001-01-02', 2);

--- a/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tgeo_spatialrels_tbl.test.out
@@ -73,13 +73,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aCovers(t1.temp, t
 SELECT COUNT(*) FROM tbl_geometry, tbl_tgeometry WHERE eDisjoint(g, temp);
  count 
 -------
- 15308
+ 15908
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry, tbl_geometry WHERE eDisjoint(temp, g);
  count 
 -------
- 15308
+ 15908
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -91,13 +91,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE eDisjoint(t1.temp,
 SELECT COUNT(*) FROM tbl_geometry3D, tbl_tgeometry3D WHERE eDisjoint(g, temp);
  count 
 -------
-  9397
+  9997
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry3D, tbl_geometry3D WHERE eDisjoint(temp, g);
  count 
 -------
-  9397
+  9997
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -121,13 +121,13 @@ SELECT COUNT(*) FROM tbl_tgeography3D t1, tbl_tgeography3D t2 WHERE eDisjoint(t1
 SELECT COUNT(*) FROM tbl_geometry t1, tbl_tgeometry t2 WHERE t1.k % 3 = 0 AND aDisjoint(g, temp);
  count 
 -------
-  4586
+  4786
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_geometry t2 WHERE t1.k % 3 = 0 AND aDisjoint(temp, g);
  count 
 -------
-  4591
+  4789
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -139,13 +139,13 @@ SELECT COUNT(*) FROM tbl_tgeometry t1, tbl_tgeometry t2 WHERE aDisjoint(t1.temp,
 SELECT COUNT(*) FROM tbl_geometry3D t1, tbl_tgeometry3D t2 WHERE t1.k % 3 = 0 AND aDisjoint(g, temp);
  count 
 -------
-  3093
+  3293
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_geometry3D t2 WHERE t1.k % 3 = 0 AND aDisjoint(temp, g);
  count 
 -------
-  3097
+  3295
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeometry3D t1, tbl_tgeometry3D t2 WHERE aDisjoint(t1.temp, t2.temp);

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels.test.out
@@ -49,25 +49,25 @@ SELECT eContains(geometry 'Polygon((1 1,1 3,3 3,3 1,1 1))', tgeompoint '[Point(1
 SELECT eContains(geometry 'Point empty', tgeompoint 'Point(1 1)@2001-01-01');
  econtains 
 -----------
- 
+ f
 (1 row)
 
 SELECT eContains(geometry 'Point empty', tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  econtains 
 -----------
- 
+ f
 (1 row)
 
 SELECT eContains(geometry 'Point empty', tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  econtains 
 -----------
- 
+ f
 (1 row)
 
 SELECT eContains(geometry 'Point empty', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  econtains 
 -----------
- 
+ f
 (1 row)
 
 /* Errors */
@@ -146,7 +146,7 @@ SELECT aCovers(geometry 'Polygon((-9 -9,-9 9,9 9,9 -9,-9 -9))', tgeompoint '[Poi
 SELECT eCovers(geometry 'Point empty', tgeompoint 'Point(1 1)@2001-01-01');
  ecovers 
 ---------
- 
+ f
 (1 row)
 
 /* Errors */
@@ -179,25 +179,25 @@ SELECT eDisjoint(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2001-01-01, Poi
 SELECT eDisjoint(geometry 'Point empty', tgeompoint 'Point(1 1)@2001-01-01');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point empty', tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point empty', tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point empty', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point(1 1 1)', tgeompoint 'Point(1 1 1)@2001-01-01');
@@ -227,25 +227,25 @@ SELECT eDisjoint(geometry 'Point(1 1 1)', tgeompoint '{[Point(1 1 1)@2001-01-01,
 SELECT eDisjoint(geometry 'Point Z empty', tgeompoint 'Point(1 1 1)@2001-01-01');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point Z empty', tgeompoint '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point Z empty', tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point Z empty', tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Point(1 1)');
@@ -275,25 +275,25 @@ SELECT eDisjoint(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Poi
 SELECT eDisjoint(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Point empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Point empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Point empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Point empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeompoint 'Point(1 1 1)@2001-01-01',  geometry 'Point(1 1 1)');
@@ -323,25 +323,25 @@ SELECT eDisjoint(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02,
 SELECT eDisjoint(tgeompoint 'Point(1 1 1)@2001-01-01',  geometry 'Point Z empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeompoint '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}',  geometry 'Point Z empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]',  geometry 'Point Z empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}',  geometry 'Point Z empty');
  edisjoint 
 -----------
- 
+ t
 (1 row)
 
 SELECT eDisjoint(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
@@ -478,25 +478,25 @@ SELECT eIntersects(geometry 'Point(1 1)', tgeompoint '[Point(1 1)@2001-01-01, Po
 SELECT eIntersects(geometry 'Point empty', tgeompoint 'Point(1 1)@2001-01-01');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point empty', tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point empty', tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point empty', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point(1 1 1)', tgeompoint 'Point(1 1 1)@2001-01-01');
@@ -526,25 +526,25 @@ SELECT eIntersects(geometry 'Point(1 1 1)', tgeompoint '{[Point(1 1 1)@2001-01-0
 SELECT eIntersects(geometry 'Point Z empty', tgeompoint 'Point(1 1 1)@2001-01-01');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point Z empty', tgeompoint '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point Z empty', tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geometry 'Point Z empty', tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point(1.5 1.5)', tgeogpoint 'Point(1.5 1.5)@2001-01-01');
@@ -574,25 +574,25 @@ SELECT eIntersects(geography 'Point(1.5 1.5)', tgeogpoint '{[Point(1.5 1.5)@2001
 SELECT eIntersects(geography 'Point empty', tgeogpoint 'Point(1.5 1.5)@2001-01-01');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point empty', tgeogpoint '{Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point empty', tgeogpoint '[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03]');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point empty', tgeogpoint '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03],[Point(3.5 3.5)@2001-01-04, Point(3.5 3.5)@2001-01-05]}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point(1.5 1.5 1.5)', tgeogpoint 'Point(1.5 1.5 1.5)@2001-01-01');
@@ -622,25 +622,25 @@ SELECT eIntersects(geography 'Point(1.5 1.5 1.5)', tgeogpoint '{[Point(1.5 1.5 1
 SELECT eIntersects(geography 'Point Z empty', tgeogpoint 'Point(1.5 1.5 1.5)@2001-01-01');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point Z empty', tgeogpoint '{Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point Z empty', tgeogpoint '[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03]');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(geography 'Point Z empty', tgeogpoint '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03],[Point(3.5 3.5 3.5)@2001-01-04, Point(3.5 3.5 3.5)@2001-01-05]}');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Point(1 1)');
@@ -670,25 +670,25 @@ SELECT eIntersects(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, P
 SELECT eIntersects(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint 'Point(1 1 1)@2001-01-01',  geometry 'Point(1 1 1)');
@@ -718,25 +718,25 @@ SELECT eIntersects(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-0
 SELECT eIntersects(tgeompoint 'Point(1 1 1)@2001-01-01',  geometry 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}',  geometry 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]',  geometry 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}',  geometry 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeogpoint 'Point(1.5 1.5)@2001-01-01',  geography 'Point(1.5 1.5)');
@@ -766,25 +766,25 @@ SELECT eIntersects(tgeogpoint '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-
 SELECT eIntersects(tgeogpoint 'Point(1.5 1.5)@2001-01-01',  geography 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeogpoint '{Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03}',  geography 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeogpoint '[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03]',  geography 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeogpoint '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03],[Point(3.5 3.5)@2001-01-04, Point(3.5 3.5)@2001-01-05]}',  geography 'Point empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeogpoint 'Point(1.5 1.5 1.5)@2001-01-01',  geography 'Point(1.5 1.5 1.5)');
@@ -814,25 +814,25 @@ SELECT eIntersects(tgeogpoint '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.
 SELECT eIntersects(tgeogpoint 'Point(1.5 1.5 1.5)@2001-01-01',  geography 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeogpoint '{Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03}',  geography 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeogpoint '[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03]',  geography 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeogpoint '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03],[Point(3.5 3.5 3.5)@2001-01-04, Point(3.5 3.5 3.5)@2001-01-05]}',  geography 'Point Z empty');
  eintersects 
 -------------
- 
+ f
 (1 row)
 
 SELECT eIntersects(tgeompoint 'Point(1 1)@2001-01-01', tgeompoint 'Point(1 1)@2001-01-01');
@@ -1044,25 +1044,25 @@ SELECT eTouches(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2001-01-01, Poin
 SELECT eTouches(geometry 'Point empty', tgeompoint 'Point(1 1)@2001-01-01');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(geometry 'Point empty', tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(geometry 'Point empty', tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(geometry 'Point empty', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Point(1 1)');
@@ -1092,25 +1092,25 @@ SELECT eTouches(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Poin
 SELECT eTouches(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Point empty');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Point empty');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Point empty');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Point empty');
  etouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT eTouches(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
@@ -1201,25 +1201,25 @@ SELECT aTouches(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2001-01-01, Poin
 SELECT aTouches(geometry 'Point empty', tgeompoint 'Point(1 1)@2001-01-01');
  atouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT aTouches(geometry 'Point empty', tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}');
  atouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT aTouches(geometry 'Point empty', tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]');
  atouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT aTouches(geometry 'Point empty', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
  atouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT aTouches(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Point(1 1)');
@@ -1249,25 +1249,25 @@ SELECT aTouches(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Poin
 SELECT aTouches(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Point empty');
  atouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT aTouches(tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Point empty');
  atouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT aTouches(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Point empty');
  atouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT aTouches(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Point empty');
  atouches 
 ----------
- 
+ f
 (1 row)
 
 SELECT aTouches(geometry 'Point(1 1)', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}');
@@ -1340,25 +1340,25 @@ SELECT eDwithin(geometry 'Linestring(1 1,2 2)', tgeompoint '{[Point(1 1)@2001-01
 SELECT eDwithin(geometry 'Linestring empty', tgeompoint 'Point(1 1)@2001-01-01', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring empty', tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring empty', tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring empty', tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring(1 1 1,2 2 2)', tgeompoint 'Point(1 1 1)@2001-01-01', 2);
@@ -1388,25 +1388,25 @@ SELECT eDwithin(geometry 'Linestring(1 1 1,2 2 2)', tgeompoint '{[Point(1 1 1)@2
 SELECT eDwithin(geometry 'Linestring Z empty', tgeompoint 'Point(1 1 1)@2001-01-01', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring Z empty', tgeompoint '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring Z empty', tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geometry 'Linestring Z empty', tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring(1.5 1.5,2.5 2.5)', tgeogpoint 'Point(1.5 1.5)@2001-01-01', 2);
@@ -1436,25 +1436,25 @@ SELECT eDwithin(geography 'Linestring(1.5 1.5,2.5 2.5)', tgeogpoint '{[Point(1.5
 SELECT eDwithin(geography 'Linestring empty', tgeogpoint 'Point(1.5 1.5)@2001-01-01', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring empty', tgeogpoint '{Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring empty', tgeogpoint '[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03]', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring empty', tgeogpoint '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03],[Point(3.5 3.5)@2001-01-04, Point(3.5 3.5)@2001-01-05]}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring(1.5 1.5 1.5,2.5 2.5 2.5)', tgeogpoint 'Point(1.5 1.5 1.5)@2001-01-01', 2);
@@ -1484,25 +1484,25 @@ SELECT eDwithin(geography 'Linestring(1.5 1.5 1.5,2.5 2.5 2.5)', tgeogpoint '{[P
 SELECT eDwithin(geography 'Linestring Z empty', tgeogpoint 'Point(1.5 1.5 1.5)@2001-01-01', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring Z empty', tgeogpoint '{Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring Z empty', tgeogpoint '[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03]', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(geography 'Linestring Z empty', tgeogpoint '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03],[Point(3.5 3.5 3.5)@2001-01-04, Point(3.5 3.5 3.5)@2001-01-05]}', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Linestring(1 1,2 2)', 2);
@@ -1532,25 +1532,25 @@ SELECT eDwithin(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Poin
 SELECT eDwithin(tgeompoint 'Point(1 1)@2001-01-01',  geometry 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint '{Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03}',  geometry 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03]',  geometry 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint '{[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02, Point(1 1)@2001-01-03],[Point(3 3)@2001-01-04, Point(3 3)@2001-01-05]}',  geometry 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint 'Point(1 1 1)@2001-01-01',  geometry 'Linestring(1 1 1,2 2 2)', 2);
@@ -1580,25 +1580,25 @@ SELECT eDwithin(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, 
 SELECT eDwithin(tgeompoint 'Point(1 1 1)@2001-01-01',  geometry 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint '{Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03}',  geometry 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint '[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03]',  geometry 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint '{[Point(1 1 1)@2001-01-01, Point(2 2 2)@2001-01-02, Point(1 1 1)@2001-01-03],[Point(3 3 3)@2001-01-04, Point(3 3 3)@2001-01-05]}',  geometry 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeogpoint 'Point(1.5 1.5)@2001-01-01',  geography 'Linestring(1.5 1.5,2.5 2.5)', 2);
@@ -1628,25 +1628,25 @@ SELECT eDwithin(tgeogpoint '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-
 SELECT eDwithin(tgeogpoint 'Point(1.5 1.5)@2001-01-01',  geography 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeogpoint '{Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03}',  geography 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeogpoint '[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03]',  geography 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeogpoint '{[Point(1.5 1.5)@2001-01-01, Point(2.5 2.5)@2001-01-02, Point(1.5 1.5)@2001-01-03],[Point(3.5 3.5)@2001-01-04, Point(3.5 3.5)@2001-01-05]}',  geography 'Linestring empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeogpoint 'Point(1.5 1.5 1.5)@2001-01-01',  geography 'Linestring(1.5 1.5 1.5,2.5 2.5 2.5)', 2);
@@ -1676,25 +1676,25 @@ SELECT eDwithin(tgeogpoint '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@
 SELECT eDwithin(tgeogpoint 'Point(1.5 1.5 1.5)@2001-01-01',  geography 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeogpoint '{Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03}',  geography 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeogpoint '[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03]',  geography 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeogpoint '{[Point(1.5 1.5 1.5)@2001-01-01, Point(2.5 2.5 2.5)@2001-01-02, Point(1.5 1.5 1.5)@2001-01-03],[Point(3.5 3.5 3.5)@2001-01-04, Point(3.5 3.5 3.5)@2001-01-05]}',  geography 'Linestring Z empty', 2);
  edwithin 
 ----------
- 
+ f
 (1 row)
 
 SELECT eDwithin(tgeompoint 'Point(1 1)@2001-01-01', tgeompoint 'Point(1 1)@2001-01-02', 2);

--- a/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
+++ b/mobilitydb/test/geo/expected/070_tpoint_spatialrels_tbl.test.out
@@ -13,13 +13,13 @@ SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aContains(g, temp);
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE eDisjoint(g, temp);
  count 
 -------
- 14918
+ 15818
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE eDisjoint(temp, g);
  count 
 -------
- 14918
+ 15818
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -31,13 +31,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE eDisjoint(t1.tem
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE eDisjoint(g, temp);
  count 
 -------
-  9195
+  9795
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE eDisjoint(temp, g);
  count 
 -------
-  9195
+  9795
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE eDisjoint(t1.temp, t2.temp);
@@ -61,13 +61,13 @@ SELECT COUNT(*) > 0 FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE eDisjoin
 SELECT COUNT(*) FROM tbl_geom, tbl_tgeompoint WHERE aDisjoint(g, temp);
  count 
 -------
-  9560
+ 10460
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint, tbl_geom WHERE aDisjoint(temp, g);
  count 
 -------
-  9560
+ 10460
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -79,13 +79,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint t1, tbl_tgeompoint t2 WHERE aDisjoint(t1.tem
 SELECT COUNT(*) FROM tbl_geom3D, tbl_tgeompoint3D WHERE aDisjoint(g, temp);
  count 
 -------
-  8412
+  9012
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D, tbl_geom3D WHERE aDisjoint(temp, g);
  count 
 -------
-  8412
+  9012
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -97,13 +97,13 @@ SELECT COUNT(*) FROM tbl_tgeompoint3D t1, tbl_tgeompoint3D t2 WHERE aDisjoint(t1
 SELECT COUNT(*) FROM tbl_geog t1, tbl_tgeogpoint t2 WHERE t1.k % 3 = 0 AND aDisjoint(g, temp);
  count 
 -------
-  2000
+  2200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_geog t2 WHERE t2.k % 3 = 0 AND aDisjoint(temp, g);
  count 
 -------
-  2000
+  2200
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE aDisjoint(t1.temp, t2.temp);
@@ -115,13 +115,13 @@ SELECT COUNT(*) FROM tbl_tgeogpoint t1, tbl_tgeogpoint t2 WHERE aDisjoint(t1.tem
 SELECT COUNT(*) FROM tbl_geog3D t1, tbl_tgeogpoint3D t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDisjoint(g, temp);
  count 
 -------
-   751
+   817
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_geog3D t2 WHERE t1.k % 3 = 0 AND t2.k % 3 = 0 AND aDisjoint(temp, g);
  count 
 -------
-   751
+   817
 (1 row)
 
 SELECT COUNT(*) FROM tbl_tgeogpoint3D t1, tbl_tgeogpoint3D t2 WHERE aDisjoint(t1.temp, t2.temp);

--- a/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
+++ b/mobilitydb/test/rgeo/expected/154_trgeo_spatialrels.test.out
@@ -134,6 +134,36 @@ SELECT aCovers(
  f
 (1 row)
 
+SELECT eDisjoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+ edisjoint 
+-----------
+ t
+(1 row)
+
+SELECT eIntersects(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+ eintersects 
+-------------
+ f
+(1 row)
+
+SELECT eCovers(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+ ecovers 
+---------
+ f
+(1 row)
+
+SELECT eTouches(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+ etouches 
+----------
+ f
+(1 row)
+
+SELECT aDisjoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+ adisjoint 
+-----------
+ t
+(1 row)
+
 SELECT eDisjoint(
   geometry 'Polygon((10 10,11 10,11 11,10 11,10 10))',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');

--- a/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
+++ b/mobilitydb/test/rgeo/queries/154_trgeo_spatialrels.test.sql
@@ -110,6 +110,15 @@ SELECT aCovers(
 -- eDisjoint / aDisjoint
 -------------------------------------------------------------------------------
 
+-- An empty geometry is a valid operand whose point set is empty, so every
+-- relationship over it has the answer the library gives: disjoint true and
+-- the rest false
+SELECT eDisjoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+SELECT eIntersects(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+SELECT eCovers(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+SELECT eTouches(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+SELECT aDisjoint(trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]', geometry 'Polygon empty');
+
 SELECT eDisjoint(
   geometry 'Polygon((10 10,11 10,11 11,10 11,10 10))',
   trgeometry 'Polygon((0 0,1 0,1 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(4 0),0)@2001-01-05]');


### PR DESCRIPTION
An empty geometry is a well-formed operand whose point set is empty, and every
spatial relationship over it has an answer. The guard testing it sits in the
same condition as the validators, so the twenty-three ever and always
relationships of the tgeo, tcbuffer and trgeometry families answer a
determinate question with the value that means "I cannot answer", and ninety
doc lines record it as "-1 on error or if the geometry is empty".

WITNESS, on master 3466cb6edd, the three families against GEOS 3.12.1, whose
answers for an empty point set are measured in ~/probes/geosempty:

```
                       master   GEOS        master   GEOS
  tgeo     eContains      -1      0    eCovers      -1      0
           eIntersects    -1      0    eTouches     -1      0
           eDisjoint      -1      1
  tcbuffer eContains      -1      0    eCovers      -1      0
           eIntersects    -1      0    eTouches     -1      0
           eDisjoint      -1      1
  trgeo    eIntersects    -1      0    eCovers      -1      0
           eTouches       -1      0    eDisjoint    -1      1
```

Fourteen rows, fourteen disagreements, and each -1 marshals to SQL NULL. GEOS
and PostGIS agree exactly on these answers, so there is no quirk to correct
between them: disjoint is true over an empty point set and every other
relationship is false, which is why a blanket "empty gives false" would be
wrong.

WHY THE VALUE HAS NO PLACE HERE. A three-valued predicate spends -1 on the
question it cannot answer. An empty operand is not that question: the point set
is empty, so the relationship is decided, and the only thing -1 records is that
the guard declined to compute it. Removing the guard is therefore not a
widening of what the functions accept but a correction of what they already
mean, and it is what makes the value domain {0,1} that the sentinel rule reads.

THE GUARD COVERS THREE THINGS BESIDES THE SHORTCUT, and each is fixed here
because none of them is reachable without removing it.

The bounding box prefilters call #geo_set_stbox and discard its answer. That
function returns false for exactly one input, an empty geometry, and leaves its
output argument untouched, so thirteen sites would read an uninitialized stack
STBox. A geometry with no box cannot decide a box test, so the prefilter is
taken only when the box exists and the relationship below answers the rest.

#spatialrel_geo_geo decomposes each operand into its elements and quantifies
over them. An empty geometry decomposes into none, and covers, contains and
disjoint are universally quantified in one argument, so the empty case reads
vacuously true: tcbuffer eCovers answers 1 against the 0 of GEOS while
cbuffer_covers_geo answers -1 and geom_covers answers 0 on the same pair. The
relationship is asked of the geometries themselves where either is empty, which
is where the library answers the empty point set. The tgeo twin already states
this rule in its own comment, "the empty collection case is caught by the
vacuous default".

The native clip paths of ever disjoint, ever intersects and ever dwithin read
the edges of the geometry, and an empty geometry has none. Reaching them
terminates the backend:

```
  SELECT eIntersects(geometry 'Point empty',
    tgeompoint '[Point(1 1)@2001-01-01, Point(2 2)@2001-01-02,
                 Point(1 1)@2001-01-03]');
  LOG:  client backend (PID 1287146) was terminated by signal 11:
        Segmentation fault
```

The instant and the step cases answer f and only the linear sequence dies, so a
value-level probe does not reach it; what reads it is a pg_regress output 494
lines long against an expected 2289. Those three paths state the precondition
where #geom_meos_coverage already states the engine's other limits.

MEASURED. The three families answer GEOS on all fourteen rows, and the suites
move only where an empty operand reaches them:

```
  070_tgeo_spatialrels        96 rows change, every one NULL -> boolean
  070_tpoint_spatialrels     101 rows change, every one NULL -> boolean
  070_tgeo_spatialrels_tbl     8 counts, all eDisjoint / aDisjoint
  070_tpoint_spatialrels_tbl  12 counts, all eDisjoint / aDisjoint
  212_tcbuffer_spatialrels_tbl 4 counts, all eDisjoint / aDisjoint
  every eIntersects count      unchanged, 22 such queries in one file alone
  compiler warnings            0, both the library and the extension
```

Disjoint is the only count that can grow, being the only relationship an empty
operand satisfies, and the growth is the fixture arithmetic: six empty
geometries against a hundred temporal values give 600, and the k % 3 variants
give 200 where the filter selects two of the six and 198 where it selects
thirty-three of the hundred.

The trgeometry and tcbuffer suites carried no empty operand, so the change
reached them untested; each gains the cases its family lacks, and the answers
harvested from the suite are the ones GEOS gives.

The temporal-result relationships keep their guard: they return a temporal
value rather than an int, so what an empty operand answers there is a different
question with a different shape, and it is not decided here.

