### PR TITLE
Answer the raster processing entry points in SQL

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3206,6 +3206,9 @@
 					<para><link linkend="raster_summaryStats"><varname>summaryStats</varname></link>: Devuelve las estadísticas de los píxeles de una banda de ráster</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_dumpAsPolygons"><varname>dumpAsPolygons</varname></link>: Devuelve los polígonos de una banda de ráster, uno por cada grupo de píxeles que comparten un valor &SRF;</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				</listitem>
 				<listitem>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3194,6 +3194,9 @@
 					<para><link linkend="raster_reclass"><varname>reclass</varname></link>: Devuelve un ráster cuya banda contiene las clases a las que una expresión asigna sus valores</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_clip"><varname>clip</varname></link>: Devuelve un ráster que conserva los píxeles de otro que una geometría cubre</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				</listitem>
 				<listitem>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3203,6 +3203,9 @@
 					<para><link linkend="raster_rescale"><varname>rescale</varname></link>: Devuelve un ráster remuestreado a otro tamaño de píxel</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_summaryStats"><varname>summaryStats</varname></link>: Devuelve las estadísticas de los píxeles de una banda de ráster</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				</listitem>
 				<listitem>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -3197,6 +3197,12 @@
 					<para><link linkend="raster_clip"><varname>clip</varname></link>: Devuelve un ráster que conserva los píxeles de otro que una geometría cubre</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_transform"><varname>transform</varname></link>: Devuelve un ráster expresado en otro sistema de referencia espacial</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_rescale"><varname>rescale</varname></link>: Devuelve un ráster remuestreado a otro tamaño de píxel</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>
 				</listitem>
 				<listitem>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -51,6 +51,10 @@
 
 	<para><ulink url="https://github.com/CartoDB/raquet">Raquet</ulink> es un formato ráster nativo en la nube que almacena teselas ráster como filas en un archivo Apache Parquet. Cada fila contiene los bytes de píxel de una tesela Web-Mercator junto con su identificador de celda <ulink url="https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/sql-reference/quadbin">QUADBIN</ulink>, un entero de 64 bits que codifica el nivel de zoom y las coordenadas x/y intercaladas mediante Morton. No se requieren metadatos espaciales adicionales: el rectángulo delimitador y el mapeo de píxel a coordenadas quedan completamente determinados por el valor QUADBIN.</para>
 
+	<para>Los dos se distinguen en lo que lleva un valor. Un valor <varname>raquet</varname> contiene sus píxeles y su celda QUADBIN en un único valor, de modo que su extensión y su rejilla de píxeles se derivan de la celda y responde únicamente a la rejilla Web-Mercator. Un <varname>raster</varname> de PostGIS declara un sistema de referencia espacial arbitrario y una georreferenciación afín arbitraria, y es el que toman las funciones de procesamiento de <xref linkend="tcell_raster_specific"/>: <link linkend="raster_clip"><varname>clip</varname></link>, <link linkend="raster_transform"><varname>transform</varname></link>, <link linkend="raster_rescale"><varname>rescale</varname></link>, <link linkend="raster_reclass"><varname>reclass</varname></link>, <link linkend="raster_summaryStats"><varname>summaryStats</varname></link> y <link linkend="raster_dumpAsPolygons"><varname>dumpAsPolygons</varname></link>. MEOS calcula ambos, de modo que ninguno necesita PostgreSQL para evaluarse.</para>
+
+	<para>Una cobertura multiespectral se lee banda por banda en ambas vías. La especificación RaQuet otorga a cada banda de una tesela una columna propia, <varname>band_1</varname>, <varname>band_2</varname> y así sucesivamente, por lo que tal cobertura es un conjunto de teselas de una sola banda que comparten una celda QUADBIN y <link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link> muestrea la banda que recibe, mientras que en la vía <varname>raster</varname> de PostGIS el argumento <varname>band</varname> la nombra. Lo que un valor <varname>raquet</varname> no transporta es la disposición entrelazada que la especificación ofrece para imágenes RGB, que empaqueta las bandas de una tesela en una única columna comprimida en JPEG o WebP.</para>
+
 	<sect1 xml:id="tcell_notation">
 		<title>Notación</title>
 		<para>La mayoría de las funciones y operadores para tipos temporales descritos en los capítulos anteriores pueden aplicarse a los tipos de índices de celdas temporales. Por lo tanto, en las signaturas de las funciones, la notación <varname>base</varname> representa una <varname>cell</varname> y la notación <varname>ttype</varname> representa también un <varname>tcell</varname>. Para evitar redundancia, presentamos a continuación únicamente las funciones y los operadores específicos de los tipos de índices de celdas.</para>
@@ -2253,19 +2257,4 @@ sudo make install
 		<para>Para incluir el ráster en la compilación de cobertura de CI junto con otras familias opcionales, añada <varname>-DRASTER=ON</varname> a la invocación de cmake en <filename>.github/workflows/pgversion.yml</filename>.</para>
 	</sect1>
 
-	<sect1 xml:id="raster_roadmap">
-		<title>Hoja de Ruta de Producción</title>
-
-		<para>Las dos vías descritas en este capítulo sirven propósitos distintos y ambas se mantienen. La vía <varname>raquet</varname> es un tipo de valor MEOS autocontenido: transporta sus píxeles y su georreferenciación QUADBIN en un único valor y no necesita PostgreSQL para evaluarse, por lo que está disponible en todos los enlaces de lenguaje derivados de MEOS. La vía <varname>raster</varname> de PostGIS ofrece el procesamiento ráster mucho más rico de la extensión <varname>postgis_raster</varname>, álgebra de mapas, estadísticas, remuestreo, recorte, conversión a polígonos, únicamente dentro de PostgreSQL.</para>
-
-		<para>Ninguna vía reemplaza a la otra. El trabajo sobre la vía <varname>raquet</varname> amplía lo que una tesela nativa de la nube puede hacer a lo largo de una trayectoria; no pretende reimplementar el procesamiento ráster.</para>
-
-		<para>Una cobertura multiespectral se lee banda por banda en ambas vías. La especificación RaQuet otorga a cada banda de una tesela una columna propia, <varname>band_1</varname>, <varname>band_2</varname> y así sucesivamente, por lo que tal cobertura es un conjunto de teselas de una sola banda que comparten una celda QUADBIN y <link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link> muestrea la banda que recibe, mientras que en la vía <varname>raster</varname> de PostGIS el argumento <varname>band</varname> la nombra. Lo que un valor <varname>raquet</varname> no transporta es la disposición entrelazada que la especificación ofrece para imágenes RGB, que empaqueta las bandas de una tesela en una única columna comprimida en JPEG o WebP.</para>
-
-		<para>Las extensiones siguientes requieren un modelo de datos ráster general, es decir, sistemas de referencia espacial arbitrarios y georreferenciación afín arbitraria. La extensión y la rejilla de píxeles de un valor <varname>raquet</varname> se derivan de su celda QUADBIN, por lo que quedan fuera de ese modelo y siguen disponibles a través de la vía <varname>raster</varname> de PostGIS:</para>
-		<itemizedlist>
-			<listitem><para><emphasis>Sistemas de referencia espacial arbitrarios</emphasis>, teselas fuera de la rejilla Web-Mercator y reproyección entre sistemas de referencia.</para></listitem>
-			<listitem><para><emphasis>Procesamiento ráster</emphasis>, álgebra de mapas, estadísticas de resumen, remuestreo y conversión a polígonos, junto con el recorte de una tesela a una región, como la extensión que un conjunto de trayectorias visita durante un intervalo de tiempo.</para></listitem>
-		</itemizedlist>
-	</sect1>
 </chapter>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -2082,6 +2082,26 @@ FROM rast;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_summaryStats">
