### PR TITLE
Run the regression suite on Windows

### DIFF
--- a/.github/workflows/windows_msys2.yml
+++ b/.github/workflows/windows_msys2.yml
@@ -10,6 +10,7 @@ on:
       - 'meos/**'
       - 'mobilitydb/**'
       - 'pgtypes/**'
+      - 'pointcloud-pg/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
     branches-ignore:
@@ -22,6 +23,7 @@ on:
       - 'meos/**'
       - 'mobilitydb/**'
       - 'pgtypes/**'
+      - 'pointcloud-pg/**'
       - 'postgis/**'
       - 'CMakeLists.txt'
     branches-ignore:
@@ -45,25 +47,81 @@ jobs:
           msystem: UCRT64
           update: true
           install: >-
+            git
+            autoconf
+            automake
+            libtool
+            make
+            diffutils
             mingw-w64-ucrt-x86_64-gcc
             mingw-w64-ucrt-x86_64-cmake
             mingw-w64-ucrt-x86_64-ninja
             mingw-w64-ucrt-x86_64-postgresql
             mingw-w64-ucrt-x86_64-postgis
+            mingw-w64-ucrt-x86_64-libxml2
+            mingw-w64-ucrt-x86_64-zlib
 
       - uses: ./.github/actions/msys2-toolchain-report
 
-      - name: Configure
+      - name: Build libh3 from source
+        # MSYS2 packages no h3, and H3=ON asks CMake for the library by name.
+        # It installs into the MSYS2 prefix, beside postgres.exe, which is where
+        # the server looks for the libh3 DLL the extension loads.
         run: |
-          mkdir build
-          cd build
-          cmake -DCMAKE_BUILD_TYPE=Release ..
+          git clone --depth 1 --branch v4.2.1 https://github.com/uber/h3.git h3-src
+          cmake -S h3-src -B h3-build \
+            -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$MSYSTEM_PREFIX" \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_TESTING=OFF \
+            -DENABLE_DOCS=OFF \
+            -DBUILD_BENCHMARKS=OFF \
+            -DBUILD_FILTERS=OFF \
+            -DBUILD_GENERATORS=OFF
+          cmake --build h3-build -j
+          cmake --install h3-build
+
+      - name: Build and install the vendored pgPointCloud
+        # POINTCLOUD maps to a PostgreSQL extension of its own, which the
+        # extension's `requires` names, and MSYS2 packages no build of it, so
+        # the one the tree carries is built the way fedora.yml builds it. It is
+        # built from a copy, since the configure step writes into its tree.
+        run: |
+          cp -r pointcloud-pg pointcloud-ext
+          cd pointcloud-ext
+          ./autogen.sh
+          ./configure --with-pgconfig="$(command -v pg_config)"
+          make -j
+          make install
+
+      - name: Build and install the h3 PostgreSQL extension
+        # H3 names the h3 extension in the extension's requires clause and
+        # MSYS2 packages none. The h3 core it builds adds the MSVC flag /W2 on
+        # Windows unless its warnings are off, and installs its own library
+        # into CMAKE_INSTALL_PREFIX, which a local directory keeps apart.
+        run: |
+          git clone --depth 1 --recurse-submodules --branch v4.2.3 \
+            https://github.com/postgis/h3-pg.git h3-pg-checkout
+          cmake -S h3-pg-checkout -B h3-pg-build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DENABLE_WARNINGS=OFF \
+            -DCMAKE_INSTALL_PREFIX="$PWD/h3-pg-prefix"
+          cmake --build h3-pg-build -j
+          cmake --install h3-pg-build
+
+      - name: Configure with every family
+        run: |
+          cmake -S . -B build -G Ninja \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DALL=ON \
+            -DH3_LIBRARY="$MSYSTEM_PREFIX/lib/libh3.dll.a" \
+            -DH3_INCLUDE_DIR="$MSYSTEM_PREFIX/include/h3"
 
       - name: Build
         run: |
-          cd build
-          cmake --build .
-          cmake --install .
+          cmake --build build
+          cmake --install build
 
       - name: Test install
         run: |
@@ -85,7 +143,7 @@ jobs:
           pg_ctl start
           # Create database and add the MobilityDB extension
           createdb -U runneradmin mydb
