### PR TITLE
Summarize what the pixels of a raster band amount to

### DIFF
--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -129,6 +129,22 @@ typedef struct
   double val;         /**< The value those pixels share */
 } GeomVal;
 
+/**
+ * @brief What a raster band's pixels amount to, taken in one pass
+ * @details The shape PostGIS states as the record of its @p ST_SummaryStats:
+ * how many pixels the band states a value for, and what those values sum to,
+ * average, spread and reach
+ */
+typedef struct
+{
+  uint32_t count;  /**< Number of pixels the statistics are taken over */
+  double sum;      /**< Sum of their values */
+  double mean;     /**< Mean of their values */
+  double stddev;   /**< Standard deviation of their values */
+  double min;      /**< Smallest of their values */
+  double max;      /**< Largest of their values */
+} BandStats;
+
 /* Input and output functions for PostGIS rasters */
 
 extern Raster *raster_from_wkb(const uint8_t *wkb, size_t size);
@@ -162,6 +178,8 @@ extern Raster *raster_rescale(const Raster *rast, double scale_x,
   double scale_y, const char *algorithm, double max_err);
 extern GeomVal *raster_dump_as_polygons(const Raster *rast, int band,
   bool exclude_nodata, int *count);
+extern BandStats *raster_summary_stats(const Raster *rast, int band,
+  bool exclude_nodata);
 extern void geomval_arr_free(GeomVal *gvarr, int count);
 
 /* Conversion functions for Raquet tiles */

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -1143,6 +1143,90 @@ raster_dump_as_polygons(const Raster *rast, int band, bool exclude_nodata,
   return result;
 }
 
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return what the pixels of a raster band amount to
+ * @details The band is read ONCE and answers one value carrying every
+ * statistic, rather than a function per statistic each of which would rescan
+ * it. Every pixel is read: rt_core samples a band only when asked for a
+ * fraction below one, and this asks for all of them, so the answer is exact
+ * rather than estimated
+ * @param[in] rast Raster to read
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] exclude_nodata True to leave the pixels the band states as nodata
+ * out of the statistics, false to count them as the values they hold
+ * @return The statistics, which the caller releases with @p free(), or NULL
+ * where the band states no pixel to count, in which case no error is stated
+ * @errval NULL
+ * @csqlfn None, the host answers this operation on its own raster type
+ */
+BandStats *
+raster_summary_stats(const Raster *rast, int band, bool exclude_nodata)
+{
+  VALIDATE_NOT_NULL(rast, NULL);
+
+  /* The band values are read, so the subject is deserialized in full */
+  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not deserialize raster");
+    return NULL;
+  }
+
+  /* A band the raster does not have is an error here, as it is for every
+   * other accessor of this family */
+  int numbands = (int) rt_raster_get_num_bands(raster);
+  if (band < 1 || band > numbands)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The raster has no band %d, it has %d", band, numbands);
+    return NULL;
+  }
+
+  rt_band rtband = rt_raster_get_band(raster, (uint32_t) (band - 1));
+  if (! rtband)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not read band %d of the raster", band);
+    return NULL;
+  }
+
+  /* A sample of one is every pixel: rt_core reads the whole band unless it is
+   * asked for a fraction strictly between zero and one. The values themselves
+   * are not wanted, only what they amount to, and no coverage is accumulated
+   * across rasters, so the three coverage accumulators are unstated */
+  rt_bandstats stats = rt_band_get_summary_stats(rtband,
+    exclude_nodata ? 1 : 0, 1.0, 0, NULL, NULL, NULL);
+  raster_destroy(raster);
+  if (! stats)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not summarize band %d of the raster", band);
+    return NULL;
+  }
+
+  /* A band whose every pixel is nodata states no value to summarize, which is
+   * an answer rather than an error; the statistics of no pixels have no mean */
+  if (stats->count < 1)
+  {
+    pfree(stats);
+    return NULL;
+  }
+
+  BandStats *result = palloc0(sizeof(BandStats));
+  result->count = stats->count;
+  result->sum = stats->sum;
+  result->mean = stats->mean;
+  result->stddev = stats->stddev;
+  result->min = stats->min;
+  result->max = stats->max;
+  pfree(stats);
+  return result;
+}
+
 /*****************************************************************************
  * Conversion functions
  *****************************************************************************/

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -768,6 +768,52 @@ int main(void)
   /* Releasing an empty answer is not an error */
   geomval_arr_free(NULL, 0);
 
