### PR TITLE
Measure the distance from a point to an arc without its circumcentre

### DIFF
--- a/meos/test/geo_test.c
+++ b/meos/test/geo_test.c
@@ -665,6 +665,38 @@ int main(void)
   assert(semi_ok == 41);
   meos_errno_reset();
 
+  /* The distance from a point to an arc takes its size from the arc too. The
+   * same semicircle has its centre at (s 0) and its radius s, so the point
+   * (s 2s) above its top lies at distance s from it, exactly: the power of
+   * the point over its distance to the centre plus the radius is 3s^2 / 3s.
+   * Its middle vertex (s s) lies on it, at distance 0. A distance read off
+   * the circumcentre with an absolute bound is, at s = 2^-16, the distance
+   * to the chord, 2s */
+  double dist_s = 1.0;
+  int dist_ok = 0;
+  for (int k = 0; k >= -40; k--, dist_s *= 0.5)
+  {
+    char semi_wkt[160], above_wkt[96], apex_wkt[96];
+    snprintf(semi_wkt, sizeof semi_wkt,
+      "CIRCULARSTRING(0 0,%.17g %.17g,%.17g 0)", dist_s, dist_s, 2 * dist_s);
+    snprintf(above_wkt, sizeof above_wkt, "POINT(%.17g %.17g)", dist_s,
+      2 * dist_s);
+    snprintf(apex_wkt, sizeof apex_wkt, "POINT(%.17g %.17g)", dist_s, dist_s);
+    GSERIALIZED *semi = geom_in(semi_wkt, -1);
+    GSERIALIZED *above = geom_in(above_wkt, -1);
+    GSERIALIZED *apex = geom_in(apex_wkt, -1);
+    assert(semi != NULL); assert(above != NULL); assert(apex != NULL);
+    assert(geom_distance2d(semi, above) == dist_s);
+    assert(geom_distance2d(semi, apex) == 0.0);
+    assert(geom_dwithin2d(semi, apex, 0.0));
+    dist_ok++;
+    free(semi); free(above); free(apex);
+  }
+  printf("the distance from a point to a semicircle is its closed form, and "
+    "its middle vertex lies on it, at %d scales from 1 to 2^-40\n", dist_ok);
+  assert(dist_ok == 41);
+  meos_errno_reset();
+
   /* A GEOMETRYCOLLECTION is the union of its components, so what it shares
    * with another geometry is the union of what the components share. The
    * overlay reads it that way now, which is how the matrix has always read a

--- a/postgis/liblwgeom/gbox.c
+++ b/postgis/liblwgeom/gbox.c
@@ -468,11 +468,6 @@ size_t gbox_serialized_size(lwflags_t flags)
 ** Compute cartesian bounding GBOX boxes from LWGEOM.
 */
 
-/* MEOS: the cross product of coordinate differences, computed exactly and
- * rounded once, from meos/src/geo/geo_funcs.c */
-extern double cross_product_exact(double ax, double ay, double bx, double by,
-	double cx, double cy, double dx, double dy);
-
 /* MEOS: the rounding of a coordinate the arc box constructs, by which the box
  * is padded outward, since a box may hold more than the arc and never less.
  * A reach beyond the chord midpoint goes through some fifty roundings of the
@@ -542,39 +537,18 @@ int lw_arc_calculate_gbox_cartesian_2d(const POINT2D *A1, const POINT2D *A2, con
 		return LW_SUCCESS;
 	}
 
-	/* MEOS: the turn at A2, the cross product of A1 - A2 and A3 - A2, exactly.
-	 * Zero where the three points are collinear, A2 on an end included, and
-	 * the arc is then the segment A1-A3; otherwise its sign is the side of the
-	 * chord A1-A3 the arc lies on. Where its two products do not nearly
-	 * cancel, their rounded difference keeps its relative precision to a few
-	 * roundings; otherwise it is computed exactly */
-	double ux = A1->x - A2->x, uy = A1->y - A2->y;
-	double vx = A3->x - A2->x, vy = A3->y - A2->y;
-	double left = ux * vy, right = uy * vx;
-	double cross = left - right;
-	if (! (fabs(cross) > 0.5 * (fabs(left) + fabs(right))))
-		cross = cross_product_exact(A2->x, A2->y, A1->x, A1->y,
-			A2->x, A2->y, A3->x, A3->y);
-	if (cross == 0.0)
+	/* MEOS: three collinear points, A2 on an end included, are the segment
+	 * A1-A3 */
+	LW_ARC_FRAME f;
+	if (! lw_arc_frame(A1, A2, A3, &f))
 		return LW_SUCCESS;
 
