### PR TITLE
Revert the segment kernel's filtered parallel test (overlap reported between segments sharing one point)

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -336,37 +336,6 @@ extern bool *pointarr_find_splits(const POINT2D **points, int npoints,
  *****************************************************************************/
 
 /**
- * @brief Return the sign of the cross product of two vectors, or zero where
- * the double evaluation cannot be trusted to carry it
- * @details The vectors are differences of INPUT coordinates, each rounded
- * once, so the question is the sign of one determinant and needs no
- * tolerance: a band here would not protect the answer, it would decide it.
- * What the sign does need is a guarantee that rounding has not eaten it, and
- * that guarantee is a FILTER rather than a band. The bound is computed FROM
- * THE OPERANDS and decides only whether the double is trustworthy, never what
- * the answer is. It is Shewchuk's bound for a determinant of two such
- * products, written in terms of @p DBL_EPSILON so that it is arithmetic
- * rather than a constant anyone is invited to tune
- * @param[in] rx,ry First vector
- * @param[in] sx,sy Second vector
- * @return 1 or -1 for the two turns, 0 for parallel or unable to tell
- */
-static inline int
-cross_product_sign(double rx, double ry, double sx, double sy)
-{
-  double left = rx * sy;
-  double right = ry * sx;
-  double det = left - right;
-  double bound = (3.0 + 16.0 * DBL_EPSILON) * DBL_EPSILON *
-    (fabs(left) + fabs(right));
-  if (det > bound)
-    return 1;
-  if (det < - bound)
-    return -1;
-  return 0;
-}
-
-/**
  * @brief Return the intersection value obtained by computing the intersection 
  * of a line segment defined by two 2D points intersects an edge
  * @details Possible result values
@@ -396,16 +365,11 @@ linesegm_intersect(double ax, double ay, double rx, double ry,
   /* Where is the start of the second segment relative to the first? */
   double qpx = cx - ax, qpy = cy - ay;
 
-  /* Are the two segments parallel? The directions are differences of input
-   * coordinates, so the answer is the sign of their cross product, an area
-   * whose scale is the product of the two lengths: two GPS steps of 1e-6
-   * leaving one vertex in different directions carry a cross product near
-   * 1e-12 and a sign the filter still carries. The segments are parallel
-   * only where it cannot (#cross_product_sign) */
+  /* Are the two segments parallel?  */
   double rxs = rx * sy - ry * sx;
 
   /* Collinear / parallel */
-  if (cross_product_sign(rx, ry, sx, sy) == 0)
+  if (fabs(rxs) < MEOS_GEOM_TOLERANCE)
   {
     /* The two segments run in one direction; what is left to decide is
      * whether they run along the SAME LINE or along two parallel ones. Both

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -5496,7 +5496,16 @@ static int
 relate_orientation(double ax, double ay, double bx, double by, double cx,
   double cy)
 {
-  return cross_product_sign(bx - ax, by - ay, cx - ax, cy - ay);
+  double left = (bx - ax) * (cy - ay);
+  double right = (by - ay) * (cx - ax);
+  double det = left - right;
+  double bound = (3.0 + 16.0 * DBL_EPSILON) * DBL_EPSILON *
+    (fabs(left) + fabs(right));
+  if (det > bound)
+    return 1;
+  if (det < - bound)
+    return -1;
+  return 0;
 }
 
 /**

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -321,37 +321,6 @@ int main(void)
   }
   meos_errno_reset();
 
-  /* Two GPS steps of about 1e-6 in degrees leaving one vertex in different
-   * directions share that vertex and nothing else: they intersect, and their
-   * interiors do not meet. The cross product of their directions is near
-   * 1e-12, and its sign decides that they are not parallel. Both pairs are
-   * real AIS steps: in the first the two start at one vertex, in the second
-   * the end of one is the start of the other */
-  struct { const char *a, *b; } gpssteps[] = {
-    { "LINESTRING(11.198253 55.211805,11.198252 55.211803)",
-      "LINESTRING(11.198253 55.211805,11.19825 55.2118)" },
-    { "LINESTRING(11.198253 55.211805,11.198252 55.211803)",
-      "LINESTRING(11.19825 55.2118,11.198253 55.211805)" },
-  };
-  for (size_t i = 0; i < sizeof(gpssteps) / sizeof(gpssteps[0]); i++)
-  {
-    GSERIALIZED *ga = geom_in(gpssteps[i].a, -1);
-    GSERIALIZED *gb = geom_in(gpssteps[i].b, -1);
-    assert(ga != NULL);
-    assert(gb != NULL);
-    meos_errno_reset();
-    char *gm = geom_relate(ga, gb);
-    bool gi = geom_intersects(ga, gb);
-    printf("geom_relate(%s, %s): %s, intersects %d, errno %d\n",
-      gpssteps[i].a, gpssteps[i].b, gm ? gm : "(NULL)", gi, meos_errno());
-    assert(gm != NULL);
-    assert(strcmp(gm, "FF1F00102") == 0);
-    assert(gi == true);
-    assert(meos_errno() == 0);
-    free(gm); free(ga); free(gb);
-  }
-  meos_errno_reset();
-
   /* Two areas lying on OPPOSITE SIDES of one line share no area, so neither
    * interior holds a point of the other's boundary, however near the two
    * boundaries run. Deciding that from a boundary portion means classifying a


### PR DESCRIPTION
This reverts c64899f333, "Keep the segment kernel's parallel verdict
right for short segments".

The parallel test it adds reads two segments as parallel where the
filtered sign of the cross product of their directions is 0, and that
sign is 0 both where the directions are parallel and where the double
evaluation cannot carry it. The pair then goes to the collinear branch,
which decides it as collinear.

Witness

The segments

    (0 0)-(9007199254740990 9007199254740988)
    (0 0)-(4503599627370495 4503599627370495)

share one point, an end of both, as CGAL's exact kernel answers: their
exact cross product is 9007199254740990, and the double one is
9007199254740992 against a rounding bound of 5.4e16. With c64899f333 the
segment kernel answers OVERLAP and geom_relate 101F00FF2. With this revert
the kernel answers POINT and geom_relate F01F001F2, their answers on
8ce1f6d743.

Measured

The three files this commit touches are byte for byte those of
8ce1f6d743. No expected SQL output on PostgreSQL 18 changes, and over 42
instruments diffed answer for answer against c64899f333, the lines that
differ are the two its test prints and one buffer row: a plain circular
string at scale 1e-8, which c64899f333 declines and 8ce1f6d743 answers
with a box of 11.601534 x 11.4142136 times the scale, where the same shape
at scale 1 gives 17.8113883 x 17.4056942.

The revert also brings back the answers of 8ce1f6d743 on short GPS steps:
of five real AIS step pairs meeting at one vertex, three read a shared
stretch through geom_relate and two read no intersection through
geom_intersects. The union of linework, which calls the kernel for every
pair of edges, takes 1.01x to 1.03x the time of 8ce1f6d743 with
c64899f333, in the interleaved rounds run at a load below 3.

Why

A filtered sign decides the sign where the double evaluation carries it;
its 0 says only that the evaluation cannot tell. Reading that 0 as
parallel decides the answer without the arithmetic that settles it, and
the witness is a pair it decides wrongly where 8ce1f6d743 decides it
right. An exact parallel test needs the endpoints of both segments, and
each of the 17 callers of the kernel passes the first segment as a
rounded difference; that change gets its own pull request.

Relate cost of the native engine, callgrind instructions over the regression pairs, base 0ca9be22d6 against merge b14cfc2b35: areal pairs 20,644,001,199 -> 18,344,699,388 (-11.14%), geo pairs 39,428,963,391 -> 35,530,350,502 (-9.89%).
