### PR TITLE
Map the values of a raster band onto classes

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3191,6 +3191,9 @@
 					<para><link linkend="raster_rasterValue"><varname>rasterValue</varname></link>: Muestrea una banda de ráster en cada instante de una trayectoria</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_reclass"><varname>reclass</varname></link>: Devuelve un ráster cuya banda contiene las clases a las que una expresión asigna sus valores</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				</listitem>
 				<listitem>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -1977,6 +1977,39 @@ WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_reclass">
+				<indexterm significance="normal"><primary><varname>reclass</varname></primary></indexterm>
+				<para>Devuelve un ráster cuya banda contiene las clases a las que una expresión asigna sus valores</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+reclass(raster,band integer,expr text,pixeltype text,nodata float8=NULL) → raster
+</programlisting>
+				<para>La expresión sigue la gramática de <varname>ST_Reclass</varname> de PostGIS: una lista de asignaciones separadas por comas, cada una un rango de origen y un destino separados por dos puntos, siendo un rango un valor o dos separados por un guion. Un rango escrito sin corchetes incluye su extremo inferior y excluye el superior, mientras que <varname>(</varname> excluye el extremo inferior y <varname>]</varname> incluye el superior, de modo que <varname>0-50</varname> deja 50 sin asignar mientras que <varname>[50-100]</varname> lo toma. Un píxel que ningún rango toma contiene el valor nodata de la banda resultante, o cero cuando la banda no declara ninguno. Esa banda tiene el tipo de píxel <varname>pixeltype</varname>, con el nombre que le da PostGIS raster, como <varname>8BUI</varname>, y no declara valor nodata cuando se omite <varname>nodata</varname>. El ráster conserva su malla y sus demás bandas, de modo que las clases pueden leerse a lo largo de una trayectoria con <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT ST_DumpValues(reclass(r, 1, '0-50:1, 51-100:2', '8BUI', 0), 1) AS plain,
+  ST_DumpValues(reclass(r, 1, '0-50:1, [50-100]:2', '8BUI', 0), 1) AS bracket
+FROM rast;
+-- {{1,1,1},{1,NULL,2},{2,2,2}} | {{1,1,1},{1,2,2},{2,2,2}}
+-- Read the classes along a trajectory
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(0.5 2.5)@2001-01-01,
+  POINT(1.5 1.5)@2001-01-02, POINT(2.5 0.5)@2001-01-03}',
+  reclass(r, 1, '0-50:1, [50-100]:2', '8BUI', 0))::text FROM rast;
+-- {1@2001-01-01, 2@2001-01-02, 2@2001-01-03}
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3200,6 +3200,9 @@
 					<para><link linkend="raster_rasterValue"><varname>rasterValue</varname></link>: Sample a raster band at each instant of a trajectory</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_reclass"><varname>reclass</varname></link>: Return a raster whose band holds the classes an expression maps its values to</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a <varname>raquet</varname> raster tile along a trajectory</para>
 				</listitem>
 				<listitem>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -1980,6 +1980,39 @@ WHERE atSpan(rasterValue(trip, elev), floatspan '[200, 9999]') IS NOT NULL;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_reclass">
+				<indexterm significance="normal"><primary><varname>reclass</varname></primary></indexterm>
+				<para>Return a raster whose band holds the classes an expression maps its values to</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+reclass(raster,band integer,expr text,pixeltype text,nodata float8=NULL) → raster
+</programlisting>
+				<para>The expression follows the grammar of the PostGIS <varname>ST_Reclass</varname>: a comma-separated list of mappings, each a source range and a destination around a colon, a range being one value or two around a dash. A range written plainly includes its low end and excludes its high end, while <varname>(</varname> excludes the low end and <varname>]</varname> includes the high end, so <varname>0-50</varname> leaves 50 unmapped where <varname>[50-100]</varname> takes it. A pixel no range takes holds the nodata value of the resulting band, or zero when the band states none. That band has the pixel type <varname>pixeltype</varname>, named as PostGIS raster names it, such as <varname>8BUI</varname>, and states no nodata value when <varname>nodata</varname> is left out. The raster keeps its grid and its other bands, so the classes can be read along a trajectory with <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT ST_DumpValues(reclass(r, 1, '0-50:1, 51-100:2', '8BUI', 0), 1) AS plain,
+  ST_DumpValues(reclass(r, 1, '0-50:1, [50-100]:2', '8BUI', 0), 1) AS bracket
+FROM rast;
+-- {{1,1,1},{1,NULL,2},{2,2,2}} | {{1,1,1},{1,2,2},{2,2,2}}
+-- Read the classes along a trajectory
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(0.5 2.5)@2001-01-01,
+  POINT(1.5 1.5)@2001-01-02, POINT(2.5 0.5)@2001-01-03}',
+  reclass(r, 1, '0-50:1, [50-100]:2', '8BUI', 0))::text FROM rast;
+-- {1@2001-01-01, 2@2001-01-02, 2@2001-01-03}
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -180,6 +180,8 @@ extern GeomVal *raster_dump_as_polygons(const Raster *rast, int band,
   bool exclude_nodata, int *count);
 extern BandStats *raster_summary_stats(const Raster *rast, int band,
   bool exclude_nodata);
