### PR TITLE
Read the shape, the bands and the Well-Known Binary of a raster in SQL

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2804,16 +2804,16 @@
 					<para><link linkend="tcell_frombinary"><varname>tcellFromBinary</varname>, <varname>tcellFromHexWKB</varname>, <varname>tcellFromMFJSON</varname></link>: Reconstruir una celda temporal a partir de su representación binaria, hexadecimal o MF-JSON</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_asBinary"><varname>asBinary</varname></link>: Devuelve la representación binaria conocida (WKB) de una tesela Raquet</para>
+					<para><link linkend="raquet_asBinary"><varname>asBinary</varname></link>: Devuelve la representación binaria conocida (WKB) de un ráster o de una tesela Raquet</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_asHexWKB"><varname>asHexWKB</varname></link>: Devuelve la representación hexadecimal binaria conocida (HexWKB) de una tesela Raquet</para>
+					<para><link linkend="raquet_asHexWKB"><varname>asHexWKB</varname></link>: Devuelve la representación hexadecimal binaria conocida (HexWKB) de un ráster o de una tesela Raquet</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link>: Devuelve una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
+					<para><link linkend="raquetFromBinary"><varname>rasterFromBinary</varname>, <varname>raquetFromBinary</varname></link>: Devuelve un ráster o una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link>: Devuelve una tesela Raquet a partir de su representación hexadecimal binaria conocida (HexWKB)</para>
+					<para><link linkend="raquetFromHexWKB"><varname>rasterFromHexWKB</varname>, <varname>raquetFromHexWKB</varname></link>: Devuelve un ráster o una tesela Raquet a partir de su representación hexadecimal binaria conocida (HexWKB)</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2867,13 +2867,25 @@
 					<para><link linkend="raster_numBands"><varname>numBands</varname></link>: Devuelve el número de bandas de un ráster</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_SRID"><varname>SRID</varname></link>: Devuelve el identificador del sistema de referencia espacial de un ráster</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_upperLeftX"><varname>upperLeftX</varname>, <varname>upperLeftY</varname></link>: Devuelve la coordenada X o Y de la esquina superior izquierda de un ráster</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_scaleX"><varname>scaleX</varname>, <varname>scaleY</varname></link>: Devuelve el ancho o el alto de píxel de un ráster, es decir, la componente X o Y de su escala</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_skewX"><varname>skewX</varname>, <varname>skewY</varname></link>: Devuelve la componente X o Y de la inclinación de un ráster</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raquet_quadbin_accessor"><varname>quadbin</varname></link>: Devuelve la celda QUADBIN de una tesela Raquet</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_width"><varname>width</varname></link>: Devuelve el ancho en píxeles de una tesela Raquet</para>
+					<para><link linkend="raquet_width"><varname>width</varname></link>: Devuelve el ancho en píxeles de un ráster o de una tesela Raquet</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_height"><varname>height</varname></link>: Devuelve el alto en píxeles de una tesela Raquet</para>
+					<para><link linkend="raquet_height"><varname>height</varname></link>: Devuelve el alto en píxeles de un ráster o de una tesela Raquet</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="raquet_nodata"><varname>nodata</varname></link>: Devuelve el valor centinela nodata de una tesela Raquet</para>

--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2888,10 +2888,13 @@
 					<para><link linkend="raquet_height"><varname>height</varname></link>: Devuelve el alto en píxeles de un ráster o de una tesela Raquet</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_nodata"><varname>nodata</varname></link>: Devuelve el valor centinela nodata de una tesela Raquet</para>
+					<para><link linkend="raster_bandPixelType"><varname>bandPixelType</varname></link>: Devuelve el nombre del tipo de dato de píxel de una banda de un ráster o de una tesela Raquet</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_pixtype"><varname>pixtype</varname></link>: Devuelve el nombre del tipo de dato de píxel de una tesela Raquet</para>
+					<para><link linkend="raster_bandHasNoDataValue"><varname>bandHasNoDataValue</varname></link>: Devuelve si una banda de un ráster o una tesela Raquet establece un valor nodata</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_bandNoDataValue"><varname>bandNoDataValue</varname></link>: Devuelve el valor nodata de una banda de un ráster o de una tesela Raquet</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="raquet_pixels"><varname>pixels</varname></link>: Devuelve los bytes de píxeles de un mosaico Raquet</para>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -384,7 +384,7 @@ SELECT stbox(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326)) &amp
 		</itemizedlist>	</sect1>
 	<sect1 xml:id="tcell_accessors">
 		<title>Accesores</title>
-		<para><link linkend="raster_numBands"><varname>numBands</varname></link> lee el número de bandas de un <varname>raster</varname> de PostGIS; los accesores que siguen leen una tesela <varname>raquet</varname>.</para>
+		<para><link linkend="raster_numBands"><varname>numBands</varname></link>, <link linkend="raster_SRID"><varname>SRID</varname></link> y los accesores de la esquina, la escala y la inclinación leen la malla de un <varname>raster</varname> de PostGIS; <link linkend="raquet_width"><varname>width</varname></link> y <link linkend="raquet_height"><varname>height</varname></link> leen por igual un ráster y una tesela <varname>raquet</varname>, y los demás accesores leen una tesela <varname>raquet</varname>.</para>
 
 		<para>Un valor <varname>raquet</varname> es autodescriptivo: los accesores siguientes leen la georreferenciación y la disposición que transporta, de modo que una tesela empaquetada con el constructor <link linkend="raquet"><varname>raquet</varname></link> o decodificada con <link linkend="raquetRead"><varname>raquetRead</varname></link> puede inspeccionarse sin conservar las columnas sueltas a partir de las cuales se construyó.</para>
 
@@ -481,6 +481,62 @@ SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
 -- 1 | 2
 </programlisting>
 			</listitem>
+			<listitem xml:id="raster_SRID">
+				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
+				<para>Devuelve el identificador del sistema de referencia espacial de un ráster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+SRID(raster) → integer
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT SRID(ST_MakeEmptyRaster(3, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 3857));
+-- 3857
+</programlisting>
+			</listitem>
+			<listitem xml:id="raster_upperLeftX">
+				<indexterm significance="normal"><primary><varname>upperLeftX</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>upperLeftY</varname></primary></indexterm>
+				<para>Devuelve la coordenada X o Y de la esquina superior izquierda de un ráster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+upperLeftX(raster) → float8
+upperLeftY(raster) → float8
+</programlisting>
+				<para>La esquina es el origen que establece la geotransformación, alrededor del cual la inclinación gira la malla, de modo que es una esquina de la extensión solo cuando ambas inclinaciones son cero.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT upperLeftX(r), upperLeftY(r)
+FROM (SELECT ST_MakeEmptyRaster(3, 2, 10.0, 20.0, 1.5, -2.0, 0.5, 0.25, 3857) AS r) t;
+-- 10 | 20
+</programlisting>
+			</listitem>
+			<listitem xml:id="raster_scaleX">
+				<indexterm significance="normal"><primary><varname>scaleX</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>scaleY</varname></primary></indexterm>
+				<para>Devuelve el ancho o el alto de píxel de un ráster, es decir, la componente X o Y de su escala</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+scaleX(raster) → float8
+scaleY(raster) → float8
+</programlisting>
+				<para>El alto de píxel es negativo para una malla cuyas filas van de norte a sur, que es como se escribe habitualmente un ráster.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT scaleX(r), scaleY(r)
+FROM (SELECT ST_MakeEmptyRaster(3, 2, 10.0, 20.0, 1.5, -2.0, 0.5, 0.25, 3857) AS r) t;
+-- 1.5 | -2
+</programlisting>
+			</listitem>
+			<listitem xml:id="raster_skewX">
+				<indexterm significance="normal"><primary><varname>skewX</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>skewY</varname></primary></indexterm>
+				<para>Devuelve la componente X o Y de la inclinación de un ráster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+skewX(raster) → float8
+skewY(raster) → float8
+</programlisting>
+				<para>Un ráster cuyas dos inclinaciones son cero está alineado con los ejes.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT skewX(r), skewY(r)
+FROM (SELECT ST_MakeEmptyRaster(3, 2, 10.0, 20.0, 1.5, -2.0, 0.5, 0.25, 3857) AS r) t;
+-- 0.5 | 0.25
+</programlisting>
+			</listitem>
 			<listitem xml:id="raquet_quadbin_accessor">
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Devuelve la celda QUADBIN de una tesela Raquet</para>
@@ -494,22 +550,26 @@ SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			</listitem>
 			<listitem xml:id="raquet_width">
 				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
-				<para>Devuelve el ancho en píxeles de una tesela Raquet</para>
+				<para>Devuelve el ancho en píxeles de un ráster o de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-width(raquet) → integer
+width({raster,raquet}) → integer
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT width(ST_MakeEmptyRaster(3, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326));
+-- 3
 SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquet_height">
 				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
-				<para>Devuelve el alto en píxeles de una tesela Raquet</para>
+				<para>Devuelve el alto en píxeles de un ráster o de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-height(raquet) → integer
+height({raster,raquet}) → integer
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT height(ST_MakeEmptyRaster(3, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326));
+-- 2
 SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -384,7 +384,7 @@ SELECT stbox(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326)) &amp
 		</itemizedlist>	</sect1>
 	<sect1 xml:id="tcell_accessors">
 		<title>Accesores</title>
-		<para><link linkend="raster_numBands"><varname>numBands</varname></link>, <link linkend="raster_SRID"><varname>SRID</varname></link> y los accesores de la esquina, la escala y la inclinación leen la malla de un <varname>raster</varname> de PostGIS; <link linkend="raquet_width"><varname>width</varname></link> y <link linkend="raquet_height"><varname>height</varname></link> leen por igual un ráster y una tesela <varname>raquet</varname>, y los demás accesores leen una tesela <varname>raquet</varname>.</para>
+		<para><link linkend="raster_numBands"><varname>numBands</varname></link>, <link linkend="raster_SRID"><varname>SRID</varname></link> y los accesores de la esquina, la escala y la inclinación leen la malla de un <varname>raster</varname> de PostGIS; <link linkend="raquet_width"><varname>width</varname></link>, <link linkend="raquet_height"><varname>height</varname></link> y los accesores de banda leen por igual un ráster y una tesela <varname>raquet</varname>, y los demás accesores leen una tesela <varname>raquet</varname>.</para>
 
 		<para>Un valor <varname>raquet</varname> es autodescriptivo: los accesores siguientes leen la georreferenciación y la disposición que transporta, de modo que una tesela empaquetada con el constructor <link linkend="raquet"><varname>raquet</varname></link> o decodificada con <link linkend="raquetRead"><varname>raquetRead</varname></link> puede inspeccionarse sin conservar las columnas sueltas a partir de las cuales se construyó.</para>
 
@@ -574,32 +574,58 @@ SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>
 			</listitem>
-			<listitem xml:id="raquet_nodata">
-				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
-				<para>Devuelve el valor centinela nodata de una tesela Raquet</para>
+			<listitem xml:id="raster_bandPixelType">
+				<indexterm significance="normal"><primary><varname>bandPixelType</varname></primary></indexterm>
+				<para>Devuelve el nombre del tipo de dato de píxel de una banda de un ráster o de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-nodata(raquet) → float8
+bandPixelType(raster,band integer=1) → text
+bandPixelType(raquet) → text
 </programlisting>
-							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8', 255));
--- 255
--- The sentinel defaults to 0 when the constructor omits it.
-SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
--- 0
+				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que el nombre que el ráster de PostGIS da a un tipo de píxel pasa a ellos tal cual; el nombre devuelto aquí es la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela, tanto para una banda de PostGIS como para una tesela, de modo que una banda y una tesela del mismo tipo informan el mismo nombre.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT bandPixelType(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '16BSI'));
+-- int16
+-- Read back the layout of a packaged tile
+SELECT quadbin(tile), width(tile), height(tile), bandPixelType(tile)
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS tile) t;
+-- 5193776270265024512 | 2 | 2 | uint8
 </programlisting>
 			</listitem>
-			<listitem xml:id="raquet_pixtype">
-				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
-				<para>Devuelve el nombre del tipo de dato de píxel de una tesela Raquet</para>
+			<listitem xml:id="raster_bandHasNoDataValue">
+				<indexterm significance="normal"><primary><varname>bandHasNoDataValue</varname></primary></indexterm>
+				<para>Devuelve si una banda de un ráster o una tesela Raquet establece un valor nodata</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-pixtype(raquet) → text
+bandHasNoDataValue(raster,band integer=1) → boolean
+bandHasNoDataValue(raquet) → boolean
 </programlisting>