+				<indexterm significance="normal"><primary><varname>summaryStats</varname></primary></indexterm>
+				<para>Devuelve las estadísticas de los píxeles de una banda de ráster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+summaryStats(raster,band integer=1,excludeNodata boolean=true) → summarystats
+</programlisting>
+				<para>La banda se lee una sola vez y devuelve el registro <varname>summarystats</varname> de PostGIS que devuelve <varname>ST_SummaryStats</varname>: el número de píxeles contados, y la suma, la media, la desviación estándar, el mínimo y el máximo de sus valores. Se leen todos los píxeles, por lo que la respuesta es exacta y no muestreada; los píxeles que la banda declara como nodata quedan fuera salvo que <varname>excludeNodata</varname> sea falso, y una banda sin ningún píxel que contar devuelve un recuento de cero y ninguna estadística.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT (summaryStats(r)).* FROM rast;
+-- 9 | 450 | 50 | 25.81988897471611 | 10 | 90
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -2102,6 +2102,29 @@ SELECT (summaryStats(r)).* FROM rast;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_dumpAsPolygons">
+				<indexterm significance="normal"><primary><varname>dumpAsPolygons</varname></primary></indexterm>
+				<para>Devuelve los polígonos de una banda de ráster, uno por cada grupo de píxeles que comparten un valor &SRF;
+</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+dumpAsPolygons(raster,band integer=1,excludeNodata boolean=true) → {geomval}
+</programlisting>
+				<para>Una banda declara un valor por píxel, y esta función declara la misma banda como las regiones que cubren esos valores, devolviendo los registros <varname>geomval</varname> de PostGIS que devuelve <varname>ST_DumpAsPolygons</varname>. Cada polígono lleva el sistema de referencia del ráster, donde <varname>ST_DumpAsPolygons</varname> no declara ninguno, de modo que puede compararse con las trayectorias a lo largo de las cuales se lee la cobertura. Los píxeles que la banda declara como nodata quedan fuera salvo que <varname>excludeNodata</varname> sea falso, una banda cuyos píxeles son todos nodata no cubre nada y no devuelve ninguna fila, y una banda que el ráster no tiene genera un error.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Classify a 3x3 synthetic elevation raster, then read each class as a region
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT val, ST_AsText(geom)
+FROM rast, dumpAsPolygons(reclass(r, 1, '0-50:1, [50-100]:2', '8BUI', 0))
+ORDER BY val;
+-- 1 | POLYGON((0 3,0 1,1 1,1 2,3 2,3 3,0 3))
+-- 2 | POLYGON((1 2,1 1,0 1,0 0,3 0,3 2,1 2))
+</programlisting>
+			</listitem>
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -2011,6 +2011,30 @@ SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(0.5 2.5)@2001-01-01,
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_clip">
+				<indexterm significance="normal"><primary><varname>clip</varname></primary></indexterm>
+				<para>Devuelve un ráster que conserva los píxeles de otro que una geometría cubre</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+clip(raster,geom geometry,crop boolean=true) → raster
+</programlisting>
+				<para>Cada banda se lee contra una máscara en la que se graba la geometría, tal como la lee <varname>ST_Clip</varname> de PostGIS: un píxel que la geometría no cubre devuelve el valor nodata de su banda, y el menor valor que admite su tipo de píxel cuando la banda no declara ninguno. Con <varname>crop</varname> el resultado conserva la extensión que comparten el ráster y la geometría, y en caso contrario la extensión del ráster. La geometría está en el sistema de referencia del ráster; una en otro sistema genera un error.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT ST_DumpValues(clip(r, geometry 'SRID=4326;POLYGON((0 1,2 1,2 3,0 3,0 1))'), 1)
+  AS cropped,
+  ST_DumpValues(clip(r, geometry 'SRID=4326;POLYGON((0 1,2 1,2 3,0 3,0 1))', false), 1)
+  AS kept_extent
+FROM rast;
+-- {{10,20},{40,50}} | {{10,20,NULL},{40,50,NULL},{NULL,NULL,NULL}}
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -2035,6 +2035,53 @@ FROM rast;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_transform">
+				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
+				<para>Devuelve un ráster expresado en otro sistema de referencia espacial</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+transform(raster,srid integer,algorithm text='NearestNeighbour',
+  maxerr float8=0.125) → raster
+</programlisting>
+				<para>Cada banda se lleva al sistema de destino y se remuestrea sobre la malla que implica la reproyección, mediante la misma deformación de GDAL que <varname>ST_Transform</varname> de PostGIS, de modo que el resultado expresa la misma cobertura leída a través de otro sistema. El algoritmo es uno de <varname>NearestNeighbour</varname>, <varname>Bilinear</varname>, <varname>Cubic</varname>, <varname>CubicSpline</varname>, <varname>Lanczos</varname>, <varname>Max</varname> y <varname>Min</varname>, nombrado sin distinguir mayúsculas de minúsculas, y <varname>maxerr</varname> es el error en píxeles de entrada que la deformación puede cometer, 0 para un cálculo exacto.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT ST_SRID(transform(r, 3857)) AS srid, ST_Width(transform(r, 3857)) AS width,
+  ST_Height(transform(r, 3857)) AS height
+FROM rast;
+-- 3857 | 3 | 3
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_rescale">
+				<indexterm significance="normal"><primary><varname>rescale</varname></primary></indexterm>
+				<para>Devuelve un ráster remuestreado a otro tamaño de píxel</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rescale(raster,scalex float8,scaley float8,algorithm text='NearestNeighbour',
+  maxerr float8=0.125) → raster
+</programlisting>
+				<para>El resultado conserva el sistema de referencia y la esquina superior izquierda del ráster y expresa su cobertura sobre una malla del tamaño de píxel pedido, mediante la misma deformación de GDAL que <varname>ST_Rescale</varname> de PostGIS, de modo que una escala más gruesa lee menos píxeles sobre el mismo terreno. Las escalas están en las unidades del sistema de referencia del ráster, y el algoritmo y el error son los de <link linkend="raster_transform"><varname>transform</varname></link>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT ST_Width(rescale(r, 0.5, -0.5)) AS width,
+  ST_Height(rescale(r, 0.5, -0.5)) AS height,
+  ST_ScaleX(rescale(r, 0.5, -0.5)) AS scalex
+FROM rast;
+-- 6 | 6 | 0.5
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Muestrea una tesela ráster <varname>raquet</varname> a lo largo de una trayectoria</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3215,6 +3215,9 @@
 					<para><link linkend="raster_summaryStats"><varname>summaryStats</varname></link>: Return the statistics of the pixels of a raster band</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_dumpAsPolygons"><varname>dumpAsPolygons</varname></link>: Return the polygons of a raster band, one for each group of pixels sharing a value &SRF;</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a <varname>raquet</varname> raster tile along a trajectory</para>
 				</listitem>
 				<listitem>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3212,6 +3212,9 @@
 					<para><link linkend="raster_rescale"><varname>rescale</varname></link>: Return a raster resampled to another pixel size</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_summaryStats"><varname>summaryStats</varname></link>: Return the statistics of the pixels of a raster band</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a <varname>raquet</varname> raster tile along a trajectory</para>
 				</listitem>
 				<listitem>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3203,6 +3203,9 @@
 					<para><link linkend="raster_reclass"><varname>reclass</varname></link>: Return a raster whose band holds the classes an expression maps its values to</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_clip"><varname>clip</varname></link>: Return a raster keeping the pixels of another that a geometry covers</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a <varname>raquet</varname> raster tile along a trajectory</para>
 				</listitem>
 				<listitem>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -3206,6 +3206,12 @@
 					<para><link linkend="raster_clip"><varname>clip</varname></link>: Return a raster keeping the pixels of another that a geometry covers</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_transform"><varname>transform</varname></link>: Return a raster stated in another spatial reference system</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_rescale"><varname>rescale</varname></link>: Return a raster resampled to another pixel size</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link>: Sample a <varname>raquet</varname> raster tile along a trajectory</para>
 				</listitem>
 				<listitem>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -2105,6 +2105,29 @@ SELECT (summaryStats(r)).* FROM rast;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_dumpAsPolygons">