-	/* MEOS: the inscribed angle a at A2, from the cross product and the dot
-	 * product of the two vectors, each to within a few roundings of itself */
-	double dot = ux * vx + uy * vy;
-	double h = hypot(cross, dot);
-	double sina = fabs(cross) / h, cosa = dot / h;
-
-	/* MEOS: the chord, its midpoint, half its length and its unit normal
-	 * toward the arc. The circle has radius half / sin a and its centre lies
-	 * half cot a from the midpoint along that normal, so the extreme of the
-	 * circle in a direction W lies half (1 + omega cos a) / sin a beyond the
-	 * midpoint, and it is on the arc where omega >= - cos a */
-	double chx = A3->x - A1->x, chy = A3->y - A1->y;
-	double len = hypot(chx, chy);
-	double half = len / 2.0;
-	double mx = A1->x + chx / 2.0, my = A1->y + chy / 2.0;
-	double side = (cross > 0.0) ? 1.0 : -1.0;
-	double nx = - side * chy / len, ny = side * chx / len;
+	/* MEOS: the circle has radius half / sin a and its centre lies half cot a
+	 * from the chord midpoint along the normal toward the arc, so the extreme
+	 * of the circle in a direction W lies half (1 + omega cos a) / sin a
+	 * beyond the midpoint, and it is on the arc where omega >= - cos a */
+	double half = f.half, mx = f.mx, my = f.my, nx = f.nx, ny = f.ny;
+	double sina = f.sina, cosa = f.cosa;
 	/* An extreme on the edge of that condition sits on an end of the arc, so
 	 * one read on the wrong side of it moves the box by a rounding: take it */
 	double slack = ARC_GBOX_ROUNDING;

--- a/postgis/liblwgeom/liblwgeom_internal.h
+++ b/postgis/liblwgeom/liblwgeom_internal.h
@@ -442,6 +442,17 @@ int lw_segment_side(const POINT2D *p1, const POINT2D *p2, const POINT2D *q);
 int lw_arc_side(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3, const POINT2D *Q);
 int lw_arc_calculate_gbox_cartesian_2d(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3, GBOX *gbox);
 double lw_arc_center(const POINT2D *p1, const POINT2D *p2, const POINT2D *p3, POINT2D *result);
+/* MEOS: an arc read off its chord A1-A3 and its inscribed angle a at A2
+ * rather than off its circumcentre, which cancels against the radius of a
+ * nearly straight arc */
+typedef struct
+{
+	double mx, my;     /* midpoint of the chord */
+	double nx, ny;     /* unit normal of the chord, toward the arc */
+	double half;       /* half the length of the chord */
+	double sina, cosa; /* sine and cosine of the angle a */
+} LW_ARC_FRAME;
+int lw_arc_frame(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3, LW_ARC_FRAME *frame); /* MEOS */
 int lw_pt_in_seg(const POINT2D *P, const POINT2D *A1, const POINT2D *A2);
 int lw_pt_in_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const POINT2D *A3);
 int lw_arc_is_pt(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3);

--- a/postgis/liblwgeom/lwalgorithm.c
+++ b/postgis/liblwgeom/lwalgorithm.c
@@ -117,6 +117,52 @@ lw_arc_is_pt(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3)
 		return LW_FALSE;
 }
 