-				<para>El nombre devuelto es el que aceptan los constructores, es decir, uno de <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname> o <varname>float64</varname>. Los constructores leen el nombre sin distinguir mayúsculas de minúsculas, de modo que el nombre que el ráster de PostGIS da a un tipo de píxel pasa a ellos tal cual; el nombre devuelto aquí es la grafía en minúsculas que la especificación RaQuet da al campo <varname>type</varname> de una tesela, por lo que se compara igual a ese campo tal cual.</para>
+				<para>Una banda que no establece ninguno no tiene píxel que excluir, de modo que cada píxel que contiene lleva un valor.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Read back the layout of a packaged tile
-SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
-FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS tile) t;
--- 5193776270265024512 | 2 | 2 | uint8 | 0
+SELECT bandHasNoDataValue(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '16BSI'::text,
+  0::float8, -9999::float8));
+-- true
+SELECT bandHasNoDataValue(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
+  'uint8'));
+-- false
+</programlisting>
+			</listitem>
+			<listitem xml:id="raster_bandNoDataValue">
+				<indexterm significance="normal"><primary><varname>bandNoDataValue</varname></primary></indexterm>
+				<para>Devuelve el valor nodata de una banda de un ráster o de una tesela Raquet</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+bandNoDataValue(raster,band integer=1) → float8
+bandNoDataValue(raquet) → float8
+</programlisting>
+				<para>Una banda que no establece ningún valor nodata devuelve <varname>NULL</varname>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT bandNoDataValue(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '16BSI'::text,
+  0::float8, -9999::float8));
+-- -9999
+SELECT bandNoDataValue(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8',
+  255));
+-- 255
+-- A tile built without a nodata value states none
+SELECT bandNoDataValue(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
+-- NULL
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquet_pixels">
@@ -608,7 +634,7 @@ FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS 
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 pixels(raquet) → bytea
 </programlisting>
-				<para>Los bytes están en orden de fila mayor y empaquetados, <varname>width</varname> × <varname>height</varname> píxeles del tamaño de <varname>pixtype</varname> cada uno, en little-endian cuando un píxel ocupa más de un byte, que es la disposición que aceptan los constructores. Por lo tanto, un mosaico se reconstruye a través de sus propios accesores.</para>
+				<para>Los bytes están en orden de fila mayor y empaquetados, <varname>width</varname> × <varname>height</varname> píxeles del tamaño de <link linkend="raster_bandPixelType"><varname>bandPixelType</varname></link> cada uno, en little-endian cuando un píxel ocupa más de un byte, que es la disposición que aceptan los constructores. Por lo tanto, un mosaico se reconstruye a través de sus propios accesores.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- \x01020304

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -81,7 +81,7 @@
 		<title>Entrada y salida</title>
 		<para>Un valor de celda temporal se introduce utilizando la sintaxis temporal estándar con el identificador de celda de 64 bits subyacente. El analizador de entrada acepta la forma hexadecimal canónica que publica cada cuadrícula — la forma que emiten la CLI de H3 y <varname>h3_cell_to_string</varname>, y la forma que lee la implementación de referencia de CARTO — con un prefijo <varname>0x</varname> opcional, en cualquiera de las dos cajas de letra y con 16 dígitos significativos como máximo. El hexadecimal es idiomático en los tres ecosistemas y es lo que emite la función de salida, de modo que todos los ejemplos siguientes lo usan. El valor debe además denotar algo que su cuadrícula indexe: para H3 una celda, una arista dirigida o un vértice, de modo que un literal hexadecimal bien formado como <varname>12345</varname>, que no es ninguno de los tres, se rechaza en lugar de almacenarse como un valor sin ubicación. Como referencia, el hexadecimal <varname>480fffffffffffff</varname> usado en los ejemplos es la celda mundial QUADBIN de resolución 0, igual al decimal <varname>5192650370358181887</varname>.</para>
 
-		<para>Las funciones <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>raquet</varname>, y <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> y <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> lo reconstruyen. Una tesela lleva sus píxeles y su georreferenciación QUADBIN en un único valor, de modo que hace un viaje de ida y vuelta a través de una cadena de bytes portable sin intervención de ninguna extensión espacial, y la forma hexadecimal permite que una columna de teselas haga ese viaje mediante un <varname>COPY</varname> basado en texto. Ambas funciones de salida aceptan un argumento opcional de ordenación de bytes, <varname>NDR</varname> para little-endian o <varname>XDR</varname> para big-endian, cuyo valor predeterminado es la ordenación del servidor.</para>
+		<para>Las funciones <varname>asBinary</varname> y <varname>asHexWKB</varname> serializan un valor <varname>raster</varname> o <varname>raquet</varname>, y <link linkend="raquetFromBinary"><varname>rasterFromBinary</varname></link>, <link linkend="raquetFromHexWKB"><varname>rasterFromHexWKB</varname></link>, <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> y <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> lo reconstruyen. Un ráster se escribe en la forma que escribe el ráster de PostGIS, de modo que una columna de rásteres hace un viaje de ida y vuelta entre PostgreSQL y cualquier programa que lea esa forma. Una tesela lleva sus píxeles y su georreferenciación QUADBIN en un único valor, de modo que hace un viaje de ida y vuelta a través de una cadena de bytes portable sin intervención de ninguna extensión espacial, y la forma hexadecimal permite que una columna de teselas haga ese viaje mediante un <varname>COPY</varname> basado en texto. Ambas funciones de salida aceptan un argumento opcional de ordenación de bytes, <varname>NDR</varname> para little-endian o <varname>XDR</varname> para big-endian, cuyo valor predeterminado es la ordenación del servidor.</para>
 
 		<itemizedlist>
 			<listitem xml:id="tcell_in_out">
@@ -147,45 +147,62 @@ SELECT ts2cellFromHexWKB(asHexWKB(ts2cell '47c3c@2001-01-01'));
 
 			<listitem xml:id="raquet_asBinary">
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
-				<para>Devuelve la representación binaria conocida (WKB) de una tesela Raquet</para>
+				<para>Devuelve la representación binaria conocida (WKB) de un ráster o de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asBinary(raquet,endian text='') → bytea
+asBinary({raster,raquet},endian text='') → bytea
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT length(asBinary(ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326)));
+-- 61
+SELECT get_byte(asBinary(ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326),
+  'XDR'), 0);
+-- 0
 SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
 -- 31
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquet_asHexWKB">
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
-				<para>Devuelve la representación hexadecimal binaria conocida (HexWKB) de una tesela Raquet</para>
+				<para>Devuelve la representación hexadecimal binaria conocida (HexWKB) de un ráster o de una tesela Raquet</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asHexWKB(raquet,endian text='') → text
+asHexWKB({raster,raquet},endian text='') → text
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT length(asHexWKB(ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326)));
+-- 122
 SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
 -- 62
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquetFromBinary">
+				<indexterm significance="normal"><primary><varname>rasterFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
-				<para>Devuelve una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
+				<para>Devuelve un ráster o una tesela Raquet a partir de su representación binaria conocida (WKB)</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterFromBinary(bytea) → raster
 raquetFromBinary(bytea) → raquet
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT rasterFromBinary(asBinary(r, 'XDR')) = r
+FROM (SELECT ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r) t;
+-- true
 SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 -- true
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquetFromHexWKB">
+				<indexterm significance="normal"><primary><varname>rasterFromHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
-				<para>Devuelve una tesela Raquet a partir de su representación hexadecimal binaria conocida (HexWKB)</para>
+				<para>Devuelve un ráster o una tesela Raquet a partir de su representación hexadecimal binaria conocida (HexWKB)</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterFromHexWKB(text) → raster
 raquetFromHexWKB(text) → raquet
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT rasterFromHexWKB(asHexWKB(r, 'XDR')) = r
+FROM (SELECT ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r) t;
+-- true
 SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 -- true

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -2158,8 +2158,8 @@ WITH rast AS (
     ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
     [40.0::float4, 50.0::float4, 60.0::float4],
     [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
-SELECT ST_SRID(transform(r, 3857)) AS srid, ST_Width(transform(r, 3857)) AS width,
-  ST_Height(transform(r, 3857)) AS height
+SELECT SRID(transform(r, 3857)) AS srid, width(transform(r, 3857)) AS width,
+  height(transform(r, 3857)) AS height
 FROM rast;
 -- 3857 | 3 | 3
 </programlisting>
@@ -2181,9 +2181,9 @@ WITH rast AS (
     ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
     [40.0::float4, 50.0::float4, 60.0::float4],
     [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
-SELECT ST_Width(rescale(r, 0.5, -0.5)) AS width,
-  ST_Height(rescale(r, 0.5, -0.5)) AS height,
-  ST_ScaleX(rescale(r, 0.5, -0.5)) AS scalex
+SELECT width(rescale(r, 0.5, -0.5)) AS width,
+  height(rescale(r, 0.5, -0.5)) AS height,
+  scaleX(rescale(r, 0.5, -0.5)) AS scalex
 FROM rast;
 -- 6 | 6 | 0.5
 </programlisting>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2897,10 +2897,13 @@
 					<para><link linkend="raquet_height"><varname>height</varname></link>: Return the height in pixels of a raster or a Raquet tile</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_nodata"><varname>nodata</varname></link>: Return the nodata sentinel value of a Raquet tile</para>
+					<para><link linkend="raster_bandPixelType"><varname>bandPixelType</varname></link>: Return the name of the pixel data type of a raster band or of a Raquet tile</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_pixtype"><varname>pixtype</varname></link>: Return the name of the pixel data type of a Raquet tile</para>
+					<para><link linkend="raster_bandHasNoDataValue"><varname>bandHasNoDataValue</varname></link>: Return whether a raster band or a Raquet tile states a nodata value</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_bandNoDataValue"><varname>bandNoDataValue</varname></link>: Return the nodata value of a raster band or of a Raquet tile</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="raquet_pixels"><varname>pixels</varname></link>: Return the pixel bytes of a Raquet tile</para>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2813,16 +2813,16 @@
 					<para><link linkend="tcell_frombinary"><varname>tcellFromBinary</varname>, <varname>tcellFromHexWKB</varname>, <varname>tcellFromMFJSON</varname></link>: Reconstruct a temporal cell from its binary, hexadecimal, or MF-JSON representation</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_asBinary"><varname>asBinary</varname></link>: Return the Well-Known Binary (WKB) representation of a Raquet tile</para>
+					<para><link linkend="raquet_asBinary"><varname>asBinary</varname></link>: Return the Well-Known Binary (WKB) representation of a raster or a Raquet tile</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_asHexWKB"><varname>asHexWKB</varname></link>: Return the Hexadecimal Well-Known Binary (HexWKB) representation of a Raquet tile</para>
+					<para><link linkend="raquet_asHexWKB"><varname>asHexWKB</varname></link>: Return the Hexadecimal Well-Known Binary (HexWKB) representation of a raster or a Raquet tile</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link>: Return a Raquet tile from its Well-Known Binary (WKB) representation</para>
+					<para><link linkend="raquetFromBinary"><varname>rasterFromBinary</varname>, <varname>raquetFromBinary</varname></link>: Return a raster or a Raquet tile from its Well-Known Binary (WKB) representation</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link>: Return a Raquet tile from its Hexadecimal Well-Known Binary (HexWKB) representation</para>
+					<para><link linkend="raquetFromHexWKB"><varname>rasterFromHexWKB</varname>, <varname>raquetFromHexWKB</varname></link>: Return a raster or a Raquet tile from its Hexadecimal Well-Known Binary (HexWKB) representation</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2876,13 +2876,25 @@
 					<para><link linkend="raster_numBands"><varname>numBands</varname></link>: Return the number of bands of a raster</para>
 				</listitem>
 				<listitem>
+					<para><link linkend="raster_SRID"><varname>SRID</varname></link>: Return the spatial reference system identifier of a raster</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_upperLeftX"><varname>upperLeftX</varname>, <varname>upperLeftY</varname></link>: Return the X or the Y coordinate of the upper left corner of a raster</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_scaleX"><varname>scaleX</varname>, <varname>scaleY</varname></link>: Return the pixel width or the pixel height of a raster, that is, the X or the Y component of its scale</para>
+				</listitem>
+				<listitem>
+					<para><link linkend="raster_skewX"><varname>skewX</varname>, <varname>skewY</varname></link>: Return the X or the Y component of the skew of a raster</para>
+				</listitem>
+				<listitem>
 					<para><link linkend="raquet_quadbin_accessor"><varname>quadbin</varname></link>: Return the QUADBIN cell of a Raquet tile</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_width"><varname>width</varname></link>: Return the width in pixels of a Raquet tile</para>
+					<para><link linkend="raquet_width"><varname>width</varname></link>: Return the width in pixels of a raster or a Raquet tile</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquet_height"><varname>height</varname></link>: Return the height in pixels of a Raquet tile</para>
+					<para><link linkend="raquet_height"><varname>height</varname></link>: Return the height in pixels of a raster or a Raquet tile</para>
 				</listitem>
 				<listitem>
 					<para><link linkend="raquet_nodata"><varname>nodata</varname></link>: Return the nodata sentinel value of a Raquet tile</para>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -2161,8 +2161,8 @@ WITH rast AS (
     ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
     [40.0::float4, 50.0::float4, 60.0::float4],
     [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
-SELECT ST_SRID(transform(r, 3857)) AS srid, ST_Width(transform(r, 3857)) AS width,
-  ST_Height(transform(r, 3857)) AS height
+SELECT SRID(transform(r, 3857)) AS srid, width(transform(r, 3857)) AS width,
+  height(transform(r, 3857)) AS height
 FROM rast;
 -- 3857 | 3 | 3
 </programlisting>
@@ -2184,9 +2184,9 @@ WITH rast AS (
     ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
     [40.0::float4, 50.0::float4, 60.0::float4],
     [70.0::float4, 80.0::float4, 90.0::float4]]) AS r )
-SELECT ST_Width(rescale(r, 0.5, -0.5)) AS width,
-  ST_Height(rescale(r, 0.5, -0.5)) AS height,
-  ST_ScaleX(rescale(r, 0.5, -0.5)) AS scalex
+SELECT width(rescale(r, 0.5, -0.5)) AS width,
+  height(rescale(r, 0.5, -0.5)) AS height,
+  scaleX(rescale(r, 0.5, -0.5)) AS scalex
 FROM rast;
 -- 6 | 6 | 0.5
 </programlisting>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -81,7 +81,7 @@
 		<title>Input and Output</title>
 		<para>A temporal cell value is entered using the standard temporal syntax with the underlying 64-bit cell identifier. The input parser accepts the canonical hexadecimal form each grid publishes — the form the H3 CLI and <varname>h3_cell_to_string</varname> emit, and the form the CARTO reference implementation reads — with an optional <varname>0x</varname> prefix, in either letter case, and at most 16 significant digits. Hexadecimal is idiomatic in all three ecosystems and is what the output function emits, so every example below uses it. The value must also denote something its grid indexes: for H3 a cell, a directed edge or a vertex, so that a well-formed hexadecimal literal such as <varname>12345</varname>, which is none of the three, is rejected rather than stored as a value with no location. For reference, the hexadecimal <varname>480fffffffffffff</varname> used in the examples is the QUADBIN resolution-0 world cell, equal to the decimal <varname>5192650370358181887</varname>.</para>
 
-		<para>The functions <varname>asBinary</varname> and <varname>asHexWKB</varname> serialize a <varname>raquet</varname> value, and <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> and <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> reconstruct it. A tile carries its pixels and its QUADBIN georeferencing in one value, so it round-trips through a portable byte string with no spatial extension involved, and the hexadecimal form lets a tile column round-trip through a text-based <varname>COPY</varname>. Both output functions accept an optional endianness argument, <varname>NDR</varname> for little-endian or <varname>XDR</varname> for big-endian, defaulting to the endianness of the server.</para>
+		<para>The functions <varname>asBinary</varname> and <varname>asHexWKB</varname> serialize a <varname>raster</varname> or a <varname>raquet</varname> value, and <link linkend="raquetFromBinary"><varname>rasterFromBinary</varname></link>, <link linkend="raquetFromHexWKB"><varname>rasterFromHexWKB</varname></link>, <link linkend="raquetFromBinary"><varname>raquetFromBinary</varname></link> and <link linkend="raquetFromHexWKB"><varname>raquetFromHexWKB</varname></link> reconstruct it. A raster is written in the form PostGIS raster writes, so a raster column round-trips between PostgreSQL and any program reading that form. A tile carries its pixels and its QUADBIN georeferencing in one value, so it round-trips through a portable byte string with no spatial extension involved, and the hexadecimal form lets a tile column round-trip through a text-based <varname>COPY</varname>. Both output functions accept an optional endianness argument, <varname>NDR</varname> for little-endian or <varname>XDR</varname> for big-endian, defaulting to the endianness of the server.</para>
 
 		<itemizedlist>
 			<listitem xml:id="tcell_in_out">
@@ -147,45 +147,62 @@ SELECT ts2cellFromHexWKB(asHexWKB(ts2cell '47c3c@2001-01-01'));
 
 			<listitem xml:id="raquet_asBinary">
 				<indexterm significance="normal"><primary><varname>asBinary</varname></primary></indexterm>
-				<para>Return the Well-Known Binary (WKB) representation of a Raquet tile</para>
+				<para>Return the Well-Known Binary (WKB) representation of a raster or a Raquet tile</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asBinary(raquet,endian text='') → bytea
+asBinary({raster,raquet},endian text='') → bytea
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT length(asBinary(ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326)));
+-- 61
+SELECT get_byte(asBinary(ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326),
+  'XDR'), 0);
+-- 0
 SELECT length(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
 -- 31
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquet_asHexWKB">
 				<indexterm significance="normal"><primary><varname>asHexWKB</varname></primary></indexterm>
-				<para>Return the Hexadecimal Well-Known Binary (HexWKB) representation of a Raquet tile</para>
+				<para>Return the Hexadecimal Well-Known Binary (HexWKB) representation of a raster or a Raquet tile</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-asHexWKB(raquet,endian text='') → text
+asHexWKB({raster,raquet},endian text='') → text
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT length(asHexWKB(ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326)));
+-- 122
 SELECT length(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8')));
 -- 62
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquetFromBinary">
+				<indexterm significance="normal"><primary><varname>rasterFromBinary</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>raquetFromBinary</varname></primary></indexterm>
-				<para>Return a Raquet tile from its Well-Known Binary (WKB) representation</para>
+				<para>Return a raster or a Raquet tile from its Well-Known Binary (WKB) representation</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterFromBinary(bytea) → raster
 raquetFromBinary(bytea) → raquet
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT rasterFromBinary(asBinary(r, 'XDR')) = r
+FROM (SELECT ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r) t;
+-- true
 SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 -- true
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquetFromHexWKB">
+				<indexterm significance="normal"><primary><varname>rasterFromHexWKB</varname></primary></indexterm>
 				<indexterm significance="normal"><primary><varname>raquetFromHexWKB</varname></primary></indexterm>
-				<para>Return a Raquet tile from its Hexadecimal Well-Known Binary (HexWKB) representation</para>
+				<para>Return a raster or a Raquet tile from its Hexadecimal Well-Known Binary (HexWKB) representation</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+rasterFromHexWKB(text) → raster
 raquetFromHexWKB(text) → raquet
 </programlisting>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT rasterFromHexWKB(asHexWKB(r, 'XDR')) = r
+FROM (SELECT ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326) AS r) t;
+-- true
 SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
   'uint8'))) = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 -- true

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -384,7 +384,7 @@ SELECT stbox(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326)) &amp
 		</itemizedlist>	</sect1>
 	<sect1 xml:id="tcell_accessors">
 		<title>Accessors</title>