+				<indexterm significance="normal"><primary><varname>dumpAsPolygons</varname></primary></indexterm>
+				<para>Return the polygons of a raster band, one for each group of pixels sharing a value &SRF;
+</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+dumpAsPolygons(raster,band integer=1,excludeNodata boolean=true) → {geomval}
+</programlisting>
+				<para>A band states a value per pixel, and this states the same band as the regions those values cover, answering the PostGIS <varname>geomval</varname> records that <varname>ST_DumpAsPolygons</varname> answers. Each polygon carries the reference system of the raster, where <varname>ST_DumpAsPolygons</varname> states none, so it can be compared with the trajectories the coverage is read along. The pixels the band states as nodata are left out unless <varname>excludeNodata</varname> is false, a band whose every pixel is nodata covers nothing and answers no row, and a band the raster does not have raises an error.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Classify a 3x3 synthetic elevation raster, then read each class as a region
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT val, ST_AsText(geom)
+FROM rast, dumpAsPolygons(reclass(r, 1, '0-50:1, [50-100]:2', '8BUI', 0))
+ORDER BY val;
+-- 1 | POLYGON((0 3,0 1,1 1,1 2,3 2,3 3,0 3))
+-- 2 | POLYGON((1 2,1 1,0 1,0 0,3 0,3 2,1 2))
+</programlisting>
+			</listitem>
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -2085,6 +2085,26 @@ FROM rast;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_summaryStats">
+				<indexterm significance="normal"><primary><varname>summaryStats</varname></primary></indexterm>
+				<para>Return the statistics of the pixels of a raster band</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+summaryStats(raster,band integer=1,excludeNodata boolean=true) → summarystats
+</programlisting>
+				<para>The band is read once and answers the PostGIS <varname>summarystats</varname> record that <varname>ST_SummaryStats</varname> answers: the number of pixels counted, and the sum, mean, standard deviation, minimum and maximum of their values. Every pixel is read, so the answer is exact rather than sampled; the pixels the band states as nodata are left out unless <varname>excludeNodata</varname> is false, and a band with no pixel to count answers a count of zero and no statistic.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT (summaryStats(r)).* FROM rast;
+-- 9 | 450 | 50 | 25.81988897471611 | 10 | 90
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -51,6 +51,10 @@
 
 	<para><ulink url="https://github.com/CartoDB/raquet">Raquet</ulink> is a cloud-native raster format that stores raster tiles as rows in an Apache Parquet file. Each row holds the pixel bytes for one Web-Mercator tile together with its <ulink url="https://docs.carto.com/data-and-analysis/analytics-toolbox-for-bigquery/sql-reference/quadbin">QUADBIN</ulink> cell identifier, a 64-bit integer that encodes the tile's zoom level and Morton-interleaved x/y coordinates. No separate spatial metadata is required: the bounding box and pixel-to-coordinate mapping are fully determined by the QUADBIN value.</para>
 
+	<para>The two differ in what a value carries. A <varname>raquet</varname> value holds its pixels and its QUADBIN cell in one value, so its extent and its pixel grid follow from the cell and it answers the Web-Mercator grid alone. A PostGIS <varname>raster</varname> states an arbitrary spatial reference system and an arbitrary affine georeferencing, and it is the one the processing functions of <xref linkend="tcell_raster_specific"/> take: <link linkend="raster_clip"><varname>clip</varname></link>, <link linkend="raster_transform"><varname>transform</varname></link>, <link linkend="raster_rescale"><varname>rescale</varname></link>, <link linkend="raster_reclass"><varname>reclass</varname></link>, <link linkend="raster_summaryStats"><varname>summaryStats</varname></link> and <link linkend="raster_dumpAsPolygons"><varname>dumpAsPolygons</varname></link>. MEOS computes both, so neither needs PostgreSQL to evaluate.</para>
+
+	<para>A multi-spectral coverage is read band by band on either path. The RaQuet specification gives each band of a tile a column of its own, <varname>band_1</varname>, <varname>band_2</varname> and so on, so such a coverage is a set of single-band tiles sharing one QUADBIN cell and <link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link> samples the band it is given, while on the PostGIS <varname>raster</varname> path the <varname>band</varname> argument names it. What a <varname>raquet</varname> value does not carry is the interleaved layout the specification offers for RGB imagery, which packs the bands of a tile into a single JPEG- or WebP-compressed column.</para>
+
 	<sect1 xml:id="tcell_notation">
 		<title>Notation</title>
 		<para>Most functions and operators for temporal types described in the previous chapters can be applied to temporal cell index types. Therefore, in the signatures of the functions, the notation <varname>base</varname> represents a <varname>cell</varname> and the notation <varname>ttype</varname> also represents a <varname>tcell</varname>. To avoid redundancy, we present next only the functions and operators specific to the cell index types.</para>
@@ -2256,19 +2260,4 @@ sudo make install
 		<para>To include raster in the CI coverage build alongside other optional families, add <varname>-DRASTER=ON</varname> to the cmake invocation in <filename>.github/workflows/pgversion.yml</filename>.</para>
 	</sect1>
 
-	<sect1 xml:id="raster_roadmap">
-		<title>Production Roadmap</title>
-
-		<para>The two paths described in this chapter serve different purposes and are both maintained. The <varname>raquet</varname> path is a self-contained MEOS value type: it carries its pixels and its QUADBIN georeferencing in a single value and needs no PostgreSQL to evaluate, so it is available to every language binding derived from MEOS. The PostGIS <varname>raster</varname> path offers the far richer raster processing of the <varname>postgis_raster</varname> extension, map algebra, statistics, resampling, clipping, conversion to polygons, inside PostgreSQL only.</para>
-
-		<para>Neither path replaces the other. Work on the <varname>raquet</varname> path extends what a cloud-native tile can do along a trajectory; it is not an attempt to reimplement raster processing.</para>
-
-		<para>A multi-spectral coverage is read band by band on either path. The RaQuet specification gives each band of a tile a column of its own, <varname>band_1</varname>, <varname>band_2</varname> and so on, so such a coverage is a set of single-band tiles sharing one QUADBIN cell and <link linkend="raster_rasterTileValue"><varname>rasterTileValue</varname></link> samples the band it is given, while on the PostGIS <varname>raster</varname> path the <varname>band</varname> argument names it. What a <varname>raquet</varname> value does not carry is the interleaved layout the specification offers for RGB imagery, which packs the bands of a tile into a single JPEG- or WebP-compressed column.</para>
-
-		<para>The extensions below require a general raster data model, that is, arbitrary spatial reference systems and arbitrary affine georeferencing. The extent and the pixel grid of a <varname>raquet</varname> value follow from its QUADBIN cell, so these lie outside that model and remain available through the PostGIS <varname>raster</varname> path:</para>
-		<itemizedlist>
-			<listitem><para><emphasis>Arbitrary spatial reference systems</emphasis>, tiles outside the Web-Mercator grid, and reprojection between reference systems.</para></listitem>
-			<listitem><para><emphasis>Raster processing</emphasis>, map algebra, summary statistics, resampling, and conversion to polygons, together with clipping a tile to a region, such as the extent a set of trajectories visits over a time interval.</para></listitem>
-		</itemizedlist>
-	</sect1>
 </chapter>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -2014,6 +2014,30 @@ SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(0.5 2.5)@2001-01-01,
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_clip">
+				<indexterm significance="normal"><primary><varname>clip</varname></primary></indexterm>
+				<para>Return a raster keeping the pixels of another that a geometry covers</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+clip(raster,geom geometry,crop boolean=true) → raster
+</programlisting>
+				<para>Every band is read against a mask the geometry is burnt into, as the PostGIS <varname>ST_Clip</varname> reads it: a pixel the geometry does not cover answers the nodata value of its band, and the smallest value its pixel type holds when the band declares none. With <varname>crop</varname> the result carries the extent the raster and the geometry share, and otherwise the extent of the raster. The geometry is in the reference system of the raster; one in another system raises an error.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT ST_DumpValues(clip(r, geometry 'SRID=4326;POLYGON((0 1,2 1,2 3,0 3,0 1))'), 1)
+  AS cropped,
+  ST_DumpValues(clip(r, geometry 'SRID=4326;POLYGON((0 1,2 1,2 3,0 3,0 1))', false), 1)
+  AS kept_extent
+FROM rast;
+-- {{10,20},{40,50}} | {{10,20,NULL},{40,50,NULL},{NULL,NULL,NULL}}
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -2038,6 +2038,53 @@ FROM rast;
 </programlisting>
 			</listitem>
 
