### PR TITLE
Box an arc by the arc it draws, at every size

### DIFF
--- a/meos/include/geo/geo_funcs.h
+++ b/meos/include/geo/geo_funcs.h
@@ -161,6 +161,8 @@ extern bool meos_spatialrel(const LWGEOM *g1, const LWGEOM *g2, spatialRel rel,
 extern bool relate_is_areal(const LWGEOM *geom);
 extern int cross_product_sign_exact(double ax, double ay, double bx, double by,
   double cx, double cy, double dx, double dy);
+extern double cross_product_exact(double ax, double ay, double bx, double by,
+  double cx, double cy, double dx, double dy);
 
 /* The edges of one geometry, kept so that several relationships asked about it
  * read them once. A relationship extracts the edges of both its operands, and

--- a/meos/src/geo/geo_funcs.c
+++ b/meos/src/geo/geo_funcs.c
@@ -692,6 +692,58 @@ grow_expansion(int elen, const double *e, double b, double *h)
 }
 
 /**
+ * @brief Add the cross product of the vectors B - A and D - C, exactly, into
+ * an expansion held in one of two buffers, and return its length
+ * @details Each difference is its rounded value plus the error of the
+ * rounding, and each product of two terms is its rounded value plus its
+ * error, so the sixteen terms add up to the cross product exactly; a term
+ * with a zero factor adds nothing and is skipped. The last component carries
+ * the sign of the whole
+ * @param[in] buf1,buf2 Room for 32 components each
+ * @param[out] result The buffer holding the expansion
+ * @return Number of components, 0 exactly where the vectors are parallel
+ */
+static int
+cross_product_expansion(double ax, double ay, double bx, double by,
+  double cx, double cy, double dx, double dy, double *buf1, double *buf2,
+  const double **result)
+{
+  double d[4], t[4];
+  two_diff(bx, ax, &d[0], &t[0]);
+  two_diff(dy, cy, &d[1], &t[1]);
+  two_diff(by, ay, &d[2], &t[2]);
+  two_diff(dx, cx, &d[3], &t[3]);
+  /* (d0 + t0) (d1 + t1) - (d2 + t2) (d3 + t3), term by term */
+  const double lf[2] = {d[0], t[0]}, lg[2] = {d[1], t[1]};
+  const double rf[2] = {d[2], t[2]}, rg[2] = {d[3], t[3]};
+  double *e = buf1, *h = buf2, *swap;
+  int elen = 0;
+  for (int i = 0; i < 2; i++)
+    for (int j = 0; j < 2; j++)
+    {
+      double x, y;
+      if (lf[i] != 0.0 && lg[j] != 0.0)
+      {
+        two_product(lf[i], lg[j], &x, &y);
+        elen = grow_expansion(elen, e, x, h);
+        swap = e; e = h; h = swap;
+        elen = grow_expansion(elen, e, y, h);
+        swap = e; e = h; h = swap;
+      }
+      if (rf[i] != 0.0 && rg[j] != 0.0)
+      {
+        two_product(rf[i], rg[j], &x, &y);
+        elen = grow_expansion(elen, e, - x, h);
+        swap = e; e = h; h = swap;
+        elen = grow_expansion(elen, e, - y, h);
+        swap = e; e = h; h = swap;
+      }
+    }
+  *result = e;
+  return elen;
+}
+
+/**
  * @brief Return the sign of the cross product of the vectors B - A and D - C,
  * decided exactly
  * @details Each difference is its rounded value plus the error of the
@@ -726,38 +778,42 @@ cross_product_sign_exact(double ax, double ay, double bx, double by,
     double err = fma(d[0], d[1], - l) - fma(d[2], d[3], - r);
     return (err > 0.0) ? 1 : ((err < 0.0) ? -1 : 0);
   }
-  /* (d0 + t0) (d1 + t1) - (d2 + t2) (d3 + t3), term by term */
-  const double lf[2] = {d[0], t[0]}, lg[2] = {d[1], t[1]};
-  const double rf[2] = {d[2], t[2]}, rg[2] = {d[3], t[3]};
   double buf1[32], buf2[32];
-  double *e = buf1, *h = buf2, *swap;
-  int elen = 0;
-  for (int i = 0; i < 2; i++)
-    for (int j = 0; j < 2; j++)
-    {
-      double x, y;
-      if (lf[i] != 0.0 && lg[j] != 0.0)
-      {
-        two_product(lf[i], lg[j], &x, &y);
-        elen = grow_expansion(elen, e, x, h);
-        swap = e; e = h; h = swap;
-        elen = grow_expansion(elen, e, y, h);
-        swap = e; e = h; h = swap;
-      }
-      if (rf[i] != 0.0 && rg[j] != 0.0)
-      {
-        two_product(rf[i], rg[j], &x, &y);
-        elen = grow_expansion(elen, e, - x, h);
-        swap = e; e = h; h = swap;
-        elen = grow_expansion(elen, e, - y, h);
-        swap = e; e = h; h = swap;
-      }
-    }
+  const double *e;
+  int elen = cross_product_expansion(ax, ay, bx, by, cx, cy, dx, dy, buf1,
+    buf2, &e);
   /* Every term with a zero factor: the cross product is zero */
   if (elen == 0)
     return 0;
   double top = e[elen - 1];
   return (top > 0.0) ? 1 : ((top < 0.0) ? -1 : 0);
+}
+
+/**
+ * @brief Return the cross product of the vectors B - A and D - C, computed
+ * exactly and rounded once
+ * @details The cross product of rounded differences carries an error of the
+ * order of a rounding of each of its two products, so where the vectors are
+ * nearly parallel and the products nearly cancel, it keeps none of its
+ * relative precision. The exact expansion of #cross_product_sign_exact,
+ * summed from its smallest component up, keeps it, however small the cross
+ * product is against the coordinates
+ * @note Exact where no product of coordinate differences overflows or
+ * underflows
+ * @return The cross product, 0 exactly where the vectors are parallel
+ */
+double
+cross_product_exact(double ax, double ay, double bx, double by, double cx,
+  double cy, double dx, double dy)
+{
+  double buf1[32], buf2[32];
+  const double *e;
+  int elen = cross_product_expansion(ax, ay, bx, by, cx, cy, dx, dy, buf1,
+    buf2, &e);
+  double sum = 0.0;
+  for (int i = 0; i < elen; i++)
+    sum += e[i];
+  return sum;
 }
 
 /*****************************************************************************

--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -625,6 +625,46 @@ int main(void)
   free(pip_wkt);
   meos_errno_reset();
 
+  /* The box of an arc takes its size from the arc. A semicircle through
+   * (0 0), (s s) and (2s 0) is 2s wide and s high, and it holds its own middle
+   * vertex (s s), so it intersects that point at every s. A box read off the
+   * circumcentre with an absolute bound is, at s = 2^-16, the box of the
+   * chord, of height 0, which the point lies outside, and at s = 2^-28 the
+   * box of a circle on the two ends. Halving a double is exact, so the box at
+   * s is the box at 1 times s to the last bit; it may hold a rounding more
+   * than the arc, and never less */
+  double semi_s = 1.0, semi_unit[4] = {0, 0, 0, 0};
+  int semi_ok = 0;
+  for (int k = 0; k >= -40; k--, semi_s *= 0.5)
+  {
+    char semi_wkt[160], apex_wkt[96];
+    snprintf(semi_wkt, sizeof semi_wkt,
+      "CIRCULARSTRING(0 0,%.17g %.17g,%.17g 0)", semi_s, semi_s, 2 * semi_s);
+    snprintf(apex_wkt, sizeof apex_wkt, "POINT(%.17g %.17g)", semi_s, semi_s);
+    GSERIALIZED *semi = geom_in(semi_wkt, -1);
+    GSERIALIZED *apex = geom_in(apex_wkt, -1);
+    assert(semi != NULL); assert(apex != NULL);
+    STBox *semi_box = geo_to_stbox(semi);
+    assert(semi_box != NULL);
+    double b[4] = {semi_box->xmin, semi_box->ymin, semi_box->xmax,
+      semi_box->ymax};
+    if (k == 0)
+      memcpy(semi_unit, b, sizeof b);
+    assert(geom_intersects2d(semi, apex));
+    assert(b[0] <= 0.0 && b[1] <= 0.0);
+    assert(b[2] >= 2 * semi_s && b[3] >= semi_s);
+    assert(b[2] - b[0] <= 2 * semi_s * (1.0 + 1e-13));
+    assert(b[3] - b[1] <= semi_s * (1.0 + 1e-13));
+    for (int i = 0; i < 4; i++)
+      assert(b[i] == semi_unit[i] * semi_s);
+    semi_ok++;
+    free(semi_box); free(semi); free(apex);
+  }
+  printf("the box of a semicircle holds it, and meets its middle vertex, at "
+    "%d scales from 1 to 2^-40, the same box to the last bit\n", semi_ok);
+  assert(semi_ok == 41);
+  meos_errno_reset();
+
   /* A GEOMETRYCOLLECTION is the union of its components, so what it shares
    * with another geometry is the union of what the components share. The
    * overlay reads it that way now, which is how the matrix has always read a

--- a/postgis/liblwgeom/gbox.c
+++ b/postgis/liblwgeom/gbox.c
@@ -468,70 +468,142 @@ size_t gbox_serialized_size(lwflags_t flags)
 ** Compute cartesian bounding GBOX boxes from LWGEOM.
 */
 
