### PR TITLE
Read the SRID where two geometries are compared or two boxes measured

### DIFF
--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -5153,6 +5153,8 @@ geo_as_geojson(const GSERIALIZED *gs, int option, int precision,
 /**
  * @ingroup meos_geo_base_comp
  * @brief Return true if the geometries/geographies are the same
+ * @details Two values in different spatial reference systems are not the
+ * same whatever their coordinates, as for the circular buffers and the poses
  * @param[in] gs1,gs2 Geometries/geographies
  */
 bool
@@ -5160,6 +5162,10 @@ geo_same(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(gs1, false); VALIDATE_NOT_NULL(gs2, false);
+
+  /* The vertex comparison below reads the coordinates alone */
+  if (gserialized_get_srid(gs1) != gserialized_get_srid(gs2))
+    return false;
 
   LWGEOM *geom1 = lwgeom_from_gserialized(gs1);
   LWGEOM *geom2 = lwgeom_from_gserialized(gs2);

--- a/meos/src/geo/tgeo_distance.c
+++ b/meos/src/geo/tgeo_distance.c
@@ -2733,6 +2733,8 @@ nad_stbox_geo(const STBox *box, const GSERIALIZED *gs)
   return result;
 }
 
+static double stbox_spatial_dist(const STBox *box1, const STBox *box2);
+
 /**
  * @ingroup meos_internal_geo_dist
  * @brief Return the nearest approach distance between two spatiotemporal
@@ -2758,7 +2760,7 @@ stbox_nad(const STBox *box1, const STBox *box2)
 
   /* The nearest approach distance is the spatial-only distance between the
    * boxes (time already tested above) */
-  return stbox_spatial_distance(box1, box2);
+  return stbox_spatial_dist(box1, box2);
 }
 
 /**
@@ -3041,17 +3043,18 @@ shortestline_tgeo_tgeo(const Temporal *temp1, const Temporal *temp2)
  *****************************************************************************/
 
 /**
- * @ingroup meos_geo_dist
  * @brief Return the spatial-only minimum distance between two spatiotemporal
  * boxes, ignoring the time dimension entirely
  * @param[in] box1,box2 Spatiotemporal boxes
- * @errval DBL_MAX
+ * @pre The boxes are comparable and both carry a spatial extent
  */
-double
-stbox_spatial_distance(const STBox *box1, const STBox *box2)
+static double
+stbox_spatial_dist(const STBox *box1, const STBox *box2)
 {
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(box1, DBL_MAX); VALIDATE_NOT_NULL(box2, DBL_MAX);
+  assert(box1); assert(box2);
+  assert(ensure_valid_stbox_stbox(box1, box2));
+  assert(ensure_has_X(T_STBOX, box1->flags));
+  assert(ensure_has_X(T_STBOX, box2->flags));
 
   /* Spatial extents overlap → exact minimum is 0 (some pair of points
    * inside the joined extent has zero distance). Every spatial axis must be
@@ -3092,6 +3095,24 @@ stbox_spatial_distance(const STBox *box1, const STBox *box2)
   pfree(DatumGetPointer(g1));
   pfree(DatumGetPointer(g2));
   return result;
+}
+
+/**
+ * @ingroup meos_geo_dist
+ * @brief Return the spatial-only minimum distance between two spatiotemporal
+ * boxes, ignoring the time dimension entirely
+ * @param[in] box1,box2 Spatiotemporal boxes
+ * @errval DBL_MAX
+ */
+double
+stbox_spatial_distance(const STBox *box1, const STBox *box2)
+{
+  /* Ensure the validity of the arguments */
+  if (! ensure_valid_stbox_stbox(box1, box2) ||
+      ! ensure_has_X(T_STBOX, box1->flags) ||
+      ! ensure_has_X(T_STBOX, box2->flags))
+    return DBL_MAX;
+  return stbox_spatial_dist(box1, box2);
 }
 
 /*****************************************************************************
@@ -3362,7 +3383,7 @@ mindistance_tgeoarr_tgeoarr(const Temporal **arr1, int count1,
        * distance, so for geodetic inputs every pair gets a zero lower bound,
        * disabling the ordering short-circuit so that all pairs are tested */
       pairs[k].bd = MEOS_FLAGS_GET_GEODETIC(arr1[0]->flags) ? 0.0 :
-        stbox_spatial_distance(&bb1[i], &bb2[j]);
+        stbox_spatial_dist(&bb1[i], &bb2[j]);
       k++;
     }
   qsort(pairs, npairs, sizeof(TgeoarrPair), tgeoarr_pair_cmp);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -2647,6 +2647,39 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* The coordinates of a value are read in its reference system. One point
