### PR TITLE
Keep the date and time zone lookup caches per thread

### DIFF
--- a/.github/workflows/meos.yml
+++ b/.github/workflows/meos.yml
@@ -83,6 +83,10 @@ jobs:
           # unit of work does. SIBLING-FROM allocator_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o lifecycle_test lifecycle_test.c -L/usr/local/lib -lmeos
           ./lifecycle_test
+          # timezone_switch_test reads one abbreviation under one timezone
+          # after another. SIBLING-FROM lifecycle_test
+          gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o timezone_switch_test timezone_switch_test.c -L/usr/local/lib -lmeos
+          ./timezone_switch_test
           gcc -Wall -Werror=implicit-function-declaration -g -I/usr/local/include -o bool_test bool_test.c -L/usr/local/lib -lmeos
           ./bool_test
           # int_test is what reads <meos.h> and <pg_int.h> in one translation

--- a/meos/test/timezone_switch_test.c
+++ b/meos/test/timezone_switch_test.c
@@ -1,0 +1,92 @@
+/*****************************************************************************
+ *
+ * This MobilityDB code is provided under The PostgreSQL License.
+ * Copyright (c) 2016-2026, Université libre de Bruxelles and MobilityDB
+ * contributors
+ *
+ * MobilityDB includes portions of PostGIS version 3 source code released
+ * under the GNU General Public License (GPLv2 or later).
+ * Copyright (c) 2001-2025, PostGIS contributors
+ *
+ * Permission to use, copy, modify, and distribute this software and its
+ * documentation for any purpose, without fee, and without a written
+ * agreement is hereby granted, provided that the above copyright notice and
+ * this paragraph and the following two paragraphs appear in all copies.
+ *
+ * IN NO EVENT SHALL UNIVERSITE LIBRE DE BRUXELLES BE LIABLE TO ANY PARTY FOR
+ * DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING
+ * LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION,
+ * EVEN IF UNIVERSITE LIBRE DE BRUXELLES HAS BEEN ADVISED OF THE POSSIBILITY
+ * OF SUCH DAMAGE.
+ *
+ * UNIVERSITE LIBRE DE BRUXELLES SPECIFICALLY DISCLAIMS ANY WARRANTIES,
+ * INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY
+ * AND FITNESS FOR A PARTICULAR PURPOSE. THE SOFTWARE PROVIDED HEREUNDER IS ON
+ * AN "AS IS" BASIS, AND UNIVERSITE LIBRE DE BRUXELLES HAS NO OBLIGATIONS TO
+ * PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+ *
+ *****************************************************************************/
+
+/**
+ * @file
+ * @brief A program that tests reading a timezone abbreviation in one timezone
+ * after another.
+ *
+ * An abbreviation the session timezone defines means what that timezone says
+ * it means, so the same abbreviation read under each timezone
+ * #meos_initialize_timezone sets takes the meaning of that timezone. LMT, the
+ * local mean time a zone keeps before its first standard time, has a different
+ * offset in every zone, which makes it the abbreviation that shows which
+ * timezone answered.
+ *
+ * The program can be build as follows
+ * @code
+ * gcc -Wall -g -I/usr/local/include -o timezone_switch_test timezone_switch_test.c -L/usr/local/lib -lmeos
+ * @endcode
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <meos.h>
+#include <pg_timestamp.h>
+
+#define INPUT "1850-01-01 12:00:00 LMT"
+
+static int failures = 0;
+
+/* Read the input in a timezone and compare its output with the expected text */
+static void
+check(const char *zone, const char *expected)
+{
+  meos_initialize_timezone(zone);
+  TimestampTz t = timestamptz_in(INPUT, -1);
+  char *out = timestamptz_out(t);
+  if (strcmp(out, expected) != 0)
+  {
+    printf("FAIL: %s in %s gives %s, expected %s\n", INPUT, zone, out,
+      expected);
+    failures++;
+  }
+  else
+    printf("ok: %s in %s gives %s\n", INPUT, zone, out);
+  free(out);
+}
+
+int
+main(void)
+{
+  meos_initialize();
+  /* The local mean time of each zone, read one zone after the other */
+  check("Europe/Moscow", "1850-01-01 12:00:00+02:30:17");
+  check("America/New_York", "1850-01-01 12:00:00-04:56:02");
+  check("Europe/Moscow", "1850-01-01 12:00:00+02:30:17");
+  meos_finalize();
+  if (failures)
+  {
+    printf("%d failure(s)\n", failures);
+    return EXIT_FAILURE;
+  }
+  printf("All timezone switch checks passed\n");
+  return EXIT_SUCCESS;
+}

--- a/pgtypes/timezone/pgtz.c
+++ b/pgtypes/timezone/pgtz.c
@@ -525,6 +525,9 @@ meos_initialize_timezone(const char *tz_str)
   if (session_timezone)
     pfree(session_timezone); 
   session_timezone = pg_tzset(tz_str);
