### PR TITLE
Locate an input vertex against lines and points exactly in relate

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -1021,4 +1021,22 @@ point_on_segment(double px, double py, double x1, double y1, double x2,
     fmax(coordinate_tolerance(x1, x2), coordinate_tolerance(y1, y2)));
 }
 
+/**
+ * @brief Return true if a point lies on a segment, decided exactly
+ * @details For a point that is an input vertex, never a constructed one: the
+ * point lies on the segment exactly where it lies on its line, a sign of a
+ * cross product of coordinate differences (#cross_product_sign), and within
+ * the box of its two ends, comparisons of input coordinates. A segment of no
+ * length holds only its one point
+ */
+static inline bool
+point_on_segment_exact(double px, double py, double x1, double y1, double x2,
+  double y2)
+{
+  if (px < fmin(x1, x2) || px > fmax(x1, x2) ||
+      py < fmin(y1, y2) || py > fmax(y1, y2))
+    return false;
+  return cross_product_sign(x1, y1, x2, y2, x1, y1, px, py) == 0;
+}
+
 #endif /* __GEO_FUNCS_H__ */

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -4141,12 +4141,28 @@ relate_same_point(double x1, double y1, double x2, double y2)
 }
 
 /**
- * @brief Return true if an edge has non-zero length.
+ * @brief Return true if an edge has non-zero length
+ * @details The ends of an edge are input vertices, so it has no length
+ * exactly where they are equal
  */
 static inline bool
 relate_edge_nonempty(const Edge *e)
 {
-  return !relate_same_point(e->x1, e->y1, e->x2, e->y2);
+  return e->x1 != e->x2 || e->y1 != e->y2;
+}
+
+/**
+ * @brief Return true if two points are one point
+ * @details Two input vertices are one point exactly where their coordinates
+ * are equal. A constructed point is rounded, and reads as another point
+ * within the MEOS tolerance
+ * @param[in] x1,y1,x2,y2 Coordinates of the two points
+ * @param[in] vertex True if both points are input vertices
+ */
+static inline bool
+relate_points_equal(double x1, double y1, double x2, double y2, bool vertex)
+{
+  return vertex ? (x1 == x2 && y1 == y2) : relate_same_point(x1, y1, x2, y2);
 }
 
 /**
@@ -4169,9 +4185,14 @@ relate_point_is_edge_endpoint(double x, double y, const Edge *e)
  * Closed lines consequently have an empty boundary.
  * The function works on the extracted Edge representation, so circular arcs
  * remain exact.
+ * @param[in] x,y Coordinates of the point
+ * @param[in] edges,nedges Edges of the linear geometry
+ * @param[in] vertex True if the point is an input vertex, compared with the
+ * endpoints exactly (#relate_points_equal)
  */
 static bool
-relate_point_on_linear_boundary(double x, double y, Edge **edges, int nedges)
+relate_point_on_linear_boundary(double x, double y, Edge **edges, int nedges,
+  bool vertex)
 {
   int count = 0;
   for (int i = 0; i < nedges; i++)
@@ -4181,9 +4202,9 @@ relate_point_on_linear_boundary(double x, double y, Edge **edges, int nedges)
       continue;
     if (!relate_edge_nonempty(e))
       continue;
-    if (relate_same_point(x, y, e->x1, e->y1))
+    if (relate_points_equal(x, y, e->x1, e->y1, vertex))
       count++;
-    if (relate_same_point(x, y, e->x2, e->y2))
+    if (relate_points_equal(x, y, e->x2, e->y2, vertex))
       count++;
   }
   return (count & 1) != 0;
@@ -4198,9 +4219,19 @@ relate_point_on_linear_boundary(double x, double y, Edge **edges, int nedges)
  * Note that an endpoint of an individual edge does NOT automatically make the
  * point part of the geometry boundary. Endpoint parity is evaluated over the
  * complete linear geometry.