+			<listitem xml:id="raster_transform">
+				<indexterm significance="normal"><primary><varname>transform</varname></primary></indexterm>
+				<para>Return a raster stated in another spatial reference system</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+transform(raster,srid integer,algorithm text='NearestNeighbour',
+  maxerr float8=0.125) → raster
+</programlisting>
+				<para>Every band is carried into the target system and resampled onto the grid the reprojection implies, through the same GDAL warp as the PostGIS <varname>ST_Transform</varname>, so the result states the same coverage read through another system. The algorithm is one of <varname>NearestNeighbour</varname>, <varname>Bilinear</varname>, <varname>Cubic</varname>, <varname>CubicSpline</varname>, <varname>Lanczos</varname>, <varname>Max</varname> and <varname>Min</varname>, named without regard to case, and <varname>maxerr</varname> is the error in input pixels the warp may commit, 0 for an exact calculation.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT ST_SRID(transform(r, 3857)) AS srid, ST_Width(transform(r, 3857)) AS width,
+  ST_Height(transform(r, 3857)) AS height
+FROM rast;
+-- 3857 | 3 | 3
+</programlisting>
+			</listitem>
+
+			<listitem xml:id="raster_rescale">
+				<indexterm significance="normal"><primary><varname>rescale</varname></primary></indexterm>
+				<para>Return a raster resampled to another pixel size</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rescale(raster,scalex float8,scaley float8,algorithm text='NearestNeighbour',
+  maxerr float8=0.125) → raster
+</programlisting>
+				<para>The result keeps the reference system and the upper left corner of the raster and states its coverage on a grid of the pixel size asked for, through the same GDAL warp as the PostGIS <varname>ST_Rescale</varname>, so a coarser scale reads fewer pixels over the same ground. The scales are in the units of the raster's reference system, and the algorithm and the error are those of <link linkend="raster_transform"><varname>transform</varname></link>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+-- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, -9999::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+    [40.0::float4, 50.0::float4, 60.0::float4],
+    [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
+SELECT ST_Width(rescale(r, 0.5, -0.5)) AS width,
+  ST_Height(rescale(r, 0.5, -0.5)) AS height,
+  ST_ScaleX(rescale(r, 0.5, -0.5)) AS scalex
+FROM rast;
+-- 6 | 6 | 0.5
+</programlisting>
+			</listitem>
+
 			<listitem xml:id="raster_rasterTileValue">
 				<indexterm significance="normal"><primary><varname>rasterTileValue</varname></primary></indexterm>
 				<para>Sample a <varname>raquet</varname> raster tile along a trajectory</para>

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -1165,7 +1165,7 @@ raster_dump_as_polygons(const Raster *rast, int band, bool exclude_nodata,
  * @return The statistics, which the caller releases with @p free(), or NULL
  * where the band states no pixel to count, in which case no error is stated
  * @errval NULL
- * @csqlfn None, the host answers this operation on its own raster type
+ * @csqlfn #Raster_summary_stats()
  */
 BandStats *
 raster_summary_stats(const Raster *rast, int band, bool exclude_nodata)
@@ -1215,11 +1215,15 @@ raster_summary_stats(const Raster *rast, int band, bool exclude_nodata)
     return NULL;
   }
 
+  /* The statistics are allocated by the raster core, so its own deallocator
+   * releases them: in the extension build that allocator is not PostgreSQL's,
+   * and pfree() on them raises "pfree called with invalid pointer" */
+
   /* A band whose every pixel is nodata states no value to summarize, which is
    * an answer rather than an error; the statistics of no pixels have no mean */
   if (stats->count < 1)
   {
-    pfree(stats);
+    rtdealloc(stats);
     return NULL;
   }
 
@@ -1230,7 +1234,7 @@ raster_summary_stats(const Raster *rast, int band, bool exclude_nodata)
   result->stddev = stats->stddev;
   result->min = stats->min;
   result->max = stats->max;
-  pfree(stats);
+  rtdealloc(stats);
   return result;
 }
 

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -1077,7 +1077,7 @@ geomval_arr_free(GeomVal *gvarr, int count)
  * @return An array the caller releases with #geomval_arr_free(), or NULL where
  * the band covers nothing, in which case @p count is 0 and no error is stated
  * @errval NULL
- * @csqlfn None, the host answers this operation on its own raster type
+ * @csqlfn #Raster_dump_as_polygons()
  */
 GeomVal *
 raster_dump_as_polygons(const Raster *rast, int band, bool exclude_nodata,
@@ -1126,9 +1126,11 @@ raster_dump_as_polygons(const Raster *rast, int band, bool exclude_nodata,
       "Could not read band %d of the raster as polygons", band);
     return NULL;
   }
+  /* The raster core allocates the array with its own allocator, not the one
+   * MEOS answers from, so it is released through the raster core as well */
   if (nelems < 1)
   {
-    pfree(geomval);
+    rtdealloc(geomval);
     return NULL;
   }
 
@@ -1144,7 +1146,7 @@ raster_dump_as_polygons(const Raster *rast, int band, bool exclude_nodata,
     result[i].val = geomval[i].val;
     lwgeom_free(geom);
   }