-          psql -p 5432 -U runneradmin -d mydb -v ON_ERROR_STOP=1 -c "CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydbFullVersion(); SELECT tfloat '[1@2000-01-01]';"
+          psql -p 5432 -U runneradmin -d mydb -v ON_ERROR_STOP=1 -c "CREATE EXTENSION pointcloud; CREATE EXTENSION mobilitydb CASCADE; SELECT postgis_full_version(); SELECT mobilitydbFullVersion(); SELECT tfloat '[1@2000-01-01]';"
       - name: Dump postgres log
         if: always()
         shell: msys2 {0}
@@ -99,7 +157,15 @@ jobs:
             done
           fi
 
-      # - name: Run tests
-        # run: |
-          # cd build
-          # ctest --output-on-failure
+      - name: Run the suite
+        run: |
+          cd build
+          ctest --output-on-failure
+
+      - name: Dump the log of the suite's server
+        if: failure()
+        run: |
+          for f in build/tmptest/log/*.log; do
+            echo "--- $f ---"
+            cat "$f"
+          done

--- a/mobilitydb/test/rgeo/expected/169_trgeo_distance_trgeo.test.out
+++ b/mobilitydb/test/rgeo/expected/169_trgeo_distance_trgeo.test.out
@@ -75,10 +75,10 @@ SELECT interp(tDistance(
 
 SELECT ST_AsText(shortestLine(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
-  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 0),0)@2001-01-01, Pose(Point(14 0),0)@2001-01-02]'));
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 2),0)@2001-01-01, Pose(Point(14 2),0)@2001-01-02]'));
        st_astext       
 -----------------------
- LINESTRING(12 0,14 0)
+ LINESTRING(12 1,14 2)
 (1 row)
 
 SELECT round((

--- a/mobilitydb/test/rgeo/queries/169_trgeo_distance_trgeo.test.sql
+++ b/mobilitydb/test/rgeo/queries/169_trgeo_distance_trgeo.test.sql
@@ -83,10 +83,11 @@ SELECT interp(tDistance(
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
   trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 0),0)@2001-01-01, Pose(Point(14 0),0)@2001-01-02]'));
 
--- The shortest line joins the two bodies themselves
+-- The shortest line joins the two bodies themselves, at the one pair of
+-- corners that come closest
 SELECT ST_AsText(shortestLine(
   trgeometry 'Polygon((0 0,2 0,2 1,0 1,0 0));[Pose(Point(0 0),0)@2001-01-01, Pose(Point(10 0),0)@2001-01-02]',
-  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 0),0)@2001-01-01, Pose(Point(14 0),0)@2001-01-02]'));
+  trgeometry 'Polygon((0 0,2 0,2 2,0 2,0 0));[Pose(Point(20 2),0)@2001-01-01, Pose(Point(14 2),0)@2001-01-02]'));
 
 -- Two long hulls passing 2.2 m apart on nearly parallel headings: the
 -- closest-feature walk reaches a transition a few 1e-14 short of the end of a

--- a/mobilitydb/test/scripts/test.cmake
+++ b/mobilitydb/test/scripts/test.cmake
@@ -20,6 +20,20 @@ set(POSTGRESQL_BIN_DIR "@POSTGRESQL_BIN_DIR@")
 set(POSTGIS_LIBRARY "@POSTGIS_LIBRARY@")
 set(XZCAT_EXECUTABLE "@XZCAT_EXECUTABLE@")
 
+# The PostgreSQL programs by their file names, which carry the platform's
+# executable suffix: MSYS2 installs a shell wrapper named plain `initdb` or
+# `psql` beside the executable, and a program run by path needs the executable
+set(INITDB "${POSTGRESQL_BIN_DIR}/initdb@CMAKE_EXECUTABLE_SUFFIX@")
+set(PG_CTL "${POSTGRESQL_BIN_DIR}/pg_ctl@CMAKE_EXECUTABLE_SUFFIX@")
+set(PSQL "${POSTGRESQL_BIN_DIR}/psql@CMAKE_EXECUTABLE_SUFFIX@")
+
+# The cluster belongs to the user running the suite, who is its superuser, and
+# listens on the default port. A caller's environment can name another user or
+# port for libpq, as the GitHub Windows images do with PGUSER=postgres for the
+# server they preinstall, so the programs run here do not read them.
+unset(ENV{PGUSER})
+unset(ENV{PGPORT})
+
 # Test directories
 set(TEST_DIR "${CMAKE_BINARY_DIR}/tmptest")
 set(TEST_DIR_DB "${TEST_DIR}/db")
@@ -73,6 +87,13 @@ if(TEST_OPER MATCHES "test_setup")
   else()
     message(STATUS "Test directories created: '${TEST_DIR}'")
   endif()
+  if(CMAKE_HOST_WIN32)
+    # The tests exchange tables with the server through files under /tmp,
+    # which a server on Windows reads as a directory at the root of the drive
+    # holding its cluster
+    string(SUBSTRING "${TEST_DIR_DB}" 0 2 _drive)
+    file(MAKE_DIRECTORY "${_drive}/tmp")
+  endif()
 
   #-------------------------
   # Create database cluster
@@ -82,7 +103,7 @@ if(TEST_OPER MATCHES "test_setup")
   # -D <directory> Directory where the database cluster should be stored.
   #    If not given, the PGDATA environment variable is used.
   execute_process(
-    COMMAND ${POSTGRESQL_BIN_DIR}/initdb -D ${TEST_DIR_DB}
+    COMMAND ${INITDB} -D ${TEST_DIR_DB}
     OUTPUT_FILE ${TEST_DIR_LOG}/initdb.log
     ERROR_FILE ${TEST_DIR_LOG}/initdb.log
     ERROR_VARIABLE TEST_ERROR
@@ -122,18 +143,37 @@ if(TEST_OPER MATCHES "test_setup")
   # -o "-k <directory>" Parameter passed to the database server (postgres)
   #   Directory of the Unix-domain socket on which postgres is to listen for
   #   connections from client applications
-  # -o "-h ''" Parameter passed to the database server (postgres)
-  #   Specifies the IP host name or address on which postgres is to listen for
-  #   TCP/IP connections from client applications. An empty value specifies not
-  #   listening on any IP addresses, in which case only Unix-domain sockets can
-  #   be used to connect to the server.
-  execute_process(
-    COMMAND ${POSTGRESQL_BIN_DIR}/pg_ctl -w -D ${TEST_DIR_DB} -l ${TEST_DIR_LOG}/postgres.log -o "-k ${TEST_DIR_LOCK}" -o "-h ''" start
-    OUTPUT_FILE ${TEST_DIR_LOG}/pg_start.log
-    ERROR_FILE ${TEST_DIR_LOG}/pg_start.log
-    ERROR_VARIABLE TEST_ERROR
-    RESULT_VARIABLE TEST_RESULT
-  )
+  # -o "-c listen_addresses=" Parameter passed to the database server (postgres)
+  #   Specifies the IP host names or addresses on which postgres is to listen
+  #   for TCP/IP connections from client applications. An empty value specifies
+  #   not listening on any IP addresses, in which case only Unix-domain sockets
+  #   can be used to connect to the server. The empty value is written without
+  #   quotes, since pg_ctl passes the options through a shell on Unix and
+  #   without one on Windows.
+  if(CMAKE_HOST_WIN32)
+    # On Windows pg_ctl hands the server the inheritable handles of its parent,
+    # among them the pipe CTest reads the output of this test from, and CTest
+    # waits on that pipe for as long as the server runs. Start-Process without
+    # a redirection starts pg_ctl through the shell, which passes on no handle,
+    # and WaitForExit waits for pg_ctl alone, where -Wait would also wait for
+    # the server it leaves running.
+    execute_process(
+      COMMAND powershell -NoProfile -NonInteractive -Command
+        "$p = Start-Process -FilePath '${PG_CTL}' -ArgumentList '-w -D \"${TEST_DIR_DB}\" -l \"${TEST_DIR_LOG}/postgres.log\" -o \"-k ${TEST_DIR_LOCK}\" -o \"-c listen_addresses=\" start' -WindowStyle Hidden -PassThru; $p.WaitForExit(); exit $p.ExitCode"
+      OUTPUT_FILE ${TEST_DIR_LOG}/pg_start.log
+      ERROR_FILE ${TEST_DIR_LOG}/pg_start.log
+      ERROR_VARIABLE TEST_ERROR
+      RESULT_VARIABLE TEST_RESULT
+    )
+  else()
+    execute_process(
+      COMMAND ${PG_CTL} -w -D ${TEST_DIR_DB} -l ${TEST_DIR_LOG}/postgres.log -o "-k ${TEST_DIR_LOCK}" -o "-c listen_addresses=" start
+      OUTPUT_FILE ${TEST_DIR_LOG}/pg_start.log
+      ERROR_FILE ${TEST_DIR_LOG}/pg_start.log
+      ERROR_VARIABLE TEST_ERROR
+      RESULT_VARIABLE TEST_RESULT
+    )
+  endif()
   if(TEST_RESULT)
     message(FATAL_ERROR "Failed to start PostgreSQL server:\n${TEST_RESULT}\n${TEST_ERROR}")
   else()
@@ -166,7 +206,7 @@ if(TEST_OPER MATCHES "test_setup")
   string(APPEND _create_ext "SELECT postgis_full_version(); ")
   string(APPEND _create_ext "SELECT mobilitydbFullVersion();")
   execute_process(
-    COMMAND ${POSTGRESQL_BIN_DIR}/psql -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres -c "${_create_ext}"
+    COMMAND ${PSQL} -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres -c "${_create_ext}"
     OUTPUT_FILE ${TEST_DIR_LOG}/create_ext.log
     ERROR_FILE ${TEST_DIR_LOG}/create_ext.log
     ERROR_VARIABLE TEST_ERROR
@@ -195,7 +235,7 @@ elseif(TEST_OPER MATCHES "run_compare")
   # Execute the test
   # Explanation of the parameters for psql (see above)
   execute_process(
-    COMMAND ${POSTGRESQL_BIN_DIR}/psql -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres
+    COMMAND ${PSQL} -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres
     INPUT_FILE ${TEST_FILE}
     OUTPUT_FILE ${TEST_DIR_OUT}/${TEST_NAME}.out
     ERROR_FILE ${TEST_DIR_OUT}/${TEST_NAME}.out
@@ -207,12 +247,22 @@ elseif(TEST_OPER MATCHES "run_compare")
 
   # Compare the files
   if(WIN32)
-    # The compare files command in cmake does not provide detailed differences
+    # The compare files command in cmake does not provide detailed differences.
+    # psql writes its output with the line endings of the platform, and the
+    # checkout writes the expected files with those of its configuration
     execute_process(
-      COMMAND ${CMAKE_COMMAND} -E compare_files ${TEST_DIR_OUT}/${TEST_NAME}.out ${TEST_FILE_DIR}/expected/${TEST_FILE_NAME}.test.out
+      COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol ${TEST_DIR_OUT}/${TEST_NAME}.out ${TEST_FILE_DIR}/expected/${TEST_FILE_NAME}.test.out
       OUTPUT_FILE ${TEST_DIR_OUT}/${TEST_NAME}.diff
       RESULT_VARIABLE TEST_RESULT
       )
+    # Where a diff program is at hand, as in MSYS2, it writes the differences
+    find_program(DIFF_EXECUTABLE diff)
+    if(TEST_RESULT AND DIFF_EXECUTABLE)
+      execute_process(
+        COMMAND ${DIFF_EXECUTABLE} --strip-trailing-cr -urdN ${TEST_FILE_DIR}/expected/${TEST_FILE_NAME}.test.out ${TEST_DIR_OUT}/${TEST_NAME}.out
+        OUTPUT_FILE ${TEST_DIR_OUT}/${TEST_NAME}.diff
+        )
+    endif()
   else()
     execute_process(
       COMMAND diff -urdN ${TEST_FILE_DIR}/expected/${TEST_FILE_NAME}.test.out ${TEST_DIR_OUT}/${TEST_NAME}.out
@@ -225,9 +275,9 @@ elseif(TEST_OPER MATCHES "run_compare")
   file(REMOVE ${TEST_DIR}/test.expected)
 
   if(TEST_RESULT)
-    # Write the differences
-    if(NOT WIN32)
-      file(READ ${TEST_DIR_OUT}/${TEST_NAME}.diff DIFFS)
+    # Write the differences, where there are some to write
+    file(READ ${TEST_DIR_OUT}/${TEST_NAME}.diff DIFFS)
+    if(DIFFS)
       message(STATUS "\nDifferences\n")
       message(STATUS "===========\n\n")
       message(STATUS "${DIFFS}\n\n")
@@ -255,14 +305,14 @@ elseif(TEST_OPER MATCHES "run_passfail")
     get_filename_component(TEST_FILE_NAME ${TEST_FILE} NAME_WLE)
     execute_process(
       COMMAND ${XZCAT_EXECUTABLE} ${TEST_FILE}
-      COMMAND ${POSTGRESQL_BIN_DIR}/psql -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres
+      COMMAND ${PSQL} -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres
       OUTPUT_QUIET
       ERROR_VARIABLE TEST_ERROR
       RESULT_VARIABLE TEST_RESULT
     )
   else()
     execute_process(
-      COMMAND ${POSTGRESQL_BIN_DIR}/psql -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres
+      COMMAND ${PSQL} -X -h ${TEST_DIR_LOCK} -e --set ON_ERROR_STOP=0 -d postgres
       INPUT_FILE ${TEST_FILE}
       OUTPUT_FILE ${TEST_DIR_OUT}/${TESTNAME}.out
       ERROR_FILE ${TEST_DIR_OUT}/${TESTNAME}.out
@@ -282,7 +332,7 @@ elseif(TEST_OPER MATCHES "teardown")
 
   # Explanation of the parameters for pg_ctl (see above)
   execute_process(
-    COMMAND ${POSTGRESQL_BIN_DIR}/pg_ctl -w -D ${TEST_DIR_DB} stop
+    COMMAND ${PG_CTL} -w -D ${TEST_DIR_DB} stop
     OUTPUT_FILE ${TEST_DIR_LOG}/pg_stop.log
     ERROR_FILE ${TEST_DIR_LOG}/pg_stop.log
     ERROR_VARIABLE TEST_ERROR


### PR DESCRIPTION
Run the regression harness on Windows

mobilitydb/test/scripts/test.cmake starts, feeds and stops the cluster of the
suite the same way on Windows as on Unix.

- It runs the PostgreSQL programs by their file names with the platform's
  executable suffix. MSYS2 installs a shell wrapper named plain initdb and
  psql beside each executable, and the harness ran the wrapper, which
  Windows cannot execute: initdb stopped at "inappropriate file type or
  format".
- It clears PGUSER and PGPORT for the programs it runs. The cluster belongs to
  the user running the suite, and the GitHub Windows images set
  PGUSER=postgres for the server they preinstall, so psql connected as a role
  the cluster does not have: 'role "postgres" does not exist'.
- It asks the server for no TCP listener with -c listen_addresses=, without
  quotes. pg_ctl hands its options to a shell on Unix, which reduces -h ''
  to an empty value, and to none on Windows, where the server read the two
  quotes as a host name: 'could not translate host name "''"'.
- On Windows it starts pg_ctl through PowerShell's Start-Process and waits for
  pg_ctl alone. pg_ctl there passes the server the inheritable handles of its
  parent, among them the pipe CTest reads the setup test from, so CTest
  waited on that pipe for as long as the server ran and the setup test never
  ended.
- On Windows it creates the directory /tmp names on the drive of the cluster,
  which is where the server there reads the files the tests exchange with it
  through COPY.
- It compares the output with the expected file ignoring line endings, since
  psql writes those of the platform and a checkout may write those of its
  configuration, and prints the differences of a failed test on Windows too,
  where a diff program is at hand.

Measured on Windows (MSYS2 UCRT64, PostgreSQL 18.4, PostGIS 3.6.2, every
family): the setup and teardown tests run in 27 seconds and leave no server
behind, and the suite answers 334 of 337 tests.


Read the shortest line of two rigid bodies at one pair of corners

169_trgeo_distance_trgeo asks for the shortest line between two moving rigid
bodies whose facing edges come closest while parallel: the edge x = 12 of the
first, over y from 0 to 1, faces the edge x = 14 of the second, so every line
from (12 y) to (14 y) with y in [0, 1] is a shortest line of length 2. The
answer is then whichever of them the arithmetic of the platform reaches first,
LINESTRING(12 0,14 0) on Linux and LINESTRING(12 1,14 1) on Windows.

The second body travels 2 higher, so the bodies come closest at one pair of
corners, (12 1) and (14 2), and the answer LINESTRING(12 1,14 2) is the same
on both platforms, harvested from each. The statement of the test, that the
shortest line joins the two bodies themselves, is unchanged.


Build every family on Windows and run the regression suite

The Windows job configures with -DALL=ON and runs the suite through ctest. It
builds what MSYS2 packages none of, the way fedora.yml builds it: libh3 from
source, installed beside postgres.exe where the server finds the DLL the
extension loads; the pgPointCloud extension the tree carries; and the h3
PostgreSQL extension, whose h3 core adds the MSVC flag /W2 on Windows unless
its warnings are off. The extension check creates pointcloud before
mobilitydb, as the suite's own setup does, and a failed suite prints the log
of its server.

Two tests of the suite answer differently on Windows because of defects of
their own, each fixed in a change of its own: 064_tpoint_distance, where the
geodetic nearest approach to an arc ending at a pole reads 0, and
450_jsonbset_tbl, where the comparison of two jsonb sets returns the raw
element comparison rather than -1, 0 or 1.


