### PR TITLE
Reproject and resample a raster

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -145,6 +145,10 @@ extern double raster_band_nodata_value(const Raster *rast, int band);
 
 extern Raster *raster_clip(const Raster *rast, const GSERIALIZED *gs,
   bool crop);
+extern Raster *raster_transform(const Raster *rast, int32_t srid,
+  const char *algorithm, double max_err);
+extern Raster *raster_rescale(const Raster *rast, double scale_x,
+  double scale_y, const char *algorithm, double max_err);
 
 /* Conversion functions for Raquet tiles */
 

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -54,6 +54,7 @@
 #include "librtcore.h"
 
 /* C */
+#include <ctype.h>
 #include <string.h>
 /* MEOS */
 #include <meos.h>
@@ -599,6 +600,10 @@ raster_band_nodata_value(const Raster *rast, int band)
  * Processing functions
  *****************************************************************************/
 
+/* Length of the longest reference system name the warp writes, EPSG: and a
+ * signed 32 bit code */
+#define MAX_SRS_LEN 32
+
 /**
  * @brief Iterator callback keeping a pixel of the subject where the mask
  * covers it
@@ -809,6 +814,224 @@ raster_clip(const Raster *rast, const GSERIALIZED *gs, bool crop)
   raster_destroy(raster);
   rt_raster_set_srid(result, srid);
   return raster_serialize_destroy(result);
+}
+
+/**
+ * @brief Return the resampling algorithm a name states
+ * @details The rt_core mapper answers nearest neighbour for a name it does not
+ * know, which turns a misspelt algorithm into a silent resampling by another
+ * one. The name is therefore tested against the set first and an unknown one
+ * raises, since a resampling is an answer and not a preference
+ * @param[in] algorithm Name of the algorithm, read without regard to case
+ * @param[out] alg The algorithm the name states
+ * @return True where the name states one of the algorithms
+ */
+static bool
+raster_resample_alg(const char *algorithm, GDALResampleAlg *alg)
+{
+  static const char *names[] = {"NEARESTNEIGHBOUR", "NEARESTNEIGHBOR",
+    "BILINEAR", "CUBIC", "CUBICSPLINE", "LANCZOS", "MAX", "MIN"};
+  size_t len = strlen(algorithm);
+  char *name = palloc(len + 1);
+  for (size_t i = 0; i < len; i++)
+    name[i] = (char) toupper((unsigned char) algorithm[i]);
+  name[len] = '\0';
+
+  bool found = false;
+  for (size_t i = 0; i < sizeof(names) / sizeof(names[0]); i++)
+  {
+    if (strcmp(name, names[i]) == 0)
+    {
+      found = true;
+      break;
+    }
+  }
+  if (found)
+    *alg = rt_util_gdal_resample_alg(name);
+  pfree(name);
+  return found;
+}
+
+/**
+ * @brief Return the spatial reference system of an SRID as a string GDAL reads
+ * @details The system is named by its authority and code rather than described
+ * by a projection string, which is the first of the three forms PostGIS itself
+ * offers GDAL for a raster and the one rt_core writes in its own calls. GDAL
+ * resolves it against the PROJ database the raster family already requires, so
+ * no catalog of this build's own is read and the answer is the same whether
+ * MEOS stands alone or runs inside PostgreSQL.
+ *
+ * A code GDAL cannot resolve is refused by the caller rather than guessed at:
+ * a raster carried into a reference system that is not the one asked for is a
+ * wrong answer, and an error is not
+ * @param[in] srid Spatial reference system identifier
+ * @errval NULL
+ * @note The string is the caller's to release with #pfree()
+ */
+static char *
+raster_srs_text(int32_t srid)
+{
+  char *result = palloc(MAX_SRS_LEN);
+  snprintf(result, MAX_SRS_LEN, "EPSG:%d", srid);
+  if (! rt_util_gdal_supported_sr(result))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "GDAL cannot resolve the spatial reference system EPSG:%d", srid);
+    pfree(result);
+    return NULL;
+  }
+  return result;
+}
+
+/**
+ * @brief Return a raster warped into another reference system, another pixel
+ * size, or both
+ * @details The two are one operation: the warp states the result in the target
+ * system and samples the subject into the grid the scale asks for, so a call
+ * asking only for a system keeps the pixel size the reprojection implies, and
+ * a call asking only for a scale regrids the subject where it stands. A target
+ * equal to the subject's own system is not a reprojection, and the reference
+ * strings are then left unstated, which is what rt_core reads as a regridding
+ * @param[in] rast Raster to warp
+ * @param[in] srid Target reference system, or the subject's own to keep it
+ * @param[in] scale_x,scale_y Pixel size in the units of the target system, or
+ * NULL to let the warp choose it
+ * @param[in] algorithm Name of the resampling algorithm
+ * @param[in] max_err Error in input pixels the warp may commit, 0 for none
+ * @errval NULL
+ */
+static Raster *
+raster_warp(const Raster *rast, int32_t srid, double *scale_x, double *scale_y,
+  const char *algorithm, double max_err)
+{
+  GDALResampleAlg alg = GRA_NearestNeighbour;
+  if (algorithm && ! raster_resample_alg(algorithm, &alg))
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Unknown resampling algorithm: %s", algorithm);
+    return NULL;
+  }
+  if (max_err < 0.0)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The error a warp may commit cannot be negative: %f", max_err);
+    return NULL;
+  }
+
+  int32_t src_srid = raster_srid(rast);
+  /* A subject standing in no reference system cannot be carried into one */
+  if (src_srid == SRID_UNKNOWN && srid != src_srid)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The raster states no SRID to reproject from");
+    return NULL;
+  }
+
+  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not deserialize raster");
+    return NULL;
+  }
+
+  /* The reference systems are read only where the warp reprojects: a warp
+   * within one system states neither, which is how rt_core is told that the
+   * grid alone moves */
+  char *src_srs = NULL, *dst_srs = NULL;
+  if (srid != src_srid)
+  {
+    src_srs = raster_srs_text(src_srid);
+    if (! src_srs)
+    {
+      raster_destroy(raster);
+      return NULL;
+    }
+    dst_srs = raster_srs_text(srid);
+    if (! dst_srs)
+    {
+      pfree(src_srs); raster_destroy(raster);
+      return NULL;
+    }
+  }
+
+  rt_raster result = rt_raster_gdal_warp(raster, src_srs, dst_srs, scale_x,
+    scale_y, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, alg, max_err);
+  if (src_srs) pfree(src_srs);
+  if (dst_srs) pfree(dst_srs);
+  raster_destroy(raster);
+  if (! result)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE, "Could not warp the raster");
+    return NULL;
+  }
+  rt_raster_set_srid(result, srid);
+  return raster_serialize_destroy(result);
+}
+
+/**
+ * @ingroup meos_raster_base_transf
+ * @brief Return a raster stated in another spatial reference system
+ * @details Every band is carried into the target system and resampled onto the
+ * grid the reprojection implies, so the result states the same coverage read
+ * through another system rather than the same pixels relabelled
+ * @param[in] rast Raster to reproject
+ * @param[in] srid Target spatial reference system identifier
+ * @param[in] algorithm Name of the resampling algorithm, NULL for nearest
+ * neighbour; one of NearestNeighbour, Bilinear, Cubic, CubicSpline, Lanczos,
+ * Max and Min, read without regard to case
+ * @param[in] max_err Error in input pixels the warp may commit, 0 for an exact
+ * calculation
+ * @errval NULL
+ * @csqlfn None, the host answers this operation on its own raster type
+ */
+Raster *
+raster_transform(const Raster *rast, int32_t srid, const char *algorithm,
+  double max_err)
+{
+  VALIDATE_NOT_NULL(rast, NULL);
+  if (srid == SRID_UNKNOWN)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The target of a reprojection cannot be an unknown SRID");
+    return NULL;
+  }
+  return raster_warp(rast, srid, NULL, NULL, algorithm, max_err);
+}
+
+/**
+ * @ingroup meos_raster_base_transf
+ * @brief Return a raster resampled to another pixel size
+ * @details The result keeps the reference system and the upper left corner of
+ * the subject and states its coverage on a grid of the pixel size asked for,
+ * so a coarser scale reads fewer pixels over the same ground
+ * @param[in] rast Raster to resample
+ * @param[in] scale_x,scale_y Pixel size in the units of the raster's own
+ * reference system, the Y component being negative for a north-up grid as the
+ * geotransform states it
+ * @param[in] algorithm Name of the resampling algorithm, NULL for nearest
+ * neighbour; one of NearestNeighbour, Bilinear, Cubic, CubicSpline, Lanczos,
+ * Max and Min, read without regard to case
+ * @param[in] max_err Error in input pixels the warp may commit, 0 for an exact
+ * calculation
+ * @errval NULL
+ * @csqlfn None, the host answers this operation on its own raster type
+ */
+Raster *
+raster_rescale(const Raster *rast, double scale_x, double scale_y,
+  const char *algorithm, double max_err)
+{
+  VALIDATE_NOT_NULL(rast, NULL);
+  /* A pixel of no width or no height covers no ground, so the grid it would
+   * state has no cell to carry a value */
+  if (scale_x == 0.0 || scale_y == 0.0)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The pixel size of a rescaled raster cannot be zero");
+    return NULL;
+  }
+  return raster_warp(rast, raster_srid(rast), &scale_x, &scale_y, algorithm,
+    max_err);
 }
 
 /*****************************************************************************

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -594,6 +594,119 @@ int main(void)
   free(region_3857); free(region); free(whole); free(cropped);
   free(traj_kept);
 
+  /* Reprojection carries the coverage into another reference system rather
+   * than relabelling the same pixels. Web Mercator states a position in
+   * metres, so the pixel of one degree becomes a pixel of some 10^5 metres,
+   * and the meridian of longitude 0 stands at x = 0 in both systems. */
+  meos_errno_reset();
+  Raster *merc = raster_transform(rast_values, 3857, NULL, 0.0);
+  assert(merc != NULL);
+  assert(meos_errno() == 0);
+  printf("raster_transform(raster, 3857): srid %d, %dx%d, scale (%f, %f), "
+    "upper left (%f, %f)\n", raster_srid(merc), raster_width(merc),
+    raster_height(merc), raster_scale_x(merc), raster_scale_y(merc),
+    raster_upper_left_x(merc), raster_upper_left_y(merc));
+  assert(raster_srid(merc) == 3857);
+  assert(raster_num_bands(merc) == 1);
+  /* The units are those of the target system, not of the source */
+  assert(raster_scale_x(merc) > 1000.0);
+  assert(raster_upper_left_x(merc) > -1e-6 &&
+    raster_upper_left_x(merc) < 1e-6);
+  assert(raster_upper_left_y(merc) > 0.0);
+
+  /* The DATA moves with the grid, which the header alone cannot show. The
+   * oracle is the result's own geotransform rather than a projection formula:
+   * both systems are north up, so the upper left pixel of the result covers
+   * the ground the upper left pixel of the subject covers, and reading the
+   * centre of that pixel must answer what that ground answered before */
+  char traj_merc_str[256];
+  snprintf(traj_merc_str, sizeof(traj_merc_str),
+    "SRID=3857;{POINT(%.6f %.6f)@2001-01-01}",
+    raster_upper_left_x(merc) + raster_scale_x(merc) / 2.0,
+    raster_upper_left_y(merc) + raster_scale_y(merc) / 2.0);
+  Temporal *traj_merc = tgeompoint_in(traj_merc_str);
+  assert(traj_merc != NULL);
+  meos_errno_reset();
+  Temporal *merc_val = raster_value(traj_merc, merc, 1);
+  assert(merc_val != NULL);
+  assert(meos_errno() == 0);
+  char *merc_val_str = tfloat_out(merc_val, 0);
+  printf("raster_transform(raster, 3857) sampled at the centre of its upper "
+    "left pixel: %s\n", merc_val_str);
+  assert(temporal_num_instants(merc_val) == 1);
+  assert(tfloat_start_value(merc_val) == 10.0);
+  free(merc_val_str); free(merc_val);
+  free(traj_merc); free(merc);
+
+  /* Rescaling states the same coverage on a grid of the pixel size asked for,
+   * keeping the reference system and the upper left corner. Halving the pixel
+   * splits each of the nine into four, so the 3x3 of one degree becomes a 6x6
+   * of half a degree over the same ground */
+  meos_errno_reset();
+  Raster *finer = raster_rescale(rast_values, 0.5, -0.5, NULL, 0.0);
+  assert(finer != NULL);
+  assert(meos_errno() == 0);
+  printf("raster_rescale(raster, 0.5, -0.5): %dx%d, scale (%f, %f), "
+    "upper left (%f, %f)\n", raster_width(finer), raster_height(finer),
+    raster_scale_x(finer), raster_scale_y(finer),
+    raster_upper_left_x(finer), raster_upper_left_y(finer));
+  assert(raster_srid(finer) == 4326);
+  assert(raster_num_bands(finer) == 1);
+  assert(raster_width(finer) == 6);
+  assert(raster_height(finer) == 6);
+  assert(raster_scale_x(finer) == 0.5);
+  assert(raster_scale_y(finer) == -0.5);
+  assert(raster_upper_left_x(finer) == 0.0);
+  assert(raster_upper_left_y(finer) == 3.0);
+
+  /* Each quarter of the pixel that held 10 holds 10, which is what a nearest
+   * neighbour resampling onto a finer grid means */
+  Temporal *traj_finer = tgeompoint_in("SRID=4326;{POINT(0.25 2.75)@2001-01-01,"
+    " POINT(0.75 2.75)@2001-01-02, POINT(0.25 2.25)@2001-01-03,"
+    " POINT(0.75 2.25)@2001-01-04}");
+  assert(traj_finer != NULL);
+  meos_errno_reset();
+  Temporal *finer_val = raster_value(traj_finer, finer, 1);
+  assert(finer_val != NULL);
+  assert(meos_errno() == 0);
+  char *finer_str = tfloat_out(finer_val, 0);
+  printf("raster_rescale(raster, 0.5, -0.5) sampled over the quarters of the "
+    "pixel holding 10: %s\n", finer_str);
+  assert(temporal_num_instants(finer_val) == 4);
+  assert(tfloat_start_value(finer_val) == 10.0);
+  assert(tfloat_end_value(finer_val) == 10.0);
+  free(finer_str); free(finer_val); free(traj_finer); free(finer);
+
+  /* The algorithm is read without regard to case, and a name the set does not
+   * hold raises rather than resampling by another algorithm than the one
+   * asked for */
+  meos_errno_reset();
+  Raster *bilinear = raster_rescale(rast_values, 0.5, -0.5, "BiLiNeAr", 0.0);
+  assert(bilinear != NULL);
+  assert(meos_errno() == 0);
+  assert(raster_width(bilinear) == 6);
+  free(bilinear);
+
+  meos_errno_reset();
+  assert(raster_rescale(rast_values, 0.5, -0.5, "Quadratic", 0.0) == NULL);
+  assert(meos_errno() != 0);
+
+  /* A reprojection states where it goes, a rescaling states a pixel that
+   * covers ground, and a warp commits no negative error */
+  meos_errno_reset();
+  /* 0 is the unknown SRID; the public surface publishes no name for it */
+  assert(raster_transform(rast_values, 0, NULL, 0.0) == NULL);
+  assert(raster_rescale(rast_values, 0.0, -0.5, NULL, 0.0) == NULL);
+  assert(raster_rescale(rast_values, 0.5, 0.0, NULL, 0.0) == NULL);
+  assert(raster_transform(rast_values, 3857, NULL, -1.0) == NULL);
+  assert(meos_errno() != 0);
+
+  /* A null argument is rejected rather than dereferenced */
+  meos_errno_reset();
+  assert(raster_transform(NULL, 3857, NULL, 0.0) == NULL);
+  assert(raster_rescale(NULL, 0.5, -0.5, NULL, 0.0) == NULL);
+  assert(meos_errno() != 0);
+
   free(vspan); free(traj_3857); free(traj_values); free(rast_values);
 
   meos_finalize();


