### PR TITLE
Read a raster file on the server under the names of the raster readers

### DIFF
--- a/doc/es/reference.xml
+++ b/doc/es/reference.xml
@@ -2830,7 +2830,7 @@
 					<para><link linkend="raquet"><varname>raquet</varname></link>: Construye una tesela ráster Raquet a partir de sus bytes de píxeles, dimensiones, celda QUADBIN y tipo de píxel</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquetRead"><varname>raquetRead</varname></link>: Decodifica un archivo ráster en memoria en una tesela ráster Raquet mediante GDAL</para>
+					<para><link linkend="raquetRead"><varname>raquetRead</varname></link>: Decodifica un archivo ráster en una tesela ráster Raquet mediante GDAL</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/es/temporal_cell_index.xml
+++ b/doc/es/temporal_cell_index.xml
@@ -279,11 +279,12 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 			</listitem>
 			<listitem xml:id="raquetRead">
 				<indexterm significance="normal"><primary><varname>raquetRead</varname></primary></indexterm>
-				<para>Decodifica un archivo ráster en memoria en una tesela ráster Raquet mediante GDAL</para>
+				<para>Decodifica un archivo ráster en una tesela ráster Raquet mediante GDAL</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 raquetRead(bytea,quadbin bigint) → raquet
+raquetRead(text,quadbin bigint) → raquet
 </programlisting>
-				<para>Lee los bytes de <varname>rasterfile</varname>, un ráster en cualquier formato compatible con GDAL (GeoTIFF, PNG, …), a través del sistema de archivos virtual <varname>/vsimem/</varname> de GDAL, y empaqueta su primera banda, en orden de fila mayor, en un único valor <varname>raquet</varname> autodescriptivo georreferenciado por la celda <varname>quadbin</varname>. El tipo de datos de la banda debe ser uno de <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname> o <varname>Float64</varname>; el valor de nodata de la banda, cuando está definido, se traslada a la tesela. Como el archivo se suministra como bytes, no se requiere acceso a archivos del lado del servidor. GDAL realiza la decodificación, por lo que el controlador de formato del ráster debe estar permitido por la configuración <varname>postgis.gdal_enabled_drivers</varname> de PostGIS (que deshabilita todos los controladores de forma predeterminada); habilítelo con, por ejemplo, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. Esta es la contraparte de ingesta del constructor <link linkend="raquet"><varname>raquet</varname></link>, que construye una tesela a partir de bytes de píxeles ya decodificados. Cuando se omite <varname>quadbin</varname> o es <varname>NULL</varname>, el identificador de la tesela se deriva de la georreferenciación del ráster: el ráster debe llevar una referencia espacial <varname>EPSG:3857</varname> (Web-Mercator) y una geotransformación alineada con los ejes que describa una única tesela QUADBIN. Un ráster sin referencia espacial, uno que no esté en <varname>EPSG:3857</varname>, o una geotransformación rotada o no alineada con la cuadrícula de teselas provoca un error en lugar de ser forzado.</para>
+				<para>Lee los bytes de <varname>rasterfile</varname>, un ráster en cualquier formato compatible con GDAL (GeoTIFF, PNG, …), a través del sistema de archivos virtual <varname>/vsimem/</varname> de GDAL, y empaqueta su primera banda, en orden de fila mayor, en un único valor <varname>raquet</varname> autodescriptivo georreferenciado por la celda <varname>quadbin</varname>. El tipo de datos de la banda debe ser uno de <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname> o <varname>Float64</varname>; el valor de nodata de la banda, cuando está definido, se traslada a la tesela. Como el archivo se suministra como bytes, no se requiere acceso a archivos del lado del servidor. GDAL realiza la decodificación, por lo que el controlador de formato del ráster debe estar permitido por la configuración <varname>postgis.gdal_enabled_drivers</varname> de PostGIS (que deshabilita todos los controladores de forma predeterminada); habilítelo con, por ejemplo, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. Esta es la contraparte de ingesta del constructor <link linkend="raquet"><varname>raquet</varname></link>, que construye una tesela a partir de bytes de píxeles ya decodificados. Cuando se omite <varname>quadbin</varname> o es <varname>NULL</varname>, el identificador de la tesela se deriva de la georreferenciación del ráster: el ráster debe llevar una referencia espacial <varname>EPSG:3857</varname> (Web-Mercator) y una geotransformación alineada con los ejes que describa una única tesela QUADBIN. Un ráster sin referencia espacial, uno que no esté en <varname>EPSG:3857</varname>, o una geotransformación rotada o no alineada con la cuadrícula de teselas provoca un error en lugar de ser forzado. La forma que recibe <varname>text</varname> lee en su lugar el archivo ráster del servidor en esa ruta, allí donde PostGIS permite leer una banda ráster almacenada fuera de la base de datos, como indica <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Decode a GeoTIFF stored in a bytea column into a raquet tile
 SELECT raquetRead(file_bytes, quadbin) AS tile FROM elevation_files;
