### PR TITLE
State the step answer of the rasterValue example

### DIFF
--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -1962,7 +1962,8 @@ WITH rast AS (
     [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
 SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
   POINT(2.5 2.5)@2001-01-02, POINT(0.5 0.5)@2001-01-03]', r)::text FROM rast;
--- {10@2001-01-01, 30@2001-01-02, 70@2001-01-03}
+-- Interp=Step;[10@2001-01-01, 20@2001-01-01 06:00:00, 30@2001-01-01 18:00:00,
+--   50@2001-01-02 08:00:00, 70@2001-01-02 20:00:00, 70@2001-01-03]
 </programlisting>
 				<para>Aplicado a un conjunto de datos de trayectorias con un ráster de elevación del terreno:</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -1965,7 +1965,8 @@ WITH rast AS (
     [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
 SELECT rasterValue(tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
   POINT(2.5 2.5)@2001-01-02, POINT(0.5 0.5)@2001-01-03]', r)::text FROM rast;
--- {10@2001-01-01, 30@2001-01-02, 70@2001-01-03}
+-- Interp=Step;[10@2001-01-01, 20@2001-01-01 06:00:00, 30@2001-01-01 18:00:00,
+--   50@2001-01-02 08:00:00, 70@2001-01-02 20:00:00, 70@2001-01-03]
 </programlisting>
 				<para>Applied to a trajectory dataset with a terrain elevation raster:</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">


### PR DESCRIPTION
The rasterValue example reads a trajectory that moves between its instants,
which the entry's paragraph says is walked at half a pixel and answers a step
tfloat holding each value until the trip reaches a pixel holding another. The
example's result comment states that answer as harvested: the step sequence
that passes over the 20 and 50 pixels between the three instants. The English
and Spanish manuals carry the same block.

