### PR TITLE
Read a raster band as the regions its values cover

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -118,6 +118,17 @@ extern uint64 raquet_hash_extended(const Raquet *rq, uint64 seed);
 
 typedef struct Raster Raster;
 
+/**
+ * @brief A polygon of a raster band together with the value its pixels share
+ * @details The shape PostGIS states as its @p geomval composite type: a group
+ * of pixels carrying one value, and that value
+ */
+typedef struct
+{
+  GSERIALIZED *geom;  /**< Polygon covering a group of pixels */
+  double val;         /**< The value those pixels share */
+} GeomVal;
+
 /* Input and output functions for PostGIS rasters */
 
 extern Raster *raster_from_wkb(const uint8_t *wkb, size_t size);
@@ -149,6 +160,9 @@ extern Raster *raster_transform(const Raster *rast, int32_t srid,
   const char *algorithm, double max_err);
 extern Raster *raster_rescale(const Raster *rast, double scale_x,
   double scale_y, const char *algorithm, double max_err);
+extern GeomVal *raster_dump_as_polygons(const Raster *rast, int band,
+  bool exclude_nodata, int *count);
+extern void geomval_arr_free(GeomVal *gvarr, int count);
 
 /* Conversion functions for Raquet tiles */
 

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -1034,6 +1034,115 @@ raster_rescale(const Raster *rast, double scale_x, double scale_y,
     max_err);
 }
 
+/**
+ * @ingroup meos_raster_base_transf
+ * @brief Release an array of polygons and the values they carry
+ * @param[in] gvarr Array answered by #raster_dump_as_polygons()
+ * @param[in] count Number of elements it holds
+ * @note Each polygon is released with it, so a caller keeping one copies it
+ * first
+ */
+void
+geomval_arr_free(GeomVal *gvarr, int count)
+{
+  if (! gvarr)
+    return;
+  for (int i = 0; i < count; i++)
+    if (gvarr[i].geom)
+      pfree(gvarr[i].geom);
+  pfree(gvarr);
+}
+
+/**
+ * @ingroup meos_raster_base_transf
+ * @brief Return the polygons of a raster band, one for each group of pixels
+ * carrying the same value
+ * @details A band states a value per pixel; this states the same band as the
+ * regions those values cover, so a coverage becomes geometry a spatial
+ * operation can read. Each polygon carries the reference system of the raster,
+ * as every spatial value this family derives from a raster does, so it can be
+ * compared with the trajectories the coverage is read along
+ * @param[in] rast Raster to read
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] exclude_nodata True to leave the pixels the band states as nodata
+ * out of the answer, false to give them a region of their own
+ * @param[out] count Number of polygons answered
+ * @return An array the caller releases with #geomval_arr_free(), or NULL where
+ * the band covers nothing, in which case @p count is 0 and no error is stated
+ * @errval NULL
+ * @csqlfn None, the host answers this operation on its own raster type
+ */
+GeomVal *
+raster_dump_as_polygons(const Raster *rast, int band, bool exclude_nodata,
+  int *count)
+{
+  VALIDATE_NOT_NULL(rast, NULL); VALIDATE_NOT_NULL(count, NULL);
+  *count = 0;
+
+  /* The bands are read, so the subject is deserialized in full */
+  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not deserialize raster");
+    return NULL;
+  }
+
+  /* A band the raster does not have is an error here, as it is for every other
+   * accessor of this family, rather than the empty set PostGIS answers */
+  int numbands = (int) rt_raster_get_num_bands(raster);
+  if (band < 1 || band > numbands)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The raster has no band %d, it has %d", band, numbands);
+    return NULL;
+  }
+
+  int32_t srid = (int32_t) rt_raster_get_srid(raster);
+
+  /* A band that is entirely nodata covers nothing, which is an answer */
+  rt_band rtband = rt_raster_get_band(raster, (uint32_t) (band - 1));
+  if (rtband && rt_band_get_isnodata_flag(rtband))
+  {
+    raster_destroy(raster);
+    return NULL;
+  }
+
+  int nelems = 0;
+  rt_geomval geomval = rt_raster_gdal_polygonize(raster, band - 1,
+    exclude_nodata ? 1 : 0, &nelems);
+  raster_destroy(raster);
+  if (! geomval)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not read band %d of the raster as polygons", band);
+    return NULL;
+  }
+  if (nelems < 1)
+  {
+    pfree(geomval);
+    return NULL;
+  }
+
+  /* Each polygon arrives as plain WKB and states no reference system of its
+   * own, so it is given the one the raster states, which is the system its
+   * coordinates are already in */
+  GeomVal *result = palloc0(sizeof(GeomVal) * (size_t) nelems);
+  for (int i = 0; i < nelems; i++)
+  {
+    LWGEOM *geom = lwpoly_as_lwgeom(geomval[i].geom);
+    lwgeom_set_srid(geom, srid);
+    result[i].geom = geo_serialize(geom);
+    result[i].val = geomval[i].val;
+    lwgeom_free(geom);
+  }
+  pfree(geomval);
+
+  *count = nelems;
+  return result;
+}
+
 /*****************************************************************************
  * Conversion functions
  *****************************************************************************/

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -707,6 +707,67 @@ int main(void)
   assert(raster_rescale(NULL, 0.5, -0.5, NULL, 0.0) == NULL);
   assert(meos_errno() != 0);
 