-  pfree(geomval);
+  rtdealloc(geomval);
 
   *count = nelems;
   return result;

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -990,7 +990,7 @@ raster_warp(const Raster *rast, int32_t srid, double *scale_x, double *scale_y,
  * @param[in] max_err Error in input pixels the warp may commit, 0 for an exact
  * calculation
  * @errval NULL
- * @csqlfn None, the host answers this operation on its own raster type
+ * @csqlfn #Raster_transform()
  */
 Raster *
 raster_transform(const Raster *rast, int32_t srid, const char *algorithm,
@@ -1022,7 +1022,7 @@ raster_transform(const Raster *rast, int32_t srid, const char *algorithm,
  * @param[in] max_err Error in input pixels the warp may commit, 0 for an exact
  * calculation
  * @errval NULL
- * @csqlfn None, the host answers this operation on its own raster type
+ * @csqlfn #Raster_rescale()
  */
 Raster *
 raster_rescale(const Raster *rast, double scale_x, double scale_y,

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -717,7 +717,7 @@ raster_geo_mask(rt_raster raster, const GSERIALIZED *gs)
  * @param[in] crop True to reduce the result to the extent the raster and the
  * geometry share
  * @errval NULL
- * @csqlfn None, the host answers this operation on its own raster type
+ * @csqlfn #Raster_clip()
  */
 Raster *
 raster_clip(const Raster *rast, const GSERIALIZED *gs, bool crop)

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -342,6 +342,18 @@ CREATE FUNCTION reclass(raster, integer, text, text,
   AS 'MODULE_PATHNAME', 'Raster_reclass'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
 
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster keeping the pixels of another that a geometry covers
+ * @param[in] rast Raster
+ * @param[in] geom Geometry, in the reference system of the raster
+ * @param[in] crop True to reduce the result to the extent the two share
+ */
+CREATE FUNCTION clip(raster, geometry, boolean DEFAULT true)
+  RETURNS raster
+  AS 'MODULE_PATHNAME', 'Raster_clip'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * Accessors for raquet tiles
  *****************************************************************************/

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -354,6 +354,35 @@ CREATE FUNCTION clip(raster, geometry, boolean DEFAULT true)
   AS 'MODULE_PATHNAME', 'Raster_clip'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster stated in another spatial reference system
+ * @param[in] rast Raster
+ * @param[in] srid Target spatial reference system identifier
+ * @param[in] algorithm Name of the resampling algorithm
+ * @param[in] maxerr Error in input pixels the warp may commit
+ */
+CREATE FUNCTION transform(raster, integer, text DEFAULT 'NearestNeighbour',
+    float8 DEFAULT 0.125)
+  RETURNS raster
+  AS 'MODULE_PATHNAME', 'Raster_transform'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster resampled to another pixel size
+ * @param[in] rast Raster
+ * @param[in] scalex,scaley Pixel size in the units of the raster's reference
+ * system
+ * @param[in] algorithm Name of the resampling algorithm
+ * @param[in] maxerr Error in input pixels the warp may commit
+ */
+CREATE FUNCTION rescale(raster, float8, float8,
+    text DEFAULT 'NearestNeighbour', float8 DEFAULT 0.125)
+  RETURNS raster
+  AS 'MODULE_PATHNAME', 'Raster_rescale'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * Accessors for raquet tiles
  *****************************************************************************/

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -396,6 +396,20 @@ CREATE FUNCTION summaryStats(raster, integer DEFAULT 1, boolean DEFAULT true)
   AS 'MODULE_PATHNAME', 'Raster_summary_stats'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the polygons of a raster band, one for each group of pixels
+ * carrying the same value
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] exclude_nodata True to leave the pixels the band states as nodata
+ * out
+ */
+CREATE FUNCTION dumpAsPolygons(raster, integer DEFAULT 1, boolean DEFAULT true)
+  RETURNS SETOF geomval
+  AS 'MODULE_PATHNAME', 'Raster_dump_as_polygons'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * Accessors for raquet tiles
  *****************************************************************************/

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -383,6 +383,19 @@ CREATE FUNCTION rescale(raster, float8, float8,
   AS 'MODULE_PATHNAME', 'Raster_rescale'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return what the pixels of a raster band amount to
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] exclude_nodata True to leave the pixels the band states as nodata
+ * out of the statistics
+ */
+CREATE FUNCTION summaryStats(raster, integer DEFAULT 1, boolean DEFAULT true)
+  RETURNS summarystats
+  AS 'MODULE_PATHNAME', 'Raster_summary_stats'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * Accessors for raquet tiles
  *****************************************************************************/

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -334,8 +334,20 @@ CREATE FUNCTION numBands(raster)
   AS 'MODULE_PATHNAME', 'Raster_num_bands'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
-/* Not STRICT: a nodata value left out states that the resulting band carries
- * none, which is a different answer from a band whose nodata value is zero */
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster whose band states the classes an expression maps its
+ * values onto
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] expr Reclassification expression
+ * @param[in] pixeltype Name of the pixel type of the resulting band
+ * @param[in] nodataval Nodata value of the resulting band, absent where the
+ * band states none
+ * @note Not STRICT: a nodata value left out states that the resulting band
+ * carries none, which is a different answer from a band whose nodata value is
+ * zero
+ */
 CREATE FUNCTION reclass(raster, integer, text, text,
     float8 DEFAULT NULL)
   RETURNS raster

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -40,6 +40,8 @@
 /* PostgreSQL */
 #include <postgres.h>
 #include <fmgr.h>
+#include <funcapi.h>
+#include <access/htup_details.h>
 #include <utils/array.h>
 /* MEOS */
 #include <meos.h>
@@ -353,6 +355,63 @@ Raster_rescale(PG_FUNCTION_ARGS)
   if (! result)
     PG_RETURN_NULL();
   PG_RETURN_POINTER(result);
+}
+
+/*****************************************************************************
+ * raster_summary_stats
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_summary_stats(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_summary_stats);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return what the pixels of a raster band amount to
+ * @details The record is built as the PostGIS RASTER_summaryStats builds it,
+ * so the SQL function answers the summarystats record ST_SummaryStats answers
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] exclude_nodata True to leave the pixels the band states as nodata
+ * out of the statistics
+ * @sqlfn summaryStats()
+ */
+Datum
+Raster_summary_stats(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int band = PG_GETARG_INT32(1);
+  bool exclude_nodata = PG_GETARG_BOOL(2);
+  TupleDesc tupdesc;
+  if (get_call_result_type(fcinfo, NULL, &tupdesc) != TYPEFUNC_COMPOSITE)
+    ereport(ERROR, (errcode(ERRCODE_FEATURE_NOT_SUPPORTED),
+      errmsg("function returning record called in context "
+             "that cannot accept type record")));
+  tupdesc = BlessTupleDesc(tupdesc);
+
+  BandStats *stats = raster_summary_stats(rast, band, exclude_nodata);
+  Datum values[6];
+  bool isnull[6] = {false, false, false, false, false, false};
+  /* An error in MEOS never returns here, so a missing result is a band with no
+   * pixel to count: the record PostGIS answers for it counts none and states
+   * no statistic, rather than being no record at all */
+  if (! stats)
+  {
+    values[0] = Int64GetDatum(0);
+    for (int i = 1; i < 6; i++)
+      isnull[i] = true;
+  }
+  else
+  {
+    values[0] = Int64GetDatum(stats->count);
+    values[1] = Float8GetDatum(stats->sum);
+    values[2] = Float8GetDatum(stats->mean);
+    values[3] = Float8GetDatum(stats->stddev);
+    values[4] = Float8GetDatum(stats->min);
+    values[5] = Float8GetDatum(stats->max);
+    pfree(stats);
+  }
+  HeapTuple tuple = heap_form_tuple(tupdesc, values, isnull);
+  PG_RETURN_DATUM(HeapTupleGetDatum(tuple));
 }
 
 /*****************************************************************************

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -298,6 +298,64 @@ Raster_clip(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
+ * raster_transform, raster_rescale
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_transform(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_transform);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster stated in another spatial reference system
+ * @param[in] rast Raster
+ * @param[in] srid Target spatial reference system identifier
+ * @param[in] algorithm Name of the resampling algorithm
+ * @param[in] maxerr Error in input pixels the warp may commit
+ * @sqlfn transform()
+ */
+Datum
+Raster_transform(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int32_t srid = PG_GETARG_INT32(1);
+  char *algorithm = text_to_cstring(PG_GETARG_TEXT_P(2));
+  double maxerr = PG_GETARG_FLOAT8(3);
+  Raster *result = raster_transform(rast, srid, algorithm, maxerr);
+  pfree(algorithm);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Raster_rescale(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_rescale);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster resampled to another pixel size
+ * @param[in] rast Raster
+ * @param[in] scalex,scaley Pixel size in the units of the raster's reference
+ * system
+ * @param[in] algorithm Name of the resampling algorithm
+ * @param[in] maxerr Error in input pixels the warp may commit
+ * @sqlfn rescale()
+ */
+Datum
+Raster_rescale(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  double scalex = PG_GETARG_FLOAT8(1);
+  double scaley = PG_GETARG_FLOAT8(2);
+  char *algorithm = text_to_cstring(PG_GETARG_TEXT_P(3));
+  double maxerr = PG_GETARG_FLOAT8(4);
+  Raster *result = raster_rescale(rast, scalex, scaley, algorithm, maxerr);
+  pfree(algorithm);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+/*****************************************************************************
  * raster_tile_value_quadbin
  *****************************************************************************/
 

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -415,6 +415,66 @@ Raster_summary_stats(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
+ * raster_dump_as_polygons
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_dump_as_polygons(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_dump_as_polygons);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the polygons of a raster band, one for each group of pixels
+ * carrying the same value
+ * @details Set-returning function emitting one PostGIS geomval record per
+ * polygon, as ST_DumpAsPolygons emits them
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @param[in] exclude_nodata True to leave the pixels the band states as nodata
+ * out
+ * @sqlfn dumpAsPolygons()
+ */
+Datum
+Raster_dump_as_polygons(PG_FUNCTION_ARGS)
+{
+  FuncCallContext *funcctx;
+
+  if (SRF_IS_FIRSTCALL())
+  {
+    funcctx = SRF_FIRSTCALL_INIT();
+    /* The polygons are kept across the calls, so they are computed in the
+     * context that outlives them */
+    MemoryContext oldctx = MemoryContextSwitchTo(
+      funcctx->multi_call_memory_ctx);
+    Datum rast_datum = PG_GETARG_DATUM(0);
+    Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+    int band = PG_GETARG_INT32(1);
+    bool exclude_nodata = PG_GETARG_BOOL(2);
+    int count = 0;
+    funcctx->user_fctx = (void *) raster_dump_as_polygons(rast, band,
+      exclude_nodata, &count);
+    funcctx->max_calls = count;
+    get_call_result_type(fcinfo, 0, &funcctx->tuple_desc);
+    BlessTupleDesc(funcctx->tuple_desc);
+    MemoryContextSwitchTo(oldctx);
+  }
+
+  funcctx = SRF_PERCALL_SETUP();
+  GeomVal *gvarr = (GeomVal *) funcctx->user_fctx;
+  if (funcctx->call_cntr >= funcctx->max_calls)
+  {
+    geomval_arr_free(gvarr, funcctx->max_calls);
+    SRF_RETURN_DONE(funcctx);
+  }
+
+  const GeomVal *gv = &gvarr[funcctx->call_cntr];
+  Datum values[2];
+  bool isnull[2] = {false, false};
+  values[0] = PointerGetDatum(gv->geom);
+  values[1] = Float8GetDatum(gv->val);
+  HeapTuple tuple = heap_form_tuple(funcctx->tuple_desc, values, isnull);
+  SRF_RETURN_NEXT(funcctx, HeapTupleGetDatum(tuple));
+}
+
+/*****************************************************************************
  * raster_tile_value_quadbin
  *****************************************************************************/
 

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -52,6 +52,7 @@
 #include "raster/raquet.h"    /* Raquet, PG_GETARG_RAQUET_P, raquet_pixtype_size */
 #include "raster/raster_quadbin.h"
 /* MobilityDB */
+#include "pg_geo/postgis.h"   /* PG_GETARG_GSERIALIZED_P */
 #include "pg_temporal/temporal.h"
 #include "pg_temporal/type_util.h" /* raquetarr_extract */
 #include "pg_raster/temporal_raster.h"
@@ -263,6 +264,34 @@ Raster_reclass(PG_FUNCTION_ARGS)
   Raster *result = raster_reclass(rast, band, expr, pixeltype, has_nodata,
     nodataval);
   pfree(expr); pfree(pixeltype);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+/*****************************************************************************
+ * raster_clip
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_clip(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_clip);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster keeping the pixels of another that a geometry covers
+ * @param[in] rast Raster
+ * @param[in] geom Geometry, in the reference system of the raster
+ * @param[in] crop True to reduce the result to the extent the two share
+ * @sqlfn clip()
+ */
+Datum
+Raster_clip(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  GSERIALIZED *gs = PG_GETARG_GSERIALIZED_P(1);
+  bool crop = PG_GETARG_BOOL(2);
+  Raster *result = raster_clip(rast, gs, crop);
+  PG_FREE_IF_COPY(gs, 1);
   if (! result)
     PG_RETURN_NULL();
   PG_RETURN_POINTER(result);

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -889,6 +889,36 @@ WITH rast AS (
 SELECT reclass(r, 1, '0-50', '32BF') FROM rast;
 ERROR:  A mapping states a source and a destination around one colon: 0-50
 WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+), g AS (
+  SELECT ST_GeomFromText('POLYGON((0 1,2 1,2 3,0 3,0 1))', 4326) AS g
+)
+SELECT ST_DumpValues(clip(r, g), 1) AS cropped,
+  ST_DumpValues(clip(r, g, false), 1) AS kept_extent,
+  ST_DumpValues(clip(r, g), 1) = ST_DumpValues(ST_Clip(r, g), 1)
+    AS cropped_as_postgis,
+  ST_DumpValues(clip(r, g, false), 1) = ST_DumpValues(ST_Clip(r, g, false), 1)
+    AS kept_as_postgis
+FROM rast, g;
+      cropped      |                 kept_extent                  | cropped_as_postgis | kept_as_postgis 
+-------------------+----------------------------------------------+--------------------+-----------------
+ {{10,20},{40,50}} | {{10,20,NULL},{40,50,NULL},{NULL,NULL,NULL}} | t                  | t
+(1 row)
+
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT clip(r, ST_GeomFromText('POLYGON((0 1,2 1,2 3,0 3,0 1))', 3857))
+FROM rast;
+ERROR:  Operation on mixed SRID
+WITH rast AS (
   SELECT ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r
 )
 SELECT stbox(r) AS box, stbox(r) = r::stbox AS cast_agrees FROM rast;

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -970,6 +970,45 @@ WITH rast AS (
 SELECT transform(r, 0) FROM rast;
 ERROR:  The target of a reprojection cannot be an unknown SRID
 WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,-9999,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT (s).count, (s).sum, (s).mean, round((s).stddev::numeric, 6) AS stddev,
+  (s).min, (s).max, as_postgis, all_pixels_as_postgis
+FROM (SELECT summaryStats(r) AS s,
+    summaryStats(r) = ST_SummaryStats(r) AS as_postgis,
+    summaryStats(r, 1, false) = ST_SummaryStats(r, 1, false)
+      AS all_pixels_as_postgis
+  FROM rast) t;
+ count | sum | mean |  stddev   | min | max | as_postgis | all_pixels_as_postgis 
+-------+-----+------+-----------+-----+-----+------------+-----------------------
+     8 | 400 |   50 | 27.386128 |  10 |  90 | t          | t
+(1 row)
+
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, -9999::float8, -9999::float8) AS r
+)
+SELECT summaryStats(r) AS stats, ST_SummaryStats(r) AS postgis_stats FROM rast;
+NOTICE:  All pixels of band have the NODATA value
+  stats   | postgis_stats 
+----------+---------------
+ (0,,,,,) | (0,,,,,)
+(1 row)
+
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT summaryStats(r, 2) FROM rast;
+ERROR:  The raster has no band 2, it has 1
+WITH rast AS (
   SELECT ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r
 )
 SELECT stbox(r) AS box, stbox(r) = r::stbox AS cast_agrees FROM rast;

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -919,6 +919,57 @@ SELECT clip(r, ST_GeomFromText('POLYGON((0 1,2 1,2 3,0 3,0 1))', 3857))
 FROM rast;
 ERROR:  Operation on mixed SRID
 WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT ST_SRID(transform(r, 3857)) AS srid,
+  ST_MetaData(transform(r, 3857)) = ST_MetaData(ST_Transform(r, 3857))
+    AS grid_as_postgis,
+  ST_DumpValues(transform(r, 3857), 1) = ST_DumpValues(ST_Transform(r, 3857), 1)
+    AS values_as_postgis,
+  ST_DumpValues(transform(r, 3857, 'bilinear'), 1) =
+    ST_DumpValues(ST_Transform(r, 3857, 'Bilinear'), 1) AS bilinear_as_postgis
+FROM rast;
+ srid | grid_as_postgis | values_as_postgis | bilinear_as_postgis 
+------+-----------------+-------------------+---------------------
+ 3857 | t               | t                 | t
+(1 row)
+
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT ST_Width(rescale(r, 0.5, -0.5)) AS w, ST_Height(rescale(r, 0.5, -0.5)) AS h,
+  ST_MetaData(rescale(r, 0.5, -0.5)) = ST_MetaData(ST_Rescale(r, 0.5, -0.5))
+    AS north_up_grid_as_postgis,
+  ST_DumpValues(rescale(r, 0.5, -0.5), 1) =
+    ST_DumpValues(ST_Rescale(r, 0.5, -0.5), 1) AS north_up_values_as_postgis,
+  ST_MetaData(rescale(r, 0.5, 0.5)) = ST_MetaData(ST_Rescale(r, 0.5, 0.5))
+    AS positive_grid_as_postgis,
+  ST_DumpValues(rescale(r, 0.5, 0.5), 1) =
+    ST_DumpValues(ST_Rescale(r, 0.5, 0.5), 1) AS positive_values_as_postgis
+FROM rast;
+ w | h | north_up_grid_as_postgis | north_up_values_as_postgis | positive_grid_as_postgis | positive_values_as_postgis 
+---+---+--------------------------+----------------------------+--------------------------+----------------------------
+ 6 | 6 | t                        | t                          | t                        | t
+(1 row)
+
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT transform(r, 0) FROM rast;
+ERROR:  The target of a reprojection cannot be an unknown SRID
+WITH rast AS (
   SELECT ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r
 )
 SELECT stbox(r) AS box, stbox(r) = r::stbox AS cast_agrees FROM rast;

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -1009,6 +1009,58 @@ WITH rast AS (
 SELECT summaryStats(r, 2) FROM rast;
 ERROR:  The raster has no band 2, it has 1
 WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[1,1,2], ARRAY[1,2,2], ARRAY[3,3,-9999]]::float8[][]
+  ) AS r
+), ours AS (
+  SELECT (d).val, (d).geom FROM (SELECT dumpAsPolygons(r) AS d FROM rast) t
+), pg AS (
+  SELECT (d).val, ST_SetSRID((d).geom, 4326) AS geom
+  FROM (SELECT ST_DumpAsPolygons(r) AS d FROM rast) t
+)
+SELECT o.val, ST_SRID(o.geom) AS srid, ST_Area(o.geom) AS area,
+  ST_Equals(o.geom, p.geom) AS as_postgis
+FROM ours o FULL JOIN pg p ON o.val = p.val
+ORDER BY o.val;
+ val | srid | area | as_postgis 
+-----+------+------+------------
+   1 | 4326 |    3 | t
+   2 | 4326 |    3 | t
+   3 | 4326 |    2 | t
+(3 rows)
+
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[1,1,2], ARRAY[1,2,2], ARRAY[3,3,-9999]]::float8[][]
+  ) AS r
+), empty AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, -9999::float8, -9999::float8) AS r
+)
+SELECT (SELECT count(*) FROM rast, dumpAsPolygons(r, 1, false)) AS regions,
+  (SELECT count(*) FROM rast, ST_DumpAsPolygons(r, 1, false)) AS postgis_regions,
+  (SELECT count(*) FROM empty, dumpAsPolygons(r)) AS empty_regions,
+  (SELECT count(*) FROM empty, ST_DumpAsPolygons(r)) AS postgis_empty_regions;
+ regions | postgis_regions | empty_regions | postgis_empty_regions 
+---------+-----------------+---------------+-----------------------
+       4 |               4 |             0 |                     0
+(1 row)
+
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT count(*) FROM rast, dumpAsPolygons(r, 2);
+ERROR:  The raster has no band 2, it has 1
+WITH rast AS (
   SELECT ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r
 )
 SELECT stbox(r) AS box, stbox(r) = r::stbox AS cast_agrees FROM rast;

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -970,6 +970,44 @@ WITH rast AS (
 SELECT transform(r, 0) FROM rast;
 
 -------------------------------------------------------------------------------
+-- summaryStats
+-------------------------------------------------------------------------------
+
+-- What a band's pixels amount to, taken in one pass, is the record PostGIS's
+-- ST_SummaryStats answers: with the nodata pixel in the centre left out, and
+-- counted as the value it holds.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,-9999,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT (s).count, (s).sum, (s).mean, round((s).stddev::numeric, 6) AS stddev,
+  (s).min, (s).max, as_postgis, all_pixels_as_postgis
+FROM (SELECT summaryStats(r) AS s,
+    summaryStats(r) = ST_SummaryStats(r) AS as_postgis,
+    summaryStats(r, 1, false) = ST_SummaryStats(r, 1, false)
+      AS all_pixels_as_postgis
+  FROM rast) t;
+
+-- A band whose every pixel is nodata, beside what ST_SummaryStats answers for
+-- it, and a band the raster does not have.
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, -9999::float8, -9999::float8) AS r
+)
+SELECT summaryStats(r) AS stats, ST_SummaryStats(r) AS postgis_stats FROM rast;
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT summaryStats(r, 2) FROM rast;
+
+-------------------------------------------------------------------------------
 -- raster conversion to stbox
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -1008,6 +1008,62 @@ WITH rast AS (
 SELECT summaryStats(r, 2) FROM rast;
 
 -------------------------------------------------------------------------------
+-- dumpAsPolygons
+-------------------------------------------------------------------------------
+
+-- A band states a value per pixel; its polygons state the regions those values
+-- cover, one per group of pixels sharing a value, as PostGIS's
+-- ST_DumpAsPolygons answers them. The band holds three regions and a nodata
+-- pixel. Each polygon carries the reference system of the raster where
+-- ST_DumpAsPolygons states none, so the comparison sets it on PostGIS's
+-- answer, and a full join shows a region either answer lacks.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[1,1,2], ARRAY[1,2,2], ARRAY[3,3,-9999]]::float8[][]
+  ) AS r
+), ours AS (
+  SELECT (d).val, (d).geom FROM (SELECT dumpAsPolygons(r) AS d FROM rast) t
+), pg AS (
+  SELECT (d).val, ST_SetSRID((d).geom, 4326) AS geom
+  FROM (SELECT ST_DumpAsPolygons(r) AS d FROM rast) t
+)
+SELECT o.val, ST_SRID(o.geom) AS srid, ST_Area(o.geom) AS area,
+  ST_Equals(o.geom, p.geom) AS as_postgis
+FROM ours o FULL JOIN pg p ON o.val = p.val
+ORDER BY o.val;
+
+-- With the nodata pixels counted, the nodata pixel is a region of its own, as
+-- ST_DumpAsPolygons counts it; a band whose every pixel is nodata covers
+-- nothing, which both answer with no polygon.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[1,1,2], ARRAY[1,2,2], ARRAY[3,3,-9999]]::float8[][]
+  ) AS r
+), empty AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, -9999::float8, -9999::float8) AS r
+)
+SELECT (SELECT count(*) FROM rast, dumpAsPolygons(r, 1, false)) AS regions,
+  (SELECT count(*) FROM rast, ST_DumpAsPolygons(r, 1, false)) AS postgis_regions,
+  (SELECT count(*) FROM empty, dumpAsPolygons(r)) AS empty_regions,
+  (SELECT count(*) FROM empty, ST_DumpAsPolygons(r)) AS postgis_empty_regions;
+
+-- A band the raster does not have is an error.
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT count(*) FROM rast, dumpAsPolygons(r, 2);
+
+-------------------------------------------------------------------------------
 -- raster conversion to stbox
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -879,6 +879,42 @@ WITH rast AS (
 SELECT reclass(r, 1, '0-50', '32BF') FROM rast;
 
 -------------------------------------------------------------------------------
+-- clip
+-------------------------------------------------------------------------------
+
+-- A raster keeps the pixels a geometry covers, the others answering nodata.
+-- The polygon's edges fall on pixel edges and cover the upper left 2x2 pixels
+-- of the band holding 10, 20, 30 / 40, 50, 60 / 70, 80, 90, so the answer is
+-- unambiguous; PostGIS's ST_Clip is the oracle, with and without cropping.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+), g AS (
+  SELECT ST_GeomFromText('POLYGON((0 1,2 1,2 3,0 3,0 1))', 4326) AS g
+)
+SELECT ST_DumpValues(clip(r, g), 1) AS cropped,
+  ST_DumpValues(clip(r, g, false), 1) AS kept_extent,
+  ST_DumpValues(clip(r, g), 1) = ST_DumpValues(ST_Clip(r, g), 1)
+    AS cropped_as_postgis,
+  ST_DumpValues(clip(r, g, false), 1) = ST_DumpValues(ST_Clip(r, g, false), 1)
+    AS kept_as_postgis
+FROM rast, g;
+
+-- A geometry in another reference system is refused rather than read as if
+-- its coordinates were the raster's.
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT clip(r, ST_GeomFromText('POLYGON((0 1,2 1,2 3,0 3,0 1))', 3857))
+FROM rast;
+
+-------------------------------------------------------------------------------
 -- raster conversion to stbox
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -915,6 +915,61 @@ SELECT clip(r, ST_GeomFromText('POLYGON((0 1,2 1,2 3,0 3,0 1))', 3857))
 FROM rast;
 
 -------------------------------------------------------------------------------
