### PR TITLE
Answer the union of linework from its input vertices

### DIFF
--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -8082,39 +8082,246 @@ linear_union_transpose(const char matrix[10], char result[10])
 }
 
 /**
- * @brief Return the sub-segment an edge draws between two of its parameters
+ * @brief Split the difference of two doubles into its rounded value and the
+ * error of that rounding, which together are the difference exactly
+ */
+static inline void
+linear_union_two_diff(double a, double b, double *x, double *y)
+{
+  *x = a - b;
+  double bv = a - *x;
+  double av = *x + bv;
+  *y = (a - av) + (bv - b);
+}
+
+/**
+ * @brief Split the product of two doubles into its rounded value and the
+ * error of that rounding, which together are the product exactly
+ * @note Exact where the product neither overflows nor underflows
+ */
+static inline void
+linear_union_two_product(double a, double b, double *x, double *y)
+{
+  *x = a * b;
+  *y = fma(a, b, - *x);
+}
+
+/**
+ * @brief Add a double to an expansion, a sum of doubles that do not overlap,
+ * held in increasing order of magnitude, and return its new length
+ * @details The sum is exact, and a zero component is dropped, so the last
+ * component carries the sign of the whole expansion
+ */
+static int
+linear_union_grow_expansion(int elen, const double *e, double b, double *h)
+{
+  double q = b;
+  int hlen = 0;
+  for (int i = 0; i < elen; i++)
+  {
+    double sum = q + e[i];
+    double bv = sum - q;
+    double av = sum - bv;
+    double err = (q - av) + (e[i] - bv);
+    q = sum;
+    if (err != 0.0)
+      h[hlen++] = err;
+  }
+  if (q != 0.0 || hlen == 0)
+    h[hlen++] = q;
+  return hlen;
+}
+
+/**
+ * @brief Return which side of the line through two points a third lies on
+ * @details The filtered sign of #relate_orientation answers where the double
+ * evaluation carries the sign. Where it cannot tell, the same determinant
+ * @p (bx - ax) * (cy - ay) - (by - ay) * (cx - ax) is summed exactly: each
+ * difference is its rounded value plus the error of the rounding, each
+ * product of two such terms is its rounded value plus its error, and the
+ * sixteen terms are added into an expansion, whose last component carries
+ * the sign of the exact determinant of the input doubles
+ * @return 1 or -1 for the two sides, 0 exactly where the three are collinear
+ */
+static int
+linear_union_orientation(double ax, double ay, double bx, double by,
+  double cx, double cy)
+{
+  int sign = relate_orientation(ax, ay, bx, by, cx, cy);
+  if (sign != 0)
+    return sign;
+  double d[4], t[4];
+  linear_union_two_diff(bx, ax, &d[0], &t[0]);
+  linear_union_two_diff(cy, ay, &d[1], &t[1]);
+  linear_union_two_diff(by, ay, &d[2], &t[2]);
+  linear_union_two_diff(cx, ax, &d[3], &t[3]);
+  /* (d0 + t0) (d1 + t1) - (d2 + t2) (d3 + t3), term by term */
+  const double lf[2] = {d[0], t[0]}, lg[2] = {d[1], t[1]};
+  const double rf[2] = {d[2], t[2]}, rg[2] = {d[3], t[3]};
+  double e[32], h[32];
+  int elen = 0;
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 2; j++)
+    {
+      double x, y;
+      linear_union_two_product(lf[i], lg[j], &x, &y);
+      elen = linear_union_grow_expansion(elen, e, x, h);
+      memcpy(e, h, sizeof(double) * (size_t) elen);
+      elen = linear_union_grow_expansion(elen, e, y, h);
+      memcpy(e, h, sizeof(double) * (size_t) elen);
+      linear_union_two_product(rf[i], rg[j], &x, &y);
+      elen = linear_union_grow_expansion(elen, e, - x, h);
+      memcpy(e, h, sizeof(double) * (size_t) elen);
+      elen = linear_union_grow_expansion(elen, e, - y, h);
+      memcpy(e, h, sizeof(double) * (size_t) elen);
+    }
+  double top = e[elen - 1];
+  return (top > 0.0) ? 1 : ((top < 0.0) ? -1 : 0);
+}
+
+/**
+ * @brief A stretch of an edge that another edge covers
+ * @details Both ends are INPUT VERTICES lying on the edge -- an end of the
+ * covering edge, or an end of the covered one where the cover runs past it --
+ * so a piece cut between two of them is drawn with coordinates the input
+ * carries, never with a point constructed at a parameter
+ */
+typedef struct
+{
+  double lo;         /**< Position of the start along the edge */
+  double hi;         /**< Position of the end along the edge */
+  POINT2D plo;       /**< Vertex at the start */
+  POINT2D phi;       /**< Vertex at the end */
+} LinearStretch;
+
+/**
+ * @brief Return the position of a point along the line an edge spans
+ * @details Points lying on that line are ordered along it by the coordinate
+ * the edge advances most in, oriented to grow from the start of the edge to
+ * its end. That is the parameter of the point on the edge up to an increasing
+ * affine map, read off the coordinate itself: comparing two positions
+ * compares two input coordinates, so the order is exact where a parameter
+ * computed as @p (p - start) . d / |d|^2 would be a rounding of it
+ */
+static inline double
+linear_union_position(const Edge *edge, double x, double y)
+{
+  if (fabs(edge->dx) >= fabs(edge->dy))
+    return (edge->dx > 0.0) ? x : -x;
+  return (edge->dy > 0.0) ? y : -y;
+}
+
+/**
+ * @brief Return true if another edge covers a stretch of an edge, and that
+ * stretch in the last argument
+ * @details The other edge shares more than a point with the edge only where
+ * both its ends lie on the line the edge spans, a question on four input
+ * vertices that two exact determinant signs answer
+ * (#linear_union_orientation). The stretch is then the span of the other
+ * edge's ends clipped to the edge's own, compared by their position along it
+ * (#linear_union_position). A pair meeting at a point leaves the edge whole
+ */
+static bool
+linear_union_cover(const Edge *b, const Edge *a, LinearStretch *s)
+{
+  assert(b); assert(a); assert(s);
+  if (linear_union_orientation(b->x1, b->y1, b->x2, b->y2, a->x1, a->y1) != 0 ||
+      linear_union_orientation(b->x1, b->y1, b->x2, b->y2, a->x2, a->y2) != 0)
+    return false;
+  double pa1 = linear_union_position(b, a->x1, a->y1);
+  double pa2 = linear_union_position(b, a->x2, a->y2);
+  bool forward = pa1 <= pa2;
+  s->lo = forward ? pa1 : pa2;
+  s->hi = forward ? pa2 : pa1;
+  s->plo.x = forward ? a->x1 : a->x2; s->plo.y = forward ? a->y1 : a->y2;
+  s->phi.x = forward ? a->x2 : a->x1; s->phi.y = forward ? a->y2 : a->y1;
+  double pb1 = linear_union_position(b, b->x1, b->y1);
+  double pb2 = linear_union_position(b, b->x2, b->y2);
+  if (s->lo < pb1)
+  {
+    s->lo = pb1; s->plo.x = b->x1; s->plo.y = b->y1;
+  }
+  if (s->hi > pb2)
+  {
+    s->hi = pb2; s->phi.x = b->x2; s->phi.y = b->y2;
+  }
+  return s->lo < s->hi;
+}
+
+/**
+ * @brief Return the segment joining two input vertices
  */
 static LWGEOM *