+  /* Reading a band as polygons states the same band as the regions its values
+   * cover. The 3x3 band holds eight distinct values and one nodata pixel, and
+   * no two neighbouring pixels share a value, so every pixel is a region of
+   * its own: eight polygons excluding the nodata pixel, nine including it */
+  int npolys = 0;
+  meos_errno_reset();
+  GeomVal *polys = raster_dump_as_polygons(rast_values, 1, true, &npolys);
+  assert(polys != NULL);
+  assert(meos_errno() == 0);
+  printf("raster_dump_as_polygons(raster, 1, true): %d polygon(s)\n", npolys);
+  assert(npolys == 8);
+
+  /* Each polygon carries the reference system of the raster, so it can be
+   * compared with the trajectories the coverage is read along, and each
+   * covers exactly the one pixel whose value it states */
+  double total = 0.0;
+  bool seen_10 = false;
+  for (int i = 0; i < npolys; i++)
+  {
+    assert(polys[i].geom != NULL);
+    assert(geo_srid(polys[i].geom) == 4326);
+    /* A pixel of one degree by one degree covers an area of 1 */
+    assert(geom_area(polys[i].geom) > 0.999 &&
+      geom_area(polys[i].geom) < 1.001);
+    total += polys[i].val;
+    if (polys[i].val == 10.0)
+      seen_10 = true;
+  }
+  /* The eight values the band states, the nodata pixel excluded */
+  printf("raster_dump_as_polygons(raster, 1, true) values sum to %f\n", total);
+  assert(total == 10.0 + 30.0 + 40.0 + 50.0 + 60.0 + 70.0 + 80.0 + 90.0);
+  assert(seen_10);
+  geomval_arr_free(polys, npolys);
+
+  /* Keeping the nodata pixel gives it a region of its own, so the count rises
+   * by exactly one */
+  meos_errno_reset();
+  int npolys_all = 0;
+  GeomVal *polys_all = raster_dump_as_polygons(rast_values, 1, false,
+    &npolys_all);
+  assert(polys_all != NULL);
+  assert(meos_errno() == 0);
+  printf("raster_dump_as_polygons(raster, 1, false): %d polygon(s)\n",
+    npolys_all);
+  assert(npolys_all == npolys + 1);
+  geomval_arr_free(polys_all, npolys_all);
+
+  /* A band the raster does not have is an error, as it is for every other
+   * accessor of this family, and a null argument is rejected */
+  meos_errno_reset();
+  int nbad = -1;
+  assert(raster_dump_as_polygons(rast_values, 0, true, &nbad) == NULL);
+  assert(nbad == 0);
+  assert(raster_dump_as_polygons(rast_values, 2, true, &nbad) == NULL);
+  assert(raster_dump_as_polygons(NULL, 1, true, &nbad) == NULL);
+  assert(raster_dump_as_polygons(rast_values, 1, true, NULL) == NULL);
+  assert(meos_errno() != 0);
+
+  /* Releasing an empty answer is not an error */
+  geomval_arr_free(NULL, 0);
+
   free(vspan); free(traj_3857); free(traj_values); free(rast_values);
 
   meos_finalize();

