### PR TITLE
Decide where two segments meet from exact signs on their endpoints

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -159,6 +159,8 @@ extern bool meos_relate_pattern(const LWGEOM *g1, const LWGEOM *g2,
 extern bool meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
   bool *result);
 extern bool relate_is_areal(const LWGEOM *geom);
+extern int cross_product_sign_exact(double ax, double ay, double bx, double by,
+  double cx, double cy, double dx, double dy);
 
 /* The edges of one geometry, kept so that several relationships asked about it
  * read them once. A relationship extracts the edges of both its operands, and
@@ -336,104 +338,152 @@ extern bool *pointarr_find_splits(const POINT2D **points, int npoints,
  *****************************************************************************/
 
 /**
+ * @brief Return the sign of the cross product of the vectors B - A and D - C
+ * @details The operands are coordinates of input vertices, and every double is
+ * an exact rational, so the sign has one answer. A filter gives it where the
+ * double evaluation carries it: Shewchuk's bound on the rounding of a
+ * difference of two products of rounded differences, computed from the
+ * operands. Two products both zero need no more: a rounded difference is zero
+ * only where the two coordinates are equal, so each product has a zero
+ * factor. Where the filter cannot tell otherwise, #cross_product_sign_exact
+ * decides the same cross product exactly. With C = A the sign is the side of
+ * the line AB that D lies on
+ * @note Exact where no product of coordinate differences overflows or
+ * underflows
+ * @return 1 or -1 for the two turns, 0 exactly where the vectors are parallel
+ */
+static inline int
+cross_product_sign(double ax, double ay, double bx, double by, double cx,
+  double cy, double dx, double dy)
+{
+  double left = (bx - ax) * (dy - cy);
+  double right = (by - ay) * (dx - cx);
+  double det = left - right;
+  double bound = (3.0 + 16.0 * DBL_EPSILON) * DBL_EPSILON *
+    (fabs(left) + fabs(right));
+  if (det > bound)
+    return 1;
+  if (det < - bound)
+    return -1;
+  if (left == 0.0 && right == 0.0)
+    return 0;
+  return cross_product_sign_exact(ax, ay, bx, by, cx, cy, dx, dy);
+}
+
+/**
+ * @brief Return the position along the segment AB of a point of its line, 0
+ * at A and 1 at B
+ * @details The two ends read exactly 0 and 1; any other point reads its
+ * projection on the segment, clamped to it
+ * @param[in] ax,ay,bx,by Coordinates of the ends of the segment
+ * @param[in] r2 Squared length of the segment, not zero
+ * @param[in] px,py Coordinates of the point
+ */
+static inline double
+linesegm_param(double ax, double ay, double bx, double by, double r2,
+  double px, double py)
+{
+  if (px == ax && py == ay)
+    return 0.0;
+  if (px == bx && py == by)
+    return 1.0;
+  double t = ((px - ax) * (bx - ax) + (py - ay) * (by - ay)) / r2;
+  return (t < 0.0) ? 0.0 : ((t > 1.0) ? 1.0 : t);
+}
+
+/**
  * @brief Return the intersection value obtained by computing the intersection 
  * of a line segment defined by two 2D points intersects an edge
- * @details Possible result values
+ * @details The verdict is decided on the four endpoints and is exact: whether
+ * the two directions are parallel, whether the segments lie on one line and
+ * whether each end lies on the line of the other segment are signs of cross
+ * products of coordinate differences (#cross_product_sign), and along one
+ * line the stretch the two share runs between positions compared exactly.
  * - No intersection: INTERSECT_NONE -> t0 and t1 undefined
- * - Single point: INTERSECT_POINT -> t1 in [0,1], t1 ignored
- * - Overlap segment: INTERSECT_OVERLAP -> t0 <= t1 in [0,1]
- * Invariants:
- * - 0 <= t0 <= 1
- * - 0 <= t1 <= 1
- * - t0 <= t1
- * - Overlap must satisfy: t1 - t0 > MEOS_GEOM_TOLERANCE
- * @param[in] ax,ay Coordinates of the first point defining the first segment
- * @param[in] rx,ry Vector AB
+ * - Single point: INTERSECT_POINT -> t0 in [0,1], t1 ignored
+ * - Overlap segment: INTERSECT_OVERLAP -> t0 < t1 in [0,1]
+ * The parameters are positions along the first segment, 0 at its start and 1
+ * at its end, and read exactly 0 or 1 where the meeting is one of its ends.
+ * A first segment of no length meets nothing
+ * @param[in] ax,ay,bx,by Coordinates of the points defining the first segment
  * @param[in] cx,cy,dx,dy Coordinates of the points defining the second segment
- * @note To avoid recomputing vector AB in EVERY call to the functions,
- * we pass the vector instead of the second point b computed as follows
- * @code
- * double rx = bx - ax, ry = by - ay;
- * @endcode
  */
 static inline IntersectResult