-linear_union_subsegment(const Edge *edge, double t0, double t1, int32_t srid)
+linear_union_piece(const POINT2D *p1, const POINT2D *p2, int32_t srid)
 {
-  assert(edge);
+  assert(p1); assert(p2);
   POINTARRAY *pa = ptarray_construct_empty(0, 0, 2);
   POINT4D p;
   memset(&p, 0, sizeof(POINT4D));
-  /* An end of the edge is written as the edge writes it: @p x1 + 1.0 * dx is
-   * not @p x2 in floating point, and a piece spanning the whole edge has to
-   * reproduce the coordinates it was read from rather than a rounding of them */
-  if (t0 <= 0.0)
-  {
-    p.x = edge->x1; p.y = edge->y1;
-  }
-  else
-  {
-    p.x = edge->x1 + t0 * edge->dx;
-    p.y = edge->y1 + t0 * edge->dy;
-  }
+  p.x = p1->x; p.y = p1->y;
   ptarray_append_point(pa, &p, LW_TRUE);
-  if (t1 >= 1.0)
-  {
-    p.x = edge->x2; p.y = edge->y2;
-  }
-  else
-  {
-    p.x = edge->x1 + t1 * edge->dx;
-    p.y = edge->y1 + t1 * edge->dy;
-  }
+  p.x = p2->x; p.y = p2->y;
   ptarray_append_point(pa, &p, LW_TRUE);
   return lwline_as_lwgeom(lwline_construct(srid, NULL, pa));
+}
+
+/**
+ * @brief Add to an array the pieces of an edge that no edge of a set covers
+ * @details The stretches the set covers are read in the order the edge is
+ * walked, and a piece runs from where one stretch ends to where the next one
+ * starts. Every end is an input vertex compared by position, so two
+ * stretches meeting at a shared vertex leave nothing between them and an edge
+ * of any length keeps what is uncovered of it, however short. An edge of zero
+ * length draws a point, which a line already walks, and adds no piece
+ * @param[in] b Edge
+ * @param[in] edges,count Edges that may cover it
+ * @param[out] cover Room for @p count stretches
+ * @param[out] pieces Array the pieces are appended to, with room for
+ * @p count + 1 of them
+ * @param[in] srid Spatial reference identifier
+ * @return Number of pieces added
+ */
+static int
+linear_union_uncovered(const Edge *b, const MeosArray *edges, int count,
+  LinearStretch *cover, LWGEOM **pieces, int32_t srid)
+{
+  assert(b); assert(edges); assert(cover); assert(pieces);
+  if (b->dx == 0.0 && b->dy == 0.0)
+    return 0;
+  int ncover = 0;
+  for (int j = 0; j < count; j++)
+  {
+    LinearStretch s;
+    if (! linear_union_cover(b, (const Edge *) meos_array_get(edges, j), &s))
+      continue;
+    int q = ncover - 1;
+    while (q >= 0 && cover[q].lo > s.lo)
+    {
+      cover[q + 1] = cover[q];
+      q--;
+    }
+    cover[q + 1] = s;
+    ncover++;
+  }
+  int npieces = 0;
+  POINT2D cur = { b->x1, b->y1 };
+  double pcur = linear_union_position(b, b->x1, b->y1);
+  for (int p = 0; p < ncover; p++)
+  {
+    if (cover[p].lo > pcur)
+      pieces[npieces++] = linear_union_piece(&cur, &cover[p].plo, srid);
+    if (cover[p].hi > pcur)
+    {
+      pcur = cover[p].hi;
+      cur = cover[p].phi;
+    }
+  }
+  if (linear_union_position(b, b->x2, b->y2) > pcur)
+  {
+    POINT2D end = { b->x2, b->y2 };
+    pieces[npieces++] = linear_union_piece(&cur, &end, srid);
+  }
+  return npieces;
 }
 
 /**
@@ -8133,15 +8340,16 @@ linear_union_straight(const MeosArray *edges)
 }
 
 /**
- * @brief Return true if two points are the same to what their coordinates
- * resolve
+ * @brief Return true if two points are the same point
+ * @details Every end of a piece is an input vertex, copied as the input
+ * holds it, so two ends are the same point exactly where their coordinates
+ * are equal: two distinct doubles are two distinct points, however near
  */
 static bool
 linear_union_same_point(const POINT2D *p1, const POINT2D *p2)
 {
   assert(p1); assert(p2);
-  return fabs(p1->x - p2->x) <= coordinate_tolerance(p1->x, p2->x) &&
-    fabs(p1->y - p2->y) <= coordinate_tolerance(p1->y, p2->y);
+  return p1->x == p2->x && p1->y == p2->y;
 }
 
 /**
@@ -8322,53 +8530,12 @@ linear_union_merge(const LWGEOM *geom1, const LWGEOM *geom2)
    * first does not cover, so at most one piece more than the overlaps it
    * carries */
   LWGEOM **pieces = palloc(sizeof(LWGEOM *) * (size_t) (n2 * (n1 + 1) + 1));