+  /* The cache of timezone abbreviations may hold the zone just freed, as
+   * PostgreSQL's assign_timezone clears it after a change of timezone */
+  ClearTimeZoneAbbrevCache();
   if (! session_timezone)
     meos_error(ERROR, MEOS_ERR_INTERNAL_ERROR,
       "Failed to initialize local timezone");
@@ -562,6 +565,7 @@ meos_finalize_timezone(void)
   {
     pfree(session_timezone);
     session_timezone = NULL;
+    ClearTimeZoneAbbrevCache();
   }
   if (timezone_cache)
   {

--- a/pgtypes/utils/datetime.c
+++ b/pgtypes/utils/datetime.c
@@ -30,6 +30,7 @@
 #include "pgtypes.h"  /* meos_strtod */
 
 #include "../../meos/include/meos_error.h"
+#include "../../meos/include/meos_tls.h"  /* MEOS: MEOS_TLS */
 
 // #include "access/htup_details.h"
 // #include "access/xact.h"
@@ -278,11 +279,12 @@ static const int szdeltatktbl = sizeof deltatktbl / sizeof deltatktbl[0];
 
 static TimeZoneAbbrevTable *zoneabbrevtbl = NULL;
 
-/* Caches of recent lookup results in the above tables */
+/* Caches of recent lookup results in the above tables.
+ * MEOS: per thread (MEOS_TLS), as the session timezone they are read under */
 
-static const datetkn *datecache[MAXDATEFIELDS] = {NULL};
+static MEOS_TLS const datetkn *datecache[MAXDATEFIELDS] = {NULL};
 
-static const datetkn *deltacache[MAXDATEFIELDS] = {NULL};
+static MEOS_TLS const datetkn *deltacache[MAXDATEFIELDS] = {NULL};
 
 /* Cache for results of timezone abbreviation lookups */
 
@@ -294,7 +296,9 @@ typedef struct TzAbbrevCache
   pg_tz     *tz;        /* relevant zone, if variable-offset */
 } TzAbbrevCache;
 
-static TzAbbrevCache tzabbrevcache[MAXDATEFIELDS];
+/* MEOS: per thread (MEOS_TLS), since an entry can hold the session timezone of
+ * the thread that filled it */
+static MEOS_TLS TzAbbrevCache tzabbrevcache[MAXDATEFIELDS];
 
 /*
  * Calendar time to Julian date conversions.


### PR DESCRIPTION
The caches pgtypes/utils/datetime.c keeps of its last lookups, datecache,
deltacache and tzabbrevcache, are thread-local in standalone MEOS, as
session_timezone, the current timezone, is. meos_initialize_timezone and
meos_finalize_timezone clear the time zone abbreviation cache when they free
the current timezone, as PostgreSQL's assign_timezone clears it after a change
of timezone. The extension keeps them process-wide, as the server does.

An entry of tzabbrevcache holds what the current timezone of the thread that
filled it says an abbreviation means, and for an abbreviation with more than
one offset in that timezone, a pointer to the timezone itself. Shared by every
thread and never cleared, it answers a thread with another thread's timezone,
and a thread with the timezone it has just freed.

Witness:
- Europe/Moscow and then America/New_York as the current timezone of one
  thread, reading 1850-01-01 12:00:00 LMT under each, the local mean time of
  the zone: New York answers 1850-01-01 04:33:41-04:56:02, Moscow's local mean
  time, where a process starting in New York answers 1850-01-01
  12:00:00-04:56:02.
- 2001-01-15 12:00:00 MSK read under Europe/Moscow, then again under
  America/New_York, in an AddressSanitizer build: heap-use-after-free in
  pg_interpret_timezone_abbrev, on the zone meos_initialize_timezone freed.
- Eight threads, four in each of the two zones, each reading the LMT input
  2000 times: 8000 of the 16000 answers carry the other zone's offset, in 5
  runs of 5.

Measured:
- meos/test/timezone_switch_test reads the LMT input under Europe/Moscow,
  America/New_York and Europe/Moscow again: 3 of 3 with this change, and the
  master build answers the New York reading with Moscow's offset.
- The MSK input under Europe/Moscow and then America/New_York in an
  AddressSanitizer build: no report; New York answers 2001-01-15
  04:00:00-05, the meaning PostgreSQL's Default set gives MSK, as a process
  starting in New York does.
- The eight threads in the two zones: 0 of 16000 answers wrong in 5 runs of 5,
  and in a ThreadSanitizer build 0 reports in 5 runs of 5. The same
  ThreadSanitizer probe against the process-wide caches reports 5 races in
  each of 3 runs, all on tzabbrevcache, with 2001, 9809 and 5931 answers
  wrong.
- Cost: 15 interleaved runs of 200000 parses under America/New_York against
  the master library and this one: a timestamp with a numeric offset at a
  median ratio of 0.989, one with the abbreviation EST at 1.002.

Why: an abbreviation read under a timezone means what that timezone says it
means, and in MEOS the current timezone belongs to a thread. PostgreSQL keeps
the cache in a backend, which serves one connection, and clears it when that
connection changes timezone; MEOS gives each thread its own current timezone,
so the cache that remembers what it said is the thread's too, and it is
cleared at the point PostgreSQL clears it.