-		<para><link linkend="raster_numBands"><varname>numBands</varname></link> reads the band count of a PostGIS <varname>raster</varname>; the accessors that follow read a <varname>raquet</varname> tile.</para>
+		<para><link linkend="raster_numBands"><varname>numBands</varname></link>, <link linkend="raster_SRID"><varname>SRID</varname></link> and the corner, scale and skew accessors read the grid of a PostGIS <varname>raster</varname>; <link linkend="raquet_width"><varname>width</varname></link> and <link linkend="raquet_height"><varname>height</varname></link> read a raster and a <varname>raquet</varname> tile alike, and the other accessors read a <varname>raquet</varname> tile.</para>
 
 		<para>A <varname>raquet</varname> value is self-describing: the accessors below read back the georeferencing and layout it carries, so a tile packaged with the <link linkend="raquet"><varname>raquet</varname></link> constructor or decoded with <link linkend="raquetRead"><varname>raquetRead</varname></link> can be inspected without keeping the loose columns it was built from.</para>
 
@@ -481,6 +481,62 @@ SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
 -- 1 | 2
 </programlisting>
 			</listitem>
+			<listitem xml:id="raster_SRID">
+				<indexterm significance="normal"><primary><varname>SRID</varname></primary></indexterm>
+				<para>Return the spatial reference system identifier of a raster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+SRID(raster) → integer
+</programlisting>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT SRID(ST_MakeEmptyRaster(3, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 3857));
+-- 3857
+</programlisting>
+			</listitem>
+			<listitem xml:id="raster_upperLeftX">
+				<indexterm significance="normal"><primary><varname>upperLeftX</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>upperLeftY</varname></primary></indexterm>
+				<para>Return the X or the Y coordinate of the upper left corner of a raster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+upperLeftX(raster) → float8
+upperLeftY(raster) → float8
+</programlisting>
+				<para>The corner is the origin the geotransform states, which the skew rotates the grid about, so it is a corner of the extent only when both skews are zero.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT upperLeftX(r), upperLeftY(r)
+FROM (SELECT ST_MakeEmptyRaster(3, 2, 10.0, 20.0, 1.5, -2.0, 0.5, 0.25, 3857) AS r) t;
+-- 10 | 20
+</programlisting>
+			</listitem>
+			<listitem xml:id="raster_scaleX">
+				<indexterm significance="normal"><primary><varname>scaleX</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>scaleY</varname></primary></indexterm>
+				<para>Return the pixel width or the pixel height of a raster, that is, the X or the Y component of its scale</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+scaleX(raster) → float8
+scaleY(raster) → float8
+</programlisting>
+				<para>The pixel height is negative for a grid whose rows run north to south, which is how a raster is ordinarily written.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT scaleX(r), scaleY(r)
+FROM (SELECT ST_MakeEmptyRaster(3, 2, 10.0, 20.0, 1.5, -2.0, 0.5, 0.25, 3857) AS r) t;
+-- 1.5 | -2
+</programlisting>
+			</listitem>
+			<listitem xml:id="raster_skewX">
+				<indexterm significance="normal"><primary><varname>skewX</varname></primary></indexterm>
+				<indexterm significance="normal"><primary><varname>skewY</varname></primary></indexterm>
+				<para>Return the X or the Y component of the skew of a raster</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+skewX(raster) → float8
+skewY(raster) → float8
+</programlisting>
+				<para>A raster whose two skews are zero is axis-aligned.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT skewX(r), skewY(r)
+FROM (SELECT ST_MakeEmptyRaster(3, 2, 10.0, 20.0, 1.5, -2.0, 0.5, 0.25, 3857) AS r) t;
+-- 0.5 | 0.25
+</programlisting>
+			</listitem>
 			<listitem xml:id="raquet_quadbin_accessor">
 				<indexterm significance="normal"><primary><varname>quadbin</varname></primary></indexterm>
 				<para>Return the QUADBIN cell of a Raquet tile</para>
@@ -494,22 +550,26 @@ SELECT quadbin(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 			</listitem>
 			<listitem xml:id="raquet_width">
 				<indexterm significance="normal"><primary><varname>width</varname></primary></indexterm>
-				<para>Return the width in pixels of a Raquet tile</para>
+				<para>Return the width in pixels of a raster or a Raquet tile</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-width(raquet) → integer
+width({raster,raquet}) → integer
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT width(ST_MakeEmptyRaster(3, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326));
+-- 3
 SELECT width(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquet_height">
 				<indexterm significance="normal"><primary><varname>height</varname></primary></indexterm>
-				<para>Return the height in pixels of a Raquet tile</para>
+				<para>Return the height in pixels of a raster or a Raquet tile</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-height(raquet) → integer
+height({raster,raquet}) → integer
 </programlisting>
 							<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT height(ST_MakeEmptyRaster(3, 2, 0.0, 2.0, 1.0, -1.0, 0.0, 0.0, 4326));
+-- 2
 SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -384,7 +384,7 @@ SELECT stbox(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326)) &amp
 		</itemizedlist>	</sect1>
 	<sect1 xml:id="tcell_accessors">
 		<title>Accessors</title>
-		<para><link linkend="raster_numBands"><varname>numBands</varname></link>, <link linkend="raster_SRID"><varname>SRID</varname></link> and the corner, scale and skew accessors read the grid of a PostGIS <varname>raster</varname>; <link linkend="raquet_width"><varname>width</varname></link> and <link linkend="raquet_height"><varname>height</varname></link> read a raster and a <varname>raquet</varname> tile alike, and the other accessors read a <varname>raquet</varname> tile.</para>
+		<para><link linkend="raster_numBands"><varname>numBands</varname></link>, <link linkend="raster_SRID"><varname>SRID</varname></link> and the corner, scale and skew accessors read the grid of a PostGIS <varname>raster</varname>; <link linkend="raquet_width"><varname>width</varname></link>, <link linkend="raquet_height"><varname>height</varname></link> and the band accessors read a raster and a <varname>raquet</varname> tile alike, and the other accessors read a <varname>raquet</varname> tile.</para>
 
 		<para>A <varname>raquet</varname> value is self-describing: the accessors below read back the georeferencing and layout it carries, so a tile packaged with the <link linkend="raquet"><varname>raquet</varname></link> constructor or decoded with <link linkend="raquetRead"><varname>raquetRead</varname></link> can be inspected without keeping the loose columns it was built from.</para>
 
@@ -574,32 +574,58 @@ SELECT height(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- 2
 </programlisting>
 			</listitem>
-			<listitem xml:id="raquet_nodata">
-				<indexterm significance="normal"><primary><varname>nodata</varname></primary></indexterm>
-				<para>Return the nodata sentinel value of a Raquet tile</para>
+			<listitem xml:id="raster_bandPixelType">
+				<indexterm significance="normal"><primary><varname>bandPixelType</varname></primary></indexterm>
+				<para>Return the name of the pixel data type of a raster band or of a Raquet tile</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-nodata(raquet) → float8
+bandPixelType(raster,band integer=1) → text
+bandPixelType(raquet) → text
 </programlisting>
-							<programlisting language="sql" xml:space="preserve" format="linespecific">
-SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8', 255));
--- 255
--- The sentinel defaults to 0 when the constructor omits it.
-SELECT nodata(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
--- 0
+				<para>The returned name is the one the constructors accept, that is, one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. The constructors read the name without regard to case, so the name PostGIS raster gives a pixel type carries into them as it stands; the name returned here is the lower-case spelling the RaQuet specification gives a tile's <varname>type</varname> field, for a PostGIS band as for a tile, so a band and a tile of the same type report the same name.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT bandPixelType(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '16BSI'));
+-- int16
+-- Read back the layout of a packaged tile
+SELECT quadbin(tile), width(tile), height(tile), bandPixelType(tile)
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS tile) t;
+-- 5193776270265024512 | 2 | 2 | uint8
 </programlisting>
 			</listitem>
-			<listitem xml:id="raquet_pixtype">
-				<indexterm significance="normal"><primary><varname>pixtype</varname></primary></indexterm>
-				<para>Return the name of the pixel data type of a Raquet tile</para>
+			<listitem xml:id="raster_bandHasNoDataValue">
+				<indexterm significance="normal"><primary><varname>bandHasNoDataValue</varname></primary></indexterm>
+				<para>Return whether a raster band or a Raquet tile states a nodata value</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
-pixtype(raquet) → text
+bandHasNoDataValue(raster,band integer=1) → boolean
+bandHasNoDataValue(raquet) → boolean
 </programlisting>
-				<para>The returned name is the one the constructors accept, that is, one of <varname>uint8</varname>, <varname>int8</varname>, <varname>uint16</varname>, <varname>int16</varname>, <varname>uint32</varname>, <varname>int32</varname>, <varname>uint64</varname>, <varname>int64</varname>, <varname>float16</varname>, <varname>float32</varname>, or <varname>float64</varname>. The constructors read the name without regard to case, so the name PostGIS raster gives a pixel type carries into them as it stands; the name returned here is the lower-case spelling the RaQuet specification gives a tile's <varname>type</varname> field, so it compares equal to that field as it stands.</para>
+				<para>A band that states none has no pixel to exclude, so every pixel it holds carries a value.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
--- Read back the layout of a packaged tile
-SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
-FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS tile) t;
--- 5193776270265024512 | 2 | 2 | uint8 | 0
+SELECT bandHasNoDataValue(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '16BSI'::text,
+  0::float8, -9999::float8));
+-- true
+SELECT bandHasNoDataValue(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512,
+  'uint8'));
+-- false
+</programlisting>
+			</listitem>
+			<listitem xml:id="raster_bandNoDataValue">
+				<indexterm significance="normal"><primary><varname>bandNoDataValue</varname></primary></indexterm>
+				<para>Return the nodata value of a raster band or of a Raquet tile</para>
+				<programlisting role="syntax" xml:space="preserve" format="linespecific">
+bandNoDataValue(raster,band integer=1) → float8
+bandNoDataValue(raquet) → float8
+</programlisting>
+				<para>A band that states no nodata value answers <varname>NULL</varname>.</para>
+				<programlisting language="sql" xml:space="preserve" format="linespecific">
+SELECT bandNoDataValue(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '16BSI'::text,
+  0::float8, -9999::float8));
+-- -9999
+SELECT bandNoDataValue(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8',
+  255));
+-- 255
+-- A tile built without a nodata value states none
+SELECT bandNoDataValue(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
+-- NULL
 </programlisting>
 			</listitem>
 			<listitem xml:id="raquet_pixels">
@@ -608,7 +634,7 @@ FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8') AS 
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 pixels(raquet) → bytea
 </programlisting>
-				<para>The bytes are row-major and packed, <varname>width</varname> × <varname>height</varname> pixels of the size of <varname>pixtype</varname> each, little-endian when a pixel is wider than one byte, which is the layout the constructors accept. A tile therefore round trips through its own accessors.</para>
+				<para>The bytes are row-major and packed, <varname>width</varname> × <varname>height</varname> pixels of the size of <link linkend="raster_bandPixelType"><varname>bandPixelType</varname></link> each, little-endian when a pixel is wider than one byte, which is the layout the constructors accept. A tile therefore round trips through its own accessors.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8'));
 -- \x01020304

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -108,8 +108,9 @@ extern Raquet *raquet_read_bytes(const uint8_t *data, size_t size, uint64 quadbi
 extern uint64 raquet_quadbin(const Raquet *rq);
 extern int raquet_width(const Raquet *rq);
 extern int raquet_height(const Raquet *rq);
-extern double raquet_nodata(const Raquet *rq);
-extern char *raquet_pixtype(const Raquet *rq);
+extern char *raquet_band_pixel_type(const Raquet *rq);
+extern bool raquet_band_has_nodata_value(const Raquet *rq);
+extern bool raquet_band_nodata_value(const Raquet *rq, double *result);
 extern uint8_t *raquet_pixels(const Raquet *rq, size_t *size_out);
 extern uint32 raquet_hash(const Raquet *rq);
 extern uint64 raquet_hash_extended(const Raquet *rq, uint64 seed);
@@ -166,7 +167,8 @@ extern double raster_skew_x(const Raster *rast);
 extern double raster_skew_y(const Raster *rast);
 extern char *raster_band_pixel_type(const Raster *rast, int band);
 extern bool raster_band_has_nodata_value(const Raster *rast, int band);
-extern double raster_band_nodata_value(const Raster *rast, int band);
+extern bool raster_band_nodata_value(const Raster *rast, int band,
+  double *result);
 
 /* Processing functions for PostGIS rasters */
 

--- a/meos/include/meos_raster.h
+++ b/meos/include/meos_raster.h
@@ -150,8 +150,8 @@ typedef struct
 
 extern Raster *raster_from_wkb(const uint8_t *wkb, size_t size);
 extern Raster *raster_from_hexwkb(const char *hexwkb);
-extern uint8_t *raster_as_wkb(const Raster *rast, size_t *size_out);
-extern char *raster_as_hexwkb(const Raster *rast, size_t *size_out);
+extern uint8_t *raster_as_wkb(const Raster *rast, uint8_t variant, size_t *size_out);
+extern char *raster_as_hexwkb(const Raster *rast, uint8_t variant, size_t *size_out);
 
 /* Accessor functions for PostGIS rasters */
 

--- a/meos/src/raster/raquet.c
+++ b/meos/src/raster/raquet.c
@@ -76,7 +76,7 @@
  */
 typedef struct
 {
-  const char *name;   /**< Name the constructors accept and #raquet_pixtype() returns */
+  const char *name;   /**< Name the constructors accept and #raquet_band_pixel_type() returns */
   const char *pgname; /**< Name PostGIS raster gives the type, also accepted */
   size_t size;        /**< Size in bytes of a single pixel */
 } pixtype_catalog_struct;
@@ -435,9 +435,9 @@ raquet_pixels_from_host(uint8 *pixels, size_t count, MeosPixType pixtype)
  * @ingroup meos_raster_base_accessor
  * @brief Return the pixel data type corresponding to a name
  * @param[in] str Pixel type name: uint8, int8, uint16, int16, uint32, int32, uint64, int64, float16, float32, or float64
- * @note This is the parser counterpart of #raquet_pixtype()
+ * @note This is the parser counterpart of #raquet_band_pixel_type()
  * @note The name is read without regard to case, so a name written either way
- * carries into the constructors. The name #raquet_pixtype() returns is the one
+ * carries into the constructors. The name #raquet_band_pixel_type() returns is the one
  * the RaQuet specification writes, in lower case, so it compares equal to the
  * `type` field of the tile a file holds
  * @note The name PostGIS raster gives a pixel type is accepted for the same
@@ -705,37 +705,60 @@ raquet_height(const Raquet *rq)
 
 /**
  * @ingroup meos_raster_base_accessor
- * @brief Return the nodata sentinel value of a Raquet tile
- * @errval DBL_MAX
- * @csqlfn #Raquet_nodata()
- */
-double
-raquet_nodata(const Raquet *rq)
-{
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rq, DBL_MAX);
-  return rq->nodata;
-}
-
-/**
- * @ingroup meos_raster_base_accessor
- * @brief Return the name of the pixel data type of a Raquet tile
+ * @brief Return the name of the pixel data type of the band of a Raquet tile
  * @param[in] rq Raquet tile
  * @errval NULL
  * @note The returned name is the one the RaQuet specification writes for the
  * type, that is, one of uint8, int8, uint16, int16, uint32, int32, uint64,
  * int64, float16, float32, or float64, so it compares equal to the `type`
  * field of the tile a RaQuet file holds
- * @csqlfn #Raquet_pixtype()
+ * @csqlfn #Raquet_band_pixel_type()
  */
 char *
-raquet_pixtype(const Raquet *rq)
+raquet_band_pixel_type(const Raquet *rq)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(rq, NULL);
   if (! ensure_valid_pixtype(rq->pixtype))
     return NULL;
   return pstrdup(MEOS_PIXTYPE_CATALOG[rq->pixtype].name);
+}
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return whether the band of a Raquet tile states a nodata value
+ * @param[in] rq Raquet tile
+ * @errval false
+ * @csqlfn #Raquet_band_has_nodata_value()
+ */
+bool
+raquet_band_has_nodata_value(const Raquet *rq)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rq, false);
+  return rq->has_nodata;
+}
+
+/**
+ * @ingroup meos_raster_base_accessor
+ * @brief Return in the last argument the nodata value of the band of a Raquet
+ * tile
+ * @param[in] rq Raquet tile
+ * @param[out] result Result
+ * @return True when the value is written, false when the band states no
+ * nodata value
+ * @errval false
+ * @csqlfn #Raquet_band_nodata_value()
+ */
+bool
+raquet_band_nodata_value(const Raquet *rq, double *result)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rq, false); VALIDATE_NOT_NULL(result, false);
+  if (! rq->has_nodata)
+    return false;
+  *result = rq->nodata;
+  return true;
 }
 
 /**

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -338,6 +338,7 @@ raster_num_bands(const Raster *rast)
  * @brief Return the width in pixels of a raster
  * @param[in] rast Raster
  * @errval INT_MAX
+ * @csqlfn #Raster_width()
  */
 int
 raster_width(const Raster *rast)