### PR DESCRIPTION
MEOS answers raster_transform(rast, srid, algorithm, max_err), which states a
raster in another spatial reference system, and raster_rescale(rast, scale_x,
scale_y, algorithm, max_err), which states it on a grid of another pixel size.
Both are one warp: the target system and the target scale are parameters of
the same rt_core entry, so a call naming only a system keeps the pixel size
the reprojection implies, and a call naming only a scale regrids the raster
where it stands. A target equal to the raster's own system states no reference
strings at all, which is how rt_core is told that the grid alone moves.

The model is the one this family already follows: MEOS supplies the temporal
algebra and the host supplies raster processing, so nothing here re-supplies
an operation PostGIS answers. What it adds is reach. A raster and a trajectory
can be read against one another only where they state their positions in the
same system, and a coverage arrives in whatever system its producer chose. The
reprojection that brings the two together has lived inside PostgreSQL, which
leaves a binding whose host carries no raster extension unable to sample such
a coverage at all. Putting the warp in MEOS is what makes the sampling this
family already answers reachable from a coverage that does not already stand
in the trajectory's own system.

A reference system reaches GDAL named by its authority and code rather than
described by a projection string. That is the first of the three forms PostGIS
offers GDAL for a raster, and the one rt_core writes in its own calls, and it
needs no catalog: GDAL resolves it against the PROJ database the raster family
already requires, so the answer is the same whether MEOS stands alone or runs
inside PostgreSQL. The two catalog-backed forms are unreachable here in any
case, since the strings PostGIS and MEOS each read from spatial_ref_sys are
static to their own translation unit and neither header publishes them. A code
GDAL cannot resolve raises rather than falling back to some other system,
because a raster carried into a system that is not the one asked for is a
wrong answer while an error is not.