+   * stated in two systems is two different geometries, and a distance between
+   * boxes in two systems has no answer, so it reports the mixture */
+  GSERIALIZED *sr1 = geom_in("SRID=4326;Point(1 1)", -1);
+  GSERIALIZED *sr2 = geom_in("SRID=5676;Point(1 1)", -1);
+  assert(sr1 != NULL); assert(sr2 != NULL);
+  meos_errno_reset();
+  assert(geo_same(sr1, sr1));
+  assert(! geo_same(sr1, sr2));
+  assert(meos_errno() == 0);
+  printf("geo_same on one point stated in two reference systems: false\n");
+  free(sr1); free(sr2);
+
+  STBox *sb1 = stbox_in("SRID=4326;STBOX X((0,0),(2,2))");
+  STBox *sb2 = stbox_in("SRID=4326;STBOX X((5,5),(7,7))");
+  STBox *sb3 = stbox_in("SRID=5676;STBOX X((5,5),(7,7))");
+  STBox *sbt = stbox_in("STBOX T([2001-01-01, 2001-01-02])");
+  assert(sb1 != NULL); assert(sb2 != NULL); assert(sb3 != NULL);
+  assert(sbt != NULL);
+  meos_errno_reset();
+  double sbd = stbox_spatial_distance(sb1, sb2);
+  assert(fabs(sbd * sbd - 18.0) < 1e-9);
+  assert(meos_errno() == 0);
+  assert(stbox_spatial_distance(sb1, sb3) == DBL_MAX);
+  printf("stbox_spatial_distance across two reference systems: errno %d\n",
+    meos_errno());
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  assert(stbox_spatial_distance(sb1, sbt) == DBL_MAX);
+  assert(meos_errno() != 0);
+  meos_errno_reset();
+  free(sb1); free(sb2); free(sb3); free(sbt);
+
   /* Finalize MEOS */
   meos_finalize();
 


### PR DESCRIPTION
Witness: geo_same(`SRID=4326;Point(1 1)`, `SRID=5676;Point(1 1)`) answers
true, and stbox_spatial_distance(`SRID=4326;STBOX X((0,0),(2,2))`,
`SRID=5676;STBOX X((5,5),(7,7))`) answers 4.24264 with no error, the number
the same pair answers in one reference system. With this change the first
answers false and the second answers DBL_MAX with an error, as
nad_stbox_stbox answers on the same pair.

Why these answers: geo_same compares through lwgeom_same, which reads types,
flags and vertices and never the SRID. Two values stated in different
reference systems are different values: PostGIS answers ST_OrderingEquals
through gserialized_cmp, which orders by SRID, and cbuffer_same, pose_same and
posechain_same answer false on a differing SRID, so geo_same answers false
without raising, as they do. A distance across two reference systems has no
answer, so stbox_spatial_distance validates as nad_stbox_stbox does, through
ensure_valid_stbox_stbox and ensure_has_X. Its body is a static kernel
asserting those preconditions, called by stbox_nad and by the pairwise lower
bound of the distance between two arrays of temporal values, which reach it
with operands already validated, so the validation is paid once per public
call and never inside those loops.

Measured: a probe over the 34 comparison, sameness and distance entries of
cbuffer, pose, posechain, stbox and geo calls each on one value against
itself and against the same coordinates in another SRID. On master 32 entries
answer the two calls differently or raise, and 2 answer them alike, these
two; with the change all 34 do. meos/test/geo_test.c asserts both new answers
and passes. ctest passes 336 of 336 on PostgreSQL 18, and MEOS, the extension
and the extension without families build with no warning on the changed
lines, as does libmeos under MSYS2 UCRT64.