+-- transform and rescale
+-------------------------------------------------------------------------------
+
+-- A raster carried into another reference system states the same coverage
+-- read through that system. PostGIS's ST_Transform is the oracle, on the grid
+-- and on the values alike, for the default nearest neighbour and for bilinear
+-- resampling named without regard to case.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT ST_SRID(transform(r, 3857)) AS srid,
+  ST_MetaData(transform(r, 3857)) = ST_MetaData(ST_Transform(r, 3857))
+    AS grid_as_postgis,
+  ST_DumpValues(transform(r, 3857), 1) = ST_DumpValues(ST_Transform(r, 3857), 1)
+    AS values_as_postgis,
+  ST_DumpValues(transform(r, 3857, 'bilinear'), 1) =
+    ST_DumpValues(ST_Transform(r, 3857, 'Bilinear'), 1) AS bilinear_as_postgis
+FROM rast;
+
+-- Halving the pixel size doubles the width and the height. ST_Rescale is the
+-- oracle, for a Y scale stated negative as the geotransform states it and
+-- positive as PostGIS users write it.
+WITH rast AS (
+  SELECT ST_SetValues(
+    ST_AddBand(
+      ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+      '32BF'::text, 0.0::float8, -9999::float8),
+    1, 1, 1, ARRAY[ARRAY[10,20,30], ARRAY[40,50,60], ARRAY[70,80,90]]::float8[][]
+  ) AS r
+)
+SELECT ST_Width(rescale(r, 0.5, -0.5)) AS w, ST_Height(rescale(r, 0.5, -0.5)) AS h,
+  ST_MetaData(rescale(r, 0.5, -0.5)) = ST_MetaData(ST_Rescale(r, 0.5, -0.5))
+    AS north_up_grid_as_postgis,
+  ST_DumpValues(rescale(r, 0.5, -0.5), 1) =
+    ST_DumpValues(ST_Rescale(r, 0.5, -0.5), 1) AS north_up_values_as_postgis,
+  ST_MetaData(rescale(r, 0.5, 0.5)) = ST_MetaData(ST_Rescale(r, 0.5, 0.5))
+    AS positive_grid_as_postgis,
+  ST_DumpValues(rescale(r, 0.5, 0.5), 1) =
+    ST_DumpValues(ST_Rescale(r, 0.5, 0.5), 1) AS positive_values_as_postgis
+FROM rast;
+
+-- A reprojection needs a target system.
+WITH rast AS (
+  SELECT ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8) AS r
+)
+SELECT transform(r, 0) FROM rast;
+
+-------------------------------------------------------------------------------
 -- raster conversion to stbox
 -------------------------------------------------------------------------------
 


