### PR TITLE
State why a total comparator documents no error value

### DIFF
--- a/tools/scripts/check_error_sentinels.py
+++ b/tools/scripts/check_error_sentinels.py
@@ -102,7 +102,12 @@ BOX_DISTANCE = re.compile(r"^nad_tbox")
 # because -1 is already one of the answers. What this catches is the public
 # comparator that answers INT_MAX SILENTLY: the value is in the code and in no
 # contract, so neither a reader nor a binding generator can find it, and the
-# check below reads a documented value it never finds.
+# check below reads a documented value it never finds. A comparator whose body
+# has no failing path states no error value, and the body test below is what
+# lets it through: h3index_cmp, meos_h3index_cmp, quadbin_cmp, s2cell_cmp,
+# int32_cmp and int64_cmp take their operands by value, validate nothing and
+# answer -1, 0 or 1 for every pair, so an INT_MAX in their contract would
+# promise a value they never produce.
 CMP = re.compile(r"_cmp$")
 PUBLIC_DOC = re.compile(r"@ingroup\s+meos_(?!internal)")
 # A pointer return: any sentinel other than NULL is wrong


### PR DESCRIPTION
check_error_sentinels.py flags a public comparator whose body answers INT_MAX
without a contract saying so, and passes a comparator whose body never answers
it. Six public comparators take that second path -- h3index_cmp,
meos_h3index_cmp, quadbin_cmp, s2cell_cmp, int32_cmp and int64_cmp -- because
each takes its operands by value, validates nothing and answers -1, 0 or 1 for
every pair; 114 calls across them answer INT_MAX zero times and raise zero
times, against a temporal_cmp(NULL, NULL) control answering 2147483647.

An INT_MAX in their contract would promise a value they never produce, so the
rule is stated once, in the checker beside the test that encodes it, rather
than in the doc comments of the six functions.