+/* MEOS: the cross product of coordinate differences, computed exactly and
+ * rounded once, from meos/src/geo/geo_funcs.c */
+extern double cross_product_exact(double ax, double ay, double bx, double by,
+	double cx, double cy, double dx, double dy);
+
+/* MEOS: the rounding of a coordinate the arc box constructs, by which the box
+ * is padded outward, since a box may hold more than the arc and never less.
+ * A reach beyond the chord midpoint goes through some fifty roundings of the
+ * unit roundoff DBL_EPSILON / 2, from the exact cross product through the
+ * angle, the chord normal and lw_arc_reach, so 32 DBL_EPSILON bounds it; the
+ * midpoint and the final sum add at most one rounding each of the two end
+ * coordinates */
+#define ARC_GBOX_ROUNDING (32.0 * DBL_EPSILON)
+
+static double
+lw_arc_gbox_pad(double c1, double c2, double reach)
+{
+	return ARC_GBOX_ROUNDING * reach + 2.0 * DBL_EPSILON * (fabs(c1) + fabs(c2));
+}
+
+/* MEOS: (1 + omega cos a) / sin a, the reach of the circle beyond the chord
+ * midpoint in a direction W, in units of half the chord, where omega and perp
+ * are the components of W along the chord normal toward the arc and across it.
+ * Where omega cos a < 0 the sum cancels, and it is rewritten as
+ * (1 - |omega|) + |omega| (1 - |cos a|) with each difference from 1 read off
+ * the other component, so a nearly straight arc keeps its bulge */
+static double
+lw_arc_reach(double omega, double perp, double sina, double cosa)
+{
+	double t;
+	if (omega * cosa >= 0.0)
+		t = 1.0 + omega * cosa;
+	else
+	{
+		double w = fabs(omega), c = fabs(cosa);
+		t = perp * perp / (1.0 + w) + w * (sina * sina / (1.0 + c));
+	}
+	return t / sina;
+}
+
+/* MEOS: the box of an arc is decided on its input vertices exactly, and
+ * constructed from the chord A1-A3 and the angle at A2 rather than from the
+ * circumcentre. lw_arc_center reads an arc as a segment where twice its cross
+ * product is below EPSILON_SQLMM, an absolute 1e-8 on an AREA, and as a
+ * closed circle where its ends lie within 1e-8 of each other: a box read off
+ * it is the box of the chord for an arc a few 1e-5 across, and of another
+ * circle below 1e-8. The circumcentre of a nearly straight arc also cancels
+ * against its radius, where the chord and the angle do not */
 int lw_arc_calculate_gbox_cartesian_2d(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3, GBOX *gbox)
 {
-	POINT2D xmin, ymin, xmax, ymax;
-	POINT2D C;
-	int A2_side;
-	double radius_A;
-
 	LWDEBUG(2, "lw_arc_calculate_gbox_cartesian_2d called.");
 
-	radius_A = lw_arc_center(A1, A2, A3, &C);
+	/* First approximation, bounds of start/end points */
+	gbox->xmin = FP_MIN(A1->x, A3->x);
+	gbox->ymin = FP_MIN(A1->y, A3->y);
+	gbox->xmax = FP_MAX(A1->x, A3->x);
+	gbox->ymax = FP_MAX(A1->y, A3->y);
 
-	/* Negative radius signals straight line, p1/p2/p3 are collinear */
-	if (radius_A < 0.0)
+	/* MEOS: matched start/end points imply the circle whose diameter runs
+	 * from A1 to A2 */
+	if (A1->x == A3->x && A1->y == A3->y)
 	{
-        gbox->xmin = FP_MIN(A1->x, A3->x);
-        gbox->ymin = FP_MIN(A1->y, A3->y);
-        gbox->xmax = FP_MAX(A1->x, A3->x);
-        gbox->ymax = FP_MAX(A1->y, A3->y);
-	    return LW_SUCCESS;
-	}
-
-	/* Matched start/end points imply circle */
-	if ( A1->x == A3->x && A1->y == A3->y )
-	{
-		gbox->xmin = C.x - radius_A;
-		gbox->ymin = C.y - radius_A;
-		gbox->xmax = C.x + radius_A;
-		gbox->ymax = C.y + radius_A;
+		double dx = A2->x - A1->x, dy = A2->y - A1->y;
+		double cx = A1->x + dx / 2.0, cy = A1->y + dy / 2.0;
+		double r = hypot(dx, dy) / 2.0;
+		double padx = lw_arc_gbox_pad(A1->x, A2->x, r);
+		double pady = lw_arc_gbox_pad(A1->y, A2->y, r);
+		gbox->xmin = cx - r - padx;
+		gbox->ymin = cy - r - pady;
+		gbox->xmax = cx + r + padx;
+		gbox->ymax = cy + r + pady;
 		return LW_SUCCESS;
 	}
 
-	/* First approximation, bounds of start/end points */
-    gbox->xmin = FP_MIN(A1->x, A3->x);
-    gbox->ymin = FP_MIN(A1->y, A3->y);
-    gbox->xmax = FP_MAX(A1->x, A3->x);
-    gbox->ymax = FP_MAX(A1->y, A3->y);
+	/* MEOS: the turn at A2, the cross product of A1 - A2 and A3 - A2, exactly.
+	 * Zero where the three points are collinear, A2 on an end included, and
+	 * the arc is then the segment A1-A3; otherwise its sign is the side of the
+	 * chord A1-A3 the arc lies on. Where its two products do not nearly
+	 * cancel, their rounded difference keeps its relative precision to a few
+	 * roundings; otherwise it is computed exactly */
+	double ux = A1->x - A2->x, uy = A1->y - A2->y;
+	double vx = A3->x - A2->x, vy = A3->y - A2->y;
+	double left = ux * vy, right = uy * vx;
+	double cross = left - right;
+	if (! (fabs(cross) > 0.5 * (fabs(left) + fabs(right))))
+		cross = cross_product_exact(A2->x, A2->y, A1->x, A1->y,
+			A2->x, A2->y, A3->x, A3->y);
+	if (cross == 0.0)
+		return LW_SUCCESS;
 
-	/* Create points for the possible extrema */
-	xmin.x = C.x - radius_A;
-	xmin.y = C.y;
-	ymin.x = C.x;
-	ymin.y = C.y - radius_A;
-	xmax.x = C.x + radius_A;
-	xmax.y = C.y;
-	ymax.x = C.x;
-	ymax.y = C.y + radius_A;
+	/* MEOS: the inscribed angle a at A2, from the cross product and the dot
+	 * product of the two vectors, each to within a few roundings of itself */
+	double dot = ux * vx + uy * vy;
+	double h = hypot(cross, dot);
+	double sina = fabs(cross) / h, cosa = dot / h;
 
-	/* Divide the circle into two parts, one on each side of a line
-	   joining p1 and p3. The circle extrema on the same side of that line
-	   as p2 is on, are also the extrema of the bbox. */
+	/* MEOS: the chord, its midpoint, half its length and its unit normal
+	 * toward the arc. The circle has radius half / sin a and its centre lies
+	 * half cot a from the midpoint along that normal, so the extreme of the
+	 * circle in a direction W lies half (1 + omega cos a) / sin a beyond the
+	 * midpoint, and it is on the arc where omega >= - cos a */
+	double chx = A3->x - A1->x, chy = A3->y - A1->y;
+	double len = hypot(chx, chy);
+	double half = len / 2.0;
+	double mx = A1->x + chx / 2.0, my = A1->y + chy / 2.0;
+	double side = (cross > 0.0) ? 1.0 : -1.0;
+	double nx = - side * chy / len, ny = side * chx / len;
+	/* An extreme on the edge of that condition sits on an end of the arc, so
+	 * one read on the wrong side of it moves the box by a rounding: take it */
+	double slack = ARC_GBOX_ROUNDING;
+	double reach, pad;
 
-	A2_side = lw_segment_side(A1, A3, A2);
-
-	if ( A2_side == lw_segment_side(A1, A3, &xmin) )
-		gbox->xmin = xmin.x;
-
-	if ( A2_side == lw_segment_side(A1, A3, &ymin) )
-		gbox->ymin = ymin.y;
-
-	if ( A2_side == lw_segment_side(A1, A3, &xmax) )
-		gbox->xmax = xmax.x;
-
-	if ( A2_side == lw_segment_side(A1, A3, &ymax) )
-		gbox->ymax = ymax.y;
+	if (nx >= - cosa - slack)
+	{
+		reach = half * lw_arc_reach(nx, ny, sina, cosa);
+		pad = lw_arc_gbox_pad(A1->x, A3->x, reach);
+		gbox->xmax = FP_MAX(gbox->xmax, mx + reach + pad);
+	}
+	if (- nx >= - cosa - slack)
+	{
+		reach = half * lw_arc_reach(- nx, ny, sina, cosa);
+		pad = lw_arc_gbox_pad(A1->x, A3->x, reach);
+		gbox->xmin = FP_MIN(gbox->xmin, mx - reach - pad);
+	}
+	if (ny >= - cosa - slack)
+	{
+		reach = half * lw_arc_reach(ny, nx, sina, cosa);
+		pad = lw_arc_gbox_pad(A1->y, A3->y, reach);
+		gbox->ymax = FP_MAX(gbox->ymax, my + reach + pad);
+	}
+	if (- ny >= - cosa - slack)
+	{
+		reach = half * lw_arc_reach(- ny, nx, sina, cosa);
+		pad = lw_arc_gbox_pad(A1->y, A3->y, reach);
+		gbox->ymin = FP_MIN(gbox->ymin, my - reach - pad);
+	}
 
 	return LW_SUCCESS;
 }