--- a/tools/scripts/liblwgeom_geos_baseline.txt
+++ b/tools/scripts/liblwgeom_geos_baseline.txt
@@ -9,6 +9,7 @@ meos/src/geo/postgis_funcs.c	lwgeom_intersection_prec
 meos/src/geo/postgis_funcs.c	lwgeom_unaryunion_prec
 meos/src/raster/raster_rtcore.c	rt_raster_add_band
 meos/src/raster/raster_rtcore.c	rt_raster_destroy
+meos/src/raster/raster_rtcore.c	rt_raster_gdal_polygonize
 meos/src/raster/raster_rtcore.c	rt_raster_gdal_rasterize
 meos/src/raster/raster_rtcore.c	rt_raster_geopoint_to_rasterpoint
 meos/src/raster/raster_rtcore.c	rt_raster_get_band


### PR DESCRIPTION
MEOS answers raster_dump_as_polygons(rast, band, exclude_nodata, &count),
which states a band as one polygon per group of neighbouring pixels carrying
the same value, together with that value. The pair is the shape PostGIS states
as its geomval composite type, and it arrives here as a GeomVal the caller
releases with geomval_arr_free(): one array, freed once, with each polygon
released alongside it.

The model is that a coverage and a trajectory meet as geometry. A band states
a value per pixel, which no spatial operation can read; the same band stated
as regions is an ordinary geometry, so the area a class covers can be
intersected, measured and compared against the trips that cross it. That is
also why each polygon carries the reference system of the raster rather than
none, which is a deliberate divergence from PostGIS: rt_raster_gdal_polygonize
builds every polygon from plain OGR WKB and neither it nor ST_DumpAsPolygons
applies an SRID, so PostGIS hands back a geometry stating no system. Under
this engine's rule that mixing reference systems is an error, such a polygon
could never be compared with the trajectory the coverage is read along. The
family already settles it the other way: raster_to_stbox reads the raster's
SRID and writes it into the box it answers, so a spatial value derived from a
raster carries the raster's system, and these polygons do too.

Two smaller divergences follow the family rather than PostGIS. A band the
raster does not have raises, as raster_value already does, where PostGIS
answers an empty set and a notice. A band that is entirely nodata answers NULL
with a count of 0 and no error, because covering nothing is an answer.

The witness is the 3x3 raster of the sampling cases, a 32BF band of one degree
pixels holding 10, nodata, 30 / 40, 50, 60 / 70, 80, 90 in SRID 4326. It reads
8 polygons excluding the nodata pixel: the band holds eight distinct values
and no two neighbouring pixels share one, so every pixel is a region of its
own, and their values sum to 430, which is 10+30+40+50+60+70+80+90. Each
polygon states SRID 4326 and an area of 1, a one degree pixel. Keeping the
nodata pixel reads 9, exactly one more, which is the region that pixel covers.
The refusals are witnessed too: band 0, band 2 on a one band raster, a null
raster and a null count each answer NULL with errno set and leave the count at
0, and releasing an empty answer is not an error.

Measured, and nothing else moves. Both targets build with 0 compiler warnings;
the extension library defines both new symbols and its undefined count is 581,
the same as before this change, which is the check a shared link would
otherwise let pass silently. check_error_sentinels and check_csqlfn read
clean. The liblwgeom GEOS baseline gains exactly one line and it is in the
raster tail: rt_raster_gdal_polygonize contains 0 GEOS calls over its 319
lines and is listed only because the checker is file granular and its file
names GEOS 8 times elsewhere. The geometry frontier is unchanged at 3 entries
in postgis_funcs.c, which is the number that matters to the GEOS carve.

There is no new SQL: PostgreSQL answers ST_DumpAsPolygons on its own raster
type, and a MobilityDB user keeps that syntax.

