### PR TITLE
Write each buffer join as the piece its coordinates can carry, and decide where two pieces meet exactly

### DIFF
--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -348,11 +348,40 @@ buffer_add_arc(LWCOMPOUND *curve, int32_t srid, double cx, double cy,
     buffer_snap_to_curve_end(curve, &first);
     snapped = &first;
   }
+  /* How far each piece bulges from its chord */
+  double half = sin(delta * 0.25);
+  double bulge = 2.0 * radius * half * half;
   for (int i = 0; i < count; i++)
   {
     double a0 = ccw ? start_angle + delta * i : start_angle - delta * i;
-    double a1 = ccw ? start_angle + delta * (i + 1) : 
+    double a1 = ccw ? start_angle + delta * (i + 1) :
       start_angle - delta * (i + 1);
+    /* A piece bulging from its chord by no more than the rounding of the
+     * coordinates it is written at is that chord: every point of the arc lies
+     * within the rounding of it, while three rounded points name the circle of
+     * such an arc no better than they name a line, and read as a circle of
+     * another radius */
+    POINT2D p0, p1;
+    if (i == 0 && snapped)
+      p0 = *snapped;
+    else
+    {
+      p0.x = cx + radius * cos(a0);
+      p0.y = cy + radius * sin(a0);
+    }
+    if (i == count - 1 && end)
+      p1 = *end;
+    else
+    {
+      p1.x = cx + radius * cos(a1);
+      p1.y = cy + radius * sin(a1);
+    }
+    if (bulge <= fmax(coordinate_tolerance(p0.x, p1.x),
+          coordinate_tolerance(p0.y, p1.y)))
+    {
+      buffer_add_segment(curve, srid, p0, p1);
+      continue;
+    }
     LWCIRCSTRING *arc = buffer_make_arc(srid, cx, cy, radius, a0, a1, ccw,
       i == 0 ? snapped : NULL, i == count - 1 ? end : NULL);
     if (arc &&
@@ -418,7 +447,30 @@ buffer_add_mitre_join(LWCOMPOUND *curve, int32_t srid, POINT2D vertex,
 }
 
 /**
+ * @brief Return true if the two ends of a join are one point
+ * @details The ends of a join are the offsets of one vertex along the normals
+ * of the two edges meeting there, each constructed and rounded to the
+ * coordinates it is written at. Where the edges turn by less than that rounding
+ * resolves, the two ends lie within it of each other and the join between them
+ * has no extent the coordinates can carry: written as an arc, its three rounded
+ * points name a circle of another radius altogether, and written as a segment
+ * it is a sliver whose direction is the rounding. The two pieces it would join
+ * meet at one point instead.
+ */
+static bool
+buffer_join_is_point(POINT2D p1, POINT2D p2)
+{
+  double tol = fmax(coordinate_tolerance(p1.x, p2.x),
+    coordinate_tolerance(p1.y, p2.y));
+  return hypot(p2.x - p1.x, p2.y - p1.y) <= tol;
+}
+
+/**
  * @brief Add a join between two offset segments
+ * @details A join whose ends are one point (#buffer_join_is_point) adds
+ * nothing, and the piece after it starts from the point the curve ends at
+ * (#buffer_snap_to_curve_end), so the two pieces share that joint rather than
+ * each placing it where its own arithmetic rounds to
  */
 static void
 buffer_add_join(LWCOMPOUND *curve, int32_t srid, POINT2D vertex, POINT2D p1,
@@ -426,6 +478,8 @@ buffer_add_join(LWCOMPOUND *curve, int32_t srid, POINT2D vertex, POINT2D p1,
   bool outer)
 {
   assert(curve);
+  if (buffer_join_is_point(p1, p2))
+    return;
   /* The inner side of a turn is always joined by the intersection
    * of the two offset lines */
   if (! outer)

--- a/meos/src/geo/geo_buffer.c
+++ b/meos/src/geo/geo_buffer.c
@@ -613,103 +613,6 @@ buffer_curvepoly_add_ring(LWCURVEPOLY *poly, LWCOMPOUND *ring)
  *****************************************************************************/
 
 /**
- * @brief Return where two segments of a buffer meet, the first given by its
- * start and its direction
- * @details The buffer asks this of its own edges, offsets it computes from
- * the input and whose ends are rounded, so the verdict is taken within
- * tolerances rather than exactly: two offsets that share a corner meet at
- * one point even where their rounded ends do not exactly coincide.
- * #linesegm_intersect decides the same question exactly, on input vertices.
- * - No intersection: INTERSECT_NONE -> t0 and t1 undefined
- * - Single point: INTERSECT_POINT -> t0 in [0,1], t1 ignored
- * - Overlap segment: INTERSECT_OVERLAP -> t0 < t1 in [0,1], apart by at
- *   least MEOS_GEOM_TOLERANCE
- * @param[in] ax,ay Coordinates of the start of the first segment
- * @param[in] rx,ry Vector from the start to the end of the first segment
- * @param[in] cx,cy,dx,dy Coordinates of the ends of the second segment
- */
-static inline IntersectResult
-buffer_linesegm_intersect(double ax, double ay, double rx, double ry,
-  double cx, double cy, double dx, double dy)
-{
-  IntersectResult res = {INTERSECT_NONE, 0, 0};
-  double sx = dx - cx, sy = dy - cy; /* vector CD */
-  /* Where is the start of the second segment relative to the first? */
-  double qpx = cx - ax, qpy = cy - ay;
-
-  /* Are the two segments parallel?  */
-  double rxs = rx * sy - ry * sx;
-
-  /* Collinear / parallel */
-  if (fabs(rxs) < MEOS_GEOM_TOLERANCE)
-  {
-    /* The two segments run in one direction; what is left to decide is
-     * whether they run along the SAME LINE or along two parallel ones. Both
-     * quantities that answer it are areas rather than lengths, and each needs
-     * a threshold in its own units:
-     * - r2 is the squared length of AB, so its bound is the SQUARE of the
-     *   tolerance. Bounded by the plain tolerance it rejects every segment
-     *   shorter than that tolerance's square root, which is 1e-6, and such a
-     *   segment then fails to overlap even an identical copy of itself.
-     * - qpxr is the cross product of AC with AB, which is the separation of
-     *   the two lines TIMES the length of AB. Bounded by the plain tolerance
-     *   it stands for a separation of tolerance/|AB|, so two lines far apart
-     *   read as one line whenever AB is short enough. Dividing by the length
-     *   puts the bound back on the separation, where it belongs. */
-    double r2 = rx * rx + ry * ry;
-    if (r2 < MEOS_GEOM_TOLERANCE * MEOS_GEOM_TOLERANCE)
-      return res;
-
-    /* Is point C aligned with segment AB? */
-    double qpxr = qpx * ry - qpy * rx;
-    /* If qpxr != 0: parallel, if qpxr == 0: collinear */
-    if (fabs(qpxr) > MEOS_GEOM_TOLERANCE * sqrt(r2))
-      return res;
-
-    double t0 = (qpx * rx + qpy * ry) / r2;
-    double t1 = t0 + (sx * rx + sy * ry) / r2;
-
-    /* Order t0 < t1 */
-    if (t0 > t1) { double tmp = t0; t0 = t1; t1 = tmp; }
-    /* No intersection */
-    if (t1 < 0 || t0 > 1)
-      return res;
-
-    /* Clamp values */
-    if (t0 < 0) t0 = 0;
-    if (t1 > 1) t1 = 1;
-
-    if (fabs(t1 - t0) < MEOS_GEOM_TOLERANCE)
-    {
-      res.type = INTERSECT_POINT;
-      res.t0 = t0;
-      return res;
-    }
-
-    res.type = INTERSECT_OVERLAP;
-    res.t0 = t0;
-    res.t1 = t1;
-    return res;
-  }
-
-  /* Proper intersection */
-  double t = (qpx * sy - qpy * sx) / rxs;
-  double u = (qpx * ry - qpy * rx) / rxs;
-
-  if (t < -MEOS_GEOM_TOLERANCE || t > 1 + MEOS_GEOM_TOLERANCE ||
-      u < -MEOS_GEOM_TOLERANCE || u > 1 + MEOS_GEOM_TOLERANCE)
-    return res;
-
-  /* Clamp values */
-  if (fabs(t) < MEOS_GEOM_TOLERANCE) t = 0;
-  if (fabs(t - 1) < MEOS_GEOM_TOLERANCE) t = 1;
-
-  res.type = INTERSECT_POINT;
-  res.t0 = t;
-  return res;
-}
-
-/**
  * @brief Return true if two buffer geometries have overlapping interiors.
  * @details This is used to determine whether individual line buffers can
  * be returned independently or whether an overlay/union operation is needed.
@@ -760,8 +663,8 @@ buffer_geometries_intersect(const LWGEOM *geom1, const LWGEOM *geom2)
       /* Line / line */
       if (a->etype == EDGE_LINESEG && b->etype == EDGE_LINESEG)
       {
-        IntersectResult r = buffer_linesegm_intersect(a->x1, a->y1,
-          a->dx, a->dy, b->x1, b->y1, b->x2, b->y2);
+        IntersectResult r = linesegm_intersect(a->x1, a->y1,
+          a->x2, a->y2, b->x1, b->y1, b->x2, b->y2);
         if (r.type != INTERSECT_NONE)
         {
           result = true;
@@ -808,8 +711,8 @@ buffer_geometries_intersect(const LWGEOM *geom1, const LWGEOM *geom2)
        * EDGE_POLYSEG and curved boundaries as EDGE_POLYARC. */
       else if (a->etype == EDGE_POLYSEG && b->etype == EDGE_POLYSEG)
       {
-        IntersectResult r = buffer_linesegm_intersect(a->x1, a->y1,
-          a->dx, a->dy, b->x1, b->y1, b->x2, b->y2);
+        IntersectResult r = linesegm_intersect(a->x1, a->y1,
+          a->x2, a->y2, b->x1, b->y1, b->x2, b->y2);
         if (r.type != INTERSECT_NONE)
         {
           result = true;
@@ -868,8 +771,8 @@ buffer_edges_intersect(const Edge *e1, const Edge *e2)
   /* Line / Line */
   if (e1->etype == EDGE_POLYSEG && e2->etype == EDGE_POLYSEG)
   {
-    IntersectResult r = buffer_linesegm_intersect(e1->x1, e1->y1,
-      e1->dx, e1->dy, e2->x1, e2->y1, e2->x2, e2->y2);
+    IntersectResult r = linesegm_intersect(e1->x1, e1->y1,
+      e1->x2, e1->y2, e2->x1, e2->y1, e2->x2, e2->y2);
     return r.type != INTERSECT_NONE;
   }
 
@@ -1213,8 +1116,8 @@ buffer_boundary_intersection(const Edge *e1, const Edge *e2)
   /* Straight segment / straight segment */
   if (e1->etype == EDGE_POLYSEG && e2->etype == EDGE_POLYSEG)
   {
-    IntersectResult result = buffer_linesegm_intersect(e1->x1, e1->y1,
-      e1->dx, e1->dy, e2->x1, e2->y1, e2->x2, e2->y2);
+    IntersectResult result = linesegm_intersect(e1->x1, e1->y1,
+      e1->x2, e1->y2, e2->x1, e2->y1, e2->x2, e2->y2);
     if (result.type == INTERSECT_OVERLAP)
       return 1;
     if (result.type == INTERSECT_POINT)
@@ -1742,8 +1645,8 @@ buffer_collect_line_line_intersections(const Edge *e1, const Edge *e2,
   MeosArray *points)
 {
   assert(e1); assert(e2); assert(points);
-  IntersectResult result = buffer_linesegm_intersect(e1->x1, e1->y1,
-    e1->dx, e1->dy, e2->x1, e2->y1, e2->x2, e2->y2);
+  IntersectResult result = linesegm_intersect(e1->x1, e1->y1,
+    e1->x2, e1->y2, e2->x1, e2->y1, e2->x2, e2->y2);
   if (result.type == INTERSECT_POINT)
   {
     double x = e1->x1 + result.t0 * e1->dx;

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -740,6 +740,93 @@ int main(void)
   free(holed_geo); free(holed_buf);
   meos_errno_reset();
 
+  /* The round join at a vertex spans the angle the two edges meeting there
+   * turn by, and at a vertex turning by less than about 2e-4 radians it bulges
+   * from its chord by less than the rounding of coordinates near 6e6. Such a
+   * join is no arc of the answer: its three rounded points name a circle of
+   * another radius, or one across the chord, and the offset beyond it does not
+   * meet it exactly. It is written as its chord, or as nothing where the chord
+   * itself is within the rounding. The witnesses are two real protected areas
+   * at coordinates near 4e5 to 9e5 and 6.1e6 to 6.3e6, each with a hole vertex
+   * turning by under 1e-8 radians, and the first of them with that vertex
+   * moved by 1e-6 along its normal, where the join's chord is just over the
+   * rounding. Each buffer at radius 1 covers the geometry it is taken of, and
+   * every arc it carries bulges from its chord by more than the rounding of
+   * its own coordinates */
+  const char *straight_joints[] = {
+    "MULTIPOLYGON(((898914.9403076661 6122116.964651632,"
+    "892000.0000313906 6128240.709886038,881878.7649123298 6134742.834215424,"
+    "895337.2320802852 6149482.958137969,911403.2986007167 6138679.914452544,"
+    "898914.9403076661 6122116.964651632),"
+    "(907237.9528864882 6136624.956954372,894477.5768949464 6145528.711752129,"
+    "891483.2765023337 6142244.494390287,893273.247674003 6139116.564902924,"
+    "900857.8283076342 6128187.6022518305,903018.1035232148 6131044.4443305535,"
+    "907237.9528864882 6136624.956954372)))",
+    "MULTIPOLYGON(((427476.90227913705 6289481.157459412,"
+    "430837.72147431236 6289481.963124866,430916.2857289751 6276994.411554065,"
+    "430917.8166187645 6276751.080126724,425577.2465192299 6276753.74492519,"
+    "425474.3087710385 6271012.617867712,416077.0768295746 6272295.634823122,"
+    "417158.4882763424 6295836.6436494235,427477.49727490137 6294083.592144184,"
+    "427476.90227913705 6289481.157459412),"
+    "(430183.978312475 6276753.744946178,430183.97828800324 6288132.508823933,"
+    "416409.7076745876 6276753.744863464,425577.2465192299 6276753.74492519,"
+    "430183.978312475 6276753.744946178)))",
+    "MULTIPOLYGON(((898914.9403076661 6122116.964651632,"
+    "892000.0000313906 6128240.709886038,881878.7649123298 6134742.834215424,"
+    "895337.2320802852 6149482.958137969,911403.2986007167 6138679.914452544,"
+    "898914.9403076661 6122116.964651632),"
+    "(907237.9528864882 6136624.956954372,894477.5768949464 6145528.711752129,"
+    "891483.2765023337 6142244.494390287,893273.247674003 6139116.564902924,"
+    "900857.8283076342 6128187.6022518305,903018.1035224171 6131044.444331157,"
+    "907237.9528864882 6136624.956954372)))"
+  };
+  char straight_patt[10] = "T*****FF*";
+  for (size_t i = 0; i < sizeof(straight_joints) / sizeof(straight_joints[0]);
+      i++)
+  {
+    GSERIALIZED *g = geom_in(straight_joints[i], -1);
+    assert(g != NULL);
+    meos_errno_reset();
+    GSERIALIZED *b = geom_buffer(g, 1.0, "");
+    printf("geom_buffer(a real area with a nearly straight hole vertex, %zu): "
+      "answered %d, errno %d\n", i, b != NULL, meos_errno());
+    assert(b != NULL);
+    assert(meos_errno() == 0);
+    bool covers = geom_relate_pattern(b, g, straight_patt);
+    printf("  it covers the geometry it is taken of: %d\n", covers);
+    assert(covers == true);
+    assert(meos_errno() == 0);
+    /* Every arc bulges from its chord by more than the rounding of its
+     * coordinates: its middle point lies further from the chord than that */
+    char *text = geo_as_text(b, 17);
+    assert(text != NULL);
+    int arcs = 0, flat = 0;
+    for (const char *s = strstr(text, "CIRCULARSTRING("); s;
+        s = strstr(s + 1, "CIRCULARSTRING("))
+    {
+      double x1, y1, xm, ym, x2, y2;
+      int n = sscanf(s, "CIRCULARSTRING(%lf %lf,%lf %lf,%lf %lf", &x1, &y1,
+        &xm, &ym, &x2, &y2);
+      assert(n == 6);
+      double scale = 0.0, c[6] = { x1, y1, xm, ym, x2, y2 };
+      for (int k = 0; k < 6; k++)
+        if (fabs(c[k]) > scale)
+          scale = fabs(c[k]);
+      double band = 4.0 * DBL_EPSILON * scale;
+      double cross = (xm - x1) * (y2 - y1) - (ym - y1) * (x2 - x1);
+      double chord2 = (x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1);
+      if (cross * cross <= band * band * chord2)
+        flat++;
+      arcs++;
+    }
+    printf("  arcs %d, of which bulging less than the rounding %d\n", arcs,
+      flat);
+    assert(arcs > 0);
+    assert(flat == 0);
+    free(text); free(b); free(g);
+    meos_errno_reset();
+  }
+
   /* What a radial distance misses its arc by is a property of the coordinates
    * it is read from, so the band it is judged against is theirs. At projected
    * coordinates the point this states lies 1.6e-11 off the circle it is placed


### PR DESCRIPTION
Write each buffer join as the piece its coordinates can carry

The buffer joins the offsets of two edges at the vertex between them by a
round, mitre or bevel join, from the end of one offset to the start of the
next, and a round join is written as circular strings of three points.
Every point of it is constructed: the vertex moved along a normal by the
buffer distance, rounded to the coordinates it lands on. Where the edges
turn by little, the join bulges from its chord by less than that rounding
-- at coordinates near 6e6 and a radius of 1, below a turn of about 2e-4
radians -- and its three rounded points no longer name its circle: they
name one of another radius, far smaller or far larger, or three points on
one line, or a circle whose arc runs the long way round across the chord,
which leaves the ring crossing itself. Below a turn of a few billionths of
a radian the two ends lie within the rounding of each other, and the join
is shorter than the coordinates can express at all.

This commit writes each arc the buffer emits -- the pieces of a join, of a
cap and of an offset arc -- as the piece its coordinates can carry.
buffer_add_arc writes a piece bulging from its chord by no more than the
rounding of its coordinates, 2 r sin^2(sweep / 4) against MEOS_GEOM_TOLERANCE
plus 4 * DBL_EPSILON times the largest of them (coordinate_tolerance), as
that chord: every point of the arc lies within the rounding of it. And
buffer_add_join adds no join whose two ends lie within that rounding of
each other: the next offset starts from the point the curve already ends
at, as buffer_snap_to_curve_end writes the start of every piece, so the two
offsets share that one point. Any other arc is written as before.

Witness

A real protected area whose hole runs almost straight through the vertex
(425577.2465192299 6276753.74492519), buffered at radius 1: master's answer
carries there a CIRCULARSTRING of three collinear points 2.2e-9 apart, and
at the exterior vertex (430916.2857289751 6276994.411554065), which turns
by 2.9e-8 radians, an arc 2.9e-8 long whose three points name a circle of
radius 3.3e-6. This commit's answer carries the two offsets meeting at the
first vertex and the chord at the second, and every other piece as on
master.

Measured

The 192 real protected-area polygons of the corpus of 283 whose WKT runs to
at most 100 kB, buffered at radii 1, 50 and 500: master answers 510 and
declines 66, this commit answers 569 and declines 7. Every answer of both
is read by an independent judge -- its own EWKB reader, the arcs stroked by
shapely -- for validity, for every arc being a circle of radius r about an
input vertex within 1e-6, and for every sampled point of the boundary lying
at distance r from the input within 1e-6. No answer of either is invalid.
Master's 510 answers split into 161 passing every check and 349 carrying an
arc whose radius or centre misses by more than 1e-6, their boundaries
nonetheless within 1.3e-9 of the buffer distance at the median. Of those
349, 17 pass every check on this commit, none of the 161 fails one, and
the rest keep an arc bulging just above the rounding, whose circle three
rounded points name no more precisely. Of the 59 answers master declines,
57 are valid with their boundaries at the buffer distance; the other two
are one area, twice in the corpus, where one node the resolution places at
a shallow crossing lies 1.0e-6 off it. One area answers 1.03e-5 off the
buffer distance on master and on this commit alike.

A real area whose hole vertex (903018.1035232148 6131044.4443305535) turns
by 4.6e-9 radians, with that vertex moved along its normal by 0 and by
1e-7 to 5 either way -- 49 positions -- and a three-vertex line through the
same vertex moved the same way, buffered at radius 1 with each join style:
master answers 8 of the 98 round-join buffers invalid and declines 6 of the
98 mitre-join ones; this commit answers all 294, none invalid.

On the 140 areas master answers at all three radii, buffering takes 1.00
to 1.04 of master's time over three interleaved rounds. Over the whole
corpus it takes 1.25, which is the cost of the 59 buffers master declines
and this commit computes.

Why

The buffer is the set of points at the buffer distance from the input, and
its coordinates are rounded constructions of them, so the answer is right
where every point it writes lies within that rounding of the set. A piece
bulging from its chord by less than the rounding is, within it, its chord:
the chord is the representation of that piece the coordinates carry, and
the arc through its three rounded points is not the piece but whatever
circle the rounding makes of them. Two ends within the rounding of each
other are one point for the same reason. The band is the rounding a
constructed point carries, coordinate_tolerance, and it decides only
between representations of constructed pieces: every point it compares is
constructed, none is an input vertex.

Test

geo_test buffers the two areas and the first of them with that vertex
moved by 1e-6, where the join is just longer than the rounding, at radius
1, and asserts that each answer covers the area and that every arc it
carries bulges from its chord by more than the rounding of its
coordinates. Against master it aborts on the second area, with two such
arcs among eight.


Decide where two buffer pieces meet with the exact segment kernel

The buffer asks where two of its straight pieces meet at five sites:
whether the buffers of two components overlap, for straight lines and for
polygon boundaries; whether two boundary edges meet; the dimension of
that meeting when a ring is tested for meeting itself; and the nodes
where a ring that does meet itself is split before it is resolved. Every
other caller of the segment kernel decides exactly on the endpoints; the
buffer kept a copy of the tolerant kernel, buffer_linesegm_intersect,
because its pieces did not share their joints. A join shorter than the
rounding of its coordinates left the first half of a round join and the
offset beyond it 2.5e-9 apart: they meet within the copy's tolerances
and share no point exactly, and with the exact kernel in the copy's
place one real buffer kept a join arc whose three points name a circle
of radius 1.46e-8.

With every joint shared by the pieces on either side of it, this commit
removes buffer_linesegm_intersect and gives the five sites
linesegm_intersect, with the two ends of each piece. The buffer no longer
decides this question against a tolerance of its own: parallel where a
cross product falls below 1e-12, one line where a separation falls below
1e-12 times the length, and a meeting where a parameter falls within
1e-12 of [0, 1].

Measured

The 192 real protected-area polygons of the corpus of 283 whose WKT runs
to at most 100 kB, buffered at radii 1, 50 and 500 -- 569 buffers and 7
declined -- answer byte for byte as on the previous commit, and so do the
294 buffers of the swept vertex. Buffering the corpus takes 0.99 to 1.00
of the previous commit's time over three interleaved rounds.

The similarity sweep of the buffer -- four shapes at scales 1 to 1e-8,
each buffered at a radius of its scale -- moves one row: the circular
string (0 0, 1e-7 1e-7, 5e-8 0) buffered at 1e-8. Two offset segments of
its ring cross there at a point interior to both, as CGAL's exact kernel
answers; the copy reads them as parallel, since the cross product of
their directions, near 1e-14, falls under its 1e-12, so master returns
the ring unresolved as the buffer, which does not cover the arc it is
taken of. This commit finds the crossing and hands the ring to the
resolution, which declines at that scale: a wrong answer becomes a
refusal. Every other row of the sweep answers as on master.

Why

Every piece of the ring is the offset of one input edge or one join, and
two consecutive pieces share their end point as the same doubles. Whether
two pieces meet then has one answer about the doubles the buffer writes,
which is the answer linesegm_intersect gives: consecutive pieces meet at
the point they share, which is why the test for a ring meeting itself
skips them, and any other two meet only where the ring runs into itself.
A tolerance on that question answers for the geometry within its band
rather than for the pieces written: it reads pieces the coordinates
place apart as meeting, and, as the similarity sweep shows, two pieces
that cross as parallel.

Test

Against the exact kernel without the previous commit, geo_test aborts on
its first buffer of a nearly straight hole vertex, with one arc among
five bulging less than the rounding of its coordinates; it holds on this
commit.