@@ -2057,8 +2058,9 @@ SELECT rasterTileValueQuadbin(traj, band_data, width, height, quadbin, 'float32'
 				<para>Lee una banda de ráster a lo largo de una trayectoria</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
+rasterValue(tgeompoint,path text,band integer=1) → tfloat
 </programlisting>
-				<para>Lee la banda <varname>band</varname> a lo largo de <varname>traj</varname>, tomando el valor del píxel en el que cae cada posición. Una trayectoria que no afirma nada entre sus instantes se lee en sus instantes y devuelve un <varname>tfloat</varname> de conjunto de instantes. Una trayectoria que se mueve entre ellos pasa por los píxeles intermedios, por lo que cada segmento se recorre píxel a píxel, y devuelve un <varname>tfloat</varname> escalonado que mantiene cada valor desde el instante en que el trayecto alcanza el píxel que lo contiene, incluido un píxel del que el trayecto solo corta una esquina. Una posición fuera del ráster o sobre un píxel sin datos no lleva valor y termina el tramo, por lo que un trayecto que sale y vuelve a entrar en el ráster devuelve una secuencia por visita, y <varname>NULL</varname> cuando nunca encuentra un píxel con datos. Una banda cuyos píxeles no se pueden leer, como una banda almacenada fuera de la base de datos en un archivo que no se puede abrir, provoca un error en lugar de leerse como una banda sin valores.</para>
+				<para>Lee la banda <varname>band</varname> a lo largo de <varname>traj</varname>, tomando el valor del píxel en el que cae cada posición. Una trayectoria que no afirma nada entre sus instantes se lee en sus instantes y devuelve un <varname>tfloat</varname> de conjunto de instantes. Una trayectoria que se mueve entre ellos pasa por los píxeles intermedios, por lo que cada segmento se recorre píxel a píxel, y devuelve un <varname>tfloat</varname> escalonado que mantiene cada valor desde el instante en que el trayecto alcanza el píxel que lo contiene, incluido un píxel del que el trayecto solo corta una esquina. Una posición fuera del ráster o sobre un píxel sin datos no lleva valor y termina el tramo, por lo que un trayecto que sale y vuelve a entrar en el ráster devuelve una secuencia por visita, y <varname>NULL</varname> cuando nunca encuentra un píxel con datos. Una banda cuyos píxeles no se pueden leer, como una banda almacenada fuera de la base de datos en un archivo que no se puede abrir, provoca un error en lugar de leerse como una banda sin valores. La forma que recibe <varname>path</varname> lee un archivo ráster del servidor, en cualquier formato compatible con GDAL, mediante GDAL, allí donde PostGIS permite leer una banda ráster almacenada fuera de la base de datos: <varname>postgis.enable_outdb_rasters</varname> debe estar activado y <varname>postgis.gdal_enabled_drivers</varname> debe habilitar el controlador del archivo. Devuelve lo que la forma que recibe un <varname>raster</varname> devuelve sobre el mismo ráster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
 WITH rast AS (
@@ -2285,8 +2287,9 @@ JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 				<para>Devuelve la parte de una trayectoria donde el valor ráster que lee cae dentro de un rango de flotante</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 atRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → tgeompoint
+atRasterValue(tgeompoint,path text,vspan floatspan,band integer=1) → tgeompoint
 </programlisting>
-				<para>Lee <varname>rasterValue</varname> a lo largo de <varname>traj</varname> y devuelve la sub-trayectoria restringida a los tiempos en que el valor del píxel está dentro de <varname>vspan</varname>. Devuelve <varname>NULL</varname> cuando ningún tiempo satisface la condición.</para>
+				<para>Lee <varname>rasterValue</varname> a lo largo de <varname>traj</varname> y devuelve la sub-trayectoria restringida a los tiempos en que el valor del píxel está dentro de <varname>vspan</varname>. Devuelve <varname>NULL</varname> cuando ningún tiempo satisface la condición. La forma que recibe <varname>path</varname> lee un archivo ráster del servidor, como lo hace la forma correspondiente de <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH rast AS (
   SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
@@ -2307,8 +2310,9 @@ SELECT asText(atRasterValue(tgeompoint 'SRID=4326;
 				<para>Devuelve la parte de una trayectoria donde el valor ráster que lee cae fuera de un rango de flotante</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 minusRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → tgeompoint
+minusRasterValue(tgeompoint,path text,vspan floatspan,band integer=1) → tgeompoint
 </programlisting>
-				<para>El complemento de <varname>atRasterValue</varname>: devuelve la sub-trayectoria restringida a los tiempos en que el valor del píxel está fuera de <varname>vspan</varname>. Devuelve <varname>NULL</varname> cuando el valor del píxel está dentro de <varname>vspan</varname> en todo momento.</para>
+				<para>El complemento de <varname>atRasterValue</varname>: devuelve la sub-trayectoria restringida a los tiempos en que el valor del píxel está fuera de <varname>vspan</varname>. Devuelve <varname>NULL</varname> cuando el valor del píxel está dentro de <varname>vspan</varname> en todo momento. La forma que recibe <varname>path</varname> lee un archivo ráster del servidor, como lo hace la forma correspondiente de <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Keep only the instant whose raster value (10) is below 40
 SELECT asText(minusRasterValue(traj, elev_raster, floatspan '[40, 9999]')) FROM trips,
@@ -2321,8 +2325,9 @@ SELECT asText(minusRasterValue(traj, elev_raster, floatspan '[40, 9999]')) FROM 
 				<para>Devuelve verdadero si la trayectoria alguna vez lee un valor de píxel ráster dentro de un rango de flotante</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 eRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
+eRasterValue(tgeompoint,path text,vspan floatspan,band integer=1) → boolean
 </programlisting>
-				<para>Devuelve <varname>true</varname> cuando <varname>traj</varname> lee alguna vez un valor de píxel dentro de <varname>vspan</varname>, <varname>false</varname> en caso contrario. Devuelve <varname>NULL</varname> únicamente cuando la entrada es <varname>NULL</varname>.</para>
+				<para>Devuelve <varname>true</varname> cuando <varname>traj</varname> lee alguna vez un valor de píxel dentro de <varname>vspan</varname>, <varname>false</varname> en caso contrario. Devuelve <varname>NULL</varname> únicamente cuando la entrada es <varname>NULL</varname>. La forma que recibe <varname>path</varname> lee un archivo ráster del servidor, como lo hace la forma correspondiente de <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that ever crossed terrain above 200 m
 SELECT tripid FROM trips,
@@ -2335,8 +2340,9 @@ SELECT tripid FROM trips,
 				<para>Devuelve verdadero si cada valor de píxel que la trayectoria lee sobre el ráster está dentro de un rango de flotante</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 aRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
+aRasterValue(tgeompoint,path text,vspan floatspan,band integer=1) → boolean
 </programlisting>
-				<para>Devuelve <varname>true</varname> cuando cada valor de píxel que <varname>traj</varname> lee sobre el ráster está dentro de <varname>vspan</varname>, <varname>false</varname> cuando al menos uno no lo está. Devuelve <varname>NULL</varname> únicamente cuando la entrada es <varname>NULL</varname>.</para>
+				<para>Devuelve <varname>true</varname> cuando cada valor de píxel que <varname>traj</varname> lee sobre el ráster está dentro de <varname>vspan</varname>, <varname>false</varname> cuando al menos uno no lo está. Devuelve <varname>NULL</varname> únicamente cuando la entrada es <varname>NULL</varname>. La forma que recibe <varname>path</varname> lee un archivo ráster del servidor, como lo hace la forma correspondiente de <link linkend="raster_rasterValue"><varname>rasterValue</varname></link>.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that stayed entirely below 100 m elevation
 SELECT tripid FROM trips,

--- a/doc/reference.xml
+++ b/doc/reference.xml
@@ -2839,7 +2839,7 @@
 					<para><link linkend="raquet"><varname>raquet</varname></link>: Construct a Raquet raster tile from its pixel bytes, dimensions, QUADBIN cell and pixel type</para>
 				</listitem>
 				<listitem>
-					<para><link linkend="raquetRead"><varname>raquetRead</varname></link>: Decode an in-memory raster file into a Raquet raster tile via GDAL</para>
+					<para><link linkend="raquetRead"><varname>raquetRead</varname></link>: Decode a raster file into a Raquet raster tile via GDAL</para>
 				</listitem>
 			</itemizedlist>
 		</sect2>

--- a/doc/temporal_cell_index.xml
+++ b/doc/temporal_cell_index.xml
@@ -279,11 +279,12 @@ SELECT raquet('\x01020304'::bytea, 2, 2, 5193776270265024512, 'uint8');
 			</listitem>
 			<listitem xml:id="raquetRead">
 				<indexterm significance="normal"><primary><varname>raquetRead</varname></primary></indexterm>
-				<para>Decode an in-memory raster file into a Raquet raster tile via GDAL</para>
+				<para>Decode a raster file into a Raquet raster tile via GDAL</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 raquetRead(bytea,quadbin bigint) → raquet
+raquetRead(text,quadbin bigint) → raquet
 </programlisting>
-				<para>Reads the bytes of <varname>rasterfile</varname>, a raster in any format GDAL supports (GeoTIFF, PNG, …), through GDAL's <varname>/vsimem/</varname> virtual filesystem, and packs its first band, row-major, into a single self-describing <varname>raquet</varname> value georeferenced by the <varname>quadbin</varname> cell. The band data type must be one of <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname>, or <varname>Float64</varname>; the band nodata value, when set, is carried into the tile. Because the file is supplied as bytes, no server-side file access is required. GDAL performs the decode, so the raster's format driver must be permitted by PostGIS's <varname>postgis.gdal_enabled_drivers</varname> setting (which disables all drivers by default); enable it with, for example, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. This is the ingest counterpart of the <link linkend="raquet"><varname>raquet</varname></link> constructor, which builds a tile from already-decoded pixel bytes. When <varname>quadbin</varname> is omitted or <varname>NULL</varname>, the tile identifier is derived from the raster's georeferencing: the raster must carry an <varname>EPSG:3857</varname> (Web-Mercator) spatial reference and an axis-aligned geotransform describing a single QUADBIN tile. A raster with no spatial reference, one that is not in <varname>EPSG:3857</varname>, or a geotransform that is rotated or not aligned to the tile grid raises an error rather than being coerced.</para>
+				<para>Reads the bytes of <varname>rasterfile</varname>, a raster in any format GDAL supports (GeoTIFF, PNG, …), through GDAL's <varname>/vsimem/</varname> virtual filesystem, and packs its first band, row-major, into a single self-describing <varname>raquet</varname> value georeferenced by the <varname>quadbin</varname> cell. The band data type must be one of <varname>Byte</varname>, <varname>Int16</varname>, <varname>Int32</varname>, <varname>Float32</varname>, or <varname>Float64</varname>; the band nodata value, when set, is carried into the tile. Because the file is supplied as bytes, no server-side file access is required. GDAL performs the decode, so the raster's format driver must be permitted by PostGIS's <varname>postgis.gdal_enabled_drivers</varname> setting (which disables all drivers by default); enable it with, for example, <varname>SET postgis.gdal_enabled_drivers = 'ENABLE_ALL'</varname>. This is the ingest counterpart of the <link linkend="raquet"><varname>raquet</varname></link> constructor, which builds a tile from already-decoded pixel bytes. When <varname>quadbin</varname> is omitted or <varname>NULL</varname>, the tile identifier is derived from the raster's georeferencing: the raster must carry an <varname>EPSG:3857</varname> (Web-Mercator) spatial reference and an axis-aligned geotransform describing a single QUADBIN tile. A raster with no spatial reference, one that is not in <varname>EPSG:3857</varname>, or a geotransform that is rotated or not aligned to the tile grid raises an error rather than being coerced. The form taking <varname>text</varname> reads the raster file at that path on the server instead, where PostGIS allows a raster band stored outside the database to be read, as <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> states.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Decode a GeoTIFF stored in a bytea column into a raquet tile
 SELECT raquetRead(file_bytes, quadbin) AS tile FROM elevation_files;
@@ -2060,8 +2061,9 @@ SELECT rasterTileValueQuadbin(traj, band_data, width, height, quadbin, 'float32'
 				<para>Read a raster band along a trajectory</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 rasterValue(tgeompoint,rast raster,band integer=1) → tfloat
+rasterValue(tgeompoint,path text,band integer=1) → tfloat
 </programlisting>
-				<para>Reads band <varname>band</varname> along <varname>traj</varname>, taking the value of the pixel each position falls in. A trajectory that states nothing between its instants is read at its instants and answers an instant-set <varname>tfloat</varname>. A trajectory that moves between them passes over the pixels between them, so each segment is traversed pixel by pixel, and it answers a step <varname>tfloat</varname> holding each value from the instant the trip reaches the pixel holding it, a pixel whose corner the trip only clips included. A position outside the raster or over a nodata pixel carries no value and ends the run, so a trip that leaves and re-enters the raster answers one sequence per visit, and <varname>NULL</varname> when it never meets a pixel carrying data. A band whose pixels cannot be read, such as a band stored outside the database in a file that cannot be opened, raises an error rather than reading as a band without values.</para>
+				<para>Reads band <varname>band</varname> along <varname>traj</varname>, taking the value of the pixel each position falls in. A trajectory that states nothing between its instants is read at its instants and answers an instant-set <varname>tfloat</varname>. A trajectory that moves between them passes over the pixels between them, so each segment is traversed pixel by pixel, and it answers a step <varname>tfloat</varname> holding each value from the instant the trip reaches the pixel holding it, a pixel whose corner the trip only clips included. A position outside the raster or over a nodata pixel carries no value and ends the run, so a trip that leaves and re-enters the raster answers one sequence per visit, and <varname>NULL</varname> when it never meets a pixel carrying data. A band whose pixels cannot be read, such as a band stored outside the database in a file that cannot be opened, raises an error rather than reading as a band without values. The form taking <varname>path</varname> reads a raster file on the server, in any format GDAL supports, through GDAL, where PostGIS allows a raster band stored outside the database to be read: <varname>postgis.enable_outdb_rasters</varname> must be on and <varname>postgis.gdal_enabled_drivers</varname> must enable the driver of the file. It answers what the form taking a <varname>raster</varname> answers over the same raster.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Build a 3x3 synthetic elevation raster (SRID 4326, 1 degree pixels)
 WITH rast AS (
@@ -2288,8 +2290,9 @@ JOIN sst_raquet r ON r.quadbin = ANY(quadbins(t.trip, 6));
 				<para>Return the part of a trajectory where the raster value it reads falls inside a float range</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 atRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → tgeompoint
+atRasterValue(tgeompoint,path text,vspan floatspan,band integer=1) → tgeompoint
 </programlisting>
-				<para>Reads <varname>rasterValue</varname> along <varname>traj</varname> and returns the sub-trajectory restricted to the times when the pixel value lies within <varname>vspan</varname>. Returns <varname>NULL</varname> when no time satisfies the condition.</para>
+				<para>Reads <varname>rasterValue</varname> along <varname>traj</varname> and returns the sub-trajectory restricted to the times when the pixel value lies within <varname>vspan</varname>. Returns <varname>NULL</varname> when no time satisfies the condition. The form taking <varname>path</varname> reads a raster file on the server, as the corresponding form of <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> does.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 WITH rast AS (
   SELECT ST_SetValues(ST_AddBand( ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0,
@@ -2310,8 +2313,9 @@ SELECT asText(atRasterValue(tgeompoint 'SRID=4326;
 				<para>Return the part of a trajectory where the raster value it reads falls outside a float range</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 minusRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → tgeompoint
+minusRasterValue(tgeompoint,path text,vspan floatspan,band integer=1) → tgeompoint
 </programlisting>
-				<para>The complement of <varname>atRasterValue</varname>: returns the sub-trajectory restricted to the times when the pixel value lies outside <varname>vspan</varname>. Returns <varname>NULL</varname> when the pixel value lies within <varname>vspan</varname> at every time.</para>
+				<para>The complement of <varname>atRasterValue</varname>: returns the sub-trajectory restricted to the times when the pixel value lies outside <varname>vspan</varname>. Returns <varname>NULL</varname> when the pixel value lies within <varname>vspan</varname> at every time. The form taking <varname>path</varname> reads a raster file on the server, as the corresponding form of <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> does.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Keep only the instant whose raster value (10) is below 40
 SELECT asText(minusRasterValue(traj, elev_raster, floatspan '[40, 9999]')) FROM trips,
@@ -2324,8 +2328,9 @@ SELECT asText(minusRasterValue(traj, elev_raster, floatspan '[40, 9999]')) FROM 
 				<para>Return true if the trajectory ever reads a raster pixel value inside a float range</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 eRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
+eRasterValue(tgeompoint,path text,vspan floatspan,band integer=1) → boolean
 </programlisting>
-				<para>Returns <varname>true</varname> when <varname>traj</varname> ever reads a pixel value within <varname>vspan</varname>, <varname>false</varname> otherwise. Returns <varname>NULL</varname> only when the input is <varname>NULL</varname>.</para>
+				<para>Returns <varname>true</varname> when <varname>traj</varname> ever reads a pixel value within <varname>vspan</varname>, <varname>false</varname> otherwise. Returns <varname>NULL</varname> only when the input is <varname>NULL</varname>. The form taking <varname>path</varname> reads a raster file on the server, as the corresponding form of <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> does.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that ever crossed terrain above 200 m
 SELECT tripid FROM trips,
@@ -2338,8 +2343,9 @@ SELECT tripid FROM trips,
 				<para>Return true if every pixel value the trajectory reads over the raster lies inside a float range</para>
 				<programlisting role="syntax" xml:space="preserve" format="linespecific">
 aRasterValue(tgeompoint,rast raster,vspan floatspan,band integer=1) → boolean
+aRasterValue(tgeompoint,path text,vspan floatspan,band integer=1) → boolean
 </programlisting>
-				<para>Returns <varname>true</varname> when every pixel value <varname>traj</varname> reads over the raster lies within <varname>vspan</varname>, <varname>false</varname> when at least one does not. Returns <varname>NULL</varname> only when the input is <varname>NULL</varname>.</para>
+				<para>Returns <varname>true</varname> when every pixel value <varname>traj</varname> reads over the raster lies within <varname>vspan</varname>, <varname>false</varname> when at least one does not. Returns <varname>NULL</varname> only when the input is <varname>NULL</varname>. The form taking <varname>path</varname> reads a raster file on the server, as the corresponding form of <link linkend="raster_rasterValue"><varname>rasterValue</varname></link> does.</para>
 				<programlisting language="sql" xml:space="preserve" format="linespecific">
 -- Trips that stayed entirely below 100 m elevation
 SELECT tripid FROM trips,

--- a/meos/src/raster/raquet_gdal.c
+++ b/meos/src/raster/raquet_gdal.c
@@ -326,9 +326,7 @@ raquet_from_gdal_dataset(GDALDatasetH ds, const char *vpath, uint64 quadbin,
  * @param[in] path Path to a GDAL-readable raster file
  * @param[in] quadbin CARTO QUADBIN cell identifying the Web-Mercator tile, or 0
  * to derive it from the raster geotransform and EPSG:3857 spatial reference
- * @note The SQL surface reads the raster from bytes rather than a server-side
- * path, so the wrapper binds #raquet_read_bytes() and this function carries no
- * @p csqlfn link
+ * @csqlfn #Raquet_read()
  */
 Raquet *
 raquet_read(const char *path, uint64 quadbin)
@@ -362,7 +360,7 @@ raquet_read(const char *path, uint64 quadbin)
  * @param[in] size Number of bytes in @p data
  * @param[in] quadbin CARTO QUADBIN cell identifying the Web-Mercator tile, or 0
  * to derive it from the raster geotransform and EPSG:3857 spatial reference
- * @csqlfn #Raquet_read()
+ * @csqlfn #Raquet_read_bytes()
  */
 Raquet *
 raquet_read_bytes(const uint8_t *data, size_t size, uint64 quadbin)
@@ -602,6 +600,7 @@ raster_gdal_close(GDALDatasetH ds, const RasterValueGdalCtx *ctx,
  * @param[in] path Path to a GDAL-readable raster file
  * @param[in] band Band number (1-based)
  * @errval NULL
+ * @csqlfn #Raster_value_gdal()
  */
 Temporal *
 raster_value_gdal(const Temporal *traj, const char *path, int band)
@@ -635,6 +634,7 @@ raster_value_gdal(const Temporal *traj, const char *path, int band)
  * @param[in] band Band number (1-based)
  * @param[in] vspan Float value range (inclusive bounds)
  * @errval NULL
+ * @csqlfn #Raster_at_value_gdal()
  */
 Temporal *
 raster_at_value_gdal(const Temporal *traj, const char *path, int band,
@@ -670,6 +670,7 @@ raster_at_value_gdal(const Temporal *traj, const char *path, int band,
  * @param[in] band Band number (1-based)
  * @param[in] vspan Float value range to exclude
  * @errval NULL
+ * @csqlfn #Raster_minus_value_gdal()
  */
 Temporal *
 raster_minus_value_gdal(const Temporal *traj, const char *path, int band,
@@ -707,6 +708,7 @@ raster_minus_value_gdal(const Temporal *traj, const char *path, int band,
  * @return 1 if the trajectory ever samples a value inside @p vspan, 0 if
  * not, and -1 on error
  * @errval -1
+ * @csqlfn #Eraster_value_gdal()
  */
 int
 eraster_value_gdal(const Temporal *traj, const char *path, int band,
@@ -738,6 +740,7 @@ eraster_value_gdal(const Temporal *traj, const char *path, int band,
  * @return 1 if every sampled value falls inside @p vspan, 0 if not, and -1
  * on error
  * @errval -1
+ * @csqlfn #Araster_value_gdal()
  */
 int
 araster_value_gdal(const Temporal *traj, const char *path, int band,

--- a/mobilitydb/sql/raster/500_raster.in.sql
+++ b/mobilitydb/sql/raster/500_raster.in.sql
@@ -45,6 +45,9 @@
  *   eRasterValue(tgeompoint, raster, floatspan, band DEFAULT 1) → boolean
  *   aRasterValue(tgeompoint, raster, floatspan, band DEFAULT 1) → boolean
  *
+ * rasterValue and the four functions above also take the path of a raster
+ * file on the server in place of the raster, which GDAL reads.
+ *
  * This file is compiled into the mobilitydb extension only when
  * MobilityDB is built with `-DRASTER=ON`; the generated
  * `mobilitydb.control` then declares `requires = '...postgis_raster'`
@@ -143,8 +146,23 @@ CREATE FUNCTION raquetRead(
     rasterfile bytea,
     quadbin    bigint DEFAULT NULL
 ) RETURNS raquet
-  AS 'MODULE_PATHNAME', 'Raquet_read'
+  AS 'MODULE_PATHNAME', 'Raquet_read_bytes'
   LANGUAGE C IMMUTABLE PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a Raquet tile read from a raster file on the server via GDAL
+ * @param[in] path Path of a raster file on the server in any GDAL-supported
+ * format
+ * @param[in] quadbin CARTO QUADBIN cell, or NULL to derive it from the raster
+ * geotransform and EPSG:3857 spatial reference
+ */
+CREATE FUNCTION raquetRead(
+    path    text,
+    quadbin bigint DEFAULT NULL
+) RETURNS raquet
+  AS 'MODULE_PATHNAME', 'Raquet_read'
+  LANGUAGE C PARALLEL SAFE;
 
 /******************************************************************************
  * rasterValue
@@ -163,6 +181,23 @@ CREATE OR REPLACE FUNCTION rasterValue(
     band  integer DEFAULT 1
 ) RETURNS tfloat
   AS 'MODULE_PATHNAME', 'Raster_value'
+  LANGUAGE C STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the values of a band of a raster file on the server read
+ * along a trajectory
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server in any GDAL-supported
+ * format
+ * @param[in] band Band number (1-based, default 1)
+ */
+CREATE OR REPLACE FUNCTION rasterValue(
+    traj  tgeompoint,
+    path  text,
+    band  integer DEFAULT 1
+) RETURNS tfloat
+  AS 'MODULE_PATHNAME', 'Raster_value_gdal'
   LANGUAGE C STRICT PARALLEL SAFE;
 
 /******************************************************************************
@@ -263,6 +298,22 @@ CREATE OR REPLACE FUNCTION atRasterValue(traj tgeompoint, rast raster,
   AS 'MODULE_PATHNAME', 'Raster_at_value'
   LANGUAGE C STRICT PARALLEL SAFE;
 
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the instants of a trajectory where the value it reads from a
+ * raster file on the server falls inside a float range
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server in any GDAL-supported
+ * format
+ * @param[in] vspan Float value range (inclusive bounds)
+ * @param[in] band Band number (1-based, default 1)
+ */
+CREATE OR REPLACE FUNCTION atRasterValue(traj tgeompoint, path text,
+    vspan floatspan, band integer DEFAULT 1)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Raster_at_value_gdal'
+  LANGUAGE C STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * minusRasterValue
  *****************************************************************************/
@@ -280,6 +331,22 @@ CREATE OR REPLACE FUNCTION minusRasterValue(traj tgeompoint, rast raster,
     vspan floatspan, band integer DEFAULT 1)
   RETURNS tgeompoint
   AS 'MODULE_PATHNAME', 'Raster_minus_value'
+  LANGUAGE C STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the instants of a trajectory where the value it reads from a
+ * raster file on the server falls outside a float range
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server in any GDAL-supported
+ * format
+ * @param[in] vspan Float value range to exclude
+ * @param[in] band Band number (1-based, default 1)
+ */
+CREATE OR REPLACE FUNCTION minusRasterValue(traj tgeompoint, path text,
+    vspan floatspan, band integer DEFAULT 1)
+  RETURNS tgeompoint
+  AS 'MODULE_PATHNAME', 'Raster_minus_value_gdal'
   LANGUAGE C STRICT PARALLEL SAFE;
 
 /******************************************************************************
@@ -301,6 +368,22 @@ CREATE OR REPLACE FUNCTION eRasterValue(traj tgeompoint, rast raster,
   AS 'MODULE_PATHNAME', 'Eraster_value'
   LANGUAGE C STRICT PARALLEL SAFE;
 
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if the trajectory ever reads a value inside a float range
+ * from a raster file on the server
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server in any GDAL-supported
+ * format
+ * @param[in] vspan Float value range
+ * @param[in] band Band number (1-based, default 1)
+ */
+CREATE OR REPLACE FUNCTION eRasterValue(traj tgeompoint, path text,
+    vspan floatspan, band integer DEFAULT 1)
+  RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Eraster_value_gdal'
+  LANGUAGE C STRICT PARALLEL SAFE;
+
 /******************************************************************************
  * aRasterValue
  *****************************************************************************/
@@ -317,6 +400,21 @@ CREATE OR REPLACE FUNCTION eRasterValue(traj tgeompoint, rast raster,
 CREATE OR REPLACE FUNCTION aRasterValue(traj tgeompoint, rast raster,
     vspan floatspan, band integer DEFAULT 1) RETURNS boolean
   AS 'MODULE_PATHNAME', 'Araster_value'
+  LANGUAGE C STRICT PARALLEL SAFE;
+
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if every value the trajectory reads from a raster file on
+ * the server falls inside a float range
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server in any GDAL-supported
+ * format
+ * @param[in] vspan Float value range
+ * @param[in] band Band number (1-based, default 1)
+ */
+CREATE OR REPLACE FUNCTION aRasterValue(traj tgeompoint, path text,
+    vspan floatspan, band integer DEFAULT 1) RETURNS boolean
+  AS 'MODULE_PATHNAME', 'Araster_value_gdal'
   LANGUAGE C STRICT PARALLEL SAFE;
 
 /******************************************************************************

--- a/mobilitydb/src/raster/temporal_raster.c
+++ b/mobilitydb/src/raster/temporal_raster.c
@@ -42,7 +42,12 @@
 #include <fmgr.h>
 #include <funcapi.h>
 #include <access/htup_details.h>
+#include <catalog/pg_type.h>
+#include <commands/extension.h>
 #include <utils/array.h>
+#include <utils/guc.h>
+#include <utils/lsyscache.h>
+#include <utils/syscache.h>
 /* MEOS */
 #include <meos.h>
 #include <meos_internal.h>
@@ -200,6 +205,219 @@ Araster_value(PG_FUNCTION_ARGS)
 
   PG_FREE_IF_COPY(traj, 0);
   PG_FREE_IF_COPY(rast, 1);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result);
+}
+
+/*****************************************************************************
+ * The file forms: a raster file on the server read through GDAL
+ *****************************************************************************/
+
+/**
+ * @brief Return true if a raster file on the server may be read, as PostGIS
+ * allows a raster band stored outside the database to be read
+ * @details PostGIS applies `postgis.gdal_enabled_drivers` to GDAL when its
+ * raster library is loaded, so the library is loaded before the file is
+ * opened. The file is then read where `postgis.enable_outdb_rasters` is on,
+ * and a path through a GDAL virtual file system other than `/vsimem/` where
+ * the drivers enabled include `VSICURL`, the tests PostGIS makes on a path
+ * before it opens it.
+ * @param[in] path Path of the raster file
+ */
+static bool
+ensure_raster_file_readable(const char *path)
+{
+  /* Looking up the input function of the raster type loads the PostGIS
+   * raster library, whose initialization applies the enabled drivers */
+  Oid ext_oid = get_extension_oid("postgis_raster", true);
+  Oid type_oid = OidIsValid(ext_oid) ?
+    GetSysCacheOid2(TYPENAMENSP, Anum_pg_type_oid, CStringGetDatum("raster"),
+      ObjectIdGetDatum(get_extension_schema(ext_oid))) : InvalidOid;
+  if (OidIsValid(type_oid))
+  {
+    Oid infunc, ioparam;
+    FmgrInfo finfo;
+    getTypeInputInfo(type_oid, &infunc, &ioparam);
+    fmgr_info(infunc, &finfo);
+  }
+  const char *outdb = GetConfigOption("postgis.enable_outdb_rasters", true,
+    false);
+  if (! outdb || strcmp(outdb, "on") != 0)
+  {
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "Reading the raster file %s on the server is disabled by "
+      "postgis.enable_outdb_rasters", path);
+    return false;
+  }
+  const char *drivers = GetConfigOption("postgis.gdal_enabled_drivers", true,
+    false);
+  if (! drivers || strstr(drivers, "DISABLE_ALL"))
+  {
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "Cannot read the raster file %s: postgis.gdal_enabled_drivers disables "
+      "every GDAL driver", path);
+    return false;
+  }
+  if (! strstr(drivers, "ENABLE_ALL") && strstr(path, "/vsi") &&
+      ! strstr(path, "/vsimem") && ! strstr(drivers, "VSICURL"))
+  {
+    meos_error(ERROR, MEOS_ERR_FEATURE_NOT_SUPPORTED,
+      "Cannot read the raster file %s: postgis.gdal_enabled_drivers does not "
+      "enable VSICURL", path);
+    return false;
+  }
+  return true;
+}
+
+PGDLLEXPORT Datum Raster_value_gdal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_value_gdal);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the values of a band of a raster file on the server read
+ * along a trajectory
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server
+ * @param[in] band Band number (1-based, default 1)
+ * @sqlfn rasterValue()
+ */
+Datum
+Raster_value_gdal(PG_FUNCTION_ARGS)
+{
+  Temporal *traj = PG_GETARG_TEMPORAL_P(0);
+  char *path = text_to_cstring(PG_GETARG_TEXT_PP(1));
+  int32 band = PG_ARGISNULL(2) ? 1 : PG_GETARG_INT32(2);
+  if (! ensure_raster_file_readable(path))
+    PG_RETURN_NULL();
+
+  Temporal *result = raster_value_gdal(traj, path, band);
+
+  pfree(path);
+  PG_FREE_IF_COPY(traj, 0);
+  if (result == NULL)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Raster_at_value_gdal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_at_value_gdal);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the instants of a trajectory where the value it reads from a
+ * raster file on the server falls inside a float range
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server
+ * @param[in] vspan Float value range (inclusive bounds)
+ * @param[in] band Band number (1-based, default 1)
+ * @sqlfn atRasterValue()
+ */
+Datum
+Raster_at_value_gdal(PG_FUNCTION_ARGS)
+{
+  Temporal *traj = PG_GETARG_TEMPORAL_P(0);
+  char *path = text_to_cstring(PG_GETARG_TEXT_PP(1));
+  Span *vspan = PG_GETARG_SPAN_P(2);
+  int32 band = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
+  if (! ensure_raster_file_readable(path))
+    PG_RETURN_NULL();
+
+  Temporal *result = raster_at_value_gdal(traj, path, band, vspan);
+
+  pfree(path);
+  PG_FREE_IF_COPY(traj, 0);
+  if (result == NULL)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Raster_minus_value_gdal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raster_minus_value_gdal);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return the instants of a trajectory where the value it reads from a
+ * raster file on the server falls outside a float range
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server
+ * @param[in] vspan Float value range to exclude
+ * @param[in] band Band number (1-based, default 1)
+ * @sqlfn minusRasterValue()
+ */
+Datum
+Raster_minus_value_gdal(PG_FUNCTION_ARGS)
+{
+  Temporal *traj = PG_GETARG_TEMPORAL_P(0);
+  char *path = text_to_cstring(PG_GETARG_TEXT_PP(1));
+  Span *vspan = PG_GETARG_SPAN_P(2);
+  int32 band = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
+  if (! ensure_raster_file_readable(path))
+    PG_RETURN_NULL();
+
+  Temporal *result = raster_minus_value_gdal(traj, path, band, vspan);
+
+  pfree(path);
+  PG_FREE_IF_COPY(traj, 0);
+  if (result == NULL)
+    PG_RETURN_NULL();
+  PG_RETURN_POINTER(result);
+}
+
+PGDLLEXPORT Datum Eraster_value_gdal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Eraster_value_gdal);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if a trajectory ever reads a value inside a float range
+ * from a raster file on the server
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server
+ * @param[in] vspan Float value range
+ * @param[in] band Band number (1-based, default 1)
+ * @sqlfn eRasterValue()
+ */
+Datum
+Eraster_value_gdal(PG_FUNCTION_ARGS)
+{
+  Temporal *traj = PG_GETARG_TEMPORAL_P(0);
+  char *path = text_to_cstring(PG_GETARG_TEXT_PP(1));
+  Span *vspan = PG_GETARG_SPAN_P(2);
+  int32 band = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
+  if (! ensure_raster_file_readable(path))
+    PG_RETURN_NULL();
+
+  int result = eraster_value_gdal(traj, path, band, vspan);
+
+  pfree(path);
+  PG_FREE_IF_COPY(traj, 0);
+  if (result < 0)
+    PG_RETURN_NULL();
+  PG_RETURN_BOOL(result);
+}
+
+PGDLLEXPORT Datum Araster_value_gdal(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Araster_value_gdal);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return true if every value a trajectory reads from a raster file on
+ * the server falls inside a float range
+ * @param[in] traj Trajectory
+ * @param[in] path Path of a raster file on the server
+ * @param[in] vspan Float value range
+ * @param[in] band Band number (1-based, default 1)
+ * @sqlfn aRasterValue()
+ */
+Datum
+Araster_value_gdal(PG_FUNCTION_ARGS)
+{
+  Temporal *traj = PG_GETARG_TEMPORAL_P(0);
+  char *path = text_to_cstring(PG_GETARG_TEXT_PP(1));
+  Span *vspan = PG_GETARG_SPAN_P(2);
+  int32 band = PG_ARGISNULL(3) ? 1 : PG_GETARG_INT32(3);
+  if (! ensure_raster_file_readable(path))
+    PG_RETURN_NULL();
+
+  int result = araster_value_gdal(traj, path, band, vspan);
+
+  pfree(path);
+  PG_FREE_IF_COPY(traj, 0);
   if (result < 0)
     PG_RETURN_NULL();
   PG_RETURN_BOOL(result);
@@ -1012,8 +1230,8 @@ Raquet_constructor(PG_FUNCTION_ARGS)
   PG_RETURN_RAQUET_P(result);
 }
 
-PGDLLEXPORT Datum Raquet_read(PG_FUNCTION_ARGS);
-PG_FUNCTION_INFO_V1(Raquet_read);
+PGDLLEXPORT Datum Raquet_read_bytes(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_read_bytes);
 /**
  * @ingroup mobilitydb_raster
  * @brief Return a Raquet tile decoded from an in-memory raster file via GDAL
@@ -1026,7 +1244,7 @@ PG_FUNCTION_INFO_V1(Raquet_read);
  * @sqlfn raquetRead()
  */
 Datum
-Raquet_read(PG_FUNCTION_ARGS)
+Raquet_read_bytes(PG_FUNCTION_ARGS)
 {
   if (PG_ARGISNULL(0))
     PG_RETURN_NULL();
@@ -1037,6 +1255,36 @@ Raquet_read(PG_FUNCTION_ARGS)
   const uint8_t *data = (const uint8_t *) VARDATA_ANY(rasterfile);
   size_t size = VARSIZE_ANY_EXHDR(rasterfile);
   Raquet *result = raquet_read_bytes(data, size, quadbin);
+  if (! result)
+    PG_RETURN_NULL();
+  PG_RETURN_RAQUET_P(result);
+}
+
+PGDLLEXPORT Datum Raquet_read(PG_FUNCTION_ARGS);
+PG_FUNCTION_INFO_V1(Raquet_read);
+/**
+ * @ingroup mobilitydb_raster
+ * @brief Return a Raquet tile read from a raster file on the server via GDAL
+ * @details The file is read where PostGIS allows a raster band stored outside
+ * the database to be read.
+ * @param[in] path Path of a raster file on the server (text)
+ * @param[in] quadbin CARTO QUADBIN cell (bigint), or NULL to derive it from the
+ * raster geotransform and EPSG:3857 spatial reference
+ * @sqlfn raquetRead()
+ */
+Datum
+Raquet_read(PG_FUNCTION_ARGS)
+{
+  if (PG_ARGISNULL(0))
+    PG_RETURN_NULL();
+  char *path = text_to_cstring(PG_GETARG_TEXT_PP(0));
+  /* A NULL quadbin requests deriving the tile identifier from the raster
+   * geotransform; raquet_read treats 0 as that request */
+  uint64 quadbin = PG_ARGISNULL(1) ? 0 : (uint64) PG_GETARG_INT64(1);
+  if (! ensure_raster_file_readable(path))
+    PG_RETURN_NULL();
+  Raquet *result = raquet_read(path, quadbin);
+  pfree(path);
   if (! result)
     PG_RETURN_NULL();
   PG_RETURN_RAQUET_P(result);

--- a/mobilitydb/test/raster/expected/500_raster.test.out
+++ b/mobilitydb/test/raster/expected/500_raster.test.out
@@ -643,6 +643,110 @@ FROM t;
 SELECT raquetRead(
   decode('49492a00080000000b000001030001000000020000000101030001000000020000000201030001000000080000000301030001000000010000000601030001000000010000001101040001000000920000001501030001000000010000001601030001000000020000001701040001000000040000001c01030001000000010000005301030001000000010000000000000001020304', 'hex'));
 ERROR:  Raster has no geotransform; cannot derive its QUADBIN cell: in-memory raster
+SET postgis.gdal_enabled_drivers = 'ENABLE_ALL';
+SET
+SET postgis.enable_outdb_rasters = true;
+SET
+SELECT lo_from_bytea(424242, ST_AsGDALRaster(ST_SetValues(ST_AddBand(
+  ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+  '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+  ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+        [40.0::float4, 50.0::float4, 60.0::float4],
+        [70.0::float4, 80.0::float4, 90.0::float4]]), 'GTiff')) = 424242
+  AS written;
+ written 
+---------
+ t
+(1 row)
+
+SELECT lo_export(424242, 'raster_file_forms.tif') AS exported;
+ exported 
+----------
+        1
+(1 row)
+
+SELECT lo_unlink(424242) AS unlinked;
+ unlinked 
+----------
+        1
+(1 row)
+
+SELECT lo_from_bytea(424243, decode('49492a00080000000b000001030001000000020000000101030001000000020000000201030001000000080000000301030001000000010000000601030001000000010000001101040001000000920000001501030001000000010000001601030001000000020000001701040001000000040000001c01030001000000010000005301030001000000010000000000000001020304', 'hex')) = 424243
+  AS written;
+ written 
+---------
+ t
+(1 row)
+
+SELECT lo_export(424243, 'raquet_file_form.tif') AS exported;
+ exported 
+----------
+        1
+(1 row)
+
+SELECT lo_unlink(424243) AS unlinked;
+ unlinked 
+----------
+        1
+(1 row)
+
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]) AS r
+), trip AS (
+  SELECT tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
+    POINT(2.5 2.5)@2001-01-02, POINT(0.5 0.5)@2001-01-03]' AS t
+)
+SELECT rasterValue(t, 'raster_file_forms.tif')::text AS file_form,
+  rasterValue(t, 'raster_file_forms.tif'::text) = rasterValue(t, r)
+    AS value_same,
+  atRasterValue(t, 'raster_file_forms.tif'::text, floatspan '[40, 90]') =
+    atRasterValue(t, r, floatspan '[40, 90]') AS at_same,
+  minusRasterValue(t, 'raster_file_forms.tif'::text, floatspan '[40, 90]') =
+    minusRasterValue(t, r, floatspan '[40, 90]') AS minus_same,
+  eRasterValue(t, 'raster_file_forms.tif'::text, floatspan '[65, 75]') AS ever_file,
+  eRasterValue(t, r, floatspan '[65, 75]') AS ever_raster,
+  aRasterValue(t, 'raster_file_forms.tif'::text, floatspan '[0, 100]') AS always_file,
+  aRasterValue(t, r, floatspan '[0, 100]') AS always_raster
+FROM rast, trip;
+                                                                                   file_form                                                                                    | value_same | at_same | minus_same | ever_file | ever_raster | always_file | always_raster 
+--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+------------+---------+------------+-----------+-------------+-------------+---------------
+ Interp=Step;[10@2001-01-01 00:00:00+00, 20@2001-01-01 06:00:00+00, 30@2001-01-01 18:00:00+00, 50@2001-01-02 06:00:00+00, 70@2001-01-02 18:00:00+00, 70@2001-01-03 00:00:00+00] | t          | t       | t          | t         | t           | t           | t
+(1 row)
+
+SELECT raquetRead('raquet_file_form.tif'::text, 5193776270265024512::bigint)::text
+     = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')::text
+       AS file_form_equals_constructor;
+ file_form_equals_constructor 
+------------------------------
+ t
+(1 row)
+
+SET postgis.enable_outdb_rasters = false;
+SET
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}',
+  'raster_file_forms.tif'::text);
+ERROR:  Reading the raster file raster_file_forms.tif on the server is disabled by postgis.enable_outdb_rasters
+SELECT raquetRead('raquet_file_form.tif'::text, 5193776270265024512::bigint);
+ERROR:  Reading the raster file raquet_file_form.tif on the server is disabled by postgis.enable_outdb_rasters
+SET postgis.enable_outdb_rasters = true;
+SET
+SET postgis.gdal_enabled_drivers = 'DISABLE_ALL';
+SET
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}',
+  'raster_file_forms.tif'::text);
+ERROR:  Cannot read the raster file raster_file_forms.tif: postgis.gdal_enabled_drivers disables every GDAL driver
+SET postgis.gdal_enabled_drivers = 'GTiff';
+SET
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}',
+  '/vsicurl/https://example.org/raster.tif'::text);
+ERROR:  Cannot read the raster file /vsicurl/https://example.org/raster.tif: postgis.gdal_enabled_drivers does not enable VSICURL
+SET postgis.gdal_enabled_drivers = 'ENABLE_ALL';
+SET
 SELECT raquetFromBinary(asBinary(raquet('\x01020304'::bytea, 2, 2,
          5193776270265024512::bigint, 'UINT8')))
        = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8');

--- a/mobilitydb/test/raster/queries/500_raster.test.sql
+++ b/mobilitydb/test/raster/queries/500_raster.test.sql
@@ -681,6 +681,78 @@ SELECT raquetRead(
   decode('49492a00080000000b000001030001000000020000000101030001000000020000000201030001000000080000000301030001000000010000000601030001000000010000001101040001000000920000001501030001000000010000001601030001000000020000001701040001000000040000001c01030001000000010000005301030001000000010000000000000001020304', 'hex'));
 
 -------------------------------------------------------------------------------
+-- The file forms of rasterValue, its restrictions and predicates, and
+-- raquetRead: a raster file on the server read through GDAL
+-------------------------------------------------------------------------------
+
+-- A raster file on the server is read where PostGIS allows a band stored
+-- outside the database to be read. The 3x3 raster of the examples and the
+-- 2 x 2 GeoTIFF above are written to files in the data directory, which a
+-- relative path names.
+SET postgis.gdal_enabled_drivers = 'ENABLE_ALL';
+SET postgis.enable_outdb_rasters = true;
+SELECT lo_from_bytea(424242, ST_AsGDALRaster(ST_SetValues(ST_AddBand(
+  ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+  '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+  ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+        [40.0::float4, 50.0::float4, 60.0::float4],
+        [70.0::float4, 80.0::float4, 90.0::float4]]), 'GTiff')) = 424242
+  AS written;
+SELECT lo_export(424242, 'raster_file_forms.tif') AS exported;
+SELECT lo_unlink(424242) AS unlinked;
+SELECT lo_from_bytea(424243, decode('49492a00080000000b000001030001000000020000000101030001000000020000000201030001000000080000000301030001000000010000000601030001000000010000001101040001000000920000001501030001000000010000001601030001000000020000001701040001000000040000001c01030001000000010000005301030001000000010000000000000001020304', 'hex')) = 424243
+  AS written;
+SELECT lo_export(424243, 'raquet_file_form.tif') AS exported;
+SELECT lo_unlink(424243) AS unlinked;
+
+-- The file forms answer what the raster forms answer over the same raster.
+-- A string literal in the second position names a file, text being the
+-- preferred type of an untyped literal.
+WITH rast AS (
+  SELECT ST_SetValues(ST_AddBand(
+    ST_MakeEmptyRaster(3, 3, 0.0, 3.0, 1.0, -1.0, 0.0, 0.0, 4326),
+    '32BF'::text, 0.0::float8, NULL::float8), 1, 1, 1,
+    ARRAY[[10.0::float4, 20.0::float4, 30.0::float4],
+          [40.0::float4, 50.0::float4, 60.0::float4],
+          [70.0::float4, 80.0::float4, 90.0::float4]]) AS r
+), trip AS (
+  SELECT tgeompoint 'SRID=4326;[POINT(0.5 2.5)@2001-01-01,
+    POINT(2.5 2.5)@2001-01-02, POINT(0.5 0.5)@2001-01-03]' AS t
+)
+SELECT rasterValue(t, 'raster_file_forms.tif')::text AS file_form,
+  rasterValue(t, 'raster_file_forms.tif'::text) = rasterValue(t, r)
+    AS value_same,
+  atRasterValue(t, 'raster_file_forms.tif'::text, floatspan '[40, 90]') =
+    atRasterValue(t, r, floatspan '[40, 90]') AS at_same,
+  minusRasterValue(t, 'raster_file_forms.tif'::text, floatspan '[40, 90]') =
+    minusRasterValue(t, r, floatspan '[40, 90]') AS minus_same,
+  eRasterValue(t, 'raster_file_forms.tif'::text, floatspan '[65, 75]') AS ever_file,
+  eRasterValue(t, r, floatspan '[65, 75]') AS ever_raster,
+  aRasterValue(t, 'raster_file_forms.tif'::text, floatspan '[0, 100]') AS always_file,
+  aRasterValue(t, r, floatspan '[0, 100]') AS always_raster
+FROM rast, trip;
+
+-- raquetRead reads the file into the tile it decodes from the same bytes
+SELECT raquetRead('raquet_file_form.tif'::text, 5193776270265024512::bigint)::text
+     = raquet('\x01020304'::bytea, 2, 2, 5193776270265024512::bigint, 'UINT8')::text
+       AS file_form_equals_constructor;
+
+-- The setting PostGIS states for a band stored outside the database decides
+-- a file read, and so do the GDAL drivers it enables.
+SET postgis.enable_outdb_rasters = false;
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}',
+  'raster_file_forms.tif'::text);
+SELECT raquetRead('raquet_file_form.tif'::text, 5193776270265024512::bigint);
+SET postgis.enable_outdb_rasters = true;
+SET postgis.gdal_enabled_drivers = 'DISABLE_ALL';
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}',
+  'raster_file_forms.tif'::text);
+SET postgis.gdal_enabled_drivers = 'GTiff';
+SELECT rasterValue(tgeompoint 'SRID=4326;{POINT(1.5 1.5)@2001-01-01}',
+  '/vsicurl/https://example.org/raster.tif'::text);
+SET postgis.gdal_enabled_drivers = 'ENABLE_ALL';
+
+-------------------------------------------------------------------------------
 -- raquet (Hex)WKB round trip
 --
 -- The tile carries its pixels and its QUADBIN georeferencing in one value, so

--- a/tools/scripts/check_csqlfn.py
+++ b/tools/scripts/check_csqlfn.py
@@ -248,9 +248,8 @@ def resolve(dirs):
         if refs:
             continue
         # A wrapper whose name is the function's own stem binds it, unless the
-        # wrapper resolves to a different MEOS function: raquet_read and
-        # raquet_read_bytes share the stem Raquet_read, which binds the bytes
-        # form, so the name alone would tag the path form that nothing binds
+        # wrapper resolves to a different MEOS function, where the name alone
+        # would tag a function that nothing binds
         stem = cap(fn)
         if stem in pgnames and deleg_of.get(stem, fn) == fn:
             auto.append((fn, stem, f, 'ownstem'))


### PR DESCRIPTION
The MEOS readers of a raster file, raster_value_gdal with its restriction
and predicate siblings and raquet_read, carry no SQL name, so each binding
names them by hand and a PostgreSQL user cannot reach them. They take the
names of the functions answering the same quantity over a raster:
rasterValue, atRasterValue, minusRasterValue, eRasterValue and
aRasterValue take the path of a raster file on the server in place of the
raster, and raquetRead takes a path beside the bytes it decodes. GDAL reads
the file in any format it supports.

The witness is the 3 x 3 raster of the manual, written to a GeoTIFF in the
data directory and read along a trip moving over it:

  SELECT rasterValue(t, 'raster_file_forms.tif') = rasterValue(t, r) ...

answers true, as do the two restrictions and the two predicates against
their raster forms, and raquetRead('raquet_file_form.tif', q) equals the
tile the constructor builds from the same pixels. On master none of these
calls resolves.

Why these names and this gate: the @sqlfn tag is the one name every
binding projects, and each file reader answers the quantity its
raster-taking sibling answers, so the second argument tells the two apart;
a string literal in that position names a file, text being the preferred
type of an untyped literal. A file on the server is read where PostGIS
allows a raster band stored outside the database to be read:
postgis.enable_outdb_rasters is on, postgis.gdal_enabled_drivers does not
disable every driver, and a path through a GDAL virtual file system other
than /vsimem/ has VSICURL enabled, the tests PostGIS makes before it opens
a file. The wrapper loads the PostGIS raster library first, whose
initialization applies the enabled drivers to GDAL, and reads the setting
itself, since PostGIS 3.6.3 declares its copy of
postgis.enable_outdb_rasters static and its raster core reads another. The
wrapper of raquetRead(bytea) is Raquet_read_bytes, the name its MEOS
function gives it, and Raquet_read binds the path form; the comment of
the csqlfn checker states its wrapper rule without naming the two
readers, each of which has a wrapper of its own name.

The numbers: in 500_raster the file forms answer what the raster forms
answer in seven comparisons, raquetRead over the file equals the
constructor, and four calls raise: the setting off for each reader, every
driver disabled, and a /vsicurl path without VSICURL; no other expected
output of the 337 regression tests on PostgreSQL 18 moves. The manual states the path forms beside each
reader in both languages, and the reference appendix carries the new
signatures.