The resampling algorithm is read without regard to case and an unknown name
raises. The rt_core mapper answers nearest neighbour for a name it does not
know, which would turn a misspelt algorithm into a silent resampling by
another one, and a resampling is an answer rather than a preference.

The witness is the 3x3 raster of the sampling cases, a 32BF band of one degree
pixels on the grid whose upper left corner is (0,3) in SRID 4326. Reprojected
to 3857 it states its corner at x = 0 and a pixel of 111344.94 metres, and the
centre of its upper left pixel still reads 10, which is what a warp moving the
header alone would fail: both systems are north up, so that pixel covers the
ground the subject's upper left pixel covers. Rescaled to half a degree it is
6 by 6 on the same corner, and each of the four quarters of that pixel reads
10. The refusals are witnessed too: an unknown algorithm name, a zero pixel
size in either axis, a negative error bound, an unknown target SRID and a null
raster each answer NULL with errno set.

Measured, and nothing else moves. pg_regress passes in full on PostgreSQL 18
against a baseline diff of the merge base, the meos/test step of meos.yml runs
clean over its 56 invocations, the seven generated smoke suites report 0
validation warnings, cppcheck reads 152 findings at HEAD against 152 at the
merge base for 0 new, and both targets build with 0 compiler warnings, the
extension under MSYS2 UCRT64 included. The liblwgeom GEOS baseline is
unchanged at 22 of 125 entry points: rt_warp.c and rt_util.c name GEOS zero
times, so the warp adds no entry point, where the sibling rt_raster.c names it
16 times and is why the clip's rasterize call is listed.

There is no new SQL: PostgreSQL answers ST_Transform, ST_Resample and
ST_Rescale on its own raster type, and a MobilityDB user keeps that syntax.
The grid alignment and skew form of ST_Resample is not answered here; it
carries five parameters that are each optional, which is a surface question
of its own rather than part of this one.