@@ -357,6 +358,7 @@ raster_width(const Raster *rast)
  * @brief Return the height in pixels of a raster
  * @param[in] rast Raster
  * @errval INT_MAX
+ * @csqlfn #Raster_height()
  */
 int
 raster_height(const Raster *rast)
@@ -376,6 +378,7 @@ raster_height(const Raster *rast)
  * @brief Return the spatial reference system identifier of a raster
  * @param[in] rast Raster
  * @errval SRID_INVALID
+ * @csqlfn #Raster_srid()
  */
 int32_t
 raster_srid(const Raster *rast)
@@ -398,6 +401,7 @@ raster_srid(const Raster *rast)
  * @note This is the origin the geotransform states, which the skew rotates
  * the grid about, so it is a corner of the extent only when both skews are
  * zero
+ * @csqlfn #Raster_upper_left_x()
  */
 double
 raster_upper_left_x(const Raster *rast)
@@ -420,6 +424,7 @@ raster_upper_left_x(const Raster *rast)
  * @note This is the origin the geotransform states, which the skew rotates
  * the grid about, so it is a corner of the extent only when both skews are
  * zero
+ * @csqlfn #Raster_upper_left_y()
  */
 double
 raster_upper_left_y(const Raster *rast)
@@ -439,6 +444,7 @@ raster_upper_left_y(const Raster *rast)
  * @brief Return the pixel width of a raster, that is, the X component of its scale
  * @param[in] rast Raster
  * @errval DBL_MAX
+ * @csqlfn #Raster_scale_x()
  */
 double
 raster_scale_x(const Raster *rast)
@@ -460,6 +466,7 @@ raster_scale_x(const Raster *rast)
  * @errval DBL_MAX
  * @note The value is negative for a grid whose rows run north to south,
  * which is how a raster is ordinarily written
+ * @csqlfn #Raster_scale_y()
  */
 double
 raster_scale_y(const Raster *rast)
@@ -481,6 +488,7 @@ raster_scale_y(const Raster *rast)
  * @errval DBL_MAX
  * @note A raster whose two skews are zero is axis-aligned, so a reader that
  * assumes an axis-aligned grid states the assumption by testing them
+ * @csqlfn #Raster_skew_x()
  */
 double
 raster_skew_x(const Raster *rast)
@@ -502,6 +510,7 @@ raster_skew_x(const Raster *rast)
  * @errval DBL_MAX
  * @note A raster whose two skews are zero is axis-aligned, so a reader that
  * assumes an axis-aligned grid states the assumption by testing them
+ * @csqlfn #Raster_skew_y()
  */
 double
 raster_skew_y(const Raster *rast)

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -52,6 +52,7 @@
 #endif
 
 #include "librtcore.h"
+#include "rt_serialize.h"
 
 /* C */
 #include <ctype.h>
@@ -133,6 +134,7 @@ raster_serialize_destroy(rt_raster raster)
  * @param[in] wkb WKB string
  * @param[in] size Size of the string
  * @errval NULL
+ * @csqlfn #Raster_from_wkb()
  */
 Raster *
 raster_from_wkb(const uint8_t *wkb, size_t size)
@@ -157,6 +159,7 @@ raster_from_wkb(const uint8_t *wkb, size_t size)
  * (HexWKB) representation
  * @param[in] hexwkb HexWKB string
  * @errval NULL
+ * @csqlfn #Raster_from_hexwkb()
  */
 Raster *
 raster_from_hexwkb(const char *hexwkb)
@@ -176,17 +179,133 @@ raster_from_hexwkb(const char *hexwkb)
 }
 
 /**
- * @ingroup meos_raster_base_inout
- * @brief Return the Well-Known Binary (WKB) representation of a raster
+ * @brief Return true when a Well-Known Binary variant asks for the
+ * little-endian byte order, the order of the machine when it names neither
+ * order or both, as #datum_as_wkb() reads it
+ * @param[in] variant Output variant
+ */
+static bool
+raster_wkb_little_endian(uint8_t variant)
+{
+  bool ndr = (variant & WKB_NDR) != 0;
+  bool xdr = (variant & WKB_XDR) != 0;
+  if (ndr != xdr)
+    return ndr;
+  return ! MEOS_IS_BIG_ENDIAN;
+}
+
+/**
+ * @brief Reverse in place the bytes of a value
+ * @param[in,out] ptr First byte of the value
+ * @param[in] size Number of bytes of the value
+ */
+static void
+raster_wkb_flip(uint8_t *ptr, size_t size)
+{
+  for (size_t i = 0, j = size - 1; i < j; i++, j--)
+  {
+    uint8_t b = ptr[i];
+    ptr[i] = ptr[j];
+    ptr[j] = b;
+  }
+}
+
+/**
+ * @brief Return the unsigned 16-bit integer at a position of a Well-Known
+ * Binary representation, read in the byte order the representation states
+ * @param[in] ptr First byte of the integer
+ * @param[in] little True when the representation is little-endian
+ */
+static uint16_t
+raster_wkb_uint16(const uint8_t *ptr, bool little)
+{
+  return little ? (uint16_t) (ptr[0] | (ptr[1] << 8)) :
+    (uint16_t) ((ptr[0] << 8) | ptr[1]);
+}
+
+/**
+ * @brief Rewrite in place the Well-Known Binary representation of a raster
+ * from the byte order it states into the other one
+ * @details The layout is the one rt_raster_to_wkb() writes: the byte order,
+ * a header of fixed-width fields, and for each band a byte stating its pixel
+ * type and flags, a nodata value as wide as a pixel, and either its pixels or,
+ * for a band stored outside the database, a band number and a path, which are
+ * bytes rather than numbers
+ * @param[in,out] wkb Well-Known Binary representation
+ * @param[in] size Size of the representation
+ * @return False when the representation ends before the layout it states
+ */
+static bool
+raster_wkb_swap(uint8_t *wkb, size_t size)
+{
+  /* Byte order, version, number of bands, the six numbers of the
+   * geotransform, SRID, width and height */
+  static const size_t header[] = {1, 2, 2, 8, 8, 8, 8, 8, 8, 4, 2, 2};
+  const size_t nheader = sizeof(header) / sizeof(header[0]);
+  size_t hsize = 0;
+  for (size_t i = 0; i < nheader; i++)
+    hsize += header[i];
+  if (size < hsize)
+    return false;
+  bool little = (wkb[0] != 0);
+  uint16_t nbands = raster_wkb_uint16(wkb + 3, little);
+  uint16_t width = raster_wkb_uint16(wkb + hsize - 4, little);
+  uint16_t height = raster_wkb_uint16(wkb + hsize - 2, little);
+  wkb[0] = little ? 0 : 1;
+  size_t pos = header[0];
+  for (size_t i = 1; i < nheader; i++)
+  {
+    raster_wkb_flip(wkb + pos, header[i]);
+    pos += header[i];
+  }
+  size_t npixels = (size_t) width * height;
+  for (uint16_t b = 0; b < nbands; b++)
+  {
+    if (pos >= size)
+      return false;
+    uint8_t flags = wkb[pos++];
+    int pixbytes = rt_pixtype_size((rt_pixtype) BANDTYPE_PIXTYPE(flags));
+    if (pixbytes < 1 || size - pos < (size_t) pixbytes)
+      return false;
+    raster_wkb_flip(wkb + pos, (size_t) pixbytes);
+    pos += (size_t) pixbytes;
+    if (BANDTYPE_IS_OFFDB(flags))
+    {
+      /* The band number is one byte and the path a null-terminated string */
+      if (pos >= size)
+        return false;
+      pos++;
+      const uint8_t *nul = memchr(wkb + pos, '\0', size - pos);
+      if (! nul)
+        return false;
+      pos = (size_t) (nul - wkb) + 1;
+    }
+    else
+    {
+      if ((size - pos) / (size_t) pixbytes < npixels)
+        return false;
+      if (pixbytes > 1)
+      {
+        for (size_t k = 0; k < npixels; k++)
+          raster_wkb_flip(wkb + pos + k * (size_t) pixbytes, (size_t) pixbytes);
+      }
+      pos += npixels * (size_t) pixbytes;
+    }
+  }
+  return pos == size;
+}
+
+/**
+ * @brief Return the Well-Known Binary representation of a raster in the byte
+ * order a variant asks for
  * @param[in] rast Raster
+ * @param[in] variant Output variant
  * @param[out] size_out Size of the output
  * @errval NULL
  */
-uint8_t *
-raster_as_wkb(const Raster *rast, size_t *size_out)
+static uint8_t *
+raster_wkb(const Raster *rast, uint8_t variant, size_t *size_out)
 {
-  /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rast, NULL); VALIDATE_NOT_NULL(size_out, NULL);
   /* The bands are needed, so the raster is fully deserialized. It keeps
    * pointers into `rast` without owning them, and is destroyed below before
    * `rast` is handed back to the caller */
@@ -198,13 +317,28 @@ raster_as_wkb(const Raster *rast, size_t *size_out)
     return NULL;
   }
   uint32_t wkb_size;
-  uint8_t *result = rt_raster_to_wkb(raster, 0, &wkb_size);
+  uint8_t *wkb = rt_raster_to_wkb(raster, 0, &wkb_size);
   raster_destroy(raster);
-  if (! result)
+  if (! wkb)
   {
     meos_error(ERROR, MEOS_ERR_WKB_OUTPUT,
       "Could not output the Well-Known Binary (WKB) representation of a "
       "raster");
+    return NULL;
+  }
+  /* rt_core writes the byte order of the machine in memory it allocates
+   * itself, so the bytes move to memory the caller releases as it releases
+   * any other result, in the byte order asked for */
+  uint8_t *result = palloc(wkb_size);
+  memcpy(result, wkb, wkb_size);
+  rtdealloc(wkb);
+  if (raster_wkb_little_endian(variant) != (result[0] != 0) &&
+      ! raster_wkb_swap(result, (size_t) wkb_size))
+  {
+    pfree(result);
+    meos_error(ERROR, MEOS_ERR_WKB_OUTPUT,
+      "Could not output the Well-Known Binary (WKB) representation of a "
+      "raster in the byte order asked for");
     return NULL;
   }
   *size_out = (size_t) wkb_size;
@@ -213,35 +347,52 @@ raster_as_wkb(const Raster *rast, size_t *size_out)
 
 /**
  * @ingroup meos_raster_base_inout
- * @brief Return the ASCII hex-encoded Well-Known Binary (HexWKB)
- * representation of a raster
+ * @brief Return the Well-Known Binary (WKB) representation of a raster
  * @param[in] rast Raster
- * @param[out] size_out Size of the output, not counting the null terminator
+ * @param[in] variant Output variant, whose WKB_NDR or WKB_XDR flag names the
+ * byte order, the order of the machine when it names neither
+ * @param[out] size_out Size of the output
  * @errval NULL
+ * @csqlfn #Raster_as_wkb()
  */