### PR DESCRIPTION
Clip a raster to the region a geometry covers

clip(raster, geometry, crop) is the SQL function of raster_clip, with the
argument order and the crop default of the PostGIS ST_Clip. Every band is read
against a mask the geometry is burnt into, so a pixel the geometry does not
cover answers the nodata value of its band, or the smallest value of its pixel
type where the band declares none; with crop the result carries the extent the
raster and the geometry share, and otherwise the extent of the raster.

The witness is the band holding 10, 20, 30 / 40, 50, 60 / 70, 80, 90 and the
polygon covering its upper left 2x2 pixels, whose edges fall on pixel edges.
clip answers {{10,20},{40,50}}, and {{10,20,NULL},{40,50,NULL},{NULL,NULL,NULL}}
without cropping, each equal to what ST_Clip answers on the same inputs, and a
geometry in another reference system raises "Operation on mixed SRID".

The model is the one PostGIS runs: the same mask burnt by
rt_raster_gdal_rasterize and read band by band, so one geometry clips a raster
to the same pixels through ST_Clip and through clip. That holds for a band
declaring no nodata value too: both results declare none and leave the
uncovered pixels at the smallest 32BF value.


Reproject and resample a raster in SQL

transform(raster, srid, algorithm, maxerr) and rescale(raster, scalex, scaley,
algorithm, maxerr) are the SQL functions of raster_transform and
raster_rescale, with the argument order and the defaults of the PostGIS
ST_Transform and ST_Rescale: nearest neighbour, and a warp error of 0.125
input pixels. The algorithm is named without regard to case.