+  /* What the band amounts to, read in one pass. Excluding nodata the eight
+   * values are 10, 30, 40, 50, 60, 70, 80 and 90, so every statistic follows
+   * in closed form: they sum to 430 and average 53.75, the smallest is 10 and
+   * the largest 90 */
+  meos_errno_reset();
+  BandStats *st = raster_summary_stats(rast_values, 1, true);
+  assert(st != NULL);
+  assert(meos_errno() == 0);
+  printf("raster_summary_stats(raster, 1, true): count %u, sum %f, mean %f, "
+    "stddev %f, min %f, max %f\n", st->count, st->sum, st->mean, st->stddev,
+    st->min, st->max);
+  assert(st->count == 8);
+  assert(st->sum == 430.0);
+  assert(st->mean == 53.75);
+  assert(st->min == 10.0);
+  assert(st->max == 90.0);
+  /* The deviations square to 4987.5, so the population standard deviation is
+   * sqrt(4987.5/8) = 24.96873, and the sample one would be sqrt(4987.5/7) =
+   * 26.69270. The band is read whole rather than sampled, so it is the first,
+   * and the bound below separates the two conventions rather than merely
+   * bracketing a number */
+  assert(st->stddev > 24.96 && st->stddev < 24.98);
+  free(st);
+
+  /* Counting the nodata pixel counts the value it holds, -9999, so the count
+   * rises by one and the sum and the minimum move to it */
+  meos_errno_reset();
+  BandStats *st_all = raster_summary_stats(rast_values, 1, false);
+  assert(st_all != NULL);
+  assert(meos_errno() == 0);
+  printf("raster_summary_stats(raster, 1, false): count %u, sum %f, min %f, "
+    "max %f\n", st_all->count, st_all->sum, st_all->min, st_all->max);
+  assert(st_all->count == 9);
+  assert(st_all->sum == 430.0 - 9999.0);
+  assert(st_all->min == -9999.0);
+  assert(st_all->max == 90.0);
+  free(st_all);
+
+  /* A band the raster does not have is an error, and a null argument is
+   * rejected rather than dereferenced */
+  meos_errno_reset();
+  assert(raster_summary_stats(rast_values, 0, true) == NULL);
+  assert(raster_summary_stats(rast_values, 2, true) == NULL);
+  assert(raster_summary_stats(NULL, 1, true) == NULL);
+  assert(meos_errno() != 0);
+
   free(vspan); free(traj_3857); free(traj_values); free(rast_values);
 
   meos_finalize();


### PR DESCRIPTION
MEOS answers raster_summary_stats(rast, band, exclude_nodata), which reads a
band once and states how many pixels carry a value, what those values sum to,
and their mean, standard deviation, smallest and largest. The six arrive as
one BandStats the caller releases with free(), which is the record convention
this family already uses for the geometry and value pair of its polygons.

The model is that a statistic of a band is one question, not six. A function
per statistic rescans the band for each, so asking for the mean and the
spread together would read every pixel twice and could answer them from two
different passes; one value read in one pass cannot disagree with itself. It
also gives a binding a shape it can project as a record, so a caller reads
the mean off the answer rather than calling a differently named function for
each field.

Every pixel is read rather than sampled. rt_core takes a sample fraction and
walks the whole band whenever that fraction is not strictly between zero and
one, so asking for one makes the answer exact rather than estimated, and the
standard deviation is then the population form sqrt(Q/k) rather than the
sample form sqrt(Q/(k-1)) its other branch would use. This also means the
process wide random number generator is never touched: srand and rand sit
inside the sampling branch alone, which this path does not take, though the
linker still records srand as a reference for the branch that is compiled but
not entered.

A band the raster does not have raises, as it does for every other accessor
of this family, where PostGIS answers an empty row. A band whose every pixel
is nodata answers NULL with no error, since the statistics of no values have
no mean to stand for them.

The witness is the 3x3 raster of the sampling cases, a 32BF band holding 10,
nodata, 30 / 40, 50, 60 / 70, 80, 90. Excluding nodata it answers count 8,
sum 430, mean 53.75, min 10 and max 90, every one of which follows in closed
form from those eight values, and stddev 24.968730, which is sqrt(4987.5/8);
the test bounds it between 24.96 and 24.98, which excludes the sample form's
26.69270, so the assertion says WHICH formula ran rather than only bracketing
a number. Counting the nodata pixel counts the value it holds: count 9, sum
-9569 and min -9999, with the maximum unmoved at 90. Band 0, band 2 on a one
band raster and a null raster each answer NULL with errno set.

Measured, and nothing else moves. Both targets build with 0 compiler
warnings; the extension library defines the new symbol, and its undefined
count rises by exactly one, srand@GLIBC_2.2.5, which glibc resolves at load
and which the diff of the two symbol sets names precisely. check_error_
sentinels and check_csqlfn read clean, and the liblwgeom GEOS baseline is
UNCHANGED at 23 of 125 entry points: rt_statistics.c names GEOS 0 times where
rt_geometry.c names it 19, so this entry point adds nothing to the frontier.

There is no new SQL: PostgreSQL answers ST_SummaryStats on its own raster
type, and a MobilityDB user keeps that syntax.