-char *
-raster_as_hexwkb(const Raster *rast, size_t *size_out)
+uint8_t *
+raster_as_wkb(const Raster *rast, uint8_t variant, size_t *size_out)
 {
   /* Ensure the validity of the arguments */
   VALIDATE_NOT_NULL(rast, NULL); VALIDATE_NOT_NULL(size_out, NULL);
-  rt_raster raster = rt_raster_deserialize((void *) rast, 0);
-  if (! raster)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "Could not deserialize raster");
+  return raster_wkb(rast, variant, size_out);
+}
+
+/**
+ * @ingroup meos_raster_base_inout
+ * @brief Return the ASCII hex-encoded Well-Known Binary (HexWKB)
+ * representation of a raster
+ * @param[in] rast Raster
+ * @param[in] variant Output variant, whose WKB_NDR or WKB_XDR flag names the
+ * byte order, the order of the machine when it names neither
+ * @param[out] size_out Size of the output, not counting the null terminator
+ * @errval NULL
+ * @csqlfn #Raster_as_hexwkb()
+ */
+char *
+raster_as_hexwkb(const Raster *rast, uint8_t variant, size_t *size_out)
+{
+  /* Ensure the validity of the arguments */
+  VALIDATE_NOT_NULL(rast, NULL); VALIDATE_NOT_NULL(size_out, NULL);
+  size_t wkb_size;
+  uint8_t *wkb = raster_wkb(rast, variant, &wkb_size);
+  if (! wkb)
     return NULL;
-  }
-  uint32_t hexwkb_size;
-  char *result = rt_raster_to_hexwkb(raster, 0, &hexwkb_size);
-  raster_destroy(raster);
-  if (! result)
+  static const char hexchr[] = "0123456789ABCDEF";
+  char *result = palloc(2 * wkb_size + 1);
+  for (size_t i = 0; i < wkb_size; i++)
   {
-    meos_error(ERROR, MEOS_ERR_WKB_OUTPUT,
-      "Could not output the ASCII hex-encoded Well-Known Binary (HexWKB) "
-      "representation of a raster");
-    return NULL;
+    result[2 * i] = hexchr[wkb[i] >> 4];
+    result[2 * i + 1] = hexchr[wkb[i] & 0x0F];
   }
-  *size_out = (size_t) hexwkb_size;
+  result[2 * wkb_size] = '\0';
+  pfree(wkb);
+  *size_out = 2 * wkb_size;
   return result;
 }
 

--- a/meos/src/raster/raster_rtcore.c
+++ b/meos/src/raster/raster_rtcore.c
@@ -532,10 +532,11 @@ raster_skew_y(const Raster *rast)
  * @param[in] band Band number (1-based)
  * @errval NULL
  * @note The name returned is the one the RaQuet specification writes, which is
- * what #raquet_pixtype() answers for a tile, so a band and a tile of the same
- * type report the same name. The PostGIS spelling is read through
+ * what #raquet_band_pixel_type() answers for a tile, so a band and a tile of
+ * the same type report the same name. The PostGIS spelling is read through
  * #raquet_pixtype_from_string(), so the one catalog states both vocabularies
  * and `1BB`, `2BUI` and `4BUI` report the `uint8` their bytes already are
+ * @csqlfn #Raster_band_pixel_type()
  */
 char *
 raster_band_pixel_type(const Raster *rast, int band)
@@ -567,6 +568,7 @@ raster_band_pixel_type(const Raster *rast, int band)
  * @errval false
  * @note A band that states none has no pixel to exclude, so every pixel it
  * holds carries a value
+ * @csqlfn #Raster_band_has_nodata_value()
  */
 bool
 raster_band_has_nodata_value(const Raster *rast, int band)
@@ -584,32 +586,31 @@ raster_band_has_nodata_value(const Raster *rast, int band)
 
 /**
  * @ingroup meos_raster_base_accessor
- * @brief Return the nodata value of a raster band
+ * @brief Return in the last argument the nodata value of a raster band
  * @param[in] rast Raster
  * @param[in] band Band number (1-based)
- * @errval DBL_MAX
- * @note A band stating no nodata value has none to return, which is an error
- * rather than a value: test it with #raster_band_has_nodata_value()
+ * @param[out] result Result
+ * @return True when the value is written, false when the band states no
+ * nodata value
+ * @errval false
+ * @csqlfn #Raster_band_nodata_value()
  */
-double
-raster_band_nodata_value(const Raster *rast, int band)
+bool
+raster_band_nodata_value(const Raster *rast, int band, double *result)
 {
   /* Ensure the validity of the arguments */
-  VALIDATE_NOT_NULL(rast, DBL_MAX);
+  VALIDATE_NOT_NULL(rast, false); VALIDATE_NOT_NULL(result, false);
   rt_raster raster;
   rt_band rtband = raster_band_of(rast, band, &raster);
   if (! rtband)
-    return DBL_MAX;
-  double result;
-  rt_errorstate state = rt_band_get_nodata(rtband, &result);
+    return false;
+  /* rt_band_get_nodata() reports an error for a band stating no nodata value,
+   * which is an answer here rather than an error, so the flag is read first */
+  bool found = (rt_band_get_hasnodata_flag(rtband) != 0);
+  if (found)
+    rt_band_get_nodata(rtband, result);
   raster_destroy(raster);
-  if (state != ES_NONE)
-  {
-    meos_error(ERROR, MEOS_ERR_INVALID_ARG_VALUE,
-      "Band %d of the raster states no nodata value", band);
-    return DBL_MAX;
-  }
-  return result;
+  return found;
 }
 
 /*****************************************************************************

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -179,9 +179,10 @@ int main(void)
   Raster *withnodata = raster_from_hexwkb(raster_values);
   assert(withnodata != NULL);
   assert(raster_band_has_nodata_value(withnodata, 1));
-  assert(raster_band_nodata_value(withnodata, 1) == -9999.0);
-  printf("raster_band_nodata_value(values, 1): %g\n",
-    raster_band_nodata_value(withnodata, 1));
+  double nodata = 0.0;
+  assert(raster_band_nodata_value(withnodata, 1, &nodata));
+  assert(nodata == -9999.0);
+  printf("raster_band_nodata_value(values, 1): %g\n", nodata);
   assert(meos_errno() == 0);
 
   /* A band number outside the bands the raster holds is an error, on either
@@ -192,9 +193,13 @@ int main(void)
   meos_errno_reset();
   assert(raster_band_pixel_type(shape, 2) == NULL);
   assert(meos_errno() != 0);
+  /* A band stating no nodata value answers false with no error and leaves the
+   * result where it stands, as a box without X answers its xmin */
   meos_errno_reset();
-  assert(raster_band_nodata_value(shape, 1) == DBL_MAX);
-  assert(meos_errno() != 0);
+  nodata = 0.0;
+  assert(! raster_band_nodata_value(shape, 1, &nodata));
+  assert(nodata == 0.0);
+  assert(meos_errno() == 0);
   meos_errno_reset();
 
   free(shape); free(withnodata);
@@ -246,7 +251,7 @@ int main(void)
   assert(! raster_band_has_nodata_value(NULL, 1));
   assert(meos_errno() != 0);
   meos_errno_reset();
-  assert(raster_band_nodata_value(NULL, 1) == DBL_MAX);
+  assert(! raster_band_nodata_value(NULL, 1, &nodata));
   assert(meos_errno() != 0);
   meos_errno_reset();
   assert(raster_to_stbox(NULL) == NULL);

--- a/meos/test/raster_test.c
+++ b/meos/test/raster_test.c
@@ -108,7 +108,7 @@ int main(void)
 
     /* The HexWKB output is read back into a raster with the same bands */
     size_t hexwkb_size;
-    char *hexwkb = raster_as_hexwkb(rast, &hexwkb_size);
+    char *hexwkb = raster_as_hexwkb(rast, 0, &hexwkb_size);
     assert(hexwkb != NULL);
     assert(hexwkb_size == strlen(hexwkb));
     Raster *rast1 = raster_from_hexwkb(hexwkb);
@@ -118,13 +118,34 @@ int main(void)
     /* The binary output round trips likewise, and the two representations
      * encode the same bytes */
     size_t wkb_size;
-    uint8_t *wkb = raster_as_wkb(rast, &wkb_size);
+    uint8_t *wkb = raster_as_wkb(rast, 0, &wkb_size);
     assert(wkb != NULL);
     assert(wkb_size * 2 == hexwkb_size);
     Raster *rast2 = raster_from_wkb(wkb, wkb_size);
     assert(rast2 != NULL);
     assert(raster_num_bands(rast2) == nbands);
     assert(meos_errno() == 0);
+
+    /* Either byte order round trips, and the first byte states the one asked
+     * for. The other order rewrites every field, so the two representations
+     * differ beyond their first byte while reading back the same raster */
+    size_t ndr_size, xdr_size, back_size;
+    uint8_t *ndr = raster_as_wkb(rast, WKB_NDR, &ndr_size);
+    uint8_t *xdr = raster_as_wkb(rast, WKB_XDR, &xdr_size);
+    assert(ndr != NULL && xdr != NULL && ndr_size == xdr_size);
+    assert(ndr[0] == 1 && xdr[0] == 0);
+    assert(memcmp(ndr + 1, xdr + 1, ndr_size - 1) != 0);
+    Raster *rast3 = raster_from_wkb(xdr, xdr_size);
+    assert(rast3 != NULL && raster_num_bands(rast3) == nbands);
+    uint8_t *back = raster_as_wkb(rast3, WKB_NDR, &back_size);
+    assert(back != NULL && back_size == ndr_size);
+    assert(memcmp(back, ndr, ndr_size) == 0);
+    char *xdrhex = raster_as_hexwkb(rast, WKB_XDR, &hexwkb_size);
+    assert(xdrhex != NULL && strncmp(xdrhex, "00", 2) == 0);
+    assert(meos_errno() == 0);
+    printf("raster_as_wkb(#%d): %zu bytes in either byte order\n", i + 1,
+      ndr_size);
+    free(ndr); free(xdr); free(back); free(xdrhex); free(rast3);
 
     free(hexwkb); free(wkb); free(rast); free(rast1); free(rast2);
   }
@@ -257,10 +278,10 @@ int main(void)
   assert(raster_to_stbox(NULL) == NULL);
   assert(meos_errno() != 0);
   meos_errno_reset();
-  assert(raster_as_wkb(NULL, &size) == NULL);
+  assert(raster_as_wkb(NULL, 0, &size) == NULL);
   assert(meos_errno() != 0);
   meos_errno_reset();
