### PR TITLE
Drop the two raster core calls the GEOS baseline lists and nothing makes

### DIFF
--- a/tools/scripts/liblwgeom_geos_baseline.txt
+++ b/tools/scripts/liblwgeom_geos_baseline.txt
@@ -11,10 +11,8 @@ meos/src/raster/raster_rtcore.c	rt_raster_add_band
 meos/src/raster/raster_rtcore.c	rt_raster_destroy
 meos/src/raster/raster_rtcore.c	rt_raster_gdal_polygonize
 meos/src/raster/raster_rtcore.c	rt_raster_gdal_rasterize
-meos/src/raster/raster_rtcore.c	rt_raster_geopoint_to_rasterpoint
 meos/src/raster/raster_rtcore.c	rt_raster_get_band
 meos/src/raster/raster_rtcore.c	rt_raster_get_envelope
-meos/src/raster/raster_rtcore.c	rt_raster_get_geotransform_matrix
 meos/src/raster/raster_rtcore.c	rt_raster_get_height
 meos/src/raster/raster_rtcore.c	rt_raster_get_inverse_geotransform_matrix
 meos/src/raster/raster_rtcore.c	rt_raster_get_num_bands


### PR DESCRIPTION
The liblwgeom GEOS checker lists rt_raster_geopoint_to_rasterpoint and
rt_raster_get_geotransform_matrix among the calls meos/src/raster/
raster_rtcore.c makes, and the file makes neither: the raster traversal
places a position in the grid through the inverse geotransform it reads
once with rt_raster_get_inverse_geotransform_matrix. The baseline states
the calls the tree makes, so the two entries go.

The witness: on master 11db0ac74f, python3
tools/scripts/check_liblwgeom_geos.py answers "2 baselined call(s) no
longer occur" and names the two.

Why the entries go rather than stay: the baseline is the set of calls that
can reach GEOS through liblwgeom or the raster core, which the checker
holds to shrink and never to grow, and an entry for a call the tree does
not make stands for nothing the set has to carry.

The numbers: the baseline goes from 24 to 22 calls of 125 entry points,
the checker answers "clean (22 baselined of 125 entry point(s))" with no
stale entry, and no other line of the file moves.