+extern Raster *raster_reclass(const Raster *rast, int band, const char *expr,
+  const char *pixeltype, bool has_nodata, double nodataval);
 extern void geomval_arr_free(GeomVal *gvarr, int count);
 
 /* Conversion functions for Raquet tiles */

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -117,6 +117,13 @@ raster_serialize_destroy(rt_raster raster)
     meos_error(ERROR, MEOS_ERR_WKB_INPUT, "Could not serialize raster");
     return NULL;
   }
+  /* The serialized form opens with its own length, which is where the varlena
+   * header stands, and rt_core writes that length as a plain number. A reader
+   * that takes it as a varlena header -- which is every reader on the
+   * PostgreSQL side -- needs it encoded as one, so it is stamped here, where
+   * the form is produced, rather than by each caller. Without it a raster this
+   * function answers reads as a band of no width and no height. */
+  SET_VARSIZE(result, ((struct rt_raster_serialized_t *) result)->size);
   return result;
 }
 
@@ -1225,6 +1232,406 @@ raster_summary_stats(const Raster *rast, int band, bool exclude_nodata)
   result->max = stats->max;
   pfree(stats);
   return result;
+}
+
+/**
+ * @brief Remove every space from a string, in place
+ * @details The grammar below is stated without regard to spacing, so the
+ * expression is closed up before it is read rather than each reader skipping
+ * whitespace of its own
+ */
+static char *
+reclass_removespaces(char *str)
+{
+  char *w = str;
+  for (char *r = str; *r; r++)
+    if (! isspace((unsigned char) *r))
+      *w++ = *r;
+  *w = '\0';
+  return str;
+}
+
+/**
+ * @brief Split a string on one separator character, the way the grammar reads
+ * @details EMPTY PIECES ARE SKIPPED, which is load bearing rather than
+ * incidental: PostGIS splits with @p strtok, so a run of separators counts as
+ * one and a leading separator opens no empty piece. That is what lets a range
+ * of negative bounds be read at all -- `-9999--1` states two pieces, `9999`
+ * and `1`, whose signs are restored afterwards from the text they came from,
+ * where a split keeping empties would state four and be refused as malformed
+ * @param[in] str String to split
+ * @param[in] sep Separator character
+ * @param[out] n Number of pieces
+ * @return An array of pieces, each and the array itself the caller's to free
+ */
+static char **
+reclass_strsplit(const char *str, char sep, int *n)
+{
+  /* An upper bound on the pieces: one more than the separators */
+  int cap = 1;
+  for (const char *p = str; *p; p++)
+    if (*p == sep)
+      cap++;
+  char **result = palloc(sizeof(char *) * (size_t) cap);
+
+  int k = 0;
+  const char *p = str;
+  while (*p)
+  {
+    while (*p == sep)
+      p++;
+    if (! *p)
+      break;
+    const char *start = p;
+    while (*p && *p != sep)
+      p++;
+    size_t len = (size_t) (p - start);
+    result[k] = palloc(len + 1);
+    memcpy(result[k], start, len);
+    result[k][len] = '\0';
+    k++;
+  }
+  /* A string holding nothing but separators states one empty piece, as the
+   * splitter this follows does for an empty string */
+  if (! k)
+  {
+    result[0] = palloc(1);
+    result[0][0] = '\0';
+    k = 1;
+  }
+  *n = k;
+  return result;
+}
+
+/**
+ * @brief Release the pieces of a split and the array holding them
+ */
+static void
+reclass_strsplit_free(char **pieces, int n)
+{
+  for (int i = 0; i < n; i++)
+    pfree(pieces[i]);
+  pfree(pieces);
+}
+
+/**
+ * @brief Remove any of a set of characters from both ends of a string
+ */
+static void
+reclass_chartrim(char *str, const char *chars)
+{
+  size_t len = strlen(str);
+  size_t start = 0;
+  while (start < len && strchr(chars, str[start]))
+    start++;
+  while (len > start && strchr(chars, str[len - 1]))
+    len--;
+  memmove(str, str + start, len - start);
+  str[len - start] = '\0';
+}
+
+/**
+ * @brief Return the LAST occurrence of one string within another
+ */
+static const char *
+reclass_strrstr(const char *haystack, const char *needle)
+{
+  size_t nlen = strlen(needle);
+  if (! nlen)
+    return haystack;
+  const char *found = NULL;
+  for (const char *p = haystack; (p = strstr(p, needle)) != NULL; p++)
+    found = p;
+  return found;
+}
+
+/**
+ * @brief Read a reclassification expression into the ranges it states
+ * @details THE GRAMMAR IS POSTGIS'S, NOT INVENTED HERE. An expression is a
+ * comma separated list of mappings; each mapping is a source range, a colon,
+ * and a destination range; each range is one value or two around a dash. A
+ * bracket states how an end is bounded: on the low end `(` excludes the value
+ * and `)` or `]` marks the range as reaching beyond it, while on the high end
+ * `]` includes the value and `(` or `[` marks it as reaching beyond. A dash
+ * belonging to a negative number is told from the separating dash by what
+ * stands before it, which is why the pieces are matched back against the text
+ * they came from
+ * @param[in] expr Expression, already closed up of spaces
+ * @param[out] count Number of ranges read
+ * @errval NULL
+ */
+static rt_reclassexpr *
+reclass_parse(const char *expr, int *count)
+{
+  int comma_n;
+  char **comma_set = reclass_strsplit(expr, ',', &comma_n);
+  if (comma_n < 1)
+  {
+    reclass_strsplit_free(comma_set, comma_n);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The reclassification expression states no mapping: %s", expr);
+    return NULL;
+  }
+
+  rt_reclassexpr *exprset = palloc0(sizeof(rt_reclassexpr) * (size_t) comma_n);
+  int j = 0;
+  bool failed = false;
+
+  for (int a = 0; a < comma_n && ! failed; a++)
+  {
+    int colon_n;
+    char **colon_set = reclass_strsplit(comma_set[a], ':', &colon_n);
+    if (colon_n != 2)
+    {
+      reclass_strsplit_free(colon_set, colon_n);
+      failed = true;
+      meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+        "A mapping states a source and a destination around one colon: %s",
+        comma_set[a]);
+      break;
+    }
+
+    exprset[j] = palloc0(sizeof(struct rt_reclassexpr_t));
+    for (int b = 0; b < colon_n && ! failed; b++)
+    {
+      int dash_n;
+      char **dash_set = reclass_strsplit(colon_set[b], '-', &dash_n);
+
+      /* A bracket standing alone before the first value belongs to it: the
+       * low end of `(-9999-100` splits as "(", "9999", "100" and the bracket
+       * has to be given back to the number it bounds */
+      if (dash_n > 1 && strlen(dash_set[0]) == 1 &&
+          strchr("()[]", dash_set[0][0]))
+      {
+        size_t len = strlen(dash_set[1]) + 2;
+        char *glued = palloc(len);
+        snprintf(glued, len, "%s%s", dash_set[0], dash_set[1]);
+        pfree(dash_set[0]); pfree(dash_set[1]);
+        dash_set[1] = glued;
+        for (int t = 1; t < dash_n; t++)
+          dash_set[t - 1] = dash_set[t];
+        dash_n--;
+      }
+
+      if (dash_n < 1 || dash_n > 2)
+      {
+        /* This break leaves the enclosing loop, so its release is not reached
+         * and the pieces are freed here */
+        reclass_strsplit_free(dash_set, dash_n);
+        failed = true;
+        meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+          "A range states one value or two around a dash: %s", colon_set[b]);
+        break;
+      }
+
+      for (int c = 0; c < dash_n && ! failed; c++)
+      {
+        /* How this end is bounded, read from the bracket that marks it. The
+         * low end and the high end read the same characters differently */
+        int exc_val = 0, inc_val = 1;
+        if (dash_n != 1)
+        {
+          if (c < 1)
+          {
+            if (strchr(dash_set[c], ')') || strchr(dash_set[c], ']'))
+            {
+              exc_val = 1; inc_val = 1;
+            }
+            else if (strchr(dash_set[c], '('))
+              inc_val = 0;
+            else
+              inc_val = 1;
+          }
+          else
+          {
+            if (strrchr(dash_set[c], '(') || strrchr(dash_set[c], '['))
+            {
+              exc_val = 1; inc_val = 0;
+            }
+            else if (strrchr(dash_set[c], ']'))
+              inc_val = 1;
+            else
+              inc_val = 0;
+          }
+        }
+
+        reclass_chartrim(dash_set[c], "()[]");
+
+        char *end = NULL;
+        errno = 0;
+        double val = strtod(dash_set[c], &end);
+        if (errno != 0 || end == dash_set[c])
+        {
+          /* The pieces are released once, where this loop ends: freeing them
+           * here as well would release them twice, since breaking leaves the
+           * enclosing loop's own release still to come */
+          failed = true;
+          meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+            "A range bound is not a number: %s", colon_set[b]);
+          break;
+        }
+
+        /* The split consumed the dash of a negative number along with the one
+         * that separates the bounds, so the sign is read back from the text
+         * the piece came from: a dash before it that itself opens the string,
+         * or follows another dash or an opening bracket, is a sign */
+        const char *at = (c < 1) ? strstr(colon_set[b], dash_set[c]) :
+          reclass_strrstr(colon_set[b], dash_set[c]);
+        if (at && at != colon_set[b] && *(at - 1) == '-' &&
+            (((at - 1) == colon_set[b]) || *(at - 2) == '-' ||
+             *(at - 2) == '[' || *(at - 2) == '('))
+          val *= -1.0;
+
+        if (b < 1)
+        {
+          if (dash_n == 1)
+          {
+            exprset[j]->src.exc_min = exprset[j]->src.exc_max = exc_val;
+            exprset[j]->src.inc_min = exprset[j]->src.inc_max = inc_val;
+            exprset[j]->src.min = exprset[j]->src.max = val;
+          }
+          else if (c < 1)
+          {
+            exprset[j]->src.exc_min = exc_val;
+            exprset[j]->src.inc_min = inc_val;
+            exprset[j]->src.min = val;
+          }
+          else
+          {
+            exprset[j]->src.exc_max = exc_val;
+            exprset[j]->src.inc_max = inc_val;
+            exprset[j]->src.max = val;
+          }
+        }
+        else
+        {
+          if (dash_n == 1)
+            exprset[j]->dst.min = exprset[j]->dst.max = val;
+          else if (c < 1)
+            exprset[j]->dst.min = val;
+          else
+            exprset[j]->dst.max = val;
+        }
+      }
+      reclass_strsplit_free(dash_set, dash_n);
+    }
+    reclass_strsplit_free(colon_set, colon_n);
+    if (! failed)
+      j++;
+  }
+  reclass_strsplit_free(comma_set, comma_n);
+
+  if (failed)
+  {
+    for (int k = 0; k <= j && k < comma_n; k++)
+      if (exprset[k])
+        pfree(exprset[k]);
+    pfree(exprset);
+    return NULL;
+  }
+
+  *count = j;
+  return exprset;
+}
+
+/**
+ * @ingroup meos_raster_base_transf
+ * @brief Return a raster whose band states the classes an expression maps its
+ * values onto
+ * @details The values of a band are read as the ranges an expression names and
+ * written as the ranges it maps them to, so a coverage of measurements becomes
+ * a coverage of classes that a trajectory can be read against. The grammar is
+ * PostGIS's: a comma separated list of mappings, each a source range and a
+ * destination range around a colon, each range one value or two around a dash,
+ * with brackets stating how an end is bounded
+ * @param[in] rast Raster to reclassify
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] expr Expression, such as `0-100:1, 101-200:2, 201-300:3`
+ * @param[in] pixeltype Name of the pixel type of the resulting band
+ * @param[in] has_nodata True where the resulting band states a nodata value
+ * @param[in] nodataval That value, read only where @p has_nodata is true
+ * @errval NULL
+ * @csqlfn #Raster_reclass()
+ */
+Raster *
+raster_reclass(const Raster *rast, int band, const char *expr,
+  const char *pixeltype, bool has_nodata, double nodataval)
+{
+  VALIDATE_NOT_NULL(rast, NULL); VALIDATE_NOT_NULL(expr, NULL);
+  VALIDATE_NOT_NULL(pixeltype, NULL);
+
+  rt_pixtype pixtype = rt_pixtype_index_from_name(pixeltype);
+  if (pixtype == PT_END)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Unknown pixel type: %s", pixeltype);
+    return NULL;
+  }
+
+  /* The band values are read and written, so the subject is deserialized in
+   * full */
+  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
+  if (! raster)
+  {
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not deserialize raster");
+    return NULL;
+  }
+
+  int numbands = (int) rt_raster_get_num_bands(raster);
+  if (band < 1 || band > numbands)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The raster has no band %d, it has %d", band, numbands);
+    return NULL;
+  }
+
+  char *clean = pstrdup(expr);
+  reclass_removespaces(clean);
+  int nexpr = 0;
+  rt_reclassexpr *exprset = reclass_parse(clean, &nexpr);
+  pfree(clean);
+  if (! exprset)
+  {
+    raster_destroy(raster);
+    return NULL;
+  }
+  if (nexpr < 1)
+  {
+    pfree(exprset); raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "The reclassification expression states no mapping: %s", expr);
+    return NULL;
+  }
+
+  rt_band rtband = rt_raster_get_band(raster, (uint32_t) (band - 1));
+  rt_band newband = rtband ? rt_band_reclass(rtband, pixtype,
+    has_nodata ? 1 : 0, nodataval, exprset, (uint32_t) nexpr) : NULL;
+  for (int k = 0; k < nexpr; k++)
+    pfree(exprset[k]);
+  pfree(exprset);
+  if (! newband)
+  {
+    raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not reclassify band %d of the raster", band);
+    return NULL;
+  }
+
+  /* The reclassified band stands where the one it was read from stood, so the
+   * result keeps the grid and every other band of the subject */
+  rt_band oldband = rt_raster_replace_band(raster, newband,
+    (uint32_t) (band - 1));
+  if (! oldband)
+  {
+    rt_band_destroy(newband); raster_destroy(raster);
+    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
+      "Could not put the reclassified band %d back", band);
+    return NULL;
+  }
+  rt_band_destroy(oldband);
+  return raster_serialize_destroy(raster);
 }
 
 /*****************************************************************************

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -814,6 +814,120 @@ int main(void)
   assert(raster_summary_stats(NULL, 1, true) == NULL);
   assert(meos_errno() != 0);
 
+  /* Reclassifying maps the values of a band onto the classes an expression
+   * names. The band holds 10, 30, 40, 50, 60, 70, 80 and 90 outside its
+   * nodata pixel.
+   * A RANGE WRITTEN PLAINLY IS HALF OPEN AT THE TOP: 0-50 states 0 included
+   * and 50 EXCLUDED, since the high end is inclusive only where a closing
+   * bracket says so. So 10, 30 and 40 take class 1, 60, 70, 80 and 90 take
+   * class 2, and 50 falls in NEITHER range and is left unmapped. The summary
+   * of the result is the oracle: seven pixels carrying three 1s and four 2s,
+   * which sum to 11 */
+  meos_errno_reset();
+  Raster *rc = raster_reclass(rast_values, 1, "0-50:1, 51-100:2", "32BF",
+    true, -9999.0);
+  assert(rc != NULL);
+  assert(meos_errno() == 0);
+  BandStats *rcst = raster_summary_stats(rc, 1, true);
+  assert(rcst != NULL);
+  printf("raster_reclass(raster, 1, \"0-50:1, 51-100:2\"): count %u, sum %f, "
+    "min %f, max %f\n", rcst->count, rcst->sum, rcst->min, rcst->max);
+  assert(rcst->count == 7);
+  assert(rcst->sum == 3.0 * 1.0 + 4.0 * 2.0);
+  assert(rcst->min == 1.0);
+  assert(rcst->max == 2.0);
+  free(rcst);
+
+  /* The grid and the reference system are those of the subject: only the
+   * values of the band move */
+  assert(raster_width(rc) == 3);
+  assert(raster_height(rc) == 3);
+  assert(raster_srid(rc) == 4326);
+  assert(raster_upper_left_x(rc) == 0.0);
+  assert(raster_upper_left_y(rc) == 3.0);
+
+  /* The pixel holding 10 is in the first class and the one holding 90 in the
+   * second, read where they stand rather than in aggregate */
+  Temporal *traj_rc = tgeompoint_in("SRID=4326;{POINT(0.5 2.5)@2001-01-01,"
+    " POINT(2.5 0.5)@2001-01-02}");
+  assert(traj_rc != NULL);
+  Temporal *rc_val = raster_value(traj_rc, rc, 1);
+  assert(rc_val != NULL);
+  char *rc_str = tfloat_out(rc_val, 0);
+  printf("raster_reclass sampled at the 10 pixel and the 90 pixel: %s\n",
+    rc_str);
+  assert(tfloat_start_value(rc_val) == 1.0);
+  assert(tfloat_end_value(rc_val) == 2.0);
+  free(rc_str); free(rc_val); free(traj_rc); free(rc);
+
+  /* A CLOSING BRACKET IS WHAT INCLUDES THE HIGH BOUND, and writing one brings
+   * the value the plain form dropped back in: [50-100] takes 50, so every one
+   * of the eight values is mapped and the pixel holding 50 reads class 2.
+   * Three 1s and five 2s sum to 13 over eight pixels, against the seven and
+   * the 11 above -- the difference IS the bracket */
+  meos_errno_reset();
+  Raster *rb = raster_reclass(rast_values, 1, "[0-50):1, [50-100]:2", "32BF",
+    true, -9999.0);
+  assert(rb != NULL);
+  assert(meos_errno() == 0);
+  BandStats *rbst = raster_summary_stats(rb, 1, true);
+  assert(rbst != NULL);
+  printf("raster_reclass(\"[0-50):1, [50-100]:2\"): count %u, sum %f\n",
+    rbst->count, rbst->sum);
+  assert(rbst->count == 8);
+  assert(rbst->sum == 3.0 * 1.0 + 5.0 * 2.0);
+  free(rbst);
+  Temporal *traj_50 = tgeompoint_in("SRID=4326;{POINT(1.5 1.5)@2001-01-01}");
+  assert(traj_50 != NULL);
+  Temporal *v50 = raster_value(traj_50, rb, 1);
+  assert(v50 != NULL);
+  printf("raster_reclass(\"[0-50):1, [50-100]:2\") at the 50 pixel: %f\n",
+    tfloat_start_value(v50));
+  assert(tfloat_start_value(v50) == 2.0);
+  free(v50); free(traj_50);
+
+  /* Its neighbour holding 40 stands inside [0-50) and takes class 1, which is
+   * what says the first range is read at all rather than everything falling
+   * through to the second */
+  Temporal *traj_40 = tgeompoint_in("SRID=4326;{POINT(0.5 1.5)@2001-01-01}");
+  assert(traj_40 != NULL);
+  Temporal *v40 = raster_value(traj_40, rb, 1);
+  assert(v40 != NULL);
+  assert(tfloat_start_value(v40) == 1.0);
+  free(v40); free(traj_40); free(rb);
+
+  /* A RANGE OF NEGATIVE BOUNDS PARSES, which is the case the splitting turns
+   * on: -9999--1 states two bounds, not four empty pieces. Counting the nodata
+   * pixel as the value it holds puts it in that range, so the nine pixels read
+   * one 7 and eight 8s, summing to 71 */
+  meos_errno_reset();
+  Raster *rn = raster_reclass(rast_values, 1, "-9999--1:7, 0-1000:8", "32BF",
+    false, 0.0);
+  assert(rn != NULL);
+  assert(meos_errno() == 0);
+  BandStats *rnst = raster_summary_stats(rn, 1, false);
+  assert(rnst != NULL);
+  printf("raster_reclass(\"-9999--1:7, 0-1000:8\"): count %u, sum %f, min %f, "
+    "max %f\n", rnst->count, rnst->sum, rnst->min, rnst->max);
+  assert(rnst->count == 9);
+  assert(rnst->sum == 7.0 + 8.0 * 8.0);
+  assert(rnst->min == 7.0);
+  assert(rnst->max == 8.0);
+  free(rnst); free(rn);
+
+  /* A malformed expression raises rather than answering the subject unchanged,
+   * which is what PostGIS does: a mapping needs its colon, a range needs
+   * numbers for bounds, and the pixel type has to be one the catalog names */
+  meos_errno_reset();
+  assert(raster_reclass(rast_values, 1, "0-50", "32BF", true, 0.0) == NULL);
+  assert(raster_reclass(rast_values, 1, "0-50:x", "32BF", true, 0.0) == NULL);
+  assert(raster_reclass(rast_values, 1, "0-50:1", "99XX", true, 0.0) == NULL);
+  assert(raster_reclass(rast_values, 0, "0-50:1", "32BF", true, 0.0) == NULL);
+  assert(raster_reclass(NULL, 1, "0-50:1", "32BF", true, 0.0) == NULL);
+  assert(raster_reclass(rast_values, 1, NULL, "32BF", true, 0.0) == NULL);
+  assert(raster_reclass(rast_values, 1, "0-50:1", NULL, true, 0.0) == NULL);
+  assert(meos_errno() != 0);
+
   free(vspan); free(traj_3857); free(traj_values); free(rast_values);
 
   meos_finalize();

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -334,6 +334,14 @@ CREATE FUNCTION numBands(raster)
   AS 'MODULE_PATHNAME', 'Raster_num_bands'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/* Not STRICT: a nodata value left out states that the resulting band carries
+ * none, which is a different answer from a band whose nodata value is zero */
+CREATE FUNCTION reclass(raster, integer, text, text,
+    float8 DEFAULT NULL)
+  RETURNS raster
+  AS 'MODULE_PATHNAME', 'Raster_reclass'
+  LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
 /******************************************************************************
  * Accessors for raquet tiles
  *****************************************************************************/

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -225,6 +225,50 @@ Raster_num_bands(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
+ * raster_reclass
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_reclass(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_reclass);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster whose band states the classes an expression maps its
+ * values onto
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] expr Reclassification expression
+ * @param[in] pixeltype Name of the pixel type of the resulting band
+ * @param[in] nodataval Nodata value of the resulting band, absent where the
+ * band states none
+ * @sqlfn reclass()
+ */
+Datum
+Raster_reclass(PG_FUNCTION_ARGS)
+{
+  /* The function is not STRICT, so every argument is tested: only the nodata
+   * value is optional, and the others reaching the kernel unread would be a
+   * wild pointer rather than an error */
+  if (PG_ARGISNULL(0) || PG_ARGISNULL(1) || PG_ARGISNULL(2) ||
+      PG_ARGISNULL(3))
+    PG_RETURN_NULL();
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int band = PG_GETARG_INT32(1);
+  char *expr = text_to_cstring(PG_GETARG_TEXT_P(2));
+  char *pixeltype = text_to_cstring(PG_GETARG_TEXT_P(3));
+  /* A nodata value the caller leaves out is no value at all, which is what
+   * the resulting band states rather than a zero standing in for it */
+  bool has_nodata = ! PG_ARGISNULL(4);
+  double nodataval = has_nodata ? PG_GETARG_FLOAT8(4) : 0.0;
+  Raster *result = raster_reclass(rast, band, expr, pixeltype, has_nodata,
+    nodataval);
+  pfree(expr); pfree(pixeltype);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+/*****************************************************************************
  * raster_tile_value_quadbin
  *****************************************************************************/
 

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -843,6 +843,52 @@ SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
 (1 row)
 
 WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT (s).count AS n, (s).sum AS total, (s).min AS lo, (s).max AS hi
+FROM (SELECT ST_SummaryStats(reclass(r, 1, '0-50:1, 51-100:2', '32BF', -9999))
+  AS s FROM rast) t;
+ n | total | lo | hi 
+---+-------+----+----
+ 8 |    12 |  1 |  2
+(1 row)
+
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT (s).count AS n, (s).sum AS total
+FROM (SELECT ST_SummaryStats(
+  reclass(r, 1, '[0-50):1, [50-100]:2', '32BF', -9999)) AS s FROM rast) t;
+ n | total 
+---+-------
+ 9 |    14
+(1 row)
+
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT reclass(r, 2, '0-50:1', '32BF') FROM rast;
+ERROR:  The raster has no band 2, it has 1
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT reclass(r, 1, '0-50', '32BF') FROM rast;
+ERROR:  A mapping states a source and a destination around one colon: 0-50
+WITH rast AS (
   SELECT ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r
 )
 SELECT stbox(r) AS box, stbox(r) = r::stbox AS cast_agrees FROM rast;

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -830,6 +830,55 @@ SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
        numBands((SELECT r FROM rast2)) AS num_bands_two;
 
 -------------------------------------------------------------------------------
+-- reclass
+-------------------------------------------------------------------------------
+
+-- A band of values becomes a band of classes. The 3x3 band below holds
+-- 10, 20, 30 / 40, 50, 60 / 70, 80, 90, and a range written plainly is HALF
+-- OPEN AT THE TOP: 0-50 takes 10, 20, 30 and 40 but NOT 50, which falls in
+-- neither range and is left unmapped.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT (s).count AS n, (s).sum AS total, (s).min AS lo, (s).max AS hi
+FROM (SELECT ST_SummaryStats(reclass(r, 1, '0-50:1, 51-100:2', '32BF', -9999))
+  AS s FROM rast) t;
+
+-- A closing bracket includes the high bound, so [50-100] takes the 50 the
+-- plain form dropped and every pixel is mapped.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT (s).count AS n, (s).sum AS total
+FROM (SELECT ST_SummaryStats(
+  reclass(r, 1, '[0-50):1, [50-100]:2', '32BF', -9999)) AS s FROM rast) t;
+
+-- A band the raster does not have, and an expression stating no mapping, are
+-- both errors.
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT reclass(r, 2, '0-50:1', '32BF') FROM rast;
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT reclass(r, 1, '0-50', '32BF') FROM rast;
+
+-------------------------------------------------------------------------------
 -- raster conversion to stbox
 -------------------------------------------------------------------------------
 

--- a/tools/scripts/liblwgeom_geos_baseline.txt
+++ b/tools/scripts/liblwgeom_geos_baseline.txt
@@ -26,4 +26,5 @@ meos/src/raster/raster_rtcore.c	rt_raster_get_x_skew
 meos/src/raster/raster_rtcore.c	rt_raster_get_y_offset
 meos/src/raster/raster_rtcore.c	rt_raster_get_y_scale
 meos/src/raster/raster_rtcore.c	rt_raster_get_y_skew
+meos/src/raster/raster_rtcore.c	rt_raster_replace_band
 meos/src/raster/raster_rtcore.c	rt_raster_set_srid


### PR DESCRIPTION
reclass(raster, band, expr, pixeltype, nodata) answers a raster whose band
holds the classes an expression maps its values to, so a coverage of
measurements becomes a coverage of classes that a trajectory is read against
with rasterValue. The MEOS entry point raster_reclass reads the expression
with the grammar of the PostGIS ST_Reclass, ported in full: a comma-separated
list of mappings, each a source range and a destination around a colon, a
range being one value or two around a dash, and a bracket stating how an end
is bounded. The reclassified band, computed by the vendored rt_band_reclass,
stands where the band it reads stood, so the raster keeps its grid and its
other bands. raster_serialize_destroy stamps the varlena header of the form
it answers.

The witness is the 3x3 band holding 10, 20, 30 / 40, 50, 60 / 70, 80, 90.
ST_DumpValues(reclass(r, 1, '0-50:1, 51-100:2', '8BUI', 0), 1) answers
{{1,1,1},{1,NULL,2},{2,2,2}}, and with [50-100] in place of 51-100 it answers
{{1,1,1},{1,2,2},{2,2,2}}: a range written plainly includes its low end and
excludes its high end, so the 50 pixel is mapped only once a closing bracket
takes it, and an unmapped pixel holds the nodata value of the resulting band.
Over reclass(r, 1, '0-50:1, 51-100:2', '32BF', -9999) on the same band,
ST_Width, ST_Height and ST_SummaryStats answer 3, 3 and a count of 8 summing
to 12; with the header as rt_core writes it they answer 0, 49136 and a count
of 0, with the notice "Band is empty as width and/or height is 0".

The model is the one PostGIS runs. The expression splits as PostGIS splits
it, a run of a separator counting as one, so -9999--1 states the two bounds
9999 and 1, whose signs are read back from the text they come from, and a
bracket standing alone before the first value is given back to it; a splitter
keeping empty pieces reads four pieces there and refuses every negative range.
The grammar is defined by that reader, so reading it the same way is what
makes one expression answer the same through ST_Reclass and through reclass.
The length that opens a serialized raster is written by rt_core as a plain
number, while PostgreSQL reads that word as a varlena header, which is why the
rt_pg layer of PostGIS stamps it before returning a raster; stamping it where
MEOS produces the form makes every raster a MEOS entry point answers readable
in PostgreSQL.

The SQL function is not STRICT: a nodata value left out states that the
resulting band carries none, which differs from a nodata value of zero, and
the wrapper answers NULL when any other argument is NULL. The cases in
500_raster read the classes back through ST_SummaryStats, contrast a plain
range with a bracketed one on the pixel the bracket decides, and raise on a
band the raster lacks and on a mapping with no colon. The C witness covers the
same contrast, the range -9999--1:7, whose -9999 pixel maps to 7 for a count
of 9 summing to 71, and the refusal of a malformed expression, an unknown pixel
type, a band out of range and each NULL argument. The manual entry, in English
and Spanish, carries harvested examples.

Measured against the committed expected outputs, every regression file answers
on PostgreSQL 18 what its expected output states, the 56 invocations of the
MEOS test step exit with status 0, and cppcheck reports 152 findings at the
head and at the base, none new. Building the base and the head and diffing
their answers over 41 instruments moves 6 lines: five are the new witness lines
of raster_reclass and one is the time_of_day() clock, so no answer the base
gives changes. The only work an existing path gains is the one header store in
raster_serialize_destroy. The GEOS-reachability baseline carries one more
entry, the call of rt_raster_replace_band in raster_rtcore.c, for 24 in all;
that function makes no GEOS call, and the checker lists it because rt_raster.c,
the file defining it, names GEOS elsewhere. The baseline's geometry entries are
unchanged.