+/* MEOS: the cross product of coordinate differences, computed exactly and
+ * rounded once, from meos/src/geo/geo_funcs.c */
+extern double cross_product_exact(double ax, double ay, double bx, double by,
+	double cx, double cy, double dx, double dy);
+
+/* MEOS: read an arc whose ends differ off its chord and the inscribed angle a
+ * at A2, deciding on the input vertices exactly. The turn at A2, the cross
+ * product of A1 - A2 and A3 - A2, is zero where the three points are
+ * collinear, A2 on an end included, and the arc is then the segment A1-A3;
+ * otherwise its sign is the side of the chord the arc lies on. Where its two
+ * products do not nearly cancel, their rounded difference keeps its relative
+ * precision to a few roundings; otherwise it is computed exactly. Returns
+ * LW_FALSE where the arc is that segment */
+int
+lw_arc_frame(const POINT2D *A1, const POINT2D *A2, const POINT2D *A3, LW_ARC_FRAME *frame)
+{
+	double ux = A1->x - A2->x, uy = A1->y - A2->y;
+	double vx = A3->x - A2->x, vy = A3->y - A2->y;
+	double left = ux * vy, right = uy * vx;
+	double cross = left - right;
+	if (! (fabs(cross) > 0.5 * (fabs(left) + fabs(right))))
+		cross = cross_product_exact(A2->x, A2->y, A1->x, A1->y,
+			A2->x, A2->y, A3->x, A3->y);
+	if (cross == 0.0)
+		return LW_FALSE;
+
+	/* The angle a, from the cross product and the dot product of the two
+	 * vectors, each to within a few roundings of itself */
+	double dot = ux * vx + uy * vy;
+	double h = sqrt(cross * cross + dot * dot);
+	frame->sina = fabs(cross) / h;
+	frame->cosa = dot / h;
+
+	/* The chord, its midpoint, half its length and its unit normal toward
+	 * the arc */
+	double chx = A3->x - A1->x, chy = A3->y - A1->y;
+	double len = sqrt(chx * chx + chy * chy);
+	double side = (cross > 0.0) ? 1.0 : -1.0;
+	frame->half = len / 2.0;
+	frame->mx = A1->x + chx / 2.0;
+	frame->my = A1->y + chy / 2.0;
+	frame->nx = - side * chy / len;
+	frame->ny = side * chx / len;
+	return LW_TRUE;
+}
+
 /**
 * Returns the length of a circular arc segment
 */

--- a/postgis/liblwgeom/measures.c
+++ b/postgis/liblwgeom/measures.c
@@ -1526,13 +1526,45 @@ lw_dist2d_seg_arc(const POINT2D *A1,
 	return LW_FALSE;
 }
 