+  LinearStretch *cover = palloc(sizeof(LinearStretch) * (size_t) (n1 + 1));
   int npieces = 0;
-  double *lo = palloc(sizeof(double) * (size_t) (n1 + 1));
-  double *hi = palloc(sizeof(double) * (size_t) (n1 + 1));
-
   for (int j = 0; j < n2; j++)
-  {
-    const Edge *b = (const Edge *) meos_array_get(e2, j);
-    int nover = 0;
-    for (int i = 0; i < n1; i++)
-    {
-      const Edge *a = (const Edge *) meos_array_get(e1, i);
-      IntersectResult r = linesegm_intersect(b->x1, b->y1, b->dx, b->dy,
-        a->x1, a->y1, a->x2, a->y2);
-      /* A pair meeting at a point leaves the segment whole; only a shared
-       * stretch removes anything from it */
-      if (r.type != INTERSECT_OVERLAP)
-        continue;
-      lo[nover] = (r.t0 < r.t1) ? r.t0 : r.t1;
-      hi[nover] = (r.t0 < r.t1) ? r.t1 : r.t0;
-      nover++;
-    }
-    /* The overlaps read in the order the segment is walked */
-    for (int p = 1; p < nover; p++)
-    {
-      double l = lo[p], h = hi[p];
-      int q = p - 1;
-      while (q >= 0 && lo[q] > l)
-      {
-        lo[q + 1] = lo[q]; hi[q + 1] = hi[q]; q--;
-      }
-      lo[q + 1] = l; hi[q + 1] = h;
-    }
-    /* A piece shorter than what the segment's own coordinates resolve is not
-     * linework, it is the rounding of the parameter that produced it */
-    double mint = (b->length > 0.0) ? b->tol / b->length : 1.0;
-    double cur = 0.0;
-    for (int p = 0; p < nover; p++)
-    {
-      if (lo[p] > cur + mint)
-        pieces[npieces++] = linear_union_subsegment(b, cur, lo[p], srid);
-      if (hi[p] > cur)
-        cur = hi[p];
-    }
-    if (1.0 > cur + mint)
-      pieces[npieces++] = linear_union_subsegment(b, cur, 1.0, srid);
-  }
-  pfree(lo); pfree(hi);
+    npieces += linear_union_uncovered((const Edge *) meos_array_get(e2, j),
+      e1, n1, cover, &pieces[npieces], srid);
+  pfree(cover);
   meos_array_destroy(e1); meos_array_destroy(e2);
 
   /* The first curve seeds the sewing, so the pieces attach to it in the order
@@ -8434,47 +8601,12 @@ linear_union_dissolve(const LWGEOM *geom, LWGEOM ***curves)
   int32_t srid = lwgeom_get_srid(geom);
 
   LWGEOM **pieces = palloc(sizeof(LWGEOM *) * (size_t) (nedges * nedges + 1));
+  LinearStretch *cover = palloc(sizeof(LinearStretch) * (size_t) (nedges + 1));
   int npieces = 0;
-  double *lo = palloc(sizeof(double) * (size_t) (nedges + 1));
-  double *hi = palloc(sizeof(double) * (size_t) (nedges + 1));
   for (int i = 0; i < nedges; i++)
-  {
-    const Edge *b = (const Edge *) meos_array_get(edges, i);
-    int nover = 0;
-    for (int j = 0; j < i; j++)
-    {
-      const Edge *a = (const Edge *) meos_array_get(edges, j);
-      IntersectResult r = linesegm_intersect(b->x1, b->y1, b->dx, b->dy,
-        a->x1, a->y1, a->x2, a->y2);
-      if (r.type != INTERSECT_OVERLAP)
-        continue;
-      lo[nover] = (r.t0 < r.t1) ? r.t0 : r.t1;
-      hi[nover] = (r.t0 < r.t1) ? r.t1 : r.t0;
-      nover++;
-    }
-    for (int p = 1; p < nover; p++)
-    {
-      double l = lo[p], h = hi[p];
-      int q = p - 1;
-      while (q >= 0 && lo[q] > l)
-      {
-        lo[q + 1] = lo[q]; hi[q + 1] = hi[q]; q--;
-      }
-      lo[q + 1] = l; hi[q + 1] = h;
-    }
-    double mint = (b->length > 0.0) ? b->tol / b->length : 1.0;
-    double cur = 0.0;
-    for (int p = 0; p < nover; p++)
-    {
-      if (lo[p] > cur + mint)
-        pieces[npieces++] = linear_union_subsegment(b, cur, lo[p], srid);
-      if (hi[p] > cur)
-        cur = hi[p];
-    }
-    if (1.0 > cur + mint)
-      pieces[npieces++] = linear_union_subsegment(b, cur, 1.0, srid);
-  }
-  pfree(lo); pfree(hi);
+    npieces += linear_union_uncovered((const Edge *) meos_array_get(edges, i),
+      edges, i, cover, &pieces[npieces], srid);
+  pfree(cover);
   meos_array_destroy(edges);
 
   int ncurves = linear_union_chain_all(pieces, npieces, srid, curves);

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -1568,6 +1568,86 @@ int main(void)
     meos_errno_reset();
   }
 
+  /* An edge shorter than the square root of the coordinate tolerance, about
+   * 1e-6, is an edge like any other: a vessel at anchor reports steps of that
+   * size in degrees, and the union keeps them. The far point makes the line
+   * one member of an array, so the union reads it through the dissolve of a
+   * single line. A stretch the line walks twice is still counted once, which
+   * the second case asserts. In the third, a step walks straight back over
+   * the first and the last leaves in another direction: the doubled step
+   * counts once and the last one is kept, where a band on the cross product
+   * reads it as running along the first. The fourth doubles back in its
+   * decimal text only: in binary the third vertex lies off the line of the
+   * first two, so the two steps share no stretch and both are kept */
+  struct { const char *line, *result; } shortcases[] = {
+    { "LINESTRING(12.272392 57.058987,12.272393 57.058987,12.272393 57.05899)",
+      "GEOMETRYCOLLECTION(POINT(-170 -80),LINESTRING(12.272392 57.058987,"
+      "12.272393 57.058987,12.272393 57.05899))" },
+    { "LINESTRING(0 0,0.000003 0,0.000001 0)",
+      "GEOMETRYCOLLECTION(POINT(-170 -80),LINESTRING(0 0,0.000003 0))" },
+    { "LINESTRING(11.198253 55.211805,11.19825 55.2118,11.198253 55.211805,"
+      "11.198252 55.211803)",
+      "GEOMETRYCOLLECTION(POINT(-170 -80),LINESTRING(11.19825 55.2118,"
+      "11.198253 55.211805,11.198252 55.211803))" },
+    { "LINESTRING(9.241645 57.790927,9.242395 57.790767,9.24127 57.791007)",
+      "GEOMETRYCOLLECTION(POINT(-170 -80),LINESTRING(9.241645 57.790927,"
+      "9.242395 57.790767,9.24127 57.791007))" },
+  };
+  GSERIALIZED *farpt = geom_in("POINT(-170 -80)", -1);
+  assert(farpt != NULL);
+  for (size_t i = 0; i < sizeof(shortcases) / sizeof(shortcases[0]); i++)
+  {
+    GSERIALIZED *sl = geom_in(shortcases[i].line, -1);
+    assert(sl != NULL);
+    GSERIALIZED *slarr[2] = {sl, farpt};
+    meos_errno_reset();
+    GSERIALIZED *slu = geom_array_union(slarr, 2);
+    assert(slu != NULL);
+    assert(meos_errno() == 0);
+    char *slwkt = geo_as_text(slu, 6);
+    assert(slwkt != NULL);
+    printf("%s with a far point: %s\n", shortcases[i].line, slwkt);
+    assert(strcmp(slwkt, shortcases[i].result) == 0);
+    free(sl); free(slu); free(slwkt);
+    meos_errno_reset();
+  }
+  /* The first vertex of this line lies off the line of its second edge by
+   * less than the rounding of the determinant that decides it, so the
+   * filtered sign cannot tell. The exact determinant is not zero: the two
+   * edges share only their common vertex, and the union walks the whole line */
+  GSERIALIZED *fz = geom_in("LINESTRING(0 0,9007199254740990 9007199254740988,"
+    "4503599627370495 4503599627370495)", -1);
+  assert(fz != NULL);
+  GSERIALIZED *fzarr[2] = {fz, farpt};
+  meos_errno_reset();
+  GSERIALIZED *fzu = geom_array_union(fzarr, 2);
+  assert(fzu != NULL);
+  assert(meos_errno() == 0);
+  printf("union of a line whose sign the filter cannot tell: length %.17g of "
+    "%.17g\n", geom_length(fzu), geom_length(fz));
+  assert(geom_length(fzu) == geom_length(fz));
+  free(fz); free(fzu);
+  meos_errno_reset();
+  /* The fourth vertex of this line lies 5e-13 from the first, a distinct
+   * point: the last edge walks back over that stretch of the first, and the
+   * pieces the union keeps are sewn at the vertices they share exactly */
+  GSERIALIZED *sw = geom_in("LINESTRING(0 0,1e-9 0,1e-9 1e-9,5e-13 0,-1e-9 0)",
+    -1);
+  assert(sw != NULL);
+  GSERIALIZED *swarr[2] = {sw, farpt};
+  meos_errno_reset();
+  GSERIALIZED *swu = geom_array_union(swarr, 2);
+  assert(swu != NULL);
+  assert(meos_errno() == 0);
+  char *swwkt = geo_as_text(swu, 15);
+  assert(swwkt != NULL);
+  printf("union of a line with two vertices 5e-13 apart: %s\n", swwkt);
+  assert(strcmp(swwkt, "GEOMETRYCOLLECTION(POINT(-170 -80),LINESTRING(5e-13 0,"
+    "1e-9 1e-9,1e-9 0,0 0,-1e-9 0))") == 0);
+  free(sw); free(swu); free(swwkt);
+  meos_errno_reset();
+  free(farpt);
+
   /* An arc is a curve, and the lift along it is read by ANGLE rather than by
    * the chord joining its ends. These two discs are mirror images about the
    * line through the points where they cross, and each carries elevations


### PR DESCRIPTION
The union of linework makes a line walk each of its points once: per
edge it keeps the stretches no earlier edge covers, the merge of two
coincident lines reads its pieces the same way, and the pieces are sewn
back into curves. On master the stretches come from the segment kernel
as parameters along the edge, a piece shorter than `b->tol / b->length`
is dropped, where `Edge.length` holds the squared length of the edge, and
two pieces are sewn where their ends lie within a coordinate tolerance of
one another. At the scale of a GPS step in degrees this decides answers
wrongly:

- A piece is dropped whole where that threshold reaches 1. For the edge
  (12.272392 57.058987)-(12.272393 57.058987) of the first witness below,
  `b->tol` is 1.05e-12, the stored length 1e-12 and the threshold 1.05.
- The kernel reads two segments as parallel when the cross product of
  their directions falls below 1e-12. For the steps
  (11.198253 55.211805)-(11.198252 55.211803) and
  (11.198253 55.211805)-(11.19825 55.2118) it reads -1.0e-12, a sign its
  rounding bound carries, and answers an overlap between two segments
  whose directions differ.

This commit decides what one edge covers of another on the input
vertices. Another edge covers part of the edge only where both its ends
lie on the line the edge spans, which is the sign of two determinants of
input coordinates: the filtered sign of relate_orientation where the
double evaluation carries it and, where the filter cannot tell, the same
determinant summed exactly -- each difference and each product split into
its rounded value and its rounding error, and the terms added into an
expansion. The covered stretch runs between input vertices, the other
edge's ends clipped to the edge's own, and stretches are ordered by their
position along the edge, read off the coordinate the edge advances most
in. Every piece kept runs between two input vertices, none is constructed
at a parameter, and two pieces are sewn where their ends are the same
vertex, compared exactly.

Witness

The union with a far point of

    LINESTRING(12.272392 57.058987,12.272393 57.058987,12.272393 57.05899)

answers the line with both its edges, 3.99999999878e-06 long, where master
answers LINESTRING(12.272393 57.058987,12.272393 57.05899),
2.99999999953e-06. The union with a far point of

    LINESTRING(11.198253 55.211805,11.19825 55.2118,11.198253 55.211805,
               11.198252 55.211803)

whose second step walks straight back over the first and whose third
leaves in another direction, answers 8.06701986861e-06, the first step
once and the third, where master answers
LINESTRING(11.198253 55.211805,11.19825 55.2118), 5.83095189596e-06. The
union with a far point of

    LINESTRING(0 0,1e-9 0,1e-9 1e-9,5e-13 0,-1e-9 0)

whose last edge walks back over the first 5e-13 of the first edge, answers
LINESTRING(5e-13 0,1e-9 1e-9,1e-9 0,0 0,-1e-9 0), 4.4138600531877265e-09
long, where master answers the line unchanged, 4.4143600531877263e-09.

Measured

Every figure below is judged by the measure of the point set the answer
covers, computed by CGAL's exact kernel on the doubles the parser reads.

Real AIS trajectories from the Danish Maritime Authority
(aisdk-2025-03-01, trips split at 180 s / 1 NM), each line united with a
far point:

                                   master               this commit
    50 trajectories, 200 vertices  15 exact, 35 short   49 exact, 1 short
    41 trips, 1431-5095 vertices   11 exact, 30 short   33 exact, 8 short

Every row master answers exactly stays exact. Built without the fallback
library the union refuses 10 of 50 and 11 of 41, where master refuses 0
and 7; every row it refuses and master answers is one master answers
wrong, and it answers every row it does not refuse exactly. The rows
still short with the fallback library are all rows the union refuses
without it. Each trajectory split into its two halves and the halves
united, a union of two members, gives the same picture: without the
fallback library 22 of 50 and 25 of 41 exact and the rest refused, where
master refuses 25 and 13, every newly refused union one master answers
wrong.

Over 3000 three-vertex lines whose third vertex lies on, or within two
units of, the midpoint of the first edge, with integer coordinates below
2^52 scaled by 1, 2^-20, 2^-40 and 2^-52, master answers 749 differently
from CGAL; for 627 of them the filtered sign cannot place the first vertex
against the second edge. This commit answers all 3000 as CGAL does, the
largest relative difference being 3.7e-16.

Over 3000 unions of two or three lines built the same way -- lines
overlapping on one carrier, a line's end moved one or two units off that
carrier, a chain walking back over its first line, an edge repeated in
reverse -- master answers 360 differently from CGAL. This commit answers
all 3000 as CGAL does; without the fallback library it answers 2611 of
them so and refuses 389, 34 of which master refuses too and 355 of which
master answers wrong.

No expected SQL output on PostgreSQL 18 changes, and over 42 instruments
diffed answer for answer against master, the only lines that differ are
the six the test of this commit prints.

Built without the fallback library, over the 30 trips both builds answer,
the dissolve takes 0.74x and 0.75x master's time in total (per-row median
0.81 and 0.83) in the two of six interleaved rounds run at a load below 3.
Each pair of edges costs two filtered signs in place of a call to the
kernel, and the expansion runs only where the filter cannot tell.

Why

A union is a point set, and its points are the ones the doubles the
parser reads denote. Every double is an exact rational, so whether one
edge covers part of another has one answer, and it is a question on input
vertices: the sign of two determinants. The filter decides that sign
wherever the double evaluation carries it and the expansion decides it
everywhere else, exactly as long as no product of coordinate differences
overflows or underflows. Once both ends lie on the line, their order
along it is the order of their parameters on the edge, an increasing
affine function of the coordinate the edge advances most in, so comparing
two positions compares two input coordinates. Every piece then runs
between two input vertices and meets the next at a vertex both carry, so
no piece is the rounding of a parameter, no two distinct vertices are
read as one, and no threshold is needed anywhere in the answer.

The doubles and the decimal text differ on 12 of the 41 trips. The line

    LINESTRING(9.241645 57.790927,9.242395 57.790767,9.24127 57.791007)

doubles back in its decimals only: the cross product of its two steps is
exactly 0 in the decimals and -2.665e-18 in the doubles, against a
rounding bound of 2.4e-22. Its two steps share no stretch, and the union
keeps both, 0.001917191957 long, as CGAL measures it.

Test

geo_test asserts six lines. Four answer differently on master and hold on
this commit: the three witnesses and the line that doubles back in its
decimals only; against master the first aborts at geo_test.c:1610. Two
answer the same on master: a line walking a stretch twice counts it once,
and a line whose first vertex the filtered sign cannot place against its
second edge keeps both edges, as CGAL measures it.