The witness is the 3x3 band of 1 degree pixels in SRID 4326. transform(r, 3857)
answers a raster in SRID 3857 whose metadata and values equal those
ST_Transform answers, with nearest neighbour and with bilinear resampling
alike. rescale(r, 0.5, -0.5) answers a 6x6 raster whose metadata and values
equal those of ST_Rescale, and so does rescale(r, 0.5, 0.5), the Y scale
written positive as PostGIS users write it. transform(r, 0) raises "The target
of a reprojection cannot be an unknown SRID".

The model is the one PostGIS runs: both functions are the GDAL warp that
rt_raster_gdal_warp performs, reached with the target system named by its
EPSG code, so one raster reprojects and resamples onto the same grid and the
same values through either function.


Summarize a raster band in SQL

summaryStats(raster, band, excludeNodata) is the SQL function of
raster_summary_stats, with the argument order and the defaults of the PostGIS
ST_SummaryStats, and it answers the PostGIS summarystats record, built as
RASTER_summaryStats builds it. A band with no pixel to count answers that
record with a count of zero and no statistic, as PostGIS answers it:
raster_summary_stats states that case as NULL without an error, and an error
in MEOS never returns to the wrapper, so the wrapper reads the NULL as that
record.

raster_summary_stats releases the statistics the raster core allocates with
rtdealloc, the raster core's own deallocator. The extension build leaves the
raster core on its default allocator, so pfree() on those statistics raises
"pfree called with invalid pointer" on every band once PostgreSQL runs the
function; standalone MEOS maps pfree() to free(), so the C witness cannot see
it.

The witness is the band holding 10, 20, 30 / 40, nodata, 60 / 70, 80, 90.
summaryStats answers (8,400,50,27.386127875258307,10,90), equal to what
ST_SummaryStats answers with the nodata pixel left out and with it counted,
and a band whose every pixel is nodata answers (0,,,,,) exactly as
ST_SummaryStats does. With pfree() in place of rtdealloc both queries raise
"pfree called with invalid pointer".

The model is the one PostGIS runs: rt_band_get_summary_stats reads every pixel
when asked for a sample of one, so the record is exact, and the same through
either function.


Read a raster band as polygons in SQL

dumpAsPolygons(raster, band, excludeNodata) is the SQL function of
raster_dump_as_polygons, with the argument order and the defaults of the
PostGIS ST_DumpAsPolygons, and it answers one PostGIS geomval record per
polygon, as that function does. Each polygon carries the reference system of
the raster, where ST_DumpAsPolygons states none, so it can be compared with
the trajectories the coverage is read along. A band whose every pixel is
nodata covers nothing and answers no row, and a band the raster does not have
raises an error.

raster_dump_as_polygons releases the array rt_raster_gdal_polygonize answers
with rtdealloc, the raster core's own deallocator, at both sites that release
it. The extension build leaves the raster core on its default allocator, so
pfree() on that array raises "pfree called with invalid pointer" once
PostgreSQL runs the function; standalone MEOS maps pfree() to free(), so the C
witness in meos/test/raster_test.c cannot see it.

The witness is the band holding 1, 1, 2 / 1, 2, 2 / 3, 3, nodata.
dumpAsPolygons answers three polygons, of values 1, 2 and 3 and areas 3, 3 and
2, each equal to the polygon ST_DumpAsPolygons answers for that value once it
is given the raster's SRID 4326. Counting the nodata pixel answers four
regions on both sides, and a band whose every pixel is nodata answers none on
both. With pfree() in place of rtdealloc both queries raise "pfree called with
invalid pointer".

The model is the set-returning shape the family already uses for
geoPoseFrames: the wrapper computes the array once in the memory of the whole
call, answers one geomval per call, and releases the array with
geomval_arr_free once the last polygon is answered.


State the reclass SQL function in a doc block

reclass states its group, its brief and its parameters in the doc block its
siblings in mobilitydb/sql/raster/500_raster.in.sql carry, in the words the
Raster_reclass wrapper states them, and keeps as a note the reason it is not
STRICT: a nodata value left out states that the resulting band carries none,
which is a different answer from a band whose nodata value is zero.


State the two raster paths where the chapter introduces them

The chapter states the two raster representations where it introduces them. A
raquet value holds its pixels and its QUADBIN cell in one value, so its extent
and its pixel grid follow from the cell and it answers the Web-Mercator grid
alone. A PostGIS raster states an arbitrary spatial reference system and an
arbitrary affine georeferencing, and it is the one clip, transform, rescale,
reclass, summaryStats and dumpAsPolygons take; MEOS computes both, so neither
needs PostgreSQL to evaluate. The paragraph on reading a multi-spectral
coverage band by band stands beside them, unchanged, in English and in
Spanish, and the chapter carries no Production Roadmap section.

Measured on the branch: every chapter entry of the manual has its appendix row
in both languages, 768 entries against 769 rows in each; the English and
Spanish chapters carry the same 136 identifiers, the same 110 signatures and
the same 118 examples, byte for byte; and no link in either manual names an
identifier that does not exist.