+/* MEOS: record a distance computed apart from its two points, in the order
+ * lw_dist2d_pt_pt records them */
+static void
+lw_dist2d_pt_pt_at(const POINT2D *thep1, const POINT2D *thep2, double dist, DISTPTS *dl)
+{
+	if (((dl->distance - dist) * (dl->mode)) > 0)
+	{
+		dl->distance = dist;
+		if (dl->twisted > 0)
+		{
+			dl->p1 = *thep1;
+			dl->p2 = *thep2;
+		}
+		else
+		{
+			dl->p1 = *thep2;
+			dl->p2 = *thep1;
+		}
+	}
+}
+
+/* MEOS: the distance from a point to an arc, decided on the input vertices
+ * exactly and measured without the circumcentre, whose distance from the arc
+ * cancels against the radius of a nearly straight arc. A point equal to a
+ * vertex of the arc lies on it, and an arc whose ends are the same vertex is
+ * the circle on the diameter A1-A2. Otherwise, in the frame of lw_arc_frame,
+ * with n the normal of the chord toward the arc, h = half cot a the signed
+ * distance from the chord midpoint to the centre C along n and R = half / sin a
+ * the radius, and with q = P - A1 and c = A3 - A1 read from the input vertex
+ * A1, which lies on the circle, the power of P with respect to the circle is
+ * q.(q - c) - 2 h q.n, and its signed distance delta to the circle is that
+ * power over |P - C| + R. The power carries rounding of the size of its terms,
+ * and |P - C| - R rounding of the size of |P - C| + R, so of the two forms the
+ * one whose bound is smaller gives delta. The nearest point of the circle lies
+ * on the arc where q.n >= - delta cos a, and otherwise the nearest point of
+ * the arc is one of its ends */
 int
 lw_dist2d_pt_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const POINT2D *A3, DISTPTS *dl)
 {
-	double radius_A, d;
-	POINT2D C; /* center of circle defined by arc A */
-	POINT2D X; /* point circle(A) where line from C to P crosses */
-
 	if (dl->mode < 0)
 	{
 		lwerror("lw_dist2d_pt_arc does not support maxdistance mode");
@@ -1543,33 +1575,73 @@ lw_dist2d_pt_arc(const POINT2D *P, const POINT2D *A1, const POINT2D *A2, const P
 	if (lw_arc_is_pt(A1, A2, A3))
 		return lw_dist2d_pt_pt(P, A1, dl);
 
-	/* Calculate centers and radii of circles. */
-	radius_A = lw_arc_center(A1, A2, A3, &C);
+	/* MEOS: the ends of the arc lie on it */
+	if (P->x == A1->x && P->y == A1->y)
+		return lw_dist2d_pt_pt(P, A1, dl);
+	if (P->x == A3->x && P->y == A3->y)
+		return lw_dist2d_pt_pt(P, A3, dl);
 
-	/* This "arc" is actually a line (A2 is colinear with A1,A3) */
-	if (radius_A < 0.0)
-		return lw_dist2d_pt_seg(P, A1, A3, dl);
-
-	/* Distance from point to center */
-	d = distance2d_pt_pt(&C, P);
-
-	/* P is the center of the circle */
-	if (FP_EQUALS(d, 0.0))
+	/* MEOS: an arc whose ends are the same vertex is a whole circle, through
+	 * A2 */
+	if (A1->x == A3->x && A1->y == A3->y)
 	{
-		dl->distance = radius_A;
-		dl->p1 = *A1;
-		dl->p2 = *P;
+		if (P->x == A2->x && P->y == A2->y)
+			return lw_dist2d_pt_pt(P, A2, dl);
+		double cx = A1->x + (A2->x - A1->x) / 2.0;
+		double cy = A1->y + (A2->y - A1->y) / 2.0;
+		double r = hypot(A2->x - A1->x, A2->y - A1->y) / 2.0;
+		double dx = P->x - cx, dy = P->y - cy;
+		double d = hypot(dx, dy);
+		POINT2D X;
+		if (d == 0.0)
+		{
+			lw_dist2d_pt_pt_at(A1, P, r, dl);
+			return LW_TRUE;
+		}
+		X.x = P->x - (d - r) * dx / d;
+		X.y = P->y - (d - r) * dy / d;
+		lw_dist2d_pt_pt_at(P, &X, fabs(d - r), dl);
 		return LW_TRUE;
 	}
 
-	/* X is the point on the circle where the line from P to C crosses */
-	X.x = C.x + (P->x - C.x) * radius_A / d;
-	X.y = C.y + (P->y - C.y) * radius_A / d;
+	/* MEOS: three collinear points, A2 on an end included, are the segment
+	 * A1-A3 */
+	LW_ARC_FRAME f;
+	if (! lw_arc_frame(A1, A2, A3, &f))
+		return lw_dist2d_pt_seg(P, A1, A3, dl);
 
-	/* Is crossing point inside the arc? Or arc is actually circle? */
-	if (p2d_same(A1, A3) || lw_pt_in_arc(&X, A1, A2, A3))
+	/* MEOS: an arc that turns at A2 passes through it */
+	if (P->x == A2->x && P->y == A2->y)
+		return lw_dist2d_pt_pt(P, A2, dl);
+
+	/* P and the centre C are read from A1, an input vertex on the circle:
+	 * C - A1 is half the chord plus h along n, of length the radius */
+	double chx = A3->x - A1->x, chy = A3->y - A1->y;
+	double hc = f.half * f.cosa / f.sina, radius = f.half / f.sina;
+	double qx = P->x - A1->x, qy = P->y - A1->y;
+	double qn = qx * f.nx + qy * f.ny;
+	double pcx = qx - (chx / 2.0 + f.nx * hc), pcy = qy - (chy / 2.0 + f.ny * hc);
+	double pc = sqrt(pcx * pcx + pcy * pcy);
+
+	/* P is the centre of the circle, every point of the arc at the radius */
+	if (pc == 0.0)
 	{
-		lw_dist2d_pt_pt(P, &X, dl);
+		lw_dist2d_pt_pt_at(A1, P, radius, dl);
+		return LW_TRUE;
+	}
+
+	double qq = qx * qx + qy * qy, qch = qx * chx + qy * chy;
+	double power = (qq - qch) - 2.0 * hc * qn;
+	double bound_power = (qq + fabs(qch) + 2.0 * fabs(hc * qn)) / (pc + radius);
+	double delta = (bound_power < pc + radius) ? power / (pc + radius) : pc - radius;
+
+	if (qn >= - delta * f.cosa)
+	{
+		/* The nearest point of the circle: P moved by delta toward C */
+		POINT2D X;
+		X.x = P->x - delta * pcx / pc;
+		X.y = P->y - delta * pcy / pc;
+		lw_dist2d_pt_pt_at(P, &X, fabs(delta), dl);
 	}
 	else
 	{


### PR DESCRIPTION
Read an arc off its chord and the angle at its middle vertex in one place

The box of an arc reads the arc off its chord A1-A3 and the inscribed angle
at A2: the turn at A2 decided exactly, then the sine and cosine of that
angle, the chord midpoint, half the chord and its unit normal toward the
arc. lw_arc_frame, in lwalgorithm.c beside lw_arc_center, computes that
frame, and lw_arc_calculate_gbox_cartesian_2d builds its box from it, so the
distance to an arc can be built in the same frame.

The frame takes the length of the chord and of the cross and dot pair as
square roots of sums of squares rather than hypot: each is a sum of two
squares far inside the range of a double, the root carries a rounding of
one more unit, and hypot's guard against overflow costs what the distance
reading the frame once per point cannot afford.

The box of each of the 3000 arcs the box is judged on still holds the arc
against the closed form, and each of the 2000 arcs scaled by 2^20 down to
2^-40 still has its box scaled by the same power, bit for bit. 175 of the
3000 boxes move, the largest by 3.3 DBL_EPSILON of the box's extent.


Measure the distance from a point to an arc without its circumcentre

lw_dist2d_pt_arc reads the arc off lw_arc_center, which takes an arc for a
segment where twice its cross product is below the absolute EPSILON_SQLMM
and for a closed circle where its ends lie within 1e-8, so from a size of
some 1e-5 down it measures the distance to the chord, and below 1e-8 the
distance to another circle. It then decides that the point is the centre
within the absolute FP_TOLERANCE, and measures |P - C| - R, which cancels
for a nearly straight arc whose centre lies far away.

The witness is the semicircle of radius s = 2^-16

  CIRCULARSTRING(0 0,1.52587890625e-05 1.52587890625e-05,3.0517578125e-05 0)

and the point above its top, POINT(1.52587890625e-05 3.0517578125e-05), at
distance s from it. geom_distance2d answers 3.0517578125e-05, the distance
to the chord, 2s, from s = 2^-16 down to 2^-24, and 0.874 s from 2^-28 down;
geom_dwithin2d of the arc and its own middle vertex at distance 0 answers
false at 2^-16 to 2^-24 and at 2^-40. The branch answers s, exactly, and
true, at every power of two from 1 to 2^-40.

lw_dist2d_pt_arc decides on the input vertices exactly: a point equal to an
end of the arc lies on it; an arc whose ends are the same vertex is the
circle on the diameter A1-A2, through A2; three collinear points, A2 on an
end included, are the segment A1-A3; and an arc that turns at A2 passes
through it. Otherwise it reads the arc in the frame of lw_arc_frame: with n
the normal of the chord toward the arc, h = half cot a the signed distance
from the chord midpoint to the centre C along n, and R = half / sin a, and
with q = P - A1 and c = A3 - A1 measured from the input vertex A1, which lies
on the circle, the power of P with respect to the circle is
q.(q - c) - 2 h q.n. Its signed distance delta to the circle is that power
over |P - C| + R, or |P - C| - R where the rounding bound of that form is
the smaller one, as it is for a point far from a strongly curved arc. The
nearest point of the circle lies on the arc where q.n >= -delta cos a, and
otherwise the nearest point of the arc is one of its ends. Every term is of
the size of the arc and of the point's offset from it, so no absolute bound
enters, and q and c are single differences of nearby coordinates.

Why the distance is right: every decision is taken on input vertices, and
exactly. The power of a point with respect to a circle is |P - C|^2 - R^2,
and q.(q - c) - 2 h q.n is that polynomial written from A1, a point of the
circle, so R^2 cancels in the algebra rather than in the arithmetic;
dividing it by |P - C| + R gives the signed distance itself. What remains
rounded is the construction of terms the size of the arc and of the point's
offset from it, so the error scales with the geometry, and the distance of a
point and an arc scaled by a power of two is their distance scaled by that
power, bit for bit.

The numbers. Two sweeps of 4000 point-arc pairs each, over eight scales from
1 to 2^-40, around the origin, (1.25, -3.5) and (6.4e6, 5.1e6), with strongly
curved, nearly straight and major arcs and points at vertices, just off the
arc, far away, at the chord midpoint and anywhere, judged against the closed
form, a rational centre with its radius to 200 digits: master's distance is
off by more than 64 DBL_EPSILON of the problem's scale on 1734 and 1731 of
them, by up to the scale itself; the branch's by at most 1.84 and 1.57, with
a median of 3e-10. 2000 pairs scaled by 2^20, 2^-8, 2^-16, 2^-20, 2^-30 and
2^-40: master's distance moves for 334 to 1688 of them, the branch's for
none. Over the corpora, 1810 of the 12880 geo_pairs distances move, by at
most 7.7e-13 relative; of the 463 pairs of points and curves among them,
judged against the closed form, the branch is nearer the exact distance on
256 and master on 207, with median errors of 0.245 and 0.316 DBL_EPSILON of
the coordinates and worst errors of 6.69 and 59.4. No distance moves over
adversarial_pairs, real_curve_pairs or areal_pairs. geom_distance2d over the
12880 geo_pairs retires 571.8 million instructions against master's 569.6
million under callgrind.

The time against GEOS, which compares cost only: the distances themselves
are judged against the closed form above, never against GEOS, which
measures to the lines the arcs are stroked into. Native / GEOS in one
process over the 30 real curve pairs, a
median of 13 circular strings and 85 vertices a pair and at most 897 and
5884, arms alternated: 0.48, 0.39 and 0.41 of the time GEOS takes as MEOS
calls it, converting both geometries and stroking every arc, against
master's 0.46, 0.47 and 0.63; and 7.16, 6.26 and 6.62 times the time GEOS
takes on geometries it is handed already converted, against master's
6.96, 7.00 and 9.68. One round under callgrind: native 19.41 million
instructions against master's 19.47 million, GEOS as MEOS calls it 47.43
million, GEOS alone 3.51 million. Of the native pass, reading both
geometries out of their serialized form and freeing them is 10.2 million and
the distance walk 9.35 million, a walk over every pair of edges with no
pruning, against the facet distance of GEOS pruned by envelopes; each is its
own change. Over the geo_pairs, whose edges are straight, the native distance
takes 0.26 to 0.35 of the time of GEOS alone and 0.21 to 0.23 of the time of
GEOS as MEOS calls it.

The distance from a segment to an arc and between two arcs read
lw_arc_center themselves, and measure the same semicircle's distance to the
segment and to the arc above it, both s, as 2s and 3s at the same scales;
each is a separate change.

meos/test/geo_test.c carries the point above the semicircle and its middle
vertex at 41 scales; on master it aborts at the distance of the point above.