### PR DESCRIPTION
The box of a circular arc is read off lw_arc_center, which takes an arc for
a segment where twice its cross product is below EPSILON_SQLMM, an absolute
1e-8 on a quantity that goes as the square of the arc's size, and for a
closed circle where its two ends lie within 1e-8 of each other. So an arc a
few 1e-5 across gets the box of its chord, and one below 1e-8 the box of
another circle.

The witness is the semicircle

  CIRCULARSTRING(0 0,1.52587890625e-05 1.52587890625e-05,3.0517578125e-05 0)

of radius s = 2^-16, which holds its own middle vertex
POINT(1.52587890625e-05 1.52587890625e-05). On master its box has height 0, and geom_intersects2d and geom_covers of the
arc and that point, and geom_covers of a disc around it and the same point
on its boundary, all answer false, from s = 2^-16 down to 2^-26; at 2^-28 the
box reads 1.414 by 1.207 times the radius, for an arc 2 by 1. The branch
answers true for all of them at every even power of two from 1 to 2^-40,
and for the intersection at every power in between, and the box is 2 by 1
times the radius to within its outward rounding.

lw_arc_calculate_gbox_cartesian_2d reads the arc without its circumcentre.
It decides on the input vertices exactly: an arc whose ends are the same
vertex is the circle on the diameter from A1 to A2, and three collinear
points, A2 on an end included, are the segment A1-A3, collinear meaning the
cross product of A1 - A2 and A3 - A2 is exactly 0. It then describes the arc
by its chord and the inscribed angle a at A2, whose sine and cosine come
from that cross product and the dot product: the circle has radius
half / sin a, its centre lies half cot a from the chord midpoint along the
normal toward the arc, and its extreme in a direction W lies
half (1 + omega cos a) / sin a beyond the midpoint, on the arc where
omega >= -cos a, omega being the component of W along that normal. Where
omega cos a < 0 the sum is rewritten so it does not cancel, which keeps the
bulge of a nearly straight arc; its circumcentre cancels against its radius
instead. The cross product is the rounded difference of its two products
where they do not nearly cancel, and otherwise cross_product_exact in
geo_funcs.c, the sum of the exact expansion whose sign cross_product_sign_exact
reads. Each extreme is padded outward by a bound on the rounding of
its construction, 32 DBL_EPSILON of the reach and 2 DBL_EPSILON of the end
coordinates.