-linesegm_intersect(double ax, double ay, double rx, double ry,
+linesegm_intersect(double ax, double ay, double bx, double by,
   double cx, double cy, double dx, double dy)
 {
   IntersectResult res = {INTERSECT_NONE, 0, 0};
-  double sx = dx - cx, sy = dy - cy; /* vector CD */
-  /* Where is the start of the second segment relative to the first? */
-  double qpx = cx - ax, qpy = cy - ay;
+  if (ax == bx && ay == by)
+    return res;
+  double rx = bx - ax, ry = by - ay;
+  double r2 = rx * rx + ry * ry;
+  /* The sides of the line of the first segment the ends of the second lie on.
+   * On one side, the segments cannot meet. Both on it, the second segment lies
+   * on the line of the first. Otherwise the two cross products these are the
+   * signs of differ, and their difference is the cross product of the two
+   * directions, so the directions cross */
+  int oc = cross_product_sign(ax, ay, bx, by, ax, ay, cx, cy);
+  int od = cross_product_sign(ax, ay, bx, by, ax, ay, dx, dy);
+  if ((oc > 0 && od > 0) || (oc < 0 && od < 0))
+    return res;
 
-  /* Are the two segments parallel?  */
-  double rxs = rx * sy - ry * sx;
-
-  /* Collinear / parallel */
-  if (fabs(rxs) < MEOS_GEOM_TOLERANCE)
+  if (oc == 0 && od == 0)
   {
-    /* The two segments run in one direction; what is left to decide is
-     * whether they run along the SAME LINE or along two parallel ones. Both
-     * quantities that answer it are areas rather than lengths, and each needs
-     * a threshold in its own units:
-     * - r2 is the squared length of AB, so its bound is the SQUARE of the
-     *   tolerance. Bounded by the plain tolerance it rejects every segment
-     *   shorter than that tolerance's square root, which is 1e-6, and such a
-     *   segment then fails to overlap even an identical copy of itself.
-     * - qpxr is the cross product of AC with AB, which is the separation of
-     *   the two lines TIMES the length of AB. Bounded by the plain tolerance
-     *   it stands for a separation of tolerance/|AB|, so two lines far apart
-     *   read as one line whenever AB is short enough. Dividing by the length
-     *   puts the bound back on the separation, where it belongs. */
-    double r2 = rx * rx + ry * ry;
-    if (r2 < MEOS_GEOM_TOLERANCE * MEOS_GEOM_TOLERANCE)
+    /* One line: the shared stretch runs between the positions of the ends
+     * along it, read off the coordinate the first segment advances most in
+     * and oriented to grow from its start to its end, so the order of two
+     * positions is the order of two input coordinates */
+    bool alongx = fabs(rx) >= fabs(ry);
+    double sgn = ((alongx ? rx : ry) > 0.0) ? 1.0 : -1.0;
+    double pa = sgn * (alongx ? ax : ay), pb = sgn * (alongx ? bx : by);
+    double pc = sgn * (alongx ? cx : cy), pd = sgn * (alongx ? dx : dy);
+    bool cfirst = pc <= pd;
+    double plo = cfirst ? pc : pd, phi = cfirst ? pd : pc;
+    double lox = cfirst ? cx : dx, loy = cfirst ? cy : dy;
+    double hix = cfirst ? dx : cx, hiy = cfirst ? dy : cy;
+    if (plo < pa)
+    {
+      plo = pa; lox = ax; loy = ay;
+    }
+    if (phi > pb)
+    {
+      phi = pb; hix = bx; hiy = by;
+    }
+    if (plo > phi)
       return res;
-
-    /* Is point C aligned with segment AB? */
-    double qpxr = qpx * ry - qpy * rx;
-    /* If qpxr != 0: parallel, if qpxr == 0: collinear */
-    if (fabs(qpxr) > MEOS_GEOM_TOLERANCE * sqrt(r2))
-      return res;
-
-    double t0 = (qpx * rx + qpy * ry) / r2;
-    double t1 = t0 + (sx * rx + sy * ry) / r2;
-
-    /* Order t0 < t1 */
-    if (t0 > t1) { double tmp = t0; t0 = t1; t1 = tmp; }
-    /* No intersection */
-    if (t1 < 0 || t0 > 1)
-      return res;
-
-    /* Clamp values */
-    if (t0 < 0) t0 = 0;
-    if (t1 > 1) t1 = 1;
-
-    if (fabs(t1 - t0) < MEOS_GEOM_TOLERANCE)
+    res.t0 = linesegm_param(ax, ay, bx, by, r2, lox, loy);
+    if (plo == phi)
     {
       res.type = INTERSECT_POINT;
-      res.t0 = t0;
       return res;
     }
-
     res.type = INTERSECT_OVERLAP;
-    res.t0 = t0;
-    res.t1 = t1;
+    res.t1 = linesegm_param(ax, ay, bx, by, r2, hix, hiy);
     return res;
   }
 
-  /* Proper intersection */
-  double t = (qpx * sy - qpy * sx) / rxs;
-  double u = (qpx * ry - qpy * rx) / rxs;
-
-  if (t < -MEOS_GEOM_TOLERANCE || t > 1 + MEOS_GEOM_TOLERANCE ||
-      u < -MEOS_GEOM_TOLERANCE || u > 1 + MEOS_GEOM_TOLERANCE)
+  /* Crossing directions: the segments meet where the first does not lie
+   * wholly on one side of the line of the second either */
+  int oa = cross_product_sign(cx, cy, dx, dy, cx, cy, ax, ay);
+  int ob = cross_product_sign(cx, cy, dx, dy, cx, cy, bx, by);
+  if ((oa > 0 && ob > 0) || (oa < 0 && ob < 0))
     return res;
-
-  /* Clamp values */
-  if (fabs(t) < MEOS_GEOM_TOLERANCE) t = 0;
-  if (fabs(t - 1) < MEOS_GEOM_TOLERANCE) t = 1;
-
   res.type = INTERSECT_POINT;
-  res.t0 = t;
+  if (oa == 0)
+    res.t0 = 0.0;
+  else if (ob == 0)
+    res.t0 = 1.0;
+  else if (oc == 0)
+    res.t0 = linesegm_param(ax, ay, bx, by, r2, cx, cy);
+  else if (od == 0)
+    res.t0 = linesegm_param(ax, ay, bx, by, r2, dx, dy);
+  else
+  {
+    /* A crossing interior to both, whose position is a quotient */
+    double sx = dx - cx, sy = dy - cy;
+    double t = ((cx - ax) * sy - (cy - ay) * sx) / (rx * sy - ry * sx);
+    res.t0 = (t < 0.0) ? 0.0 : ((t > 1.0) ? 1.0 : t);
+  }
   return res;
 }
 

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -559,6 +559,103 @@ buffer_curvepoly_add_ring(LWCURVEPOLY *poly, LWCOMPOUND *ring)
  *****************************************************************************/
 
 /**
+ * @brief Return where two segments of a buffer meet, the first given by its
+ * start and its direction
+ * @details The buffer asks this of its own edges, offsets it computes from
+ * the input and whose ends are rounded, so the verdict is taken within
+ * tolerances rather than exactly: two offsets that share a corner meet at
+ * one point even where their rounded ends do not exactly coincide.
+ * #linesegm_intersect decides the same question exactly, on input vertices.
+ * - No intersection: INTERSECT_NONE -> t0 and t1 undefined
+ * - Single point: INTERSECT_POINT -> t0 in [0,1], t1 ignored
+ * - Overlap segment: INTERSECT_OVERLAP -> t0 < t1 in [0,1], apart by at
+ *   least MEOS_GEOM_TOLERANCE
+ * @param[in] ax,ay Coordinates of the start of the first segment
+ * @param[in] rx,ry Vector from the start to the end of the first segment
+ * @param[in] cx,cy,dx,dy Coordinates of the ends of the second segment
+ */
+static inline IntersectResult
+buffer_linesegm_intersect(double ax, double ay, double rx, double ry,
+  double cx, double cy, double dx, double dy)
+{
+  IntersectResult res = {INTERSECT_NONE, 0, 0};
+  double sx = dx - cx, sy = dy - cy; /* vector CD */
+  /* Where is the start of the second segment relative to the first? */
+  double qpx = cx - ax, qpy = cy - ay;
+
+  /* Are the two segments parallel?  */
+  double rxs = rx * sy - ry * sx;
+
+  /* Collinear / parallel */
+  if (fabs(rxs) < MEOS_GEOM_TOLERANCE)
+  {
+    /* The two segments run in one direction; what is left to decide is
+     * whether they run along the SAME LINE or along two parallel ones. Both
+     * quantities that answer it are areas rather than lengths, and each needs
+     * a threshold in its own units:
+     * - r2 is the squared length of AB, so its bound is the SQUARE of the
+     *   tolerance. Bounded by the plain tolerance it rejects every segment
+     *   shorter than that tolerance's square root, which is 1e-6, and such a
+     *   segment then fails to overlap even an identical copy of itself.
+     * - qpxr is the cross product of AC with AB, which is the separation of
+     *   the two lines TIMES the length of AB. Bounded by the plain tolerance
+     *   it stands for a separation of tolerance/|AB|, so two lines far apart
+     *   read as one line whenever AB is short enough. Dividing by the length
+     *   puts the bound back on the separation, where it belongs. */
+    double r2 = rx * rx + ry * ry;
+    if (r2 < MEOS_GEOM_TOLERANCE * MEOS_GEOM_TOLERANCE)
+      return res;
+
+    /* Is point C aligned with segment AB? */
+    double qpxr = qpx * ry - qpy * rx;
+    /* If qpxr != 0: parallel, if qpxr == 0: collinear */
+    if (fabs(qpxr) > MEOS_GEOM_TOLERANCE * sqrt(r2))
+      return res;
+
+    double t0 = (qpx * rx + qpy * ry) / r2;
+    double t1 = t0 + (sx * rx + sy * ry) / r2;
+
+    /* Order t0 < t1 */
+    if (t0 > t1) { double tmp = t0; t0 = t1; t1 = tmp; }
+    /* No intersection */
+    if (t1 < 0 || t0 > 1)
+      return res;
+
+    /* Clamp values */
+    if (t0 < 0) t0 = 0;
+    if (t1 > 1) t1 = 1;
+
+    if (fabs(t1 - t0) < MEOS_GEOM_TOLERANCE)
+    {
+      res.type = INTERSECT_POINT;
+      res.t0 = t0;
+      return res;
+    }
+
+    res.type = INTERSECT_OVERLAP;
+    res.t0 = t0;
+    res.t1 = t1;
+    return res;
+  }
+
+  /* Proper intersection */
+  double t = (qpx * sy - qpy * sx) / rxs;
+  double u = (qpx * ry - qpy * rx) / rxs;
+
+  if (t < -MEOS_GEOM_TOLERANCE || t > 1 + MEOS_GEOM_TOLERANCE ||
+      u < -MEOS_GEOM_TOLERANCE || u > 1 + MEOS_GEOM_TOLERANCE)
+    return res;
+
+  /* Clamp values */
+  if (fabs(t) < MEOS_GEOM_TOLERANCE) t = 0;
+  if (fabs(t - 1) < MEOS_GEOM_TOLERANCE) t = 1;
+
+  res.type = INTERSECT_POINT;
+  res.t0 = t;
+  return res;
+}
+
+/**
  * @brief Return true if two buffer geometries have overlapping interiors.
  * @details This is used to determine whether individual line buffers can
  * be returned independently or whether an overlay/union operation is needed.
@@ -609,8 +706,8 @@ buffer_geometries_intersect(const LWGEOM *geom1, const LWGEOM *geom2)
       /* Line / line */
       if (a->etype == EDGE_LINESEG && b->etype == EDGE_LINESEG)
       {
-        IntersectResult r = linesegm_intersect(a->x1, a->y1, a->dx, a->dy,
-          b->x1, b->y1, b->x2, b->y2);
+        IntersectResult r = buffer_linesegm_intersect(a->x1, a->y1,
+          a->dx, a->dy, b->x1, b->y1, b->x2, b->y2);
         if (r.type != INTERSECT_NONE)
         {
           result = true;
@@ -657,8 +754,8 @@ buffer_geometries_intersect(const LWGEOM *geom1, const LWGEOM *geom2)
        * EDGE_POLYSEG and curved boundaries as EDGE_POLYARC. */
       else if (a->etype == EDGE_POLYSEG && b->etype == EDGE_POLYSEG)
       {
-        IntersectResult r = linesegm_intersect(a->x1, a->y1, a->dx, a->dy,
-          b->x1, b->y1, b->x2, b->y2);
+        IntersectResult r = buffer_linesegm_intersect(a->x1, a->y1,
+          a->dx, a->dy, b->x1, b->y1, b->x2, b->y2);
         if (r.type != INTERSECT_NONE)
         {
           result = true;
@@ -717,8 +814,8 @@ buffer_edges_intersect(const Edge *e1, const Edge *e2)
   /* Line / Line */
   if (e1->etype == EDGE_POLYSEG && e2->etype == EDGE_POLYSEG)
   {
-    IntersectResult r = linesegm_intersect(e1->x1, e1->y1, e1->dx, e1->dy,
-      e2->x1, e2->y1, e2->x2, e2->y2);
+    IntersectResult r = buffer_linesegm_intersect(e1->x1, e1->y1,
+      e1->dx, e1->dy, e2->x1, e2->y1, e2->x2, e2->y2);
     return r.type != INTERSECT_NONE;
   }
 
@@ -1062,8 +1159,8 @@ buffer_boundary_intersection(const Edge *e1, const Edge *e2)
   /* Straight segment / straight segment */
   if (e1->etype == EDGE_POLYSEG && e2->etype == EDGE_POLYSEG)
   {
-    IntersectResult result = linesegm_intersect(e1->x1, e1->y1, e1->dx, e1->dy,
-      e2->x1, e2->y1, e2->x2, e2->y2);
+    IntersectResult result = buffer_linesegm_intersect(e1->x1, e1->y1,
+      e1->dx, e1->dy, e2->x1, e2->y1, e2->x2, e2->y2);
     if (result.type == INTERSECT_OVERLAP)
       return 1;
     if (result.type == INTERSECT_POINT)
@@ -1591,8 +1688,8 @@ buffer_collect_line_line_intersections(const Edge *e1, const Edge *e2,
   MeosArray *points)
 {
   assert(e1); assert(e2); assert(points);
-  IntersectResult result = linesegm_intersect(e1->x1, e1->y1, e1->dx, e1->dy,
-    e2->x1, e2->y1, e2->x2, e2->y2);
+  IntersectResult result = buffer_linesegm_intersect(e1->x1, e1->y1,
+    e1->dx, e1->dy, e2->x1, e2->y1, e2->x2, e2->y2);
   if (result.type == INTERSECT_POINT)
   {
     double x = e1->x1 + result.t0 * e1->dx;

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -637,6 +637,130 @@ build_edge_rtree(const Edge *edges, int nedges, int32_t srid)
 }
 
 /*****************************************************************************
+ * The sign of a cross product where the filter cannot tell
+ *****************************************************************************/
+
+/**
+ * @brief Split the difference of two doubles into its rounded value and the
+ * error of that rounding, which together are the difference exactly
+ */
+static inline void
+two_diff(double a, double b, double *x, double *y)
+{
+  *x = a - b;
+  double bv = a - *x;
+  double av = *x + bv;
+  *y = (a - av) + (bv - b);
+}
+
+/**
+ * @brief Split the product of two doubles into its rounded value and the
+ * error of that rounding, which together are the product exactly
+ * @note Exact where the product neither overflows nor underflows
+ */
+static inline void
+two_product(double a, double b, double *x, double *y)
+{
+  *x = a * b;
+  *y = fma(a, b, - *x);
+}
+
+/**
+ * @brief Add a double to an expansion, a sum of doubles that do not overlap,
+ * held in increasing order of magnitude, and return its new length
+ * @details The sum is exact, and a zero component is dropped, so the last
+ * component carries the sign of the whole expansion
+ */
+static inline int
+grow_expansion(int elen, const double *e, double b, double *h)
+{
+  double q = b;
+  int hlen = 0;
+  for (int i = 0; i < elen; i++)
+  {
+    double sum = q + e[i];
+    double bv = sum - q;
+    double av = sum - bv;
+    double err = (q - av) + (e[i] - bv);
+    q = sum;
+    if (err != 0.0)
+      h[hlen++] = err;
+  }
+  if (q != 0.0 || hlen == 0)
+    h[hlen++] = q;
+  return hlen;
+}
+
+/**
+ * @brief Return the sign of the cross product of the vectors B - A and D - C,
+ * decided exactly
+ * @details Each difference is its rounded value plus the error of the
+ * rounding. Where the four differences are exact, which the calls the filter
+ * of #cross_product_sign cannot sign mostly are, the cross product is a
+ * difference of two products of doubles: rounding is monotone, so two rounded
+ * products that differ order as the exact ones do, and two that are equal
+ * leave the sign to the difference of their rounding errors, which are exact.
+ * Otherwise each product of two terms is its rounded value plus its error,
+ * and the sixteen terms are added into an expansion whose last component
+ * carries the sign; a term with a zero factor adds nothing and is skipped.
+ * #cross_product_sign calls it where its filter cannot tell, which keeps this
+ * out of every call the filter decides
+ * @note Exact where no product of coordinate differences overflows or
+ * underflows
+ * @return 1 or -1 for the two turns, 0 exactly where the vectors are parallel
+ */
+int
+cross_product_sign_exact(double ax, double ay, double bx, double by,
+  double cx, double cy, double dx, double dy)
+{
+  double d[4], t[4];
+  two_diff(bx, ax, &d[0], &t[0]);
+  two_diff(dy, cy, &d[1], &t[1]);
+  two_diff(by, ay, &d[2], &t[2]);
+  two_diff(dx, cx, &d[3], &t[3]);
+  if (t[0] == 0.0 && t[1] == 0.0 && t[2] == 0.0 && t[3] == 0.0)
+  {
+    double l = d[0] * d[1], r = d[2] * d[3];
+    if (l != r)
+      return (l > r) ? 1 : -1;
+    double err = fma(d[0], d[1], - l) - fma(d[2], d[3], - r);
+    return (err > 0.0) ? 1 : ((err < 0.0) ? -1 : 0);
+  }
+  /* (d0 + t0) (d1 + t1) - (d2 + t2) (d3 + t3), term by term */
+  const double lf[2] = {d[0], t[0]}, lg[2] = {d[1], t[1]};
+  const double rf[2] = {d[2], t[2]}, rg[2] = {d[3], t[3]};
+  double buf1[32], buf2[32];
+  double *e = buf1, *h = buf2, *swap;
+  int elen = 0;
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 2; j++)
+    {
+      double x, y;
+      if (lf[i] != 0.0 && lg[j] != 0.0)
+      {
+        two_product(lf[i], lg[j], &x, &y);
+        elen = grow_expansion(elen, e, x, h);
+        swap = e; e = h; h = swap;
+        elen = grow_expansion(elen, e, y, h);
+        swap = e; e = h; h = swap;
+      }
+      if (rf[i] != 0.0 && rg[j] != 0.0)
+      {
+        two_product(rf[i], rg[j], &x, &y);
+        elen = grow_expansion(elen, e, - x, h);
+        swap = e; e = h; h = swap;
+        elen = grow_expansion(elen, e, - y, h);
+        swap = e; e = h; h = swap;
+      }
+    }
+  /* Every term with a zero factor: the cross product is zero */
+  if (elen == 0)
+    return 0;
+  double top = e[elen - 1];
+  return (top > 0.0) ? 1 : ((top < 0.0) ? -1 : 0);
+}
+
+/*****************************************************************************
  * Functions computing the intersection of two segments derived from PostGIS
  * The seg2d_intersection function is a modified version of the PostGIS
  * lw_segment_intersects function and also returns the intersection point
@@ -4374,7 +4498,7 @@ relate_linear_edges_overlap(const Edge *a, const Edge *b, double *t0,
 {
   if (a->etype == EDGE_LINESEG && b->etype == EDGE_LINESEG)
   {
-    IntersectResult r = linesegm_intersect(a->x1, a->y1, a->dx, a->dy,
+    IntersectResult r = linesegm_intersect(a->x1, a->y1, a->x2, a->y2,
         b->x1, b->y1, b->x2, b->y2);
     if (r.type != INTERSECT_OVERLAP)
       return false;
@@ -4697,8 +4821,8 @@ relate_linear_area_edge_intersection(const Edge *line, const Edge *boundary,
   /* Line / Poly */
   if (line->etype == EDGE_LINESEG && boundary->etype == EDGE_POLYSEG)
   {
-    IntersectResult r =  linesegm_intersect(line->x1, line->y1, line->dx,
-      line->dy, boundary->x1, boundary->y1, boundary->x2, boundary->y2);
+    IntersectResult r =  linesegm_intersect(line->x1, line->y1, line->x2,
+      line->y2, boundary->x1, boundary->y1, boundary->x2, boundary->y2);
     if (r.type == INTERSECT_NONE)
       return;
     if (r.type == INTERSECT_OVERLAP)
@@ -5063,7 +5187,7 @@ relate_linear_edge_points(const Edge *a, const Edge *b, POINT2D *out)
   int count = 0;
   if (a->etype == EDGE_LINESEG && b->etype == EDGE_LINESEG)
   {
-    IntersectResult r = linesegm_intersect(a->x1, a->y1, a->dx, a->dy,
+    IntersectResult r = linesegm_intersect(a->x1, a->y1, a->x2, a->y2,
       b->x1, b->y1, b->x2, b->y2);
     if (r.type == INTERSECT_POINT)
     {
@@ -5674,7 +5798,7 @@ relate_area_edge_intersection(const Edge *a, const Edge *b, double ix[2],
   /* Line / Line */
   if (a->etype == EDGE_POLYSEG && b->etype == EDGE_POLYSEG)
   {
-    IntersectResult r = linesegm_intersect(a->x1, a->y1, a->dx, a->dy,
+    IntersectResult r = linesegm_intersect(a->x1, a->y1, a->x2, a->y2,
       b->x1, b->y1, b->x2, b->y2);
     if (r.type == INTERSECT_NONE)
       return 0;
@@ -7424,7 +7548,7 @@ relate_edges_meet(const Edge *a, const Edge *b)
     EDGE_LINEARC : EDGE_LINESEG;
   if (ea.etype == EDGE_LINESEG && eb.etype == EDGE_LINESEG)
   {
-    IntersectResult r = linesegm_intersect(ea.x1, ea.y1, ea.dx, ea.dy,
+    IntersectResult r = linesegm_intersect(ea.x1, ea.y1, ea.x2, ea.y2,
       eb.x1, eb.y1, eb.x2, eb.y2);
     return r.type != INTERSECT_NONE;
   }
@@ -8082,104 +8206,6 @@ linear_union_transpose(const char matrix[10], char result[10])
 }
 
 /**
- * @brief Split the difference of two doubles into its rounded value and the
- * error of that rounding, which together are the difference exactly
- */
-static inline void
-linear_union_two_diff(double a, double b, double *x, double *y)
-{
-  *x = a - b;
-  double bv = a - *x;
-  double av = *x + bv;
-  *y = (a - av) + (bv - b);
-}
-
-/**
- * @brief Split the product of two doubles into its rounded value and the
- * error of that rounding, which together are the product exactly
- * @note Exact where the product neither overflows nor underflows
- */
-static inline void
-linear_union_two_product(double a, double b, double *x, double *y)
-{
-  *x = a * b;
-  *y = fma(a, b, - *x);
-}
-
-/**
- * @brief Add a double to an expansion, a sum of doubles that do not overlap,
- * held in increasing order of magnitude, and return its new length
- * @details The sum is exact, and a zero component is dropped, so the last
- * component carries the sign of the whole expansion
- */
-static int
-linear_union_grow_expansion(int elen, const double *e, double b, double *h)
-{
-  double q = b;
-  int hlen = 0;
-  for (int i = 0; i < elen; i++)
-  {
-    double sum = q + e[i];
-    double bv = sum - q;
-    double av = sum - bv;
-    double err = (q - av) + (e[i] - bv);
-    q = sum;
-    if (err != 0.0)
-      h[hlen++] = err;
-  }
-  if (q != 0.0 || hlen == 0)
-    h[hlen++] = q;
-  return hlen;
-}
-
-/**
- * @brief Return which side of the line through two points a third lies on
- * @details The filtered sign of #relate_orientation answers where the double
- * evaluation carries the sign. Where it cannot tell, the same determinant
- * @p (bx - ax) * (cy - ay) - (by - ay) * (cx - ax) is summed exactly: each
- * difference is its rounded value plus the error of the rounding, each
- * product of two such terms is its rounded value plus its error, and the
- * sixteen terms are added into an expansion, whose last component carries
- * the sign of the exact determinant of the input doubles
- * @return 1 or -1 for the two sides, 0 exactly where the three are collinear
- */
-static int
-linear_union_orientation(double ax, double ay, double bx, double by,
-  double cx, double cy)
-{
-  int sign = relate_orientation(ax, ay, bx, by, cx, cy);
-  if (sign != 0)
-    return sign;
-  double d[4], t[4];
-  linear_union_two_diff(bx, ax, &d[0], &t[0]);
-  linear_union_two_diff(cy, ay, &d[1], &t[1]);
-  linear_union_two_diff(by, ay, &d[2], &t[2]);
-  linear_union_two_diff(cx, ax, &d[3], &t[3]);
-  /* (d0 + t0) (d1 + t1) - (d2 + t2) (d3 + t3), term by term */
-  const double lf[2] = {d[0], t[0]}, lg[2] = {d[1], t[1]};
-  const double rf[2] = {d[2], t[2]}, rg[2] = {d[3], t[3]};
-  double e[32], h[32];
-  int elen = 0;
-  for (int i = 0; i < 2; i++)
-    for (int j = 0; j < 2; j++)
-    {
-      double x, y;
-      linear_union_two_product(lf[i], lg[j], &x, &y);
-      elen = linear_union_grow_expansion(elen, e, x, h);
-      memcpy(e, h, sizeof(double) * (size_t) elen);
-      elen = linear_union_grow_expansion(elen, e, y, h);
-      memcpy(e, h, sizeof(double) * (size_t) elen);
-      linear_union_two_product(rf[i], rg[j], &x, &y);
-      elen = linear_union_grow_expansion(elen, e, - x, h);
-      memcpy(e, h, sizeof(double) * (size_t) elen);
-      elen = linear_union_grow_expansion(elen, e, - y, h);
-      memcpy(e, h, sizeof(double) * (size_t) elen);
-    }
-  double top = e[elen - 1];
-  return (top > 0.0) ? 1 : ((top < 0.0) ? -1 : 0);
-}
-
-/**
  * @brief A stretch of an edge that another edge covers
  * @details Both ends are INPUT VERTICES lying on the edge -- an end of the
  * covering edge, or an end of the covered one where the cover runs past it --
@@ -8216,17 +8242,19 @@ linear_union_position(const Edge *edge, double x, double y)
  * stretch in the last argument
  * @details The other edge shares more than a point with the edge only where
  * both its ends lie on the line the edge spans, a question on four input
- * vertices that two exact determinant signs answer
- * (#linear_union_orientation). The stretch is then the span of the other
- * edge's ends clipped to the edge's own, compared by their position along it
- * (#linear_union_position). A pair meeting at a point leaves the edge whole
+ * vertices that two exact determinant signs answer (#cross_product_sign).
+ * The stretch is then the span of the other edge's ends clipped to the
+ * edge's own, compared by their position along it (#linear_union_position).
+ * A pair meeting at a point leaves the edge whole
  */
 static bool
 linear_union_cover(const Edge *b, const Edge *a, LinearStretch *s)
 {
   assert(b); assert(a); assert(s);
-  if (linear_union_orientation(b->x1, b->y1, b->x2, b->y2, a->x1, a->y1) != 0 ||
-      linear_union_orientation(b->x1, b->y1, b->x2, b->y2, a->x2, a->y2) != 0)
+  if (cross_product_sign(b->x1, b->y1, b->x2, b->y2, b->x1, b->y1,
+        a->x1, a->y1) != 0 ||
+      cross_product_sign(b->x1, b->y1, b->x2, b->y2, b->x1, b->y1,
+        a->x2, a->y2) != 0)
     return false;
   double pa1 = linear_union_position(b, a->x1, a->y1);
   double pa2 = linear_union_position(b, a->x2, a->y2);

--- a/meos/src/geo/postgis_funcs.c
+++ b/meos/src/geo/postgis_funcs.c
@@ -2276,7 +2276,7 @@ geom_areal_touching_stretches(const GSERIALIZED *gs1, const GSERIALIZED *gs2)
       if (fmax(b->x1, b->x2) < axmin || fmin(b->x1, b->x2) > axmax ||
           fmax(b->y1, b->y2) < aymin || fmin(b->y1, b->y2) > aymax)
         continue;
-      IntersectResult r = linesegm_intersect(a->x1, a->y1, arx, ary,
+      IntersectResult r = linesegm_intersect(a->x1, a->y1, a->x2, a->y2,
         b->x1, b->y1, b->x2, b->y2);
       if (r.type != INTERSECT_OVERLAP)
         continue;

--- a/meos/src/geo/tpoint_geom_clip.c
+++ b/meos/src/geo/tpoint_geom_clip.c
@@ -352,9 +352,6 @@ intervals_from_lines(const POINT2D *a, const POINT2D *b, Edge **edges,
   const double seg_xmax = Max(ax, bx);
   const double seg_ymin = Min(ay, by);
   const double seg_ymax = Max(ay, by);
-  /* Segment vector */
-  const double rx = bx - ax;  
-  const double ry = by - ay;  
 
   bool has_intersection = false;
   Span in;
@@ -373,7 +370,7 @@ intervals_from_lines(const POINT2D *a, const POINT2D *b, Edge **edges,
       continue;
 
     /* Compute the intersection */
-    IntersectResult r = linesegm_intersect(ax, ay, rx, ry,
+    IntersectResult r = linesegm_intersect(ax, ay, bx, by,
       e->x1, e->y1, e->x2, e->y2);
     /* If there is no intersection  */
     if (r.type == INTERSECT_NONE)
@@ -572,7 +569,7 @@ intervals_from_polygons(const POINT2D *a, const POINT2D *b, Edge **edges,
     if (e->etype == EDGE_POLYSEG)
     {
       /* Compute the crossing with the straight boundary segment */
-      IntersectResult r = linesegm_intersect(ax, ay, rx, ry,
+      IntersectResult r = linesegm_intersect(ax, ay, bx, by,
         e->x1, e->y1, e->x2, e->y2);
       if (r.type == INTERSECT_POINT)
       {
@@ -1865,7 +1862,7 @@ edge_intersect(const Edge *e1, const Edge *e2)
     double out[2];
     return arcsegm_intersect(e1->x1, e1->y1, e1->dx, e1->dy, e2, out) > 0;
   }
-  IntersectResult r = linesegm_intersect(e1->x1, e1->y1, e1->dx, e1->dy,
+  IntersectResult r = linesegm_intersect(e1->x1, e1->y1, e1->x2, e1->y2,
     e2->x1, e2->y1, e2->x2, e2->y2);
   return r.type != INTERSECT_NONE;
 }
@@ -2071,7 +2068,7 @@ segment_within_closure(const Edge *e, Edge **aedges, int na, bool has_area)
     }
     else
     {
-      IntersectResult r = linesegm_intersect(e->x1, e->y1, e->dx, e->dy,
+      IntersectResult r = linesegm_intersect(e->x1, e->y1, e->x2, e->y2,
         ea->x1, ea->y1, ea->x2, ea->y2);
       if (r.type == INTERSECT_POINT)
         ts[nt++] = r.t0;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -321,6 +321,36 @@ int main(void)
   }
   meos_errno_reset();
 
+  /* Two GPS steps of about 1e-6 in degrees leaving one vertex in different
+   * directions share that vertex and nothing else: they intersect, and their
+   * interiors do not meet. Both pairs are real AIS steps: in the first the two
+   * start at one vertex, in the second the end of one is the start of the
+   * other */
+  struct { const char *a, *b; } gpssteps[] = {
+    { "LINESTRING(11.198253 55.211805,11.198252 55.211803)",
+      "LINESTRING(11.198253 55.211805,11.19825 55.2118)" },
+    { "LINESTRING(11.198253 55.211805,11.198252 55.211803)",
+      "LINESTRING(11.19825 55.2118,11.198253 55.211805)" },
+  };
+  for (size_t i = 0; i < sizeof(gpssteps) / sizeof(gpssteps[0]); i++)
+  {
+    GSERIALIZED *ga = geom_in(gpssteps[i].a, -1);
+    GSERIALIZED *gb = geom_in(gpssteps[i].b, -1);
+    assert(ga != NULL);
+    assert(gb != NULL);
+    meos_errno_reset();
+    char *gm = geom_relate(ga, gb);
+    bool gi = geom_intersects(ga, gb);
+    printf("geom_relate(%s, %s): %s, intersects %d, errno %d\n",
+      gpssteps[i].a, gpssteps[i].b, gm ? gm : "(NULL)", gi, meos_errno());
+    assert(gm != NULL);
+    assert(strcmp(gm, "FF1F00102") == 0);
+    assert(gi == true);
+    assert(meos_errno() == 0);
+    free(gm); free(ga); free(gb);
+  }
+  meos_errno_reset();
+
   /* Two areas lying on OPPOSITE SIDES of one line share no area, so neither
    * interior holds a point of the other's boundary, however near the two
    * boundaries run. Deciding that from a boundary portion means classifying a


### PR DESCRIPTION
The segment kernel decides whether two straight segments meet, and along
what, for the relate engine, the union of linework, the trajectory clip
and the buffer. On master it takes the first segment as a vector and
decides with tolerances: the directions are parallel where their cross
product falls below 1e-12, the two lie on one line where their
separation falls below 1e-12, and a crossing counts where its parameters
fall within 1e-12 of [0, 1]. The cross product is an area, so two
segments near 1e-6 long read as parallel whatever their directions.

This commit gives the kernel the endpoints of both segments and decides
every verdict on them exactly. Parallel directions, one line, and the
side of a line each end lies on are signs of cross products of
coordinate differences. cross_product_sign, inline in geo_funcs.h,
filters each with Shewchuk's bound and answers 0 where both products
hold a zero difference; where it cannot tell otherwise,
cross_product_sign_exact decides the same cross product exactly: by the
order of the two rounded products, and then of their exact rounding
errors, where the four differences are exact, and otherwise by summing
its terms in an expansion that skips every term with a zero factor. The
expansion is the arithmetic the union of linework carries, moved out of
it so both read one copy. Along one line the shared stretch runs between
positions read off the coordinate the first segment advances most in,
compared exactly, and a meeting at an end of the first segment reads the
parameter 0 or 1 exactly. The kernel keeps no tolerance. Its ten callers
-- five in the relate engine, the touching stretches of two areal
geometries, four in the trajectory clip -- pass the endpoints they hold.
The buffer asks the question of offsets it constructs, whose ends are
rounded, so it keeps master's kernel, tolerances included, as its own
buffer_linesegm_intersect: two offsets sharing a corner meet there even
where their rounded ends do not exactly coincide.

Witness

Two real AIS steps sharing their first vertex,

    LINESTRING(11.198253 55.211805,11.198252 55.211803)
    LINESTRING(11.198253 55.211805,11.19825 55.2118)

relate as FF1F00102, meeting at that vertex only, as CGAL's exact kernel
answers, where master's kernel answers OVERLAP and geom_relate
1FFF00102. Two steps where the end of one is the start of the other
intersect, where master answers geom_intersects false beside a matrix
whose boundary/boundary cell reads 0.

Measured

Over 3000 segment pairs -- sharing an end, meeting at an interior point,
overlapping, touching, apart on one line, parallel one unit apart, one
end one or two units off the other's line, crossing, apart -- with
integer coordinates below 2^52 scaled by 1, 2^-20, 2^-40 and 2^-52,
master's kernel answers 209 differently from CGAL (198 an overlap where
the two share one point, 11 no meeting where they share one); this
commit answers all 3000 as CGAL does. Of five real AIS step pairs
meeting at one vertex, master reads three as sharing a stretch through
geom_relate and two as not intersecting through geom_intersects; this
commit reads all five as FF1F00102 and intersecting. A collinear overlap
and a proper crossing answer as on master.

The relate acceptance set -- 931 h3 cells against themselves, 1444 areal
pairs and a real protected-area pair in projected coordinates -- holds
1864 of 1864 self-matrices at the definition and 918 of 918 interior
cells at the exact shared area, on master and on this commit.

The buffer keeps master's kernel for the offsets it constructs, and its
answers do not move: the 192 real protected-area polygons of the corpus
of 283 whose WKT runs to at most 100 kB, buffered at radii 1, 50 and
500, answer byte for byte as on master -- 510 buffers and 66 declined
-- where the exact kernel in the buffer's place changes one of those
576 answers, into a buffer at radius 1 carrying a join arc of radius
1.46e-8, which is not a valid polygon. The scale sweep of the buffer
moves one row, and the move is the relate engine's: a plain circular
string at scale 1e-8 buffers to the same polygon on both, whose box
spans -1 to 11 times the scale on each axis while the arc reaches -5.41
and 15.41 by closed form; master reads that polygon as covering the arc,
and this commit reads it as not.

The union of linework reads the kernel where it relates two curves.
Against the measure CGAL computes on the doubles, over real AIS
trajectories from the Danish Maritime Authority (aisdk-2025-03-01, trips
split at 180 s / 1 NM), each line united with a far point: built without
the fallback library the union answers all 50 and all 41 exactly, where
master refuses 10 and 11; with it, all 50 and all 41, where master
answers 1 and 8 short. Each trajectory split into two halves and the
halves united: without the fallback library it answers 25 of 50 and 29
of 41 exactly and refuses the rest, where master refuses 28 and 16; it
refuses no union master answers, and every union master refuses and it
answers is exact. With the fallback library the halves come out 1 and 8
short of CGAL, where master's come out 2 and 9 short; each short one of
this commit's is a union its native route refuses. Over 3000 adversarial
unions of two or three lines, built without the fallback library, it
refuses none where master refuses 389, and with it neither refuses any;
no answer on either build differs from CGAL.

The pair (0 0)-(9007199254740990 9007199254740988),
(0 0)-(4503599627370495 4503599627370495), whose cross product the
filter cannot sign, reads POINT in the kernel on master and on this
commit, as CGAL does; geom_relate answers F01F001F2 on both where CGAL's
answer is FF1F00102, and that cell gets its own change.

Across the 42 instruments of the discrimination run -- the output of
every MEOS test program, and a probe that buffers and self-relates real
protected areas in projected coordinates and sweeps the buffer's scale
-- no answer moves between master and this commit but three: the two
witnesses geo_test adds, appended, and the scale row's covers.

cross_product_sign_exact agrees with a full sixteen-term expansion on
7,000,000 inputs built to reach each of its stages: lattice points
scaled by powers of two up to 2^52, near a line, sharing a point or on
vertical lines, and doubles near a line whose differences round.

Timed interleaved against master in six rounds, best of three each,
geom_relate over the 1444 areal pairs takes 0.93 to 1.00 of master's
time, less in every round, though under callgrind it executes
8,526,200,727 instructions against master's 7,038,110,053. Over the
protected-area pair the kernel is 0.05 per cent of the instructions and
the two totals agree to 0.04 per cent, 77,418,787,516 against
77,390,710,153; its wall clock reads 0.98 to 1.19 of master's under a
load of 1.3 to 2.5.

Why

The operands are the doubles the parser reads, and every double is an
exact rational, so whether two segments are parallel, lie on one line or
meet has one answer about them: signs of cross products of their
coordinate differences. The filter decides each sign wherever the double
evaluation carries it and cross_product_sign_exact decides it everywhere
else, exactly as long as no product of coordinate differences overflows
or underflows. On one line, the order of two points along it is the
order of their parameters, an increasing affine function of the
coordinate the segment advances most in, so comparing two positions
compares two coordinates. No verdict then depends on a threshold, and
none changes with the scale of the coordinates. The buffer asks the
question of pieces it constructs one at a time, whose shared ends round
apart by a few ulps, so an exact verdict reads two pieces meant to join
as separate; it keeps master's kernel until the buffer builds each joint
once.

Test

geo_test asserts both witnesses: the first aborts against master at
geo_test.c:347 and holds on this commit.