### PR TITLE
Keep the segment kernel's parallel verdict right for short segments

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -336,6 +336,37 @@ extern bool *pointarr_find_splits(const POINT2D **points, int npoints,
  *****************************************************************************/
 
 /**
+ * @brief Return the sign of the cross product of two vectors, or zero where
+ * the double evaluation cannot be trusted to carry it
+ * @details The vectors are differences of INPUT coordinates, each rounded
+ * once, so the question is the sign of one determinant and needs no
+ * tolerance: a band here would not protect the answer, it would decide it.
+ * What the sign does need is a guarantee that rounding has not eaten it, and
+ * that guarantee is a FILTER rather than a band. The bound is computed FROM
+ * THE OPERANDS and decides only whether the double is trustworthy, never what
+ * the answer is. It is Shewchuk's bound for a determinant of two such
+ * products, written in terms of @p DBL_EPSILON so that it is arithmetic
+ * rather than a constant anyone is invited to tune
+ * @param[in] rx,ry First vector
+ * @param[in] sx,sy Second vector
+ * @return 1 or -1 for the two turns, 0 for parallel or unable to tell
+ */
+static inline int
+cross_product_sign(double rx, double ry, double sx, double sy)
+{
+  double left = rx * sy;
+  double right = ry * sx;
+  double det = left - right;
+  double bound = (3.0 + 16.0 * DBL_EPSILON) * DBL_EPSILON *
+    (fabs(left) + fabs(right));
+  if (det > bound)
+    return 1;
+  if (det < - bound)
+    return -1;
+  return 0;
+}
+
+/**
  * @brief Return the intersection value obtained by computing the intersection 
  * of a line segment defined by two 2D points intersects an edge
  * @details Possible result values
@@ -365,11 +396,16 @@ linesegm_intersect(double ax, double ay, double rx, double ry,
   /* Where is the start of the second segment relative to the first? */
   double qpx = cx - ax, qpy = cy - ay;
 
-  /* Are the two segments parallel?  */
+  /* Are the two segments parallel? The directions are differences of input
+   * coordinates, so the answer is the sign of their cross product, an area
+   * whose scale is the product of the two lengths: two GPS steps of 1e-6
+   * leaving one vertex in different directions carry a cross product near
+   * 1e-12 and a sign the filter still carries. The segments are parallel
+   * only where it cannot (#cross_product_sign) */
   double rxs = rx * sy - ry * sx;
 
   /* Collinear / parallel */
-  if (fabs(rxs) < MEOS_GEOM_TOLERANCE)
+  if (cross_product_sign(rx, ry, sx, sy) == 0)
   {
     /* The two segments run in one direction; what is left to decide is
      * whether they run along the SAME LINE or along two parallel ones. Both

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -5496,16 +5496,7 @@ static int
 relate_orientation(double ax, double ay, double bx, double by, double cx,
   double cy)
 {
-  double left = (bx - ax) * (cy - ay);
-  double right = (by - ay) * (cx - ax);
-  double det = left - right;
-  double bound = (3.0 + 16.0 * DBL_EPSILON) * DBL_EPSILON *
-    (fabs(left) + fabs(right));
-  if (det > bound)
-    return 1;
-  if (det < - bound)
-    return -1;
-  return 0;
+  return cross_product_sign(bx - ax, by - ay, cx - ax, cy - ay);
 }
 
 /**

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -321,6 +321,37 @@ int main(void)
   }
   meos_errno_reset();
 
+  /* Two GPS steps of about 1e-6 in degrees leaving one vertex in different
+   * directions share that vertex and nothing else: they intersect, and their
+   * interiors do not meet. The cross product of their directions is near
+   * 1e-12, and its sign decides that they are not parallel. Both pairs are
+   * real AIS steps: in the first the two start at one vertex, in the second
+   * the end of one is the start of the other */
+  struct { const char *a, *b; } gpssteps[] = {
+    { "LINESTRING(11.198253 55.211805,11.198252 55.211803)",
+      "LINESTRING(11.198253 55.211805,11.19825 55.2118)" },
+    { "LINESTRING(11.198253 55.211805,11.198252 55.211803)",
+      "LINESTRING(11.19825 55.2118,11.198253 55.211805)" },
+  };
+  for (size_t i = 0; i < sizeof(gpssteps) / sizeof(gpssteps[0]); i++)
+  {
+    GSERIALIZED *ga = geom_in(gpssteps[i].a, -1);
+    GSERIALIZED *gb = geom_in(gpssteps[i].b, -1);
+    assert(ga != NULL);
+    assert(gb != NULL);
+    meos_errno_reset();
+    char *gm = geom_relate(ga, gb);
+    bool gi = geom_intersects(ga, gb);
+    printf("geom_relate(%s, %s): %s, intersects %d, errno %d\n",
+      gpssteps[i].a, gpssteps[i].b, gm ? gm : "(NULL)", gi, meos_errno());
+    assert(gm != NULL);
+    assert(strcmp(gm, "FF1F00102") == 0);
+    assert(gi == true);
+    assert(meos_errno() == 0);
+    free(gm); free(ga); free(gb);
+  }
+  meos_errno_reset();
+
   /* Two areas lying on OPPOSITE SIDES of one line share no area, so neither
    * interior holds a point of the other's boundary, however near the two
    * boundaries run. Deciding that from a boundary portion means classifying a


### PR DESCRIPTION
The segment kernel decides that two segments are parallel before it asks
whether they run along one line. On master it reads the cross product of
the two directions against the geometry tolerance, fabs(rxs) < 1e-12. The
cross product is the sine of the angle between the segments times both
their lengths, an area, so every pair of segments near 1e-6 long reads as
parallel whatever their directions. Two GPS steps in degrees leaving one
vertex in different directions then report a shared stretch, or no
meeting at all.

This commit reads the pair as parallel only where the sign of that cross
product is zero or the double evaluation cannot carry it:
cross_product_sign, a static inline in geo_funcs.h beside the kernel,
bounds the rounding of the determinant with Shewchuk's bound computed
from the operands. relate_orientation, which evaluates the same bound,
becomes a caller of it.

Witness

Two real AIS steps sharing their first vertex,

    LINESTRING(11.198253 55.211805,11.198252 55.211803)
    LINESTRING(11.198253 55.211805,11.19825 55.2118)

relate as FF1F00102, meeting at that vertex only, where master answers
1FFF00102, a shared stretch between segments whose directions differ. Two
steps where the end of one is the start of the other intersect, where
master answers geom_intersects false beside a matrix whose
boundary/boundary cell reads 0.

Measured

Five segment pairs from real AIS trajectories (aisdk-2025-03-01), through
geom_relate and geom_intersects: master reads a shared stretch for 3 and
no intersection for the 2 others, all five meeting at one shared vertex;
this commit answers FF1F00102 and intersects for all five. An exactly
collinear overlapping pair (101FF0FF2) and a crossing pair (0F1FF0102)
answer as on master.

The union of linework reads the kernel too. Against the exact measure of
the point set a line covers, on the doubles, over the same data (trips
split at 180 s / 1 NM): 50 trajectories of 200 vertices answer as on
master, and 41 trips of 1431-5095 vertices answer 13 exact where master
answers 11. Built without the fallback library the union refuses 1 of
the 41, where master refuses 7. Every row master answers exactly stays
exact.

What does not move: the relate acceptance set -- 931 h3 cells against
themselves, 1444 areal pairs and a real protected-area pair in projected
coordinates -- holds 1864 of 1864 self-matrices at the definition and 918
of 918 interior cells at the exact shared area, on master and on this
commit. Thirty real protected-area polygons buffered at radii 1, 50 and
500 answer the same buffers on both. The scale sweep of the buffer, whose
witness is scale invariance -- the box of a correct buffer divided by the
scale does not depend on the scale, so no reference engine enters it --
moves one row: a circular string buffered at scale 1e-8, which master
answers 11.601534 x 11.4142136 where the same shape answers 17.8113883 x
17.4056942 at scale 1, and which this commit declines. The kernel is inlined where
it is on master: 3 out-of-line copies in libmeos.so and 15 calls to them
on both. No expected SQL output on PostgreSQL 18 changes, and over 42
instruments diffed answer for answer against master, the lines that
differ are the two the test of this commit prints and that row of the
scale sweep.

The union's dissolve, which calls the kernel for every pair of edges,
takes 1.01x to 1.03x master's time in total on the 41 trips (per-row
median 1.04 to 1.05) and 1.02x to 1.08x on the 50 trajectories, over the
rows both builds answer, in the three of six interleaved rounds run on a
quiet machine.

Why

The directions are differences of input coordinates, so whether they are
parallel is the sign of one determinant, and every double is an exact
rational, so that sign has one answer. A threshold on the determinant
decides the answer for every pair whose determinant falls under it, and
for short segments that is every pair. A filter decides only whether the
double evaluation carries the sign: Shewchuk's bound is the largest error
the evaluation can make, computed from the two products, so a determinant
beyond it has the sign it shows. The pair reads as parallel only within
that rounding, where the collinear branch that follows decides as it does
on master.

Test

geo_test asserts both witnesses: the first aborts against master at
geo_test.c:348 and holds on this commit.