Why the box is right: every decision is exact, and the only numbers not
decided are constructed ones, the extremes, which a box may exceed and never
fall short of. The pad is relative to the arc and to its coordinates, so the
box of an arc scaled by a power of two is its box scaled by the same power,
bit for bit.

The numbers. 3000 arcs over eight scales from 1 to 2^-40, around the origin,
(1.25, -3.5) and (6.4e6, 5.1e6), strongly curved, nearly straight, major and
nearly closed, judged against the closed form, a rational centre with a
radius to 200 digits: master's box misses part of the arc for 1959 of them,
1520 by more than 4 ulps and some by the arc's whole width; the branch's box
holds the arc for all 3000, with a median excess of 6.4 ulps of the
coordinates. 2000 arcs scaled by 2^20, 2^-8, 2^-16, 2^-20, 2^-30 and 2^-40:
master's box moves for 147 to 2000 of them, the branch's for none. The relate
engine reads no arc box, and its matrices over 14408 pairs of four corpora,
7830 of them carrying a curve, match master's line for line. Parsing the 30 real curve pairs and reading their boxes
takes 1.014, 0.970 and 0.984 of master's time in three interleaved rounds.

The distance from a point to an arc reads lw_arc_center itself, and
geom_dwithin2d of the witness and its middle vertex at distance 0 is false
at the same scales; it is a separate change.

meos/test/geo_test.c carries the semicircle at 41 scales, asserting that its
box holds it, meets its middle vertex and scales exactly; on master it
aborts at the intersection of the arc and that vertex.