-  assert(raster_as_hexwkb(NULL, &size) == NULL);
+  assert(raster_as_hexwkb(NULL, 0, &size) == NULL);
   assert(meos_errno() != 0);
 
   /* A raster is read against the length it is given, so every truncation of a
@@ -269,7 +290,7 @@ int main(void)
   size_t wkb_size;
   Raster *rast = raster_from_hexwkb(raster_one_band);
   assert(rast != NULL);
-  uint8_t *wkb = raster_as_wkb(rast, &wkb_size);
+  uint8_t *wkb = raster_as_wkb(rast, 0, &wkb_size);
   assert(wkb != NULL);
   for (size_t trunc = 0; trunc < wkb_size; trunc++)
   {

--- a/mobilitydb/pg_include/pg_temporal/temporal.h
+++ b/mobilitydb/pg_include/pg_temporal/temporal.h
@@ -198,6 +198,7 @@ extern interpType input_interp_string(FunctionCallInfo fcinfo, int argno);
 extern Temporal *temporal_recv(StringInfo buf);
 extern void temporal_write(const Temporal *temp, StringInfo buf);
 
+extern uint8_t get_endian_variant(const text *txt);
 extern bytea *Datum_as_wkb(FunctionCallInfo fcinfo, Datum value, MeosType type,
   bool extended);
 extern text *Datum_as_hexwkb(FunctionCallInfo fcinfo, Datum value,

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -430,6 +430,44 @@ CREATE FUNCTION skewY(raster)
   AS 'MODULE_PATHNAME', 'Raster_skew_y'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/******************************************************************************
+ * Bands of a raster
+ *****************************************************************************/
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the name of the pixel data type of a raster band
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ */
+CREATE FUNCTION bandPixelType(raster, integer DEFAULT 1)
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Raster_band_pixel_type'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return whether a raster band states a nodata value
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ */
+CREATE FUNCTION bandHasNoDataValue(raster, integer DEFAULT 1)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Raster_band_has_nodata_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the nodata value of a raster band, or NULL when the band
+ * states none
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ */
+CREATE FUNCTION bandNoDataValue(raster, integer DEFAULT 1)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raster_band_nodata_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /**
  * @ingroup mobilitydb_raster
  * @brief Return a raster whose band states the classes an expression maps its
@@ -534,13 +572,17 @@ CREATE FUNCTION height(raquet)
   RETURNS integer
   AS 'MODULE_PATHNAME', 'Raquet_height'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION nodata(raquet)
-  RETURNS float8
-  AS 'MODULE_PATHNAME', 'Raquet_nodata'
-  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
-CREATE FUNCTION pixtype(raquet)
+CREATE FUNCTION bandPixelType(raquet)
   RETURNS text
-  AS 'MODULE_PATHNAME', 'Raquet_pixtype'
+  AS 'MODULE_PATHNAME', 'Raquet_band_pixel_type'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION bandHasNoDataValue(raquet)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Raquet_band_has_nodata_value'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+CREATE FUNCTION bandNoDataValue(raquet)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raquet_band_nodata_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 CREATE FUNCTION pixels(raquet)
   RETURNS bytea

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -334,6 +334,102 @@ CREATE FUNCTION numBands(raster)
   AS 'MODULE_PATHNAME', 'Raster_num_bands'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+/******************************************************************************
+ * Shape of a raster
+ *****************************************************************************/
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the width in pixels of a raster
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION width(raster)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Raster_width'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the height in pixels of a raster
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION height(raster)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Raster_height'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the spatial reference system identifier of a raster
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION SRID(raster)
+  RETURNS integer
+  AS 'MODULE_PATHNAME', 'Raster_srid'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the X coordinate of the upper left corner of a raster
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION upperLeftX(raster)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raster_upper_left_x'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the Y coordinate of the upper left corner of a raster
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION upperLeftY(raster)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raster_upper_left_y'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the pixel width of a raster, that is, the X component of its
+ * scale
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION scaleX(raster)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raster_scale_x'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the pixel height of a raster, that is, the Y component of its
+ * scale
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION scaleY(raster)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raster_scale_y'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the X component of the skew of a raster
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION skewX(raster)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raster_skew_x'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the Y component of the skew of a raster
+ * @param[in] rast Raster
+ */
+CREATE FUNCTION skewY(raster)
+  RETURNS float8
+  AS 'MODULE_PATHNAME', 'Raster_skew_y'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
 /**
  * @ingroup mobilitydb_raster
  * @brief Return a raster whose band states the classes an expression maps its
@@ -564,10 +660,8 @@ CREATE CAST (raquet AS stbox) WITH FUNCTION stbox(raquet);
 /******************************************************************************
  * Conversions of rasters
  *
- * A raster states its shape through PostGIS raster's own accessors, which this
- * extension does not restate. The spatiotemporal box is the exception: PostGIS
- * has no stbox, so this conversion adds the temporal layer's box to the raster
- * a user already holds rather than re-supplying an accessor they have.
+ * PostGIS has no stbox, so this conversion adds the temporal layer's box to
+ * the raster a user already holds.
  *****************************************************************************/
 
 /**

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -468,6 +468,38 @@ CREATE FUNCTION bandNoDataValue(raster, integer DEFAULT 1)
   AS 'MODULE_PATHNAME', 'Raster_band_nodata_value'
   LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
 
+-- GENERATED-REPRESENTATIONS-BEGIN raster_base — tools/codegen/inherited/generate.py from templates/representations.sql.tmpl;
+-- DO NOT EDIT BY HAND; edit the template + manifest.d/representation_families.yaml and re-run.
+/******************************************************************************
+ * Well-Known Binary representations of a raster
+ *
+ * A raster round-trips through the Well-Known Binary PostGIS writes for it,
+ * in the byte order asked for, so a binding reads and writes the rasters of a
+ * PostGIS column with no PostgreSQL in between.
+ ******************************************************************************/
+
+CREATE FUNCTION rasterFromBinary(bytea)
+  RETURNS raster
+  AS 'MODULE_PATHNAME', 'Raster_from_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION rasterFromHexWKB(text)
+  RETURNS raster
+  AS 'MODULE_PATHNAME', 'Raster_from_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asBinary(raster, endian text DEFAULT '')
+  RETURNS bytea
+  AS 'MODULE_PATHNAME', 'Raster_as_wkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+CREATE FUNCTION asHexWKB(raster, endian text DEFAULT '')
+  RETURNS text
+  AS 'MODULE_PATHNAME', 'Raster_as_hexwkb'
+  LANGUAGE C IMMUTABLE STRICT PARALLEL SAFE;
+
+-- GENERATED-REPRESENTATIONS-END raster_base
+
 /**
  * @ingroup mobilitydb_raster
  * @brief Return a raster whose band states the classes an expression maps its

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -453,6 +453,91 @@ Raster_band_nodata_value(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
+ * Well-Known Binary representations of a raster
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_from_wkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_from_wkb);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster from its Well-Known Binary (WKB) representation
+ * @sqlfn rasterFromBinary()
+ */
+Datum
+Raster_from_wkb(PG_FUNCTION_ARGS)
+{
+  bytea *bytea_wkb = PG_GETARG_BYTEA_P(0);
+  uint8_t *wkb = (uint8_t *) VARDATA(bytea_wkb);
+  Raster *result = raster_from_wkb(wkb, VARSIZE(bytea_wkb) - VARHDRSZ);
+  PG_FREE_IF_COPY(bytea_wkb, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Raster_from_hexwkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_from_hexwkb);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a raster from its ASCII hex-encoded Well-Known Binary
+ * (HexWKB) representation
+ * @sqlfn rasterFromHexWKB()
+ */
+Datum
+Raster_from_hexwkb(PG_FUNCTION_ARGS)
+{
+  text *hexwkb_text = PG_GETARG_TEXT_P(0);
+  char *hexwkb = text_to_cstring(hexwkb_text);
+  Raster *result = raster_from_hexwkb(hexwkb);
+  pfree(hexwkb);
+  PG_FREE_IF_COPY(hexwkb_text, 0);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Raster_as_wkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_as_wkb);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the Well-Known Binary (WKB) representation of a raster
+ * @sqlfn asBinary()
+ */
+Datum
+Raster_as_wkb(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  uint8_t variant = get_endian_variant(PG_GETARG_TEXT_P(1));
+  size_t wkb_size;
+  uint8_t *wkb = raster_as_wkb(rast, variant, &wkb_size);
+  bytea *result = bstring2bytea(wkb, wkb_size);
+  pfree(wkb);
+  PG_RETURN_BYTEA_P(result);
+}
+
+PGDLLEXPORT Datum Raster_as_hexwkb(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_as_hexwkb);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the ASCII hex-encoded Well-Known Binary (HexWKB)
+ * representation of a raster
+ * @sqlfn asHexWKB()
+ */
+Datum
+Raster_as_hexwkb(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  uint8_t variant = get_endian_variant(PG_GETARG_TEXT_P(1));
+  size_t hexwkb_size;
+  char *hexwkb = raster_as_hexwkb(rast, variant, &hexwkb_size);
+  text *result = cstring_to_text(hexwkb);
+  pfree(hexwkb);
+  PG_RETURN_TEXT_P(result);
+}
+
+/*****************************************************************************
  * raster_reclass
  *****************************************************************************/
 

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -387,6 +387,72 @@ Raster_skew_y(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
+ * Bands of a raster
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_band_pixel_type(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_band_pixel_type);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the name of the pixel data type of a raster band
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @sqlfn bandPixelType()
+ */
+Datum
+Raster_band_pixel_type(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int band = PG_GETARG_INT32(1);
+  char *str = raster_band_pixel_type(rast, band);
+  text *result = cstring_to_text(str);
+  pfree(str);
+  PG_RETURN_TEXT_P(result);
+}
+
+PGDLLEXPORT Datum Raster_band_has_nodata_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_band_has_nodata_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return whether a raster band states a nodata value
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @sqlfn bandHasNoDataValue()
+ */
+Datum
+Raster_band_has_nodata_value(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int band = PG_GETARG_INT32(1);
+  bool result = raster_band_has_nodata_value(rast, band);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Raster_band_nodata_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_band_nodata_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the nodata value of a raster band, or NULL when the band
+ * states none
+ * @param[in] rast Raster
+ * @param[in] band Number of the band, starting at 1
+ * @sqlfn bandNoDataValue()
+ */
+Datum
+Raster_band_nodata_value(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int band = PG_GETARG_INT32(1);
+  double result;
+  if (! raster_band_nodata_value(rast, band, &result))
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
+}
+
+/*****************************************************************************
  * raster_reclass
  *****************************************************************************/
 
@@ -1030,38 +1096,58 @@ Raquet_height(PG_FUNCTION_ARGS)
   PG_RETURN_INT32(result);
 }
 
-PGDLLEXPORT Datum Raquet_nodata(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Raquet_nodata);
+PGDLLEXPORT Datum Raquet_band_pixel_type(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_band_pixel_type);
 /**
  * @ingroup mobilitydb_raster
- * @brief Return the nodata sentinel value of a Raquet tile
- * @sqlfn nodata()
+ * @brief Return the name of the pixel data type of the band of a Raquet tile
+ * @sqlfn bandPixelType()
  */
 Datum
-Raquet_nodata(PG_FUNCTION_ARGS)
+Raquet_band_pixel_type(PG_FUNCTION_ARGS)
 {
   Raquet *rq = PG_GETARG_RAQUET_P(0);
-  double result = raquet_nodata(rq);
-  PG_FREE_IF_COPY(rq, 0);
-  PG_RETURN_FLOAT8(result);
-}
-
-PGDLLEXPORT Datum Raquet_pixtype(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Raquet_pixtype);
-/**
- * @ingroup mobilitydb_raster
- * @brief Return the name of the pixel data type of a Raquet tile
- * @sqlfn pixtype()
- */
-Datum
-Raquet_pixtype(PG_FUNCTION_ARGS)
-{
-  Raquet *rq = PG_GETARG_RAQUET_P(0);
-  char *str = raquet_pixtype(rq);
+  char *str = raquet_band_pixel_type(rq);
   text *result = cstring_to_text(str);
   pfree(str);
   PG_FREE_IF_COPY(rq, 0);
   PG_RETURN_TEXT_P(result);
+}
+
+PGDLLEXPORT Datum Raquet_band_has_nodata_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_band_has_nodata_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return whether the band of a Raquet tile states a nodata value
+ * @sqlfn bandHasNoDataValue()
+ */
+Datum
+Raquet_band_has_nodata_value(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  bool result = raquet_band_has_nodata_value(rq);
+  PG_FREE_IF_COPY(rq, 0);
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Raquet_band_nodata_value(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_band_nodata_value);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the nodata value of the band of a Raquet tile, or NULL when
+ * the band states none
+ * @sqlfn bandNoDataValue()
+ */
+Datum
+Raquet_band_nodata_value(PG_FUNCTION_ARGS)
+{
+  Raquet *rq = PG_GETARG_RAQUET_P(0);
+  double result;
+  bool found = raquet_band_nodata_value(rq, &result);
+  PG_FREE_IF_COPY(rq, 0);
+  if (! found)
+    PG_RETURN_NULL();
+  PG_RETURN_FLOAT8(result);
 }
 
 PGDLLEXPORT Datum Raquet_pixels(PG_FUNCTION_ARGS);

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -228,6 +228,165 @@ Raster_num_bands(PG_FUNCTION_ARGS)
 }
 
 /*****************************************************************************
+ * Shape of a raster
+ *****************************************************************************/
+
+PGDLLEXPORT Datum Raster_width(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_width);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the width in pixels of a raster
+ * @param[in] rast Raster
+ * @sqlfn width()
+ */
+Datum
+Raster_width(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int result = raster_width(rast);
+  PG_RETURN_INT32(result);
+}
+
+PGDLLEXPORT Datum Raster_height(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_height);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the height in pixels of a raster
+ * @param[in] rast Raster
+ * @sqlfn height()
+ */
+Datum
+Raster_height(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int result = raster_height(rast);
+  PG_RETURN_INT32(result);
+}
+
+PGDLLEXPORT Datum Raster_srid(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_srid);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the spatial reference system identifier of a raster
+ * @param[in] rast Raster
+ * @sqlfn SRID()
+ */
+Datum
+Raster_srid(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  int32_t result = raster_srid(rast);
+  PG_RETURN_INT32(result);
+}
+
+PGDLLEXPORT Datum Raster_upper_left_x(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_upper_left_x);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the X coordinate of the upper left corner of a raster
+ * @param[in] rast Raster
+ * @sqlfn upperLeftX()
+ */
+Datum
+Raster_upper_left_x(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  double result = raster_upper_left_x(rast);
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Raster_upper_left_y(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_upper_left_y);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the Y coordinate of the upper left corner of a raster
+ * @param[in] rast Raster
+ * @sqlfn upperLeftY()
+ */
+Datum
+Raster_upper_left_y(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  double result = raster_upper_left_y(rast);
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Raster_scale_x(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_scale_x);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the pixel width of a raster, that is, the X component of its
+ * scale
+ * @param[in] rast Raster
+ * @sqlfn scaleX()
+ */
+Datum
+Raster_scale_x(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  double result = raster_scale_x(rast);
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Raster_scale_y(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_scale_y);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the pixel height of a raster, that is, the Y component of its
+ * scale
+ * @param[in] rast Raster
+ * @sqlfn scaleY()
+ */
+Datum
+Raster_scale_y(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  double result = raster_scale_y(rast);
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Raster_skew_x(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_skew_x);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the X component of the skew of a raster
+ * @param[in] rast Raster
+ * @sqlfn skewX()
+ */
+Datum
+Raster_skew_x(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  double result = raster_skew_x(rast);
+  PG_RETURN_FLOAT8(result);
+}
+
+PGDLLEXPORT Datum Raster_skew_y(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_skew_y);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the Y component of the skew of a raster
+ * @param[in] rast Raster
+ * @sqlfn skewY()
+ */
+Datum
+Raster_skew_y(PG_FUNCTION_ARGS)
+{
+  Datum rast_datum = PG_GETARG_DATUM(0);
+  Raster *rast = (Raster *) PG_DETOAST_DATUM(rast_datum);
+  double result = raster_skew_y(rast);
+  PG_RETURN_FLOAT8(result);
+}
+
+/*****************************************************************************
  * raster_reclass
  *****************************************************************************/
 

--- a/mobilitydb/src/temporal/type_out.c
+++ b/mobilitydb/src/temporal/type_out.c
@@ -302,9 +302,10 @@ Temporal_as_mfjson(PG_FUNCTION_ARGS)
  *****************************************************************************/
 
 /**
- * @brief Ensure that a string represents a valid endian flag
+ * @brief Return the WKB output variant an endian argument names, raising an
+ * error for a string naming no byte order
  */
-static uint8_t
+uint8_t
 get_endian_variant(const text *txt)
 {
   char *endian = text_to_cstring(txt);

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -562,31 +562,31 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
  t
 (1 row)
 
-SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
+SELECT quadbin(tile), width(tile), height(tile), bandPixelType(tile), bandNoDataValue(tile)
 FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
         'UINT8') AS tile) t;
-       quadbin       | width | height | pixtype | nodata 
----------------------+-------+--------+---------+--------
- 5193776270265024512 |     2 |      2 | uint8   |      0
+       quadbin       | width | height | bandpixeltype | bandnodatavalue 
+---------------------+-------+--------+---------------+-----------------
+ 5193776270265024512 |     2 |      2 | uint8         |                
 (1 row)
 
-SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'INT16')),
-       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'INT32')),
-       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT32')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')),
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'INT16')),
+       bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'INT32')),
+       bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT32')),
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          'FLOAT64')),
-       pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'INT8')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT16')),
-       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT32')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+       bandPixelType(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'INT8')),
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT16')),
+       bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT32')),
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          'INT64')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          'UINT64')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT16'));
- pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype | pixtype 
----------+---------+---------+---------+---------+---------+---------+---------+---------+---------+---------
- uint8   | int16   | int32   | float32 | float64 | int8    | uint16  | uint32  | int64   | uint64  | float16
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT16'));
+ bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype 
+---------------+---------------+---------------+---------------+---------------+---------------+---------------+---------------+---------------+---------------+---------------
+ uint8         | int16         | int32         | float32       | float64       | int8          | uint16        | uint32        | int64         | uint64        | float16
 (1 row)
 
 SELECT raquet('\x0102030405060708'::bytea, 2, 1, 5193776270265024512::bigint,
@@ -600,17 +600,17 @@ SELECT raquet('\x0102030405060708'::bytea, 2, 1, 5193776270265024512::bigint,
  t                 | t               | t
 (1 row)
 
-SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
   'uint8'));
- pixtype 
----------
+ bandpixeltype 
+---------------
  uint8
 (1 row)
 
-SELECT pixtype(raquet('\x0102030405060708'::bytea, 2, 1,
+SELECT bandPixelType(raquet('\x0102030405060708'::bytea, 2, 1,
   5193776270265024512::bigint, 'float32'));
- pixtype 
----------
+ bandpixeltype 
+---------------
  float32
 (1 row)
 
@@ -621,23 +621,23 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint8')
  t
 (1 row)
 
-SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, '8BUI')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, '16BSI')),
-       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, '32BF')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, '8BUI')),
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, '16BSI')),
+       bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, '32BF')),
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          '64BF')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, '16BF')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, '16BF')),
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          '64BSI'));
- pixtype | pixtype | pixtype | pixtype | pixtype | pixtype 
----------+---------+---------+---------+---------+---------
- uint8   | int16   | float32 | float64 | float16 | int64
+ bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype | bandpixeltype 
+---------------+---------------+---------------+---------------+---------------+---------------
+ uint8         | int16         | float32       | float64       | float16       | int64
 (1 row)
 
-SELECT pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint,
   ST_BandPixelType(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '32BF'), 1)));
- pixtype 
----------
+ bandpixeltype 
+---------------
  float32
 (1 row)
 
@@ -648,12 +648,12 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '8BUI')
  t
 (1 row)
 
-SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '1BB')),
-       pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '2BUI')),
-       pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '4BUI'));
- pixtype | pixtype | pixtype 
----------+---------+---------
- uint8   | uint8   | uint8
+SELECT bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '1BB')),
+       bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '2BUI')),
+       bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '4BUI'));
+ bandpixeltype | bandpixeltype | bandpixeltype 
+---------------+---------------+---------------
+ uint8         | uint8         | uint8
 (1 row)
 
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '4BUI')
@@ -663,20 +663,31 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '4BUI')
  t
 (1 row)
 
-SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
   ST_BandPixelType(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '4BUI'), 1)));
- pixtype 
----------
+ bandpixeltype 
+---------------
  uint8
 (1 row)
 
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint12');
 ERROR:  Unknown pixel type "uint12": use uint8, int16, int32, float32, float64, int8, uint16, uint32, int64, uint64, or float16, or the name PostGIS raster gives one of them
-SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
-  -9999.0));
- nodata 
---------
-  -9999
+SELECT bandHasNoDataValue(tile), bandNoDataValue(tile)
+FROM (SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
+  -9999.0) AS tile) t;
+ bandhasnodatavalue | bandnodatavalue 
+--------------------+-----------------
+ t                  |           -9999
+(1 row)
+
+SELECT bandHasNoDataValue(tile), bandNoDataValue(tile),
+  raquet(pixels(tile), width(tile), height(tile), quadbin(tile),
+    bandPixelType(tile), bandNoDataValue(tile)) = tile AS round_trips
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+        'UINT8') AS tile) t;
+ bandhasnodatavalue | bandnodatavalue | round_trips 
+--------------------+-----------------+-------------
+ f                  |                 | t
 (1 row)
 
 SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
@@ -687,7 +698,7 @@ SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
 (1 row)
 
 SELECT raquet(pixels(tile), width(tile), height(tile), quadbin(tile),
-         pixtype(tile), nodata(tile)) = tile AS round_trips
+         bandPixelType(tile), bandNoDataValue(tile)) = tile AS round_trips
 FROM (SELECT raquet('\x0102030405060708'::bytea, 2, 2,
         5193776270265024512::bigint, 'INT16', -9999.0) AS tile) t;
  round_trips 
@@ -860,6 +871,37 @@ FROM rast;
      3 |      2 | 3857 |         10 |         20 |    1.5 |     -2 |   0.5 |  0.25 | t
 (2 rows)
 
+WITH rast(r) AS (VALUES
+  (ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8)),
+  (ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '16BSI'::text, 0.0::float8, -9999::float8)))
+SELECT bandPixelType(r), ST_BandPixelType(r) AS postgis_name,
+  bandHasNoDataValue(r), bandNoDataValue(r),
+  bandNoDataValue(r) IS NOT DISTINCT FROM ST_BandNoDataValue(r) AS as_postgis
+FROM rast;
+ bandpixeltype | postgis_name | bandhasnodatavalue | bandnodatavalue | as_postgis 
+---------------+--------------+--------------------+-----------------+------------
+ float32       | 32BF         | f                  |                 | t
+ int16         | 16BSI        | t                  |           -9999 | t
+(2 rows)
+
+WITH rast AS (
+  SELECT ST_AddBand(ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0,
+    0.0, 0.0, 4326), '32BF'::text, 0.0::float8, NULL::float8),
+    '8BUI'::text, 0::float8, 255::float8) AS r)
+SELECT bandPixelType(r, 2), bandHasNoDataValue(r, 2), bandNoDataValue(r, 2)
+FROM rast;
+ bandpixeltype | bandhasnodatavalue | bandnodatavalue 
+---------------+--------------------+-----------------
+ uint8         | t                  |             255
+(1 row)
+
+WITH rast AS (
+  SELECT ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, NULL::float8) AS r)
+SELECT bandNoDataValue(r, 2) FROM rast;
+ERROR:  Raster has no band 2, it has 1
 WITH rast AS (
   SELECT ST_SetValues(
     ST_AddBand(

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -842,6 +842,24 @@ SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
              1 |             2
 (1 row)
 
+WITH rast(r) AS (VALUES
+  (ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8)),
+  (ST_MakeEmptyRaster(3, 2, 10.0, 20.0, 1.5, -2.0, 0.5, 0.25, 3857)))
+SELECT width(r), height(r), SRID(r), upperLeftX(r), upperLeftY(r), scaleX(r),
+  scaleY(r), skewX(r), skewY(r),
+  width(r) = ST_Width(r) AND height(r) = ST_Height(r) AND
+  SRID(r) = ST_SRID(r) AND upperLeftX(r) = ST_UpperLeftX(r) AND
+  upperLeftY(r) = ST_UpperLeftY(r) AND scaleX(r) = ST_ScaleX(r) AND
+  scaleY(r) = ST_ScaleY(r) AND skewX(r) = ST_SkewX(r) AND
+  skewY(r) = ST_SkewY(r) AS as_postgis
+FROM rast;
+ width | height | srid | upperleftx | upperlefty | scalex | scaley | skewx | skewy | as_postgis 
+-------+--------+------+------------+------------+--------+--------+-------+-------+------------
+     3 |      3 | 4326 |          0 |          3 |      1 |     -1 |     0 |     0 | t
+     3 |      2 | 3857 |         10 |         20 |    1.5 |     -2 |   0.5 |  0.25 | t
+(2 rows)
+
 WITH rast AS (
   SELECT ST_SetValues(
     ST_AddBand(

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -562,6 +562,31 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
  t
 (1 row)
 
+WITH rast AS (
+  SELECT ST_AddBand(ST_AddBand(ST_AddBand(ST_AddBand(
+    ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.5, 0.25, 3857),
+    '8BUI'::text, 200::float8, 255::float8),
+    '16BSI'::text, 258::float8, -9999::float8),
+    '32BF'::text, 1.5::float8, NULL::float8),
+    '64BF'::text, 1e10::float8, -1.5::float8) AS r)
+SELECT rasterFromBinary(asBinary(r, 'XDR')) = r AS xdr,
+  rasterFromBinary(asBinary(r, 'NDR')) = r AS ndr,
+  rasterFromHexWKB(asHexWKB(r, 'XDR')) = r AS hex_xdr,
+  rasterFromHexWKB(asHexWKB(r)) = r AS hex_native,
+  ST_RastFromWKB(asBinary(r, 'XDR')) = r AS postgis_reads_xdr,
+  asBinary(r) = ST_AsBinary(r) AND asHexWKB(r) = ST_AsHexWKB(r)
+    AS native_as_postgis,
+  get_byte(asBinary(r, 'NDR'), 0) AS ndr_first_byte,
+  get_byte(asBinary(r, 'XDR'), 0) AS xdr_first_byte,
+  asBinary(r, 'XDR') <> asBinary(r, 'NDR') AS orders_differ
+FROM rast;
+ xdr | ndr | hex_xdr | hex_native | postgis_reads_xdr | native_as_postgis | ndr_first_byte | xdr_first_byte | orders_differ 
+-----+-----+---------+------------+-------------------+-------------------+----------------+----------------+---------------
+ t   | t   | t       | t          | t                 | t                 |              1 |              0 | t
+(1 row)
+
+SELECT rasterFromHexWKB('0100');
+ERROR:  Could not parse the Well-Known Binary (WKB) representation of a raster
 SELECT quadbin(tile), width(tile), height(tile), bandPixelType(tile), bandNoDataValue(tile)
 FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
         'UINT8') AS tile) t;

--- a/mobilitydb/test/raster/expected/500_raster_tbl.test.out
+++ b/mobilitydb/test/raster/expected/500_raster_tbl.test.out
@@ -20,7 +20,7 @@ SELECT COUNT(DISTINCT width(tile)), COUNT(DISTINCT height(tile)) FROM tbl_raquet
      1 |     1
 (1 row)
 
-SELECT COUNT(DISTINCT pixtype(tile)) FROM tbl_raquet;
+SELECT COUNT(DISTINCT bandPixelType(tile)) FROM tbl_raquet;
  count 
 -------
      1

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -610,25 +610,25 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
 
 -- The accessors read back the georeferencing and layout the tile carries, so a
 -- packaged tile needs none of the loose columns it was built from.
-SELECT quadbin(tile), width(tile), height(tile), pixtype(tile), nodata(tile)
+SELECT quadbin(tile), width(tile), height(tile), bandPixelType(tile), bandNoDataValue(tile)
 FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
         'UINT8') AS tile) t;
 
--- Every pixel type name round-trips through the constructor and pixtype.
-SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'INT16')),
-       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'INT32')),
-       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT32')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+-- Every pixel type name round-trips through the constructor and bandPixelType.
+SELECT bandPixelType(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT8')),
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'INT16')),
+       bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'INT32')),
+       bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT32')),
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          'FLOAT64')),
-       pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'INT8')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT16')),
-       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT32')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+       bandPixelType(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, 'INT8')),
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT16')),
+       bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, 'UINT32')),
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          'INT64')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          'UINT64')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT16'));
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, 'FLOAT16'));
 
 -- The pixel size of a type is the one the specification gives it, so a band of
 -- one pixel is exactly as many bytes wide.
@@ -642,9 +642,9 @@ SELECT raquet('\x0102030405060708'::bytea, 2, 1, 5193776270265024512::bigint,
 -- The pixel type name is read without regard to case, so the lower-case
 -- spelling the RaQuet specification gives a tile's type field is accepted as
 -- it stands. The name reported back keeps the documented upper case.
-SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
   'uint8'));
-SELECT pixtype(raquet('\x0102030405060708'::bytea, 2, 1,
+SELECT bandPixelType(raquet('\x0102030405060708'::bytea, 2, 1,
   5193776270265024512::bigint, 'float32'));
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint8')
        = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
@@ -652,17 +652,17 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint8')
 -- A pixel type is also accepted under the name PostGIS raster gives it, so the
 -- band type an ST_BandPixelType call reports passes into the constructor as it
 -- stands. The tile reports the name of the RaQuet specification.
-SELECT pixtype(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, '8BUI')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, '16BSI')),
-       pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, '32BF')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01'::bytea, 1, 1, 5193776270265024512::bigint, '8BUI')),
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, '16BSI')),
+       bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint, '32BF')),
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          '64BF')),
-       pixtype(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, '16BF')),
-       pixtype(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
+       bandPixelType(raquet('\x0102'::bytea, 1, 1, 5193776270265024512::bigint, '16BF')),
+       bandPixelType(raquet('\x0102030405060708'::bytea, 1, 1, 5193776270265024512::bigint,
          '64BSI'));
 
 -- The band type of a PostGIS raster carries into the constructor unchanged.
-SELECT pixtype(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01020304'::bytea, 1, 1, 5193776270265024512::bigint,
   ST_BandPixelType(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '32BF'), 1)));
 
 -- The two spellings name the same tile.
@@ -671,24 +671,33 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '8BUI')
 
 -- A PostGIS pixel type bounded to less than a byte names a uint8 band, since
 -- PostGIS stores one a byte a pixel.
-SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '1BB')),
-       pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '2BUI')),
-       pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '4BUI'));
+SELECT bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '1BB')),
+       bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '2BUI')),
+       bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '4BUI'));
 
 -- The bound is the only thing such a name adds, so the tile is the uint8 one.
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, '4BUI')
        = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint8');
 
 -- A band type ST_BandPixelType reports for such a type carries in as it stands.
-SELECT pixtype(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+SELECT bandPixelType(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
   ST_BandPixelType(ST_AddBand(ST_MakeEmptyRaster(1, 1, 0, 0, 1), '4BUI'), 1)));
 
 -- An unknown name is still rejected, whatever its case.
 SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'uint12');
 
--- The nodata sentinel supplied to the constructor is the one reported back.
-SELECT nodata(raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
-  -9999.0));
+-- The nodata value supplied to the constructor is the one reported back.
+SELECT bandHasNoDataValue(tile), bandNoDataValue(tile)
+FROM (SELECT raquet('\x0102'::bytea, 2, 1, 5193776270265024512::bigint, 'UINT8',
+  -9999.0) AS tile) t;
+
+-- A tile built without a nodata value states none, so its nodata value is NULL
+-- rather than a number, and the constructor given that NULL rebuilds the tile.
+SELECT bandHasNoDataValue(tile), bandNoDataValue(tile),
+  raquet(pixels(tile), width(tile), height(tile), quadbin(tile),
+    bandPixelType(tile), bandNoDataValue(tile)) = tile AS round_trips
+FROM (SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
+        'UINT8') AS tile) t;
 
 -- The pixel bytes are returned in the layout the constructor accepts, so a
 -- tile rebuilt from its own accessors equals the tile it came from.
@@ -696,7 +705,7 @@ SELECT pixels(raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint,
   'UINT8'));
 
 SELECT raquet(pixels(tile), width(tile), height(tile), quadbin(tile),
-         pixtype(tile), nodata(tile)) = tile AS round_trips
+         bandPixelType(tile), bandNoDataValue(tile)) = tile AS round_trips
 FROM (SELECT raquet('\x0102030405060708'::bytea, 2, 2,
         5193776270265024512::bigint, 'INT16', -9999.0) AS tile) t;
 
@@ -848,6 +857,38 @@ SELECT width(r), height(r), SRID(r), upperLeftX(r), upperLeftY(r), scaleX(r),
   scaleY(r) = ST_ScaleY(r) AND skewX(r) = ST_SkewX(r) AND
   skewY(r) = ST_SkewY(r) AS as_postgis
 FROM rast;
+
+-------------------------------------------------------------------------------
+-- Bands of a raster
+-------------------------------------------------------------------------------
+
+-- A band reports its pixel type under the name the RaQuet specification gives
+-- it, the name a raquet tile of that type reports, and its nodata value as
+-- PostGIS reports it: the value the band states, and NULL for a band stating
+-- none.
+WITH rast(r) AS (VALUES
+  (ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8)),
+  (ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '16BSI'::text, 0.0::float8, -9999::float8)))
+SELECT bandPixelType(r), ST_BandPixelType(r) AS postgis_name,
+  bandHasNoDataValue(r), bandNoDataValue(r),
+  bandNoDataValue(r) IS NOT DISTINCT FROM ST_BandNoDataValue(r) AS as_postgis
+FROM rast;
+
+-- The band is named by its number, so the second band of a raster answers for
+-- itself, and a band the raster does not have is an error.
+WITH rast AS (
+  SELECT ST_AddBand(ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0,
+    0.0, 0.0, 4326), '32BF'::text, 0.0::float8, NULL::float8),
+    '8BUI'::text, 0::float8, 255::float8) AS r)
+SELECT bandPixelType(r, 2), bandHasNoDataValue(r, 2), bandNoDataValue(r, 2)
+FROM rast;
+
+WITH rast AS (
+  SELECT ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
+    4326), '32BF'::text, 0.0::float8, NULL::float8) AS r)
+SELECT bandNoDataValue(r, 2) FROM rast;
 
 -------------------------------------------------------------------------------
 -- reclass

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -830,6 +830,26 @@ SELECT numBands((SELECT r FROM rast1)) AS num_bands_one,
        numBands((SELECT r FROM rast2)) AS num_bands_two;
 
 -------------------------------------------------------------------------------
