### PR TITLE
Read the side the answer lies on from the answer, not from the operands

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -102,6 +102,10 @@ typedef struct
   double theta1;
   double theta2;
   bool ccw;
+  /* Set where, IN THE DIRECTION THIS PIECE IS STORED IN, the answer lies to
+   * its left. The selection knows it and the chaining walk needs it: see
+   * #buffer_add_selected_piece() */
+  bool answer_left;
 } BufferPiece;
 
 /**
@@ -2537,6 +2541,39 @@ buffer_collect_boundary_intersections(const LWGEOM *geom1, const LWGEOM *geom2,
  * tells a caller that a pair with nothing in @p shared is one whose reported
  * coincidence does not resolve rather than one meeting at nodes
  */
+/**
+ * @brief Add a selected piece, recording which side of it the answer lies on
+ * @details THE CHAINING WALK NEEDS ONE FRAME AND THE PIECES DO NOT CARRY ONE.
+ * A piece arrives in the direction its OWN geometry happens to be written in,
+ * and the two operands are written independently, so a walk crossing from one
+ * boundary to the other reverses the side the answer sits on halfway round.
+ * Where exactly two piece-ends meet that costs nothing, because there is no
+ * choice to make. At a node FOUR of them share it decides the answer, and no
+ * ordering rule alone can be right in both frames at once.
+ * Near a piece the answer coincides with the piece's OWN geometry on one side,
+ * and which side is #buffer_piece_interior_side(). The exception is a piece of
+ * the SUBTRACTED geometry in a difference: what the subtrahend encloses is
+ * exactly what the answer does not, so there the answer is on the other side.
+ * THE PIECE IS STORED AS IT ARRIVES. Reversing it here answers the same
+ * question and rotates the start vertex of every ring assembled from it, which
+ * is a spelling change across the whole surface for a defect living at pinch
+ * nodes alone.
+ * A side that cannot be read leaves the flag false, and the walk falls back on
+ * the ordering by itself, which is what it has to go on today.
+ */
+static void
+buffer_add_selected_piece(MeosArray *result, const BufferPiece *piece,
+  BufferLocator *own, bool inverted)
+{
+  assert(result); assert(piece); assert(own);
+  BufferPiece kept = *piece;
+  int side = buffer_piece_interior_side(&kept, own);
+  /* 0 = the geometry's interior lies LEFT of the piece, 1 = RIGHT */
+  kept.answer_left = (side == 0 || side == 1) ?
+    ((side == 0) != inverted) : false;
+  meos_array_add(result, &kept);
+}
+
 static void
 buffer_select_overlay_boundary(const MeosArray *pieces_a, BufferLocator *loc_b,
   const MeosArray *pieces_b, BufferLocator *loc_a, ClipOper oper,
@@ -2559,7 +2596,7 @@ buffer_select_overlay_boundary(const MeosArray *pieces_a, BufferLocator *loc_b,
     BufferPiece *piece = (BufferPiece *) meos_array_get(pieces_a, i);
     BufferPieceLocation location = buffer_classify_piece(piece, loc_b);
     if (location == keep_a)
-      meos_array_add(result, piece);
+      buffer_add_selected_piece(result, piece, loc_a, false);
     else if (location == BUFFER_PIECE_BOUNDARY)
     {
       *coincident = true;
@@ -2575,7 +2612,7 @@ buffer_select_overlay_boundary(const MeosArray *pieces_a, BufferLocator *loc_b,
     BufferPiece *piece = (BufferPiece *) meos_array_get(pieces_b, i);
     BufferPieceLocation location = buffer_classify_piece(piece, loc_a);
     if (location == keep_b)
-      meos_array_add(result, piece);
+      buffer_add_selected_piece(result, piece, loc_b, oper == CL_DIFFERENCE);
     else if (location == BUFFER_PIECE_BOUNDARY)
     {
       *coincident = true;
@@ -2763,12 +2800,17 @@ buffer_piece_end_direction(const BufferPiece *piece, bool at_start,
  */
 static int
 buffer_find_connected_piece(const MeosArray *pieces, const bool *used,
-  POINT2D point, double from_dx, double from_dy, bool *reverse)
+  POINT2D point, double from_dx, double from_dy, bool want_left, bool *reverse)
 {
   assert(pieces); assert(used); assert(reverse);
   int best = -1;
   bool best_reverse = false;
   double best_turn = 0.0;
+  /* A candidate KEEPING THE ANSWER ON THE SIDE THIS RING IS TRACING IT ON is
+   * preferred over one crossing to the other side, and the ordering below then
+   * chooses among those. Only a node several pieces share offers both, so this
+   * decides exactly the case the ordering cannot */
+  bool have_framed = false;
   bool have_direction = (from_dx != 0.0 || from_dy != 0.0);
   for (uint32_t i = 0; i < pieces->count; i++)
   {
@@ -2784,6 +2826,17 @@ buffer_find_connected_piece(const MeosArray *pieces, const bool *used,
       rev = true;
     else
       continue;
+    /* Traversing a piece backwards puts the answer on its other side */
+    bool framed = (piece->answer_left != rev) == want_left;
+    if (have_framed && ! framed)
+      continue;
+    if (framed && ! have_framed)
+    {
+      /* The first candidate holding the frame discards every earlier one */
+      have_framed = true;
+      best = -1;
+      best_turn = 0.0;
+    }
     /* The first piece of a ring, and a node with one candidate, need no turn */
     if (! have_direction)
     {
@@ -2855,6 +2908,10 @@ buffer_chain_ring_with_pieces(const MeosArray *pieces, bool *used,
   if (! curve)
     return NULL;
   BufferPiece oriented = *first;
+  /* The ring takes its first piece as it stands, so THAT piece fixes the side
+   * this ring keeps the answer on. Reading the frame off the ring rather than
+   * imposing one leaves every start vertex where it was */
+  bool want_left = oriented.answer_left;
   buffer_append_piece_to_curve(curve, srid, &oriented);
   meos_array_add(ordered, &oriented);
   used[start_index] = true;
@@ -2870,7 +2927,7 @@ buffer_chain_ring_with_pieces(const MeosArray *pieces, bool *used,
   {
     bool reverse = false;
     int index = buffer_find_connected_piece(pieces, used, current, -from_dx,
-      -from_dy, &reverse);
+      -from_dy, want_left, &reverse);
     if (index < 0)
     {
       lwgeom_free(lwcompound_as_lwgeom(curve));

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -2438,6 +2438,44 @@ int main(void)
   free(pzw); free(pz); free(pz_a); free(pz_b);
   meos_errno_reset();
 
+  /* THE SAME PINCH WITH THE OTHER OPERAND CURVED, which is what says the walk
+   * reads the side from the answer rather than from the direction an operand
+   * happens to be written in. The triangle's apex (2 4) sits EXACTLY on the
+   * circle, so four piece-ends meet there again -- but the disc arrives as
+   * arcs carrying their own sense while the square above arrives as segments,
+   * and a walk taking each piece as written keeps the answer on one side for
+   * one operand and on the other for the other.
+   * The disc is partitioned by the triangle, so what the two overlays cover
+   * between them is the disc, and each keeps its arcs.
+   * THE IDENTITY IS ONLY APPROXIMATE HERE AND THE REASON IS THE MEASURE, not
+   * the answer: geom_area() strokes each PART separately, and the chords it
+   * lays across two half-arcs are not the chords it lays across the whole
+   * circle, so the two sides differ by about 2.3e-05 where the subject itself
+   * carries the arcs. Under an area that integrates the arcs the two sides are
+   * 6.909180872 and 5.657189742, summing to 4*pi exactly. What discriminates
+   * here is therefore the ARCS SURVIVING, which the fall-through cannot do;
+   * the sum is a sanity bound on top of it */
+  GSERIALIZED *cz_a = geom_in(
+    "CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))", -1);
+  GSERIALIZED *cz_b = geom_in("TRIANGLE((0 0,4 0,2 4,0 0))", -1);
+  assert(cz_a != NULL); assert(cz_b != NULL);
+  meos_errno_reset();
+  GSERIALIZED *cz_i = geom_intersection2d(cz_a, cz_b);
+  GSERIALIZED *cz_k = geom_difference2d(cz_a, cz_b);
+  assert(cz_i != NULL); assert(cz_k != NULL);
+  assert(meos_errno() == 0);
+  double cz_whole = geom_area(cz_a);
+  double cz_parts = geom_area(cz_i) + geom_area(cz_k);
+  printf("a curved pinch partitions its disc: %.9f against %.9f\n", cz_parts,
+    cz_whole);
+  assert(fabs(cz_parts - cz_whole) < 1e-4 * cz_whole);
+  char *cz_w = geo_as_text(cz_k, 6);
+  printf("a curved pinch keeps: %.60s\n", cz_w);
+  assert(strstr(cz_w, "CIRCULARSTRING") != NULL);
+  free(cz_w);
+  free(cz_i); free(cz_k); free(cz_a); free(cz_b);
+  meos_errno_reset();
+
   /* A REGION WHOLLY INSIDE ANOTHER LEAVES NOTHING BEHIND, and it leaves
    * nothing behind whether or not the two boundaries touch on the way: what
    * they share along the touch is of no area, and a difference of regions does


### PR DESCRIPTION
## The witness

A triangle whose apex sits **exactly on a circle**, so four piece-ends meet at
that apex and the answer is two lobes pinched there:

```sql
SELECT ST_Difference(
  geometry 'CURVEPOLYGON(CIRCULARSTRING(0 2,2 4,4 2,2 0,0 2))',
  geometry 'TRIANGLE((0 0,4 0,2 4,0 0))');
```

Before this commit the overlay welds the two lobes into **one ring that visits
the apex twice**, the ring bounds no surface, and the answer comes from the
fall-through as a chain of chords. It now answers the two lobes with their arcs
kept: `5.657189742` kept and `6.909180872` shared, partitioning the disc to
`4*pi` exactly.

## Why the walk could not decide

A boundary piece arrives in the direction its **own** geometry happens to be
written in, and the two operands are written independently. A walk that crosses
from one boundary to the other therefore reverses the side the answer sits on
halfway round, and the ordering rule — turn as sharply as the node allows — is
applied in two different frames within one ring. Where exactly two piece-ends
meet that costs nothing, because there is no choice to make. At a node four of
them share, it decides the answer.

**This is a frame problem, not an ordering one**, and the measurement that says
so is that the *same* triangle against a **square** already answers correctly,
because both operands then arrive as segments in one frame:

| | |
|---|---|
| square minus triangle | `MULTIPOLYGON(((4 0,4 4,2 4,4 0)),((2 4,0 4,0 0,2 4)))` — correct |
| disc minus triangle | one self-crossing ring, no surface, GEOS strokes it |

Two orderings were tried against those two rows and **each satisfies exactly one
of them**: taking the last piece round answers the disc and regresses the
square; the standard planar face traversal answers the disc and breaks the
square's own assertion. No ordering can be right in both frames at once.

## What it does

The selection already knows the side: near a kept piece the answer coincides
with that piece's own geometry on one side, and `buffer_piece_interior_side()`
reads which. The exception is a piece of the **subtracted** geometry in a
difference, where what the subtrahend encloses is exactly what the answer does
not. So each selected piece records whether the answer lies to its left **as it
is stored**, each ring reads its frame off the first piece it takes, and a
candidate that would cross to the other side loses to one that does not. The
ordering then chooses among the candidates that hold the frame, unchanged.

**The pieces are not reversed, and that is deliberate.** Reversing them answers
the same question and rotates the start vertex of every ring assembled from
them — a spelling change across the whole areal surface for a defect that lives
at pinch nodes alone. Reading the frame off the ring instead leaves every start
vertex where it is: the union of two overlapping squares still spells
`POLYGON((1 2,0 2,0 0,2 0,2 1,3 1,3 3,1 3,1 2))`, byte for byte.

The sibling this mirrors is `lwgeom_force_clockwise`, the normalisation that
makes a direction comparison mean a *side* comparison elsewhere in the engine.
It cannot be used here: it handles `POLYGON`, `TRIANGLE`, `MULTIPOLYGON` and
`COLLECTION` and returns without touching a `CURVEPOLYGON` or a `MULTISURFACE`,
which are exactly the operands this reaches.

## Measured, and what did not move

| | |
|---|---|
| the four pairs a 225-pair type sweep finds | **4 of 4** now answer natively with their arcs kept |
| against an arc-exact area and exact circle-segment Booleans | **0 mismatches**, the new pair reading `6.909180872` / `5.657189742` |
| what a pair shares where it shares no area | `POINT(2 1)`, `POINT(1 1)`, `LINESTRING(1 0,1 1)`, `POLYGON EMPTY` — unchanged |
| ring spelling | unchanged, checked on the union whose expectation pins it |
| two builds over 42 instruments | 3 lines move: the 2 this commit's own test prints, plus a timestamp |
| `pg_regress` on PostgreSQL 18 | all tests passed |
| `libmeos` under MSYS2 UCRT64 | clean |
| cppcheck | 152 findings on both arms, **0 new** |

**The projected regime, which this was not aimed at and closes anyway:**

| | before | after |
|---|---|---|
| `6.4e6`, 10 mm feature | `-2.18e-06` | **`-4.27e-14`** |
| `180 89`, 0.1 mm feature | `-1.23e-10` | **`-3.37e-20`** |

7 of 7 configurations now partition, where 5 of 7 did. Those two residuals had
no named cause; it is the same frame ambiguity, showing up as a tiny area error
rather than as a broken ring.

## On the test

It asserts the arcs survive — which the fall-through cannot do — and bounds the
partition sum on top of that. It is a **bound rather than an identity** because
`geom_area()` strokes each *part* separately, and the chords it lays across two
half-arcs are not those it lays across the whole circle, so the two sides differ
by `2.3e-05` where the *subject* itself carries arcs. Under an area that
integrates the arcs they sum to `4*pi` exactly. The assertion aborts at the
parent commit on the arcs.