+ *
+ * Whether an input vertex lies on a straight edge is a question on three
+ * input vertices, decided exactly (#point_on_segment_exact); a constructed
+ * point is rounded and is located within the tolerance its coordinates call
+ * for (#point_on_segment)
+ * @param[in] x,y Coordinates of the point
+ * @param[in] edges,nedges Edges of the linear geometry
+ * @param[in] vertex True if the point is an input vertex rather than a point
+ * the engine constructs
  */
 static int
-relate_point_in_linear(double x, double y, Edge **edges, int nedges)
+relate_point_in_linear(double x, double y, Edge **edges, int nedges,
+  bool vertex)
 {
   bool found = false;
   for (int i = 0; i < nedges; i++)
@@ -4210,7 +4241,8 @@ relate_point_in_linear(double x, double y, Edge **edges, int nedges)
       continue;
     bool on = false;
     if (e->etype == EDGE_LINESEG)
-      on = point_on_segment(x, y, e->x1, e->y1, e->x2, e->y2);
+      on = vertex ? point_on_segment_exact(x, y, e->x1, e->y1, e->x2, e->y2) :
+        point_on_segment(x, y, e->x1, e->y1, e->x2, e->y2);
     else if (e->etype == EDGE_LINEARC)
       on = point_on_arc(x, y, e);
     if (on)
@@ -4222,7 +4254,7 @@ relate_point_in_linear(double x, double y, Edge **edges, int nedges)
 
   if (! found)
     return 2;
-  if (relate_point_on_linear_boundary(x, y, edges, nedges))
+  if (relate_point_on_linear_boundary(x, y, edges, nedges, vertex))
     return 1;
   return 0;
 }
@@ -4294,13 +4326,15 @@ relate_extract_points(const LWGEOM *geom, int *count)
 
 /**
  * @brief Return true if a point belongs to a set of points
+ * @details The point and the set are input vertices, so the point belongs to
+ * the set exactly where its coordinates are those of one of its points
  */
 static bool
 relate_point_in_points(double x, double y, const POINT2D *points, int count)
 {
   for (int i = 0; i < count; i++)
   {
-    if (relate_same_point(x, y, points[i].x, points[i].y))
+    if (relate_points_equal(x, y, points[i].x, points[i].y, true))
       return true;
   }
   return false;
@@ -4357,7 +4391,8 @@ relate_point_linear(const LWGEOM *point_geom, const LWGEOM *line_geom,
    * boundary row stays F */
   for (int i = 0; i < np; i++)
   {
-    switch (relate_point_in_linear(points[i].x, points[i].y, edges, nedges))
+    switch (relate_point_in_linear(points[i].x, points[i].y, edges, nedges,
+      true))
     {
       case 0:
         de9im_add(&m->ii, 0);
@@ -4838,7 +4873,7 @@ relate_linear_area_edge_intersection(const Edge *line, const Edge *boundary,
     /* Point intersection */
     double x = line->x1 + r.t0 * line->dx;
     double y = line->y1 + r.t0 * line->dy;
-    int lloc = relate_point_in_linear(x, y, all_lines, nlines);
+    int lloc = relate_point_in_linear(x, y, all_lines, nlines, false);
     if (lloc == 0)
       m->ib = 0;
     else if (lloc == 1)
@@ -4858,7 +4893,7 @@ relate_linear_area_edge_intersection(const Edge *line, const Edge *boundary,
       double t = roots[i];
       double x = line->x1 + t * line->dx;
       double y = line->y1 + t * line->dy;
-      int lloc = relate_point_in_linear(x, y, all_lines, nlines);
+      int lloc = relate_point_in_linear(x, y, all_lines, nlines, false);
       if (lloc == 0)
         m->ib = 0;
       else if (lloc == 1)
@@ -4884,7 +4919,7 @@ relate_linear_area_edge_intersection(const Edge *line, const Edge *boundary,
       double x = boundary->x1 + roots[i] * boundary->dx;
       double y = boundary->y1 + roots[i] * boundary->dy;
       double t = relate_arc_parameter(line, x, y);
-      int lloc = relate_point_in_linear(x, y, all_lines, nlines);
+      int lloc = relate_point_in_linear(x, y, all_lines, nlines, false);
       if (lloc == 0)
         m->ib = 0;
       else if (lloc == 1)
@@ -4925,7 +4960,8 @@ relate_linear_area_edge_intersection(const Edge *line, const Edge *boundary,
 
     for (int i = 0; i < n; i++)
     {
-      int lloc = relate_point_in_linear(ix[i], iy[i], all_lines, nlines);
+      int lloc = relate_point_in_linear(ix[i], iy[i], all_lines, nlines,
+        false);
       if (lloc == 0)
         m->ib = 0;
       else if (lloc == 1)
@@ -5162,10 +5198,10 @@ relate_linear_boundary_points(Edge **edges, int nedges, int *count)
       /* Keep a single entry per distinct point */
       bool seen = false;
       for (int j = 0; j < *count && ! seen; j++)
-        seen = relate_same_point(x, y, result[j].x, result[j].y);
+        seen = relate_points_equal(x, y, result[j].x, result[j].y, true);
       if (seen)
         continue;
-      if (! relate_point_on_linear_boundary(x, y, edges, nedges))
+      if (! relate_point_on_linear_boundary(x, y, edges, nedges, true))
         continue;
       result[*count].x = x;
       result[*count].y = y;
@@ -5231,6 +5267,65 @@ relate_linear_edge_points(const Edge *a, const Edge *b, POINT2D *out)
 }
 
 /**
+ * @brief Return true if two straight edges meet at one point lying on neither
+ * Mod-2 boundary
+ * @details Where the two edges meet at one point is a question on their four
+ * input vertices, answered exactly: at an end of either edge where that end
+ * lies on the other (#point_on_segment_exact), and otherwise at a crossing
+ * interior to both, which the rounded parameter of the crossing cannot tell
+ * from a meeting at an end. An end is a boundary point where its coordinates are those of one.
+ * A crossing interior to both edges is one only where a boundary point lies
+ * on both edges: two segments of different directions share one point at
+ * most, so that boundary point is the crossing
+ * @param[in] a,b Straight edges
+ * @param[in] b1,nb1,b2,nb2 Mod-2 boundary points of the two geometries
+ */
+static bool
+relate_segments_meet_inside(const Edge *a, const Edge *b, const POINT2D *b1,
+  int nb1, const POINT2D *b2, int nb2)
+{
+  IntersectResult r = linesegm_intersect(a->x1, a->y1, a->x2, a->y2,
+    b->x1, b->y1, b->x2, b->y2);
+  if (r.type != INTERSECT_POINT)
+    return false;
+  bool vertex = true;
+  double x = 0.0, y = 0.0;
+  if (point_on_segment_exact(a->x1, a->y1, b->x1, b->y1, b->x2, b->y2))
+  {
+    x = a->x1; y = a->y1;
+  }
+  else if (point_on_segment_exact(a->x2, a->y2, b->x1, b->y1, b->x2, b->y2))
+  {
+    x = a->x2; y = a->y2;
+  }
+  else if (point_on_segment_exact(b->x1, b->y1, a->x1, a->y1, a->x2, a->y2))
+  {
+    x = b->x1; y = b->y1;
+  }
+  else if (point_on_segment_exact(b->x2, b->y2, a->x1, a->y1, a->x2, a->y2))
+  {
+    x = b->x2; y = b->y2;
+  }
+  else
+    vertex = false;
+  for (int k = 0; k < 2; k++)
+  {
+    const POINT2D *bp = k ? b2 : b1;
+    int nb = k ? nb2 : nb1;
+    for (int p = 0; p < nb; p++)
+    {
+      if (vertex ? (bp[p].x == x && bp[p].y == y) :
+          (point_on_segment_exact(bp[p].x, bp[p].y, a->x1, a->y1, a->x2,
+             a->y2) &&
+           point_on_segment_exact(bp[p].x, bp[p].y, b->x1, b->y1, b->x2,
+             b->y2)))
+        return false;
+    }
+  }
+  return true;
+}
+
+/**
  * @brief Compute the DE-9IM matrix for two linear geometries
  * @details Every cell has exactly one source, so no cell can be attributed
  * twice or left to the visiting order of the edge pairs:
@@ -5288,6 +5383,13 @@ relate_linear_linear(const LWGEOM *g1, const LWGEOM *g2,
       else if (relate_linear_edges_overlap(a, b, &t0, &t1))
         de9im_add(&m->ii, 1);
 
+      /* Two straight edges meet at a point decided on their input vertices */
+      if (a->etype == EDGE_LINESEG && b->etype == EDGE_LINESEG)
+      {
+        if (relate_segments_meet_inside(a, b, b1, nb1, b2, nb2))
+          de9im_add(&m->ii, 0);
+        continue;
+      }
       int np = relate_linear_edge_points(a, b, points);
       for (int k = 0; k < np; k++)
       {
@@ -5308,7 +5410,7 @@ relate_linear_linear(const LWGEOM *g1, const LWGEOM *g2,
    * g2, in the interior of g2, or outside g2 altogether */
   for (int p = 0; p < nb1; p++)
   {
-    int loc = relate_point_in_linear(b1[p].x, b1[p].y, e2, n2);
+    int loc = relate_point_in_linear(b1[p].x, b1[p].y, e2, n2, true);
     if (loc == 1)
       de9im_add(&m->bb, 0);
     else if (loc == 0)
@@ -5320,7 +5422,7 @@ relate_linear_linear(const LWGEOM *g1, const LWGEOM *g2,
   /* Boundary column of g2, symmetrically */
   for (int p = 0; p < nb2; p++)
   {
-    int loc = relate_point_in_linear(b2[p].x, b2[p].y, e1, n1);
+    int loc = relate_point_in_linear(b2[p].x, b2[p].y, e1, n1, true);
     if (loc == 1)
       de9im_add(&m->bb, 0);
     else if (loc == 0)
@@ -5427,7 +5529,7 @@ relate_linear_area(const LWGEOM *line_geom, const LWGEOM *area_geom,
         double x, y;
         relate_area_edge_point(boundary, (bparams[k] + bparams[k + 1]) * 0.5,
           &x, &y);
-        if (relate_point_in_linear(x, y, lines, nl) == 2)
+        if (relate_point_in_linear(x, y, lines, nl, false) == 2)
         {
           m->eb = 1;
           break;
@@ -5482,7 +5584,7 @@ relate_linear_area(const LWGEOM *line_geom, const LWGEOM *area_geom,
     {
       double x = endpoint == 0 ? line->x1 : line->x2;
       double y = endpoint == 0 ? line->y1 : line->y2;
-      int lloc = relate_point_in_linear(x, y, lines, nl);
+      int lloc = relate_point_in_linear(x, y, lines, nl, true);
       if (lloc == 2)
         continue;
       int aloc = relate_point_in_area(x, y, area_edges, na);
@@ -5523,8 +5625,9 @@ relate_linear_area(const LWGEOM *line_geom, const LWGEOM *area_geom,
       continue;
     if (! relate_edge_nonempty(line))
       continue;
-    if (relate_point_on_linear_boundary(line->x1, line->y1, lines, nl) ||
-        relate_point_on_linear_boundary(line->x2, line->y2, lines, nl))
+    if (relate_point_on_linear_boundary(line->x1, line->y1, lines, nl,
+          true) ||
+        relate_point_on_linear_boundary(line->x2, line->y2, lines, nl, true))
       has_boundary = true;
   }
 
@@ -5545,7 +5648,7 @@ relate_linear_area(const LWGEOM *line_geom, const LWGEOM *area_geom,
       const double y[2] = {line->y1, line->y2};
       for (int k = 0; k < 2; k++)
       {
-        if (!relate_point_on_linear_boundary(x[k], y[k], lines, nl))
+        if (!relate_point_on_linear_boundary(x[k], y[k], lines, nl, true))
           continue;
         int aloc = relate_point_in_area(x[k], y[k], area_edges, na);
         if (aloc == 2)
@@ -7128,7 +7231,7 @@ relate_comp_covered(const LWGEOM *comp, const RelateComp *comps, int ncomp,
     {
       result = relate_in_area_union(e->x1, e->y1, comps, ncomp) ||
         (nledges > 0 && relate_point_in_linear(e->x1, e->y1, ledges,
-          nledges) != 2);
+          nledges, true) != 2);
       continue;
     }
     /* A linear edge is covered when every portion of it left by the areal

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -351,6 +351,76 @@ int main(void)
   }
   meos_errno_reset();
 
+  /* Where an end of one line lies relative to the other line is a question
+   * on three input vertices, with one exact answer. An end half a unit in the
+   * last place off the other line, or a few units in the last place from its
+   * end, lies off it, which is what CGAL's exact kernel answers for each of
+   * these pairs: in the first two the lines share their first vertex and
+   * nothing else, and in the other three an end of the second line lies
+   * inside the first and nothing else is shared. The pairs run at
+   * coordinates near 4.5e15, 4.8e14, 3.3e8, 290 and 0.03 */
+  struct { const char *a, *b, *matrix; } lineends[] = {
+    { "LINESTRING(0 0,9007199254740990 9007199254740988)",
+      "LINESTRING(0 0,4503599627370495 4503599627370495)", "FF1F00102" },
+    { "LINESTRING(-283144758449940 485509397516197,"
+        "-284886900263520 481648740423073)",
+      "LINESTRING(-283144758449940 485509397516197,"
+        "-284886900263521 481648740423072)", "FF1F00102" },
+    { "LINESTRING(-327175204.0343151 -97720966.76015949,"
+        "-327816177.3798351 -97936883.91283894)",
+      "LINESTRING(-327335447.3706951 -97774946.04832935,"
+        "-327816177.3798342 -97936883.91283894)", "F01FF0102" },
+    { "LINESTRING(286.8830701420029 -413.570565510352,"
+        "290.10594642651085 -410.84838066357406)",
+      "LINESTRING(287.6887820147749 -412.89002537870874,"
+        "290.1059464265127 -410.84838066357406)", "F01FF0102" },
+    { "LINESTRING(0.030081357121877428 0.00023621927371220153,"
+        "0.036577042090003786 0.005648444167555056)",
+      "LINESTRING(0.03170527655384636 0.0015892739890230878,"
+        "0.036577042090003564 0.005648444167555056)", "F01FF0102" },
+  };
+  for (size_t i = 0; i < sizeof(lineends) / sizeof(lineends[0]); i++)
+  {
+    GSERIALIZED *ga = geom_in(lineends[i].a, -1);
+    GSERIALIZED *gb = geom_in(lineends[i].b, -1);
+    assert(ga != NULL);
+    assert(gb != NULL);
+    meos_errno_reset();
+    char *gm = geom_relate(ga, gb);
+    printf("geom_relate(two lines meeting at one point, %zu): %s, errno %d\n",
+      i, gm ? gm : "(NULL)", meos_errno());
+    assert(gm != NULL);
+    assert(strcmp(gm, lineends[i].matrix) == 0);
+    assert(meos_errno() == 0);
+    free(gm); free(ga); free(gb);
+  }
+  meos_errno_reset();
+
+  /* Two input points are one point exactly where their coordinates are
+   * equal. Points 1e-13 apart are two points: the two are disjoint, as
+   * geom_intersects answers, and a line 1e-13 long has both of its ends in
+   * its boundary, one of them the point and the other outside it */
+  struct { const char *a, *b, *matrix; } tinypts[] = {
+    { "POINT(0 0)", "POINT(1e-13 0)", "FF0FFF0F2" },
+    { "LINESTRING(0 0,1e-13 0)", "POINT(1e-13 0)", "FF10F0FF2" },
+  };
+  for (size_t i = 0; i < sizeof(tinypts) / sizeof(tinypts[0]); i++)
+  {
+    GSERIALIZED *ga = geom_in(tinypts[i].a, -1);
+    GSERIALIZED *gb = geom_in(tinypts[i].b, -1);
+    assert(ga != NULL);
+    assert(gb != NULL);
+    meos_errno_reset();
+    char *gm = geom_relate(ga, gb);
+    printf("geom_relate(%s, %s): %s, errno %d\n", tinypts[i].a, tinypts[i].b,
+      gm ? gm : "(NULL)", meos_errno());
+    assert(gm != NULL);
+    assert(strcmp(gm, tinypts[i].matrix) == 0);
+    assert(meos_errno() == 0);
+    free(gm); free(ga); free(gb);
+  }
+  meos_errno_reset();
+
   /* Two areas lying on OPPOSITE SIDES of one line share no area, so neither
    * interior holds a point of the other's boundary, however near the two
    * boundaries run. Deciding that from a boundary portion means classifying a


### PR DESCRIPTION
The relate engine locates points against linear geometries and against
sets of points, and many of those points are input vertices: the ends of
a line, the Mod-2 boundary points of a linear geometry, the points of a
point geometry. On master each is located within tolerances. A point
lies on a straight edge where it falls within coordinate_tolerance of
it, 4 * DBL_EPSILON times the largest coordinate, which is half a unit
at 4.5e15; and two points are one where their coordinates differ by at
most 1e-12, which at coordinates near 1 is thousands of units in the
last place. An end of one line half a unit in the last place off the
other, or a few units from its end, therefore reads as lying on it, and
the matrix names an intersection the two do not have.

This commit decides those questions exactly wherever the point is an
input vertex. point_on_segment_exact, in geo_funcs.h beside
point_on_segment, reads a point as on a segment where the sign of the
cross product (#cross_product_sign) is zero and the point lies in the box
of the segment's ends. relate_point_in_linear and
relate_point_on_linear_boundary take a flag, set by each caller, saying
whether the point is an input vertex: the boundary points of both
operands, the ends of a line against the linework it belongs to, the
points of a point geometry and the points of a component tested for
cover pass true and are located exactly and counted for the Mod-2 parity
by equal coordinates; the five sites locating a point the engine
constructs -- a crossing, a point at a parameter, a midpoint -- pass
false and keep the tolerance, since a rounded point is never exactly on
the edge it was placed on. Where two straight edges meet at one point,
the II cell decides from the four input vertices whether that point is
an end of either edge, and compares an end with the boundary points by
its coordinates, where master rebuilt the point from a parameter and
compared it within 1e-12. An edge has no length exactly where its two
ends are equal, and a point belongs to a set of points exactly where its
coordinates are those of one of them.

Witness

    LINESTRING(0 0,9007199254740990 9007199254740988)
    LINESTRING(0 0,4503599627370495 4503599627370495)

share their first vertex and nothing else, as CGAL's exact kernel
answers: the second ends 2 * (2^52 - 1) / |AB|, about 0.71 units, off the
line of the first. Master answers F01F001F2, the end of the second inside
the first; this commit answers FF1F00102. POINT(0 0) and POINT(1e-13 0)
relate as FF0FFF0F2, disjoint, as geom_intersects already answers, where
master's matrix reads them as equal, 0FFFFFFF2.

Measured

3000 adversarial segment pairs, integer coordinates below 2^52 scaled by
1, 2^-20, 2^-40 and 2^-52 -- sharing an end, meeting at an interior
point, overlapping, touching, apart on one line, parallel, one end one
or two units off the other's line, crossing, apart -- each related as two
one-segment lines and judged against the matrix computed on the doubles
with rational arithmetic, itself agreeing with CGAL's classification of
all 3000: master's geom_relate answers 402 wrongly, this commit none.
6000 pairs of lines of two or three segments grown from those pairs --
one continuing past its end, starting before its start, turning at its
end, taking a vertex at its rounded midpoint, or both continuing or
turning -- judged against the matrix computed the same way, which agrees
with GEOS on all 6000: master answers 647 wrongly, this commit none.
The relate acceptance set -- 931 h3 cells against themselves, 1444 areal
pairs and a real protected-area pair in projected coordinates -- answers
byte for byte as on master, 1864 of 1864 self-matrices at the definition
and 918 of 918 interior cells at the exact shared area; so do the 130
pairs of the relate corpora in meos/test and 122 pairs of real AIS
trips: each against itself, its two halves against each other, and each
against the next.
Counted by callgrind, relating the 3000 pairs takes 1.0005 of master's
instructions, and relating the two halves of 21 of those trips 0.954.

Why

The ends of a line and the points of a point geometry are the doubles
the parser reads, and every double is an exact rational, so whether one
of them lies on a segment, or is another, has one answer about them: the
sign of a cross product of coordinate differences and comparisons of
coordinates. A tolerance answers for the geometry within its band rather
than for the input, and no band is right at every scale: a distance that
suits coordinates near 1e6 swallows units in the last place near 1e15,
and an absolute 1e-12 swallows thousands of them near 1. A point the
engine constructs is rounded and lies on its own edge only within that
rounding, so those sites keep their band.

Test

geo_test relates the witness, four adversarial pairs at coordinates near
4.8e14, 3.3e8, 290 and 0.03, and the two points and a line 1e-13 long
against its end; against master it aborts on the witness.