+-- Shape of a raster
+-------------------------------------------------------------------------------
+
+-- The shape of a raster is the one PostGIS reads from the same grid: a banded
+-- raster in EPSG:4326, and a band-free one in EPSG:3857 whose grid is skewed,
+-- so no two of its nine numbers coincide.
+WITH rast(r) AS (VALUES
+  (ST_AddBand(ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8)),
+  (ST_MakeEmptyRaster(3, 2, 10.0, 20.0, 1.5, -2.0, 0.5, 0.25, 3857)))
+SELECT width(r), height(r), SRID(r), upperLeftX(r), upperLeftY(r), scaleX(r),
+  scaleY(r), skewX(r), skewY(r),
+  width(r) = ST_Width(r) AND height(r) = ST_Height(r) AND
+  SRID(r) = ST_SRID(r) AND upperLeftX(r) = ST_UpperLeftX(r) AND
+  upperLeftY(r) = ST_UpperLeftY(r) AND scaleX(r) = ST_ScaleX(r) AND
+  scaleY(r) = ST_ScaleY(r) AND skewX(r) = ST_SkewX(r) AND
+  skewY(r) = ST_SkewY(r) AS as_postgis
+FROM rast;
+
+-------------------------------------------------------------------------------
 -- reclass
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -605,6 +605,36 @@ SELECT raquetFromHexWKB(asHexWKB(raquet('\x01020304'::bytea, 2, 2,
        = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');
 
 -------------------------------------------------------------------------------
+-- raster (Hex)WKB round trip
+--
+-- A raster round-trips through its Well-Known Binary in either byte order,
+-- with bands of one, two, four and eight bytes a pixel, and PostGIS reads the
+-- big-endian form back to the same raster.
+-------------------------------------------------------------------------------
+
+WITH rast AS (
+  SELECT ST_AddBand(ST_AddBand(ST_AddBand(ST_AddBand(
+    ST_MakeEmptyRaster(2, 2, 0.0, 2.0, 1.0, -1.0, 0.5, 0.25, 3857),
+    '8BUI'::text, 200::float8, 255::float8),
+    '16BSI'::text, 258::float8, -9999::float8),
+    '32BF'::text, 1.5::float8, NULL::float8),
+    '64BF'::text, 1e10::float8, -1.5::float8) AS r)
+SELECT rasterFromBinary(asBinary(r, 'XDR')) = r AS xdr,
+  rasterFromBinary(asBinary(r, 'NDR')) = r AS ndr,
+  rasterFromHexWKB(asHexWKB(r, 'XDR')) = r AS hex_xdr,
+  rasterFromHexWKB(asHexWKB(r)) = r AS hex_native,
+  ST_RastFromWKB(asBinary(r, 'XDR')) = r AS postgis_reads_xdr,
+  asBinary(r) = ST_AsBinary(r) AND asHexWKB(r) = ST_AsHexWKB(r)
+    AS native_as_postgis,
+  get_byte(asBinary(r, 'NDR'), 0) AS ndr_first_byte,
+  get_byte(asBinary(r, 'XDR'), 0) AS xdr_first_byte,
+  asBinary(r, 'XDR') <> asBinary(r, 'NDR') AS orders_differ
+FROM rast;
+
+-- A string shorter than the raster it states is refused, not read past its end.
+SELECT rasterFromHexWKB('0100');
+
+-------------------------------------------------------------------------------
 -- raquet accessors
 -------------------------------------------------------------------------------
 

--- a/mobilitydb/test/raster/queries/500_raster_tbl.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster_tbl.test.sql
@@ -42,7 +42,7 @@ SET datestyle = 'ISO, MDY';
 SELECT COUNT(*) FROM tbl_raquet;
 SELECT COUNT(*) FROM tbl_raquet WHERE tile IS NULL;
 SELECT COUNT(DISTINCT width(tile)), COUNT(DISTINCT height(tile)) FROM tbl_raquet;
-SELECT COUNT(DISTINCT pixtype(tile)) FROM tbl_raquet;
+SELECT COUNT(DISTINCT bandPixelType(tile)) FROM tbl_raquet;
 
 -------------------------------------------------------------------------------
 -- Input/output round-trip

--- a/tools/codegen/inherited/INHERITANCE_MAP.md
+++ b/tools/codegen/inherited/INHERITANCE_MAP.md
@@ -247,7 +247,7 @@ point in pure SQL (§6, `320_tnpoint_spatialrels`).
 
 | `<sect1>` | MEOS prefix | generated? | canonical generator / notes |
 |---|---|---|---|
-| Input and Output | `temporal_` | ✓ **GEN** | **two sub-families**, both full coverage (`--gaps`: `io_families` 20/20, `representation_families` 20/20): (a) **type I/O** `<type>_in`/`_out`/`_recv`/`_send` — `io_type.sql.tmpl` + `io_families`, **14 entries** (temporal, geo, tpoint, cbuffer, npoint, pose, posechain, rgeo, h3, quadbin, s2cell, pointcloud, pointcloud_patch, json). (b) **canonical representations** — `asText`/`asEWKT`/`asBinary`/`asEWKB`/`asHexWKB`/`asMFJSON` + the `From*` constructors — `representations.sql.tmpl` + `representation_families`, **19 entries**: the same 14 temporal families plus the five base-value entries `npoint_base`, `pose_base`, `posechain_base`, `cbuffer_base`, `raquet_base`, whose representations belong to the base type rather than to its temporal type |
+| Input and Output | `temporal_` | ✓ **GEN** | **two sub-families**, both full coverage (`--gaps`: `io_families` 20/20, `representation_families` 20/20): (a) **type I/O** `<type>_in`/`_out`/`_recv`/`_send` — `io_type.sql.tmpl` + `io_families`, **14 entries** (temporal, geo, tpoint, cbuffer, npoint, pose, posechain, rgeo, h3, quadbin, s2cell, pointcloud, pointcloud_patch, json). (b) **canonical representations** — `asText`/`asEWKT`/`asBinary`/`asEWKB`/`asHexWKB`/`asMFJSON` + the `From*` constructors — `representations.sql.tmpl` + `representation_families`, **20 entries**: the same 14 temporal families plus the six base-value entries `npoint_base`, `pose_base`, `posechain_base`, `cbuffer_base`, `raquet_base`, `raster_base`, whose representations belong to the base type rather than to its temporal type |
 | Constructors | `temporal_` | ✓ **GEN** | `constructors.sql.tmpl` + `constructor_families`, **14 entries** all `reference: true` (temporal, cbuffer, geo, h3, json, npoint, pose, posechain, quadbin, rgeo, s2cell, tpcpatch, tpcpoint, tpoint). The pose entry also names `tpose(tgeompoint, tfloat)` in an `fns:` block, the one constructor of the axis a template does not shape |
 | Conversions | `temporal_` | ◐ PARTIAL | `conversions.sql.tmpl` + `conversion_families`, **9 entries** (temporal, cbuffer, h3, json, npoint, pose, quadbin, rgeo, s2cell) — `--gaps`: `conversion_families` 16/20, missing tposechain, tgeography, tpcpoint, tpcpatch. `geo`/`tpoint` have no dedicated entry: their conversion surface is already named as the RETURNS/argument type of other families' declarations (e.g. rgeo's `tgeometry(trgeometry)`) |
 | Accessors | `temporal_` | ✓ **GEN** | `accessors.sql.tmpl` multi-base renderer from base `022_temporal.in.sql` — the value/time/generic set for ALL families (§4c); per-family value shape = manifest `types:` tokens. A few interleaved/positional accessors stay hand per family |
@@ -480,10 +480,11 @@ EWKT/EWKB are **TSpatial<T>-level**, the `E` = carries the SRID
 `endian text DEFAULT ''` on `asBinary`/`asHexWKB`.
 
 Governed by `templates/representations.sql.tmpl` + `representation_families`,
-**19 entries** all `reference: true` — the 14 families of `io_families` above
+**20 entries** all `reference: true` — the 14 families of `io_families` above
 (temporal, cbuffer, geo, h3, json, npoint, pointcloud, pointcloud_patch, pose,
-posechain, quadbin, rgeo, s2cell, tpoint) plus the five base-value entries
-`cbuffer_base`, `npoint_base`, `pose_base`, `posechain_base`, `raquet_base`.
+posechain, quadbin, rgeo, s2cell, tpoint) plus the six base-value entries
+`cbuffer_base`, `npoint_base`, `pose_base`, `posechain_base`, `raquet_base`,
+`raster_base`.
 
 ⛔ An ENTRY COUNT is a hand-written total that no `--gaps` figure covers, so it is a
 different class from the `N/M` coverage ratios beside it: a family joining an axis moves

--- a/tools/codegen/inherited/manifest.d/representation_families.yaml
+++ b/tools/codegen/inherited/manifest.d/representation_families.yaml
@@ -639,3 +639,22 @@ representation_families:
     - FromHexWKB
     - asBinary
     - asHexWKB
+- family: raster_base
+  file: mobilitydb/sql/raster/500_raster.in.sql
+  reference: true
+  begin: "\n * Well-Known Binary representations of a raster\n"
+  end: "\n * @brief Return a raster whose band states the classes an expression maps its\n"
+  temps:
+  - temp: raster
+  syms:
+    FromBinary: Raster_from_wkb
+    FromHexWKB: Raster_from_hexwkb
+    asBinary: Raster_as_wkb
+    asHexWKB: Raster_as_hexwkb
+  blocks:
+  - lit: "/******************************************************************************\n * Well-Known Binary representations of a raster\n *\n * A raster round-trips through the Well-Known Binary PostGIS writes for it,\n * in the byte order asked for, so a binding reads and writes the rasters of a\n * PostGIS column with no PostgreSQL in between.\n ******************************************************************************/"
+  - ops:
+    - FromBinary
+    - FromHexWKB
+    - asBinary
+    - asHexWKB


### PR DESCRIPTION
Read the shape of a raster in SQL

width, height, SRID, upperLeftX, upperLeftY, scaleX, scaleY, skewX and
skewY are the SQL functions of the MEOS accessors that read the grid of a
raster, named as the PostGIS functions answering the same numbers, ST_Width
to ST_SkewY, without their ST_ prefix. width and height already read a
raquet tile, so a raster and a tile answer them alike, and the manual states
each of the two as one entry over both types.

The witness is two rasters: a banded one in EPSG:4326 with 1 degree pixels,
and a band-free one in EPSG:3857 whose grid is 3 by 2 pixels from the corner
(10, 20), with scale (1.5, -2) and skew (0.5, 0.25), so no two of its nine
numbers coincide. Each function answers on both what the PostGIS function of
the same name answers.

The model is the one PostGIS runs: each accessor reads the header rt_core
deserializes from the raster, the geotransform ST_Width and its siblings
read.

Measured on the branch: every chapter entry has its appendix row in both
languages, 772 entries against 773 rows in each, and the English and Spanish
chapters carry the same 140 identifiers, 114 signatures and 123 examples.


Read the bands of a raster and of a raquet tile under one set of names

bandPixelType, bandHasNoDataValue and bandNoDataValue read a band of a
raster, named by its number with 1 as the default, and the band of a raquet
tile. For a raster they are the PostGIS names ST_BandPixelType and
ST_BandNoDataValue without their ST_ prefix, and bandHasNoDataValue is the
name of the MEOS function it calls; a raquet tile answers the same three
questions under the same three names, in place of pixtype and nodata, which
no release carries. The pixel type is named as the RaQuet specification
names it, for a band and a tile alike.

A band that states no nodata value answers NULL, as ST_BandNoDataValue
answers it. In MEOS, raster_band_nodata_value and raquet_band_nodata_value
answer in the shape stbox_xmin answers a coordinate a box may lack: true
with the value written, or false with nothing written and no error, beside
raster_band_has_nodata_value and raquet_band_has_nodata_value.
raquet_band_pixel_type names the pixel type of a tile. rt_band_get_nodata
reports an error for a band stating no nodata value, so the raster function
reads the band's flag first.

The witness is a 32BF band stating no nodata value and a 16BSI band stating
-9999: bandPixelType answers float32 and int16, and bandNoDataValue answers
NULL and -9999, each as ST_BandNoDataValue answers it. The second band of a
two-band raster answers for itself, and a band the raster does not have
raises "Raster has no band 2, it has 1". A raquet tile built without a
nodata value answers false and NULL, and the constructor given that NULL
rebuilds the tile; read from its stored sentinel, the same tile answers 0.
The C witness meos/test/raster_test.c asserts false and no error for the
band stating none.

The model is the one the box accessors follow: an accessor whose answer may
be absent writes it into its last argument and answers whether it did, and
its SQL function answers NULL when it did not.

Measured on the branch: every chapter entry has its appendix row in both
languages, 773 entries against 774 rows in each, and the English and Spanish
chapters carry the same 141 identifiers, 115 signatures and 124 examples.


Read and write a raster in Well-Known Binary in SQL

rasterFromBinary, rasterFromHexWKB, asBinary and asHexWKB are the SQL
functions of raster_from_wkb, raster_from_hexwkb, raster_as_wkb and
raster_as_hexwkb. The reading pair takes the name every MobilityDB type gives
its WKB input, as raquetFromBinary and raquetFromHexWKB beside it do; the
writing pair takes the endian argument every asBinary and asHexWKB takes,
NDR or XDR, and the order of the server when it is left out. The four are
the representation_families entry raster_base, which the inherited generator
renders and validates as it does raquet_base, and INHERITANCE_MAP.md counts
it.

raster_as_wkb and raster_as_hexwkb take the uint8_t variant raquet_as_wkb
takes. rt_raster_to_wkb writes the order of the machine only, so MEOS
rewrites the representation in the other order field by field, along the
layout that writer states, and copies it out of the memory rt_core allocates
into memory the caller releases as it releases any other MEOS result. The
raster functions read the endian argument through get_endian_variant, the
helper every asBinary reads it through.

The witness is a 2x2 raster in EPSG:3857 on a skewed grid with four bands of
one, two, four and eight bytes a pixel, 8BUI, 16BSI, 32BF and 64BF, three of
them stating a nodata value. It round-trips through asBinary and asHexWKB in
either byte order, the first byte states the order asked for, the two orders
differ beyond it, ST_RastFromWKB reads the big-endian form back to the same
raster, and the native form equals what ST_AsBinary and ST_AsHexWKB write. A
string too short for the raster it states raises "Could not parse the
Well-Known Binary (WKB) representation of a raster". The C witness
meos/test/raster_test.c round-trips its two rasters, of 102 and 143 bytes, in
either order.

The model is the one the Well-Known Binary of every MobilityDB type follows:
its first byte states the order it is written in, and a reader turns either
order into the same value.

Measured on the branch: the inherited generator validates 337 regions with
none differing and its coverage ratchet holds at 120 of 219 files governed;
every chapter entry has its appendix row in both languages, 773 entries
against 774 rows in each; and the English and Spanish chapters carry the same
141 identifiers, 115 signatures and 124 examples.


Read the raster examples of the manual through the MobilityDB functions

The transform and rescale examples of the tessellations chapter read the
raster they answer with SRID, width, height and scaleX, the functions this
extension states for a raster, in English and in Spanish. The examples keep
ST_MakeEmptyRaster, ST_AddBand and ST_SetValues, which build the raster and
have no MobilityDB counterpart, and the paragraph naming ST_BandPixelType
keeps it, since it states the pixel type names PostGIS gives.

The witness is the two examples themselves: run against the branch, they
answer 3857 | 3 | 3 and 6 | 6 | 0.5, the results the chapter states.

Measured on the branch: the chapter holds no call to a PostGIS raster
function a MobilityDB function answers, against 29 calls to
ST_MakeEmptyRaster, and the English and Spanish chapters carry the same 124
examples.


