### PR TITLE
Drop Google's Chrome package source along with Microsoft's

### DIFF
--- a/.github/actions/apt-resilient/action.yml
+++ b/.github/actions/apt-resilient/action.yml
@@ -28,18 +28,20 @@ runs:
     - name: Drop the package sources the build does not read
       shell: bash
       run: |
-        # The runner image ships Microsoft's azure-cli and prod repositories, and
-        # every package this project installs comes from the Ubuntu archives, so
-        # those two repositories answer for nothing here. They do fail: from the
-        # Azure runners they return `403  Forbidden`, which makes `apt-get update`
-        # exit 100 and fails a step that asked only for Ubuntu packages.
+        # The runner image ships Microsoft's azure-cli and prod repositories and
+        # Google's Chrome repository, and every package this project installs
+        # comes from the Ubuntu archives, so those repositories answer for
+        # nothing here. They do fail: from the Azure runners Microsoft's return
+        # `403  Forbidden`, and a fetch of Google's package index can fail its
+        # hash check. Either makes `apt-get update` exit 100 and fails a step
+        # that asked only for Ubuntu packages.
         #
-        # Retries and timeouts above cannot reach that failure — a 403 is an
-        # immediate, unchanging answer, so every retry repeats it. Removing the
+        # Retries and timeouts above do not reach these failures — a job that
+        # meets one carries both settings and still exits 100. Removing the
         # sources is what removes the dependency; apt then reports on exactly the
         # repositories the build reads, and a genuine Ubuntu archive failure still
         # fails the step.
-        sources=$(grep -rl 'packages\.microsoft\.com' \
+        sources=$(grep -rlE 'packages\.microsoft\.com|dl\.google\.com' \
           /etc/apt/sources.list /etc/apt/sources.list.d 2>/dev/null || true)
         if [ -n "$sources" ]; then
           echo "$sources" | while IFS= read -r source; do


### PR DESCRIPTION
The runner image carries Google's Chrome repository beside Microsoft's two,
and no package this project installs comes from it. Its index fails as well:
attempt 1 of run 34384497905, the Cppcheck job on master at b613fb803c, stops
in "Install build dependencies and cppcheck" on `Err:27
https://dl.google.com/linux/chrome-stable/deb stable/main amd64 Packages` and
`E: Failed to fetch .../binary-amd64/Packages.gz  Hash`, and `apt-get update`
exits 100 with the retries and timeouts of the action already in place.

The action removes every source naming dl.google.com as it removes those
naming packages.microsoft.com, so apt reads only the archives the build
installs from. No workflow or action under .github names Google or Chrome, so
nothing reads the source it removes.

